### PR TITLE
refactor(messaging): tooltip-first element-template field hints

### DIFF
--- a/connectors/kafka/element-templates/hybrid/kafka-inbound-connector-boundary-hybrid.json
+++ b/connectors/kafka/element-templates/hybrid/kafka-inbound-connector-boundary-hybrid.json
@@ -57,7 +57,6 @@
   }, {
     "id" : "authenticationType",
     "label" : "Authentication type",
-    "description" : "Username/password or custom",
     "optional" : false,
     "value" : "credentials",
     "constraints" : {
@@ -68,6 +67,7 @@
       "name" : "authenticationType",
       "type" : "zeebe:property"
     },
+    "tooltip" : "Username/password or custom.",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "Credentials",
@@ -79,18 +79,17 @@
   }, {
     "id" : "authentication.username",
     "label" : "Username",
-    "description" : "Provide the username (must have permissions to produce message to the topic)",
     "optional" : true,
     "group" : "authentication",
     "binding" : {
       "name" : "authentication.username",
       "type" : "zeebe:property"
     },
+    "tooltip" : "The user must have permissions to produce messages to the topic.",
     "type" : "String"
   }, {
     "id" : "authentication.password",
     "label" : "Password",
-    "description" : "Provide a password for the user",
     "optional" : true,
     "group" : "authentication",
     "binding" : {
@@ -101,7 +100,6 @@
   }, {
     "id" : "topic.bootstrapServers",
     "label" : "Bootstrap servers",
-    "description" : "Provide bootstrap server(s), comma-delimited if there are multiple",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -111,11 +109,11 @@
       "name" : "topic.bootstrapServers",
       "type" : "zeebe:property"
     },
+    "tooltip" : "Bootstrap server(s), comma-delimited if there are multiple.",
     "type" : "String"
   }, {
     "id" : "topic.topicName",
     "label" : "Topic",
-    "description" : "Provide topic name",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -129,7 +127,6 @@
   }, {
     "id" : "groupId",
     "label" : "Consumer group ID",
-    "description" : "Provide the consumer group ID used by the connector. Leave empty for an automatically generated one",
     "optional" : false,
     "group" : "kafka",
     "binding" : {
@@ -141,7 +138,6 @@
   }, {
     "id" : "additionalProperties",
     "label" : "Additional properties",
-    "description" : "Provide additional Kafka consumer properties in JSON",
     "optional" : true,
     "feel" : "required",
     "group" : "kafka",
@@ -149,11 +145,11 @@
       "name" : "additionalProperties",
       "type" : "zeebe:property"
     },
+    "tooltip" : "Additional Kafka consumer properties in JSON.",
     "type" : "String"
   }, {
     "id" : "offsets",
     "label" : "Offsets",
-    "description" : "List of offsets, e.g. '10' or '=[10, 23]'. If specified, it has to have the same number of values as the number of partitions",
     "optional" : true,
     "feel" : "optional",
     "group" : "kafka",
@@ -161,11 +157,11 @@
       "name" : "offsets",
       "type" : "zeebe:property"
     },
+    "tooltip" : "List of offsets, e.g. '10' or '=[10, 23]'. If specified, it has to have the same number of values as the number of partitions.",
     "type" : "String"
   }, {
     "id" : "autoOffsetReset",
     "label" : "Auto offset reset",
-    "description" : "What to do when there is no initial offset in Kafka or if the current offset does not exist any more on the server. You should only select none if you specified the offsets",
     "optional" : false,
     "value" : "latest",
     "constraints" : {
@@ -176,6 +172,7 @@
       "name" : "autoOffsetReset",
       "type" : "zeebe:property"
     },
+    "tooltip" : "What to do when there is no initial offset in Kafka or if the current offset does not exist any more on the server. You should only select none if you specified the offsets.",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "None",
@@ -210,7 +207,6 @@
   }, {
     "id" : "schemaStrategy.avro.schema",
     "label" : "Schema",
-    "description" : "Avro inline schema for the message value",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -226,11 +222,11 @@
       "equals" : "inlineSchema",
       "type" : "simple"
     },
+    "tooltip" : "Avro inline schema for the message value",
     "type" : "Text"
   }, {
     "id" : "schemaStrategy.schemaType",
     "label" : "Schema type",
-    "description" : "Select the schema type. For details, visit the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/kafka/?kafka=inbound\" target=\"_blank\">documentation</a>",
     "optional" : false,
     "value" : "avro",
     "group" : "schema",
@@ -243,6 +239,7 @@
       "equals" : "schemaRegistry",
       "type" : "simple"
     },
+    "tooltip" : "For details, visit the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/kafka/?kafka=inbound\" target=\"_blank\">Kafka connector documentation</a>",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "JSON",
@@ -254,7 +251,6 @@
   }, {
     "id" : "schemaStrategy.schemaRegistryUrl",
     "label" : "Schema registry URL",
-    "description" : "Provide the schema registry URL",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true

--- a/connectors/kafka/element-templates/hybrid/kafka-inbound-connector-boundary-hybrid.json
+++ b/connectors/kafka/element-templates/hybrid/kafka-inbound-connector-boundary-hybrid.json
@@ -110,6 +110,7 @@
       "type" : "zeebe:property"
     },
     "tooltip" : "Bootstrap server(s), comma-delimited if there are multiple.",
+    "placeholder" : "broker1:9092,broker2:9092",
     "type" : "String"
   }, {
     "id" : "topic.topicName",
@@ -239,7 +240,7 @@
       "equals" : "schemaRegistry",
       "type" : "simple"
     },
-    "tooltip" : "For details, visit the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/kafka/?kafka=inbound\" target=\"_blank\">Kafka connector documentation</a>",
+    "tooltip" : "Format used to (de)serialize the message value: JSON or Avro. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/kafka/?kafka=inbound\" target=\"_blank\">Kafka connector</a> guide.",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "JSON",

--- a/connectors/kafka/element-templates/hybrid/kafka-inbound-connector-intermediate-hybrid.json
+++ b/connectors/kafka/element-templates/hybrid/kafka-inbound-connector-intermediate-hybrid.json
@@ -57,7 +57,6 @@
   }, {
     "id" : "authenticationType",
     "label" : "Authentication type",
-    "description" : "Username/password or custom",
     "optional" : false,
     "value" : "credentials",
     "constraints" : {
@@ -68,6 +67,7 @@
       "name" : "authenticationType",
       "type" : "zeebe:property"
     },
+    "tooltip" : "Username/password or custom.",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "Credentials",
@@ -79,18 +79,17 @@
   }, {
     "id" : "authentication.username",
     "label" : "Username",
-    "description" : "Provide the username (must have permissions to produce message to the topic)",
     "optional" : true,
     "group" : "authentication",
     "binding" : {
       "name" : "authentication.username",
       "type" : "zeebe:property"
     },
+    "tooltip" : "The user must have permissions to produce messages to the topic.",
     "type" : "String"
   }, {
     "id" : "authentication.password",
     "label" : "Password",
-    "description" : "Provide a password for the user",
     "optional" : true,
     "group" : "authentication",
     "binding" : {
@@ -101,7 +100,6 @@
   }, {
     "id" : "topic.bootstrapServers",
     "label" : "Bootstrap servers",
-    "description" : "Provide bootstrap server(s), comma-delimited if there are multiple",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -111,11 +109,11 @@
       "name" : "topic.bootstrapServers",
       "type" : "zeebe:property"
     },
+    "tooltip" : "Bootstrap server(s), comma-delimited if there are multiple.",
     "type" : "String"
   }, {
     "id" : "topic.topicName",
     "label" : "Topic",
-    "description" : "Provide topic name",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -129,7 +127,6 @@
   }, {
     "id" : "groupId",
     "label" : "Consumer group ID",
-    "description" : "Provide the consumer group ID used by the connector. Leave empty for an automatically generated one",
     "optional" : false,
     "group" : "kafka",
     "binding" : {
@@ -141,7 +138,6 @@
   }, {
     "id" : "additionalProperties",
     "label" : "Additional properties",
-    "description" : "Provide additional Kafka consumer properties in JSON",
     "optional" : true,
     "feel" : "required",
     "group" : "kafka",
@@ -149,11 +145,11 @@
       "name" : "additionalProperties",
       "type" : "zeebe:property"
     },
+    "tooltip" : "Additional Kafka consumer properties in JSON.",
     "type" : "String"
   }, {
     "id" : "offsets",
     "label" : "Offsets",
-    "description" : "List of offsets, e.g. '10' or '=[10, 23]'. If specified, it has to have the same number of values as the number of partitions",
     "optional" : true,
     "feel" : "optional",
     "group" : "kafka",
@@ -161,11 +157,11 @@
       "name" : "offsets",
       "type" : "zeebe:property"
     },
+    "tooltip" : "List of offsets, e.g. '10' or '=[10, 23]'. If specified, it has to have the same number of values as the number of partitions.",
     "type" : "String"
   }, {
     "id" : "autoOffsetReset",
     "label" : "Auto offset reset",
-    "description" : "What to do when there is no initial offset in Kafka or if the current offset does not exist any more on the server. You should only select none if you specified the offsets",
     "optional" : false,
     "value" : "latest",
     "constraints" : {
@@ -176,6 +172,7 @@
       "name" : "autoOffsetReset",
       "type" : "zeebe:property"
     },
+    "tooltip" : "What to do when there is no initial offset in Kafka or if the current offset does not exist any more on the server. You should only select none if you specified the offsets.",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "None",
@@ -210,7 +207,6 @@
   }, {
     "id" : "schemaStrategy.avro.schema",
     "label" : "Schema",
-    "description" : "Avro inline schema for the message value",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -226,11 +222,11 @@
       "equals" : "inlineSchema",
       "type" : "simple"
     },
+    "tooltip" : "Avro inline schema for the message value",
     "type" : "Text"
   }, {
     "id" : "schemaStrategy.schemaType",
     "label" : "Schema type",
-    "description" : "Select the schema type. For details, visit the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/kafka/?kafka=inbound\" target=\"_blank\">documentation</a>",
     "optional" : false,
     "value" : "avro",
     "group" : "schema",
@@ -243,6 +239,7 @@
       "equals" : "schemaRegistry",
       "type" : "simple"
     },
+    "tooltip" : "For details, visit the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/kafka/?kafka=inbound\" target=\"_blank\">Kafka connector documentation</a>",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "JSON",
@@ -254,7 +251,6 @@
   }, {
     "id" : "schemaStrategy.schemaRegistryUrl",
     "label" : "Schema registry URL",
-    "description" : "Provide the schema registry URL",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true

--- a/connectors/kafka/element-templates/hybrid/kafka-inbound-connector-intermediate-hybrid.json
+++ b/connectors/kafka/element-templates/hybrid/kafka-inbound-connector-intermediate-hybrid.json
@@ -110,6 +110,7 @@
       "type" : "zeebe:property"
     },
     "tooltip" : "Bootstrap server(s), comma-delimited if there are multiple.",
+    "placeholder" : "broker1:9092,broker2:9092",
     "type" : "String"
   }, {
     "id" : "topic.topicName",
@@ -239,7 +240,7 @@
       "equals" : "schemaRegistry",
       "type" : "simple"
     },
-    "tooltip" : "For details, visit the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/kafka/?kafka=inbound\" target=\"_blank\">Kafka connector documentation</a>",
+    "tooltip" : "Format used to (de)serialize the message value: JSON or Avro. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/kafka/?kafka=inbound\" target=\"_blank\">Kafka connector</a> guide.",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "JSON",

--- a/connectors/kafka/element-templates/hybrid/kafka-inbound-connector-receive-hybrid.json
+++ b/connectors/kafka/element-templates/hybrid/kafka-inbound-connector-receive-hybrid.json
@@ -56,7 +56,6 @@
   }, {
     "id" : "authenticationType",
     "label" : "Authentication type",
-    "description" : "Username/password or custom",
     "optional" : false,
     "value" : "credentials",
     "constraints" : {
@@ -67,6 +66,7 @@
       "name" : "authenticationType",
       "type" : "zeebe:property"
     },
+    "tooltip" : "Username/password or custom.",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "Credentials",
@@ -78,18 +78,17 @@
   }, {
     "id" : "authentication.username",
     "label" : "Username",
-    "description" : "Provide the username (must have permissions to produce message to the topic)",
     "optional" : true,
     "group" : "authentication",
     "binding" : {
       "name" : "authentication.username",
       "type" : "zeebe:property"
     },
+    "tooltip" : "The user must have permissions to produce messages to the topic.",
     "type" : "String"
   }, {
     "id" : "authentication.password",
     "label" : "Password",
-    "description" : "Provide a password for the user",
     "optional" : true,
     "group" : "authentication",
     "binding" : {
@@ -100,7 +99,6 @@
   }, {
     "id" : "topic.bootstrapServers",
     "label" : "Bootstrap servers",
-    "description" : "Provide bootstrap server(s), comma-delimited if there are multiple",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -110,11 +108,11 @@
       "name" : "topic.bootstrapServers",
       "type" : "zeebe:property"
     },
+    "tooltip" : "Bootstrap server(s), comma-delimited if there are multiple.",
     "type" : "String"
   }, {
     "id" : "topic.topicName",
     "label" : "Topic",
-    "description" : "Provide topic name",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -128,7 +126,6 @@
   }, {
     "id" : "groupId",
     "label" : "Consumer group ID",
-    "description" : "Provide the consumer group ID used by the connector. Leave empty for an automatically generated one",
     "optional" : false,
     "group" : "kafka",
     "binding" : {
@@ -140,7 +137,6 @@
   }, {
     "id" : "additionalProperties",
     "label" : "Additional properties",
-    "description" : "Provide additional Kafka consumer properties in JSON",
     "optional" : true,
     "feel" : "required",
     "group" : "kafka",
@@ -148,11 +144,11 @@
       "name" : "additionalProperties",
       "type" : "zeebe:property"
     },
+    "tooltip" : "Additional Kafka consumer properties in JSON.",
     "type" : "String"
   }, {
     "id" : "offsets",
     "label" : "Offsets",
-    "description" : "List of offsets, e.g. '10' or '=[10, 23]'. If specified, it has to have the same number of values as the number of partitions",
     "optional" : true,
     "feel" : "optional",
     "group" : "kafka",
@@ -160,11 +156,11 @@
       "name" : "offsets",
       "type" : "zeebe:property"
     },
+    "tooltip" : "List of offsets, e.g. '10' or '=[10, 23]'. If specified, it has to have the same number of values as the number of partitions.",
     "type" : "String"
   }, {
     "id" : "autoOffsetReset",
     "label" : "Auto offset reset",
-    "description" : "What to do when there is no initial offset in Kafka or if the current offset does not exist any more on the server. You should only select none if you specified the offsets",
     "optional" : false,
     "value" : "latest",
     "constraints" : {
@@ -175,6 +171,7 @@
       "name" : "autoOffsetReset",
       "type" : "zeebe:property"
     },
+    "tooltip" : "What to do when there is no initial offset in Kafka or if the current offset does not exist any more on the server. You should only select none if you specified the offsets.",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "None",
@@ -209,7 +206,6 @@
   }, {
     "id" : "schemaStrategy.avro.schema",
     "label" : "Schema",
-    "description" : "Avro inline schema for the message value",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -225,11 +221,11 @@
       "equals" : "inlineSchema",
       "type" : "simple"
     },
+    "tooltip" : "Avro inline schema for the message value",
     "type" : "Text"
   }, {
     "id" : "schemaStrategy.schemaType",
     "label" : "Schema type",
-    "description" : "Select the schema type. For details, visit the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/kafka/?kafka=inbound\" target=\"_blank\">documentation</a>",
     "optional" : false,
     "value" : "avro",
     "group" : "schema",
@@ -242,6 +238,7 @@
       "equals" : "schemaRegistry",
       "type" : "simple"
     },
+    "tooltip" : "For details, visit the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/kafka/?kafka=inbound\" target=\"_blank\">Kafka connector documentation</a>",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "JSON",
@@ -253,7 +250,6 @@
   }, {
     "id" : "schemaStrategy.schemaRegistryUrl",
     "label" : "Schema registry URL",
-    "description" : "Provide the schema registry URL",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true

--- a/connectors/kafka/element-templates/hybrid/kafka-inbound-connector-receive-hybrid.json
+++ b/connectors/kafka/element-templates/hybrid/kafka-inbound-connector-receive-hybrid.json
@@ -109,6 +109,7 @@
       "type" : "zeebe:property"
     },
     "tooltip" : "Bootstrap server(s), comma-delimited if there are multiple.",
+    "placeholder" : "broker1:9092,broker2:9092",
     "type" : "String"
   }, {
     "id" : "topic.topicName",
@@ -238,7 +239,7 @@
       "equals" : "schemaRegistry",
       "type" : "simple"
     },
-    "tooltip" : "For details, visit the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/kafka/?kafka=inbound\" target=\"_blank\">Kafka connector documentation</a>",
+    "tooltip" : "Format used to (de)serialize the message value: JSON or Avro. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/kafka/?kafka=inbound\" target=\"_blank\">Kafka connector</a> guide.",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "JSON",

--- a/connectors/kafka/element-templates/hybrid/kafka-inbound-connector-start-message-hybrid.json
+++ b/connectors/kafka/element-templates/hybrid/kafka-inbound-connector-start-message-hybrid.json
@@ -57,7 +57,6 @@
   }, {
     "id" : "authenticationType",
     "label" : "Authentication type",
-    "description" : "Username/password or custom",
     "optional" : false,
     "value" : "credentials",
     "constraints" : {
@@ -68,6 +67,7 @@
       "name" : "authenticationType",
       "type" : "zeebe:property"
     },
+    "tooltip" : "Username/password or custom.",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "Credentials",
@@ -79,18 +79,17 @@
   }, {
     "id" : "authentication.username",
     "label" : "Username",
-    "description" : "Provide the username (must have permissions to produce message to the topic)",
     "optional" : true,
     "group" : "authentication",
     "binding" : {
       "name" : "authentication.username",
       "type" : "zeebe:property"
     },
+    "tooltip" : "The user must have permissions to produce messages to the topic.",
     "type" : "String"
   }, {
     "id" : "authentication.password",
     "label" : "Password",
-    "description" : "Provide a password for the user",
     "optional" : true,
     "group" : "authentication",
     "binding" : {
@@ -101,7 +100,6 @@
   }, {
     "id" : "topic.bootstrapServers",
     "label" : "Bootstrap servers",
-    "description" : "Provide bootstrap server(s), comma-delimited if there are multiple",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -111,11 +109,11 @@
       "name" : "topic.bootstrapServers",
       "type" : "zeebe:property"
     },
+    "tooltip" : "Bootstrap server(s), comma-delimited if there are multiple.",
     "type" : "String"
   }, {
     "id" : "topic.topicName",
     "label" : "Topic",
-    "description" : "Provide topic name",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -129,7 +127,6 @@
   }, {
     "id" : "groupId",
     "label" : "Consumer group ID",
-    "description" : "Provide the consumer group ID used by the connector. Leave empty for an automatically generated one",
     "optional" : false,
     "group" : "kafka",
     "binding" : {
@@ -141,7 +138,6 @@
   }, {
     "id" : "additionalProperties",
     "label" : "Additional properties",
-    "description" : "Provide additional Kafka consumer properties in JSON",
     "optional" : true,
     "feel" : "required",
     "group" : "kafka",
@@ -149,11 +145,11 @@
       "name" : "additionalProperties",
       "type" : "zeebe:property"
     },
+    "tooltip" : "Additional Kafka consumer properties in JSON.",
     "type" : "String"
   }, {
     "id" : "offsets",
     "label" : "Offsets",
-    "description" : "List of offsets, e.g. '10' or '=[10, 23]'. If specified, it has to have the same number of values as the number of partitions",
     "optional" : true,
     "feel" : "optional",
     "group" : "kafka",
@@ -161,11 +157,11 @@
       "name" : "offsets",
       "type" : "zeebe:property"
     },
+    "tooltip" : "List of offsets, e.g. '10' or '=[10, 23]'. If specified, it has to have the same number of values as the number of partitions.",
     "type" : "String"
   }, {
     "id" : "autoOffsetReset",
     "label" : "Auto offset reset",
-    "description" : "What to do when there is no initial offset in Kafka or if the current offset does not exist any more on the server. You should only select none if you specified the offsets",
     "optional" : false,
     "value" : "latest",
     "constraints" : {
@@ -176,6 +172,7 @@
       "name" : "autoOffsetReset",
       "type" : "zeebe:property"
     },
+    "tooltip" : "What to do when there is no initial offset in Kafka or if the current offset does not exist any more on the server. You should only select none if you specified the offsets.",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "None",
@@ -210,7 +207,6 @@
   }, {
     "id" : "schemaStrategy.avro.schema",
     "label" : "Schema",
-    "description" : "Avro inline schema for the message value",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -226,11 +222,11 @@
       "equals" : "inlineSchema",
       "type" : "simple"
     },
+    "tooltip" : "Avro inline schema for the message value",
     "type" : "Text"
   }, {
     "id" : "schemaStrategy.schemaType",
     "label" : "Schema type",
-    "description" : "Select the schema type. For details, visit the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/kafka/?kafka=inbound\" target=\"_blank\">documentation</a>",
     "optional" : false,
     "value" : "avro",
     "group" : "schema",
@@ -243,6 +239,7 @@
       "equals" : "schemaRegistry",
       "type" : "simple"
     },
+    "tooltip" : "For details, visit the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/kafka/?kafka=inbound\" target=\"_blank\">Kafka connector documentation</a>",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "JSON",
@@ -254,7 +251,6 @@
   }, {
     "id" : "schemaStrategy.schemaRegistryUrl",
     "label" : "Schema registry URL",
-    "description" : "Provide the schema registry URL",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true

--- a/connectors/kafka/element-templates/hybrid/kafka-inbound-connector-start-message-hybrid.json
+++ b/connectors/kafka/element-templates/hybrid/kafka-inbound-connector-start-message-hybrid.json
@@ -110,6 +110,7 @@
       "type" : "zeebe:property"
     },
     "tooltip" : "Bootstrap server(s), comma-delimited if there are multiple.",
+    "placeholder" : "broker1:9092,broker2:9092",
     "type" : "String"
   }, {
     "id" : "topic.topicName",
@@ -239,7 +240,7 @@
       "equals" : "schemaRegistry",
       "type" : "simple"
     },
-    "tooltip" : "For details, visit the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/kafka/?kafka=inbound\" target=\"_blank\">Kafka connector documentation</a>",
+    "tooltip" : "Format used to (de)serialize the message value: JSON or Avro. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/kafka/?kafka=inbound\" target=\"_blank\">Kafka connector</a> guide.",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "JSON",

--- a/connectors/kafka/element-templates/hybrid/kafka-outbound-connector-hybrid.json
+++ b/connectors/kafka/element-templates/hybrid/kafka-outbound-connector-hybrid.json
@@ -91,6 +91,7 @@
       "type" : "zeebe:input"
     },
     "tooltip" : "Bootstrap server(s), comma-delimited if there are multiple.",
+    "placeholder" : "broker1:9092,broker2:9092",
     "type" : "String"
   }, {
     "id" : "topic.topicName",
@@ -193,7 +194,7 @@
       "equals" : "schemaRegistry",
       "type" : "simple"
     },
-    "tooltip" : "For details, visit the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/kafka/?kafka=inbound\" target=\"_blank\">Kafka connector documentation</a>",
+    "tooltip" : "Format used to (de)serialize the message value: JSON or Avro. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/kafka/?kafka=inbound\" target=\"_blank\">Kafka connector</a> guide.",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "JSON",

--- a/connectors/kafka/element-templates/hybrid/kafka-outbound-connector-hybrid.json
+++ b/connectors/kafka/element-templates/hybrid/kafka-outbound-connector-hybrid.json
@@ -57,7 +57,6 @@
   }, {
     "id" : "authentication.username",
     "label" : "Username",
-    "description" : "Provide the username (must have permissions to produce message to the topic)",
     "optional" : true,
     "feel" : "optional",
     "group" : "authentication",
@@ -65,11 +64,11 @@
       "name" : "authentication.username",
       "type" : "zeebe:input"
     },
+    "tooltip" : "The user must have permissions to produce messages to the topic.",
     "type" : "String"
   }, {
     "id" : "authentication.password",
     "label" : "Password",
-    "description" : "Provide a password for the user",
     "optional" : true,
     "feel" : "optional",
     "group" : "authentication",
@@ -81,7 +80,6 @@
   }, {
     "id" : "topic.bootstrapServers",
     "label" : "Bootstrap servers",
-    "description" : "Provide bootstrap server(s), comma-delimited if there are multiple",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -92,11 +90,11 @@
       "name" : "topic.bootstrapServers",
       "type" : "zeebe:input"
     },
+    "tooltip" : "Bootstrap server(s), comma-delimited if there are multiple.",
     "type" : "String"
   }, {
     "id" : "topic.topicName",
     "label" : "Topic",
-    "description" : "Provide topic name",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -111,7 +109,6 @@
   }, {
     "id" : "additionalProperties",
     "label" : "Additional properties",
-    "description" : "Provide additional Kafka producer properties in JSON",
     "optional" : true,
     "feel" : "required",
     "group" : "kafka",
@@ -119,6 +116,7 @@
       "name" : "additionalProperties",
       "type" : "zeebe:input"
     },
+    "tooltip" : "Additional Kafka producer properties in JSON.",
     "type" : "String"
   }, {
     "id" : "schemaStrategy.type",
@@ -143,7 +141,6 @@
   }, {
     "id" : "schemaStrategy.avro.schema",
     "label" : "Schema",
-    "description" : "Avro inline schema for the message value",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -159,11 +156,11 @@
       "equals" : "inlineSchema",
       "type" : "simple"
     },
+    "tooltip" : "Avro inline schema for the message value",
     "type" : "Text"
   }, {
     "id" : "schemaStrategy.schema",
     "label" : "Schema",
-    "description" : "Schema (JSON or AVRO) for the message value",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -179,11 +176,11 @@
       "equals" : "schemaRegistry",
       "type" : "simple"
     },
+    "tooltip" : "Schema (JSON or Avro) for the message value.",
     "type" : "Text"
   }, {
     "id" : "schemaStrategy.schemaType",
     "label" : "Schema type",
-    "description" : "Select the schema type. For details, visit the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/kafka/?kafka=inbound\" target=\"_blank\">documentation</a>",
     "optional" : false,
     "value" : "avro",
     "group" : "schema",
@@ -196,6 +193,7 @@
       "equals" : "schemaRegistry",
       "type" : "simple"
     },
+    "tooltip" : "For details, visit the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/kafka/?kafka=inbound\" target=\"_blank\">Kafka connector documentation</a>",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "JSON",
@@ -207,7 +205,6 @@
   }, {
     "id" : "schemaStrategy.schemaRegistryUrl",
     "label" : "Schema registry URL",
-    "description" : "Provide the schema registry URL",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -227,7 +224,6 @@
   }, {
     "id" : "message.key",
     "label" : "Key",
-    "description" : "Provide message key",
     "optional" : false,
     "feel" : "optional",
     "group" : "message",
@@ -239,7 +235,6 @@
   }, {
     "id" : "message.value",
     "label" : "Value",
-    "description" : "Provide message value",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -254,7 +249,6 @@
   }, {
     "id" : "headers",
     "label" : "Headers",
-    "description" : "Provide Kafka producer headers in JSON",
     "optional" : true,
     "feel" : "required",
     "group" : "message",
@@ -262,6 +256,7 @@
       "name" : "headers",
       "type" : "zeebe:input"
     },
+    "tooltip" : "Kafka producer headers in JSON.",
     "type" : "String"
   }, {
     "id" : "version",

--- a/connectors/kafka/element-templates/kafka-inbound-connector-boundary.json
+++ b/connectors/kafka/element-templates/kafka-inbound-connector-boundary.json
@@ -105,6 +105,7 @@
       "type" : "zeebe:property"
     },
     "tooltip" : "Bootstrap server(s), comma-delimited if there are multiple.",
+    "placeholder" : "broker1:9092,broker2:9092",
     "type" : "String"
   }, {
     "id" : "topic.topicName",
@@ -234,7 +235,7 @@
       "equals" : "schemaRegistry",
       "type" : "simple"
     },
-    "tooltip" : "For details, visit the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/kafka/?kafka=inbound\" target=\"_blank\">Kafka connector documentation</a>",
+    "tooltip" : "Format used to (de)serialize the message value: JSON or Avro. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/kafka/?kafka=inbound\" target=\"_blank\">Kafka connector</a> guide.",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "JSON",

--- a/connectors/kafka/element-templates/kafka-inbound-connector-boundary.json
+++ b/connectors/kafka/element-templates/kafka-inbound-connector-boundary.json
@@ -52,7 +52,6 @@
   }, {
     "id" : "authenticationType",
     "label" : "Authentication type",
-    "description" : "Username/password or custom",
     "optional" : false,
     "value" : "credentials",
     "constraints" : {
@@ -63,6 +62,7 @@
       "name" : "authenticationType",
       "type" : "zeebe:property"
     },
+    "tooltip" : "Username/password or custom.",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "Credentials",
@@ -74,18 +74,17 @@
   }, {
     "id" : "authentication.username",
     "label" : "Username",
-    "description" : "Provide the username (must have permissions to produce message to the topic)",
     "optional" : true,
     "group" : "authentication",
     "binding" : {
       "name" : "authentication.username",
       "type" : "zeebe:property"
     },
+    "tooltip" : "The user must have permissions to produce messages to the topic.",
     "type" : "String"
   }, {
     "id" : "authentication.password",
     "label" : "Password",
-    "description" : "Provide a password for the user",
     "optional" : true,
     "group" : "authentication",
     "binding" : {
@@ -96,7 +95,6 @@
   }, {
     "id" : "topic.bootstrapServers",
     "label" : "Bootstrap servers",
-    "description" : "Provide bootstrap server(s), comma-delimited if there are multiple",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -106,11 +104,11 @@
       "name" : "topic.bootstrapServers",
       "type" : "zeebe:property"
     },
+    "tooltip" : "Bootstrap server(s), comma-delimited if there are multiple.",
     "type" : "String"
   }, {
     "id" : "topic.topicName",
     "label" : "Topic",
-    "description" : "Provide topic name",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -124,7 +122,6 @@
   }, {
     "id" : "groupId",
     "label" : "Consumer group ID",
-    "description" : "Provide the consumer group ID used by the connector. Leave empty for an automatically generated one",
     "optional" : false,
     "group" : "kafka",
     "binding" : {
@@ -136,7 +133,6 @@
   }, {
     "id" : "additionalProperties",
     "label" : "Additional properties",
-    "description" : "Provide additional Kafka consumer properties in JSON",
     "optional" : true,
     "feel" : "required",
     "group" : "kafka",
@@ -144,11 +140,11 @@
       "name" : "additionalProperties",
       "type" : "zeebe:property"
     },
+    "tooltip" : "Additional Kafka consumer properties in JSON.",
     "type" : "String"
   }, {
     "id" : "offsets",
     "label" : "Offsets",
-    "description" : "List of offsets, e.g. '10' or '=[10, 23]'. If specified, it has to have the same number of values as the number of partitions",
     "optional" : true,
     "feel" : "optional",
     "group" : "kafka",
@@ -156,11 +152,11 @@
       "name" : "offsets",
       "type" : "zeebe:property"
     },
+    "tooltip" : "List of offsets, e.g. '10' or '=[10, 23]'. If specified, it has to have the same number of values as the number of partitions.",
     "type" : "String"
   }, {
     "id" : "autoOffsetReset",
     "label" : "Auto offset reset",
-    "description" : "What to do when there is no initial offset in Kafka or if the current offset does not exist any more on the server. You should only select none if you specified the offsets",
     "optional" : false,
     "value" : "latest",
     "constraints" : {
@@ -171,6 +167,7 @@
       "name" : "autoOffsetReset",
       "type" : "zeebe:property"
     },
+    "tooltip" : "What to do when there is no initial offset in Kafka or if the current offset does not exist any more on the server. You should only select none if you specified the offsets.",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "None",
@@ -205,7 +202,6 @@
   }, {
     "id" : "schemaStrategy.avro.schema",
     "label" : "Schema",
-    "description" : "Avro inline schema for the message value",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -221,11 +217,11 @@
       "equals" : "inlineSchema",
       "type" : "simple"
     },
+    "tooltip" : "Avro inline schema for the message value",
     "type" : "Text"
   }, {
     "id" : "schemaStrategy.schemaType",
     "label" : "Schema type",
-    "description" : "Select the schema type. For details, visit the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/kafka/?kafka=inbound\" target=\"_blank\">documentation</a>",
     "optional" : false,
     "value" : "avro",
     "group" : "schema",
@@ -238,6 +234,7 @@
       "equals" : "schemaRegistry",
       "type" : "simple"
     },
+    "tooltip" : "For details, visit the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/kafka/?kafka=inbound\" target=\"_blank\">Kafka connector documentation</a>",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "JSON",
@@ -249,7 +246,6 @@
   }, {
     "id" : "schemaStrategy.schemaRegistryUrl",
     "label" : "Schema registry URL",
-    "description" : "Provide the schema registry URL",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true

--- a/connectors/kafka/element-templates/kafka-inbound-connector-intermediate.json
+++ b/connectors/kafka/element-templates/kafka-inbound-connector-intermediate.json
@@ -105,6 +105,7 @@
       "type" : "zeebe:property"
     },
     "tooltip" : "Bootstrap server(s), comma-delimited if there are multiple.",
+    "placeholder" : "broker1:9092,broker2:9092",
     "type" : "String"
   }, {
     "id" : "topic.topicName",
@@ -234,7 +235,7 @@
       "equals" : "schemaRegistry",
       "type" : "simple"
     },
-    "tooltip" : "For details, visit the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/kafka/?kafka=inbound\" target=\"_blank\">Kafka connector documentation</a>",
+    "tooltip" : "Format used to (de)serialize the message value: JSON or Avro. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/kafka/?kafka=inbound\" target=\"_blank\">Kafka connector</a> guide.",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "JSON",

--- a/connectors/kafka/element-templates/kafka-inbound-connector-intermediate.json
+++ b/connectors/kafka/element-templates/kafka-inbound-connector-intermediate.json
@@ -52,7 +52,6 @@
   }, {
     "id" : "authenticationType",
     "label" : "Authentication type",
-    "description" : "Username/password or custom",
     "optional" : false,
     "value" : "credentials",
     "constraints" : {
@@ -63,6 +62,7 @@
       "name" : "authenticationType",
       "type" : "zeebe:property"
     },
+    "tooltip" : "Username/password or custom.",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "Credentials",
@@ -74,18 +74,17 @@
   }, {
     "id" : "authentication.username",
     "label" : "Username",
-    "description" : "Provide the username (must have permissions to produce message to the topic)",
     "optional" : true,
     "group" : "authentication",
     "binding" : {
       "name" : "authentication.username",
       "type" : "zeebe:property"
     },
+    "tooltip" : "The user must have permissions to produce messages to the topic.",
     "type" : "String"
   }, {
     "id" : "authentication.password",
     "label" : "Password",
-    "description" : "Provide a password for the user",
     "optional" : true,
     "group" : "authentication",
     "binding" : {
@@ -96,7 +95,6 @@
   }, {
     "id" : "topic.bootstrapServers",
     "label" : "Bootstrap servers",
-    "description" : "Provide bootstrap server(s), comma-delimited if there are multiple",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -106,11 +104,11 @@
       "name" : "topic.bootstrapServers",
       "type" : "zeebe:property"
     },
+    "tooltip" : "Bootstrap server(s), comma-delimited if there are multiple.",
     "type" : "String"
   }, {
     "id" : "topic.topicName",
     "label" : "Topic",
-    "description" : "Provide topic name",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -124,7 +122,6 @@
   }, {
     "id" : "groupId",
     "label" : "Consumer group ID",
-    "description" : "Provide the consumer group ID used by the connector. Leave empty for an automatically generated one",
     "optional" : false,
     "group" : "kafka",
     "binding" : {
@@ -136,7 +133,6 @@
   }, {
     "id" : "additionalProperties",
     "label" : "Additional properties",
-    "description" : "Provide additional Kafka consumer properties in JSON",
     "optional" : true,
     "feel" : "required",
     "group" : "kafka",
@@ -144,11 +140,11 @@
       "name" : "additionalProperties",
       "type" : "zeebe:property"
     },
+    "tooltip" : "Additional Kafka consumer properties in JSON.",
     "type" : "String"
   }, {
     "id" : "offsets",
     "label" : "Offsets",
-    "description" : "List of offsets, e.g. '10' or '=[10, 23]'. If specified, it has to have the same number of values as the number of partitions",
     "optional" : true,
     "feel" : "optional",
     "group" : "kafka",
@@ -156,11 +152,11 @@
       "name" : "offsets",
       "type" : "zeebe:property"
     },
+    "tooltip" : "List of offsets, e.g. '10' or '=[10, 23]'. If specified, it has to have the same number of values as the number of partitions.",
     "type" : "String"
   }, {
     "id" : "autoOffsetReset",
     "label" : "Auto offset reset",
-    "description" : "What to do when there is no initial offset in Kafka or if the current offset does not exist any more on the server. You should only select none if you specified the offsets",
     "optional" : false,
     "value" : "latest",
     "constraints" : {
@@ -171,6 +167,7 @@
       "name" : "autoOffsetReset",
       "type" : "zeebe:property"
     },
+    "tooltip" : "What to do when there is no initial offset in Kafka or if the current offset does not exist any more on the server. You should only select none if you specified the offsets.",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "None",
@@ -205,7 +202,6 @@
   }, {
     "id" : "schemaStrategy.avro.schema",
     "label" : "Schema",
-    "description" : "Avro inline schema for the message value",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -221,11 +217,11 @@
       "equals" : "inlineSchema",
       "type" : "simple"
     },
+    "tooltip" : "Avro inline schema for the message value",
     "type" : "Text"
   }, {
     "id" : "schemaStrategy.schemaType",
     "label" : "Schema type",
-    "description" : "Select the schema type. For details, visit the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/kafka/?kafka=inbound\" target=\"_blank\">documentation</a>",
     "optional" : false,
     "value" : "avro",
     "group" : "schema",
@@ -238,6 +234,7 @@
       "equals" : "schemaRegistry",
       "type" : "simple"
     },
+    "tooltip" : "For details, visit the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/kafka/?kafka=inbound\" target=\"_blank\">Kafka connector documentation</a>",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "JSON",
@@ -249,7 +246,6 @@
   }, {
     "id" : "schemaStrategy.schemaRegistryUrl",
     "label" : "Schema registry URL",
-    "description" : "Provide the schema registry URL",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true

--- a/connectors/kafka/element-templates/kafka-inbound-connector-receive.json
+++ b/connectors/kafka/element-templates/kafka-inbound-connector-receive.json
@@ -104,6 +104,7 @@
       "type" : "zeebe:property"
     },
     "tooltip" : "Bootstrap server(s), comma-delimited if there are multiple.",
+    "placeholder" : "broker1:9092,broker2:9092",
     "type" : "String"
   }, {
     "id" : "topic.topicName",
@@ -233,7 +234,7 @@
       "equals" : "schemaRegistry",
       "type" : "simple"
     },
-    "tooltip" : "For details, visit the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/kafka/?kafka=inbound\" target=\"_blank\">Kafka connector documentation</a>",
+    "tooltip" : "Format used to (de)serialize the message value: JSON or Avro. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/kafka/?kafka=inbound\" target=\"_blank\">Kafka connector</a> guide.",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "JSON",

--- a/connectors/kafka/element-templates/kafka-inbound-connector-receive.json
+++ b/connectors/kafka/element-templates/kafka-inbound-connector-receive.json
@@ -51,7 +51,6 @@
   }, {
     "id" : "authenticationType",
     "label" : "Authentication type",
-    "description" : "Username/password or custom",
     "optional" : false,
     "value" : "credentials",
     "constraints" : {
@@ -62,6 +61,7 @@
       "name" : "authenticationType",
       "type" : "zeebe:property"
     },
+    "tooltip" : "Username/password or custom.",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "Credentials",
@@ -73,18 +73,17 @@
   }, {
     "id" : "authentication.username",
     "label" : "Username",
-    "description" : "Provide the username (must have permissions to produce message to the topic)",
     "optional" : true,
     "group" : "authentication",
     "binding" : {
       "name" : "authentication.username",
       "type" : "zeebe:property"
     },
+    "tooltip" : "The user must have permissions to produce messages to the topic.",
     "type" : "String"
   }, {
     "id" : "authentication.password",
     "label" : "Password",
-    "description" : "Provide a password for the user",
     "optional" : true,
     "group" : "authentication",
     "binding" : {
@@ -95,7 +94,6 @@
   }, {
     "id" : "topic.bootstrapServers",
     "label" : "Bootstrap servers",
-    "description" : "Provide bootstrap server(s), comma-delimited if there are multiple",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -105,11 +103,11 @@
       "name" : "topic.bootstrapServers",
       "type" : "zeebe:property"
     },
+    "tooltip" : "Bootstrap server(s), comma-delimited if there are multiple.",
     "type" : "String"
   }, {
     "id" : "topic.topicName",
     "label" : "Topic",
-    "description" : "Provide topic name",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -123,7 +121,6 @@
   }, {
     "id" : "groupId",
     "label" : "Consumer group ID",
-    "description" : "Provide the consumer group ID used by the connector. Leave empty for an automatically generated one",
     "optional" : false,
     "group" : "kafka",
     "binding" : {
@@ -135,7 +132,6 @@
   }, {
     "id" : "additionalProperties",
     "label" : "Additional properties",
-    "description" : "Provide additional Kafka consumer properties in JSON",
     "optional" : true,
     "feel" : "required",
     "group" : "kafka",
@@ -143,11 +139,11 @@
       "name" : "additionalProperties",
       "type" : "zeebe:property"
     },
+    "tooltip" : "Additional Kafka consumer properties in JSON.",
     "type" : "String"
   }, {
     "id" : "offsets",
     "label" : "Offsets",
-    "description" : "List of offsets, e.g. '10' or '=[10, 23]'. If specified, it has to have the same number of values as the number of partitions",
     "optional" : true,
     "feel" : "optional",
     "group" : "kafka",
@@ -155,11 +151,11 @@
       "name" : "offsets",
       "type" : "zeebe:property"
     },
+    "tooltip" : "List of offsets, e.g. '10' or '=[10, 23]'. If specified, it has to have the same number of values as the number of partitions.",
     "type" : "String"
   }, {
     "id" : "autoOffsetReset",
     "label" : "Auto offset reset",
-    "description" : "What to do when there is no initial offset in Kafka or if the current offset does not exist any more on the server. You should only select none if you specified the offsets",
     "optional" : false,
     "value" : "latest",
     "constraints" : {
@@ -170,6 +166,7 @@
       "name" : "autoOffsetReset",
       "type" : "zeebe:property"
     },
+    "tooltip" : "What to do when there is no initial offset in Kafka or if the current offset does not exist any more on the server. You should only select none if you specified the offsets.",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "None",
@@ -204,7 +201,6 @@
   }, {
     "id" : "schemaStrategy.avro.schema",
     "label" : "Schema",
-    "description" : "Avro inline schema for the message value",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -220,11 +216,11 @@
       "equals" : "inlineSchema",
       "type" : "simple"
     },
+    "tooltip" : "Avro inline schema for the message value",
     "type" : "Text"
   }, {
     "id" : "schemaStrategy.schemaType",
     "label" : "Schema type",
-    "description" : "Select the schema type. For details, visit the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/kafka/?kafka=inbound\" target=\"_blank\">documentation</a>",
     "optional" : false,
     "value" : "avro",
     "group" : "schema",
@@ -237,6 +233,7 @@
       "equals" : "schemaRegistry",
       "type" : "simple"
     },
+    "tooltip" : "For details, visit the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/kafka/?kafka=inbound\" target=\"_blank\">Kafka connector documentation</a>",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "JSON",
@@ -248,7 +245,6 @@
   }, {
     "id" : "schemaStrategy.schemaRegistryUrl",
     "label" : "Schema registry URL",
-    "description" : "Provide the schema registry URL",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true

--- a/connectors/kafka/element-templates/kafka-inbound-connector-start-message.json
+++ b/connectors/kafka/element-templates/kafka-inbound-connector-start-message.json
@@ -105,6 +105,7 @@
       "type" : "zeebe:property"
     },
     "tooltip" : "Bootstrap server(s), comma-delimited if there are multiple.",
+    "placeholder" : "broker1:9092,broker2:9092",
     "type" : "String"
   }, {
     "id" : "topic.topicName",
@@ -234,7 +235,7 @@
       "equals" : "schemaRegistry",
       "type" : "simple"
     },
-    "tooltip" : "For details, visit the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/kafka/?kafka=inbound\" target=\"_blank\">Kafka connector documentation</a>",
+    "tooltip" : "Format used to (de)serialize the message value: JSON or Avro. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/kafka/?kafka=inbound\" target=\"_blank\">Kafka connector</a> guide.",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "JSON",

--- a/connectors/kafka/element-templates/kafka-inbound-connector-start-message.json
+++ b/connectors/kafka/element-templates/kafka-inbound-connector-start-message.json
@@ -52,7 +52,6 @@
   }, {
     "id" : "authenticationType",
     "label" : "Authentication type",
-    "description" : "Username/password or custom",
     "optional" : false,
     "value" : "credentials",
     "constraints" : {
@@ -63,6 +62,7 @@
       "name" : "authenticationType",
       "type" : "zeebe:property"
     },
+    "tooltip" : "Username/password or custom.",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "Credentials",
@@ -74,18 +74,17 @@
   }, {
     "id" : "authentication.username",
     "label" : "Username",
-    "description" : "Provide the username (must have permissions to produce message to the topic)",
     "optional" : true,
     "group" : "authentication",
     "binding" : {
       "name" : "authentication.username",
       "type" : "zeebe:property"
     },
+    "tooltip" : "The user must have permissions to produce messages to the topic.",
     "type" : "String"
   }, {
     "id" : "authentication.password",
     "label" : "Password",
-    "description" : "Provide a password for the user",
     "optional" : true,
     "group" : "authentication",
     "binding" : {
@@ -96,7 +95,6 @@
   }, {
     "id" : "topic.bootstrapServers",
     "label" : "Bootstrap servers",
-    "description" : "Provide bootstrap server(s), comma-delimited if there are multiple",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -106,11 +104,11 @@
       "name" : "topic.bootstrapServers",
       "type" : "zeebe:property"
     },
+    "tooltip" : "Bootstrap server(s), comma-delimited if there are multiple.",
     "type" : "String"
   }, {
     "id" : "topic.topicName",
     "label" : "Topic",
-    "description" : "Provide topic name",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -124,7 +122,6 @@
   }, {
     "id" : "groupId",
     "label" : "Consumer group ID",
-    "description" : "Provide the consumer group ID used by the connector. Leave empty for an automatically generated one",
     "optional" : false,
     "group" : "kafka",
     "binding" : {
@@ -136,7 +133,6 @@
   }, {
     "id" : "additionalProperties",
     "label" : "Additional properties",
-    "description" : "Provide additional Kafka consumer properties in JSON",
     "optional" : true,
     "feel" : "required",
     "group" : "kafka",
@@ -144,11 +140,11 @@
       "name" : "additionalProperties",
       "type" : "zeebe:property"
     },
+    "tooltip" : "Additional Kafka consumer properties in JSON.",
     "type" : "String"
   }, {
     "id" : "offsets",
     "label" : "Offsets",
-    "description" : "List of offsets, e.g. '10' or '=[10, 23]'. If specified, it has to have the same number of values as the number of partitions",
     "optional" : true,
     "feel" : "optional",
     "group" : "kafka",
@@ -156,11 +152,11 @@
       "name" : "offsets",
       "type" : "zeebe:property"
     },
+    "tooltip" : "List of offsets, e.g. '10' or '=[10, 23]'. If specified, it has to have the same number of values as the number of partitions.",
     "type" : "String"
   }, {
     "id" : "autoOffsetReset",
     "label" : "Auto offset reset",
-    "description" : "What to do when there is no initial offset in Kafka or if the current offset does not exist any more on the server. You should only select none if you specified the offsets",
     "optional" : false,
     "value" : "latest",
     "constraints" : {
@@ -171,6 +167,7 @@
       "name" : "autoOffsetReset",
       "type" : "zeebe:property"
     },
+    "tooltip" : "What to do when there is no initial offset in Kafka or if the current offset does not exist any more on the server. You should only select none if you specified the offsets.",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "None",
@@ -205,7 +202,6 @@
   }, {
     "id" : "schemaStrategy.avro.schema",
     "label" : "Schema",
-    "description" : "Avro inline schema for the message value",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -221,11 +217,11 @@
       "equals" : "inlineSchema",
       "type" : "simple"
     },
+    "tooltip" : "Avro inline schema for the message value",
     "type" : "Text"
   }, {
     "id" : "schemaStrategy.schemaType",
     "label" : "Schema type",
-    "description" : "Select the schema type. For details, visit the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/kafka/?kafka=inbound\" target=\"_blank\">documentation</a>",
     "optional" : false,
     "value" : "avro",
     "group" : "schema",
@@ -238,6 +234,7 @@
       "equals" : "schemaRegistry",
       "type" : "simple"
     },
+    "tooltip" : "For details, visit the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/kafka/?kafka=inbound\" target=\"_blank\">Kafka connector documentation</a>",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "JSON",
@@ -249,7 +246,6 @@
   }, {
     "id" : "schemaStrategy.schemaRegistryUrl",
     "label" : "Schema registry URL",
-    "description" : "Provide the schema registry URL",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true

--- a/connectors/kafka/element-templates/kafka-outbound-connector.json
+++ b/connectors/kafka/element-templates/kafka-outbound-connector.json
@@ -86,6 +86,7 @@
       "type" : "zeebe:input"
     },
     "tooltip" : "Bootstrap server(s), comma-delimited if there are multiple.",
+    "placeholder" : "broker1:9092,broker2:9092",
     "type" : "String"
   }, {
     "id" : "topic.topicName",
@@ -188,7 +189,7 @@
       "equals" : "schemaRegistry",
       "type" : "simple"
     },
-    "tooltip" : "For details, visit the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/kafka/?kafka=inbound\" target=\"_blank\">Kafka connector documentation</a>",
+    "tooltip" : "Format used to (de)serialize the message value: JSON or Avro. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/kafka/?kafka=inbound\" target=\"_blank\">Kafka connector</a> guide.",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "JSON",

--- a/connectors/kafka/element-templates/kafka-outbound-connector.json
+++ b/connectors/kafka/element-templates/kafka-outbound-connector.json
@@ -52,7 +52,6 @@
   }, {
     "id" : "authentication.username",
     "label" : "Username",
-    "description" : "Provide the username (must have permissions to produce message to the topic)",
     "optional" : true,
     "feel" : "optional",
     "group" : "authentication",
@@ -60,11 +59,11 @@
       "name" : "authentication.username",
       "type" : "zeebe:input"
     },
+    "tooltip" : "The user must have permissions to produce messages to the topic.",
     "type" : "String"
   }, {
     "id" : "authentication.password",
     "label" : "Password",
-    "description" : "Provide a password for the user",
     "optional" : true,
     "feel" : "optional",
     "group" : "authentication",
@@ -76,7 +75,6 @@
   }, {
     "id" : "topic.bootstrapServers",
     "label" : "Bootstrap servers",
-    "description" : "Provide bootstrap server(s), comma-delimited if there are multiple",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -87,11 +85,11 @@
       "name" : "topic.bootstrapServers",
       "type" : "zeebe:input"
     },
+    "tooltip" : "Bootstrap server(s), comma-delimited if there are multiple.",
     "type" : "String"
   }, {
     "id" : "topic.topicName",
     "label" : "Topic",
-    "description" : "Provide topic name",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -106,7 +104,6 @@
   }, {
     "id" : "additionalProperties",
     "label" : "Additional properties",
-    "description" : "Provide additional Kafka producer properties in JSON",
     "optional" : true,
     "feel" : "required",
     "group" : "kafka",
@@ -114,6 +111,7 @@
       "name" : "additionalProperties",
       "type" : "zeebe:input"
     },
+    "tooltip" : "Additional Kafka producer properties in JSON.",
     "type" : "String"
   }, {
     "id" : "schemaStrategy.type",
@@ -138,7 +136,6 @@
   }, {
     "id" : "schemaStrategy.avro.schema",
     "label" : "Schema",
-    "description" : "Avro inline schema for the message value",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -154,11 +151,11 @@
       "equals" : "inlineSchema",
       "type" : "simple"
     },
+    "tooltip" : "Avro inline schema for the message value",
     "type" : "Text"
   }, {
     "id" : "schemaStrategy.schema",
     "label" : "Schema",
-    "description" : "Schema (JSON or AVRO) for the message value",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -174,11 +171,11 @@
       "equals" : "schemaRegistry",
       "type" : "simple"
     },
+    "tooltip" : "Schema (JSON or Avro) for the message value.",
     "type" : "Text"
   }, {
     "id" : "schemaStrategy.schemaType",
     "label" : "Schema type",
-    "description" : "Select the schema type. For details, visit the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/kafka/?kafka=inbound\" target=\"_blank\">documentation</a>",
     "optional" : false,
     "value" : "avro",
     "group" : "schema",
@@ -191,6 +188,7 @@
       "equals" : "schemaRegistry",
       "type" : "simple"
     },
+    "tooltip" : "For details, visit the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/kafka/?kafka=inbound\" target=\"_blank\">Kafka connector documentation</a>",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "JSON",
@@ -202,7 +200,6 @@
   }, {
     "id" : "schemaStrategy.schemaRegistryUrl",
     "label" : "Schema registry URL",
-    "description" : "Provide the schema registry URL",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -222,7 +219,6 @@
   }, {
     "id" : "message.key",
     "label" : "Key",
-    "description" : "Provide message key",
     "optional" : false,
     "feel" : "optional",
     "group" : "message",
@@ -234,7 +230,6 @@
   }, {
     "id" : "message.value",
     "label" : "Value",
-    "description" : "Provide message value",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -249,7 +244,6 @@
   }, {
     "id" : "headers",
     "label" : "Headers",
-    "description" : "Provide Kafka producer headers in JSON",
     "optional" : true,
     "feel" : "required",
     "group" : "message",
@@ -257,6 +251,7 @@
       "name" : "headers",
       "type" : "zeebe:input"
     },
+    "tooltip" : "Kafka producer headers in JSON.",
     "type" : "String"
   }, {
     "id" : "version",

--- a/connectors/kafka/src/main/java/io/camunda/connector/kafka/inbound/KafkaConnectorProperties.java
+++ b/connectors/kafka/src/main/java/io/camunda/connector/kafka/inbound/KafkaConnectorProperties.java
@@ -33,15 +33,13 @@ public record KafkaConnectorProperties(
                   label = "Credentials"),
               @TemplateProperty.DropdownPropertyChoice(value = "custom", label = "Custom")
             },
-            description = "Username/password or custom")
+            tooltip = "Username/password or custom.")
         AuthenticationType authenticationType,
     @Valid KafkaAuthentication authentication,
     @Valid @NotNull KafkaTopic topic,
     @TemplateProperty(
             group = "kafka",
             label = "Consumer group ID",
-            description =
-                "Provide the consumer group ID used by the connector. Leave empty for an automatically generated one",
             tooltip =
                 "It is strongly recommended to provide an explicit consumer group ID. "
                     + "Use a stable, application-specific identifier that represents the logical consumer group in your application "
@@ -54,7 +52,7 @@ public record KafkaConnectorProperties(
             label = "Additional properties",
             optional = true,
             feel = FeelMode.required,
-            description = "Provide additional Kafka consumer properties in JSON")
+            tooltip = "Additional Kafka consumer properties in JSON.")
         Map<String, Object> additionalProperties,
     @FEEL
         @TemplateProperty(
@@ -62,8 +60,8 @@ public record KafkaConnectorProperties(
             label = "Offsets",
             feel = FeelMode.optional,
             optional = true,
-            description =
-                "List of offsets, e.g. '10' or '=[10, 23]'. If specified, it has to have the same number of values as the number of partitions")
+            tooltip =
+                "List of offsets, e.g. '10' or '=[10, 23]'. If specified, it has to have the same number of values as the number of partitions.")
         List<Long> offsets,
     @NotNull
         @TemplateProperty(
@@ -76,8 +74,8 @@ public record KafkaConnectorProperties(
               @TemplateProperty.DropdownPropertyChoice(value = "latest", label = "Latest"),
               @TemplateProperty.DropdownPropertyChoice(value = "earliest", label = "Earliest")
             },
-            description =
-                "What to do when there is no initial offset in Kafka or if the current offset does not exist any more on the server. You should only select none if you specified the offsets")
+            tooltip =
+                "What to do when there is no initial offset in Kafka or if the current offset does not exist any more on the server. You should only select none if you specified the offsets.")
         AutoOffsetReset autoOffsetReset, // = AutoOffsetReset.NONE;
     @Valid InboundSchemaStrategy schemaStrategy) {
 

--- a/connectors/kafka/src/main/java/io/camunda/connector/kafka/model/KafkaAuthentication.java
+++ b/connectors/kafka/src/main/java/io/camunda/connector/kafka/model/KafkaAuthentication.java
@@ -13,14 +13,9 @@ public record KafkaAuthentication(
             group = "authentication",
             label = "Username",
             optional = true,
-            description =
-                "Provide the username (must have permissions to produce message to the topic)")
+            tooltip = "The user must have permissions to produce messages to the topic.")
         String username,
-    @TemplateProperty(
-            group = "authentication",
-            label = "Password",
-            optional = true,
-            description = "Provide a password for the user")
+    @TemplateProperty(group = "authentication", label = "Password", optional = true)
         String password) {
   @Override
   public String toString() {

--- a/connectors/kafka/src/main/java/io/camunda/connector/kafka/model/KafkaTopic.java
+++ b/connectors/kafka/src/main/java/io/camunda/connector/kafka/model/KafkaTopic.java
@@ -16,8 +16,6 @@ public record KafkaTopic(
         @TemplateProperty(
             group = "kafka",
             label = "Bootstrap servers",
-            description = "Provide bootstrap server(s), comma-delimited if there are multiple")
+            tooltip = "Bootstrap server(s), comma-delimited if there are multiple.")
         String bootstrapServers,
-    @NotEmpty
-        @TemplateProperty(label = "Topic", group = "kafka", description = "Provide topic name")
-        String topicName) {}
+    @NotEmpty @TemplateProperty(label = "Topic", group = "kafka") String topicName) {}

--- a/connectors/kafka/src/main/java/io/camunda/connector/kafka/model/KafkaTopic.java
+++ b/connectors/kafka/src/main/java/io/camunda/connector/kafka/model/KafkaTopic.java
@@ -16,6 +16,7 @@ public record KafkaTopic(
         @TemplateProperty(
             group = "kafka",
             label = "Bootstrap servers",
+            placeholder = "broker1:9092,broker2:9092",
             tooltip = "Bootstrap server(s), comma-delimited if there are multiple.")
         String bootstrapServers,
     @NotEmpty @TemplateProperty(label = "Topic", group = "kafka") String topicName) {}

--- a/connectors/kafka/src/main/java/io/camunda/connector/kafka/model/schema/AbstractSchemaRegistryStrategy.java
+++ b/connectors/kafka/src/main/java/io/camunda/connector/kafka/model/schema/AbstractSchemaRegistryStrategy.java
@@ -22,15 +22,14 @@ public abstract class AbstractSchemaRegistryStrategy {
         @TemplateProperty.DropdownPropertyChoice(value = "json", label = "JSON"),
         @TemplateProperty.DropdownPropertyChoice(value = "avro", label = "Avro")
       },
-      description =
-          "Select the schema type. For details, visit the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/kafka/?kafka=inbound\" target=\"_blank\">documentation</a>")
+      tooltip =
+          "For details, visit the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/kafka/?kafka=inbound\" target=\"_blank\">Kafka connector documentation</a>")
   SchemaType schemaType;
 
   @NotBlank
   @TemplateProperty(
       group = "schema",
       label = "Schema registry URL",
-      description = "Provide the schema registry URL",
       constraints = @TemplateProperty.PropertyConstraints(notEmpty = true))
   private String schemaRegistryUrl;
 

--- a/connectors/kafka/src/main/java/io/camunda/connector/kafka/model/schema/AbstractSchemaRegistryStrategy.java
+++ b/connectors/kafka/src/main/java/io/camunda/connector/kafka/model/schema/AbstractSchemaRegistryStrategy.java
@@ -23,7 +23,7 @@ public abstract class AbstractSchemaRegistryStrategy {
         @TemplateProperty.DropdownPropertyChoice(value = "avro", label = "Avro")
       },
       tooltip =
-          "For details, visit the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/kafka/?kafka=inbound\" target=\"_blank\">Kafka connector documentation</a>")
+          "Format used to (de)serialize the message value: JSON or Avro. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/kafka/?kafka=inbound\" target=\"_blank\">Kafka connector</a> guide.")
   SchemaType schemaType;
 
   @NotBlank

--- a/connectors/kafka/src/main/java/io/camunda/connector/kafka/model/schema/AvroInlineSchemaStrategy.java
+++ b/connectors/kafka/src/main/java/io/camunda/connector/kafka/model/schema/AvroInlineSchemaStrategy.java
@@ -24,7 +24,7 @@ public record AvroInlineSchemaStrategy(
             type = TemplateProperty.PropertyType.Text,
             label = "Schema",
             constraints = @TemplateProperty.PropertyConstraints(notEmpty = true),
-            description = "Avro inline schema for the message value")
+            tooltip = "Avro inline schema for the message value")
         String schema)
     implements InboundSchemaStrategy, OutboundSchemaStrategy {
 

--- a/connectors/kafka/src/main/java/io/camunda/connector/kafka/model/schema/OutboundSchemaRegistryStrategy.java
+++ b/connectors/kafka/src/main/java/io/camunda/connector/kafka/model/schema/OutboundSchemaRegistryStrategy.java
@@ -30,7 +30,7 @@ public final class OutboundSchemaRegistryStrategy extends AbstractSchemaRegistry
       type = TemplateProperty.PropertyType.Text,
       label = "Schema",
       constraints = @TemplateProperty.PropertyConstraints(notEmpty = true),
-      description = "Schema (JSON or AVRO) for the message value")
+      tooltip = "Schema (JSON or Avro) for the message value.")
   String schema;
 
   public OutboundSchemaRegistryStrategy(

--- a/connectors/kafka/src/main/java/io/camunda/connector/kafka/outbound/model/KafkaConnectorRequest.java
+++ b/connectors/kafka/src/main/java/io/camunda/connector/kafka/outbound/model/KafkaConnectorRequest.java
@@ -27,14 +27,14 @@ public record KafkaConnectorRequest(
             label = "Headers",
             optional = true,
             feel = FeelMode.required,
-            description = "Provide Kafka producer headers in JSON")
+            tooltip = "Kafka producer headers in JSON.")
         Map<String, String> headers,
     @TemplateProperty(
             group = "kafka",
             label = "Additional properties",
             optional = true,
             feel = FeelMode.required,
-            description = "Provide additional Kafka producer properties in JSON")
+            tooltip = "Additional Kafka producer properties in JSON.")
         Map<String, Object> additionalProperties) {
   @Override
   public @Valid OutboundSchemaStrategy schemaStrategy() {

--- a/connectors/kafka/src/main/java/io/camunda/connector/kafka/outbound/model/KafkaMessage.java
+++ b/connectors/kafka/src/main/java/io/camunda/connector/kafka/outbound/model/KafkaMessage.java
@@ -10,8 +10,5 @@ import io.camunda.connector.generator.java.annotation.TemplateProperty;
 import jakarta.validation.constraints.NotNull;
 
 public record KafkaMessage(
-    @TemplateProperty(group = "message", label = "Key", description = "Provide message key")
-        Object key,
-    @NotNull
-        @TemplateProperty(group = "message", label = "Value", description = "Provide message value")
-        Object value) {}
+    @TemplateProperty(group = "message", label = "Key") Object key,
+    @NotNull @TemplateProperty(group = "message", label = "Value") Object value) {}

--- a/connectors/rabbitmq/element-templates/hybrid/rabbitmq-inbound-connector-boundary-hybrid.json
+++ b/connectors/rabbitmq/element-templates/hybrid/rabbitmq-inbound-connector-boundary-hybrid.json
@@ -147,7 +147,7 @@
       "equals" : "credentials",
       "type" : "simple"
     },
-    "tooltip" : "Virtual host: get from RabbitMQ external application configurations. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\" target=\"_blank\">RabbitMQ routing data docs</a>",
+    "tooltip" : "Get from RabbitMQ external application configurations. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\" target=\"_blank\">RabbitMQ routing data docs</a>",
     "type" : "String"
   }, {
     "id" : "routing.hostName",
@@ -166,7 +166,7 @@
       "equals" : "credentials",
       "type" : "simple"
     },
-    "tooltip" : "Host name: get from RabbitMQ external application configurations. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\" target=\"_blank\">RabbitMQ routing data docs</a>",
+    "tooltip" : "Get from RabbitMQ external application configurations. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\" target=\"_blank\">RabbitMQ routing data docs</a>",
     "type" : "String"
   }, {
     "id" : "routing.port",
@@ -185,7 +185,7 @@
       "equals" : "credentials",
       "type" : "simple"
     },
-    "tooltip" : "Port: get from RabbitMQ external application configurations. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\" target=\"_blank\">RabbitMQ routing data docs</a>",
+    "tooltip" : "Get from RabbitMQ external application configurations. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\" target=\"_blank\">RabbitMQ routing data docs</a>",
     "type" : "String"
   }, {
     "id" : "queueName",
@@ -210,7 +210,6 @@
       "name" : "consumerTag",
       "type" : "zeebe:property"
     },
-    "tooltip" : "Consumer tag to use for the subscription",
     "type" : "String"
   }, {
     "id" : "arguments",
@@ -222,7 +221,6 @@
       "name" : "arguments",
       "type" : "zeebe:property"
     },
-    "tooltip" : "Arguments to use for the subscription",
     "type" : "String"
   }, {
     "id" : "exclusive",

--- a/connectors/rabbitmq/element-templates/hybrid/rabbitmq-inbound-connector-boundary-hybrid.json
+++ b/connectors/rabbitmq/element-templates/hybrid/rabbitmq-inbound-connector-boundary-hybrid.json
@@ -74,7 +74,6 @@
   }, {
     "id" : "authentication.uri",
     "label" : "URI",
-    "description" : "URI should contain username, password, host name, port number, and virtual host",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true,
@@ -93,6 +92,7 @@
       "equals" : "uri",
       "type" : "simple"
     },
+    "tooltip" : "URI should contain username, password, host name, port number, and virtual host",
     "type" : "String"
   }, {
     "id" : "authentication.userName",
@@ -133,7 +133,6 @@
   }, {
     "id" : "routing.virtualHost",
     "label" : "Virtual host",
-    "description" : "Virtual name: get from RabbitMQ external application configurations. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\"target=\"_blank\">documentation</a>",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -148,11 +147,11 @@
       "equals" : "credentials",
       "type" : "simple"
     },
+    "tooltip" : "Virtual host: get from RabbitMQ external application configurations. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\" target=\"_blank\">RabbitMQ routing data docs</a>",
     "type" : "String"
   }, {
     "id" : "routing.hostName",
     "label" : "Host name",
-    "description" : "Host name: get from RabbitMQ external application configurations. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\"target=\"_blank\">documentation</a>",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -167,11 +166,11 @@
       "equals" : "credentials",
       "type" : "simple"
     },
+    "tooltip" : "Host name: get from RabbitMQ external application configurations. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\" target=\"_blank\">RabbitMQ routing data docs</a>",
     "type" : "String"
   }, {
     "id" : "routing.port",
     "label" : "Port",
-    "description" : "Port: get from RabbitMQ external application configurations. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\"target=\"_blank\">documentation</a>",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -186,11 +185,11 @@
       "equals" : "credentials",
       "type" : "simple"
     },
+    "tooltip" : "Port: get from RabbitMQ external application configurations. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\" target=\"_blank\">RabbitMQ routing data docs</a>",
     "type" : "String"
   }, {
     "id" : "queueName",
     "label" : "Queue name",
-    "description" : "Name of the queue to subscribe to",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -200,22 +199,22 @@
       "name" : "queueName",
       "type" : "zeebe:property"
     },
+    "tooltip" : "Name of the queue to subscribe to",
     "type" : "String"
   }, {
     "id" : "consumerTag",
     "label" : "Consumer tag",
-    "description" : "Consumer tag to use for the subscription",
     "optional" : false,
     "group" : "subscription",
     "binding" : {
       "name" : "consumerTag",
       "type" : "zeebe:property"
     },
+    "tooltip" : "Consumer tag to use for the subscription",
     "type" : "String"
   }, {
     "id" : "arguments",
     "label" : "Arguments",
-    "description" : "Arguments to use for the subscription",
     "optional" : true,
     "feel" : "required",
     "group" : "subscription",
@@ -223,6 +222,7 @@
       "name" : "arguments",
       "type" : "zeebe:property"
     },
+    "tooltip" : "Arguments to use for the subscription",
     "type" : "String"
   }, {
     "id" : "exclusive",

--- a/connectors/rabbitmq/element-templates/hybrid/rabbitmq-inbound-connector-intermediate-hybrid.json
+++ b/connectors/rabbitmq/element-templates/hybrid/rabbitmq-inbound-connector-intermediate-hybrid.json
@@ -147,7 +147,7 @@
       "equals" : "credentials",
       "type" : "simple"
     },
-    "tooltip" : "Virtual host: get from RabbitMQ external application configurations. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\" target=\"_blank\">RabbitMQ routing data docs</a>",
+    "tooltip" : "Get from RabbitMQ external application configurations. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\" target=\"_blank\">RabbitMQ routing data docs</a>",
     "type" : "String"
   }, {
     "id" : "routing.hostName",
@@ -166,7 +166,7 @@
       "equals" : "credentials",
       "type" : "simple"
     },
-    "tooltip" : "Host name: get from RabbitMQ external application configurations. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\" target=\"_blank\">RabbitMQ routing data docs</a>",
+    "tooltip" : "Get from RabbitMQ external application configurations. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\" target=\"_blank\">RabbitMQ routing data docs</a>",
     "type" : "String"
   }, {
     "id" : "routing.port",
@@ -185,7 +185,7 @@
       "equals" : "credentials",
       "type" : "simple"
     },
-    "tooltip" : "Port: get from RabbitMQ external application configurations. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\" target=\"_blank\">RabbitMQ routing data docs</a>",
+    "tooltip" : "Get from RabbitMQ external application configurations. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\" target=\"_blank\">RabbitMQ routing data docs</a>",
     "type" : "String"
   }, {
     "id" : "queueName",
@@ -210,7 +210,6 @@
       "name" : "consumerTag",
       "type" : "zeebe:property"
     },
-    "tooltip" : "Consumer tag to use for the subscription",
     "type" : "String"
   }, {
     "id" : "arguments",
@@ -222,7 +221,6 @@
       "name" : "arguments",
       "type" : "zeebe:property"
     },
-    "tooltip" : "Arguments to use for the subscription",
     "type" : "String"
   }, {
     "id" : "exclusive",

--- a/connectors/rabbitmq/element-templates/hybrid/rabbitmq-inbound-connector-intermediate-hybrid.json
+++ b/connectors/rabbitmq/element-templates/hybrid/rabbitmq-inbound-connector-intermediate-hybrid.json
@@ -74,7 +74,6 @@
   }, {
     "id" : "authentication.uri",
     "label" : "URI",
-    "description" : "URI should contain username, password, host name, port number, and virtual host",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true,
@@ -93,6 +92,7 @@
       "equals" : "uri",
       "type" : "simple"
     },
+    "tooltip" : "URI should contain username, password, host name, port number, and virtual host",
     "type" : "String"
   }, {
     "id" : "authentication.userName",
@@ -133,7 +133,6 @@
   }, {
     "id" : "routing.virtualHost",
     "label" : "Virtual host",
-    "description" : "Virtual name: get from RabbitMQ external application configurations. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\"target=\"_blank\">documentation</a>",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -148,11 +147,11 @@
       "equals" : "credentials",
       "type" : "simple"
     },
+    "tooltip" : "Virtual host: get from RabbitMQ external application configurations. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\" target=\"_blank\">RabbitMQ routing data docs</a>",
     "type" : "String"
   }, {
     "id" : "routing.hostName",
     "label" : "Host name",
-    "description" : "Host name: get from RabbitMQ external application configurations. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\"target=\"_blank\">documentation</a>",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -167,11 +166,11 @@
       "equals" : "credentials",
       "type" : "simple"
     },
+    "tooltip" : "Host name: get from RabbitMQ external application configurations. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\" target=\"_blank\">RabbitMQ routing data docs</a>",
     "type" : "String"
   }, {
     "id" : "routing.port",
     "label" : "Port",
-    "description" : "Port: get from RabbitMQ external application configurations. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\"target=\"_blank\">documentation</a>",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -186,11 +185,11 @@
       "equals" : "credentials",
       "type" : "simple"
     },
+    "tooltip" : "Port: get from RabbitMQ external application configurations. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\" target=\"_blank\">RabbitMQ routing data docs</a>",
     "type" : "String"
   }, {
     "id" : "queueName",
     "label" : "Queue name",
-    "description" : "Name of the queue to subscribe to",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -200,22 +199,22 @@
       "name" : "queueName",
       "type" : "zeebe:property"
     },
+    "tooltip" : "Name of the queue to subscribe to",
     "type" : "String"
   }, {
     "id" : "consumerTag",
     "label" : "Consumer tag",
-    "description" : "Consumer tag to use for the subscription",
     "optional" : false,
     "group" : "subscription",
     "binding" : {
       "name" : "consumerTag",
       "type" : "zeebe:property"
     },
+    "tooltip" : "Consumer tag to use for the subscription",
     "type" : "String"
   }, {
     "id" : "arguments",
     "label" : "Arguments",
-    "description" : "Arguments to use for the subscription",
     "optional" : true,
     "feel" : "required",
     "group" : "subscription",
@@ -223,6 +222,7 @@
       "name" : "arguments",
       "type" : "zeebe:property"
     },
+    "tooltip" : "Arguments to use for the subscription",
     "type" : "String"
   }, {
     "id" : "exclusive",

--- a/connectors/rabbitmq/element-templates/hybrid/rabbitmq-inbound-connector-message-start-hybrid.json
+++ b/connectors/rabbitmq/element-templates/hybrid/rabbitmq-inbound-connector-message-start-hybrid.json
@@ -147,7 +147,7 @@
       "equals" : "credentials",
       "type" : "simple"
     },
-    "tooltip" : "Virtual host: get from RabbitMQ external application configurations. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\" target=\"_blank\">RabbitMQ routing data docs</a>",
+    "tooltip" : "Get from RabbitMQ external application configurations. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\" target=\"_blank\">RabbitMQ routing data docs</a>",
     "type" : "String"
   }, {
     "id" : "routing.hostName",
@@ -166,7 +166,7 @@
       "equals" : "credentials",
       "type" : "simple"
     },
-    "tooltip" : "Host name: get from RabbitMQ external application configurations. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\" target=\"_blank\">RabbitMQ routing data docs</a>",
+    "tooltip" : "Get from RabbitMQ external application configurations. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\" target=\"_blank\">RabbitMQ routing data docs</a>",
     "type" : "String"
   }, {
     "id" : "routing.port",
@@ -185,7 +185,7 @@
       "equals" : "credentials",
       "type" : "simple"
     },
-    "tooltip" : "Port: get from RabbitMQ external application configurations. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\" target=\"_blank\">RabbitMQ routing data docs</a>",
+    "tooltip" : "Get from RabbitMQ external application configurations. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\" target=\"_blank\">RabbitMQ routing data docs</a>",
     "type" : "String"
   }, {
     "id" : "queueName",
@@ -210,7 +210,6 @@
       "name" : "consumerTag",
       "type" : "zeebe:property"
     },
-    "tooltip" : "Consumer tag to use for the subscription",
     "type" : "String"
   }, {
     "id" : "arguments",
@@ -222,7 +221,6 @@
       "name" : "arguments",
       "type" : "zeebe:property"
     },
-    "tooltip" : "Arguments to use for the subscription",
     "type" : "String"
   }, {
     "id" : "exclusive",

--- a/connectors/rabbitmq/element-templates/hybrid/rabbitmq-inbound-connector-message-start-hybrid.json
+++ b/connectors/rabbitmq/element-templates/hybrid/rabbitmq-inbound-connector-message-start-hybrid.json
@@ -74,7 +74,6 @@
   }, {
     "id" : "authentication.uri",
     "label" : "URI",
-    "description" : "URI should contain username, password, host name, port number, and virtual host",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true,
@@ -93,6 +92,7 @@
       "equals" : "uri",
       "type" : "simple"
     },
+    "tooltip" : "URI should contain username, password, host name, port number, and virtual host",
     "type" : "String"
   }, {
     "id" : "authentication.userName",
@@ -133,7 +133,6 @@
   }, {
     "id" : "routing.virtualHost",
     "label" : "Virtual host",
-    "description" : "Virtual name: get from RabbitMQ external application configurations. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\"target=\"_blank\">documentation</a>",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -148,11 +147,11 @@
       "equals" : "credentials",
       "type" : "simple"
     },
+    "tooltip" : "Virtual host: get from RabbitMQ external application configurations. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\" target=\"_blank\">RabbitMQ routing data docs</a>",
     "type" : "String"
   }, {
     "id" : "routing.hostName",
     "label" : "Host name",
-    "description" : "Host name: get from RabbitMQ external application configurations. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\"target=\"_blank\">documentation</a>",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -167,11 +166,11 @@
       "equals" : "credentials",
       "type" : "simple"
     },
+    "tooltip" : "Host name: get from RabbitMQ external application configurations. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\" target=\"_blank\">RabbitMQ routing data docs</a>",
     "type" : "String"
   }, {
     "id" : "routing.port",
     "label" : "Port",
-    "description" : "Port: get from RabbitMQ external application configurations. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\"target=\"_blank\">documentation</a>",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -186,11 +185,11 @@
       "equals" : "credentials",
       "type" : "simple"
     },
+    "tooltip" : "Port: get from RabbitMQ external application configurations. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\" target=\"_blank\">RabbitMQ routing data docs</a>",
     "type" : "String"
   }, {
     "id" : "queueName",
     "label" : "Queue name",
-    "description" : "Name of the queue to subscribe to",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -200,22 +199,22 @@
       "name" : "queueName",
       "type" : "zeebe:property"
     },
+    "tooltip" : "Name of the queue to subscribe to",
     "type" : "String"
   }, {
     "id" : "consumerTag",
     "label" : "Consumer tag",
-    "description" : "Consumer tag to use for the subscription",
     "optional" : false,
     "group" : "subscription",
     "binding" : {
       "name" : "consumerTag",
       "type" : "zeebe:property"
     },
+    "tooltip" : "Consumer tag to use for the subscription",
     "type" : "String"
   }, {
     "id" : "arguments",
     "label" : "Arguments",
-    "description" : "Arguments to use for the subscription",
     "optional" : true,
     "feel" : "required",
     "group" : "subscription",
@@ -223,6 +222,7 @@
       "name" : "arguments",
       "type" : "zeebe:property"
     },
+    "tooltip" : "Arguments to use for the subscription",
     "type" : "String"
   }, {
     "id" : "exclusive",

--- a/connectors/rabbitmq/element-templates/hybrid/rabbitmq-inbound-connector-receive-hybrid.json
+++ b/connectors/rabbitmq/element-templates/hybrid/rabbitmq-inbound-connector-receive-hybrid.json
@@ -146,7 +146,7 @@
       "equals" : "credentials",
       "type" : "simple"
     },
-    "tooltip" : "Virtual host: get from RabbitMQ external application configurations. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\" target=\"_blank\">RabbitMQ routing data docs</a>",
+    "tooltip" : "Get from RabbitMQ external application configurations. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\" target=\"_blank\">RabbitMQ routing data docs</a>",
     "type" : "String"
   }, {
     "id" : "routing.hostName",
@@ -165,7 +165,7 @@
       "equals" : "credentials",
       "type" : "simple"
     },
-    "tooltip" : "Host name: get from RabbitMQ external application configurations. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\" target=\"_blank\">RabbitMQ routing data docs</a>",
+    "tooltip" : "Get from RabbitMQ external application configurations. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\" target=\"_blank\">RabbitMQ routing data docs</a>",
     "type" : "String"
   }, {
     "id" : "routing.port",
@@ -184,7 +184,7 @@
       "equals" : "credentials",
       "type" : "simple"
     },
-    "tooltip" : "Port: get from RabbitMQ external application configurations. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\" target=\"_blank\">RabbitMQ routing data docs</a>",
+    "tooltip" : "Get from RabbitMQ external application configurations. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\" target=\"_blank\">RabbitMQ routing data docs</a>",
     "type" : "String"
   }, {
     "id" : "queueName",
@@ -209,7 +209,6 @@
       "name" : "consumerTag",
       "type" : "zeebe:property"
     },
-    "tooltip" : "Consumer tag to use for the subscription",
     "type" : "String"
   }, {
     "id" : "arguments",
@@ -221,7 +220,6 @@
       "name" : "arguments",
       "type" : "zeebe:property"
     },
-    "tooltip" : "Arguments to use for the subscription",
     "type" : "String"
   }, {
     "id" : "exclusive",

--- a/connectors/rabbitmq/element-templates/hybrid/rabbitmq-inbound-connector-receive-hybrid.json
+++ b/connectors/rabbitmq/element-templates/hybrid/rabbitmq-inbound-connector-receive-hybrid.json
@@ -73,7 +73,6 @@
   }, {
     "id" : "authentication.uri",
     "label" : "URI",
-    "description" : "URI should contain username, password, host name, port number, and virtual host",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true,
@@ -92,6 +91,7 @@
       "equals" : "uri",
       "type" : "simple"
     },
+    "tooltip" : "URI should contain username, password, host name, port number, and virtual host",
     "type" : "String"
   }, {
     "id" : "authentication.userName",
@@ -132,7 +132,6 @@
   }, {
     "id" : "routing.virtualHost",
     "label" : "Virtual host",
-    "description" : "Virtual name: get from RabbitMQ external application configurations. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\"target=\"_blank\">documentation</a>",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -147,11 +146,11 @@
       "equals" : "credentials",
       "type" : "simple"
     },
+    "tooltip" : "Virtual host: get from RabbitMQ external application configurations. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\" target=\"_blank\">RabbitMQ routing data docs</a>",
     "type" : "String"
   }, {
     "id" : "routing.hostName",
     "label" : "Host name",
-    "description" : "Host name: get from RabbitMQ external application configurations. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\"target=\"_blank\">documentation</a>",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -166,11 +165,11 @@
       "equals" : "credentials",
       "type" : "simple"
     },
+    "tooltip" : "Host name: get from RabbitMQ external application configurations. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\" target=\"_blank\">RabbitMQ routing data docs</a>",
     "type" : "String"
   }, {
     "id" : "routing.port",
     "label" : "Port",
-    "description" : "Port: get from RabbitMQ external application configurations. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\"target=\"_blank\">documentation</a>",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -185,11 +184,11 @@
       "equals" : "credentials",
       "type" : "simple"
     },
+    "tooltip" : "Port: get from RabbitMQ external application configurations. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\" target=\"_blank\">RabbitMQ routing data docs</a>",
     "type" : "String"
   }, {
     "id" : "queueName",
     "label" : "Queue name",
-    "description" : "Name of the queue to subscribe to",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -199,22 +198,22 @@
       "name" : "queueName",
       "type" : "zeebe:property"
     },
+    "tooltip" : "Name of the queue to subscribe to",
     "type" : "String"
   }, {
     "id" : "consumerTag",
     "label" : "Consumer tag",
-    "description" : "Consumer tag to use for the subscription",
     "optional" : false,
     "group" : "subscription",
     "binding" : {
       "name" : "consumerTag",
       "type" : "zeebe:property"
     },
+    "tooltip" : "Consumer tag to use for the subscription",
     "type" : "String"
   }, {
     "id" : "arguments",
     "label" : "Arguments",
-    "description" : "Arguments to use for the subscription",
     "optional" : true,
     "feel" : "required",
     "group" : "subscription",
@@ -222,6 +221,7 @@
       "name" : "arguments",
       "type" : "zeebe:property"
     },
+    "tooltip" : "Arguments to use for the subscription",
     "type" : "String"
   }, {
     "id" : "exclusive",

--- a/connectors/rabbitmq/element-templates/hybrid/rabbitmq-outbound-connector-hybrid.json
+++ b/connectors/rabbitmq/element-templates/hybrid/rabbitmq-outbound-connector-hybrid.json
@@ -143,7 +143,7 @@
       "name" : "routing.exchange",
       "type" : "zeebe:input"
     },
-    "tooltip" : "Topic exchange: get from RabbitMQ external application configurations. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\" target=\"_blank\">RabbitMQ routing data docs</a>",
+    "tooltip" : "Topic exchange to publish to. Get from RabbitMQ external application configurations. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\" target=\"_blank\">RabbitMQ routing data docs</a>",
     "type" : "String"
   }, {
     "id" : "routing.routingKey",
@@ -158,7 +158,7 @@
       "name" : "routing.routingKey",
       "type" : "zeebe:input"
     },
-    "tooltip" : "Routing key: a binding is a \"link\" that was set up to bind a queue to an exchange. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\" target=\"_blank\">RabbitMQ routing data docs</a>",
+    "tooltip" : "A binding is a \"link\" that was set up to bind a queue to an exchange. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\" target=\"_blank\">RabbitMQ routing data docs</a>",
     "type" : "String"
   }, {
     "id" : "routing.virtualHost",
@@ -178,7 +178,7 @@
       "equals" : "credentials",
       "type" : "simple"
     },
-    "tooltip" : "Virtual host: get from RabbitMQ external application configurations. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\" target=\"_blank\">RabbitMQ routing data docs</a>",
+    "tooltip" : "Get from RabbitMQ external application configurations. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\" target=\"_blank\">RabbitMQ routing data docs</a>",
     "type" : "String"
   }, {
     "id" : "routing.hostName",
@@ -198,7 +198,7 @@
       "equals" : "credentials",
       "type" : "simple"
     },
-    "tooltip" : "Host name: get from RabbitMQ external application configurations. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\" target=\"_blank\">RabbitMQ routing data docs</a>",
+    "tooltip" : "Get from RabbitMQ external application configurations. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\" target=\"_blank\">RabbitMQ routing data docs</a>",
     "type" : "String"
   }, {
     "id" : "routing.port",
@@ -218,7 +218,7 @@
       "equals" : "credentials",
       "type" : "simple"
     },
-    "tooltip" : "Port: get from RabbitMQ external application configurations. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\" target=\"_blank\">RabbitMQ routing data docs</a>",
+    "tooltip" : "Get from RabbitMQ external application configurations. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\" target=\"_blank\">RabbitMQ routing data docs</a>",
     "type" : "String"
   }, {
     "id" : "message.properties",

--- a/connectors/rabbitmq/element-templates/hybrid/rabbitmq-outbound-connector-hybrid.json
+++ b/connectors/rabbitmq/element-templates/hybrid/rabbitmq-outbound-connector-hybrid.json
@@ -71,7 +71,6 @@
   }, {
     "id" : "authentication.uri",
     "label" : "URI",
-    "description" : "URI should contain username, password, host name, port number, and virtual host",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true,
@@ -91,6 +90,7 @@
       "equals" : "uri",
       "type" : "simple"
     },
+    "tooltip" : "URI should contain username, password, host name, port number, and virtual host",
     "type" : "String"
   }, {
     "id" : "authentication.userName",
@@ -133,7 +133,6 @@
   }, {
     "id" : "routing.exchange",
     "label" : "Exchange",
-    "description" : "Topic exchange: get from RabbitMQ external application configurations. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\"target=\"_blank\">documentation</a>",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -144,11 +143,11 @@
       "name" : "routing.exchange",
       "type" : "zeebe:input"
     },
+    "tooltip" : "Topic exchange: get from RabbitMQ external application configurations. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\" target=\"_blank\">RabbitMQ routing data docs</a>",
     "type" : "String"
   }, {
     "id" : "routing.routingKey",
     "label" : "Routing key",
-    "description" : "Routing key: a binding is a \"link\" that was set up to bind a queue to an exchange. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\"target=\"_blank\">documentation</a>",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -159,11 +158,11 @@
       "name" : "routing.routingKey",
       "type" : "zeebe:input"
     },
+    "tooltip" : "Routing key: a binding is a \"link\" that was set up to bind a queue to an exchange. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\" target=\"_blank\">RabbitMQ routing data docs</a>",
     "type" : "String"
   }, {
     "id" : "routing.virtualHost",
     "label" : "Virtual host",
-    "description" : "Virtual name: get from RabbitMQ external application configurations. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\"target=\"_blank\">documentation</a>",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -179,11 +178,11 @@
       "equals" : "credentials",
       "type" : "simple"
     },
+    "tooltip" : "Virtual host: get from RabbitMQ external application configurations. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\" target=\"_blank\">RabbitMQ routing data docs</a>",
     "type" : "String"
   }, {
     "id" : "routing.hostName",
     "label" : "Host name",
-    "description" : "Host name: get from RabbitMQ external application configurations. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\"target=\"_blank\">documentation</a>",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -199,11 +198,11 @@
       "equals" : "credentials",
       "type" : "simple"
     },
+    "tooltip" : "Host name: get from RabbitMQ external application configurations. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\" target=\"_blank\">RabbitMQ routing data docs</a>",
     "type" : "String"
   }, {
     "id" : "routing.port",
     "label" : "Port",
-    "description" : "Port: get from RabbitMQ external application configurations. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\"target=\"_blank\">documentation</a>",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -219,11 +218,11 @@
       "equals" : "credentials",
       "type" : "simple"
     },
+    "tooltip" : "Port: get from RabbitMQ external application configurations. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\" target=\"_blank\">RabbitMQ routing data docs</a>",
     "type" : "String"
   }, {
     "id" : "message.properties",
     "label" : "Properties",
-    "description" : "Properties for the message, routing headers, etc",
     "optional" : true,
     "value" : "={}",
     "feel" : "required",
@@ -232,11 +231,11 @@
       "name" : "message.properties",
       "type" : "zeebe:input"
     },
+    "tooltip" : "Properties for the message, routing headers, etc",
     "type" : "Text"
   }, {
     "id" : "message.body",
     "label" : "Message",
-    "description" : "Data to send to RabbitMQ",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -247,6 +246,7 @@
       "name" : "message.body",
       "type" : "zeebe:input"
     },
+    "tooltip" : "Data to send to RabbitMQ",
     "type" : "Text"
   }, {
     "id" : "version",

--- a/connectors/rabbitmq/element-templates/rabbitmq-inbound-connector-boundary.json
+++ b/connectors/rabbitmq/element-templates/rabbitmq-inbound-connector-boundary.json
@@ -142,7 +142,7 @@
       "equals" : "credentials",
       "type" : "simple"
     },
-    "tooltip" : "Virtual host: get from RabbitMQ external application configurations. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\" target=\"_blank\">RabbitMQ routing data docs</a>",
+    "tooltip" : "Get from RabbitMQ external application configurations. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\" target=\"_blank\">RabbitMQ routing data docs</a>",
     "type" : "String"
   }, {
     "id" : "routing.hostName",
@@ -161,7 +161,7 @@
       "equals" : "credentials",
       "type" : "simple"
     },
-    "tooltip" : "Host name: get from RabbitMQ external application configurations. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\" target=\"_blank\">RabbitMQ routing data docs</a>",
+    "tooltip" : "Get from RabbitMQ external application configurations. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\" target=\"_blank\">RabbitMQ routing data docs</a>",
     "type" : "String"
   }, {
     "id" : "routing.port",
@@ -180,7 +180,7 @@
       "equals" : "credentials",
       "type" : "simple"
     },
-    "tooltip" : "Port: get from RabbitMQ external application configurations. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\" target=\"_blank\">RabbitMQ routing data docs</a>",
+    "tooltip" : "Get from RabbitMQ external application configurations. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\" target=\"_blank\">RabbitMQ routing data docs</a>",
     "type" : "String"
   }, {
     "id" : "queueName",
@@ -205,7 +205,6 @@
       "name" : "consumerTag",
       "type" : "zeebe:property"
     },
-    "tooltip" : "Consumer tag to use for the subscription",
     "type" : "String"
   }, {
     "id" : "arguments",
@@ -217,7 +216,6 @@
       "name" : "arguments",
       "type" : "zeebe:property"
     },
-    "tooltip" : "Arguments to use for the subscription",
     "type" : "String"
   }, {
     "id" : "exclusive",

--- a/connectors/rabbitmq/element-templates/rabbitmq-inbound-connector-boundary.json
+++ b/connectors/rabbitmq/element-templates/rabbitmq-inbound-connector-boundary.json
@@ -69,7 +69,6 @@
   }, {
     "id" : "authentication.uri",
     "label" : "URI",
-    "description" : "URI should contain username, password, host name, port number, and virtual host",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true,
@@ -88,6 +87,7 @@
       "equals" : "uri",
       "type" : "simple"
     },
+    "tooltip" : "URI should contain username, password, host name, port number, and virtual host",
     "type" : "String"
   }, {
     "id" : "authentication.userName",
@@ -128,7 +128,6 @@
   }, {
     "id" : "routing.virtualHost",
     "label" : "Virtual host",
-    "description" : "Virtual name: get from RabbitMQ external application configurations. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\"target=\"_blank\">documentation</a>",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -143,11 +142,11 @@
       "equals" : "credentials",
       "type" : "simple"
     },
+    "tooltip" : "Virtual host: get from RabbitMQ external application configurations. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\" target=\"_blank\">RabbitMQ routing data docs</a>",
     "type" : "String"
   }, {
     "id" : "routing.hostName",
     "label" : "Host name",
-    "description" : "Host name: get from RabbitMQ external application configurations. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\"target=\"_blank\">documentation</a>",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -162,11 +161,11 @@
       "equals" : "credentials",
       "type" : "simple"
     },
+    "tooltip" : "Host name: get from RabbitMQ external application configurations. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\" target=\"_blank\">RabbitMQ routing data docs</a>",
     "type" : "String"
   }, {
     "id" : "routing.port",
     "label" : "Port",
-    "description" : "Port: get from RabbitMQ external application configurations. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\"target=\"_blank\">documentation</a>",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -181,11 +180,11 @@
       "equals" : "credentials",
       "type" : "simple"
     },
+    "tooltip" : "Port: get from RabbitMQ external application configurations. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\" target=\"_blank\">RabbitMQ routing data docs</a>",
     "type" : "String"
   }, {
     "id" : "queueName",
     "label" : "Queue name",
-    "description" : "Name of the queue to subscribe to",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -195,22 +194,22 @@
       "name" : "queueName",
       "type" : "zeebe:property"
     },
+    "tooltip" : "Name of the queue to subscribe to",
     "type" : "String"
   }, {
     "id" : "consumerTag",
     "label" : "Consumer tag",
-    "description" : "Consumer tag to use for the subscription",
     "optional" : false,
     "group" : "subscription",
     "binding" : {
       "name" : "consumerTag",
       "type" : "zeebe:property"
     },
+    "tooltip" : "Consumer tag to use for the subscription",
     "type" : "String"
   }, {
     "id" : "arguments",
     "label" : "Arguments",
-    "description" : "Arguments to use for the subscription",
     "optional" : true,
     "feel" : "required",
     "group" : "subscription",
@@ -218,6 +217,7 @@
       "name" : "arguments",
       "type" : "zeebe:property"
     },
+    "tooltip" : "Arguments to use for the subscription",
     "type" : "String"
   }, {
     "id" : "exclusive",

--- a/connectors/rabbitmq/element-templates/rabbitmq-inbound-connector-intermediate.json
+++ b/connectors/rabbitmq/element-templates/rabbitmq-inbound-connector-intermediate.json
@@ -142,7 +142,7 @@
       "equals" : "credentials",
       "type" : "simple"
     },
-    "tooltip" : "Virtual host: get from RabbitMQ external application configurations. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\" target=\"_blank\">RabbitMQ routing data docs</a>",
+    "tooltip" : "Get from RabbitMQ external application configurations. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\" target=\"_blank\">RabbitMQ routing data docs</a>",
     "type" : "String"
   }, {
     "id" : "routing.hostName",
@@ -161,7 +161,7 @@
       "equals" : "credentials",
       "type" : "simple"
     },
-    "tooltip" : "Host name: get from RabbitMQ external application configurations. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\" target=\"_blank\">RabbitMQ routing data docs</a>",
+    "tooltip" : "Get from RabbitMQ external application configurations. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\" target=\"_blank\">RabbitMQ routing data docs</a>",
     "type" : "String"
   }, {
     "id" : "routing.port",
@@ -180,7 +180,7 @@
       "equals" : "credentials",
       "type" : "simple"
     },
-    "tooltip" : "Port: get from RabbitMQ external application configurations. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\" target=\"_blank\">RabbitMQ routing data docs</a>",
+    "tooltip" : "Get from RabbitMQ external application configurations. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\" target=\"_blank\">RabbitMQ routing data docs</a>",
     "type" : "String"
   }, {
     "id" : "queueName",
@@ -205,7 +205,6 @@
       "name" : "consumerTag",
       "type" : "zeebe:property"
     },
-    "tooltip" : "Consumer tag to use for the subscription",
     "type" : "String"
   }, {
     "id" : "arguments",
@@ -217,7 +216,6 @@
       "name" : "arguments",
       "type" : "zeebe:property"
     },
-    "tooltip" : "Arguments to use for the subscription",
     "type" : "String"
   }, {
     "id" : "exclusive",

--- a/connectors/rabbitmq/element-templates/rabbitmq-inbound-connector-intermediate.json
+++ b/connectors/rabbitmq/element-templates/rabbitmq-inbound-connector-intermediate.json
@@ -69,7 +69,6 @@
   }, {
     "id" : "authentication.uri",
     "label" : "URI",
-    "description" : "URI should contain username, password, host name, port number, and virtual host",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true,
@@ -88,6 +87,7 @@
       "equals" : "uri",
       "type" : "simple"
     },
+    "tooltip" : "URI should contain username, password, host name, port number, and virtual host",
     "type" : "String"
   }, {
     "id" : "authentication.userName",
@@ -128,7 +128,6 @@
   }, {
     "id" : "routing.virtualHost",
     "label" : "Virtual host",
-    "description" : "Virtual name: get from RabbitMQ external application configurations. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\"target=\"_blank\">documentation</a>",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -143,11 +142,11 @@
       "equals" : "credentials",
       "type" : "simple"
     },
+    "tooltip" : "Virtual host: get from RabbitMQ external application configurations. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\" target=\"_blank\">RabbitMQ routing data docs</a>",
     "type" : "String"
   }, {
     "id" : "routing.hostName",
     "label" : "Host name",
-    "description" : "Host name: get from RabbitMQ external application configurations. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\"target=\"_blank\">documentation</a>",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -162,11 +161,11 @@
       "equals" : "credentials",
       "type" : "simple"
     },
+    "tooltip" : "Host name: get from RabbitMQ external application configurations. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\" target=\"_blank\">RabbitMQ routing data docs</a>",
     "type" : "String"
   }, {
     "id" : "routing.port",
     "label" : "Port",
-    "description" : "Port: get from RabbitMQ external application configurations. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\"target=\"_blank\">documentation</a>",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -181,11 +180,11 @@
       "equals" : "credentials",
       "type" : "simple"
     },
+    "tooltip" : "Port: get from RabbitMQ external application configurations. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\" target=\"_blank\">RabbitMQ routing data docs</a>",
     "type" : "String"
   }, {
     "id" : "queueName",
     "label" : "Queue name",
-    "description" : "Name of the queue to subscribe to",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -195,22 +194,22 @@
       "name" : "queueName",
       "type" : "zeebe:property"
     },
+    "tooltip" : "Name of the queue to subscribe to",
     "type" : "String"
   }, {
     "id" : "consumerTag",
     "label" : "Consumer tag",
-    "description" : "Consumer tag to use for the subscription",
     "optional" : false,
     "group" : "subscription",
     "binding" : {
       "name" : "consumerTag",
       "type" : "zeebe:property"
     },
+    "tooltip" : "Consumer tag to use for the subscription",
     "type" : "String"
   }, {
     "id" : "arguments",
     "label" : "Arguments",
-    "description" : "Arguments to use for the subscription",
     "optional" : true,
     "feel" : "required",
     "group" : "subscription",
@@ -218,6 +217,7 @@
       "name" : "arguments",
       "type" : "zeebe:property"
     },
+    "tooltip" : "Arguments to use for the subscription",
     "type" : "String"
   }, {
     "id" : "exclusive",

--- a/connectors/rabbitmq/element-templates/rabbitmq-inbound-connector-message-start.json
+++ b/connectors/rabbitmq/element-templates/rabbitmq-inbound-connector-message-start.json
@@ -142,7 +142,7 @@
       "equals" : "credentials",
       "type" : "simple"
     },
-    "tooltip" : "Virtual host: get from RabbitMQ external application configurations. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\" target=\"_blank\">RabbitMQ routing data docs</a>",
+    "tooltip" : "Get from RabbitMQ external application configurations. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\" target=\"_blank\">RabbitMQ routing data docs</a>",
     "type" : "String"
   }, {
     "id" : "routing.hostName",
@@ -161,7 +161,7 @@
       "equals" : "credentials",
       "type" : "simple"
     },
-    "tooltip" : "Host name: get from RabbitMQ external application configurations. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\" target=\"_blank\">RabbitMQ routing data docs</a>",
+    "tooltip" : "Get from RabbitMQ external application configurations. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\" target=\"_blank\">RabbitMQ routing data docs</a>",
     "type" : "String"
   }, {
     "id" : "routing.port",
@@ -180,7 +180,7 @@
       "equals" : "credentials",
       "type" : "simple"
     },
-    "tooltip" : "Port: get from RabbitMQ external application configurations. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\" target=\"_blank\">RabbitMQ routing data docs</a>",
+    "tooltip" : "Get from RabbitMQ external application configurations. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\" target=\"_blank\">RabbitMQ routing data docs</a>",
     "type" : "String"
   }, {
     "id" : "queueName",
@@ -205,7 +205,6 @@
       "name" : "consumerTag",
       "type" : "zeebe:property"
     },
-    "tooltip" : "Consumer tag to use for the subscription",
     "type" : "String"
   }, {
     "id" : "arguments",
@@ -217,7 +216,6 @@
       "name" : "arguments",
       "type" : "zeebe:property"
     },
-    "tooltip" : "Arguments to use for the subscription",
     "type" : "String"
   }, {
     "id" : "exclusive",

--- a/connectors/rabbitmq/element-templates/rabbitmq-inbound-connector-message-start.json
+++ b/connectors/rabbitmq/element-templates/rabbitmq-inbound-connector-message-start.json
@@ -69,7 +69,6 @@
   }, {
     "id" : "authentication.uri",
     "label" : "URI",
-    "description" : "URI should contain username, password, host name, port number, and virtual host",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true,
@@ -88,6 +87,7 @@
       "equals" : "uri",
       "type" : "simple"
     },
+    "tooltip" : "URI should contain username, password, host name, port number, and virtual host",
     "type" : "String"
   }, {
     "id" : "authentication.userName",
@@ -128,7 +128,6 @@
   }, {
     "id" : "routing.virtualHost",
     "label" : "Virtual host",
-    "description" : "Virtual name: get from RabbitMQ external application configurations. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\"target=\"_blank\">documentation</a>",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -143,11 +142,11 @@
       "equals" : "credentials",
       "type" : "simple"
     },
+    "tooltip" : "Virtual host: get from RabbitMQ external application configurations. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\" target=\"_blank\">RabbitMQ routing data docs</a>",
     "type" : "String"
   }, {
     "id" : "routing.hostName",
     "label" : "Host name",
-    "description" : "Host name: get from RabbitMQ external application configurations. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\"target=\"_blank\">documentation</a>",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -162,11 +161,11 @@
       "equals" : "credentials",
       "type" : "simple"
     },
+    "tooltip" : "Host name: get from RabbitMQ external application configurations. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\" target=\"_blank\">RabbitMQ routing data docs</a>",
     "type" : "String"
   }, {
     "id" : "routing.port",
     "label" : "Port",
-    "description" : "Port: get from RabbitMQ external application configurations. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\"target=\"_blank\">documentation</a>",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -181,11 +180,11 @@
       "equals" : "credentials",
       "type" : "simple"
     },
+    "tooltip" : "Port: get from RabbitMQ external application configurations. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\" target=\"_blank\">RabbitMQ routing data docs</a>",
     "type" : "String"
   }, {
     "id" : "queueName",
     "label" : "Queue name",
-    "description" : "Name of the queue to subscribe to",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -195,22 +194,22 @@
       "name" : "queueName",
       "type" : "zeebe:property"
     },
+    "tooltip" : "Name of the queue to subscribe to",
     "type" : "String"
   }, {
     "id" : "consumerTag",
     "label" : "Consumer tag",
-    "description" : "Consumer tag to use for the subscription",
     "optional" : false,
     "group" : "subscription",
     "binding" : {
       "name" : "consumerTag",
       "type" : "zeebe:property"
     },
+    "tooltip" : "Consumer tag to use for the subscription",
     "type" : "String"
   }, {
     "id" : "arguments",
     "label" : "Arguments",
-    "description" : "Arguments to use for the subscription",
     "optional" : true,
     "feel" : "required",
     "group" : "subscription",
@@ -218,6 +217,7 @@
       "name" : "arguments",
       "type" : "zeebe:property"
     },
+    "tooltip" : "Arguments to use for the subscription",
     "type" : "String"
   }, {
     "id" : "exclusive",

--- a/connectors/rabbitmq/element-templates/rabbitmq-inbound-connector-receive.json
+++ b/connectors/rabbitmq/element-templates/rabbitmq-inbound-connector-receive.json
@@ -141,7 +141,7 @@
       "equals" : "credentials",
       "type" : "simple"
     },
-    "tooltip" : "Virtual host: get from RabbitMQ external application configurations. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\" target=\"_blank\">RabbitMQ routing data docs</a>",
+    "tooltip" : "Get from RabbitMQ external application configurations. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\" target=\"_blank\">RabbitMQ routing data docs</a>",
     "type" : "String"
   }, {
     "id" : "routing.hostName",
@@ -160,7 +160,7 @@
       "equals" : "credentials",
       "type" : "simple"
     },
-    "tooltip" : "Host name: get from RabbitMQ external application configurations. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\" target=\"_blank\">RabbitMQ routing data docs</a>",
+    "tooltip" : "Get from RabbitMQ external application configurations. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\" target=\"_blank\">RabbitMQ routing data docs</a>",
     "type" : "String"
   }, {
     "id" : "routing.port",
@@ -179,7 +179,7 @@
       "equals" : "credentials",
       "type" : "simple"
     },
-    "tooltip" : "Port: get from RabbitMQ external application configurations. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\" target=\"_blank\">RabbitMQ routing data docs</a>",
+    "tooltip" : "Get from RabbitMQ external application configurations. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\" target=\"_blank\">RabbitMQ routing data docs</a>",
     "type" : "String"
   }, {
     "id" : "queueName",
@@ -204,7 +204,6 @@
       "name" : "consumerTag",
       "type" : "zeebe:property"
     },
-    "tooltip" : "Consumer tag to use for the subscription",
     "type" : "String"
   }, {
     "id" : "arguments",
@@ -216,7 +215,6 @@
       "name" : "arguments",
       "type" : "zeebe:property"
     },
-    "tooltip" : "Arguments to use for the subscription",
     "type" : "String"
   }, {
     "id" : "exclusive",

--- a/connectors/rabbitmq/element-templates/rabbitmq-inbound-connector-receive.json
+++ b/connectors/rabbitmq/element-templates/rabbitmq-inbound-connector-receive.json
@@ -68,7 +68,6 @@
   }, {
     "id" : "authentication.uri",
     "label" : "URI",
-    "description" : "URI should contain username, password, host name, port number, and virtual host",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true,
@@ -87,6 +86,7 @@
       "equals" : "uri",
       "type" : "simple"
     },
+    "tooltip" : "URI should contain username, password, host name, port number, and virtual host",
     "type" : "String"
   }, {
     "id" : "authentication.userName",
@@ -127,7 +127,6 @@
   }, {
     "id" : "routing.virtualHost",
     "label" : "Virtual host",
-    "description" : "Virtual name: get from RabbitMQ external application configurations. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\"target=\"_blank\">documentation</a>",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -142,11 +141,11 @@
       "equals" : "credentials",
       "type" : "simple"
     },
+    "tooltip" : "Virtual host: get from RabbitMQ external application configurations. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\" target=\"_blank\">RabbitMQ routing data docs</a>",
     "type" : "String"
   }, {
     "id" : "routing.hostName",
     "label" : "Host name",
-    "description" : "Host name: get from RabbitMQ external application configurations. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\"target=\"_blank\">documentation</a>",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -161,11 +160,11 @@
       "equals" : "credentials",
       "type" : "simple"
     },
+    "tooltip" : "Host name: get from RabbitMQ external application configurations. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\" target=\"_blank\">RabbitMQ routing data docs</a>",
     "type" : "String"
   }, {
     "id" : "routing.port",
     "label" : "Port",
-    "description" : "Port: get from RabbitMQ external application configurations. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\"target=\"_blank\">documentation</a>",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -180,11 +179,11 @@
       "equals" : "credentials",
       "type" : "simple"
     },
+    "tooltip" : "Port: get from RabbitMQ external application configurations. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\" target=\"_blank\">RabbitMQ routing data docs</a>",
     "type" : "String"
   }, {
     "id" : "queueName",
     "label" : "Queue name",
-    "description" : "Name of the queue to subscribe to",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -194,22 +193,22 @@
       "name" : "queueName",
       "type" : "zeebe:property"
     },
+    "tooltip" : "Name of the queue to subscribe to",
     "type" : "String"
   }, {
     "id" : "consumerTag",
     "label" : "Consumer tag",
-    "description" : "Consumer tag to use for the subscription",
     "optional" : false,
     "group" : "subscription",
     "binding" : {
       "name" : "consumerTag",
       "type" : "zeebe:property"
     },
+    "tooltip" : "Consumer tag to use for the subscription",
     "type" : "String"
   }, {
     "id" : "arguments",
     "label" : "Arguments",
-    "description" : "Arguments to use for the subscription",
     "optional" : true,
     "feel" : "required",
     "group" : "subscription",
@@ -217,6 +216,7 @@
       "name" : "arguments",
       "type" : "zeebe:property"
     },
+    "tooltip" : "Arguments to use for the subscription",
     "type" : "String"
   }, {
     "id" : "exclusive",

--- a/connectors/rabbitmq/element-templates/rabbitmq-outbound-connector.json
+++ b/connectors/rabbitmq/element-templates/rabbitmq-outbound-connector.json
@@ -138,7 +138,7 @@
       "name" : "routing.exchange",
       "type" : "zeebe:input"
     },
-    "tooltip" : "Topic exchange: get from RabbitMQ external application configurations. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\" target=\"_blank\">RabbitMQ routing data docs</a>",
+    "tooltip" : "Topic exchange to publish to. Get from RabbitMQ external application configurations. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\" target=\"_blank\">RabbitMQ routing data docs</a>",
     "type" : "String"
   }, {
     "id" : "routing.routingKey",
@@ -153,7 +153,7 @@
       "name" : "routing.routingKey",
       "type" : "zeebe:input"
     },
-    "tooltip" : "Routing key: a binding is a \"link\" that was set up to bind a queue to an exchange. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\" target=\"_blank\">RabbitMQ routing data docs</a>",
+    "tooltip" : "A binding is a \"link\" that was set up to bind a queue to an exchange. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\" target=\"_blank\">RabbitMQ routing data docs</a>",
     "type" : "String"
   }, {
     "id" : "routing.virtualHost",
@@ -173,7 +173,7 @@
       "equals" : "credentials",
       "type" : "simple"
     },
-    "tooltip" : "Virtual host: get from RabbitMQ external application configurations. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\" target=\"_blank\">RabbitMQ routing data docs</a>",
+    "tooltip" : "Get from RabbitMQ external application configurations. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\" target=\"_blank\">RabbitMQ routing data docs</a>",
     "type" : "String"
   }, {
     "id" : "routing.hostName",
@@ -193,7 +193,7 @@
       "equals" : "credentials",
       "type" : "simple"
     },
-    "tooltip" : "Host name: get from RabbitMQ external application configurations. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\" target=\"_blank\">RabbitMQ routing data docs</a>",
+    "tooltip" : "Get from RabbitMQ external application configurations. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\" target=\"_blank\">RabbitMQ routing data docs</a>",
     "type" : "String"
   }, {
     "id" : "routing.port",
@@ -213,7 +213,7 @@
       "equals" : "credentials",
       "type" : "simple"
     },
-    "tooltip" : "Port: get from RabbitMQ external application configurations. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\" target=\"_blank\">RabbitMQ routing data docs</a>",
+    "tooltip" : "Get from RabbitMQ external application configurations. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\" target=\"_blank\">RabbitMQ routing data docs</a>",
     "type" : "String"
   }, {
     "id" : "message.properties",

--- a/connectors/rabbitmq/element-templates/rabbitmq-outbound-connector.json
+++ b/connectors/rabbitmq/element-templates/rabbitmq-outbound-connector.json
@@ -66,7 +66,6 @@
   }, {
     "id" : "authentication.uri",
     "label" : "URI",
-    "description" : "URI should contain username, password, host name, port number, and virtual host",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true,
@@ -86,6 +85,7 @@
       "equals" : "uri",
       "type" : "simple"
     },
+    "tooltip" : "URI should contain username, password, host name, port number, and virtual host",
     "type" : "String"
   }, {
     "id" : "authentication.userName",
@@ -128,7 +128,6 @@
   }, {
     "id" : "routing.exchange",
     "label" : "Exchange",
-    "description" : "Topic exchange: get from RabbitMQ external application configurations. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\"target=\"_blank\">documentation</a>",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -139,11 +138,11 @@
       "name" : "routing.exchange",
       "type" : "zeebe:input"
     },
+    "tooltip" : "Topic exchange: get from RabbitMQ external application configurations. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\" target=\"_blank\">RabbitMQ routing data docs</a>",
     "type" : "String"
   }, {
     "id" : "routing.routingKey",
     "label" : "Routing key",
-    "description" : "Routing key: a binding is a \"link\" that was set up to bind a queue to an exchange. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\"target=\"_blank\">documentation</a>",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -154,11 +153,11 @@
       "name" : "routing.routingKey",
       "type" : "zeebe:input"
     },
+    "tooltip" : "Routing key: a binding is a \"link\" that was set up to bind a queue to an exchange. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\" target=\"_blank\">RabbitMQ routing data docs</a>",
     "type" : "String"
   }, {
     "id" : "routing.virtualHost",
     "label" : "Virtual host",
-    "description" : "Virtual name: get from RabbitMQ external application configurations. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\"target=\"_blank\">documentation</a>",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -174,11 +173,11 @@
       "equals" : "credentials",
       "type" : "simple"
     },
+    "tooltip" : "Virtual host: get from RabbitMQ external application configurations. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\" target=\"_blank\">RabbitMQ routing data docs</a>",
     "type" : "String"
   }, {
     "id" : "routing.hostName",
     "label" : "Host name",
-    "description" : "Host name: get from RabbitMQ external application configurations. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\"target=\"_blank\">documentation</a>",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -194,11 +193,11 @@
       "equals" : "credentials",
       "type" : "simple"
     },
+    "tooltip" : "Host name: get from RabbitMQ external application configurations. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\" target=\"_blank\">RabbitMQ routing data docs</a>",
     "type" : "String"
   }, {
     "id" : "routing.port",
     "label" : "Port",
-    "description" : "Port: get from RabbitMQ external application configurations. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\"target=\"_blank\">documentation</a>",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -214,11 +213,11 @@
       "equals" : "credentials",
       "type" : "simple"
     },
+    "tooltip" : "Port: get from RabbitMQ external application configurations. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\" target=\"_blank\">RabbitMQ routing data docs</a>",
     "type" : "String"
   }, {
     "id" : "message.properties",
     "label" : "Properties",
-    "description" : "Properties for the message, routing headers, etc",
     "optional" : true,
     "value" : "={}",
     "feel" : "required",
@@ -227,11 +226,11 @@
       "name" : "message.properties",
       "type" : "zeebe:input"
     },
+    "tooltip" : "Properties for the message, routing headers, etc",
     "type" : "Text"
   }, {
     "id" : "message.body",
     "label" : "Message",
-    "description" : "Data to send to RabbitMQ",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -242,6 +241,7 @@
       "name" : "message.body",
       "type" : "zeebe:input"
     },
+    "tooltip" : "Data to send to RabbitMQ",
     "type" : "Text"
   }, {
     "id" : "version",

--- a/connectors/rabbitmq/src/main/java/io/camunda/connector/rabbitmq/common/model/FactoryRoutingData.java
+++ b/connectors/rabbitmq/src/main/java/io/camunda/connector/rabbitmq/common/model/FactoryRoutingData.java
@@ -20,7 +20,7 @@ public record FactoryRoutingData(
                     property = "authentication.authType",
                     equals = "credentials"),
             tooltip =
-                "Virtual host: get from RabbitMQ external application configurations. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\" target=\"_blank\">RabbitMQ routing data docs</a>")
+                "Get from RabbitMQ external application configurations. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\" target=\"_blank\">RabbitMQ routing data docs</a>")
         String virtualHost,
     @NotBlank
         @TemplateProperty(
@@ -31,7 +31,7 @@ public record FactoryRoutingData(
                     property = "authentication.authType",
                     equals = "credentials"),
             tooltip =
-                "Host name: get from RabbitMQ external application configurations. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\" target=\"_blank\">RabbitMQ routing data docs</a>")
+                "Get from RabbitMQ external application configurations. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\" target=\"_blank\">RabbitMQ routing data docs</a>")
         String hostName,
     @NotNull
         @TemplateProperty(
@@ -42,5 +42,5 @@ public record FactoryRoutingData(
                     property = "authentication.authType",
                     equals = "credentials"),
             tooltip =
-                "Port: get from RabbitMQ external application configurations. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\" target=\"_blank\">RabbitMQ routing data docs</a>")
+                "Get from RabbitMQ external application configurations. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\" target=\"_blank\">RabbitMQ routing data docs</a>")
         String port) {}

--- a/connectors/rabbitmq/src/main/java/io/camunda/connector/rabbitmq/common/model/FactoryRoutingData.java
+++ b/connectors/rabbitmq/src/main/java/io/camunda/connector/rabbitmq/common/model/FactoryRoutingData.java
@@ -19,8 +19,8 @@ public record FactoryRoutingData(
                 @TemplateProperty.PropertyCondition(
                     property = "authentication.authType",
                     equals = "credentials"),
-            description =
-                "Virtual name: get from RabbitMQ external application configurations. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\"target=\"_blank\">documentation</a>")
+            tooltip =
+                "Virtual host: get from RabbitMQ external application configurations. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\" target=\"_blank\">RabbitMQ routing data docs</a>")
         String virtualHost,
     @NotBlank
         @TemplateProperty(
@@ -30,8 +30,8 @@ public record FactoryRoutingData(
                 @TemplateProperty.PropertyCondition(
                     property = "authentication.authType",
                     equals = "credentials"),
-            description =
-                "Host name: get from RabbitMQ external application configurations. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\"target=\"_blank\">documentation</a>")
+            tooltip =
+                "Host name: get from RabbitMQ external application configurations. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\" target=\"_blank\">RabbitMQ routing data docs</a>")
         String hostName,
     @NotNull
         @TemplateProperty(
@@ -41,6 +41,6 @@ public record FactoryRoutingData(
                 @TemplateProperty.PropertyCondition(
                     property = "authentication.authType",
                     equals = "credentials"),
-            description =
-                "Port: get from RabbitMQ external application configurations. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\"target=\"_blank\">documentation</a>")
+            tooltip =
+                "Port: get from RabbitMQ external application configurations. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\" target=\"_blank\">RabbitMQ routing data docs</a>")
         String port) {}

--- a/connectors/rabbitmq/src/main/java/io/camunda/connector/rabbitmq/common/model/UriAuthentication.java
+++ b/connectors/rabbitmq/src/main/java/io/camunda/connector/rabbitmq/common/model/UriAuthentication.java
@@ -20,7 +20,7 @@ public record UriAuthentication(
         @TemplateProperty(
             group = "authentication",
             label = "URI",
-            description =
+            tooltip =
                 "URI should contain username, password, host name, port number, and virtual host")
         String uri)
     implements RabbitMqAuthentication {

--- a/connectors/rabbitmq/src/main/java/io/camunda/connector/rabbitmq/inbound/model/RabbitMqInboundProperties.java
+++ b/connectors/rabbitmq/src/main/java/io/camunda/connector/rabbitmq/inbound/model/RabbitMqInboundProperties.java
@@ -27,16 +27,12 @@ public class RabbitMqInboundProperties {
       tooltip = "Name of the queue to subscribe to")
   private String queueName;
 
-  @TemplateProperty(
-      label = "Consumer tag",
-      group = "subscription",
-      tooltip = "Consumer tag to use for the subscription")
+  @TemplateProperty(label = "Consumer tag", group = "subscription")
   private String consumerTag;
 
   @Valid
   @TemplateProperty(
       label = "Arguments",
-      tooltip = "Arguments to use for the subscription",
       group = "subscription",
       optional = true,
       feel = FeelMode.required)

--- a/connectors/rabbitmq/src/main/java/io/camunda/connector/rabbitmq/inbound/model/RabbitMqInboundProperties.java
+++ b/connectors/rabbitmq/src/main/java/io/camunda/connector/rabbitmq/inbound/model/RabbitMqInboundProperties.java
@@ -24,19 +24,19 @@ public class RabbitMqInboundProperties {
   @TemplateProperty(
       label = "Queue name",
       group = "subscription",
-      description = "Name of the queue to subscribe to")
+      tooltip = "Name of the queue to subscribe to")
   private String queueName;
 
   @TemplateProperty(
       label = "Consumer tag",
       group = "subscription",
-      description = "Consumer tag to use for the subscription")
+      tooltip = "Consumer tag to use for the subscription")
   private String consumerTag;
 
   @Valid
   @TemplateProperty(
       label = "Arguments",
-      description = "Arguments to use for the subscription",
+      tooltip = "Arguments to use for the subscription",
       group = "subscription",
       optional = true,
       feel = FeelMode.required)

--- a/connectors/rabbitmq/src/main/java/io/camunda/connector/rabbitmq/outbound/model/RabbitMqMessage.java
+++ b/connectors/rabbitmq/src/main/java/io/camunda/connector/rabbitmq/outbound/model/RabbitMqMessage.java
@@ -17,12 +17,12 @@ public record RabbitMqMessage(
             optional = true,
             defaultValue = "={}",
             type = TemplateProperty.PropertyType.Text,
-            description = "Properties for the message, routing headers, etc")
+            tooltip = "Properties for the message, routing headers, etc")
         Object properties,
     @NotNull
         @TemplateProperty(
             group = "message",
             label = "Message",
             type = TemplateProperty.PropertyType.Text,
-            description = "Data to send to RabbitMQ")
+            tooltip = "Data to send to RabbitMQ")
         Object body) {}

--- a/connectors/rabbitmq/src/main/java/io/camunda/connector/rabbitmq/outbound/model/RabbitMqOutboundRouting.java
+++ b/connectors/rabbitmq/src/main/java/io/camunda/connector/rabbitmq/outbound/model/RabbitMqOutboundRouting.java
@@ -29,15 +29,15 @@ public record RabbitMqOutboundRouting(
     @NotBlank
         @TemplateProperty(
             group = "routing",
-            description =
-                "Topic exchange: get from RabbitMQ external application configurations. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\"target=\"_blank\">documentation</a>")
+            tooltip =
+                "Topic exchange: get from RabbitMQ external application configurations. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\" target=\"_blank\">RabbitMQ routing data docs</a>")
         String exchange,
     @NotBlank
         @TemplateProperty(
             group = "routing",
             label = "Routing key",
-            description =
-                "Routing key: a binding is a \"link\" that was set up to bind a queue to an exchange. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\"target=\"_blank\">documentation</a>")
+            tooltip =
+                "Routing key: a binding is a \"link\" that was set up to bind a queue to an exchange. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\" target=\"_blank\">RabbitMQ routing data docs</a>")
         String routingKey,
     @NestedProperties(
             addNestedPath = false,

--- a/connectors/rabbitmq/src/main/java/io/camunda/connector/rabbitmq/outbound/model/RabbitMqOutboundRouting.java
+++ b/connectors/rabbitmq/src/main/java/io/camunda/connector/rabbitmq/outbound/model/RabbitMqOutboundRouting.java
@@ -30,14 +30,14 @@ public record RabbitMqOutboundRouting(
         @TemplateProperty(
             group = "routing",
             tooltip =
-                "Topic exchange: get from RabbitMQ external application configurations. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\" target=\"_blank\">RabbitMQ routing data docs</a>")
+                "Topic exchange to publish to. Get from RabbitMQ external application configurations. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\" target=\"_blank\">RabbitMQ routing data docs</a>")
         String exchange,
     @NotBlank
         @TemplateProperty(
             group = "routing",
             label = "Routing key",
             tooltip =
-                "Routing key: a binding is a \"link\" that was set up to bind a queue to an exchange. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\" target=\"_blank\">RabbitMQ routing data docs</a>")
+                "A binding is a \"link\" that was set up to bind a queue to an exchange. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\" target=\"_blank\">RabbitMQ routing data docs</a>")
         String routingKey,
     @NestedProperties(
             addNestedPath = false,

--- a/connectors/slack/element-templates/hybrid/slack-inbound-boundary-hybrid.json
+++ b/connectors/slack/element-templates/hybrid/slack-inbound-boundary-hybrid.json
@@ -51,7 +51,6 @@
   }, {
     "id" : "inbound.context",
     "label" : "Webhook ID",
-    "description" : "The webhook ID is a part of the URL endpoint",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -61,11 +60,11 @@
       "name" : "inbound.context",
       "type" : "zeebe:property"
     },
+    "tooltip" : "The webhook ID is a part of the URL endpoint",
     "type" : "String"
   }, {
     "id" : "inbound.slackSigningSecret",
     "label" : "Slack signing secret",
-    "description" : "Slack signing secret. <a href='https://api.slack.com/authentication/verifying-requests-from-slack' target='_blank'>See documentation</a> regarding the Slack signing secret",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -75,6 +74,7 @@
       "name" : "inbound.slackSigningSecret",
       "type" : "zeebe:property"
     },
+    "tooltip" : "<a href='https://api.slack.com/authentication/verifying-requests-from-slack' target='_blank'>Slack request signing documentation</a>",
     "type" : "String"
   }, {
     "id" : "inbound.verificationExpression",

--- a/connectors/slack/element-templates/hybrid/slack-inbound-boundary-hybrid.json
+++ b/connectors/slack/element-templates/hybrid/slack-inbound-boundary-hybrid.json
@@ -74,7 +74,7 @@
       "name" : "inbound.slackSigningSecret",
       "type" : "zeebe:property"
     },
-    "tooltip" : "<a href='https://api.slack.com/authentication/verifying-requests-from-slack' target='_blank'>Slack request signing documentation</a>",
+    "tooltip" : "Used to verify that incoming requests originate from Slack. See <a href='https://api.slack.com/authentication/verifying-requests-from-slack' target='_blank'>Verifying requests from Slack</a>",
     "type" : "String"
   }, {
     "id" : "inbound.verificationExpression",

--- a/connectors/slack/element-templates/hybrid/slack-inbound-intermediate-hybrid.json
+++ b/connectors/slack/element-templates/hybrid/slack-inbound-intermediate-hybrid.json
@@ -51,7 +51,6 @@
   }, {
     "id" : "inbound.context",
     "label" : "Webhook ID",
-    "description" : "The webhook ID is a part of the URL endpoint",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -61,11 +60,11 @@
       "name" : "inbound.context",
       "type" : "zeebe:property"
     },
+    "tooltip" : "The webhook ID is a part of the URL endpoint",
     "type" : "String"
   }, {
     "id" : "inbound.slackSigningSecret",
     "label" : "Slack signing secret",
-    "description" : "Slack signing secret. <a href='https://api.slack.com/authentication/verifying-requests-from-slack' target='_blank'>See documentation</a> regarding the Slack signing secret",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -75,6 +74,7 @@
       "name" : "inbound.slackSigningSecret",
       "type" : "zeebe:property"
     },
+    "tooltip" : "<a href='https://api.slack.com/authentication/verifying-requests-from-slack' target='_blank'>Slack request signing documentation</a>",
     "type" : "String"
   }, {
     "id" : "inbound.verificationExpression",

--- a/connectors/slack/element-templates/hybrid/slack-inbound-intermediate-hybrid.json
+++ b/connectors/slack/element-templates/hybrid/slack-inbound-intermediate-hybrid.json
@@ -74,7 +74,7 @@
       "name" : "inbound.slackSigningSecret",
       "type" : "zeebe:property"
     },
-    "tooltip" : "<a href='https://api.slack.com/authentication/verifying-requests-from-slack' target='_blank'>Slack request signing documentation</a>",
+    "tooltip" : "Used to verify that incoming requests originate from Slack. See <a href='https://api.slack.com/authentication/verifying-requests-from-slack' target='_blank'>Verifying requests from Slack</a>",
     "type" : "String"
   }, {
     "id" : "inbound.verificationExpression",

--- a/connectors/slack/element-templates/hybrid/slack-inbound-message-start-hybrid.json
+++ b/connectors/slack/element-templates/hybrid/slack-inbound-message-start-hybrid.json
@@ -51,7 +51,6 @@
   }, {
     "id" : "inbound.context",
     "label" : "Webhook ID",
-    "description" : "The webhook ID is a part of the URL endpoint",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -61,11 +60,11 @@
       "name" : "inbound.context",
       "type" : "zeebe:property"
     },
+    "tooltip" : "The webhook ID is a part of the URL endpoint",
     "type" : "String"
   }, {
     "id" : "inbound.slackSigningSecret",
     "label" : "Slack signing secret",
-    "description" : "Slack signing secret. <a href='https://api.slack.com/authentication/verifying-requests-from-slack' target='_blank'>See documentation</a> regarding the Slack signing secret",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -75,6 +74,7 @@
       "name" : "inbound.slackSigningSecret",
       "type" : "zeebe:property"
     },
+    "tooltip" : "<a href='https://api.slack.com/authentication/verifying-requests-from-slack' target='_blank'>Slack request signing documentation</a>",
     "type" : "String"
   }, {
     "id" : "inbound.verificationExpression",

--- a/connectors/slack/element-templates/hybrid/slack-inbound-message-start-hybrid.json
+++ b/connectors/slack/element-templates/hybrid/slack-inbound-message-start-hybrid.json
@@ -74,7 +74,7 @@
       "name" : "inbound.slackSigningSecret",
       "type" : "zeebe:property"
     },
-    "tooltip" : "<a href='https://api.slack.com/authentication/verifying-requests-from-slack' target='_blank'>Slack request signing documentation</a>",
+    "tooltip" : "Used to verify that incoming requests originate from Slack. See <a href='https://api.slack.com/authentication/verifying-requests-from-slack' target='_blank'>Verifying requests from Slack</a>",
     "type" : "String"
   }, {
     "id" : "inbound.verificationExpression",

--- a/connectors/slack/element-templates/hybrid/slack-inbound-receive-hybrid.json
+++ b/connectors/slack/element-templates/hybrid/slack-inbound-receive-hybrid.json
@@ -73,7 +73,7 @@
       "name" : "inbound.slackSigningSecret",
       "type" : "zeebe:property"
     },
-    "tooltip" : "<a href='https://api.slack.com/authentication/verifying-requests-from-slack' target='_blank'>Slack request signing documentation</a>",
+    "tooltip" : "Used to verify that incoming requests originate from Slack. See <a href='https://api.slack.com/authentication/verifying-requests-from-slack' target='_blank'>Verifying requests from Slack</a>",
     "type" : "String"
   }, {
     "id" : "inbound.verificationExpression",

--- a/connectors/slack/element-templates/hybrid/slack-inbound-receive-hybrid.json
+++ b/connectors/slack/element-templates/hybrid/slack-inbound-receive-hybrid.json
@@ -50,7 +50,6 @@
   }, {
     "id" : "inbound.context",
     "label" : "Webhook ID",
-    "description" : "The webhook ID is a part of the URL endpoint",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -60,11 +59,11 @@
       "name" : "inbound.context",
       "type" : "zeebe:property"
     },
+    "tooltip" : "The webhook ID is a part of the URL endpoint",
     "type" : "String"
   }, {
     "id" : "inbound.slackSigningSecret",
     "label" : "Slack signing secret",
-    "description" : "Slack signing secret. <a href='https://api.slack.com/authentication/verifying-requests-from-slack' target='_blank'>See documentation</a> regarding the Slack signing secret",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -74,6 +73,7 @@
       "name" : "inbound.slackSigningSecret",
       "type" : "zeebe:property"
     },
+    "tooltip" : "<a href='https://api.slack.com/authentication/verifying-requests-from-slack' target='_blank'>Slack request signing documentation</a>",
     "type" : "String"
   }, {
     "id" : "inbound.verificationExpression",

--- a/connectors/slack/element-templates/hybrid/slack-outbound-connector-hybrid.json
+++ b/connectors/slack/element-templates/hybrid/slack-outbound-connector-hybrid.json
@@ -166,7 +166,6 @@
   }, {
     "id" : "data.blockContent",
     "label" : "Message block",
-    "description" : "An array of rich message content blocks. Learn more at the <a href=\"https://api.slack.com/reference/surfaces/formatting#stack_of_blocks\" target=\"_blank\">official Slack documentation page</a>",
     "optional" : false,
     "value" : "=[\n\t{\n\t\t\"type\": \"header\",\n\t\t\"text\": {\n\t\t\t\"type\": \"plain_text\",\n\t\t\t\"text\": \"New request\"\n\t\t}\n\t},\n\t{\n\t\t\"type\": \"section\",\n\t\t\"fields\": [\n\t\t\t{\n\t\t\t\t\"type\": \"mrkdwn\",\n\t\t\t\t\"text\": \"*Type:*\\nPaid Time Off\"\n\t\t\t},\n\t\t\t{\n\t\t\t\t\"type\": \"mrkdwn\",\n\t\t\t\t\"text\": \"*Created by:*\\n<example.com|John Doe>\"\n\t\t\t}\n\t\t]\n\t},\n\t{\n\t\t\"type\": \"section\",\n\t\t\"fields\": [\n\t\t\t{\n\t\t\t\t\"type\": \"mrkdwn\",\n\t\t\t\t\"text\": \"*When:*\\nAug 10 - Aug 13\"\n\t\t\t}\n\t\t]\n\t},\n\t{\n\t\t\"type\": \"section\",\n\t\t\"text\": {\n\t\t\t\"type\": \"mrkdwn\",\n\t\t\t\"text\": \"<https://example.com|View request>\"\n\t\t}\n\t}\n]",
     "constraints" : {
@@ -189,11 +188,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "An array of rich message content blocks. See the <a href=\"https://api.slack.com/reference/surfaces/formatting#stack_of_blocks\" target=\"_blank\">Slack Block Kit reference</a>",
     "type" : "String"
   }, {
     "id" : "data_documents_documentMode",
     "label" : "Number of documents",
-    "description" : "<a href=\"https://docs.camunda.io/docs/apis-tools/camunda-api-rest/specifications/upload-document-alpha/\">Camunda documents</a> can be added as attachments",
     "value" : "none",
     "group" : "message",
     "binding" : {
@@ -205,6 +204,7 @@
       "equals" : "chat.postMessage",
       "type" : "simple"
     },
+    "tooltip" : "<a href=\"https://docs.camunda.io/docs/apis-tools/camunda-api-rest/specifications/upload-document-alpha/\">Camunda documents</a> can be added as attachments",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "None",
@@ -618,7 +618,6 @@
   }, {
     "id" : "data.users",
     "label" : "Users",
-    "description" : "Comma-separated list of users, e.g., '@user1,@user2' or '=[ \"@user1\", \"user2@company.com\"]'",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -634,11 +633,12 @@
       "equals" : "conversations.invite",
       "type" : "simple"
     },
+    "tooltip" : "Comma-separated list of users.",
+    "placeholder" : "@user1,@user2",
     "type" : "String"
   }, {
     "id" : "reaction.channel",
     "label" : "Channel",
-    "description" : "Channel ID of the message to react to",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -654,11 +654,11 @@
       "equals" : "reactions.add",
       "type" : "simple"
     },
+    "tooltip" : "Channel ID of the message to react to",
     "type" : "String"
   }, {
     "id" : "data.emoji",
     "label" : "Emoji name",
-    "description" : "Emoji name (e.g. eyes)",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -674,11 +674,11 @@
       "equals" : "reactions.add",
       "type" : "simple"
     },
+    "placeholder" : "eyes",
     "type" : "String"
   }, {
     "id" : "data.timestamp",
     "label" : "Message timestamp",
-    "description" : "Timestamp of the Slack message to react to",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -694,11 +694,11 @@
       "equals" : "reactions.add",
       "type" : "simple"
     },
+    "tooltip" : "Timestamp of the Slack message to react to",
     "type" : "String"
   }, {
     "id" : "pinMessage.channel",
     "label" : "Channel",
-    "description" : "Channel ID of the message to pin",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -714,11 +714,11 @@
       "equals" : "pins.add",
       "type" : "simple"
     },
+    "tooltip" : "Channel ID of the message to pin",
     "type" : "String"
   }, {
     "id" : "pinMessage.timestamp",
     "label" : "Message timestamp",
-    "description" : "Timestamp of the Slack message to pin",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -734,11 +734,11 @@
       "equals" : "pins.add",
       "type" : "simple"
     },
+    "tooltip" : "Timestamp of the Slack message to pin",
     "type" : "String"
   }, {
     "id" : "unpinMessage.channel",
     "label" : "Channel",
-    "description" : "Channel ID of the message to unpin",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -754,11 +754,11 @@
       "equals" : "pins.remove",
       "type" : "simple"
     },
+    "tooltip" : "Channel ID of the message to unpin",
     "type" : "String"
   }, {
     "id" : "unpinMessage.timestamp",
     "label" : "Message timestamp",
-    "description" : "Timestamp of the Slack message to unpin",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -774,6 +774,7 @@
       "equals" : "pins.remove",
       "type" : "simple"
     },
+    "tooltip" : "Timestamp of the Slack message to unpin",
     "type" : "String"
   }, {
     "id" : "version",

--- a/connectors/slack/element-templates/slack-inbound-boundary.json
+++ b/connectors/slack/element-templates/slack-inbound-boundary.json
@@ -69,7 +69,7 @@
       "name" : "inbound.slackSigningSecret",
       "type" : "zeebe:property"
     },
-    "tooltip" : "<a href='https://api.slack.com/authentication/verifying-requests-from-slack' target='_blank'>Slack request signing documentation</a>",
+    "tooltip" : "Used to verify that incoming requests originate from Slack. See <a href='https://api.slack.com/authentication/verifying-requests-from-slack' target='_blank'>Verifying requests from Slack</a>",
     "type" : "String"
   }, {
     "id" : "inbound.verificationExpression",

--- a/connectors/slack/element-templates/slack-inbound-boundary.json
+++ b/connectors/slack/element-templates/slack-inbound-boundary.json
@@ -46,7 +46,6 @@
   }, {
     "id" : "inbound.context",
     "label" : "Webhook ID",
-    "description" : "The webhook ID is a part of the URL endpoint",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -56,11 +55,11 @@
       "name" : "inbound.context",
       "type" : "zeebe:property"
     },
+    "tooltip" : "The webhook ID is a part of the URL endpoint",
     "type" : "String"
   }, {
     "id" : "inbound.slackSigningSecret",
     "label" : "Slack signing secret",
-    "description" : "Slack signing secret. <a href='https://api.slack.com/authentication/verifying-requests-from-slack' target='_blank'>See documentation</a> regarding the Slack signing secret",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -70,6 +69,7 @@
       "name" : "inbound.slackSigningSecret",
       "type" : "zeebe:property"
     },
+    "tooltip" : "<a href='https://api.slack.com/authentication/verifying-requests-from-slack' target='_blank'>Slack request signing documentation</a>",
     "type" : "String"
   }, {
     "id" : "inbound.verificationExpression",

--- a/connectors/slack/element-templates/slack-inbound-intermediate.json
+++ b/connectors/slack/element-templates/slack-inbound-intermediate.json
@@ -69,7 +69,7 @@
       "name" : "inbound.slackSigningSecret",
       "type" : "zeebe:property"
     },
-    "tooltip" : "<a href='https://api.slack.com/authentication/verifying-requests-from-slack' target='_blank'>Slack request signing documentation</a>",
+    "tooltip" : "Used to verify that incoming requests originate from Slack. See <a href='https://api.slack.com/authentication/verifying-requests-from-slack' target='_blank'>Verifying requests from Slack</a>",
     "type" : "String"
   }, {
     "id" : "inbound.verificationExpression",

--- a/connectors/slack/element-templates/slack-inbound-intermediate.json
+++ b/connectors/slack/element-templates/slack-inbound-intermediate.json
@@ -46,7 +46,6 @@
   }, {
     "id" : "inbound.context",
     "label" : "Webhook ID",
-    "description" : "The webhook ID is a part of the URL endpoint",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -56,11 +55,11 @@
       "name" : "inbound.context",
       "type" : "zeebe:property"
     },
+    "tooltip" : "The webhook ID is a part of the URL endpoint",
     "type" : "String"
   }, {
     "id" : "inbound.slackSigningSecret",
     "label" : "Slack signing secret",
-    "description" : "Slack signing secret. <a href='https://api.slack.com/authentication/verifying-requests-from-slack' target='_blank'>See documentation</a> regarding the Slack signing secret",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -70,6 +69,7 @@
       "name" : "inbound.slackSigningSecret",
       "type" : "zeebe:property"
     },
+    "tooltip" : "<a href='https://api.slack.com/authentication/verifying-requests-from-slack' target='_blank'>Slack request signing documentation</a>",
     "type" : "String"
   }, {
     "id" : "inbound.verificationExpression",

--- a/connectors/slack/element-templates/slack-inbound-message-start.json
+++ b/connectors/slack/element-templates/slack-inbound-message-start.json
@@ -69,7 +69,7 @@
       "name" : "inbound.slackSigningSecret",
       "type" : "zeebe:property"
     },
-    "tooltip" : "<a href='https://api.slack.com/authentication/verifying-requests-from-slack' target='_blank'>Slack request signing documentation</a>",
+    "tooltip" : "Used to verify that incoming requests originate from Slack. See <a href='https://api.slack.com/authentication/verifying-requests-from-slack' target='_blank'>Verifying requests from Slack</a>",
     "type" : "String"
   }, {
     "id" : "inbound.verificationExpression",

--- a/connectors/slack/element-templates/slack-inbound-message-start.json
+++ b/connectors/slack/element-templates/slack-inbound-message-start.json
@@ -46,7 +46,6 @@
   }, {
     "id" : "inbound.context",
     "label" : "Webhook ID",
-    "description" : "The webhook ID is a part of the URL endpoint",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -56,11 +55,11 @@
       "name" : "inbound.context",
       "type" : "zeebe:property"
     },
+    "tooltip" : "The webhook ID is a part of the URL endpoint",
     "type" : "String"
   }, {
     "id" : "inbound.slackSigningSecret",
     "label" : "Slack signing secret",
-    "description" : "Slack signing secret. <a href='https://api.slack.com/authentication/verifying-requests-from-slack' target='_blank'>See documentation</a> regarding the Slack signing secret",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -70,6 +69,7 @@
       "name" : "inbound.slackSigningSecret",
       "type" : "zeebe:property"
     },
+    "tooltip" : "<a href='https://api.slack.com/authentication/verifying-requests-from-slack' target='_blank'>Slack request signing documentation</a>",
     "type" : "String"
   }, {
     "id" : "inbound.verificationExpression",

--- a/connectors/slack/element-templates/slack-inbound-receive.json
+++ b/connectors/slack/element-templates/slack-inbound-receive.json
@@ -68,7 +68,7 @@
       "name" : "inbound.slackSigningSecret",
       "type" : "zeebe:property"
     },
-    "tooltip" : "<a href='https://api.slack.com/authentication/verifying-requests-from-slack' target='_blank'>Slack request signing documentation</a>",
+    "tooltip" : "Used to verify that incoming requests originate from Slack. See <a href='https://api.slack.com/authentication/verifying-requests-from-slack' target='_blank'>Verifying requests from Slack</a>",
     "type" : "String"
   }, {
     "id" : "inbound.verificationExpression",

--- a/connectors/slack/element-templates/slack-inbound-receive.json
+++ b/connectors/slack/element-templates/slack-inbound-receive.json
@@ -45,7 +45,6 @@
   }, {
     "id" : "inbound.context",
     "label" : "Webhook ID",
-    "description" : "The webhook ID is a part of the URL endpoint",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -55,11 +54,11 @@
       "name" : "inbound.context",
       "type" : "zeebe:property"
     },
+    "tooltip" : "The webhook ID is a part of the URL endpoint",
     "type" : "String"
   }, {
     "id" : "inbound.slackSigningSecret",
     "label" : "Slack signing secret",
-    "description" : "Slack signing secret. <a href='https://api.slack.com/authentication/verifying-requests-from-slack' target='_blank'>See documentation</a> regarding the Slack signing secret",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -69,6 +68,7 @@
       "name" : "inbound.slackSigningSecret",
       "type" : "zeebe:property"
     },
+    "tooltip" : "<a href='https://api.slack.com/authentication/verifying-requests-from-slack' target='_blank'>Slack request signing documentation</a>",
     "type" : "String"
   }, {
     "id" : "inbound.verificationExpression",

--- a/connectors/slack/element-templates/slack-outbound-connector.json
+++ b/connectors/slack/element-templates/slack-outbound-connector.json
@@ -161,7 +161,6 @@
   }, {
     "id" : "data.blockContent",
     "label" : "Message block",
-    "description" : "An array of rich message content blocks. Learn more at the <a href=\"https://api.slack.com/reference/surfaces/formatting#stack_of_blocks\" target=\"_blank\">official Slack documentation page</a>",
     "optional" : false,
     "value" : "=[\n\t{\n\t\t\"type\": \"header\",\n\t\t\"text\": {\n\t\t\t\"type\": \"plain_text\",\n\t\t\t\"text\": \"New request\"\n\t\t}\n\t},\n\t{\n\t\t\"type\": \"section\",\n\t\t\"fields\": [\n\t\t\t{\n\t\t\t\t\"type\": \"mrkdwn\",\n\t\t\t\t\"text\": \"*Type:*\\nPaid Time Off\"\n\t\t\t},\n\t\t\t{\n\t\t\t\t\"type\": \"mrkdwn\",\n\t\t\t\t\"text\": \"*Created by:*\\n<example.com|John Doe>\"\n\t\t\t}\n\t\t]\n\t},\n\t{\n\t\t\"type\": \"section\",\n\t\t\"fields\": [\n\t\t\t{\n\t\t\t\t\"type\": \"mrkdwn\",\n\t\t\t\t\"text\": \"*When:*\\nAug 10 - Aug 13\"\n\t\t\t}\n\t\t]\n\t},\n\t{\n\t\t\"type\": \"section\",\n\t\t\"text\": {\n\t\t\t\"type\": \"mrkdwn\",\n\t\t\t\"text\": \"<https://example.com|View request>\"\n\t\t}\n\t}\n]",
     "constraints" : {
@@ -184,11 +183,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "An array of rich message content blocks. See the <a href=\"https://api.slack.com/reference/surfaces/formatting#stack_of_blocks\" target=\"_blank\">Slack Block Kit reference</a>",
     "type" : "String"
   }, {
     "id" : "data_documents_documentMode",
     "label" : "Number of documents",
-    "description" : "<a href=\"https://docs.camunda.io/docs/apis-tools/camunda-api-rest/specifications/upload-document-alpha/\">Camunda documents</a> can be added as attachments",
     "value" : "none",
     "group" : "message",
     "binding" : {
@@ -200,6 +199,7 @@
       "equals" : "chat.postMessage",
       "type" : "simple"
     },
+    "tooltip" : "<a href=\"https://docs.camunda.io/docs/apis-tools/camunda-api-rest/specifications/upload-document-alpha/\">Camunda documents</a> can be added as attachments",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "None",
@@ -613,7 +613,6 @@
   }, {
     "id" : "data.users",
     "label" : "Users",
-    "description" : "Comma-separated list of users, e.g., '@user1,@user2' or '=[ \"@user1\", \"user2@company.com\"]'",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -629,11 +628,12 @@
       "equals" : "conversations.invite",
       "type" : "simple"
     },
+    "tooltip" : "Comma-separated list of users.",
+    "placeholder" : "@user1,@user2",
     "type" : "String"
   }, {
     "id" : "reaction.channel",
     "label" : "Channel",
-    "description" : "Channel ID of the message to react to",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -649,11 +649,11 @@
       "equals" : "reactions.add",
       "type" : "simple"
     },
+    "tooltip" : "Channel ID of the message to react to",
     "type" : "String"
   }, {
     "id" : "data.emoji",
     "label" : "Emoji name",
-    "description" : "Emoji name (e.g. eyes)",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -669,11 +669,11 @@
       "equals" : "reactions.add",
       "type" : "simple"
     },
+    "placeholder" : "eyes",
     "type" : "String"
   }, {
     "id" : "data.timestamp",
     "label" : "Message timestamp",
-    "description" : "Timestamp of the Slack message to react to",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -689,11 +689,11 @@
       "equals" : "reactions.add",
       "type" : "simple"
     },
+    "tooltip" : "Timestamp of the Slack message to react to",
     "type" : "String"
   }, {
     "id" : "pinMessage.channel",
     "label" : "Channel",
-    "description" : "Channel ID of the message to pin",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -709,11 +709,11 @@
       "equals" : "pins.add",
       "type" : "simple"
     },
+    "tooltip" : "Channel ID of the message to pin",
     "type" : "String"
   }, {
     "id" : "pinMessage.timestamp",
     "label" : "Message timestamp",
-    "description" : "Timestamp of the Slack message to pin",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -729,11 +729,11 @@
       "equals" : "pins.add",
       "type" : "simple"
     },
+    "tooltip" : "Timestamp of the Slack message to pin",
     "type" : "String"
   }, {
     "id" : "unpinMessage.channel",
     "label" : "Channel",
-    "description" : "Channel ID of the message to unpin",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -749,11 +749,11 @@
       "equals" : "pins.remove",
       "type" : "simple"
     },
+    "tooltip" : "Channel ID of the message to unpin",
     "type" : "String"
   }, {
     "id" : "unpinMessage.timestamp",
     "label" : "Message timestamp",
-    "description" : "Timestamp of the Slack message to unpin",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -769,6 +769,7 @@
       "equals" : "pins.remove",
       "type" : "simple"
     },
+    "tooltip" : "Timestamp of the Slack message to unpin",
     "type" : "String"
   }, {
     "id" : "version",

--- a/connectors/slack/src/main/java/io/camunda/connector/slack/inbound/model/SlackWebhookProperties.java
+++ b/connectors/slack/src/main/java/io/camunda/connector/slack/inbound/model/SlackWebhookProperties.java
@@ -29,7 +29,7 @@ public record SlackWebhookProperties(
             label = "Slack signing secret",
             group = "endpoint",
             tooltip =
-                "<a href='https://api.slack.com/authentication/verifying-requests-from-slack' target='_blank'>Slack request signing documentation</a>",
+                "Used to verify that incoming requests originate from Slack. See <a href='https://api.slack.com/authentication/verifying-requests-from-slack' target='_blank'>Verifying requests from Slack</a>",
             feel = FeelMode.disabled)
         @NotBlank
         String slackSigningSecret,

--- a/connectors/slack/src/main/java/io/camunda/connector/slack/inbound/model/SlackWebhookProperties.java
+++ b/connectors/slack/src/main/java/io/camunda/connector/slack/inbound/model/SlackWebhookProperties.java
@@ -20,7 +20,7 @@ public record SlackWebhookProperties(
             id = "context",
             label = "Webhook ID",
             group = "endpoint",
-            description = "The webhook ID is a part of the URL endpoint",
+            tooltip = "The webhook ID is a part of the URL endpoint",
             feel = FeelMode.disabled)
         @NotBlank
         String context,
@@ -28,8 +28,8 @@ public record SlackWebhookProperties(
             id = "slackSigningSecret",
             label = "Slack signing secret",
             group = "endpoint",
-            description =
-                "Slack signing secret. <a href='https://api.slack.com/authentication/verifying-requests-from-slack' target='_blank'>See documentation</a> regarding the Slack signing secret",
+            tooltip =
+                "<a href='https://api.slack.com/authentication/verifying-requests-from-slack' target='_blank'>Slack request signing documentation</a>",
             feel = FeelMode.disabled)
         @NotBlank
         String slackSigningSecret,

--- a/connectors/slack/src/main/java/io/camunda/connector/slack/outbound/model/ChatPostMessageData.java
+++ b/connectors/slack/src/main/java/io/camunda/connector/slack/outbound/model/ChatPostMessageData.java
@@ -92,8 +92,8 @@ public record ChatPostMessageData(
         String text,
     @TemplateProperty(
             label = "Message block",
-            description =
-                "An array of rich message content blocks. Learn more at the <a href=\"https://api.slack.com/reference/surfaces/formatting#stack_of_blocks\" target=\"_blank\">official Slack documentation page</a>",
+            tooltip =
+                "An array of rich message content blocks. See the <a href=\"https://api.slack.com/reference/surfaces/formatting#stack_of_blocks\" target=\"_blank\">Slack Block Kit reference</a>",
             id = "data.blockContent",
             group = "message",
             feel = FeelMode.required,
@@ -111,7 +111,7 @@ public record ChatPostMessageData(
             group = "message",
             binding = @PropertyBinding(name = "data.documents"),
             optional = true,
-            description =
+            tooltip =
                 "<a href=\"https://docs.camunda.io/docs/apis-tools/camunda-api-rest/specifications/upload-document-alpha/\">Camunda documents</a> can be added as attachments")
         List<Document> documents)
     implements SlackRequestData {

--- a/connectors/slack/src/main/java/io/camunda/connector/slack/outbound/model/ConversationsInviteData.java
+++ b/connectors/slack/src/main/java/io/camunda/connector/slack/outbound/model/ConversationsInviteData.java
@@ -95,8 +95,8 @@ public record ConversationsInviteData(
     @TemplateProperty(
             label = "Users",
             id = "data.users",
-            description =
-                "Comma-separated list of users, e.g., '@user1,@user2' or '=[ \"@user1\", \"user2@company.com\"]'",
+            tooltip = "Comma-separated list of users.",
+            placeholder = "@user1,@user2",
             group = "invite",
             binding = @PropertyBinding(name = "data.users"),
             feel = FeelMode.optional)

--- a/connectors/slack/src/main/java/io/camunda/connector/slack/outbound/model/PinsAddData.java
+++ b/connectors/slack/src/main/java/io/camunda/connector/slack/outbound/model/PinsAddData.java
@@ -27,7 +27,7 @@ import java.io.IOException;
 public record PinsAddData(
     @TemplateProperty(
             label = "Channel",
-            description = "Channel ID of the message to pin",
+            tooltip = "Channel ID of the message to pin",
             id = "pinMessage.channel",
             group = "pinMessage",
             binding = @PropertyBinding(name = "data.channel"),
@@ -36,7 +36,7 @@ public record PinsAddData(
         String channel,
     @TemplateProperty(
             label = "Message timestamp",
-            description = "Timestamp of the Slack message to pin",
+            tooltip = "Timestamp of the Slack message to pin",
             id = "pinMessage.timestamp",
             group = "pinMessage",
             feel = FeelMode.required,

--- a/connectors/slack/src/main/java/io/camunda/connector/slack/outbound/model/PinsRemoveData.java
+++ b/connectors/slack/src/main/java/io/camunda/connector/slack/outbound/model/PinsRemoveData.java
@@ -27,7 +27,7 @@ import java.io.IOException;
 public record PinsRemoveData(
     @TemplateProperty(
             label = "Channel",
-            description = "Channel ID of the message to unpin",
+            tooltip = "Channel ID of the message to unpin",
             id = "unpinMessage.channel",
             group = "unpinMessage",
             binding = @PropertyBinding(name = "data.channel"),
@@ -36,7 +36,7 @@ public record PinsRemoveData(
         String channel,
     @TemplateProperty(
             label = "Message timestamp",
-            description = "Timestamp of the Slack message to unpin",
+            tooltip = "Timestamp of the Slack message to unpin",
             id = "unpinMessage.timestamp",
             group = "unpinMessage",
             feel = FeelMode.required,

--- a/connectors/slack/src/main/java/io/camunda/connector/slack/outbound/model/ReactionsAddData.java
+++ b/connectors/slack/src/main/java/io/camunda/connector/slack/outbound/model/ReactionsAddData.java
@@ -33,7 +33,7 @@ import java.io.IOException;
 public record ReactionsAddData(
     @TemplateProperty(
             label = "Channel",
-            description = "Channel ID of the message to react to",
+            tooltip = "Channel ID of the message to react to",
             id = "reaction.channel",
             group = "reaction",
             binding = @PropertyBinding(name = "data.channel"),
@@ -42,7 +42,7 @@ public record ReactionsAddData(
         String channel,
     @TemplateProperty(
             label = "Emoji name",
-            description = "Emoji name (e.g. eyes)",
+            placeholder = "eyes",
             id = "data.emoji",
             group = "reaction",
             binding = @PropertyBinding(name = "data.emoji"),
@@ -51,7 +51,7 @@ public record ReactionsAddData(
         String emoji,
     @TemplateProperty(
             label = "Message timestamp",
-            description = "Timestamp of the Slack message to react to",
+            tooltip = "Timestamp of the Slack message to react to",
             id = "data.timestamp",
             group = "reaction",
             feel = FeelMode.required,


### PR DESCRIPTION
Part of #7470. One of 8 review-sized slices of the `description` → `tooltip` migration (originally the umbrella PR #7651, split per review feedback for reviewability).

**Priority:** `tooltip` > `placeholder` > `description`. Field hints move to `tooltip=`; always-visible `description=` is kept only for value-constraints, `Note:`/`Warning:` markers, and genuinely critical guidance.

**Connectors in this slice:** Kafka, RabbitMQ, Slack (outbound + inbound).

Templates are regenerated from the migrated Java `@TemplateProperty` sources. The Webhook connector is intentionally **not** here — its model is shared with agentic-ai-owned a2a templates, so it is deferred to the `element-template-generator` follow-up.