### PR TITLE
refactor(idp-extraction): tooltip-first element-template field hints

### DIFF
--- a/connectors/idp-extraction/element-templates/hybrid/hybrid-idp-classification-outbound-connector-hybrid.json
+++ b/connectors/idp-extraction/element-templates/hybrid/hybrid-idp-classification-outbound-connector-hybrid.json
@@ -53,7 +53,6 @@
   }, {
     "id" : "input.converseData",
     "label" : "AWS Bedrock Converse Parameters",
-    "description" : "Specify the parameters for AWS Bedrock",
     "optional" : false,
     "value" : "={\n  modelId: \"\",\n  temperature: 0.5\n}",
     "feel" : "optional",
@@ -66,7 +65,6 @@
   }, {
     "id" : "input.documentTypes",
     "label" : "Document types",
-    "description" : "The possible classification types considered by the model",
     "optional" : false,
     "value" : "=[\n  {\n    name: \"\",\n    classificationInstructions: \"\",\n    description: \"\",\n    outputValue: \"\"\n  }\n]",
     "constraints" : {
@@ -78,11 +76,11 @@
       "name" : "input.documentTypes",
       "type" : "zeebe:input"
     },
+    "tooltip" : "The possible classification types considered by the model",
     "type" : "Text"
   }, {
     "id" : "input.fallbackOutputValue",
     "label" : "Fallback output value",
-    "description" : "The value to return if the model has low confidence on all document types.",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -93,11 +91,11 @@
       "name" : "input.fallbackOutputValue",
       "type" : "zeebe:input"
     },
+    "tooltip" : "The value to return if the model has low confidence on all document types.",
     "type" : "Text"
   }, {
     "id" : "input.document",
     "label" : "Document",
-    "description" : "Specify the document",
     "optional" : false,
     "value" : "=document",
     "constraints" : {
@@ -141,7 +139,6 @@
   }, {
     "id" : "extractor.endpoint",
     "label" : "Azure Document Intelligence Endpoint",
-    "description" : "Specify the endpoint of the Azure Document Intelligence",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -160,7 +157,6 @@
   }, {
     "id" : "extractor.apiKey",
     "label" : "Azure Document Intelligence API Key",
-    "description" : "Specify the API key of the Azure Document Intelligence",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -208,7 +204,6 @@
   }, {
     "id" : "extractor.bearerToken",
     "label" : "Bearer token",
-    "description" : "Enter a valid Google API Bearer token",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -230,11 +225,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Enter a valid Google API Bearer token",
     "type" : "String"
   }, {
     "id" : "extractor.oauthClientId",
     "label" : "Client ID",
-    "description" : "Enter Google API Client ID",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -256,11 +251,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Enter Google API Client ID",
     "type" : "String"
   }, {
     "id" : "extractor.oauthClientSecret",
     "label" : "Client secret",
-    "description" : "Enter Google API client Secret",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -282,11 +277,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Enter Google API client Secret",
     "type" : "String"
   }, {
     "id" : "extractor.oauthRefreshToken",
     "label" : "Refresh token",
-    "description" : "Enter a valid Google API refresh token",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -308,11 +303,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Enter a valid Google API refresh token",
     "type" : "String"
   }, {
     "id" : "extractor.serviceAccountJson",
     "label" : "Service account json",
-    "description" : "Enter a the contents of your service account json file",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -334,11 +329,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Enter the contents of your service account JSON file",
     "type" : "String"
   }, {
     "id" : "extractor.documentAiRegion",
     "label" : "Region",
-    "description" : "Select the region for Document AI",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -353,6 +348,7 @@
       "equals" : "documentAi",
       "type" : "simple"
     },
+    "tooltip" : "Select the region for Document AI",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "EU",
@@ -380,7 +376,6 @@
   }, {
     "id" : "extractor.processorId",
     "label" : "Processor ID",
-    "description" : "The id of the processor used to parse the document",
     "optional" : false,
     "feel" : "optional",
     "group" : "extractor",
@@ -393,6 +388,7 @@
       "equals" : "documentAi",
       "type" : "simple"
     },
+    "tooltip" : "The id of the processor used to parse the document",
     "type" : "String"
   }, {
     "id" : "extractor.awsAuthType",
@@ -423,7 +419,6 @@
   }, {
     "id" : "extractor.accessKey",
     "label" : "Access key",
-    "description" : "Provide an IAM access key tailored to a user, equipped with the necessary permissions",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -445,11 +440,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Provide an IAM access key tailored to a user, equipped with the necessary permissions",
     "type" : "String"
   }, {
     "id" : "extractor.secretKey",
     "label" : "Secret key",
-    "description" : "Provide a secret key of a user with permissions to invoke specified AWS Lambda function",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -471,11 +466,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Provide the AWS secret access key of a user with permissions for Amazon Textract and S3",
     "type" : "String"
   }, {
     "id" : "extractor.region",
     "label" : "Region",
-    "description" : "Specify the AWS region",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -490,11 +485,11 @@
       "equals" : "textract",
       "type" : "simple"
     },
+    "tooltip" : "Specify the AWS region",
     "type" : "Text"
   }, {
     "id" : "extractor.bucketName",
     "label" : "AWS S3 Bucket name",
-    "description" : "Specify the name of the AWS S3 bucket where document will be stored temporarily during Textract analysis",
     "optional" : false,
     "value" : "idp-extraction-connector",
     "constraints" : {
@@ -510,11 +505,11 @@
       "equals" : "textract",
       "type" : "simple"
     },
+    "tooltip" : "Specify the name of the AWS S3 bucket where document will be stored temporarily during Textract analysis",
     "type" : "Text"
   }, {
     "id" : "extractor.abbyyBaseUrl",
     "label" : "ABBYY Vantage Base URL",
-    "description" : "Base URL of the ABBYY Vantage instance (e.g., https://vantage-us.abbyy.com)",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -530,11 +525,12 @@
       "equals" : "abbyy",
       "type" : "simple"
     },
+    "tooltip" : "Base URL of the ABBYY Vantage instance",
+    "placeholder" : "https://vantage-us.abbyy.com",
     "type" : "Text"
   }, {
     "id" : "extractor.abbyyClientId",
     "label" : "Client ID",
-    "description" : "OAuth2 Client ID from ABBYY Vantage Public API Client settings",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -550,11 +546,11 @@
       "equals" : "abbyy",
       "type" : "simple"
     },
+    "tooltip" : "OAuth2 Client ID from ABBYY Vantage Public API Client settings",
     "type" : "Text"
   }, {
     "id" : "extractor.abbyyClientSecret",
     "label" : "Client Secret",
-    "description" : "OAuth2 Client Secret from ABBYY Vantage Public API Client settings",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -570,11 +566,11 @@
       "equals" : "abbyy",
       "type" : "simple"
     },
+    "tooltip" : "OAuth2 Client Secret from ABBYY Vantage Public API Client settings",
     "type" : "Text"
   }, {
     "id" : "extractor.abbyySkillId",
     "label" : "Skill ID",
-    "description" : "The ABBYY Vantage OCR skill ID (skill must be configured to output Text format)",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -590,6 +586,7 @@
       "equals" : "abbyy",
       "type" : "simple"
     },
+    "tooltip" : "The ABBYY Vantage OCR skill ID (skill must be configured to output Text format)",
     "type" : "Text"
   }, {
     "id" : "ai.type",
@@ -616,7 +613,6 @@
   }, {
     "id" : "ai.usingOpenAI",
     "label" : "Model type",
-    "description" : "Specify if the Azure AI Foundry is using OpenAI",
     "optional" : false,
     "value" : "false",
     "constraints" : {
@@ -632,6 +628,7 @@
       "equals" : "azureAiFoundry",
       "type" : "simple"
     },
+    "tooltip" : "Specify if the Azure AI Foundry is using OpenAI",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "Base Azure Foundry model",
@@ -643,7 +640,6 @@
   }, {
     "id" : "ai.endpoint",
     "label" : "Azure AI Endpoint",
-    "description" : "Specify the endpoint of Azure AI",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -662,7 +658,6 @@
   }, {
     "id" : "ai.apiKey",
     "label" : "Azure AI API Key",
-    "description" : "Specify the API key of Azure AI",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -707,7 +702,6 @@
   }, {
     "id" : "ai.accessKey",
     "label" : "Access key",
-    "description" : "Provide an IAM access key tailored to a user, equipped with the necessary permissions",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -729,11 +723,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Provide an IAM access key tailored to a user, equipped with the necessary permissions",
     "type" : "String"
   }, {
     "id" : "ai.secretKey",
     "label" : "Secret key",
-    "description" : "Provide a secret key of a user with permissions to invoke specified AWS Lambda function",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -755,11 +749,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Provide the AWS secret access key of a user with permissions for Amazon Bedrock",
     "type" : "String"
   }, {
     "id" : "ai.region",
     "label" : "Region",
-    "description" : "Specify the AWS region",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -774,11 +768,11 @@
       "equals" : "bedrockAi",
       "type" : "simple"
     },
+    "tooltip" : "Specify the AWS region",
     "type" : "Text"
   }, {
     "id" : "ai.openAiEndpoint",
     "label" : "OpenAI Spec Endpoint",
-    "description" : "Specify the OpenAI compatible specification endpoint.",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -793,11 +787,11 @@
       "equals" : "openAi",
       "type" : "simple"
     },
+    "tooltip" : "The OpenAI-compatible specification endpoint.",
     "type" : "Text"
   }, {
     "id" : "ai.openAiHeaders",
     "label" : "Headers",
-    "description" : "Map of HTTP headers to add to the request.",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -812,6 +806,7 @@
       "equals" : "openAi",
       "type" : "simple"
     },
+    "tooltip" : "Map of HTTP headers to add to the request.",
     "type" : "String"
   }, {
     "id" : "ai.authType",
@@ -845,7 +840,6 @@
   }, {
     "id" : "ai.bearerToken",
     "label" : "Bearer token",
-    "description" : "Enter a valid Google API Bearer token",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -867,11 +861,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Enter a valid Google API Bearer token",
     "type" : "String"
   }, {
     "id" : "ai.oauthClientId",
     "label" : "Client ID",
-    "description" : "Enter Google API Client ID",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -893,11 +887,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Enter Google API Client ID",
     "type" : "String"
   }, {
     "id" : "ai.oauthClientSecret",
     "label" : "Client secret",
-    "description" : "Enter Google API client Secret",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -919,11 +913,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Enter Google API client Secret",
     "type" : "String"
   }, {
     "id" : "ai.oauthRefreshToken",
     "label" : "Refresh token",
-    "description" : "Enter a valid Google API refresh token",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -945,11 +939,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Enter a valid Google API refresh token",
     "type" : "String"
   }, {
     "id" : "ai.serviceAccountJson",
     "label" : "Service account json",
-    "description" : "Enter a the contents of your service account json file",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -971,6 +965,7 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Enter the contents of your service account JSON file",
     "type" : "String"
   }, {
     "id" : "ai.gcpRegion",

--- a/connectors/idp-extraction/element-templates/hybrid/hybrid-idp-classification-outbound-connector-hybrid.json
+++ b/connectors/idp-extraction/element-templates/hybrid/hybrid-idp-classification-outbound-connector-hybrid.json
@@ -225,7 +225,6 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "Enter a valid Google API Bearer token",
     "type" : "String"
   }, {
     "id" : "extractor.oauthClientId",
@@ -251,7 +250,6 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "Enter Google API Client ID",
     "type" : "String"
   }, {
     "id" : "extractor.oauthClientSecret",
@@ -277,7 +275,6 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "Enter Google API client Secret",
     "type" : "String"
   }, {
     "id" : "extractor.oauthRefreshToken",
@@ -303,7 +300,6 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "Enter a valid Google API refresh token",
     "type" : "String"
   }, {
     "id" : "extractor.serviceAccountJson",
@@ -348,7 +344,7 @@
       "equals" : "documentAi",
       "type" : "simple"
     },
-    "tooltip" : "Select the region for Document AI",
+    "tooltip" : "Geographic location where the Document AI processor runs. EU = European Union, US = United States.",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "EU",
@@ -388,7 +384,7 @@
       "equals" : "documentAi",
       "type" : "simple"
     },
-    "tooltip" : "The id of the processor used to parse the document",
+    "tooltip" : "Processor used to parse the document",
     "type" : "String"
   }, {
     "id" : "extractor.awsAuthType",
@@ -440,7 +436,7 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "Provide an IAM access key tailored to a user, equipped with the necessary permissions",
+    "tooltip" : "IAM access key of a user with the necessary permissions",
     "type" : "String"
   }, {
     "id" : "extractor.secretKey",
@@ -466,7 +462,7 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "Provide the AWS secret access key of a user with permissions for Amazon Textract and S3",
+    "tooltip" : "AWS secret access key of a user with permissions for Amazon Textract and S3",
     "type" : "String"
   }, {
     "id" : "extractor.region",
@@ -485,7 +481,6 @@
       "equals" : "textract",
       "type" : "simple"
     },
-    "tooltip" : "Specify the AWS region",
     "type" : "Text"
   }, {
     "id" : "extractor.bucketName",
@@ -505,7 +500,7 @@
       "equals" : "textract",
       "type" : "simple"
     },
-    "tooltip" : "Specify the name of the AWS S3 bucket where document will be stored temporarily during Textract analysis",
+    "tooltip" : "Where the document will be stored temporarily during Textract analysis",
     "type" : "Text"
   }, {
     "id" : "extractor.abbyyBaseUrl",
@@ -525,7 +520,6 @@
       "equals" : "abbyy",
       "type" : "simple"
     },
-    "tooltip" : "Base URL of the ABBYY Vantage instance",
     "placeholder" : "https://vantage-us.abbyy.com",
     "type" : "Text"
   }, {
@@ -586,7 +580,7 @@
       "equals" : "abbyy",
       "type" : "simple"
     },
-    "tooltip" : "The ABBYY Vantage OCR skill ID (skill must be configured to output Text format)",
+    "tooltip" : "The skill must be configured to output Text format.",
     "type" : "Text"
   }, {
     "id" : "ai.type",
@@ -628,7 +622,7 @@
       "equals" : "azureAiFoundry",
       "type" : "simple"
     },
-    "tooltip" : "Specify if the Azure AI Foundry is using OpenAI",
+    "tooltip" : "Base Azure Foundry model = a model deployed directly in Azure AI Foundry; Azure OpenAI model = a model served through Azure OpenAI.",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "Base Azure Foundry model",
@@ -768,7 +762,6 @@
       "equals" : "bedrockAi",
       "type" : "simple"
     },
-    "tooltip" : "Specify the AWS region",
     "type" : "Text"
   }, {
     "id" : "ai.openAiEndpoint",
@@ -787,7 +780,6 @@
       "equals" : "openAi",
       "type" : "simple"
     },
-    "tooltip" : "The OpenAI-compatible specification endpoint.",
     "type" : "Text"
   }, {
     "id" : "ai.openAiHeaders",
@@ -861,7 +853,6 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "Enter a valid Google API Bearer token",
     "type" : "String"
   }, {
     "id" : "ai.oauthClientId",
@@ -887,7 +878,6 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "Enter Google API Client ID",
     "type" : "String"
   }, {
     "id" : "ai.oauthClientSecret",
@@ -913,7 +903,6 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "Enter Google API client Secret",
     "type" : "String"
   }, {
     "id" : "ai.oauthRefreshToken",
@@ -939,7 +928,6 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "Enter a valid Google API refresh token",
     "type" : "String"
   }, {
     "id" : "ai.serviceAccountJson",
@@ -965,7 +953,7 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "Enter the contents of your service account JSON file",
+    "tooltip" : "Contents of your service account JSON file",
     "type" : "String"
   }, {
     "id" : "ai.gcpRegion",

--- a/connectors/idp-extraction/element-templates/hybrid/hybrid-idp-extraction-outbound-connector-hybrid.json
+++ b/connectors/idp-extraction/element-templates/hybrid/hybrid-idp-extraction-outbound-connector-hybrid.json
@@ -293,7 +293,6 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "Enter a valid Google API Bearer token",
     "type" : "String"
   }, {
     "id" : "baseRequest.authentication.oauthClientId",
@@ -319,7 +318,6 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "Enter Google API Client ID",
     "type" : "String"
   }, {
     "id" : "baseRequest.authentication.oauthClientSecret",
@@ -345,7 +343,6 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "Enter Google API client Secret",
     "type" : "String"
   }, {
     "id" : "baseRequest.authentication.oauthRefreshToken",
@@ -371,7 +368,6 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "Enter a valid Google API refresh token",
     "type" : "String"
   }, {
     "id" : "baseRequest.authentication.serviceAccountJson",
@@ -417,7 +413,7 @@
       "equals" : "aws",
       "type" : "simple"
     },
-    "tooltip" : "Specify the name of the AWS S3 bucket where document will be stored temporarily during Textract analysis",
+    "tooltip" : "Where the document will be stored temporarily during Textract analysis",
     "type" : "Text"
   }, {
     "id" : "baseRequest.extractionEngineType",
@@ -534,7 +530,7 @@
       "equals" : "azure",
       "type" : "simple"
     },
-    "tooltip" : "Specify if the Azure AI Foundry is using OpenAI",
+    "tooltip" : "Base Azure Foundry model = a model deployed directly in Azure AI Foundry; Azure OpenAI model = an OpenAI model served through Azure OpenAI",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "Base Azure Foundry model",
@@ -733,7 +729,7 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "The id of the processor used to parse the document",
+    "tooltip" : "Processor used to parse the document",
     "type" : "String"
   }, {
     "id" : "baseRequest.openAiEndpoint",

--- a/connectors/idp-extraction/element-templates/hybrid/hybrid-idp-extraction-outbound-connector-hybrid.json
+++ b/connectors/idp-extraction/element-templates/hybrid/hybrid-idp-extraction-outbound-connector-hybrid.json
@@ -272,7 +272,6 @@
   }, {
     "id" : "baseRequest.authentication.bearerToken",
     "label" : "Bearer token",
-    "description" : "Enter a valid Google API Bearer token",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -294,11 +293,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Enter a valid Google API Bearer token",
     "type" : "String"
   }, {
     "id" : "baseRequest.authentication.oauthClientId",
     "label" : "Client ID",
-    "description" : "Enter Google API Client ID",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -320,11 +319,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Enter Google API Client ID",
     "type" : "String"
   }, {
     "id" : "baseRequest.authentication.oauthClientSecret",
     "label" : "Client secret",
-    "description" : "Enter Google API client Secret",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -346,11 +345,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Enter Google API client Secret",
     "type" : "String"
   }, {
     "id" : "baseRequest.authentication.oauthRefreshToken",
     "label" : "Refresh token",
-    "description" : "Enter a valid Google API refresh token",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -372,11 +371,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Enter a valid Google API refresh token",
     "type" : "String"
   }, {
     "id" : "baseRequest.authentication.serviceAccountJson",
     "label" : "Service account json",
-    "description" : "Enter a the contents of your service account json file",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -398,11 +397,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Enter the contents of your service account JSON file",
     "type" : "String"
   }, {
     "id" : "baseRequest.s3BucketName",
     "label" : "AWS S3 Bucket name",
-    "description" : "Specify the name of the AWS S3 bucket where document will be stored temporarily during Textract analysis",
     "optional" : false,
     "value" : "idp-extraction-connector",
     "constraints" : {
@@ -418,11 +417,11 @@
       "equals" : "aws",
       "type" : "simple"
     },
+    "tooltip" : "Specify the name of the AWS S3 bucket where document will be stored temporarily during Textract analysis",
     "type" : "Text"
   }, {
     "id" : "baseRequest.extractionEngineType",
     "label" : "Extraction engine type",
-    "description" : "Specify extraction engine to be used",
     "optional" : false,
     "value" : "AWS_TEXTRACT",
     "constraints" : {
@@ -484,7 +483,6 @@
   }, {
     "id" : "baseRequest.documentIntelligenceConfiguration.endpoint",
     "label" : "Azure Document Intelligence Endpoint",
-    "description" : "Specify the endpoint of the Azure Document Intelligence",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -503,7 +501,6 @@
   }, {
     "id" : "baseRequest.documentIntelligenceConfiguration.apiKey",
     "label" : "Azure Document Intelligence API Key",
-    "description" : "Specify the API key of the Azure Document Intelligence",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -522,7 +519,6 @@
   }, {
     "id" : "baseRequest.aiFoundryConfig.usingOpenAI",
     "label" : "Model type",
-    "description" : "Specify if the Azure AI Foundry is using OpenAI",
     "optional" : false,
     "value" : "false",
     "constraints" : {
@@ -538,6 +534,7 @@
       "equals" : "azure",
       "type" : "simple"
     },
+    "tooltip" : "Specify if the Azure AI Foundry is using OpenAI",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "Base Azure Foundry model",
@@ -549,7 +546,6 @@
   }, {
     "id" : "baseRequest.aiFoundryConfig.endpoint",
     "label" : "Azure AI Foundry Endpoint",
-    "description" : "Specify the endpoint of the Azure AI Foundry",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -568,7 +564,6 @@
   }, {
     "id" : "baseRequest.aiFoundryConfig.apiKey",
     "label" : "Azure AI Foundry API Key",
-    "description" : "Specify the API key of the Azure AI Foundry",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -652,7 +647,6 @@
   }, {
     "id" : "baseRequest.configuration.bucketName",
     "label" : "Bucket name",
-    "description" : "The Google Cloud Storage bucket where the document will be temporarily stored",
     "optional" : false,
     "feel" : "optional",
     "group" : "configuration",
@@ -671,11 +665,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "The Google Cloud Storage bucket where the document will be temporarily stored",
     "type" : "String"
   }, {
     "id" : "baseRequest.configuration.documentAiRegion",
     "label" : "Region",
-    "description" : "Can be 'eu' or 'us'",
     "optional" : false,
     "feel" : "optional",
     "group" : "configuration",
@@ -694,6 +688,7 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Can be 'eu' or 'us'",
     "type" : "String"
   }, {
     "id" : "baseRequest.configuration.projectId",
@@ -720,7 +715,6 @@
   }, {
     "id" : "baseRequest.configuration.processorId",
     "label" : "Processor ID",
-    "description" : "The id of the processor used to parse the document",
     "optional" : false,
     "feel" : "optional",
     "group" : "configuration",
@@ -739,11 +733,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "The id of the processor used to parse the document",
     "type" : "String"
   }, {
     "id" : "baseRequest.openAiEndpoint",
     "label" : "OpenAI Spec Endpoint",
-    "description" : "Specify the OpenAI compatible specification endpoint.",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -758,11 +752,11 @@
       "equals" : "openai",
       "type" : "simple"
     },
+    "tooltip" : "The OpenAI-compatible specification endpoint.",
     "type" : "Text"
   }, {
     "id" : "baseRequest.openAiHeaders",
     "label" : "Headers",
-    "description" : "Map of HTTP headers to add to the request.",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -777,6 +771,7 @@
       "equals" : "openai",
       "type" : "simple"
     },
+    "tooltip" : "Map of HTTP headers to add to the request.",
     "type" : "String"
   }, {
     "id" : "version",

--- a/connectors/idp-extraction/element-templates/hybrid/hybrid-idp-structured-extraction-outbound-connector-hybrid.json
+++ b/connectors/idp-extraction/element-templates/hybrid/hybrid-idp-structured-extraction-outbound-connector-hybrid.json
@@ -216,7 +216,6 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "Enter a valid Google API Bearer token",
     "type" : "String"
   }, {
     "id" : "extractor.oauthClientId",
@@ -242,7 +241,6 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "Enter Google API Client ID",
     "type" : "String"
   }, {
     "id" : "extractor.oauthClientSecret",
@@ -268,7 +266,6 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "Enter Google API client Secret",
     "type" : "String"
   }, {
     "id" : "extractor.oauthRefreshToken",
@@ -294,7 +291,6 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "Enter a valid Google API refresh token",
     "type" : "String"
   }, {
     "id" : "extractor.serviceAccountJson",
@@ -339,7 +335,7 @@
       "equals" : "documentAi",
       "type" : "simple"
     },
-    "tooltip" : "Select the region for Document AI",
+    "tooltip" : "Geographic location where the Document AI processor runs. EU = European Union, US = United States.",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "EU",
@@ -379,7 +375,7 @@
       "equals" : "documentAi",
       "type" : "simple"
     },
-    "tooltip" : "The id of the processor used to parse the document",
+    "tooltip" : "Processor used to parse the document",
     "type" : "String"
   }, {
     "id" : "extractor.awsAuthType",
@@ -431,7 +427,7 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "Provide an IAM access key tailored to a user, equipped with the necessary permissions",
+    "tooltip" : "IAM access key of a user with the necessary permissions",
     "type" : "String"
   }, {
     "id" : "extractor.secretKey",
@@ -457,7 +453,7 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "Provide the AWS secret access key of a user with permissions for Amazon Textract and S3",
+    "tooltip" : "AWS secret access key of a user with permissions for Amazon Textract and S3",
     "type" : "String"
   }, {
     "id" : "extractor.region",
@@ -476,7 +472,6 @@
       "equals" : "textract",
       "type" : "simple"
     },
-    "tooltip" : "Specify the AWS region",
     "type" : "Text"
   }, {
     "id" : "extractor.bucketName",
@@ -496,7 +491,7 @@
       "equals" : "textract",
       "type" : "simple"
     },
-    "tooltip" : "Specify the name of the AWS S3 bucket where document will be stored temporarily during Textract analysis",
+    "tooltip" : "Where the document will be stored temporarily during Textract analysis",
     "type" : "Text"
   }, {
     "id" : "extractor.abbyyBaseUrl",
@@ -516,7 +511,6 @@
       "equals" : "abbyy",
       "type" : "simple"
     },
-    "tooltip" : "Base URL of the ABBYY Vantage instance",
     "placeholder" : "https://vantage-us.abbyy.com",
     "type" : "Text"
   }, {
@@ -577,7 +571,7 @@
       "equals" : "abbyy",
       "type" : "simple"
     },
-    "tooltip" : "The ABBYY Vantage OCR skill ID (skill must be configured to output Text format)",
+    "tooltip" : "The skill must be configured to output Text format.",
     "type" : "Text"
   }, {
     "id" : "version",

--- a/connectors/idp-extraction/element-templates/hybrid/hybrid-idp-structured-extraction-outbound-connector-hybrid.json
+++ b/connectors/idp-extraction/element-templates/hybrid/hybrid-idp-structured-extraction-outbound-connector-hybrid.json
@@ -50,7 +50,6 @@
   }, {
     "id" : "input.includedFields",
     "label" : "Included Fields",
-    "description" : "List of fields that should be returned from the extraction",
     "optional" : false,
     "value" : "=[\n  \n]",
     "feel" : "optional",
@@ -59,11 +58,11 @@
       "name" : "input.includedFields",
       "type" : "zeebe:input"
     },
+    "tooltip" : "List of fields that should be returned from the extraction",
     "type" : "String"
   }, {
     "id" : "input.renameMappings",
     "label" : "Rename mappings",
-    "description" : "List of keys that should be renamed and not be given the default name",
     "optional" : false,
     "value" : "={\n  \n}",
     "feel" : "optional",
@@ -72,22 +71,22 @@
       "name" : "input.renameMappings",
       "type" : "zeebe:input"
     },
+    "tooltip" : "List of keys that should be renamed and not be given the default name",
     "type" : "String"
   }, {
     "id" : "input.delimiter",
     "label" : "delimiter",
-    "description" : "The delimiter used for the variable name of the extracted field",
     "optional" : false,
     "group" : "input",
     "binding" : {
       "name" : "input.delimiter",
       "type" : "zeebe:input"
     },
+    "tooltip" : "The delimiter used for the variable name of the extracted field",
     "type" : "String"
   }, {
     "id" : "input.document",
     "label" : "Document",
-    "description" : "Specify the document",
     "optional" : false,
     "value" : "=document",
     "constraints" : {
@@ -131,7 +130,6 @@
   }, {
     "id" : "extractor.endpoint",
     "label" : "Azure Document Intelligence Endpoint",
-    "description" : "Specify the endpoint of the Azure Document Intelligence",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -150,7 +148,6 @@
   }, {
     "id" : "extractor.apiKey",
     "label" : "Azure Document Intelligence API Key",
-    "description" : "Specify the API key of the Azure Document Intelligence",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -198,7 +195,6 @@
   }, {
     "id" : "extractor.bearerToken",
     "label" : "Bearer token",
-    "description" : "Enter a valid Google API Bearer token",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -220,11 +216,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Enter a valid Google API Bearer token",
     "type" : "String"
   }, {
     "id" : "extractor.oauthClientId",
     "label" : "Client ID",
-    "description" : "Enter Google API Client ID",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -246,11 +242,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Enter Google API Client ID",
     "type" : "String"
   }, {
     "id" : "extractor.oauthClientSecret",
     "label" : "Client secret",
-    "description" : "Enter Google API client Secret",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -272,11 +268,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Enter Google API client Secret",
     "type" : "String"
   }, {
     "id" : "extractor.oauthRefreshToken",
     "label" : "Refresh token",
-    "description" : "Enter a valid Google API refresh token",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -298,11 +294,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Enter a valid Google API refresh token",
     "type" : "String"
   }, {
     "id" : "extractor.serviceAccountJson",
     "label" : "Service account json",
-    "description" : "Enter a the contents of your service account json file",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -324,11 +320,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Enter the contents of your service account JSON file",
     "type" : "String"
   }, {
     "id" : "extractor.documentAiRegion",
     "label" : "Region",
-    "description" : "Select the region for Document AI",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -343,6 +339,7 @@
       "equals" : "documentAi",
       "type" : "simple"
     },
+    "tooltip" : "Select the region for Document AI",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "EU",
@@ -370,7 +367,6 @@
   }, {
     "id" : "extractor.processorId",
     "label" : "Processor ID",
-    "description" : "The id of the processor used to parse the document",
     "optional" : false,
     "feel" : "optional",
     "group" : "extractor",
@@ -383,6 +379,7 @@
       "equals" : "documentAi",
       "type" : "simple"
     },
+    "tooltip" : "The id of the processor used to parse the document",
     "type" : "String"
   }, {
     "id" : "extractor.awsAuthType",
@@ -413,7 +410,6 @@
   }, {
     "id" : "extractor.accessKey",
     "label" : "Access key",
-    "description" : "Provide an IAM access key tailored to a user, equipped with the necessary permissions",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -435,11 +431,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Provide an IAM access key tailored to a user, equipped with the necessary permissions",
     "type" : "String"
   }, {
     "id" : "extractor.secretKey",
     "label" : "Secret key",
-    "description" : "Provide a secret key of a user with permissions to invoke specified AWS Lambda function",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -461,11 +457,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Provide the AWS secret access key of a user with permissions for Amazon Textract and S3",
     "type" : "String"
   }, {
     "id" : "extractor.region",
     "label" : "Region",
-    "description" : "Specify the AWS region",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -480,11 +476,11 @@
       "equals" : "textract",
       "type" : "simple"
     },
+    "tooltip" : "Specify the AWS region",
     "type" : "Text"
   }, {
     "id" : "extractor.bucketName",
     "label" : "AWS S3 Bucket name",
-    "description" : "Specify the name of the AWS S3 bucket where document will be stored temporarily during Textract analysis",
     "optional" : false,
     "value" : "idp-extraction-connector",
     "constraints" : {
@@ -500,11 +496,11 @@
       "equals" : "textract",
       "type" : "simple"
     },
+    "tooltip" : "Specify the name of the AWS S3 bucket where document will be stored temporarily during Textract analysis",
     "type" : "Text"
   }, {
     "id" : "extractor.abbyyBaseUrl",
     "label" : "ABBYY Vantage Base URL",
-    "description" : "Base URL of the ABBYY Vantage instance (e.g., https://vantage-us.abbyy.com)",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -520,11 +516,12 @@
       "equals" : "abbyy",
       "type" : "simple"
     },
+    "tooltip" : "Base URL of the ABBYY Vantage instance",
+    "placeholder" : "https://vantage-us.abbyy.com",
     "type" : "Text"
   }, {
     "id" : "extractor.abbyyClientId",
     "label" : "Client ID",
-    "description" : "OAuth2 Client ID from ABBYY Vantage Public API Client settings",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -540,11 +537,11 @@
       "equals" : "abbyy",
       "type" : "simple"
     },
+    "tooltip" : "OAuth2 Client ID from ABBYY Vantage Public API Client settings",
     "type" : "Text"
   }, {
     "id" : "extractor.abbyyClientSecret",
     "label" : "Client Secret",
-    "description" : "OAuth2 Client Secret from ABBYY Vantage Public API Client settings",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -560,11 +557,11 @@
       "equals" : "abbyy",
       "type" : "simple"
     },
+    "tooltip" : "OAuth2 Client Secret from ABBYY Vantage Public API Client settings",
     "type" : "Text"
   }, {
     "id" : "extractor.abbyySkillId",
     "label" : "Skill ID",
-    "description" : "The ABBYY Vantage OCR skill ID (skill must be configured to output Text format)",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -580,6 +577,7 @@
       "equals" : "abbyy",
       "type" : "simple"
     },
+    "tooltip" : "The ABBYY Vantage OCR skill ID (skill must be configured to output Text format)",
     "type" : "Text"
   }, {
     "id" : "version",

--- a/connectors/idp-extraction/element-templates/hybrid/hybrid-idp-unstructured-extraction-outbound-connector-hybrid.json
+++ b/connectors/idp-extraction/element-templates/hybrid/hybrid-idp-unstructured-extraction-outbound-connector-hybrid.json
@@ -61,7 +61,6 @@
       "name" : "input.taxonomyItems",
       "type" : "zeebe:input"
     },
-    "tooltip" : "Array of taxonomy items",
     "type" : "Text"
   }, {
     "id" : "input.converseData",
@@ -207,7 +206,6 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "Enter a valid Google API Bearer token",
     "type" : "String"
   }, {
     "id" : "extractor.oauthClientId",
@@ -233,7 +231,6 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "Enter Google API Client ID",
     "type" : "String"
   }, {
     "id" : "extractor.oauthClientSecret",
@@ -259,7 +256,6 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "Enter Google API client Secret",
     "type" : "String"
   }, {
     "id" : "extractor.oauthRefreshToken",
@@ -285,7 +281,6 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "Enter a valid Google API refresh token",
     "type" : "String"
   }, {
     "id" : "extractor.serviceAccountJson",
@@ -330,7 +325,7 @@
       "equals" : "documentAi",
       "type" : "simple"
     },
-    "tooltip" : "Select the region for Document AI",
+    "tooltip" : "Geographic location where the Document AI processor runs. EU = European Union, US = United States.",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "EU",
@@ -370,7 +365,7 @@
       "equals" : "documentAi",
       "type" : "simple"
     },
-    "tooltip" : "The id of the processor used to parse the document",
+    "tooltip" : "Processor used to parse the document",
     "type" : "String"
   }, {
     "id" : "extractor.awsAuthType",
@@ -422,7 +417,7 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "Provide an IAM access key tailored to a user, equipped with the necessary permissions",
+    "tooltip" : "IAM access key of a user with the necessary permissions",
     "type" : "String"
   }, {
     "id" : "extractor.secretKey",
@@ -448,7 +443,7 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "Provide the AWS secret access key of a user with permissions for Amazon Textract and S3",
+    "tooltip" : "AWS secret access key of a user with permissions for Amazon Textract and S3",
     "type" : "String"
   }, {
     "id" : "extractor.region",
@@ -467,7 +462,6 @@
       "equals" : "textract",
       "type" : "simple"
     },
-    "tooltip" : "Specify the AWS region",
     "type" : "Text"
   }, {
     "id" : "extractor.bucketName",
@@ -487,7 +481,7 @@
       "equals" : "textract",
       "type" : "simple"
     },
-    "tooltip" : "Specify the name of the AWS S3 bucket where document will be stored temporarily during Textract analysis",
+    "tooltip" : "Where the document will be stored temporarily during Textract analysis",
     "type" : "Text"
   }, {
     "id" : "extractor.abbyyBaseUrl",
@@ -507,7 +501,6 @@
       "equals" : "abbyy",
       "type" : "simple"
     },
-    "tooltip" : "Base URL of the ABBYY Vantage instance",
     "placeholder" : "https://vantage-us.abbyy.com",
     "type" : "Text"
   }, {
@@ -568,7 +561,7 @@
       "equals" : "abbyy",
       "type" : "simple"
     },
-    "tooltip" : "The ABBYY Vantage OCR skill ID (skill must be configured to output Text format)",
+    "tooltip" : "The skill must be configured to output Text format.",
     "type" : "Text"
   }, {
     "id" : "ai.type",
@@ -610,7 +603,7 @@
       "equals" : "azureAiFoundry",
       "type" : "simple"
     },
-    "tooltip" : "Specify if the Azure AI Foundry is using OpenAI",
+    "tooltip" : "Base Azure Foundry model = a model deployed directly in Azure AI Foundry; Azure OpenAI model = a model served through Azure OpenAI.",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "Base Azure Foundry model",
@@ -750,7 +743,6 @@
       "equals" : "bedrockAi",
       "type" : "simple"
     },
-    "tooltip" : "Specify the AWS region",
     "type" : "Text"
   }, {
     "id" : "ai.openAiEndpoint",
@@ -769,7 +761,6 @@
       "equals" : "openAi",
       "type" : "simple"
     },
-    "tooltip" : "The OpenAI-compatible specification endpoint.",
     "type" : "Text"
   }, {
     "id" : "ai.openAiHeaders",
@@ -843,7 +834,6 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "Enter a valid Google API Bearer token",
     "type" : "String"
   }, {
     "id" : "ai.oauthClientId",
@@ -869,7 +859,6 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "Enter Google API Client ID",
     "type" : "String"
   }, {
     "id" : "ai.oauthClientSecret",
@@ -895,7 +884,6 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "Enter Google API client Secret",
     "type" : "String"
   }, {
     "id" : "ai.oauthRefreshToken",
@@ -921,7 +909,6 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "Enter a valid Google API refresh token",
     "type" : "String"
   }, {
     "id" : "ai.serviceAccountJson",
@@ -947,7 +934,7 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "Enter the contents of your service account JSON file",
+    "tooltip" : "Contents of your service account JSON file",
     "type" : "String"
   }, {
     "id" : "ai.gcpRegion",

--- a/connectors/idp-extraction/element-templates/hybrid/hybrid-idp-unstructured-extraction-outbound-connector-hybrid.json
+++ b/connectors/idp-extraction/element-templates/hybrid/hybrid-idp-unstructured-extraction-outbound-connector-hybrid.json
@@ -53,7 +53,6 @@
   }, {
     "id" : "input.taxonomyItems",
     "label" : "Taxonomy Items",
-    "description" : "Array of taxonomy items",
     "optional" : false,
     "value" : "=[\n  {name: \"\", prompt: \"\"},\n  {name: \"\", prompt: \"\"}\n]",
     "feel" : "optional",
@@ -62,11 +61,11 @@
       "name" : "input.taxonomyItems",
       "type" : "zeebe:input"
     },
+    "tooltip" : "Array of taxonomy items",
     "type" : "Text"
   }, {
     "id" : "input.converseData",
     "label" : "Ai converse parameters",
-    "description" : "Specify the parameters for the ai conversation",
     "optional" : false,
     "value" : "={\n  modelId: \"\",\n  temperature: 0.5\n}",
     "feel" : "optional",
@@ -79,7 +78,6 @@
   }, {
     "id" : "input.document",
     "label" : "Document",
-    "description" : "Specify the document",
     "optional" : false,
     "value" : "=document",
     "constraints" : {
@@ -123,7 +121,6 @@
   }, {
     "id" : "extractor.endpoint",
     "label" : "Azure Document Intelligence Endpoint",
-    "description" : "Specify the endpoint of the Azure Document Intelligence",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -142,7 +139,6 @@
   }, {
     "id" : "extractor.apiKey",
     "label" : "Azure Document Intelligence API Key",
-    "description" : "Specify the API key of the Azure Document Intelligence",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -190,7 +186,6 @@
   }, {
     "id" : "extractor.bearerToken",
     "label" : "Bearer token",
-    "description" : "Enter a valid Google API Bearer token",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -212,11 +207,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Enter a valid Google API Bearer token",
     "type" : "String"
   }, {
     "id" : "extractor.oauthClientId",
     "label" : "Client ID",
-    "description" : "Enter Google API Client ID",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -238,11 +233,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Enter Google API Client ID",
     "type" : "String"
   }, {
     "id" : "extractor.oauthClientSecret",
     "label" : "Client secret",
-    "description" : "Enter Google API client Secret",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -264,11 +259,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Enter Google API client Secret",
     "type" : "String"
   }, {
     "id" : "extractor.oauthRefreshToken",
     "label" : "Refresh token",
-    "description" : "Enter a valid Google API refresh token",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -290,11 +285,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Enter a valid Google API refresh token",
     "type" : "String"
   }, {
     "id" : "extractor.serviceAccountJson",
     "label" : "Service account json",
-    "description" : "Enter a the contents of your service account json file",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -316,11 +311,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Enter the contents of your service account JSON file",
     "type" : "String"
   }, {
     "id" : "extractor.documentAiRegion",
     "label" : "Region",
-    "description" : "Select the region for Document AI",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -335,6 +330,7 @@
       "equals" : "documentAi",
       "type" : "simple"
     },
+    "tooltip" : "Select the region for Document AI",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "EU",
@@ -362,7 +358,6 @@
   }, {
     "id" : "extractor.processorId",
     "label" : "Processor ID",
-    "description" : "The id of the processor used to parse the document",
     "optional" : false,
     "feel" : "optional",
     "group" : "extractor",
@@ -375,6 +370,7 @@
       "equals" : "documentAi",
       "type" : "simple"
     },
+    "tooltip" : "The id of the processor used to parse the document",
     "type" : "String"
   }, {
     "id" : "extractor.awsAuthType",
@@ -405,7 +401,6 @@
   }, {
     "id" : "extractor.accessKey",
     "label" : "Access key",
-    "description" : "Provide an IAM access key tailored to a user, equipped with the necessary permissions",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -427,11 +422,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Provide an IAM access key tailored to a user, equipped with the necessary permissions",
     "type" : "String"
   }, {
     "id" : "extractor.secretKey",
     "label" : "Secret key",
-    "description" : "Provide a secret key of a user with permissions to invoke specified AWS Lambda function",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -453,11 +448,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Provide the AWS secret access key of a user with permissions for Amazon Textract and S3",
     "type" : "String"
   }, {
     "id" : "extractor.region",
     "label" : "Region",
-    "description" : "Specify the AWS region",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -472,11 +467,11 @@
       "equals" : "textract",
       "type" : "simple"
     },
+    "tooltip" : "Specify the AWS region",
     "type" : "Text"
   }, {
     "id" : "extractor.bucketName",
     "label" : "AWS S3 Bucket name",
-    "description" : "Specify the name of the AWS S3 bucket where document will be stored temporarily during Textract analysis",
     "optional" : false,
     "value" : "idp-extraction-connector",
     "constraints" : {
@@ -492,11 +487,11 @@
       "equals" : "textract",
       "type" : "simple"
     },
+    "tooltip" : "Specify the name of the AWS S3 bucket where document will be stored temporarily during Textract analysis",
     "type" : "Text"
   }, {
     "id" : "extractor.abbyyBaseUrl",
     "label" : "ABBYY Vantage Base URL",
-    "description" : "Base URL of the ABBYY Vantage instance (e.g., https://vantage-us.abbyy.com)",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -512,11 +507,12 @@
       "equals" : "abbyy",
       "type" : "simple"
     },
+    "tooltip" : "Base URL of the ABBYY Vantage instance",
+    "placeholder" : "https://vantage-us.abbyy.com",
     "type" : "Text"
   }, {
     "id" : "extractor.abbyyClientId",
     "label" : "Client ID",
-    "description" : "OAuth2 Client ID from ABBYY Vantage Public API Client settings",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -532,11 +528,11 @@
       "equals" : "abbyy",
       "type" : "simple"
     },
+    "tooltip" : "OAuth2 Client ID from ABBYY Vantage Public API Client settings",
     "type" : "Text"
   }, {
     "id" : "extractor.abbyyClientSecret",
     "label" : "Client Secret",
-    "description" : "OAuth2 Client Secret from ABBYY Vantage Public API Client settings",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -552,11 +548,11 @@
       "equals" : "abbyy",
       "type" : "simple"
     },
+    "tooltip" : "OAuth2 Client Secret from ABBYY Vantage Public API Client settings",
     "type" : "Text"
   }, {
     "id" : "extractor.abbyySkillId",
     "label" : "Skill ID",
-    "description" : "The ABBYY Vantage OCR skill ID (skill must be configured to output Text format)",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -572,6 +568,7 @@
       "equals" : "abbyy",
       "type" : "simple"
     },
+    "tooltip" : "The ABBYY Vantage OCR skill ID (skill must be configured to output Text format)",
     "type" : "Text"
   }, {
     "id" : "ai.type",
@@ -598,7 +595,6 @@
   }, {
     "id" : "ai.usingOpenAI",
     "label" : "Model type",
-    "description" : "Specify if the Azure AI Foundry is using OpenAI",
     "optional" : false,
     "value" : "false",
     "constraints" : {
@@ -614,6 +610,7 @@
       "equals" : "azureAiFoundry",
       "type" : "simple"
     },
+    "tooltip" : "Specify if the Azure AI Foundry is using OpenAI",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "Base Azure Foundry model",
@@ -625,7 +622,6 @@
   }, {
     "id" : "ai.endpoint",
     "label" : "Azure AI Endpoint",
-    "description" : "Specify the endpoint of Azure AI",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -644,7 +640,6 @@
   }, {
     "id" : "ai.apiKey",
     "label" : "Azure AI API Key",
-    "description" : "Specify the API key of Azure AI",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -689,7 +684,6 @@
   }, {
     "id" : "ai.accessKey",
     "label" : "Access key",
-    "description" : "Provide an IAM access key tailored to a user, equipped with the necessary permissions",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -711,11 +705,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Provide an IAM access key tailored to a user, equipped with the necessary permissions",
     "type" : "String"
   }, {
     "id" : "ai.secretKey",
     "label" : "Secret key",
-    "description" : "Provide a secret key of a user with permissions to invoke specified AWS Lambda function",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -737,11 +731,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Provide the AWS secret access key of a user with permissions for Amazon Bedrock",
     "type" : "String"
   }, {
     "id" : "ai.region",
     "label" : "Region",
-    "description" : "Specify the AWS region",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -756,11 +750,11 @@
       "equals" : "bedrockAi",
       "type" : "simple"
     },
+    "tooltip" : "Specify the AWS region",
     "type" : "Text"
   }, {
     "id" : "ai.openAiEndpoint",
     "label" : "OpenAI Spec Endpoint",
-    "description" : "Specify the OpenAI compatible specification endpoint.",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -775,11 +769,11 @@
       "equals" : "openAi",
       "type" : "simple"
     },
+    "tooltip" : "The OpenAI-compatible specification endpoint.",
     "type" : "Text"
   }, {
     "id" : "ai.openAiHeaders",
     "label" : "Headers",
-    "description" : "Map of HTTP headers to add to the request.",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -794,6 +788,7 @@
       "equals" : "openAi",
       "type" : "simple"
     },
+    "tooltip" : "Map of HTTP headers to add to the request.",
     "type" : "String"
   }, {
     "id" : "ai.authType",
@@ -827,7 +822,6 @@
   }, {
     "id" : "ai.bearerToken",
     "label" : "Bearer token",
-    "description" : "Enter a valid Google API Bearer token",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -849,11 +843,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Enter a valid Google API Bearer token",
     "type" : "String"
   }, {
     "id" : "ai.oauthClientId",
     "label" : "Client ID",
-    "description" : "Enter Google API Client ID",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -875,11 +869,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Enter Google API Client ID",
     "type" : "String"
   }, {
     "id" : "ai.oauthClientSecret",
     "label" : "Client secret",
-    "description" : "Enter Google API client Secret",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -901,11 +895,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Enter Google API client Secret",
     "type" : "String"
   }, {
     "id" : "ai.oauthRefreshToken",
     "label" : "Refresh token",
-    "description" : "Enter a valid Google API refresh token",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -927,11 +921,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Enter a valid Google API refresh token",
     "type" : "String"
   }, {
     "id" : "ai.serviceAccountJson",
     "label" : "Service account json",
-    "description" : "Enter a the contents of your service account json file",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -953,6 +947,7 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Enter the contents of your service account JSON file",
     "type" : "String"
   }, {
     "id" : "ai.gcpRegion",

--- a/connectors/idp-extraction/element-templates/idp-classification-outbound-connector.json
+++ b/connectors/idp-extraction/element-templates/idp-classification-outbound-connector.json
@@ -48,7 +48,6 @@
   }, {
     "id" : "input.converseData",
     "label" : "AWS Bedrock Converse Parameters",
-    "description" : "Specify the parameters for AWS Bedrock",
     "optional" : false,
     "value" : "={\n  modelId: \"\",\n  temperature: 0.5\n}",
     "feel" : "optional",
@@ -61,7 +60,6 @@
   }, {
     "id" : "input.documentTypes",
     "label" : "Document types",
-    "description" : "The possible classification types considered by the model",
     "optional" : false,
     "value" : "=[\n  {\n    name: \"\",\n    classificationInstructions: \"\",\n    description: \"\",\n    outputValue: \"\"\n  }\n]",
     "constraints" : {
@@ -73,11 +71,11 @@
       "name" : "input.documentTypes",
       "type" : "zeebe:input"
     },
+    "tooltip" : "The possible classification types considered by the model",
     "type" : "Text"
   }, {
     "id" : "input.fallbackOutputValue",
     "label" : "Fallback output value",
-    "description" : "The value to return if the model has low confidence on all document types.",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -88,11 +86,11 @@
       "name" : "input.fallbackOutputValue",
       "type" : "zeebe:input"
     },
+    "tooltip" : "The value to return if the model has low confidence on all document types.",
     "type" : "Text"
   }, {
     "id" : "input.document",
     "label" : "Document",
-    "description" : "Specify the document",
     "optional" : false,
     "value" : "=document",
     "constraints" : {
@@ -136,7 +134,6 @@
   }, {
     "id" : "extractor.endpoint",
     "label" : "Azure Document Intelligence Endpoint",
-    "description" : "Specify the endpoint of the Azure Document Intelligence",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -155,7 +152,6 @@
   }, {
     "id" : "extractor.apiKey",
     "label" : "Azure Document Intelligence API Key",
-    "description" : "Specify the API key of the Azure Document Intelligence",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -203,7 +199,6 @@
   }, {
     "id" : "extractor.bearerToken",
     "label" : "Bearer token",
-    "description" : "Enter a valid Google API Bearer token",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -225,11 +220,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Enter a valid Google API Bearer token",
     "type" : "String"
   }, {
     "id" : "extractor.oauthClientId",
     "label" : "Client ID",
-    "description" : "Enter Google API Client ID",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -251,11 +246,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Enter Google API Client ID",
     "type" : "String"
   }, {
     "id" : "extractor.oauthClientSecret",
     "label" : "Client secret",
-    "description" : "Enter Google API client Secret",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -277,11 +272,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Enter Google API client Secret",
     "type" : "String"
   }, {
     "id" : "extractor.oauthRefreshToken",
     "label" : "Refresh token",
-    "description" : "Enter a valid Google API refresh token",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -303,11 +298,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Enter a valid Google API refresh token",
     "type" : "String"
   }, {
     "id" : "extractor.serviceAccountJson",
     "label" : "Service account json",
-    "description" : "Enter a the contents of your service account json file",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -329,11 +324,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Enter the contents of your service account JSON file",
     "type" : "String"
   }, {
     "id" : "extractor.documentAiRegion",
     "label" : "Region",
-    "description" : "Select the region for Document AI",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -348,6 +343,7 @@
       "equals" : "documentAi",
       "type" : "simple"
     },
+    "tooltip" : "Select the region for Document AI",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "EU",
@@ -375,7 +371,6 @@
   }, {
     "id" : "extractor.processorId",
     "label" : "Processor ID",
-    "description" : "The id of the processor used to parse the document",
     "optional" : false,
     "feel" : "optional",
     "group" : "extractor",
@@ -388,6 +383,7 @@
       "equals" : "documentAi",
       "type" : "simple"
     },
+    "tooltip" : "The id of the processor used to parse the document",
     "type" : "String"
   }, {
     "id" : "extractor.awsAuthType",
@@ -418,7 +414,6 @@
   }, {
     "id" : "extractor.accessKey",
     "label" : "Access key",
-    "description" : "Provide an IAM access key tailored to a user, equipped with the necessary permissions",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -440,11 +435,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Provide an IAM access key tailored to a user, equipped with the necessary permissions",
     "type" : "String"
   }, {
     "id" : "extractor.secretKey",
     "label" : "Secret key",
-    "description" : "Provide a secret key of a user with permissions to invoke specified AWS Lambda function",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -466,11 +461,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Provide the AWS secret access key of a user with permissions for Amazon Textract and S3",
     "type" : "String"
   }, {
     "id" : "extractor.region",
     "label" : "Region",
-    "description" : "Specify the AWS region",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -485,11 +480,11 @@
       "equals" : "textract",
       "type" : "simple"
     },
+    "tooltip" : "Specify the AWS region",
     "type" : "Text"
   }, {
     "id" : "extractor.bucketName",
     "label" : "AWS S3 Bucket name",
-    "description" : "Specify the name of the AWS S3 bucket where document will be stored temporarily during Textract analysis",
     "optional" : false,
     "value" : "idp-extraction-connector",
     "constraints" : {
@@ -505,11 +500,11 @@
       "equals" : "textract",
       "type" : "simple"
     },
+    "tooltip" : "Specify the name of the AWS S3 bucket where document will be stored temporarily during Textract analysis",
     "type" : "Text"
   }, {
     "id" : "extractor.abbyyBaseUrl",
     "label" : "ABBYY Vantage Base URL",
-    "description" : "Base URL of the ABBYY Vantage instance (e.g., https://vantage-us.abbyy.com)",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -525,11 +520,12 @@
       "equals" : "abbyy",
       "type" : "simple"
     },
+    "tooltip" : "Base URL of the ABBYY Vantage instance",
+    "placeholder" : "https://vantage-us.abbyy.com",
     "type" : "Text"
   }, {
     "id" : "extractor.abbyyClientId",
     "label" : "Client ID",
-    "description" : "OAuth2 Client ID from ABBYY Vantage Public API Client settings",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -545,11 +541,11 @@
       "equals" : "abbyy",
       "type" : "simple"
     },
+    "tooltip" : "OAuth2 Client ID from ABBYY Vantage Public API Client settings",
     "type" : "Text"
   }, {
     "id" : "extractor.abbyyClientSecret",
     "label" : "Client Secret",
-    "description" : "OAuth2 Client Secret from ABBYY Vantage Public API Client settings",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -565,11 +561,11 @@
       "equals" : "abbyy",
       "type" : "simple"
     },
+    "tooltip" : "OAuth2 Client Secret from ABBYY Vantage Public API Client settings",
     "type" : "Text"
   }, {
     "id" : "extractor.abbyySkillId",
     "label" : "Skill ID",
-    "description" : "The ABBYY Vantage OCR skill ID (skill must be configured to output Text format)",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -585,6 +581,7 @@
       "equals" : "abbyy",
       "type" : "simple"
     },
+    "tooltip" : "The ABBYY Vantage OCR skill ID (skill must be configured to output Text format)",
     "type" : "Text"
   }, {
     "id" : "ai.type",
@@ -611,7 +608,6 @@
   }, {
     "id" : "ai.usingOpenAI",
     "label" : "Model type",
-    "description" : "Specify if the Azure AI Foundry is using OpenAI",
     "optional" : false,
     "value" : "false",
     "constraints" : {
@@ -627,6 +623,7 @@
       "equals" : "azureAiFoundry",
       "type" : "simple"
     },
+    "tooltip" : "Specify if the Azure AI Foundry is using OpenAI",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "Base Azure Foundry model",
@@ -638,7 +635,6 @@
   }, {
     "id" : "ai.endpoint",
     "label" : "Azure AI Endpoint",
-    "description" : "Specify the endpoint of Azure AI",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -657,7 +653,6 @@
   }, {
     "id" : "ai.apiKey",
     "label" : "Azure AI API Key",
-    "description" : "Specify the API key of Azure AI",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -702,7 +697,6 @@
   }, {
     "id" : "ai.accessKey",
     "label" : "Access key",
-    "description" : "Provide an IAM access key tailored to a user, equipped with the necessary permissions",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -724,11 +718,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Provide an IAM access key tailored to a user, equipped with the necessary permissions",
     "type" : "String"
   }, {
     "id" : "ai.secretKey",
     "label" : "Secret key",
-    "description" : "Provide a secret key of a user with permissions to invoke specified AWS Lambda function",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -750,11 +744,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Provide the AWS secret access key of a user with permissions for Amazon Bedrock",
     "type" : "String"
   }, {
     "id" : "ai.region",
     "label" : "Region",
-    "description" : "Specify the AWS region",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -769,11 +763,11 @@
       "equals" : "bedrockAi",
       "type" : "simple"
     },
+    "tooltip" : "Specify the AWS region",
     "type" : "Text"
   }, {
     "id" : "ai.openAiEndpoint",
     "label" : "OpenAI Spec Endpoint",
-    "description" : "Specify the OpenAI compatible specification endpoint.",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -788,11 +782,11 @@
       "equals" : "openAi",
       "type" : "simple"
     },
+    "tooltip" : "The OpenAI-compatible specification endpoint.",
     "type" : "Text"
   }, {
     "id" : "ai.openAiHeaders",
     "label" : "Headers",
-    "description" : "Map of HTTP headers to add to the request.",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -807,6 +801,7 @@
       "equals" : "openAi",
       "type" : "simple"
     },
+    "tooltip" : "Map of HTTP headers to add to the request.",
     "type" : "String"
   }, {
     "id" : "ai.authType",
@@ -840,7 +835,6 @@
   }, {
     "id" : "ai.bearerToken",
     "label" : "Bearer token",
-    "description" : "Enter a valid Google API Bearer token",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -862,11 +856,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Enter a valid Google API Bearer token",
     "type" : "String"
   }, {
     "id" : "ai.oauthClientId",
     "label" : "Client ID",
-    "description" : "Enter Google API Client ID",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -888,11 +882,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Enter Google API Client ID",
     "type" : "String"
   }, {
     "id" : "ai.oauthClientSecret",
     "label" : "Client secret",
-    "description" : "Enter Google API client Secret",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -914,11 +908,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Enter Google API client Secret",
     "type" : "String"
   }, {
     "id" : "ai.oauthRefreshToken",
     "label" : "Refresh token",
-    "description" : "Enter a valid Google API refresh token",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -940,11 +934,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Enter a valid Google API refresh token",
     "type" : "String"
   }, {
     "id" : "ai.serviceAccountJson",
     "label" : "Service account json",
-    "description" : "Enter a the contents of your service account json file",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -966,6 +960,7 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Enter the contents of your service account JSON file",
     "type" : "String"
   }, {
     "id" : "ai.gcpRegion",

--- a/connectors/idp-extraction/element-templates/idp-classification-outbound-connector.json
+++ b/connectors/idp-extraction/element-templates/idp-classification-outbound-connector.json
@@ -220,7 +220,6 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "Enter a valid Google API Bearer token",
     "type" : "String"
   }, {
     "id" : "extractor.oauthClientId",
@@ -246,7 +245,6 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "Enter Google API Client ID",
     "type" : "String"
   }, {
     "id" : "extractor.oauthClientSecret",
@@ -272,7 +270,6 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "Enter Google API client Secret",
     "type" : "String"
   }, {
     "id" : "extractor.oauthRefreshToken",
@@ -298,7 +295,6 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "Enter a valid Google API refresh token",
     "type" : "String"
   }, {
     "id" : "extractor.serviceAccountJson",
@@ -343,7 +339,7 @@
       "equals" : "documentAi",
       "type" : "simple"
     },
-    "tooltip" : "Select the region for Document AI",
+    "tooltip" : "Geographic location where the Document AI processor runs. EU = European Union, US = United States.",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "EU",
@@ -383,7 +379,7 @@
       "equals" : "documentAi",
       "type" : "simple"
     },
-    "tooltip" : "The id of the processor used to parse the document",
+    "tooltip" : "Processor used to parse the document",
     "type" : "String"
   }, {
     "id" : "extractor.awsAuthType",
@@ -435,7 +431,7 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "Provide an IAM access key tailored to a user, equipped with the necessary permissions",
+    "tooltip" : "IAM access key of a user with the necessary permissions",
     "type" : "String"
   }, {
     "id" : "extractor.secretKey",
@@ -461,7 +457,7 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "Provide the AWS secret access key of a user with permissions for Amazon Textract and S3",
+    "tooltip" : "AWS secret access key of a user with permissions for Amazon Textract and S3",
     "type" : "String"
   }, {
     "id" : "extractor.region",
@@ -480,7 +476,6 @@
       "equals" : "textract",
       "type" : "simple"
     },
-    "tooltip" : "Specify the AWS region",
     "type" : "Text"
   }, {
     "id" : "extractor.bucketName",
@@ -500,7 +495,7 @@
       "equals" : "textract",
       "type" : "simple"
     },
-    "tooltip" : "Specify the name of the AWS S3 bucket where document will be stored temporarily during Textract analysis",
+    "tooltip" : "Where the document will be stored temporarily during Textract analysis",
     "type" : "Text"
   }, {
     "id" : "extractor.abbyyBaseUrl",
@@ -520,7 +515,6 @@
       "equals" : "abbyy",
       "type" : "simple"
     },
-    "tooltip" : "Base URL of the ABBYY Vantage instance",
     "placeholder" : "https://vantage-us.abbyy.com",
     "type" : "Text"
   }, {
@@ -581,7 +575,7 @@
       "equals" : "abbyy",
       "type" : "simple"
     },
-    "tooltip" : "The ABBYY Vantage OCR skill ID (skill must be configured to output Text format)",
+    "tooltip" : "The skill must be configured to output Text format.",
     "type" : "Text"
   }, {
     "id" : "ai.type",
@@ -623,7 +617,7 @@
       "equals" : "azureAiFoundry",
       "type" : "simple"
     },
-    "tooltip" : "Specify if the Azure AI Foundry is using OpenAI",
+    "tooltip" : "Base Azure Foundry model = a model deployed directly in Azure AI Foundry; Azure OpenAI model = a model served through Azure OpenAI.",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "Base Azure Foundry model",
@@ -763,7 +757,6 @@
       "equals" : "bedrockAi",
       "type" : "simple"
     },
-    "tooltip" : "Specify the AWS region",
     "type" : "Text"
   }, {
     "id" : "ai.openAiEndpoint",
@@ -782,7 +775,6 @@
       "equals" : "openAi",
       "type" : "simple"
     },
-    "tooltip" : "The OpenAI-compatible specification endpoint.",
     "type" : "Text"
   }, {
     "id" : "ai.openAiHeaders",
@@ -856,7 +848,6 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "Enter a valid Google API Bearer token",
     "type" : "String"
   }, {
     "id" : "ai.oauthClientId",
@@ -882,7 +873,6 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "Enter Google API Client ID",
     "type" : "String"
   }, {
     "id" : "ai.oauthClientSecret",
@@ -908,7 +898,6 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "Enter Google API client Secret",
     "type" : "String"
   }, {
     "id" : "ai.oauthRefreshToken",
@@ -934,7 +923,6 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "Enter a valid Google API refresh token",
     "type" : "String"
   }, {
     "id" : "ai.serviceAccountJson",
@@ -960,7 +948,7 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "Enter the contents of your service account JSON file",
+    "tooltip" : "Contents of your service account JSON file",
     "type" : "String"
   }, {
     "id" : "ai.gcpRegion",

--- a/connectors/idp-extraction/element-templates/idp-extraction-outbound-connector.json
+++ b/connectors/idp-extraction/element-templates/idp-extraction-outbound-connector.json
@@ -267,7 +267,6 @@
   }, {
     "id" : "baseRequest.authentication.bearerToken",
     "label" : "Bearer token",
-    "description" : "Enter a valid Google API Bearer token",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -289,11 +288,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Enter a valid Google API Bearer token",
     "type" : "String"
   }, {
     "id" : "baseRequest.authentication.oauthClientId",
     "label" : "Client ID",
-    "description" : "Enter Google API Client ID",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -315,11 +314,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Enter Google API Client ID",
     "type" : "String"
   }, {
     "id" : "baseRequest.authentication.oauthClientSecret",
     "label" : "Client secret",
-    "description" : "Enter Google API client Secret",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -341,11 +340,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Enter Google API client Secret",
     "type" : "String"
   }, {
     "id" : "baseRequest.authentication.oauthRefreshToken",
     "label" : "Refresh token",
-    "description" : "Enter a valid Google API refresh token",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -367,11 +366,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Enter a valid Google API refresh token",
     "type" : "String"
   }, {
     "id" : "baseRequest.authentication.serviceAccountJson",
     "label" : "Service account json",
-    "description" : "Enter a the contents of your service account json file",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -393,11 +392,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Enter the contents of your service account JSON file",
     "type" : "String"
   }, {
     "id" : "baseRequest.s3BucketName",
     "label" : "AWS S3 Bucket name",
-    "description" : "Specify the name of the AWS S3 bucket where document will be stored temporarily during Textract analysis",
     "optional" : false,
     "value" : "idp-extraction-connector",
     "constraints" : {
@@ -413,11 +412,11 @@
       "equals" : "aws",
       "type" : "simple"
     },
+    "tooltip" : "Specify the name of the AWS S3 bucket where document will be stored temporarily during Textract analysis",
     "type" : "Text"
   }, {
     "id" : "baseRequest.extractionEngineType",
     "label" : "Extraction engine type",
-    "description" : "Specify extraction engine to be used",
     "optional" : false,
     "value" : "AWS_TEXTRACT",
     "constraints" : {
@@ -479,7 +478,6 @@
   }, {
     "id" : "baseRequest.documentIntelligenceConfiguration.endpoint",
     "label" : "Azure Document Intelligence Endpoint",
-    "description" : "Specify the endpoint of the Azure Document Intelligence",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -498,7 +496,6 @@
   }, {
     "id" : "baseRequest.documentIntelligenceConfiguration.apiKey",
     "label" : "Azure Document Intelligence API Key",
-    "description" : "Specify the API key of the Azure Document Intelligence",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -517,7 +514,6 @@
   }, {
     "id" : "baseRequest.aiFoundryConfig.usingOpenAI",
     "label" : "Model type",
-    "description" : "Specify if the Azure AI Foundry is using OpenAI",
     "optional" : false,
     "value" : "false",
     "constraints" : {
@@ -533,6 +529,7 @@
       "equals" : "azure",
       "type" : "simple"
     },
+    "tooltip" : "Specify if the Azure AI Foundry is using OpenAI",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "Base Azure Foundry model",
@@ -544,7 +541,6 @@
   }, {
     "id" : "baseRequest.aiFoundryConfig.endpoint",
     "label" : "Azure AI Foundry Endpoint",
-    "description" : "Specify the endpoint of the Azure AI Foundry",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -563,7 +559,6 @@
   }, {
     "id" : "baseRequest.aiFoundryConfig.apiKey",
     "label" : "Azure AI Foundry API Key",
-    "description" : "Specify the API key of the Azure AI Foundry",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -647,7 +642,6 @@
   }, {
     "id" : "baseRequest.configuration.bucketName",
     "label" : "Bucket name",
-    "description" : "The Google Cloud Storage bucket where the document will be temporarily stored",
     "optional" : false,
     "feel" : "optional",
     "group" : "configuration",
@@ -666,11 +660,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "The Google Cloud Storage bucket where the document will be temporarily stored",
     "type" : "String"
   }, {
     "id" : "baseRequest.configuration.documentAiRegion",
     "label" : "Region",
-    "description" : "Can be 'eu' or 'us'",
     "optional" : false,
     "feel" : "optional",
     "group" : "configuration",
@@ -689,6 +683,7 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Can be 'eu' or 'us'",
     "type" : "String"
   }, {
     "id" : "baseRequest.configuration.projectId",
@@ -715,7 +710,6 @@
   }, {
     "id" : "baseRequest.configuration.processorId",
     "label" : "Processor ID",
-    "description" : "The id of the processor used to parse the document",
     "optional" : false,
     "feel" : "optional",
     "group" : "configuration",
@@ -734,11 +728,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "The id of the processor used to parse the document",
     "type" : "String"
   }, {
     "id" : "baseRequest.openAiEndpoint",
     "label" : "OpenAI Spec Endpoint",
-    "description" : "Specify the OpenAI compatible specification endpoint.",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -753,11 +747,11 @@
       "equals" : "openai",
       "type" : "simple"
     },
+    "tooltip" : "The OpenAI-compatible specification endpoint.",
     "type" : "Text"
   }, {
     "id" : "baseRequest.openAiHeaders",
     "label" : "Headers",
-    "description" : "Map of HTTP headers to add to the request.",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -772,6 +766,7 @@
       "equals" : "openai",
       "type" : "simple"
     },
+    "tooltip" : "Map of HTTP headers to add to the request.",
     "type" : "String"
   }, {
     "id" : "version",

--- a/connectors/idp-extraction/element-templates/idp-extraction-outbound-connector.json
+++ b/connectors/idp-extraction/element-templates/idp-extraction-outbound-connector.json
@@ -288,7 +288,6 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "Enter a valid Google API Bearer token",
     "type" : "String"
   }, {
     "id" : "baseRequest.authentication.oauthClientId",
@@ -314,7 +313,6 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "Enter Google API Client ID",
     "type" : "String"
   }, {
     "id" : "baseRequest.authentication.oauthClientSecret",
@@ -340,7 +338,6 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "Enter Google API client Secret",
     "type" : "String"
   }, {
     "id" : "baseRequest.authentication.oauthRefreshToken",
@@ -366,7 +363,6 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "Enter a valid Google API refresh token",
     "type" : "String"
   }, {
     "id" : "baseRequest.authentication.serviceAccountJson",
@@ -412,7 +408,7 @@
       "equals" : "aws",
       "type" : "simple"
     },
-    "tooltip" : "Specify the name of the AWS S3 bucket where document will be stored temporarily during Textract analysis",
+    "tooltip" : "Where the document will be stored temporarily during Textract analysis",
     "type" : "Text"
   }, {
     "id" : "baseRequest.extractionEngineType",
@@ -529,7 +525,7 @@
       "equals" : "azure",
       "type" : "simple"
     },
-    "tooltip" : "Specify if the Azure AI Foundry is using OpenAI",
+    "tooltip" : "Base Azure Foundry model = a model deployed directly in Azure AI Foundry; Azure OpenAI model = an OpenAI model served through Azure OpenAI",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "Base Azure Foundry model",
@@ -728,7 +724,7 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "The id of the processor used to parse the document",
+    "tooltip" : "Processor used to parse the document",
     "type" : "String"
   }, {
     "id" : "baseRequest.openAiEndpoint",

--- a/connectors/idp-extraction/element-templates/idp-structured-extraction-outbound-connector.json
+++ b/connectors/idp-extraction/element-templates/idp-structured-extraction-outbound-connector.json
@@ -211,7 +211,6 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "Enter a valid Google API Bearer token",
     "type" : "String"
   }, {
     "id" : "extractor.oauthClientId",
@@ -237,7 +236,6 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "Enter Google API Client ID",
     "type" : "String"
   }, {
     "id" : "extractor.oauthClientSecret",
@@ -263,7 +261,6 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "Enter Google API client Secret",
     "type" : "String"
   }, {
     "id" : "extractor.oauthRefreshToken",
@@ -289,7 +286,6 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "Enter a valid Google API refresh token",
     "type" : "String"
   }, {
     "id" : "extractor.serviceAccountJson",
@@ -334,7 +330,7 @@
       "equals" : "documentAi",
       "type" : "simple"
     },
-    "tooltip" : "Select the region for Document AI",
+    "tooltip" : "Geographic location where the Document AI processor runs. EU = European Union, US = United States.",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "EU",
@@ -374,7 +370,7 @@
       "equals" : "documentAi",
       "type" : "simple"
     },
-    "tooltip" : "The id of the processor used to parse the document",
+    "tooltip" : "Processor used to parse the document",
     "type" : "String"
   }, {
     "id" : "extractor.awsAuthType",
@@ -426,7 +422,7 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "Provide an IAM access key tailored to a user, equipped with the necessary permissions",
+    "tooltip" : "IAM access key of a user with the necessary permissions",
     "type" : "String"
   }, {
     "id" : "extractor.secretKey",
@@ -452,7 +448,7 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "Provide the AWS secret access key of a user with permissions for Amazon Textract and S3",
+    "tooltip" : "AWS secret access key of a user with permissions for Amazon Textract and S3",
     "type" : "String"
   }, {
     "id" : "extractor.region",
@@ -471,7 +467,6 @@
       "equals" : "textract",
       "type" : "simple"
     },
-    "tooltip" : "Specify the AWS region",
     "type" : "Text"
   }, {
     "id" : "extractor.bucketName",
@@ -491,7 +486,7 @@
       "equals" : "textract",
       "type" : "simple"
     },
-    "tooltip" : "Specify the name of the AWS S3 bucket where document will be stored temporarily during Textract analysis",
+    "tooltip" : "Where the document will be stored temporarily during Textract analysis",
     "type" : "Text"
   }, {
     "id" : "extractor.abbyyBaseUrl",
@@ -511,7 +506,6 @@
       "equals" : "abbyy",
       "type" : "simple"
     },
-    "tooltip" : "Base URL of the ABBYY Vantage instance",
     "placeholder" : "https://vantage-us.abbyy.com",
     "type" : "Text"
   }, {
@@ -572,7 +566,7 @@
       "equals" : "abbyy",
       "type" : "simple"
     },
-    "tooltip" : "The ABBYY Vantage OCR skill ID (skill must be configured to output Text format)",
+    "tooltip" : "The skill must be configured to output Text format.",
     "type" : "Text"
   }, {
     "id" : "version",

--- a/connectors/idp-extraction/element-templates/idp-structured-extraction-outbound-connector.json
+++ b/connectors/idp-extraction/element-templates/idp-structured-extraction-outbound-connector.json
@@ -45,7 +45,6 @@
   }, {
     "id" : "input.includedFields",
     "label" : "Included Fields",
-    "description" : "List of fields that should be returned from the extraction",
     "optional" : false,
     "value" : "=[\n  \n]",
     "feel" : "optional",
@@ -54,11 +53,11 @@
       "name" : "input.includedFields",
       "type" : "zeebe:input"
     },
+    "tooltip" : "List of fields that should be returned from the extraction",
     "type" : "String"
   }, {
     "id" : "input.renameMappings",
     "label" : "Rename mappings",
-    "description" : "List of keys that should be renamed and not be given the default name",
     "optional" : false,
     "value" : "={\n  \n}",
     "feel" : "optional",
@@ -67,22 +66,22 @@
       "name" : "input.renameMappings",
       "type" : "zeebe:input"
     },
+    "tooltip" : "List of keys that should be renamed and not be given the default name",
     "type" : "String"
   }, {
     "id" : "input.delimiter",
     "label" : "delimiter",
-    "description" : "The delimiter used for the variable name of the extracted field",
     "optional" : false,
     "group" : "input",
     "binding" : {
       "name" : "input.delimiter",
       "type" : "zeebe:input"
     },
+    "tooltip" : "The delimiter used for the variable name of the extracted field",
     "type" : "String"
   }, {
     "id" : "input.document",
     "label" : "Document",
-    "description" : "Specify the document",
     "optional" : false,
     "value" : "=document",
     "constraints" : {
@@ -126,7 +125,6 @@
   }, {
     "id" : "extractor.endpoint",
     "label" : "Azure Document Intelligence Endpoint",
-    "description" : "Specify the endpoint of the Azure Document Intelligence",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -145,7 +143,6 @@
   }, {
     "id" : "extractor.apiKey",
     "label" : "Azure Document Intelligence API Key",
-    "description" : "Specify the API key of the Azure Document Intelligence",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -193,7 +190,6 @@
   }, {
     "id" : "extractor.bearerToken",
     "label" : "Bearer token",
-    "description" : "Enter a valid Google API Bearer token",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -215,11 +211,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Enter a valid Google API Bearer token",
     "type" : "String"
   }, {
     "id" : "extractor.oauthClientId",
     "label" : "Client ID",
-    "description" : "Enter Google API Client ID",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -241,11 +237,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Enter Google API Client ID",
     "type" : "String"
   }, {
     "id" : "extractor.oauthClientSecret",
     "label" : "Client secret",
-    "description" : "Enter Google API client Secret",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -267,11 +263,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Enter Google API client Secret",
     "type" : "String"
   }, {
     "id" : "extractor.oauthRefreshToken",
     "label" : "Refresh token",
-    "description" : "Enter a valid Google API refresh token",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -293,11 +289,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Enter a valid Google API refresh token",
     "type" : "String"
   }, {
     "id" : "extractor.serviceAccountJson",
     "label" : "Service account json",
-    "description" : "Enter a the contents of your service account json file",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -319,11 +315,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Enter the contents of your service account JSON file",
     "type" : "String"
   }, {
     "id" : "extractor.documentAiRegion",
     "label" : "Region",
-    "description" : "Select the region for Document AI",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -338,6 +334,7 @@
       "equals" : "documentAi",
       "type" : "simple"
     },
+    "tooltip" : "Select the region for Document AI",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "EU",
@@ -365,7 +362,6 @@
   }, {
     "id" : "extractor.processorId",
     "label" : "Processor ID",
-    "description" : "The id of the processor used to parse the document",
     "optional" : false,
     "feel" : "optional",
     "group" : "extractor",
@@ -378,6 +374,7 @@
       "equals" : "documentAi",
       "type" : "simple"
     },
+    "tooltip" : "The id of the processor used to parse the document",
     "type" : "String"
   }, {
     "id" : "extractor.awsAuthType",
@@ -408,7 +405,6 @@
   }, {
     "id" : "extractor.accessKey",
     "label" : "Access key",
-    "description" : "Provide an IAM access key tailored to a user, equipped with the necessary permissions",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -430,11 +426,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Provide an IAM access key tailored to a user, equipped with the necessary permissions",
     "type" : "String"
   }, {
     "id" : "extractor.secretKey",
     "label" : "Secret key",
-    "description" : "Provide a secret key of a user with permissions to invoke specified AWS Lambda function",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -456,11 +452,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Provide the AWS secret access key of a user with permissions for Amazon Textract and S3",
     "type" : "String"
   }, {
     "id" : "extractor.region",
     "label" : "Region",
-    "description" : "Specify the AWS region",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -475,11 +471,11 @@
       "equals" : "textract",
       "type" : "simple"
     },
+    "tooltip" : "Specify the AWS region",
     "type" : "Text"
   }, {
     "id" : "extractor.bucketName",
     "label" : "AWS S3 Bucket name",
-    "description" : "Specify the name of the AWS S3 bucket where document will be stored temporarily during Textract analysis",
     "optional" : false,
     "value" : "idp-extraction-connector",
     "constraints" : {
@@ -495,11 +491,11 @@
       "equals" : "textract",
       "type" : "simple"
     },
+    "tooltip" : "Specify the name of the AWS S3 bucket where document will be stored temporarily during Textract analysis",
     "type" : "Text"
   }, {
     "id" : "extractor.abbyyBaseUrl",
     "label" : "ABBYY Vantage Base URL",
-    "description" : "Base URL of the ABBYY Vantage instance (e.g., https://vantage-us.abbyy.com)",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -515,11 +511,12 @@
       "equals" : "abbyy",
       "type" : "simple"
     },
+    "tooltip" : "Base URL of the ABBYY Vantage instance",
+    "placeholder" : "https://vantage-us.abbyy.com",
     "type" : "Text"
   }, {
     "id" : "extractor.abbyyClientId",
     "label" : "Client ID",
-    "description" : "OAuth2 Client ID from ABBYY Vantage Public API Client settings",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -535,11 +532,11 @@
       "equals" : "abbyy",
       "type" : "simple"
     },
+    "tooltip" : "OAuth2 Client ID from ABBYY Vantage Public API Client settings",
     "type" : "Text"
   }, {
     "id" : "extractor.abbyyClientSecret",
     "label" : "Client Secret",
-    "description" : "OAuth2 Client Secret from ABBYY Vantage Public API Client settings",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -555,11 +552,11 @@
       "equals" : "abbyy",
       "type" : "simple"
     },
+    "tooltip" : "OAuth2 Client Secret from ABBYY Vantage Public API Client settings",
     "type" : "Text"
   }, {
     "id" : "extractor.abbyySkillId",
     "label" : "Skill ID",
-    "description" : "The ABBYY Vantage OCR skill ID (skill must be configured to output Text format)",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -575,6 +572,7 @@
       "equals" : "abbyy",
       "type" : "simple"
     },
+    "tooltip" : "The ABBYY Vantage OCR skill ID (skill must be configured to output Text format)",
     "type" : "Text"
   }, {
     "id" : "version",

--- a/connectors/idp-extraction/element-templates/idp-unstructured-extraction-outbound-connector.json
+++ b/connectors/idp-extraction/element-templates/idp-unstructured-extraction-outbound-connector.json
@@ -56,7 +56,6 @@
       "name" : "input.taxonomyItems",
       "type" : "zeebe:input"
     },
-    "tooltip" : "Array of taxonomy items",
     "type" : "Text"
   }, {
     "id" : "input.converseData",
@@ -202,7 +201,6 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "Enter a valid Google API Bearer token",
     "type" : "String"
   }, {
     "id" : "extractor.oauthClientId",
@@ -228,7 +226,6 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "Enter Google API Client ID",
     "type" : "String"
   }, {
     "id" : "extractor.oauthClientSecret",
@@ -254,7 +251,6 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "Enter Google API client Secret",
     "type" : "String"
   }, {
     "id" : "extractor.oauthRefreshToken",
@@ -280,7 +276,6 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "Enter a valid Google API refresh token",
     "type" : "String"
   }, {
     "id" : "extractor.serviceAccountJson",
@@ -325,7 +320,7 @@
       "equals" : "documentAi",
       "type" : "simple"
     },
-    "tooltip" : "Select the region for Document AI",
+    "tooltip" : "Geographic location where the Document AI processor runs. EU = European Union, US = United States.",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "EU",
@@ -365,7 +360,7 @@
       "equals" : "documentAi",
       "type" : "simple"
     },
-    "tooltip" : "The id of the processor used to parse the document",
+    "tooltip" : "Processor used to parse the document",
     "type" : "String"
   }, {
     "id" : "extractor.awsAuthType",
@@ -417,7 +412,7 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "Provide an IAM access key tailored to a user, equipped with the necessary permissions",
+    "tooltip" : "IAM access key of a user with the necessary permissions",
     "type" : "String"
   }, {
     "id" : "extractor.secretKey",
@@ -443,7 +438,7 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "Provide the AWS secret access key of a user with permissions for Amazon Textract and S3",
+    "tooltip" : "AWS secret access key of a user with permissions for Amazon Textract and S3",
     "type" : "String"
   }, {
     "id" : "extractor.region",
@@ -462,7 +457,6 @@
       "equals" : "textract",
       "type" : "simple"
     },
-    "tooltip" : "Specify the AWS region",
     "type" : "Text"
   }, {
     "id" : "extractor.bucketName",
@@ -482,7 +476,7 @@
       "equals" : "textract",
       "type" : "simple"
     },
-    "tooltip" : "Specify the name of the AWS S3 bucket where document will be stored temporarily during Textract analysis",
+    "tooltip" : "Where the document will be stored temporarily during Textract analysis",
     "type" : "Text"
   }, {
     "id" : "extractor.abbyyBaseUrl",
@@ -502,7 +496,6 @@
       "equals" : "abbyy",
       "type" : "simple"
     },
-    "tooltip" : "Base URL of the ABBYY Vantage instance",
     "placeholder" : "https://vantage-us.abbyy.com",
     "type" : "Text"
   }, {
@@ -563,7 +556,7 @@
       "equals" : "abbyy",
       "type" : "simple"
     },
-    "tooltip" : "The ABBYY Vantage OCR skill ID (skill must be configured to output Text format)",
+    "tooltip" : "The skill must be configured to output Text format.",
     "type" : "Text"
   }, {
     "id" : "ai.type",
@@ -605,7 +598,7 @@
       "equals" : "azureAiFoundry",
       "type" : "simple"
     },
-    "tooltip" : "Specify if the Azure AI Foundry is using OpenAI",
+    "tooltip" : "Base Azure Foundry model = a model deployed directly in Azure AI Foundry; Azure OpenAI model = a model served through Azure OpenAI.",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "Base Azure Foundry model",
@@ -745,7 +738,6 @@
       "equals" : "bedrockAi",
       "type" : "simple"
     },
-    "tooltip" : "Specify the AWS region",
     "type" : "Text"
   }, {
     "id" : "ai.openAiEndpoint",
@@ -764,7 +756,6 @@
       "equals" : "openAi",
       "type" : "simple"
     },
-    "tooltip" : "The OpenAI-compatible specification endpoint.",
     "type" : "Text"
   }, {
     "id" : "ai.openAiHeaders",
@@ -838,7 +829,6 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "Enter a valid Google API Bearer token",
     "type" : "String"
   }, {
     "id" : "ai.oauthClientId",
@@ -864,7 +854,6 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "Enter Google API Client ID",
     "type" : "String"
   }, {
     "id" : "ai.oauthClientSecret",
@@ -890,7 +879,6 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "Enter Google API client Secret",
     "type" : "String"
   }, {
     "id" : "ai.oauthRefreshToken",
@@ -916,7 +904,6 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "Enter a valid Google API refresh token",
     "type" : "String"
   }, {
     "id" : "ai.serviceAccountJson",
@@ -942,7 +929,7 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "Enter the contents of your service account JSON file",
+    "tooltip" : "Contents of your service account JSON file",
     "type" : "String"
   }, {
     "id" : "ai.gcpRegion",

--- a/connectors/idp-extraction/element-templates/idp-unstructured-extraction-outbound-connector.json
+++ b/connectors/idp-extraction/element-templates/idp-unstructured-extraction-outbound-connector.json
@@ -48,7 +48,6 @@
   }, {
     "id" : "input.taxonomyItems",
     "label" : "Taxonomy Items",
-    "description" : "Array of taxonomy items",
     "optional" : false,
     "value" : "=[\n  {name: \"\", prompt: \"\"},\n  {name: \"\", prompt: \"\"}\n]",
     "feel" : "optional",
@@ -57,11 +56,11 @@
       "name" : "input.taxonomyItems",
       "type" : "zeebe:input"
     },
+    "tooltip" : "Array of taxonomy items",
     "type" : "Text"
   }, {
     "id" : "input.converseData",
     "label" : "Ai converse parameters",
-    "description" : "Specify the parameters for the ai conversation",
     "optional" : false,
     "value" : "={\n  modelId: \"\",\n  temperature: 0.5\n}",
     "feel" : "optional",
@@ -74,7 +73,6 @@
   }, {
     "id" : "input.document",
     "label" : "Document",
-    "description" : "Specify the document",
     "optional" : false,
     "value" : "=document",
     "constraints" : {
@@ -118,7 +116,6 @@
   }, {
     "id" : "extractor.endpoint",
     "label" : "Azure Document Intelligence Endpoint",
-    "description" : "Specify the endpoint of the Azure Document Intelligence",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -137,7 +134,6 @@
   }, {
     "id" : "extractor.apiKey",
     "label" : "Azure Document Intelligence API Key",
-    "description" : "Specify the API key of the Azure Document Intelligence",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -185,7 +181,6 @@
   }, {
     "id" : "extractor.bearerToken",
     "label" : "Bearer token",
-    "description" : "Enter a valid Google API Bearer token",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -207,11 +202,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Enter a valid Google API Bearer token",
     "type" : "String"
   }, {
     "id" : "extractor.oauthClientId",
     "label" : "Client ID",
-    "description" : "Enter Google API Client ID",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -233,11 +228,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Enter Google API Client ID",
     "type" : "String"
   }, {
     "id" : "extractor.oauthClientSecret",
     "label" : "Client secret",
-    "description" : "Enter Google API client Secret",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -259,11 +254,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Enter Google API client Secret",
     "type" : "String"
   }, {
     "id" : "extractor.oauthRefreshToken",
     "label" : "Refresh token",
-    "description" : "Enter a valid Google API refresh token",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -285,11 +280,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Enter a valid Google API refresh token",
     "type" : "String"
   }, {
     "id" : "extractor.serviceAccountJson",
     "label" : "Service account json",
-    "description" : "Enter a the contents of your service account json file",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -311,11 +306,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Enter the contents of your service account JSON file",
     "type" : "String"
   }, {
     "id" : "extractor.documentAiRegion",
     "label" : "Region",
-    "description" : "Select the region for Document AI",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -330,6 +325,7 @@
       "equals" : "documentAi",
       "type" : "simple"
     },
+    "tooltip" : "Select the region for Document AI",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "EU",
@@ -357,7 +353,6 @@
   }, {
     "id" : "extractor.processorId",
     "label" : "Processor ID",
-    "description" : "The id of the processor used to parse the document",
     "optional" : false,
     "feel" : "optional",
     "group" : "extractor",
@@ -370,6 +365,7 @@
       "equals" : "documentAi",
       "type" : "simple"
     },
+    "tooltip" : "The id of the processor used to parse the document",
     "type" : "String"
   }, {
     "id" : "extractor.awsAuthType",
@@ -400,7 +396,6 @@
   }, {
     "id" : "extractor.accessKey",
     "label" : "Access key",
-    "description" : "Provide an IAM access key tailored to a user, equipped with the necessary permissions",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -422,11 +417,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Provide an IAM access key tailored to a user, equipped with the necessary permissions",
     "type" : "String"
   }, {
     "id" : "extractor.secretKey",
     "label" : "Secret key",
-    "description" : "Provide a secret key of a user with permissions to invoke specified AWS Lambda function",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -448,11 +443,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Provide the AWS secret access key of a user with permissions for Amazon Textract and S3",
     "type" : "String"
   }, {
     "id" : "extractor.region",
     "label" : "Region",
-    "description" : "Specify the AWS region",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -467,11 +462,11 @@
       "equals" : "textract",
       "type" : "simple"
     },
+    "tooltip" : "Specify the AWS region",
     "type" : "Text"
   }, {
     "id" : "extractor.bucketName",
     "label" : "AWS S3 Bucket name",
-    "description" : "Specify the name of the AWS S3 bucket where document will be stored temporarily during Textract analysis",
     "optional" : false,
     "value" : "idp-extraction-connector",
     "constraints" : {
@@ -487,11 +482,11 @@
       "equals" : "textract",
       "type" : "simple"
     },
+    "tooltip" : "Specify the name of the AWS S3 bucket where document will be stored temporarily during Textract analysis",
     "type" : "Text"
   }, {
     "id" : "extractor.abbyyBaseUrl",
     "label" : "ABBYY Vantage Base URL",
-    "description" : "Base URL of the ABBYY Vantage instance (e.g., https://vantage-us.abbyy.com)",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -507,11 +502,12 @@
       "equals" : "abbyy",
       "type" : "simple"
     },
+    "tooltip" : "Base URL of the ABBYY Vantage instance",
+    "placeholder" : "https://vantage-us.abbyy.com",
     "type" : "Text"
   }, {
     "id" : "extractor.abbyyClientId",
     "label" : "Client ID",
-    "description" : "OAuth2 Client ID from ABBYY Vantage Public API Client settings",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -527,11 +523,11 @@
       "equals" : "abbyy",
       "type" : "simple"
     },
+    "tooltip" : "OAuth2 Client ID from ABBYY Vantage Public API Client settings",
     "type" : "Text"
   }, {
     "id" : "extractor.abbyyClientSecret",
     "label" : "Client Secret",
-    "description" : "OAuth2 Client Secret from ABBYY Vantage Public API Client settings",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -547,11 +543,11 @@
       "equals" : "abbyy",
       "type" : "simple"
     },
+    "tooltip" : "OAuth2 Client Secret from ABBYY Vantage Public API Client settings",
     "type" : "Text"
   }, {
     "id" : "extractor.abbyySkillId",
     "label" : "Skill ID",
-    "description" : "The ABBYY Vantage OCR skill ID (skill must be configured to output Text format)",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -567,6 +563,7 @@
       "equals" : "abbyy",
       "type" : "simple"
     },
+    "tooltip" : "The ABBYY Vantage OCR skill ID (skill must be configured to output Text format)",
     "type" : "Text"
   }, {
     "id" : "ai.type",
@@ -593,7 +590,6 @@
   }, {
     "id" : "ai.usingOpenAI",
     "label" : "Model type",
-    "description" : "Specify if the Azure AI Foundry is using OpenAI",
     "optional" : false,
     "value" : "false",
     "constraints" : {
@@ -609,6 +605,7 @@
       "equals" : "azureAiFoundry",
       "type" : "simple"
     },
+    "tooltip" : "Specify if the Azure AI Foundry is using OpenAI",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "Base Azure Foundry model",
@@ -620,7 +617,6 @@
   }, {
     "id" : "ai.endpoint",
     "label" : "Azure AI Endpoint",
-    "description" : "Specify the endpoint of Azure AI",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -639,7 +635,6 @@
   }, {
     "id" : "ai.apiKey",
     "label" : "Azure AI API Key",
-    "description" : "Specify the API key of Azure AI",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -684,7 +679,6 @@
   }, {
     "id" : "ai.accessKey",
     "label" : "Access key",
-    "description" : "Provide an IAM access key tailored to a user, equipped with the necessary permissions",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -706,11 +700,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Provide an IAM access key tailored to a user, equipped with the necessary permissions",
     "type" : "String"
   }, {
     "id" : "ai.secretKey",
     "label" : "Secret key",
-    "description" : "Provide a secret key of a user with permissions to invoke specified AWS Lambda function",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -732,11 +726,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Provide the AWS secret access key of a user with permissions for Amazon Bedrock",
     "type" : "String"
   }, {
     "id" : "ai.region",
     "label" : "Region",
-    "description" : "Specify the AWS region",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -751,11 +745,11 @@
       "equals" : "bedrockAi",
       "type" : "simple"
     },
+    "tooltip" : "Specify the AWS region",
     "type" : "Text"
   }, {
     "id" : "ai.openAiEndpoint",
     "label" : "OpenAI Spec Endpoint",
-    "description" : "Specify the OpenAI compatible specification endpoint.",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -770,11 +764,11 @@
       "equals" : "openAi",
       "type" : "simple"
     },
+    "tooltip" : "The OpenAI-compatible specification endpoint.",
     "type" : "Text"
   }, {
     "id" : "ai.openAiHeaders",
     "label" : "Headers",
-    "description" : "Map of HTTP headers to add to the request.",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -789,6 +783,7 @@
       "equals" : "openAi",
       "type" : "simple"
     },
+    "tooltip" : "Map of HTTP headers to add to the request.",
     "type" : "String"
   }, {
     "id" : "ai.authType",
@@ -822,7 +817,6 @@
   }, {
     "id" : "ai.bearerToken",
     "label" : "Bearer token",
-    "description" : "Enter a valid Google API Bearer token",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -844,11 +838,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Enter a valid Google API Bearer token",
     "type" : "String"
   }, {
     "id" : "ai.oauthClientId",
     "label" : "Client ID",
-    "description" : "Enter Google API Client ID",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -870,11 +864,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Enter Google API Client ID",
     "type" : "String"
   }, {
     "id" : "ai.oauthClientSecret",
     "label" : "Client secret",
-    "description" : "Enter Google API client Secret",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -896,11 +890,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Enter Google API client Secret",
     "type" : "String"
   }, {
     "id" : "ai.oauthRefreshToken",
     "label" : "Refresh token",
-    "description" : "Enter a valid Google API refresh token",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -922,11 +916,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Enter a valid Google API refresh token",
     "type" : "String"
   }, {
     "id" : "ai.serviceAccountJson",
     "label" : "Service account json",
-    "description" : "Enter a the contents of your service account json file",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -948,6 +942,7 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Enter the contents of your service account JSON file",
     "type" : "String"
   }, {
     "id" : "ai.gcpRegion",

--- a/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/model/TaxonomyItem.java
+++ b/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/model/TaxonomyItem.java
@@ -13,7 +13,7 @@ public record TaxonomyItem(
     @TemplateProperty(
             label = "Name",
             id = "name",
-            description = "The name of the taxonomy item",
+            tooltip = "The name of the taxonomy item.",
             binding = @TemplateProperty.PropertyBinding(name = "name"),
             constraints = @TemplateProperty.PropertyConstraints(notEmpty = true))
         @NotNull
@@ -21,7 +21,7 @@ public record TaxonomyItem(
     @TemplateProperty(
             label = "Prompt",
             id = "prompt",
-            description = "The prompt for the taxonomy item",
+            tooltip = "The prompt for the taxonomy item.",
             binding = @TemplateProperty.PropertyBinding(name = "prompt"),
             constraints = @TemplateProperty.PropertyConstraints(notEmpty = true))
         @NotNull

--- a/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/model/providers/AwsProvider.java
+++ b/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/model/providers/AwsProvider.java
@@ -30,7 +30,7 @@ public final class AwsProvider extends AwsBaseRequest implements ProviderConfig 
       label = "AWS S3 Bucket name",
       group = "configuration",
       type = TemplateProperty.PropertyType.Text,
-      description =
+      tooltip =
           "Specify the name of the AWS S3 bucket where document will be stored temporarily during Textract analysis",
       defaultValue = "idp-extraction-connector",
       binding = @TemplateProperty.PropertyBinding(name = "s3BucketName"),
@@ -44,7 +44,6 @@ public final class AwsProvider extends AwsBaseRequest implements ProviderConfig 
       label = "Extraction engine type",
       group = "configuration",
       type = Dropdown,
-      description = "Specify extraction engine to be used",
       binding = @TemplateProperty.PropertyBinding(name = "extractionEngineType"),
       constraints = @TemplateProperty.PropertyConstraints(notEmpty = true),
       feel = FeelMode.disabled,

--- a/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/model/providers/AwsProvider.java
+++ b/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/model/providers/AwsProvider.java
@@ -30,8 +30,7 @@ public final class AwsProvider extends AwsBaseRequest implements ProviderConfig 
       label = "AWS S3 Bucket name",
       group = "configuration",
       type = TemplateProperty.PropertyType.Text,
-      tooltip =
-          "Specify the name of the AWS S3 bucket where document will be stored temporarily during Textract analysis",
+      tooltip = "Where the document will be stored temporarily during Textract analysis",
       defaultValue = "idp-extraction-connector",
       binding = @TemplateProperty.PropertyBinding(name = "s3BucketName"),
       feel = FeelMode.disabled,

--- a/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/model/providers/OpenAiProvider.java
+++ b/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/model/providers/OpenAiProvider.java
@@ -28,8 +28,8 @@ public final class OpenAiProvider implements ProviderConfig {
       id = "openAiEndpoint",
       label = "OpenAI Spec Endpoint",
       group = "configuration",
+      tooltip = "The OpenAI-compatible specification endpoint.",
       type = TemplateProperty.PropertyType.Text,
-      description = "Specify the OpenAI compatible specification endpoint.",
       binding = @TemplateProperty.PropertyBinding(name = "openAiEndpoint"),
       feel = FeelMode.disabled,
       constraints = @TemplateProperty.PropertyConstraints(notEmpty = true))
@@ -41,7 +41,7 @@ public final class OpenAiProvider implements ProviderConfig {
       id = "openAiHeaders",
       label = "Headers",
       group = "configuration",
-      description = "Map of HTTP headers to add to the request.",
+      tooltip = "Map of HTTP headers to add to the request.",
       feel = FeelMode.disabled,
       constraints = @TemplateProperty.PropertyConstraints(notEmpty = true))
   @NotNull

--- a/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/model/providers/azure/AiFoundryConfig.java
+++ b/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/model/providers/azure/AiFoundryConfig.java
@@ -26,7 +26,8 @@ public class AiFoundryConfig {
       label = "Model type",
       group = "configuration",
       type = Dropdown,
-      tooltip = "Specify if the Azure AI Foundry is using OpenAI",
+      tooltip =
+          "Base Azure Foundry model = a model deployed directly in Azure AI Foundry; Azure OpenAI model = an OpenAI model served through Azure OpenAI",
       defaultValue = "false",
       constraints = @TemplateProperty.PropertyConstraints(notEmpty = true),
       choices = {

--- a/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/model/providers/azure/AiFoundryConfig.java
+++ b/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/model/providers/azure/AiFoundryConfig.java
@@ -26,7 +26,7 @@ public class AiFoundryConfig {
       label = "Model type",
       group = "configuration",
       type = Dropdown,
-      description = "Specify if the Azure AI Foundry is using OpenAI",
+      tooltip = "Specify if the Azure AI Foundry is using OpenAI",
       defaultValue = "false",
       constraints = @TemplateProperty.PropertyConstraints(notEmpty = true),
       choices = {
@@ -42,7 +42,6 @@ public class AiFoundryConfig {
       label = "Azure AI Foundry Endpoint",
       group = "configuration",
       type = TemplateProperty.PropertyType.Text,
-      description = "Specify the endpoint of the Azure AI Foundry",
       binding = @TemplateProperty.PropertyBinding(name = "endpoint"),
       feel = FeelMode.disabled,
       constraints = @TemplateProperty.PropertyConstraints(notEmpty = true))
@@ -54,7 +53,6 @@ public class AiFoundryConfig {
       label = "Azure AI Foundry API Key",
       group = "configuration",
       type = TemplateProperty.PropertyType.Text,
-      description = "Specify the API key of the Azure AI Foundry",
       binding = @TemplateProperty.PropertyBinding(name = "apiKey"),
       feel = FeelMode.disabled,
       constraints = @TemplateProperty.PropertyConstraints(notEmpty = true))

--- a/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/model/providers/azure/DocumentIntelligenceConfiguration.java
+++ b/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/model/providers/azure/DocumentIntelligenceConfiguration.java
@@ -24,7 +24,6 @@ public class DocumentIntelligenceConfiguration {
       label = "Azure Document Intelligence Endpoint",
       group = "configuration",
       type = TemplateProperty.PropertyType.Text,
-      description = "Specify the endpoint of the Azure Document Intelligence",
       binding = @TemplateProperty.PropertyBinding(name = "endpoint"),
       feel = FeelMode.disabled,
       constraints = @TemplateProperty.PropertyConstraints(notEmpty = true))
@@ -36,7 +35,6 @@ public class DocumentIntelligenceConfiguration {
       label = "Azure Document Intelligence API Key",
       group = "configuration",
       type = TemplateProperty.PropertyType.Text,
-      description = "Specify the API key of the Azure Document Intelligence",
       binding = @TemplateProperty.PropertyBinding(name = "apiKey"),
       feel = FeelMode.disabled,
       constraints = @TemplateProperty.PropertyConstraints(notEmpty = true))

--- a/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/model/providers/gcp/DocumentAiRequestConfiguration.java
+++ b/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/model/providers/gcp/DocumentAiRequestConfiguration.java
@@ -23,7 +23,7 @@ public final class DocumentAiRequestConfiguration implements GcpRequestConfigura
       group = "configuration",
       id = "documentAiRegion",
       label = "Region",
-      description = "Can be 'eu' or 'us'")
+      tooltip = "Can be 'eu' or 'us'")
   private String region;
 
   @TemplateProperty(group = "configuration", id = "projectId", label = "Project ID")
@@ -33,7 +33,7 @@ public final class DocumentAiRequestConfiguration implements GcpRequestConfigura
       group = "configuration",
       id = "processorId",
       label = "Processor ID",
-      description = "The id of the processor used to parse the document")
+      tooltip = "The id of the processor used to parse the document")
   private String processorId;
 
   public DocumentAiRequestConfiguration() {}

--- a/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/model/providers/gcp/DocumentAiRequestConfiguration.java
+++ b/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/model/providers/gcp/DocumentAiRequestConfiguration.java
@@ -33,7 +33,7 @@ public final class DocumentAiRequestConfiguration implements GcpRequestConfigura
       group = "configuration",
       id = "processorId",
       label = "Processor ID",
-      tooltip = "The id of the processor used to parse the document")
+      tooltip = "Processor used to parse the document")
   private String processorId;
 
   public DocumentAiRequestConfiguration() {}

--- a/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/model/providers/gcp/GcpAuthentication.java
+++ b/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/model/providers/gcp/GcpAuthentication.java
@@ -38,7 +38,6 @@ public record GcpAuthentication(
     @TemplateProperty(
             id = "bearerToken",
             label = "Bearer token",
-            tooltip = "Enter a valid Google API Bearer token",
             group = "authentication",
             feel = FeelMode.optional,
             constraints = @PropertyConstraints(notEmpty = true),
@@ -50,7 +49,6 @@ public record GcpAuthentication(
     @TemplateProperty(
             id = "oauthClientId",
             label = "Client ID",
-            tooltip = "Enter Google API Client ID",
             group = "authentication",
             feel = FeelMode.optional,
             constraints = @PropertyConstraints(notEmpty = true),
@@ -62,7 +60,6 @@ public record GcpAuthentication(
     @TemplateProperty(
             id = "oauthClientSecret",
             label = "Client secret",
-            tooltip = "Enter Google API client Secret",
             group = "authentication",
             feel = FeelMode.optional,
             constraints = @PropertyConstraints(notEmpty = true),
@@ -74,7 +71,6 @@ public record GcpAuthentication(
     @TemplateProperty(
             id = "oauthRefreshToken",
             label = "Refresh token",
-            tooltip = "Enter a valid Google API refresh token",
             group = "authentication",
             feel = FeelMode.optional,
             constraints = @PropertyConstraints(notEmpty = true),

--- a/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/model/providers/gcp/GcpAuthentication.java
+++ b/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/model/providers/gcp/GcpAuthentication.java
@@ -38,7 +38,7 @@ public record GcpAuthentication(
     @TemplateProperty(
             id = "bearerToken",
             label = "Bearer token",
-            description = "Enter a valid Google API Bearer token",
+            tooltip = "Enter a valid Google API Bearer token",
             group = "authentication",
             feel = FeelMode.optional,
             constraints = @PropertyConstraints(notEmpty = true),
@@ -50,7 +50,7 @@ public record GcpAuthentication(
     @TemplateProperty(
             id = "oauthClientId",
             label = "Client ID",
-            description = "Enter Google API Client ID",
+            tooltip = "Enter Google API Client ID",
             group = "authentication",
             feel = FeelMode.optional,
             constraints = @PropertyConstraints(notEmpty = true),
@@ -62,7 +62,7 @@ public record GcpAuthentication(
     @TemplateProperty(
             id = "oauthClientSecret",
             label = "Client secret",
-            description = "Enter Google API client Secret",
+            tooltip = "Enter Google API client Secret",
             group = "authentication",
             feel = FeelMode.optional,
             constraints = @PropertyConstraints(notEmpty = true),
@@ -74,7 +74,7 @@ public record GcpAuthentication(
     @TemplateProperty(
             id = "oauthRefreshToken",
             label = "Refresh token",
-            description = "Enter a valid Google API refresh token",
+            tooltip = "Enter a valid Google API refresh token",
             group = "authentication",
             feel = FeelMode.optional,
             constraints = @PropertyConstraints(notEmpty = true),
@@ -86,7 +86,7 @@ public record GcpAuthentication(
     @TemplateProperty(
             id = "serviceAccountJson",
             label = "Service account json",
-            description = "Enter a the contents of your service account json file",
+            tooltip = "Enter the contents of your service account JSON file",
             group = "authentication",
             feel = FeelMode.optional,
             constraints = @PropertyConstraints(notEmpty = true),

--- a/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/model/providers/gcp/VertexRequestConfiguration.java
+++ b/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/model/providers/gcp/VertexRequestConfiguration.java
@@ -28,7 +28,7 @@ public final class VertexRequestConfiguration implements GcpRequestConfiguration
   @TemplateProperty(
       group = "configuration",
       label = "Bucket name",
-      description = "The Google Cloud Storage bucket where the document will be temporarily stored")
+      tooltip = "The Google Cloud Storage bucket where the document will be temporarily stored")
   private String bucketName;
 
   public VertexRequestConfiguration() {}

--- a/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/request/classification/ClassificationRequestData.java
+++ b/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/request/classification/ClassificationRequestData.java
@@ -22,7 +22,6 @@ public class ClassificationRequestData extends DocumentRequestData {
       label = "AWS Bedrock Converse Parameters",
       group = "input",
       type = TemplateProperty.PropertyType.Text,
-      description = "Specify the parameters for AWS Bedrock",
       defaultValue = "={\n  modelId: \"\",\n  temperature: 0.5\n}",
       binding = @TemplateProperty.PropertyBinding(name = "converseData"),
       feel = FeelMode.optional)
@@ -33,7 +32,7 @@ public class ClassificationRequestData extends DocumentRequestData {
       label = "Document types",
       group = "input",
       type = TemplateProperty.PropertyType.Text,
-      description = "The possible classification types considered by the model",
+      tooltip = "The possible classification types considered by the model",
       defaultValue =
           "=[\n  {\n    name: \"\",\n    classificationInstructions: \"\",\n    description: \"\",\n    outputValue: \"\"\n  }\n]",
       binding = @TemplateProperty.PropertyBinding(name = "documentTypes"),
@@ -48,7 +47,7 @@ public class ClassificationRequestData extends DocumentRequestData {
       label = "Fallback output value",
       group = "input",
       type = TemplateProperty.PropertyType.Text,
-      description = "The value to return if the model has low confidence on all document types.",
+      tooltip = "The value to return if the model has low confidence on all document types.",
       constraints = @TemplateProperty.PropertyConstraints(notEmpty = true),
       binding = @TemplateProperty.PropertyBinding(name = "fallbackOutputValue"),
       feel = FeelMode.optional)

--- a/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/request/common/DocumentRequestData.java
+++ b/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/request/common/DocumentRequestData.java
@@ -17,7 +17,6 @@ public class DocumentRequestData {
       label = "Document",
       group = "input",
       type = TemplateProperty.PropertyType.Text,
-      description = "Specify the document",
       defaultValue = "=document",
       binding = @TemplateProperty.PropertyBinding(name = "document"),
       feel = FeelMode.optional,

--- a/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/request/common/ai/AzureAiRequest.java
+++ b/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/request/common/ai/AzureAiRequest.java
@@ -20,7 +20,8 @@ public record AzureAiRequest(
             label = "Model type",
             group = "ai",
             type = Dropdown,
-            tooltip = "Specify if the Azure AI Foundry is using OpenAI",
+            tooltip =
+                "Base Azure Foundry model = a model deployed directly in Azure AI Foundry; Azure OpenAI model = a model served through Azure OpenAI.",
             defaultValue = "false",
             constraints = @TemplateProperty.PropertyConstraints(notEmpty = true),
             choices = {

--- a/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/request/common/ai/AzureAiRequest.java
+++ b/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/request/common/ai/AzureAiRequest.java
@@ -20,7 +20,7 @@ public record AzureAiRequest(
             label = "Model type",
             group = "ai",
             type = Dropdown,
-            description = "Specify if the Azure AI Foundry is using OpenAI",
+            tooltip = "Specify if the Azure AI Foundry is using OpenAI",
             defaultValue = "false",
             constraints = @TemplateProperty.PropertyConstraints(notEmpty = true),
             choices = {
@@ -35,7 +35,6 @@ public record AzureAiRequest(
             label = "Azure AI Endpoint",
             group = "ai",
             type = TemplateProperty.PropertyType.Text,
-            description = "Specify the endpoint of Azure AI",
             binding = @TemplateProperty.PropertyBinding(name = "endpoint"),
             feel = FeelMode.disabled,
             constraints = @TemplateProperty.PropertyConstraints(notEmpty = true))
@@ -46,7 +45,6 @@ public record AzureAiRequest(
             label = "Azure AI API Key",
             group = "ai",
             type = TemplateProperty.PropertyType.Text,
-            description = "Specify the API key of Azure AI",
             binding = @TemplateProperty.PropertyBinding(name = "apiKey"),
             feel = FeelMode.disabled,
             constraints = @TemplateProperty.PropertyConstraints(notEmpty = true))

--- a/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/request/common/ai/BedrockAiRequest.java
+++ b/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/request/common/ai/BedrockAiRequest.java
@@ -60,7 +60,6 @@ public record BedrockAiRequest(
     @TemplateProperty(
             id = "region",
             group = "ai",
-            tooltip = "Specify the AWS region",
             type = TemplateProperty.PropertyType.Text,
             feel = FeelMode.disabled,
             constraints = @TemplateProperty.PropertyConstraints(notEmpty = true))

--- a/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/request/common/ai/BedrockAiRequest.java
+++ b/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/request/common/ai/BedrockAiRequest.java
@@ -34,7 +34,7 @@ public record BedrockAiRequest(
     @TemplateProperty(
             id = "accessKey",
             label = "Access key",
-            description =
+            tooltip =
                 "Provide an IAM access key tailored to a user, equipped with the necessary permissions",
             group = "ai",
             feel = FeelMode.optional,
@@ -47,8 +47,8 @@ public record BedrockAiRequest(
     @TemplateProperty(
             id = "secretKey",
             label = "Secret key",
-            description =
-                "Provide a secret key of a user with permissions to invoke specified AWS Lambda function",
+            tooltip =
+                "Provide the AWS secret access key of a user with permissions for Amazon Bedrock",
             group = "ai",
             feel = FeelMode.optional,
             constraints = @TemplateProperty.PropertyConstraints(notEmpty = true),
@@ -60,7 +60,7 @@ public record BedrockAiRequest(
     @TemplateProperty(
             id = "region",
             group = "ai",
-            description = "Specify the AWS region",
+            tooltip = "Specify the AWS region",
             type = TemplateProperty.PropertyType.Text,
             feel = FeelMode.disabled,
             constraints = @TemplateProperty.PropertyConstraints(notEmpty = true))

--- a/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/request/common/ai/OpenAiRequest.java
+++ b/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/request/common/ai/OpenAiRequest.java
@@ -20,8 +20,8 @@ public record OpenAiRequest(
             id = "openAiEndpoint",
             label = "OpenAI Spec Endpoint",
             group = "ai",
+            tooltip = "The OpenAI-compatible specification endpoint.",
             type = TemplateProperty.PropertyType.Text,
-            description = "Specify the OpenAI compatible specification endpoint.",
             binding = @TemplateProperty.PropertyBinding(name = "openAiEndpoint"),
             feel = FeelMode.disabled,
             constraints = @TemplateProperty.PropertyConstraints(notEmpty = true))
@@ -32,7 +32,7 @@ public record OpenAiRequest(
             id = "openAiHeaders",
             label = "Headers",
             group = "ai",
-            description = "Map of HTTP headers to add to the request.",
+            tooltip = "Map of HTTP headers to add to the request.",
             feel = FeelMode.disabled,
             constraints = @TemplateProperty.PropertyConstraints(notEmpty = true))
         @NotNull

--- a/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/request/common/ai/OpenAiRequest.java
+++ b/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/request/common/ai/OpenAiRequest.java
@@ -20,7 +20,6 @@ public record OpenAiRequest(
             id = "openAiEndpoint",
             label = "OpenAI Spec Endpoint",
             group = "ai",
-            tooltip = "The OpenAI-compatible specification endpoint.",
             type = TemplateProperty.PropertyType.Text,
             binding = @TemplateProperty.PropertyBinding(name = "openAiEndpoint"),
             feel = FeelMode.disabled,

--- a/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/request/common/ai/VertexAiRequest.java
+++ b/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/request/common/ai/VertexAiRequest.java
@@ -33,7 +33,6 @@ public record VertexAiRequest(
     @TemplateProperty(
             id = "bearerToken",
             label = "Bearer token",
-            tooltip = "Enter a valid Google API Bearer token",
             group = "ai",
             feel = FeelMode.optional,
             constraints = @TemplateProperty.PropertyConstraints(notEmpty = true),
@@ -43,7 +42,6 @@ public record VertexAiRequest(
     @TemplateProperty(
             id = "oauthClientId",
             label = "Client ID",
-            tooltip = "Enter Google API Client ID",
             group = "ai",
             feel = FeelMode.optional,
             constraints = @TemplateProperty.PropertyConstraints(notEmpty = true),
@@ -53,7 +51,6 @@ public record VertexAiRequest(
     @TemplateProperty(
             id = "oauthClientSecret",
             label = "Client secret",
-            tooltip = "Enter Google API client Secret",
             group = "ai",
             feel = FeelMode.optional,
             constraints = @TemplateProperty.PropertyConstraints(notEmpty = true),
@@ -63,7 +60,6 @@ public record VertexAiRequest(
     @TemplateProperty(
             id = "oauthRefreshToken",
             label = "Refresh token",
-            tooltip = "Enter a valid Google API refresh token",
             group = "ai",
             feel = FeelMode.optional,
             constraints = @TemplateProperty.PropertyConstraints(notEmpty = true),
@@ -73,7 +69,7 @@ public record VertexAiRequest(
     @TemplateProperty(
             id = "serviceAccountJson",
             label = "Service account json",
-            tooltip = "Enter the contents of your service account JSON file",
+            tooltip = "Contents of your service account JSON file",
             group = "ai",
             feel = FeelMode.optional,
             constraints = @TemplateProperty.PropertyConstraints(notEmpty = true),

--- a/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/request/common/ai/VertexAiRequest.java
+++ b/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/request/common/ai/VertexAiRequest.java
@@ -33,7 +33,7 @@ public record VertexAiRequest(
     @TemplateProperty(
             id = "bearerToken",
             label = "Bearer token",
-            description = "Enter a valid Google API Bearer token",
+            tooltip = "Enter a valid Google API Bearer token",
             group = "ai",
             feel = FeelMode.optional,
             constraints = @TemplateProperty.PropertyConstraints(notEmpty = true),
@@ -43,7 +43,7 @@ public record VertexAiRequest(
     @TemplateProperty(
             id = "oauthClientId",
             label = "Client ID",
-            description = "Enter Google API Client ID",
+            tooltip = "Enter Google API Client ID",
             group = "ai",
             feel = FeelMode.optional,
             constraints = @TemplateProperty.PropertyConstraints(notEmpty = true),
@@ -53,7 +53,7 @@ public record VertexAiRequest(
     @TemplateProperty(
             id = "oauthClientSecret",
             label = "Client secret",
-            description = "Enter Google API client Secret",
+            tooltip = "Enter Google API client Secret",
             group = "ai",
             feel = FeelMode.optional,
             constraints = @TemplateProperty.PropertyConstraints(notEmpty = true),
@@ -63,7 +63,7 @@ public record VertexAiRequest(
     @TemplateProperty(
             id = "oauthRefreshToken",
             label = "Refresh token",
-            description = "Enter a valid Google API refresh token",
+            tooltip = "Enter a valid Google API refresh token",
             group = "ai",
             feel = FeelMode.optional,
             constraints = @TemplateProperty.PropertyConstraints(notEmpty = true),
@@ -73,7 +73,7 @@ public record VertexAiRequest(
     @TemplateProperty(
             id = "serviceAccountJson",
             label = "Service account json",
-            description = "Enter a the contents of your service account json file",
+            tooltip = "Enter the contents of your service account JSON file",
             group = "ai",
             feel = FeelMode.optional,
             constraints = @TemplateProperty.PropertyConstraints(notEmpty = true),

--- a/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/request/common/extraction/AbbyyVantageExtractorRequest.java
+++ b/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/request/common/extraction/AbbyyVantageExtractorRequest.java
@@ -18,7 +18,6 @@ public record AbbyyVantageExtractorRequest(
             label = "ABBYY Vantage Base URL",
             group = "extractor",
             type = TemplateProperty.PropertyType.Text,
-            tooltip = "Base URL of the ABBYY Vantage instance",
             placeholder = "https://vantage-us.abbyy.com",
             feel = FeelMode.optional,
             constraints = @TemplateProperty.PropertyConstraints(notEmpty = true))
@@ -49,8 +48,7 @@ public record AbbyyVantageExtractorRequest(
             label = "Skill ID",
             group = "extractor",
             type = TemplateProperty.PropertyType.Text,
-            tooltip =
-                "The ABBYY Vantage OCR skill ID (skill must be configured to output Text format)",
+            tooltip = "The skill must be configured to output Text format.",
             feel = FeelMode.optional,
             constraints = @TemplateProperty.PropertyConstraints(notEmpty = true))
         @NotNull

--- a/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/request/common/extraction/AbbyyVantageExtractorRequest.java
+++ b/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/request/common/extraction/AbbyyVantageExtractorRequest.java
@@ -18,8 +18,8 @@ public record AbbyyVantageExtractorRequest(
             label = "ABBYY Vantage Base URL",
             group = "extractor",
             type = TemplateProperty.PropertyType.Text,
-            description =
-                "Base URL of the ABBYY Vantage instance (e.g., https://vantage-us.abbyy.com)",
+            tooltip = "Base URL of the ABBYY Vantage instance",
+            placeholder = "https://vantage-us.abbyy.com",
             feel = FeelMode.optional,
             constraints = @TemplateProperty.PropertyConstraints(notEmpty = true))
         @NotNull
@@ -29,7 +29,7 @@ public record AbbyyVantageExtractorRequest(
             label = "Client ID",
             group = "extractor",
             type = TemplateProperty.PropertyType.Text,
-            description = "OAuth2 Client ID from ABBYY Vantage Public API Client settings",
+            tooltip = "OAuth2 Client ID from ABBYY Vantage Public API Client settings",
             feel = FeelMode.optional,
             constraints = @TemplateProperty.PropertyConstraints(notEmpty = true))
         @NotNull
@@ -39,7 +39,7 @@ public record AbbyyVantageExtractorRequest(
             label = "Client Secret",
             group = "extractor",
             type = TemplateProperty.PropertyType.Text,
-            description = "OAuth2 Client Secret from ABBYY Vantage Public API Client settings",
+            tooltip = "OAuth2 Client Secret from ABBYY Vantage Public API Client settings",
             feel = FeelMode.optional,
             constraints = @TemplateProperty.PropertyConstraints(notEmpty = true))
         @NotNull
@@ -49,7 +49,7 @@ public record AbbyyVantageExtractorRequest(
             label = "Skill ID",
             group = "extractor",
             type = TemplateProperty.PropertyType.Text,
-            description =
+            tooltip =
                 "The ABBYY Vantage OCR skill ID (skill must be configured to output Text format)",
             feel = FeelMode.optional,
             constraints = @TemplateProperty.PropertyConstraints(notEmpty = true))

--- a/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/request/common/extraction/DocumentAiExtractorRequest.java
+++ b/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/request/common/extraction/DocumentAiExtractorRequest.java
@@ -33,7 +33,6 @@ public record DocumentAiExtractorRequest(
     @TemplateProperty(
             id = "bearerToken",
             label = "Bearer token",
-            tooltip = "Enter a valid Google API Bearer token",
             group = "extractor",
             feel = FeelMode.optional,
             constraints = @TemplateProperty.PropertyConstraints(notEmpty = true),
@@ -45,7 +44,6 @@ public record DocumentAiExtractorRequest(
     @TemplateProperty(
             id = "oauthClientId",
             label = "Client ID",
-            tooltip = "Enter Google API Client ID",
             group = "extractor",
             feel = FeelMode.optional,
             constraints = @TemplateProperty.PropertyConstraints(notEmpty = true),
@@ -57,7 +55,6 @@ public record DocumentAiExtractorRequest(
     @TemplateProperty(
             id = "oauthClientSecret",
             label = "Client secret",
-            tooltip = "Enter Google API client Secret",
             group = "extractor",
             feel = FeelMode.optional,
             constraints = @TemplateProperty.PropertyConstraints(notEmpty = true),
@@ -69,7 +66,6 @@ public record DocumentAiExtractorRequest(
     @TemplateProperty(
             id = "oauthRefreshToken",
             label = "Refresh token",
-            tooltip = "Enter a valid Google API refresh token",
             group = "extractor",
             feel = FeelMode.optional,
             constraints = @TemplateProperty.PropertyConstraints(notEmpty = true),
@@ -94,7 +90,8 @@ public record DocumentAiExtractorRequest(
             group = "extractor",
             id = "documentAiRegion",
             label = "Region",
-            tooltip = "Select the region for Document AI",
+            tooltip =
+                "Geographic location where the Document AI processor runs. EU = European Union, US = United States.",
             type = Dropdown,
             constraints = @TemplateProperty.PropertyConstraints(notEmpty = true),
             choices = {
@@ -107,6 +104,6 @@ public record DocumentAiExtractorRequest(
             group = "extractor",
             id = "processorId",
             label = "Processor ID",
-            tooltip = "The id of the processor used to parse the document")
+            tooltip = "Processor used to parse the document")
         String processorId)
     implements ExtractionProvider {}

--- a/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/request/common/extraction/DocumentAiExtractorRequest.java
+++ b/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/request/common/extraction/DocumentAiExtractorRequest.java
@@ -33,7 +33,7 @@ public record DocumentAiExtractorRequest(
     @TemplateProperty(
             id = "bearerToken",
             label = "Bearer token",
-            description = "Enter a valid Google API Bearer token",
+            tooltip = "Enter a valid Google API Bearer token",
             group = "extractor",
             feel = FeelMode.optional,
             constraints = @TemplateProperty.PropertyConstraints(notEmpty = true),
@@ -45,7 +45,7 @@ public record DocumentAiExtractorRequest(
     @TemplateProperty(
             id = "oauthClientId",
             label = "Client ID",
-            description = "Enter Google API Client ID",
+            tooltip = "Enter Google API Client ID",
             group = "extractor",
             feel = FeelMode.optional,
             constraints = @TemplateProperty.PropertyConstraints(notEmpty = true),
@@ -57,7 +57,7 @@ public record DocumentAiExtractorRequest(
     @TemplateProperty(
             id = "oauthClientSecret",
             label = "Client secret",
-            description = "Enter Google API client Secret",
+            tooltip = "Enter Google API client Secret",
             group = "extractor",
             feel = FeelMode.optional,
             constraints = @TemplateProperty.PropertyConstraints(notEmpty = true),
@@ -69,7 +69,7 @@ public record DocumentAiExtractorRequest(
     @TemplateProperty(
             id = "oauthRefreshToken",
             label = "Refresh token",
-            description = "Enter a valid Google API refresh token",
+            tooltip = "Enter a valid Google API refresh token",
             group = "extractor",
             feel = FeelMode.optional,
             constraints = @TemplateProperty.PropertyConstraints(notEmpty = true),
@@ -81,7 +81,7 @@ public record DocumentAiExtractorRequest(
     @TemplateProperty(
             id = "serviceAccountJson",
             label = "Service account json",
-            description = "Enter a the contents of your service account json file",
+            tooltip = "Enter the contents of your service account JSON file",
             group = "extractor",
             feel = FeelMode.optional,
             constraints = @TemplateProperty.PropertyConstraints(notEmpty = true),
@@ -94,7 +94,7 @@ public record DocumentAiExtractorRequest(
             group = "extractor",
             id = "documentAiRegion",
             label = "Region",
-            description = "Select the region for Document AI",
+            tooltip = "Select the region for Document AI",
             type = Dropdown,
             constraints = @TemplateProperty.PropertyConstraints(notEmpty = true),
             choices = {
@@ -107,6 +107,6 @@ public record DocumentAiExtractorRequest(
             group = "extractor",
             id = "processorId",
             label = "Processor ID",
-            description = "The id of the processor used to parse the document")
+            tooltip = "The id of the processor used to parse the document")
         String processorId)
     implements ExtractionProvider {}

--- a/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/request/common/extraction/DocumentIntelligenceExtractorRequest.java
+++ b/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/request/common/extraction/DocumentIntelligenceExtractorRequest.java
@@ -18,7 +18,6 @@ public record DocumentIntelligenceExtractorRequest(
             label = "Azure Document Intelligence Endpoint",
             group = "extractor",
             type = TemplateProperty.PropertyType.Text,
-            description = "Specify the endpoint of the Azure Document Intelligence",
             binding = @TemplateProperty.PropertyBinding(name = "endpoint"),
             feel = FeelMode.disabled,
             constraints = @TemplateProperty.PropertyConstraints(notEmpty = true))
@@ -29,7 +28,6 @@ public record DocumentIntelligenceExtractorRequest(
             label = "Azure Document Intelligence API Key",
             group = "extractor",
             type = TemplateProperty.PropertyType.Text,
-            description = "Specify the API key of the Azure Document Intelligence",
             binding = @TemplateProperty.PropertyBinding(name = "apiKey"),
             feel = FeelMode.disabled,
             constraints = @TemplateProperty.PropertyConstraints(notEmpty = true))

--- a/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/request/common/extraction/TextractExtractorRequest.java
+++ b/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/request/common/extraction/TextractExtractorRequest.java
@@ -34,8 +34,7 @@ public record TextractExtractorRequest(
     @TemplateProperty(
             id = "accessKey",
             label = "Access key",
-            tooltip =
-                "Provide an IAM access key tailored to a user, equipped with the necessary permissions",
+            tooltip = "IAM access key of a user with the necessary permissions",
             group = "extractor",
             feel = FeelMode.optional,
             constraints = @TemplateProperty.PropertyConstraints(notEmpty = true),
@@ -47,8 +46,7 @@ public record TextractExtractorRequest(
     @TemplateProperty(
             id = "secretKey",
             label = "Secret key",
-            tooltip =
-                "Provide the AWS secret access key of a user with permissions for Amazon Textract and S3",
+            tooltip = "AWS secret access key of a user with permissions for Amazon Textract and S3",
             group = "extractor",
             feel = FeelMode.optional,
             constraints = @TemplateProperty.PropertyConstraints(notEmpty = true),
@@ -60,7 +58,6 @@ public record TextractExtractorRequest(
     @TemplateProperty(
             id = "region",
             group = "extractor",
-            tooltip = "Specify the AWS region",
             type = TemplateProperty.PropertyType.Text,
             feel = FeelMode.disabled,
             constraints = @TemplateProperty.PropertyConstraints(notEmpty = true))
@@ -71,8 +68,7 @@ public record TextractExtractorRequest(
             label = "AWS S3 Bucket name",
             group = "extractor",
             type = TemplateProperty.PropertyType.Text,
-            tooltip =
-                "Specify the name of the AWS S3 bucket where document will be stored temporarily during Textract analysis",
+            tooltip = "Where the document will be stored temporarily during Textract analysis",
             defaultValue = "idp-extraction-connector",
             binding = @TemplateProperty.PropertyBinding(name = "bucketName"),
             feel = FeelMode.disabled,

--- a/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/request/common/extraction/TextractExtractorRequest.java
+++ b/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/request/common/extraction/TextractExtractorRequest.java
@@ -34,7 +34,7 @@ public record TextractExtractorRequest(
     @TemplateProperty(
             id = "accessKey",
             label = "Access key",
-            description =
+            tooltip =
                 "Provide an IAM access key tailored to a user, equipped with the necessary permissions",
             group = "extractor",
             feel = FeelMode.optional,
@@ -47,8 +47,8 @@ public record TextractExtractorRequest(
     @TemplateProperty(
             id = "secretKey",
             label = "Secret key",
-            description =
-                "Provide a secret key of a user with permissions to invoke specified AWS Lambda function",
+            tooltip =
+                "Provide the AWS secret access key of a user with permissions for Amazon Textract and S3",
             group = "extractor",
             feel = FeelMode.optional,
             constraints = @TemplateProperty.PropertyConstraints(notEmpty = true),
@@ -60,7 +60,7 @@ public record TextractExtractorRequest(
     @TemplateProperty(
             id = "region",
             group = "extractor",
-            description = "Specify the AWS region",
+            tooltip = "Specify the AWS region",
             type = TemplateProperty.PropertyType.Text,
             feel = FeelMode.disabled,
             constraints = @TemplateProperty.PropertyConstraints(notEmpty = true))
@@ -71,7 +71,7 @@ public record TextractExtractorRequest(
             label = "AWS S3 Bucket name",
             group = "extractor",
             type = TemplateProperty.PropertyType.Text,
-            description =
+            tooltip =
                 "Specify the name of the AWS S3 bucket where document will be stored temporarily during Textract analysis",
             defaultValue = "idp-extraction-connector",
             binding = @TemplateProperty.PropertyBinding(name = "bucketName"),

--- a/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/request/structured/StructuredExtractionRequestData.java
+++ b/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/request/structured/StructuredExtractionRequestData.java
@@ -18,7 +18,7 @@ public class StructuredExtractionRequestData extends DocumentRequestData {
       label = "Included Fields",
       group = "input",
       type = TemplateProperty.PropertyType.String,
-      description = "List of fields that should be returned from the extraction",
+      tooltip = "List of fields that should be returned from the extraction",
       defaultValue = "=[\n  \n]",
       binding = @TemplateProperty.PropertyBinding(name = "includedFields"),
       feel = FeelMode.optional)
@@ -29,7 +29,7 @@ public class StructuredExtractionRequestData extends DocumentRequestData {
       label = "Rename mappings",
       group = "input",
       type = TemplateProperty.PropertyType.String,
-      description = "List of keys that should be renamed and not be given the default name",
+      tooltip = "List of keys that should be renamed and not be given the default name",
       defaultValue = "={\n  \n}",
       binding = @TemplateProperty.PropertyBinding(name = "renameMappings"),
       feel = FeelMode.optional)
@@ -40,7 +40,7 @@ public class StructuredExtractionRequestData extends DocumentRequestData {
       label = "delimiter",
       group = "input",
       type = TemplateProperty.PropertyType.String,
-      description = "The delimiter used for the variable name of the extracted field",
+      tooltip = "The delimiter used for the variable name of the extracted field",
       binding = @TemplateProperty.PropertyBinding(name = "delimiter"),
       feel = FeelMode.disabled)
   String delimiter;

--- a/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/request/unstructured/UnstructuredExtractionRequestData.java
+++ b/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/request/unstructured/UnstructuredExtractionRequestData.java
@@ -19,7 +19,6 @@ public class UnstructuredExtractionRequestData extends DocumentRequestData {
       label = "Taxonomy Items",
       group = "input",
       type = TemplateProperty.PropertyType.Text,
-      tooltip = "Array of taxonomy items",
       defaultValue = "=[\n  {name: \"\", prompt: \"\"},\n  {name: \"\", prompt: \"\"}\n]",
       binding = @TemplateProperty.PropertyBinding(name = "taxonomyItems"),
       feel = FeelMode.optional)

--- a/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/request/unstructured/UnstructuredExtractionRequestData.java
+++ b/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/request/unstructured/UnstructuredExtractionRequestData.java
@@ -19,7 +19,7 @@ public class UnstructuredExtractionRequestData extends DocumentRequestData {
       label = "Taxonomy Items",
       group = "input",
       type = TemplateProperty.PropertyType.Text,
-      description = "Array of taxonomy items",
+      tooltip = "Array of taxonomy items",
       defaultValue = "=[\n  {name: \"\", prompt: \"\"},\n  {name: \"\", prompt: \"\"}\n]",
       binding = @TemplateProperty.PropertyBinding(name = "taxonomyItems"),
       feel = FeelMode.optional)
@@ -30,7 +30,6 @@ public class UnstructuredExtractionRequestData extends DocumentRequestData {
       label = "Ai converse parameters",
       group = "input",
       type = TemplateProperty.PropertyType.Text,
-      description = "Specify the parameters for the ai conversation",
       defaultValue = "={\n  modelId: \"\",\n  temperature: 0.5\n}",
       binding = @TemplateProperty.PropertyBinding(name = "converseData"),
       feel = FeelMode.optional)


### PR DESCRIPTION
Part of #7470. One of 8 review-sized slices of the `description` → `tooltip` migration (originally the umbrella PR #7651, split per review feedback for reviewability).

**Priority:** `tooltip` > `placeholder` > `description`. Field hints move to `tooltip=`; always-visible `description=` is kept only for value-constraints, `Note:`/`Warning:` markers, and genuinely critical guidance.

**Connectors in this slice:** IDP extraction (classification, extraction, structured & unstructured extraction) — its own slice because of size.

Templates are regenerated from the migrated Java `@TemplateProperty` sources.