### PR TITLE
refactor(misc connectors): tooltip-first element-template field hints

### DIFF
--- a/connectors/automation-anywhere/element-templates/automation-anywhere-outbound-connector.json
+++ b/connectors/automation-anywhere/element-templates/automation-anywhere-outbound-connector.json
@@ -85,7 +85,7 @@
   }, {
     "id" : "authentication.type",
     "label" : "Type",
-    "description" : "Choose the authentication type. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/automation-anywhere/\" target=\"_blank\">documentation</a>",
+    "description" : "Choose the authentication type. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/automation-anywhere/\" target=\"_blank\">Automation Anywhere connector documentation</a>",
     "value" : "passwordBasedAuthentication",
     "group" : "authentication",
     "binding" : {
@@ -226,7 +226,6 @@
   }, {
     "id" : "operation.queueId",
     "label" : "Work queue ID",
-    "description" : "The queue ID of the item",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -242,11 +241,11 @@
       "equals" : "addWorkItemsToTheQueue",
       "type" : "simple"
     },
+    "tooltip" : "The queue ID of the item",
     "type" : "String"
   }, {
     "id" : "operation.data",
     "label" : "Work item json data",
-    "description" : "Work item json input data. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/automation-anywhere/\" target=\"_blank\">documentation</a>",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -262,11 +261,11 @@
       "equals" : "addWorkItemsToTheQueue",
       "type" : "simple"
     },
+    "tooltip" : "Work item json input data. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/automation-anywhere/\" target=\"_blank\">Automation Anywhere connector documentation</a>",
     "type" : "Text"
   }, {
     "id" : "operation.workQueueId",
     "label" : "Work queue ID",
-    "description" : "The queue ID of the item",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -282,11 +281,11 @@
       "equals" : "listWorkItemsInQueue",
       "type" : "simple"
     },
+    "tooltip" : "The queue ID of the item",
     "type" : "String"
   }, {
     "id" : "operation.workItemId",
     "label" : "Work item ID",
-    "description" : "The queue item identifier to be fetched from queue",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -302,11 +301,11 @@
       "equals" : "listWorkItemsInQueue",
       "type" : "simple"
     },
+    "tooltip" : "The queue item identifier to be fetched from queue",
     "type" : "Number"
   }, {
     "id" : "configuration.connectionTimeoutInSeconds",
     "label" : "Connection timeout in seconds",
-    "description" : "Sets the timeout in seconds to establish a connection or 0 for an infinite timeout",
     "optional" : true,
     "value" : 20,
     "feel" : "static",
@@ -315,6 +314,7 @@
       "name" : "configuration.connectionTimeoutInSeconds",
       "type" : "zeebe:input"
     },
+    "tooltip" : "Sets the timeout in seconds to establish a connection or 0 for an infinite timeout",
     "type" : "Number"
   }, {
     "id" : "version",

--- a/connectors/automation-anywhere/element-templates/automation-anywhere-outbound-connector.json
+++ b/connectors/automation-anywhere/element-templates/automation-anywhere-outbound-connector.json
@@ -241,7 +241,6 @@
       "equals" : "addWorkItemsToTheQueue",
       "type" : "simple"
     },
-    "tooltip" : "The queue ID of the item",
     "type" : "String"
   }, {
     "id" : "operation.data",
@@ -261,7 +260,7 @@
       "equals" : "addWorkItemsToTheQueue",
       "type" : "simple"
     },
-    "tooltip" : "Work item json input data. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/automation-anywhere/\" target=\"_blank\">Automation Anywhere connector documentation</a>",
+    "tooltip" : "JSON data for the work item, mapping queue column names to values. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/automation-anywhere/\" target=\"_blank\">Automation Anywhere connector documentation</a>",
     "type" : "Text"
   }, {
     "id" : "operation.workQueueId",
@@ -281,7 +280,6 @@
       "equals" : "listWorkItemsInQueue",
       "type" : "simple"
     },
-    "tooltip" : "The queue ID of the item",
     "type" : "String"
   }, {
     "id" : "operation.workItemId",

--- a/connectors/automation-anywhere/element-templates/hybrid/automation-anywhere-outbound-connector-hybrid.json
+++ b/connectors/automation-anywhere/element-templates/hybrid/automation-anywhere-outbound-connector-hybrid.json
@@ -90,7 +90,7 @@
   }, {
     "id" : "authentication.type",
     "label" : "Type",
-    "description" : "Choose the authentication type. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/automation-anywhere/\" target=\"_blank\">documentation</a>",
+    "description" : "Choose the authentication type. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/automation-anywhere/\" target=\"_blank\">Automation Anywhere connector documentation</a>",
     "value" : "passwordBasedAuthentication",
     "group" : "authentication",
     "binding" : {
@@ -231,7 +231,6 @@
   }, {
     "id" : "operation.queueId",
     "label" : "Work queue ID",
-    "description" : "The queue ID of the item",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -247,11 +246,11 @@
       "equals" : "addWorkItemsToTheQueue",
       "type" : "simple"
     },
+    "tooltip" : "The queue ID of the item",
     "type" : "String"
   }, {
     "id" : "operation.data",
     "label" : "Work item json data",
-    "description" : "Work item json input data. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/automation-anywhere/\" target=\"_blank\">documentation</a>",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -267,11 +266,11 @@
       "equals" : "addWorkItemsToTheQueue",
       "type" : "simple"
     },
+    "tooltip" : "Work item json input data. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/automation-anywhere/\" target=\"_blank\">Automation Anywhere connector documentation</a>",
     "type" : "Text"
   }, {
     "id" : "operation.workQueueId",
     "label" : "Work queue ID",
-    "description" : "The queue ID of the item",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -287,11 +286,11 @@
       "equals" : "listWorkItemsInQueue",
       "type" : "simple"
     },
+    "tooltip" : "The queue ID of the item",
     "type" : "String"
   }, {
     "id" : "operation.workItemId",
     "label" : "Work item ID",
-    "description" : "The queue item identifier to be fetched from queue",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -307,11 +306,11 @@
       "equals" : "listWorkItemsInQueue",
       "type" : "simple"
     },
+    "tooltip" : "The queue item identifier to be fetched from queue",
     "type" : "Number"
   }, {
     "id" : "configuration.connectionTimeoutInSeconds",
     "label" : "Connection timeout in seconds",
-    "description" : "Sets the timeout in seconds to establish a connection or 0 for an infinite timeout",
     "optional" : true,
     "value" : 20,
     "feel" : "static",
@@ -320,6 +319,7 @@
       "name" : "configuration.connectionTimeoutInSeconds",
       "type" : "zeebe:input"
     },
+    "tooltip" : "Sets the timeout in seconds to establish a connection or 0 for an infinite timeout",
     "type" : "Number"
   }, {
     "id" : "version",

--- a/connectors/automation-anywhere/element-templates/hybrid/automation-anywhere-outbound-connector-hybrid.json
+++ b/connectors/automation-anywhere/element-templates/hybrid/automation-anywhere-outbound-connector-hybrid.json
@@ -246,7 +246,6 @@
       "equals" : "addWorkItemsToTheQueue",
       "type" : "simple"
     },
-    "tooltip" : "The queue ID of the item",
     "type" : "String"
   }, {
     "id" : "operation.data",
@@ -266,7 +265,7 @@
       "equals" : "addWorkItemsToTheQueue",
       "type" : "simple"
     },
-    "tooltip" : "Work item json input data. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/automation-anywhere/\" target=\"_blank\">Automation Anywhere connector documentation</a>",
+    "tooltip" : "JSON data for the work item, mapping queue column names to values. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/automation-anywhere/\" target=\"_blank\">Automation Anywhere connector documentation</a>",
     "type" : "Text"
   }, {
     "id" : "operation.workQueueId",
@@ -286,7 +285,6 @@
       "equals" : "listWorkItemsInQueue",
       "type" : "simple"
     },
-    "tooltip" : "The queue ID of the item",
     "type" : "String"
   }, {
     "id" : "operation.workItemId",

--- a/connectors/automation-anywhere/src/main/java/io/camunda/connector/automationanywhere/model/request/Configuration.java
+++ b/connectors/automation-anywhere/src/main/java/io/camunda/connector/automationanywhere/model/request/Configuration.java
@@ -17,6 +17,6 @@ public record Configuration(
             defaultValueType = TemplateProperty.DefaultValueType.Number,
             defaultValue = "20",
             optional = true,
-            description =
+            tooltip =
                 "Sets the timeout in seconds to establish a connection or 0 for an infinite timeout")
         Integer connectionTimeoutInSeconds) {}

--- a/connectors/automation-anywhere/src/main/java/io/camunda/connector/automationanywhere/model/request/auth/Authentication.java
+++ b/connectors/automation-anywhere/src/main/java/io/camunda/connector/automationanywhere/model/request/auth/Authentication.java
@@ -24,6 +24,6 @@ import io.camunda.connector.generator.java.annotation.TemplateDiscriminatorPrope
     name = "type",
     defaultValue = "passwordBasedAuthentication",
     description =
-        "Choose the authentication type. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/automation-anywhere/\" target=\"_blank\">documentation</a>")
+        "Choose the authentication type. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/automation-anywhere/\" target=\"_blank\">Automation Anywhere connector documentation</a>")
 public sealed interface Authentication
     permits PasswordBasedAuthentication, ApiKeyAuthentication, TokenBasedAuthentication {}

--- a/connectors/automation-anywhere/src/main/java/io/camunda/connector/automationanywhere/model/request/operation/AddWorkItemOperationData.java
+++ b/connectors/automation-anywhere/src/main/java/io/camunda/connector/automationanywhere/model/request/operation/AddWorkItemOperationData.java
@@ -24,19 +24,14 @@ import jakarta.validation.constraints.NotNull;
       "insert queue item"
     })
 public record AddWorkItemOperationData(
-    @TemplateProperty(
-            label = "Work queue ID",
-            group = "input",
-            tooltip = "The queue ID of the item")
-        @NotNull
-        Object queueId,
+    @TemplateProperty(label = "Work queue ID", group = "input") @NotNull Object queueId,
     @TemplateProperty(
             label = "Work item json data",
             group = "input",
             feel = FeelMode.required,
             type = TemplateProperty.PropertyType.Text,
             tooltip =
-                "Work item json input data. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/automation-anywhere/\" target=\"_blank\">Automation Anywhere connector documentation</a>")
+                "JSON data for the work item, mapping queue column names to values. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/automation-anywhere/\" target=\"_blank\">Automation Anywhere connector documentation</a>")
         @NotNull
         Object data)
     implements OperationData {}

--- a/connectors/automation-anywhere/src/main/java/io/camunda/connector/automationanywhere/model/request/operation/AddWorkItemOperationData.java
+++ b/connectors/automation-anywhere/src/main/java/io/camunda/connector/automationanywhere/model/request/operation/AddWorkItemOperationData.java
@@ -27,7 +27,7 @@ public record AddWorkItemOperationData(
     @TemplateProperty(
             label = "Work queue ID",
             group = "input",
-            description = "The queue ID of the item")
+            tooltip = "The queue ID of the item")
         @NotNull
         Object queueId,
     @TemplateProperty(
@@ -35,8 +35,8 @@ public record AddWorkItemOperationData(
             group = "input",
             feel = FeelMode.required,
             type = TemplateProperty.PropertyType.Text,
-            description =
-                "Work item json input data. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/automation-anywhere/\" target=\"_blank\">documentation</a>")
+            tooltip =
+                "Work item json input data. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/automation-anywhere/\" target=\"_blank\">Automation Anywhere connector documentation</a>")
         @NotNull
         Object data)
     implements OperationData {}

--- a/connectors/automation-anywhere/src/main/java/io/camunda/connector/automationanywhere/model/request/operation/GetWorkItemOperationData.java
+++ b/connectors/automation-anywhere/src/main/java/io/camunda/connector/automationanywhere/model/request/operation/GetWorkItemOperationData.java
@@ -27,13 +27,13 @@ public record GetWorkItemOperationData(
             label = "Work queue ID",
             group = "input",
             id = "workQueueId",
-            description = "The queue ID of the item")
+            tooltip = "The queue ID of the item")
         @NotNull
         Object queueId,
     @TemplateProperty(
             label = "Work item ID",
             group = "input",
-            description = "The queue item identifier to be fetched from queue")
+            tooltip = "The queue item identifier to be fetched from queue")
         @NotNull
         Integer workItemId)
     implements OperationData {}

--- a/connectors/automation-anywhere/src/main/java/io/camunda/connector/automationanywhere/model/request/operation/GetWorkItemOperationData.java
+++ b/connectors/automation-anywhere/src/main/java/io/camunda/connector/automationanywhere/model/request/operation/GetWorkItemOperationData.java
@@ -23,12 +23,7 @@ import jakarta.validation.constraints.NotNull;
       "read queue item"
     })
 public record GetWorkItemOperationData(
-    @TemplateProperty(
-            label = "Work queue ID",
-            group = "input",
-            id = "workQueueId",
-            tooltip = "The queue ID of the item")
-        @NotNull
+    @TemplateProperty(label = "Work queue ID", group = "input", id = "workQueueId") @NotNull
         Object queueId,
     @TemplateProperty(
             label = "Work item ID",

--- a/connectors/box/element-templates/box-outbound-connector.json
+++ b/connectors/box/element-templates/box-outbound-connector.json
@@ -137,7 +137,6 @@
   }, {
     "id" : "operation.recursive",
     "label" : "Recursive",
-    "description" : "Deletes all items contained by the folder",
     "optional" : false,
     "value" : true,
     "feel" : "static",
@@ -151,6 +150,7 @@
       "equals" : "deleteFolder",
       "type" : "simple"
     },
+    "tooltip" : "Deletes all items contained by the folder",
     "type" : "Boolean"
   }, {
     "id" : "operation.uploadFileName",
@@ -193,7 +193,6 @@
   }, {
     "id" : "operation.document_documentSource",
     "label" : "Document source",
-    "description" : "The document reference that will be uploaded",
     "value" : "camunda",
     "group" : "operation",
     "binding" : {
@@ -205,6 +204,7 @@
       "equals" : "uploadFile",
       "type" : "simple"
     },
+    "tooltip" : "The document reference that will be uploaded",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "Camunda Document",
@@ -368,7 +368,6 @@
   }, {
     "id" : "operation.downloadFilePath",
     "label" : "File path",
-    "description" : "Path to the file item to download",
     "optional" : false,
     "feel" : "optional",
     "group" : "operation",
@@ -381,6 +380,7 @@
       "equals" : "downloadFile",
       "type" : "simple"
     },
+    "tooltip" : "Path to the file item to download",
     "type" : "String"
   }, {
     "id" : "operation.moveFilePath",
@@ -461,7 +461,6 @@
   }, {
     "id" : "operation.searchSortColumn",
     "label" : "Search sort column",
-    "description" : "Column for sorting search results",
     "optional" : false,
     "value" : "modified_at",
     "constraints" : {
@@ -478,11 +477,11 @@
       "equals" : "search",
       "type" : "simple"
     },
+    "tooltip" : "Column for sorting search results",
     "type" : "String"
   }, {
     "id" : "operation.searchSortDirection",
     "label" : "Search sort direction",
-    "description" : "Direction for sorting search results",
     "optional" : false,
     "value" : "DESC",
     "group" : "operation",
@@ -495,6 +494,7 @@
       "equals" : "search",
       "type" : "simple"
     },
+    "tooltip" : "Direction for sorting search results",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "ASC",
@@ -506,7 +506,6 @@
   }, {
     "id" : "operation.searchOffset",
     "label" : "Search offset",
-    "description" : "Offset for search results",
     "optional" : false,
     "value" : 0,
     "feel" : "static",
@@ -520,11 +519,11 @@
       "equals" : "search",
       "type" : "simple"
     },
+    "tooltip" : "Offset for search results",
     "type" : "Number"
   }, {
     "id" : "operation.searchLimit",
     "label" : "Search limit",
-    "description" : "Limit",
     "optional" : false,
     "value" : 30,
     "feel" : "static",
@@ -566,7 +565,6 @@
   }, {
     "id" : "authentication.clientIdEnterprise",
     "label" : "Client id",
-    "description" : "The client id",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -586,7 +584,6 @@
   }, {
     "id" : "authentication.clientSecretEnterprise",
     "label" : "Client secret",
-    "description" : "The client secret",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -606,7 +603,6 @@
   }, {
     "id" : "authentication.enterpriseId",
     "label" : "Enterprise ID",
-    "description" : "The enterprise ID to authenticate against",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -622,11 +618,11 @@
       "equals" : "clientCredentialsEnterprise",
       "type" : "simple"
     },
+    "tooltip" : "The enterprise ID to authenticate against",
     "type" : "String"
   }, {
     "id" : "authentication.clientIdUser",
     "label" : "Client id",
-    "description" : "The client id",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -646,7 +642,6 @@
   }, {
     "id" : "authentication.clientSecretUser",
     "label" : "Client secret",
-    "description" : "The client secret",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -666,7 +661,6 @@
   }, {
     "id" : "authentication.userId",
     "label" : "User ID",
-    "description" : "The user ID to of the account to authenticate against",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -682,11 +676,11 @@
       "equals" : "clientCredentialsUser",
       "type" : "simple"
     },
+    "tooltip" : "The user ID of the account to authenticate against",
     "type" : "String"
   }, {
     "id" : "authentication.accessToken",
     "label" : "Access key",
-    "description" : "The access key or developer token",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -702,11 +696,11 @@
       "equals" : "developerToken",
       "type" : "simple"
     },
+    "tooltip" : "The access key or developer token",
     "type" : "String"
   }, {
     "id" : "authentication.jsonConfig",
     "label" : "JSON config",
-    "description" : "The JSON config as string",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -722,6 +716,7 @@
       "equals" : "jwtJsonConfig",
       "type" : "simple"
     },
+    "tooltip" : "The JSON config as string",
     "type" : "String"
   }, {
     "id" : "version",

--- a/connectors/box/element-templates/box-outbound-connector.json
+++ b/connectors/box/element-templates/box-outbound-connector.json
@@ -477,7 +477,6 @@
       "equals" : "search",
       "type" : "simple"
     },
-    "tooltip" : "Column for sorting search results",
     "type" : "String"
   }, {
     "id" : "operation.searchSortDirection",
@@ -494,7 +493,7 @@
       "equals" : "search",
       "type" : "simple"
     },
-    "tooltip" : "Direction for sorting search results",
+    "tooltip" : "Sort order for results: ASC (ascending) or DESC (descending)",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "ASC",
@@ -519,7 +518,6 @@
       "equals" : "search",
       "type" : "simple"
     },
-    "tooltip" : "Offset for search results",
     "type" : "Number"
   }, {
     "id" : "operation.searchLimit",

--- a/connectors/box/element-templates/hybrid/box-outbound-connector-hybrid.json
+++ b/connectors/box/element-templates/hybrid/box-outbound-connector-hybrid.json
@@ -482,7 +482,6 @@
       "equals" : "search",
       "type" : "simple"
     },
-    "tooltip" : "Column for sorting search results",
     "type" : "String"
   }, {
     "id" : "operation.searchSortDirection",
@@ -499,7 +498,7 @@
       "equals" : "search",
       "type" : "simple"
     },
-    "tooltip" : "Direction for sorting search results",
+    "tooltip" : "Sort order for results: ASC (ascending) or DESC (descending)",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "ASC",
@@ -524,7 +523,6 @@
       "equals" : "search",
       "type" : "simple"
     },
-    "tooltip" : "Offset for search results",
     "type" : "Number"
   }, {
     "id" : "operation.searchLimit",

--- a/connectors/box/element-templates/hybrid/box-outbound-connector-hybrid.json
+++ b/connectors/box/element-templates/hybrid/box-outbound-connector-hybrid.json
@@ -142,7 +142,6 @@
   }, {
     "id" : "operation.recursive",
     "label" : "Recursive",
-    "description" : "Deletes all items contained by the folder",
     "optional" : false,
     "value" : true,
     "feel" : "static",
@@ -156,6 +155,7 @@
       "equals" : "deleteFolder",
       "type" : "simple"
     },
+    "tooltip" : "Deletes all items contained by the folder",
     "type" : "Boolean"
   }, {
     "id" : "operation.uploadFileName",
@@ -198,7 +198,6 @@
   }, {
     "id" : "operation.document_documentSource",
     "label" : "Document source",
-    "description" : "The document reference that will be uploaded",
     "value" : "camunda",
     "group" : "operation",
     "binding" : {
@@ -210,6 +209,7 @@
       "equals" : "uploadFile",
       "type" : "simple"
     },
+    "tooltip" : "The document reference that will be uploaded",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "Camunda Document",
@@ -373,7 +373,6 @@
   }, {
     "id" : "operation.downloadFilePath",
     "label" : "File path",
-    "description" : "Path to the file item to download",
     "optional" : false,
     "feel" : "optional",
     "group" : "operation",
@@ -386,6 +385,7 @@
       "equals" : "downloadFile",
       "type" : "simple"
     },
+    "tooltip" : "Path to the file item to download",
     "type" : "String"
   }, {
     "id" : "operation.moveFilePath",
@@ -466,7 +466,6 @@
   }, {
     "id" : "operation.searchSortColumn",
     "label" : "Search sort column",
-    "description" : "Column for sorting search results",
     "optional" : false,
     "value" : "modified_at",
     "constraints" : {
@@ -483,11 +482,11 @@
       "equals" : "search",
       "type" : "simple"
     },
+    "tooltip" : "Column for sorting search results",
     "type" : "String"
   }, {
     "id" : "operation.searchSortDirection",
     "label" : "Search sort direction",
-    "description" : "Direction for sorting search results",
     "optional" : false,
     "value" : "DESC",
     "group" : "operation",
@@ -500,6 +499,7 @@
       "equals" : "search",
       "type" : "simple"
     },
+    "tooltip" : "Direction for sorting search results",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "ASC",
@@ -511,7 +511,6 @@
   }, {
     "id" : "operation.searchOffset",
     "label" : "Search offset",
-    "description" : "Offset for search results",
     "optional" : false,
     "value" : 0,
     "feel" : "static",
@@ -525,11 +524,11 @@
       "equals" : "search",
       "type" : "simple"
     },
+    "tooltip" : "Offset for search results",
     "type" : "Number"
   }, {
     "id" : "operation.searchLimit",
     "label" : "Search limit",
-    "description" : "Limit",
     "optional" : false,
     "value" : 30,
     "feel" : "static",
@@ -571,7 +570,6 @@
   }, {
     "id" : "authentication.clientIdEnterprise",
     "label" : "Client id",
-    "description" : "The client id",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -591,7 +589,6 @@
   }, {
     "id" : "authentication.clientSecretEnterprise",
     "label" : "Client secret",
-    "description" : "The client secret",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -611,7 +608,6 @@
   }, {
     "id" : "authentication.enterpriseId",
     "label" : "Enterprise ID",
-    "description" : "The enterprise ID to authenticate against",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -627,11 +623,11 @@
       "equals" : "clientCredentialsEnterprise",
       "type" : "simple"
     },
+    "tooltip" : "The enterprise ID to authenticate against",
     "type" : "String"
   }, {
     "id" : "authentication.clientIdUser",
     "label" : "Client id",
-    "description" : "The client id",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -651,7 +647,6 @@
   }, {
     "id" : "authentication.clientSecretUser",
     "label" : "Client secret",
-    "description" : "The client secret",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -671,7 +666,6 @@
   }, {
     "id" : "authentication.userId",
     "label" : "User ID",
-    "description" : "The user ID to of the account to authenticate against",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -687,11 +681,11 @@
       "equals" : "clientCredentialsUser",
       "type" : "simple"
     },
+    "tooltip" : "The user ID of the account to authenticate against",
     "type" : "String"
   }, {
     "id" : "authentication.accessToken",
     "label" : "Access key",
-    "description" : "The access key or developer token",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -707,11 +701,11 @@
       "equals" : "developerToken",
       "type" : "simple"
     },
+    "tooltip" : "The access key or developer token",
     "type" : "String"
   }, {
     "id" : "authentication.jsonConfig",
     "label" : "JSON config",
-    "description" : "The JSON config as string",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -727,6 +721,7 @@
       "equals" : "jwtJsonConfig",
       "type" : "simple"
     },
+    "tooltip" : "The JSON config as string",
     "type" : "String"
   }, {
     "id" : "version",

--- a/connectors/box/src/main/java/io/camunda/connector/box/model/BoxRequest.java
+++ b/connectors/box/src/main/java/io/camunda/connector/box/model/BoxRequest.java
@@ -52,55 +52,45 @@ public record BoxRequest(
         @TemplateProperty(
                 group = "authentication",
                 label = "Access key",
-                description = "The access key or developer token")
+                tooltip = "The access key or developer token")
             @NotBlank
             String accessToken)
         implements Authentication {}
 
     @TemplateSubType(id = "clientCredentialsUser", label = "Client Credentials User")
     record ClientCredentialsUser(
-        @TemplateProperty(
-                group = "authentication",
-                id = "clientIdUser",
-                label = "Client id",
-                description = "The client id")
+        @TemplateProperty(group = "authentication", id = "clientIdUser", label = "Client id")
             @NotBlank
             String clientId,
         @TemplateProperty(
                 group = "authentication",
                 id = "clientSecretUser",
-                label = "Client secret",
-                description = "The client secret")
+                label = "Client secret")
             @NotBlank
             String clientSecret,
         @TemplateProperty(
                 group = "authentication",
                 label = "User ID",
-                description = "The user ID to of the account to authenticate against")
+                tooltip = "The user ID of the account to authenticate against")
             @NotBlank
             String userId)
         implements Authentication {}
 
     @TemplateSubType(id = "clientCredentialsEnterprise", label = "Client Credentials Enterprise")
     record ClientCredentialsEnterprise(
-        @TemplateProperty(
-                group = "authentication",
-                id = "clientIdEnterprise",
-                label = "Client id",
-                description = "The client id")
+        @TemplateProperty(group = "authentication", id = "clientIdEnterprise", label = "Client id")
             @NotBlank
             String clientId,
         @TemplateProperty(
                 group = "authentication",
                 id = "clientSecretEnterprise",
-                label = "Client secret",
-                description = "The client secret")
+                label = "Client secret")
             @NotBlank
             String clientSecret,
         @TemplateProperty(
                 group = "authentication",
                 label = "Enterprise ID",
-                description = "The enterprise ID to authenticate against")
+                tooltip = "The enterprise ID to authenticate against")
             @NotBlank
             String enterpriseId)
         implements Authentication {}
@@ -110,7 +100,7 @@ public record BoxRequest(
         @TemplateProperty(
                 group = "authentication",
                 label = "JSON config",
-                description = "The JSON config as string")
+                tooltip = "The JSON config as string")
             @NotBlank
             String jsonConfig)
         implements Authentication {}
@@ -172,7 +162,7 @@ public record BoxRequest(
                 defaultValueType = TemplateProperty.DefaultValueType.Boolean,
                 group = "operation",
                 label = "Recursive",
-                description = "Deletes all items contained by the folder")
+                tooltip = "Deletes all items contained by the folder")
             boolean recursive)
         implements Operation {}
 
@@ -190,7 +180,7 @@ public record BoxRequest(
         @TemplateDocumentProperty(
                 id = "uploadFileDocument",
                 group = "operation",
-                description = "The document reference that will be uploaded")
+                tooltip = "The document reference that will be uploaded")
             @NotNull
             Document document)
         implements Operation {
@@ -210,7 +200,7 @@ public record BoxRequest(
                 id = "downloadFilePath",
                 group = "operation",
                 label = "File path",
-                description = "Path to the file item to download")
+                tooltip = "Path to the file item to download")
             String filePath)
         implements Operation {}
 
@@ -250,28 +240,27 @@ public record BoxRequest(
         @TemplateProperty(
                 id = "searchSortColumn",
                 defaultValue = "modified_at",
-                description = "Column for sorting search results",
+                tooltip = "Column for sorting search results",
                 group = "operation")
             @NotBlank
             String sortColumn,
         @TemplateProperty(
                 id = "searchSortDirection",
                 defaultValue = "DESC",
-                description = "Direction for sorting search results",
+                tooltip = "Direction for sorting search results",
                 group = "operation")
             SortDirection sortDirection,
         @TemplateProperty(
                 id = "searchOffset",
                 defaultValueType = TemplateProperty.DefaultValueType.Number,
                 defaultValue = "0",
-                description = "Offset for search results",
+                tooltip = "Offset for search results",
                 group = "operation")
             Long offset,
         @TemplateProperty(
                 id = "searchLimit",
                 defaultValueType = TemplateProperty.DefaultValueType.Number,
                 defaultValue = "30",
-                description = "Limit",
                 group = "operation")
             @Min(1)
             @Max(200)

--- a/connectors/box/src/main/java/io/camunda/connector/box/model/BoxRequest.java
+++ b/connectors/box/src/main/java/io/camunda/connector/box/model/BoxRequest.java
@@ -240,21 +240,19 @@ public record BoxRequest(
         @TemplateProperty(
                 id = "searchSortColumn",
                 defaultValue = "modified_at",
-                tooltip = "Column for sorting search results",
                 group = "operation")
             @NotBlank
             String sortColumn,
         @TemplateProperty(
                 id = "searchSortDirection",
                 defaultValue = "DESC",
-                tooltip = "Direction for sorting search results",
+                tooltip = "Sort order for results: ASC (ascending) or DESC (descending)",
                 group = "operation")
             SortDirection sortDirection,
         @TemplateProperty(
                 id = "searchOffset",
                 defaultValueType = TemplateProperty.DefaultValueType.Number,
                 defaultValue = "0",
-                tooltip = "Offset for search results",
                 group = "operation")
             Long offset,
         @TemplateProperty(

--- a/connectors/camunda-message/element-templates/hybrid/hybrid-send-message-connector-intermediate-throw-event-hybrid.json
+++ b/connectors/camunda-message/element-templates/hybrid/hybrid-send-message-connector-intermediate-throw-event-hybrid.json
@@ -117,7 +117,6 @@
   }, {
     "id" : "correlationType.timeToLive",
     "label" : "Time to live (as ISO 8601)",
-    "description" : "Duration for which the message remains buffered",
     "optional" : true,
     "feel" : "optional",
     "group" : "operation",
@@ -130,6 +129,7 @@
       "equals" : "publish",
       "type" : "simple"
     },
+    "tooltip" : "Duration for which the message remains buffered",
     "type" : "String"
   }, {
     "id" : "correlationType.messageId",

--- a/connectors/camunda-message/element-templates/hybrid/hybrid-send-message-connector-message-end-event-hybrid.json
+++ b/connectors/camunda-message/element-templates/hybrid/hybrid-send-message-connector-message-end-event-hybrid.json
@@ -117,7 +117,6 @@
   }, {
     "id" : "correlationType.timeToLive",
     "label" : "Time to live (as ISO 8601)",
-    "description" : "Duration for which the message remains buffered",
     "optional" : true,
     "feel" : "optional",
     "group" : "operation",
@@ -130,6 +129,7 @@
       "equals" : "publish",
       "type" : "simple"
     },
+    "tooltip" : "Duration for which the message remains buffered",
     "type" : "String"
   }, {
     "id" : "correlationType.messageId",

--- a/connectors/camunda-message/element-templates/hybrid/hybrid-send-message-connector-send-task-hybrid.json
+++ b/connectors/camunda-message/element-templates/hybrid/hybrid-send-message-connector-send-task-hybrid.json
@@ -116,7 +116,6 @@
   }, {
     "id" : "correlationType.timeToLive",
     "label" : "Time to live (as ISO 8601)",
-    "description" : "Duration for which the message remains buffered",
     "optional" : true,
     "feel" : "optional",
     "group" : "operation",
@@ -129,6 +128,7 @@
       "equals" : "publish",
       "type" : "simple"
     },
+    "tooltip" : "Duration for which the message remains buffered",
     "type" : "String"
   }, {
     "id" : "correlationType.messageId",

--- a/connectors/camunda-message/element-templates/send-message-connector-intermediate-throw-event.json
+++ b/connectors/camunda-message/element-templates/send-message-connector-intermediate-throw-event.json
@@ -112,7 +112,6 @@
   }, {
     "id" : "correlationType.timeToLive",
     "label" : "Time to live (as ISO 8601)",
-    "description" : "Duration for which the message remains buffered",
     "optional" : true,
     "feel" : "optional",
     "group" : "operation",
@@ -125,6 +124,7 @@
       "equals" : "publish",
       "type" : "simple"
     },
+    "tooltip" : "Duration for which the message remains buffered",
     "type" : "String"
   }, {
     "id" : "correlationType.messageId",

--- a/connectors/camunda-message/element-templates/send-message-connector-message-end-event.json
+++ b/connectors/camunda-message/element-templates/send-message-connector-message-end-event.json
@@ -112,7 +112,6 @@
   }, {
     "id" : "correlationType.timeToLive",
     "label" : "Time to live (as ISO 8601)",
-    "description" : "Duration for which the message remains buffered",
     "optional" : true,
     "feel" : "optional",
     "group" : "operation",
@@ -125,6 +124,7 @@
       "equals" : "publish",
       "type" : "simple"
     },
+    "tooltip" : "Duration for which the message remains buffered",
     "type" : "String"
   }, {
     "id" : "correlationType.messageId",

--- a/connectors/camunda-message/element-templates/send-message-connector-send-task.json
+++ b/connectors/camunda-message/element-templates/send-message-connector-send-task.json
@@ -111,7 +111,6 @@
   }, {
     "id" : "correlationType.timeToLive",
     "label" : "Time to live (as ISO 8601)",
-    "description" : "Duration for which the message remains buffered",
     "optional" : true,
     "feel" : "optional",
     "group" : "operation",
@@ -124,6 +123,7 @@
       "equals" : "publish",
       "type" : "simple"
     },
+    "tooltip" : "Duration for which the message remains buffered",
     "type" : "String"
   }, {
     "id" : "correlationType.messageId",

--- a/connectors/camunda-message/src/main/java/io/camunda/connector/message/SendMessageRequest.java
+++ b/connectors/camunda-message/src/main/java/io/camunda/connector/message/SendMessageRequest.java
@@ -55,7 +55,7 @@ public record SendMessageRequest(
                 optional = true,
                 group = "operation",
                 label = "Time to live (as ISO 8601)",
-                description = "Duration for which the message remains buffered")
+                tooltip = "Duration for which the message remains buffered")
             Duration timeToLive,
         @TemplateProperty(optional = true, group = "operation", label = "Message id (optional)")
             String messageId)

--- a/connectors/email/element-templates/email-outbound-connector.json
+++ b/connectors/email/element-templates/email-outbound-connector.json
@@ -377,7 +377,6 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "Email's subject",
     "type" : "String"
   }, {
     "id" : "contentType",
@@ -403,7 +402,7 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "The content type of the email.",
+    "tooltip" : "Format of the email body: PLAIN sends plain text only, HTML sends HTML only, HTML & Plaintext sends both as a multipart message.",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "PLAIN",
@@ -440,7 +439,6 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "Email's content",
     "type" : "Text"
   }, {
     "id" : "smtpHtmlBody",
@@ -467,7 +465,6 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "Email's HTML content",
     "type" : "Text"
   }, {
     "id" : "data_smtpAction_attachments_documentMode",
@@ -912,6 +909,7 @@
   }, {
     "id" : "pop3MessageIdRead",
     "label" : "Message ID",
+    "description" : "Warning: reading an email using POP3 will delete it.",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -933,7 +931,7 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "The ID of the message, typically returned by a previous email task. Warning: reading an email using POP3 will delete it.",
+    "tooltip" : "ID of the message, typically returned by a previous email task.",
     "type" : "String"
   }, {
     "id" : "imapMaxToBeRead",
@@ -1098,7 +1096,8 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "Specify the folder in which to conduct the email search. If left blank, the search will default to the 'INBOX' folder. You may also specify subfolders using a dot-separated path (e.g., 'INBOX.Archives').",
+    "tooltip" : "Folder in which to conduct the email search. If left blank, the search will default to the 'INBOX' folder. You may also specify subfolders using a dot-separated path.",
+    "placeholder" : "INBOX.Archives",
     "type" : "String"
   }, {
     "id" : "imapMessageIdRead",

--- a/connectors/email/element-templates/email-outbound-connector.json
+++ b/connectors/email/element-templates/email-outbound-connector.json
@@ -403,7 +403,7 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "Email's contentType",
+    "tooltip" : "The content type of the email.",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "PLAIN",
@@ -467,12 +467,11 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "Email's Html content",
+    "tooltip" : "Email's HTML content",
     "type" : "Text"
   }, {
     "id" : "data_smtpAction_attachments_documentMode",
     "label" : "Number of documents",
-    "description" : "Email's attachment. e.g., =[ document1, document2]",
     "value" : "none",
     "group" : "sendEmailSmtp",
     "binding" : {
@@ -490,7 +489,7 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "Email's attachments, should be set as a list ",
+    "tooltip" : "Email attachments, set as a list, e.g. =[document1, document2]",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "None",
@@ -864,7 +863,6 @@
   }, {
     "id" : "searchStringEmailPop3",
     "label" : "Search criteria",
-    "description" : "Refer to our detailed documentation for full search syntax and examples: [Email Documentation](https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/email/).",
     "optional" : true,
     "feel" : "required",
     "group" : "searchEmailsPop3",
@@ -883,7 +881,7 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "Define the search criteria using supported keywords and syntax to filter emails.",
+    "tooltip" : "Define the search criteria using supported keywords and syntax to filter emails. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/email/\">Email connector search syntax</a>.",
     "type" : "Text"
   }, {
     "id" : "pop3MessageIdDelete",
@@ -935,7 +933,7 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "The ID of the message, typically returned by a previous email task. Warning: reading an email using POP3 will delete it",
+    "tooltip" : "The ID of the message, typically returned by a previous email task. Warning: reading an email using POP3 will delete it.",
     "type" : "String"
   }, {
     "id" : "imapMaxToBeRead",
@@ -1059,7 +1057,6 @@
   }, {
     "id" : "searchStringEmailImap",
     "label" : "Search criteria",
-    "description" : "Refer to our detailed documentation for full search syntax and examples: [Email Documentation](https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/email/).",
     "optional" : true,
     "feel" : "required",
     "group" : "searchEmailsImap",
@@ -1078,7 +1075,7 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "Define the search criteria using supported keywords and syntax to filter emails.",
+    "tooltip" : "Define the search criteria using supported keywords and syntax to filter emails. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/email/\">Email connector search syntax</a>.",
     "type" : "Text"
   }, {
     "id" : "searchEmailFolder",

--- a/connectors/email/element-templates/hybrid/email-outbound-connector-hybrid.json
+++ b/connectors/email/element-templates/hybrid/email-outbound-connector-hybrid.json
@@ -382,7 +382,6 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "Email's subject",
     "type" : "String"
   }, {
     "id" : "contentType",
@@ -408,7 +407,7 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "The content type of the email.",
+    "tooltip" : "Format of the email body: PLAIN sends plain text only, HTML sends HTML only, HTML & Plaintext sends both as a multipart message.",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "PLAIN",
@@ -445,7 +444,6 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "Email's content",
     "type" : "Text"
   }, {
     "id" : "smtpHtmlBody",
@@ -472,7 +470,6 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "Email's HTML content",
     "type" : "Text"
   }, {
     "id" : "data_smtpAction_attachments_documentMode",
@@ -917,6 +914,7 @@
   }, {
     "id" : "pop3MessageIdRead",
     "label" : "Message ID",
+    "description" : "Warning: reading an email using POP3 will delete it.",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -938,7 +936,7 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "The ID of the message, typically returned by a previous email task. Warning: reading an email using POP3 will delete it.",
+    "tooltip" : "ID of the message, typically returned by a previous email task.",
     "type" : "String"
   }, {
     "id" : "imapMaxToBeRead",
@@ -1103,7 +1101,8 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "Specify the folder in which to conduct the email search. If left blank, the search will default to the 'INBOX' folder. You may also specify subfolders using a dot-separated path (e.g., 'INBOX.Archives').",
+    "tooltip" : "Folder in which to conduct the email search. If left blank, the search will default to the 'INBOX' folder. You may also specify subfolders using a dot-separated path.",
+    "placeholder" : "INBOX.Archives",
     "type" : "String"
   }, {
     "id" : "imapMessageIdRead",

--- a/connectors/email/element-templates/hybrid/email-outbound-connector-hybrid.json
+++ b/connectors/email/element-templates/hybrid/email-outbound-connector-hybrid.json
@@ -408,7 +408,7 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "Email's contentType",
+    "tooltip" : "The content type of the email.",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "PLAIN",
@@ -472,12 +472,11 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "Email's Html content",
+    "tooltip" : "Email's HTML content",
     "type" : "Text"
   }, {
     "id" : "data_smtpAction_attachments_documentMode",
     "label" : "Number of documents",
-    "description" : "Email's attachment. e.g., =[ document1, document2]",
     "value" : "none",
     "group" : "sendEmailSmtp",
     "binding" : {
@@ -495,7 +494,7 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "Email's attachments, should be set as a list ",
+    "tooltip" : "Email attachments, set as a list, e.g. =[document1, document2]",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "None",
@@ -869,7 +868,6 @@
   }, {
     "id" : "searchStringEmailPop3",
     "label" : "Search criteria",
-    "description" : "Refer to our detailed documentation for full search syntax and examples: [Email Documentation](https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/email/).",
     "optional" : true,
     "feel" : "required",
     "group" : "searchEmailsPop3",
@@ -888,7 +886,7 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "Define the search criteria using supported keywords and syntax to filter emails.",
+    "tooltip" : "Define the search criteria using supported keywords and syntax to filter emails. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/email/\">Email connector search syntax</a>.",
     "type" : "Text"
   }, {
     "id" : "pop3MessageIdDelete",
@@ -940,7 +938,7 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "The ID of the message, typically returned by a previous email task. Warning: reading an email using POP3 will delete it",
+    "tooltip" : "The ID of the message, typically returned by a previous email task. Warning: reading an email using POP3 will delete it.",
     "type" : "String"
   }, {
     "id" : "imapMaxToBeRead",
@@ -1064,7 +1062,6 @@
   }, {
     "id" : "searchStringEmailImap",
     "label" : "Search criteria",
-    "description" : "Refer to our detailed documentation for full search syntax and examples: [Email Documentation](https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/email/).",
     "optional" : true,
     "feel" : "required",
     "group" : "searchEmailsImap",
@@ -1083,7 +1080,7 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "Define the search criteria using supported keywords and syntax to filter emails.",
+    "tooltip" : "Define the search criteria using supported keywords and syntax to filter emails. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/email/\">Email connector search syntax</a>.",
     "type" : "Text"
   }, {
     "id" : "searchEmailFolder",

--- a/connectors/email/src/main/java/io/camunda/connector/email/outbound/protocols/actions/ImapSearchEmails.java
+++ b/connectors/email/src/main/java/io/camunda/connector/email/outbound/protocols/actions/ImapSearchEmails.java
@@ -28,9 +28,7 @@ public record ImapSearchEmails(
             group = "searchEmailsImap",
             id = "searchStringEmailImap",
             tooltip =
-                "Define the search criteria using supported keywords and syntax to filter emails.",
-            description =
-                "Refer to our detailed documentation for full search syntax and examples: [Email Documentation](https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/email/).",
+                "Define the search criteria using supported keywords and syntax to filter emails. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/email/\">Email connector search syntax</a>.",
             type = TemplateProperty.PropertyType.Text,
             feel = FeelMode.required,
             optional = true,

--- a/connectors/email/src/main/java/io/camunda/connector/email/outbound/protocols/actions/ImapSearchEmails.java
+++ b/connectors/email/src/main/java/io/camunda/connector/email/outbound/protocols/actions/ImapSearchEmails.java
@@ -39,7 +39,8 @@ public record ImapSearchEmails(
             group = "searchEmailsImap",
             id = "searchEmailFolder",
             tooltip =
-                "Specify the folder in which to conduct the email search. If left blank, the search will default to the 'INBOX' folder. You may also specify subfolders using a dot-separated path (e.g., 'INBOX.Archives').",
+                "Folder in which to conduct the email search. If left blank, the search will default to the 'INBOX' folder. You may also specify subfolders using a dot-separated path.",
+            placeholder = "INBOX.Archives",
             optional = true,
             feel = FeelMode.optional,
             binding = @TemplateProperty.PropertyBinding(name = "data.imapAction.searchEmailFolder"))

--- a/connectors/email/src/main/java/io/camunda/connector/email/outbound/protocols/actions/Pop3ReadEmail.java
+++ b/connectors/email/src/main/java/io/camunda/connector/email/outbound/protocols/actions/Pop3ReadEmail.java
@@ -29,8 +29,8 @@ public record Pop3ReadEmail(
             label = "Message ID",
             group = "readEmailPop3",
             id = "pop3MessageIdRead",
-            tooltip =
-                "The ID of the message, typically returned by a previous email task. Warning: reading an email using POP3 will delete it.",
+            tooltip = "ID of the message, typically returned by a previous email task.",
+            description = "Warning: reading an email using POP3 will delete it.",
             feel = FeelMode.optional,
             binding = @TemplateProperty.PropertyBinding(name = "data.pop3Action.messageId"))
         @Valid

--- a/connectors/email/src/main/java/io/camunda/connector/email/outbound/protocols/actions/Pop3ReadEmail.java
+++ b/connectors/email/src/main/java/io/camunda/connector/email/outbound/protocols/actions/Pop3ReadEmail.java
@@ -30,7 +30,7 @@ public record Pop3ReadEmail(
             group = "readEmailPop3",
             id = "pop3MessageIdRead",
             tooltip =
-                "The ID of the message, typically returned by a previous email task. Warning: reading an email using POP3 will delete it",
+                "The ID of the message, typically returned by a previous email task. Warning: reading an email using POP3 will delete it.",
             feel = FeelMode.optional,
             binding = @TemplateProperty.PropertyBinding(name = "data.pop3Action.messageId"))
         @Valid

--- a/connectors/email/src/main/java/io/camunda/connector/email/outbound/protocols/actions/Pop3SearchEmails.java
+++ b/connectors/email/src/main/java/io/camunda/connector/email/outbound/protocols/actions/Pop3SearchEmails.java
@@ -28,9 +28,7 @@ public record Pop3SearchEmails(
             group = "searchEmailsPop3",
             id = "searchStringEmailPop3",
             tooltip =
-                "Define the search criteria using supported keywords and syntax to filter emails.",
-            description =
-                "Refer to our detailed documentation for full search syntax and examples: [Email Documentation](https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/email/).",
+                "Define the search criteria using supported keywords and syntax to filter emails. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/email/\">Email connector search syntax</a>.",
             type = TemplateProperty.PropertyType.Text,
             feel = FeelMode.required,
             optional = true,

--- a/connectors/email/src/main/java/io/camunda/connector/email/outbound/protocols/actions/SmtpSendEmail.java
+++ b/connectors/email/src/main/java/io/camunda/connector/email/outbound/protocols/actions/SmtpSendEmail.java
@@ -102,7 +102,7 @@ public record SmtpSendEmail(
             id = "contentType",
             defaultValue = "PLAIN",
             type = TemplateProperty.PropertyType.Dropdown,
-            tooltip = "Email's contentType",
+            tooltip = "The content type of the email.",
             binding = @TemplateProperty.PropertyBinding(name = "data.smtpAction.contentType"))
         @Valid
         @NotNull
@@ -127,7 +127,7 @@ public record SmtpSendEmail(
             group = "sendEmailSmtp",
             id = "smtpHtmlBody",
             type = TemplateProperty.PropertyType.Text,
-            tooltip = "Email's Html content",
+            tooltip = "Email's HTML content",
             binding = @TemplateProperty.PropertyBinding(name = "data.smtpAction.htmlBody"),
             feel = FeelMode.optional,
             condition =
@@ -139,9 +139,8 @@ public record SmtpSendEmail(
     @TemplateDocumentProperty(
             group = "sendEmailSmtp",
             id = "attachmentsSmtp",
-            tooltip = "Email's attachments, should be set as a list ",
+            tooltip = "Email attachments, set as a list, e.g. =[document1, document2]",
             optional = true,
-            description = "Email's attachment. e.g., =[ document1, document2]",
             binding = @TemplateProperty.PropertyBinding(name = "data.smtpAction.attachments"))
         List<Document> attachments)
     implements SmtpAction {

--- a/connectors/email/src/main/java/io/camunda/connector/email/outbound/protocols/actions/SmtpSendEmail.java
+++ b/connectors/email/src/main/java/io/camunda/connector/email/outbound/protocols/actions/SmtpSendEmail.java
@@ -90,7 +90,6 @@ public record SmtpSendEmail(
             group = "sendEmailSmtp",
             id = "smtpSubject",
             type = TemplateProperty.PropertyType.String,
-            tooltip = "Email's subject",
             binding = @TemplateProperty.PropertyBinding(name = "data.smtpAction.subject"),
             feel = FeelMode.optional)
         @Valid
@@ -102,7 +101,8 @@ public record SmtpSendEmail(
             id = "contentType",
             defaultValue = "PLAIN",
             type = TemplateProperty.PropertyType.Dropdown,
-            tooltip = "The content type of the email.",
+            tooltip =
+                "Format of the email body: PLAIN sends plain text only, HTML sends HTML only, HTML & Plaintext sends both as a multipart message.",
             binding = @TemplateProperty.PropertyBinding(name = "data.smtpAction.contentType"))
         @Valid
         @NotNull
@@ -113,7 +113,6 @@ public record SmtpSendEmail(
             group = "sendEmailSmtp",
             id = "smtpBody",
             type = TemplateProperty.PropertyType.Text,
-            tooltip = "Email's content",
             binding = @TemplateProperty.PropertyBinding(name = "data.smtpAction.body"),
             feel = FeelMode.optional,
             condition =
@@ -127,7 +126,6 @@ public record SmtpSendEmail(
             group = "sendEmailSmtp",
             id = "smtpHtmlBody",
             type = TemplateProperty.PropertyType.Text,
-            tooltip = "Email's HTML content",
             binding = @TemplateProperty.PropertyBinding(name = "data.smtpAction.htmlBody"),
             feel = FeelMode.optional,
             condition =

--- a/connectors/jdbc/element-templates/hybrid/jdbc-outbound-connector-hybrid.json
+++ b/connectors/jdbc/element-templates/hybrid/jdbc-outbound-connector-hybrid.json
@@ -63,7 +63,7 @@
       "name" : "database",
       "type" : "zeebe:input"
     },
-    "tooltip" : "Select the database you want to connect to. If you choose Oracle, make sure the Oracle JDBC driver is included. <a href=\"https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/sql/#database\">Oracle JDBC driver setup</a>.",
+    "tooltip" : "If you choose Oracle, make sure the Oracle JDBC driver is included. <a href=\"https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/sql/#database\">Oracle JDBC driver setup</a>.",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "MariaDB",

--- a/connectors/jdbc/element-templates/hybrid/jdbc-outbound-connector-hybrid.json
+++ b/connectors/jdbc/element-templates/hybrid/jdbc-outbound-connector-hybrid.json
@@ -54,7 +54,6 @@
   }, {
     "id" : "database",
     "label" : "Select a database",
-    "description" : "Select the database you want to connect to. If you choose Oracle, make sure the Oracle JDBC driver is included. <a href=\"https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/sql/#database\">Learn how to set it up.</a>",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -64,6 +63,7 @@
       "name" : "database",
       "type" : "zeebe:input"
     },
+    "tooltip" : "Select the database you want to connect to. If you choose Oracle, make sure the Oracle JDBC driver is included. <a href=\"https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/sql/#database\">Oracle JDBC driver setup</a>.",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "MariaDB",
@@ -101,7 +101,6 @@
   }, {
     "id" : "connection.uri",
     "label" : "URI",
-    "description" : "URI should contain JDBC driver, host name, and port number. For more information, see the <a href=\"https://docs.camunda.io/docs/8.6/components/connectors/out-of-the-box-connectors/sql/#uri-connection\" target=\"_blank\">documentation</a>.)",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true,
@@ -121,11 +120,11 @@
       "equals" : "uri",
       "type" : "simple"
     },
+    "tooltip" : "URI should contain JDBC driver, host name, and port number. See the <a href=\"https://docs.camunda.io/docs/8.6/components/connectors/out-of-the-box-connectors/sql/#uri-connection\" target=\"_blank\">URI connection</a> reference.",
     "type" : "String"
   }, {
     "id" : "connection.uriProperties",
     "label" : "Properties",
-    "description" : "Additional properties for the connection ('user' and 'password' for instance). For more information, see the <a href=\"https://docs.camunda.io/docs/8.6/components/connectors/out-of-the-box-connectors/sql/#connection\" target=\"_blank\">documentation</a>.",
     "optional" : true,
     "feel" : "required",
     "group" : "connection",
@@ -138,6 +137,7 @@
       "equals" : "uri",
       "type" : "simple"
     },
+    "tooltip" : "Additional properties for the connection ('user' and 'password' for instance). See the <a href=\"https://docs.camunda.io/docs/8.6/components/connectors/out-of-the-box-connectors/sql/#connection\" target=\"_blank\">SQL connection properties</a> reference.",
     "type" : "String"
   }, {
     "id" : "connection.host",
@@ -228,7 +228,6 @@
   }, {
     "id" : "connection.properties",
     "label" : "Properties",
-    "description" : "Additional properties for the connection. For more information, see the <a href=\"https://docs.camunda.io/docs/8.6/components/connectors/out-of-the-box-connectors/sql/#connection\" target=\"_blank\">documentation</a>.",
     "optional" : true,
     "feel" : "required",
     "group" : "connection",
@@ -241,11 +240,11 @@
       "equals" : "detailed",
       "type" : "simple"
     },
+    "tooltip" : "Additional properties for the connection. See the <a href=\"https://docs.camunda.io/docs/8.6/components/connectors/out-of-the-box-connectors/sql/#connection\" target=\"_blank\">SQL connection properties</a> reference.",
     "type" : "String"
   }, {
     "id" : "data.returnResults",
     "label" : "Return results",
-    "description" : "Check this box if the SQL statement return results, e.g. a SELECT or any statement with a RETURNING clause",
     "optional" : false,
     "value" : false,
     "feel" : "static",
@@ -254,11 +253,11 @@
       "name" : "data.returnResults",
       "type" : "zeebe:input"
     },
+    "tooltip" : "Check this box if the SQL statement returns results, e.g. a SELECT or any statement with a RETURNING clause",
     "type" : "Boolean"
   }, {
     "id" : "data.query",
     "label" : "SQL Query to execute",
-    "description" : "You can use named, positional or binding <a href=\"https://docs.camunda.io/docs/8.6/components/connectors/out-of-the-box-connectors/sql/#variables\" target=\"_blank\">parameters</a>",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -269,11 +268,11 @@
       "name" : "data.query",
       "type" : "zeebe:input"
     },
+    "tooltip" : "You can use named, positional or binding <a href=\"https://docs.camunda.io/docs/8.6/components/connectors/out-of-the-box-connectors/sql/#variables\" target=\"_blank\">parameters</a>",
     "type" : "String"
   }, {
     "id" : "data.variables",
     "label" : "SQL Query variables",
-    "description" : "The <a href=\"https://docs.camunda.io/docs/8.6/components/connectors/out-of-the-box-connectors/sql/#variables\" target=\"_blank\">variables</a> to use in the SQL query.",
     "optional" : true,
     "feel" : "required",
     "group" : "query",
@@ -281,6 +280,7 @@
       "name" : "data.variables",
       "type" : "zeebe:input"
     },
+    "tooltip" : "The <a href=\"https://docs.camunda.io/docs/8.6/components/connectors/out-of-the-box-connectors/sql/#variables\" target=\"_blank\">variables</a> to use in the SQL query.",
     "type" : "String"
   }, {
     "id" : "version",

--- a/connectors/jdbc/element-templates/jdbc-outbound-connector.json
+++ b/connectors/jdbc/element-templates/jdbc-outbound-connector.json
@@ -49,7 +49,6 @@
   }, {
     "id" : "database",
     "label" : "Select a database",
-    "description" : "Select the database you want to connect to. If you choose Oracle, make sure the Oracle JDBC driver is included. <a href=\"https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/sql/#database\">Learn how to set it up.</a>",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -59,6 +58,7 @@
       "name" : "database",
       "type" : "zeebe:input"
     },
+    "tooltip" : "Select the database you want to connect to. If you choose Oracle, make sure the Oracle JDBC driver is included. <a href=\"https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/sql/#database\">Oracle JDBC driver setup</a>.",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "MariaDB",
@@ -96,7 +96,6 @@
   }, {
     "id" : "connection.uri",
     "label" : "URI",
-    "description" : "URI should contain JDBC driver, host name, and port number. For more information, see the <a href=\"https://docs.camunda.io/docs/8.6/components/connectors/out-of-the-box-connectors/sql/#uri-connection\" target=\"_blank\">documentation</a>.)",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true,
@@ -116,11 +115,11 @@
       "equals" : "uri",
       "type" : "simple"
     },
+    "tooltip" : "URI should contain JDBC driver, host name, and port number. See the <a href=\"https://docs.camunda.io/docs/8.6/components/connectors/out-of-the-box-connectors/sql/#uri-connection\" target=\"_blank\">URI connection</a> reference.",
     "type" : "String"
   }, {
     "id" : "connection.uriProperties",
     "label" : "Properties",
-    "description" : "Additional properties for the connection ('user' and 'password' for instance). For more information, see the <a href=\"https://docs.camunda.io/docs/8.6/components/connectors/out-of-the-box-connectors/sql/#connection\" target=\"_blank\">documentation</a>.",
     "optional" : true,
     "feel" : "required",
     "group" : "connection",
@@ -133,6 +132,7 @@
       "equals" : "uri",
       "type" : "simple"
     },
+    "tooltip" : "Additional properties for the connection ('user' and 'password' for instance). See the <a href=\"https://docs.camunda.io/docs/8.6/components/connectors/out-of-the-box-connectors/sql/#connection\" target=\"_blank\">SQL connection properties</a> reference.",
     "type" : "String"
   }, {
     "id" : "connection.host",
@@ -223,7 +223,6 @@
   }, {
     "id" : "connection.properties",
     "label" : "Properties",
-    "description" : "Additional properties for the connection. For more information, see the <a href=\"https://docs.camunda.io/docs/8.6/components/connectors/out-of-the-box-connectors/sql/#connection\" target=\"_blank\">documentation</a>.",
     "optional" : true,
     "feel" : "required",
     "group" : "connection",
@@ -236,11 +235,11 @@
       "equals" : "detailed",
       "type" : "simple"
     },
+    "tooltip" : "Additional properties for the connection. See the <a href=\"https://docs.camunda.io/docs/8.6/components/connectors/out-of-the-box-connectors/sql/#connection\" target=\"_blank\">SQL connection properties</a> reference.",
     "type" : "String"
   }, {
     "id" : "data.returnResults",
     "label" : "Return results",
-    "description" : "Check this box if the SQL statement return results, e.g. a SELECT or any statement with a RETURNING clause",
     "optional" : false,
     "value" : false,
     "feel" : "static",
@@ -249,11 +248,11 @@
       "name" : "data.returnResults",
       "type" : "zeebe:input"
     },
+    "tooltip" : "Check this box if the SQL statement returns results, e.g. a SELECT or any statement with a RETURNING clause",
     "type" : "Boolean"
   }, {
     "id" : "data.query",
     "label" : "SQL Query to execute",
-    "description" : "You can use named, positional or binding <a href=\"https://docs.camunda.io/docs/8.6/components/connectors/out-of-the-box-connectors/sql/#variables\" target=\"_blank\">parameters</a>",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -264,11 +263,11 @@
       "name" : "data.query",
       "type" : "zeebe:input"
     },
+    "tooltip" : "You can use named, positional or binding <a href=\"https://docs.camunda.io/docs/8.6/components/connectors/out-of-the-box-connectors/sql/#variables\" target=\"_blank\">parameters</a>",
     "type" : "String"
   }, {
     "id" : "data.variables",
     "label" : "SQL Query variables",
-    "description" : "The <a href=\"https://docs.camunda.io/docs/8.6/components/connectors/out-of-the-box-connectors/sql/#variables\" target=\"_blank\">variables</a> to use in the SQL query.",
     "optional" : true,
     "feel" : "required",
     "group" : "query",
@@ -276,6 +275,7 @@
       "name" : "data.variables",
       "type" : "zeebe:input"
     },
+    "tooltip" : "The <a href=\"https://docs.camunda.io/docs/8.6/components/connectors/out-of-the-box-connectors/sql/#variables\" target=\"_blank\">variables</a> to use in the SQL query.",
     "type" : "String"
   }, {
     "id" : "version",

--- a/connectors/jdbc/element-templates/jdbc-outbound-connector.json
+++ b/connectors/jdbc/element-templates/jdbc-outbound-connector.json
@@ -58,7 +58,7 @@
       "name" : "database",
       "type" : "zeebe:input"
     },
-    "tooltip" : "Select the database you want to connect to. If you choose Oracle, make sure the Oracle JDBC driver is included. <a href=\"https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/sql/#database\">Oracle JDBC driver setup</a>.",
+    "tooltip" : "If you choose Oracle, make sure the Oracle JDBC driver is included. <a href=\"https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/sql/#database\">Oracle JDBC driver setup</a>.",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "MariaDB",

--- a/connectors/jdbc/src/main/java/io/camunda/connector/jdbc/model/request/JdbcRequest.java
+++ b/connectors/jdbc/src/main/java/io/camunda/connector/jdbc/model/request/JdbcRequest.java
@@ -18,10 +18,10 @@ public record JdbcRequest(
         @TemplateProperty(
             id = "database",
             label = "Select a database",
-            description =
+            tooltip =
                 "Select the database you want to connect to. "
                     + "If you choose Oracle, make sure the Oracle JDBC driver is included. "
-                    + "<a href=\"https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/sql/#database\">Learn how to set it up.</a>",
+                    + "<a href=\"https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/sql/#database\">Oracle JDBC driver setup</a>.",
             group = "database",
             type = Dropdown,
             constraints = @TemplateProperty.PropertyConstraints(notEmpty = true),

--- a/connectors/jdbc/src/main/java/io/camunda/connector/jdbc/model/request/JdbcRequest.java
+++ b/connectors/jdbc/src/main/java/io/camunda/connector/jdbc/model/request/JdbcRequest.java
@@ -19,8 +19,7 @@ public record JdbcRequest(
             id = "database",
             label = "Select a database",
             tooltip =
-                "Select the database you want to connect to. "
-                    + "If you choose Oracle, make sure the Oracle JDBC driver is included. "
+                "If you choose Oracle, make sure the Oracle JDBC driver is included. "
                     + "<a href=\"https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/sql/#database\">Oracle JDBC driver setup</a>.",
             group = "database",
             type = Dropdown,

--- a/connectors/jdbc/src/main/java/io/camunda/connector/jdbc/model/request/JdbcRequestData.java
+++ b/connectors/jdbc/src/main/java/io/camunda/connector/jdbc/model/request/JdbcRequestData.java
@@ -19,8 +19,8 @@ public record JdbcRequestData(
             defaultValueType = TemplateProperty.DefaultValueType.Boolean,
             group = "query",
             type = TemplateProperty.PropertyType.Boolean,
-            description =
-                "Check this box if the SQL statement return results, e.g. a SELECT or any statement with a RETURNING clause")
+            tooltip =
+                "Check this box if the SQL statement returns results, e.g. a SELECT or any statement with a RETURNING clause")
         boolean returnResults,
     @NotBlank
         @TemplateProperty(
@@ -28,7 +28,7 @@ public record JdbcRequestData(
             label = "SQL Query to execute",
             group = "query",
             constraints = @TemplateProperty.PropertyConstraints(notEmpty = true),
-            description =
+            tooltip =
                 "You can use named, positional or binding <a href=\"https://docs.camunda.io/docs/8.6/components/connectors/out-of-the-box-connectors/sql/#variables\" target=\"_blank\">parameters</a>")
         String query,
     @TemplateProperty(
@@ -37,7 +37,7 @@ public record JdbcRequestData(
             group = "query",
             optional = true,
             feel = FeelMode.required,
-            description =
+            tooltip =
                 "The <a href=\"https://docs.camunda.io/docs/8.6/components/connectors/out-of-the-box-connectors/sql/#variables\" target=\"_blank\">variables</a> to use in the SQL query.")
         @FEEL
         Object variables) {

--- a/connectors/jdbc/src/main/java/io/camunda/connector/jdbc/model/request/connection/DetailedConnection.java
+++ b/connectors/jdbc/src/main/java/io/camunda/connector/jdbc/model/request/connection/DetailedConnection.java
@@ -30,8 +30,8 @@ public record DetailedConnection(
             label = "Properties",
             optional = true,
             feel = FeelMode.required,
-            description =
-                "Additional properties for the connection. For more information, see the <a href=\"https://docs.camunda.io/docs/8.6/components/connectors/out-of-the-box-connectors/sql/#connection\" target=\"_blank\">documentation</a>.")
+            tooltip =
+                "Additional properties for the connection. See the <a href=\"https://docs.camunda.io/docs/8.6/components/connectors/out-of-the-box-connectors/sql/#connection\" target=\"_blank\">SQL connection properties</a> reference.")
         @FEEL
         Map<String, String> properties)
     implements JdbcConnection {

--- a/connectors/jdbc/src/main/java/io/camunda/connector/jdbc/model/request/connection/UriConnection.java
+++ b/connectors/jdbc/src/main/java/io/camunda/connector/jdbc/model/request/connection/UriConnection.java
@@ -25,16 +25,16 @@ public record UriConnection(
         @TemplateProperty(
             group = "connection",
             label = "URI",
-            description =
-                "URI should contain JDBC driver, host name, and port number. For more information, see the <a href=\"https://docs.camunda.io/docs/8.6/components/connectors/out-of-the-box-connectors/sql/#uri-connection\" target=\"_blank\">documentation</a>.)")
+            tooltip =
+                "URI should contain JDBC driver, host name, and port number. See the <a href=\"https://docs.camunda.io/docs/8.6/components/connectors/out-of-the-box-connectors/sql/#uri-connection\" target=\"_blank\">URI connection</a> reference.")
         String uri,
     @TemplateProperty(
             group = "connection",
             label = "Properties",
             feel = FeelMode.required,
             optional = true,
-            description =
-                "Additional properties for the connection ('user' and 'password' for instance). For more information, see the <a href=\"https://docs.camunda.io/docs/8.6/components/connectors/out-of-the-box-connectors/sql/#connection\" target=\"_blank\">documentation</a>.")
+            tooltip =
+                "Additional properties for the connection ('user' and 'password' for instance). See the <a href=\"https://docs.camunda.io/docs/8.6/components/connectors/out-of-the-box-connectors/sql/#connection\" target=\"_blank\">SQL connection properties</a> reference.")
         @FEEL
         Map<String, String> uriProperties)
     implements JdbcConnection {

--- a/connectors/sendgrid/element-templates/hybrid/sendgrid-outbound-connector-hybrid.json
+++ b/connectors/sendgrid/element-templates/hybrid/sendgrid-outbound-connector-hybrid.json
@@ -240,13 +240,13 @@
   }, {
     "id" : "attachments_documentMode",
     "label" : "Number of documents",
-    "description" : "List of <a href=\"https://docs.camunda.io/docs/apis-tools/camunda-api-rest/specifications/upload-document-alpha/\">Camunda Documents</a>",
     "value" : "none",
     "group" : "content",
     "binding" : {
       "name" : "attachments_documentMode",
       "type" : "zeebe:input"
     },
+    "tooltip" : "List of <a href=\"https://docs.camunda.io/docs/apis-tools/camunda-api-rest/specifications/upload-document-alpha/\">Camunda Documents</a>",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "None",

--- a/connectors/sendgrid/element-templates/hybrid/sendgrid-outbound-connector-hybrid.json
+++ b/connectors/sendgrid/element-templates/hybrid/sendgrid-outbound-connector-hybrid.json
@@ -246,7 +246,7 @@
       "name" : "attachments_documentMode",
       "type" : "zeebe:input"
     },
-    "tooltip" : "List of <a href=\"https://docs.camunda.io/docs/apis-tools/camunda-api-rest/specifications/upload-document-alpha/\">Camunda Documents</a>",
+    "tooltip" : "Files to attach to the email, referenced as <a href=\"https://docs.camunda.io/docs/apis-tools/camunda-api-rest/specifications/upload-document-alpha/\">Camunda documents</a>.",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "None",

--- a/connectors/sendgrid/element-templates/sendgrid-outbound-connector.json
+++ b/connectors/sendgrid/element-templates/sendgrid-outbound-connector.json
@@ -235,13 +235,13 @@
   }, {
     "id" : "attachments_documentMode",
     "label" : "Number of documents",
-    "description" : "List of <a href=\"https://docs.camunda.io/docs/apis-tools/camunda-api-rest/specifications/upload-document-alpha/\">Camunda Documents</a>",
     "value" : "none",
     "group" : "content",
     "binding" : {
       "name" : "attachments_documentMode",
       "type" : "zeebe:input"
     },
+    "tooltip" : "List of <a href=\"https://docs.camunda.io/docs/apis-tools/camunda-api-rest/specifications/upload-document-alpha/\">Camunda Documents</a>",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "None",

--- a/connectors/sendgrid/element-templates/sendgrid-outbound-connector.json
+++ b/connectors/sendgrid/element-templates/sendgrid-outbound-connector.json
@@ -241,7 +241,7 @@
       "name" : "attachments_documentMode",
       "type" : "zeebe:input"
     },
-    "tooltip" : "List of <a href=\"https://docs.camunda.io/docs/apis-tools/camunda-api-rest/specifications/upload-document-alpha/\">Camunda Documents</a>",
+    "tooltip" : "Files to attach to the email, referenced as <a href=\"https://docs.camunda.io/docs/apis-tools/camunda-api-rest/specifications/upload-document-alpha/\">Camunda documents</a>.",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "None",

--- a/connectors/sendgrid/src/main/java/io/camunda/connector/sendgrid/model/SendGridRequest.java
+++ b/connectors/sendgrid/src/main/java/io/camunda/connector/sendgrid/model/SendGridRequest.java
@@ -107,7 +107,7 @@ public class SendGridRequest {
       id = "attachments",
       group = "content",
       optional = true,
-      description =
+      tooltip =
           "List of <a href=\"https://docs.camunda.io/docs/apis-tools/camunda-api-rest/specifications/upload-document-alpha/\">Camunda Documents</a>")
   private List<Document> attachments;
 

--- a/connectors/sendgrid/src/main/java/io/camunda/connector/sendgrid/model/SendGridRequest.java
+++ b/connectors/sendgrid/src/main/java/io/camunda/connector/sendgrid/model/SendGridRequest.java
@@ -108,7 +108,7 @@ public class SendGridRequest {
       group = "content",
       optional = true,
       tooltip =
-          "List of <a href=\"https://docs.camunda.io/docs/apis-tools/camunda-api-rest/specifications/upload-document-alpha/\">Camunda Documents</a>")
+          "Files to attach to the email, referenced as <a href=\"https://docs.camunda.io/docs/apis-tools/camunda-api-rest/specifications/upload-document-alpha/\">Camunda documents</a>.")
   private List<Document> attachments;
 
   @AssertTrue(message = "must not be empty")

--- a/connectors/soap/element-templates/hybrid/soap-outbound-connector-hybrid.json
+++ b/connectors/soap/element-templates/hybrid/soap-outbound-connector-hybrid.json
@@ -248,7 +248,6 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "The keystore to use",
     "type" : "String"
   }, {
     "id" : "authentication.certificate.keystorePassword",
@@ -274,7 +273,6 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "The password to access the keystore",
     "type" : "String"
   }, {
     "id" : "authentication.certificate.alias",
@@ -326,7 +324,6 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "The password to access the certificate",
     "type" : "String"
   }, {
     "id" : "authentication.signatureAlgorithm",
@@ -429,7 +426,6 @@
       "equals" : "1.1",
       "type" : "simple"
     },
-    "tooltip" : "The SOAPAction HTTP header to be used in the request",
     "type" : "String"
   }, {
     "id" : "header.type",

--- a/connectors/soap/element-templates/hybrid/soap-outbound-connector-hybrid.json
+++ b/connectors/soap/element-templates/hybrid/soap-outbound-connector-hybrid.json
@@ -57,7 +57,6 @@
   }, {
     "id" : "serviceUrl",
     "label" : "Service URL",
-    "description" : "The URL where the service runs",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -68,6 +67,7 @@
       "name" : "serviceUrl",
       "type" : "zeebe:input"
     },
+    "tooltip" : "The URL where the service runs",
     "type" : "String"
   }, {
     "id" : "authentication.authentication",
@@ -175,7 +175,6 @@
   }, {
     "id" : "authentication.certificate.certificate",
     "label" : "Certificate",
-    "description" : "The X.509 certificate to use to sign the request",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -197,11 +196,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "The X.509 certificate to use to sign the request",
     "type" : "String"
   }, {
     "id" : "authentication.certificate.privateKey",
     "label" : "Private key",
-    "description" : "The private key for the certificate",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -223,11 +222,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "The private key for the certificate",
     "type" : "String"
   }, {
     "id" : "authentication.certificate.keystoreLocation",
     "label" : "Keystore location",
-    "description" : "The keystore to use",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -249,11 +248,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "The keystore to use",
     "type" : "String"
   }, {
     "id" : "authentication.certificate.keystorePassword",
     "label" : "Keystore password",
-    "description" : "The password to access the keystore",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -275,11 +274,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "The password to access the keystore",
     "type" : "String"
   }, {
     "id" : "authentication.certificate.alias",
     "label" : "Certificate alias",
-    "description" : "The alias for the certificate in the keystore",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -301,11 +300,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "The alias for the certificate in the keystore",
     "type" : "String"
   }, {
     "id" : "authentication.certificate.password",
     "label" : "Certificate password",
-    "description" : "The password to access the certificate",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -327,11 +326,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "The password to access the certificate",
     "type" : "String"
   }, {
     "id" : "authentication.signatureAlgorithm",
     "label" : "Signature algorithm",
-    "description" : "Fully qualified name of an alternative signature algorithm",
     "optional" : true,
     "feel" : "optional",
     "group" : "authentication",
@@ -344,11 +343,11 @@
       "equals" : "signature",
       "type" : "simple"
     },
+    "tooltip" : "Fully qualified name of an alternative signature algorithm",
     "type" : "String"
   }, {
     "id" : "authentication.digestAlgorithm",
     "label" : "Digest algorithm",
-    "description" : "Fully qualified name of an alternative digest algorithm",
     "optional" : true,
     "feel" : "optional",
     "group" : "authentication",
@@ -361,11 +360,11 @@
       "equals" : "signature",
       "type" : "simple"
     },
+    "tooltip" : "Fully qualified name of an alternative digest algorithm",
     "type" : "String"
   }, {
     "id" : "authentication.timestamp",
     "label" : "Timestamp timeout in seconds",
-    "description" : "If set, adds a timestamp header with the given timeout",
     "optional" : true,
     "feel" : "static",
     "group" : "authentication",
@@ -378,11 +377,11 @@
       "equals" : "signature",
       "type" : "simple"
     },
+    "tooltip" : "If set, adds a timestamp header with the given timeout",
     "type" : "Number"
   }, {
     "id" : "authentication.encryptionParts",
     "label" : "Signature parts",
-    "description" : "Array of signature parts with namespace and localName",
     "optional" : true,
     "feel" : "required",
     "group" : "authentication",
@@ -395,6 +394,7 @@
       "equals" : "signature",
       "type" : "simple"
     },
+    "tooltip" : "Array of signature parts with namespace and localName",
     "type" : "String"
   }, {
     "id" : "soapVersion.version",
@@ -417,7 +417,6 @@
   }, {
     "id" : "soapVersion.soapAction",
     "label" : "SOAPAction HTTP header",
-    "description" : "The SOAPAction HTTP header to be used in the request",
     "optional" : true,
     "feel" : "optional",
     "group" : "soap-message",
@@ -430,6 +429,7 @@
       "equals" : "1.1",
       "type" : "simple"
     },
+    "tooltip" : "The SOAPAction HTTP header to be used in the request",
     "type" : "String"
   }, {
     "id" : "header.type",
@@ -455,7 +455,6 @@
   }, {
     "id" : "header.template",
     "label" : "XML template",
-    "description" : "The template for the header in XML format",
     "optional" : false,
     "feel" : "optional",
     "group" : "soap-message",
@@ -468,11 +467,11 @@
       "equals" : "template",
       "type" : "simple"
     },
+    "tooltip" : "The template for the header in XML format",
     "type" : "Text"
   }, {
     "id" : "header.context",
     "label" : "XML template context",
-    "description" : "The context that is used to fill the template",
     "optional" : false,
     "feel" : "required",
     "group" : "soap-message",
@@ -485,11 +484,11 @@
       "equals" : "template",
       "type" : "simple"
     },
+    "tooltip" : "The context that is used to fill the template",
     "type" : "String"
   }, {
     "id" : "header.json",
     "label" : "JSON definition",
-    "description" : "Definition of the SOAP header as JSON object",
     "optional" : false,
     "feel" : "required",
     "group" : "soap-message",
@@ -502,6 +501,7 @@
       "equals" : "json",
       "type" : "simple"
     },
+    "tooltip" : "Definition of the SOAP header as JSON object",
     "type" : "String"
   }, {
     "id" : "body.type",
@@ -524,7 +524,6 @@
   }, {
     "id" : "body.template",
     "label" : "XML template",
-    "description" : "The template for the body in XML format",
     "optional" : false,
     "feel" : "optional",
     "group" : "soap-message",
@@ -537,11 +536,11 @@
       "equals" : "template",
       "type" : "simple"
     },
+    "tooltip" : "The template for the body in XML format",
     "type" : "Text"
   }, {
     "id" : "body.context",
     "label" : "XML template context",
-    "description" : "The context that is used to fill the template",
     "optional" : false,
     "feel" : "required",
     "group" : "soap-message",
@@ -554,11 +553,11 @@
       "equals" : "template",
       "type" : "simple"
     },
+    "tooltip" : "The context that is used to fill the template",
     "type" : "String"
   }, {
     "id" : "body.json",
     "label" : "JSON definition",
-    "description" : "Definition of the SOAP body as JSON object",
     "optional" : false,
     "feel" : "required",
     "group" : "soap-message",
@@ -571,11 +570,11 @@
       "equals" : "json",
       "type" : "simple"
     },
+    "tooltip" : "Definition of the SOAP body as JSON object",
     "type" : "String"
   }, {
     "id" : "namespaces",
     "label" : "Namespaces",
-    "description" : "The namespaces that should be declared on the SOAP Envelope",
     "optional" : true,
     "feel" : "required",
     "group" : "soap-message",
@@ -583,11 +582,11 @@
       "name" : "namespaces",
       "type" : "zeebe:input"
     },
+    "tooltip" : "The namespaces that should be declared on the SOAP Envelope",
     "type" : "String"
   }, {
     "id" : "connectionTimeoutInSeconds",
     "label" : "Connection timeout in seconds",
-    "description" : "Sets timeout in seconds to establish a connection or 0 for an infinite timeout",
     "optional" : true,
     "value" : 20,
     "feel" : "static",
@@ -596,6 +595,7 @@
       "name" : "connectionTimeoutInSeconds",
       "type" : "zeebe:input"
     },
+    "tooltip" : "Time in seconds to wait when establishing a connection, or 0 to wait indefinitely",
     "type" : "Number"
   }, {
     "id" : "version",

--- a/connectors/soap/element-templates/soap-outbound-connector.json
+++ b/connectors/soap/element-templates/soap-outbound-connector.json
@@ -243,7 +243,6 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "The keystore to use",
     "type" : "String"
   }, {
     "id" : "authentication.certificate.keystorePassword",
@@ -269,7 +268,6 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "The password to access the keystore",
     "type" : "String"
   }, {
     "id" : "authentication.certificate.alias",
@@ -321,7 +319,6 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "The password to access the certificate",
     "type" : "String"
   }, {
     "id" : "authentication.signatureAlgorithm",
@@ -424,7 +421,6 @@
       "equals" : "1.1",
       "type" : "simple"
     },
-    "tooltip" : "The SOAPAction HTTP header to be used in the request",
     "type" : "String"
   }, {
     "id" : "header.type",

--- a/connectors/soap/element-templates/soap-outbound-connector.json
+++ b/connectors/soap/element-templates/soap-outbound-connector.json
@@ -52,7 +52,6 @@
   }, {
     "id" : "serviceUrl",
     "label" : "Service URL",
-    "description" : "The URL where the service runs",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -63,6 +62,7 @@
       "name" : "serviceUrl",
       "type" : "zeebe:input"
     },
+    "tooltip" : "The URL where the service runs",
     "type" : "String"
   }, {
     "id" : "authentication.authentication",
@@ -170,7 +170,6 @@
   }, {
     "id" : "authentication.certificate.certificate",
     "label" : "Certificate",
-    "description" : "The X.509 certificate to use to sign the request",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -192,11 +191,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "The X.509 certificate to use to sign the request",
     "type" : "String"
   }, {
     "id" : "authentication.certificate.privateKey",
     "label" : "Private key",
-    "description" : "The private key for the certificate",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -218,11 +217,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "The private key for the certificate",
     "type" : "String"
   }, {
     "id" : "authentication.certificate.keystoreLocation",
     "label" : "Keystore location",
-    "description" : "The keystore to use",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -244,11 +243,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "The keystore to use",
     "type" : "String"
   }, {
     "id" : "authentication.certificate.keystorePassword",
     "label" : "Keystore password",
-    "description" : "The password to access the keystore",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -270,11 +269,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "The password to access the keystore",
     "type" : "String"
   }, {
     "id" : "authentication.certificate.alias",
     "label" : "Certificate alias",
-    "description" : "The alias for the certificate in the keystore",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -296,11 +295,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "The alias for the certificate in the keystore",
     "type" : "String"
   }, {
     "id" : "authentication.certificate.password",
     "label" : "Certificate password",
-    "description" : "The password to access the certificate",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -322,11 +321,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "The password to access the certificate",
     "type" : "String"
   }, {
     "id" : "authentication.signatureAlgorithm",
     "label" : "Signature algorithm",
-    "description" : "Fully qualified name of an alternative signature algorithm",
     "optional" : true,
     "feel" : "optional",
     "group" : "authentication",
@@ -339,11 +338,11 @@
       "equals" : "signature",
       "type" : "simple"
     },
+    "tooltip" : "Fully qualified name of an alternative signature algorithm",
     "type" : "String"
   }, {
     "id" : "authentication.digestAlgorithm",
     "label" : "Digest algorithm",
-    "description" : "Fully qualified name of an alternative digest algorithm",
     "optional" : true,
     "feel" : "optional",
     "group" : "authentication",
@@ -356,11 +355,11 @@
       "equals" : "signature",
       "type" : "simple"
     },
+    "tooltip" : "Fully qualified name of an alternative digest algorithm",
     "type" : "String"
   }, {
     "id" : "authentication.timestamp",
     "label" : "Timestamp timeout in seconds",
-    "description" : "If set, adds a timestamp header with the given timeout",
     "optional" : true,
     "feel" : "static",
     "group" : "authentication",
@@ -373,11 +372,11 @@
       "equals" : "signature",
       "type" : "simple"
     },
+    "tooltip" : "If set, adds a timestamp header with the given timeout",
     "type" : "Number"
   }, {
     "id" : "authentication.encryptionParts",
     "label" : "Signature parts",
-    "description" : "Array of signature parts with namespace and localName",
     "optional" : true,
     "feel" : "required",
     "group" : "authentication",
@@ -390,6 +389,7 @@
       "equals" : "signature",
       "type" : "simple"
     },
+    "tooltip" : "Array of signature parts with namespace and localName",
     "type" : "String"
   }, {
     "id" : "soapVersion.version",
@@ -412,7 +412,6 @@
   }, {
     "id" : "soapVersion.soapAction",
     "label" : "SOAPAction HTTP header",
-    "description" : "The SOAPAction HTTP header to be used in the request",
     "optional" : true,
     "feel" : "optional",
     "group" : "soap-message",
@@ -425,6 +424,7 @@
       "equals" : "1.1",
       "type" : "simple"
     },
+    "tooltip" : "The SOAPAction HTTP header to be used in the request",
     "type" : "String"
   }, {
     "id" : "header.type",
@@ -450,7 +450,6 @@
   }, {
     "id" : "header.template",
     "label" : "XML template",
-    "description" : "The template for the header in XML format",
     "optional" : false,
     "feel" : "optional",
     "group" : "soap-message",
@@ -463,11 +462,11 @@
       "equals" : "template",
       "type" : "simple"
     },
+    "tooltip" : "The template for the header in XML format",
     "type" : "Text"
   }, {
     "id" : "header.context",
     "label" : "XML template context",
-    "description" : "The context that is used to fill the template",
     "optional" : false,
     "feel" : "required",
     "group" : "soap-message",
@@ -480,11 +479,11 @@
       "equals" : "template",
       "type" : "simple"
     },
+    "tooltip" : "The context that is used to fill the template",
     "type" : "String"
   }, {
     "id" : "header.json",
     "label" : "JSON definition",
-    "description" : "Definition of the SOAP header as JSON object",
     "optional" : false,
     "feel" : "required",
     "group" : "soap-message",
@@ -497,6 +496,7 @@
       "equals" : "json",
       "type" : "simple"
     },
+    "tooltip" : "Definition of the SOAP header as JSON object",
     "type" : "String"
   }, {
     "id" : "body.type",
@@ -519,7 +519,6 @@
   }, {
     "id" : "body.template",
     "label" : "XML template",
-    "description" : "The template for the body in XML format",
     "optional" : false,
     "feel" : "optional",
     "group" : "soap-message",
@@ -532,11 +531,11 @@
       "equals" : "template",
       "type" : "simple"
     },
+    "tooltip" : "The template for the body in XML format",
     "type" : "Text"
   }, {
     "id" : "body.context",
     "label" : "XML template context",
-    "description" : "The context that is used to fill the template",
     "optional" : false,
     "feel" : "required",
     "group" : "soap-message",
@@ -549,11 +548,11 @@
       "equals" : "template",
       "type" : "simple"
     },
+    "tooltip" : "The context that is used to fill the template",
     "type" : "String"
   }, {
     "id" : "body.json",
     "label" : "JSON definition",
-    "description" : "Definition of the SOAP body as JSON object",
     "optional" : false,
     "feel" : "required",
     "group" : "soap-message",
@@ -566,11 +565,11 @@
       "equals" : "json",
       "type" : "simple"
     },
+    "tooltip" : "Definition of the SOAP body as JSON object",
     "type" : "String"
   }, {
     "id" : "namespaces",
     "label" : "Namespaces",
-    "description" : "The namespaces that should be declared on the SOAP Envelope",
     "optional" : true,
     "feel" : "required",
     "group" : "soap-message",
@@ -578,11 +577,11 @@
       "name" : "namespaces",
       "type" : "zeebe:input"
     },
+    "tooltip" : "The namespaces that should be declared on the SOAP Envelope",
     "type" : "String"
   }, {
     "id" : "connectionTimeoutInSeconds",
     "label" : "Connection timeout in seconds",
-    "description" : "Sets timeout in seconds to establish a connection or 0 for an infinite timeout",
     "optional" : true,
     "value" : 20,
     "feel" : "static",
@@ -591,6 +590,7 @@
       "name" : "connectionTimeoutInSeconds",
       "type" : "zeebe:input"
     },
+    "tooltip" : "Time in seconds to wait when establishing a connection, or 0 to wait indefinitely",
     "type" : "Number"
   }, {
     "id" : "version",

--- a/connectors/soap/src/main/java/io/camunda/connectors/soap/SoapConnectorInput.java
+++ b/connectors/soap/src/main/java/io/camunda/connectors/soap/SoapConnectorInput.java
@@ -38,7 +38,7 @@ public record SoapConnectorInput(
     @TemplateProperty(
             group = "connection",
             label = "Service URL",
-            description = "The URL where the service runs")
+            tooltip = "The URL where the service runs")
         @NotNull
         String serviceUrl,
     @Valid Authentication authentication,
@@ -47,7 +47,7 @@ public record SoapConnectorInput(
     @Valid SoapBodyPart body,
     @TemplateProperty(
             label = "Namespaces",
-            description = "The namespaces that should be declared on the SOAP Envelope",
+            tooltip = "The namespaces that should be declared on the SOAP Envelope",
             optional = true,
             group = "soap-message",
             feel = FeelMode.required)
@@ -57,8 +57,8 @@ public record SoapConnectorInput(
             defaultValue = "20",
             defaultValueType = TemplateProperty.DefaultValueType.Number,
             optional = true,
-            description =
-                "Sets timeout in seconds to establish a connection or 0 for an infinite timeout")
+            tooltip =
+                "Time in seconds to wait when establishing a connection, or 0 to wait indefinitely")
         Integer connectionTimeoutInSeconds) {
   public enum YesNo {
     Yes,
@@ -83,13 +83,13 @@ public record SoapConnectorInput(
     record HeaderTemplate(
         @TemplateProperty(
                 label = "XML template",
-                description = "The template for the header in XML format",
+                tooltip = "The template for the header in XML format",
                 type = PropertyType.Text,
                 group = "soap-message")
             String template,
         @TemplateProperty(
                 label = "XML template context",
-                description = "The context that is used to fill the template",
+                tooltip = "The context that is used to fill the template",
                 group = "soap-message",
                 feel = FeelMode.required)
             Map<String, Object> context)
@@ -99,7 +99,7 @@ public record SoapConnectorInput(
     record HeaderJson(
         @TemplateProperty(
                 label = "JSON definition",
-                description = "Definition of the SOAP header as JSON object",
+                tooltip = "Definition of the SOAP header as JSON object",
                 group = "soap-message",
                 feel = FeelMode.required)
             Map<String, Object> json)
@@ -126,13 +126,13 @@ public record SoapConnectorInput(
     record BodyTemplate(
         @TemplateProperty(
                 label = "XML template",
-                description = "The template for the body in XML format",
+                tooltip = "The template for the body in XML format",
                 type = PropertyType.Text,
                 group = "soap-message")
             String template,
         @TemplateProperty(
                 label = "XML template context",
-                description = "The context that is used to fill the template",
+                tooltip = "The context that is used to fill the template",
                 group = "soap-message",
                 feel = FeelMode.required)
             Map<String, Object> context)
@@ -142,7 +142,7 @@ public record SoapConnectorInput(
     record BodyJson(
         @TemplateProperty(
                 label = "JSON definition",
-                description = "Definition of the SOAP body as JSON object",
+                tooltip = "Definition of the SOAP body as JSON object",
                 group = "soap-message",
                 feel = FeelMode.required)
             Map<String, Object> json)
@@ -163,7 +163,7 @@ public record SoapConnectorInput(
     record _1_1(
         @TemplateProperty(
                 label = "SOAPAction HTTP header",
-                description = "The SOAPAction HTTP header to be used in the request",
+                tooltip = "The SOAPAction HTTP header to be used in the request",
                 optional = true,
                 group = "soap-message")
             String soapAction)
@@ -218,17 +218,17 @@ public record SoapConnectorInput(
                 label = "Signature algorithm",
                 group = "authentication",
                 optional = true,
-                description = "Fully qualified name of an alternative signature algorithm")
+                tooltip = "Fully qualified name of an alternative signature algorithm")
             String signatureAlgorithm,
         @TemplateProperty(
                 label = "Digest algorithm",
                 group = "authentication",
                 optional = true,
-                description = "Fully qualified name of an alternative digest algorithm")
+                tooltip = "Fully qualified name of an alternative digest algorithm")
             String digestAlgorithm,
         @TemplateProperty(
                 label = "Timestamp timeout in seconds",
-                description = "If set, adds a timestamp header with the given timeout",
+                tooltip = "If set, adds a timestamp header with the given timeout",
                 group = "authentication",
                 optional = true)
             Integer timestamp,
@@ -237,7 +237,7 @@ public record SoapConnectorInput(
                 group = "authentication",
                 feel = FeelMode.required,
                 optional = true,
-                description = "Array of signature parts with namespace and localName")
+                tooltip = "Array of signature parts with namespace and localName")
             List<EncryptionPart> encryptionParts)
         implements Authentication {
       @JsonTypeInfo(use = Id.NAME, property = "certificateType")
@@ -257,13 +257,13 @@ public record SoapConnectorInput(
             @TemplateProperty(
                     label = "Certificate",
                     group = "authentication",
-                    description = "The X.509 certificate to use to sign the request")
+                    tooltip = "The X.509 certificate to use to sign the request")
                 @NotNull
                 String certificate,
             @TemplateProperty(
                     label = "Private key",
                     group = "authentication",
-                    description = "The private key for the certificate")
+                    tooltip = "The private key for the certificate")
                 @NotNull
                 String privateKey)
             implements Certificate {
@@ -282,25 +282,25 @@ public record SoapConnectorInput(
         record KeystoreCertificate(
             @TemplateProperty(
                     label = "Keystore location",
-                    description = "The keystore to use",
+                    tooltip = "The keystore to use",
                     group = "authentication")
                 @NotNull
                 String keystoreLocation,
             @TemplateProperty(
                     label = "Keystore password",
-                    description = "The password to access the keystore",
+                    tooltip = "The password to access the keystore",
                     group = "authentication")
                 @NotNull
                 String keystorePassword,
             @TemplateProperty(
                     label = "Certificate alias",
-                    description = "The alias for the certificate in the keystore",
+                    tooltip = "The alias for the certificate in the keystore",
                     group = "authentication")
                 @NotNull
                 String alias,
             @TemplateProperty(
                     label = "Certificate password",
-                    description = "The password to access the certificate",
+                    tooltip = "The password to access the certificate",
                     group = "authentication")
                 @NotNull
                 String password)

--- a/connectors/soap/src/main/java/io/camunda/connectors/soap/SoapConnectorInput.java
+++ b/connectors/soap/src/main/java/io/camunda/connectors/soap/SoapConnectorInput.java
@@ -161,11 +161,7 @@ public record SoapConnectorInput(
   public sealed interface Version {
     @TemplateSubType(id = "1.1", label = "1.1")
     record _1_1(
-        @TemplateProperty(
-                label = "SOAPAction HTTP header",
-                tooltip = "The SOAPAction HTTP header to be used in the request",
-                optional = true,
-                group = "soap-message")
+        @TemplateProperty(label = "SOAPAction HTTP header", optional = true, group = "soap-message")
             String soapAction)
         implements Version {}
 
@@ -280,17 +276,9 @@ public record SoapConnectorInput(
 
         @TemplateSubType(id = "keystore", label = "Keystore certificate")
         record KeystoreCertificate(
-            @TemplateProperty(
-                    label = "Keystore location",
-                    tooltip = "The keystore to use",
-                    group = "authentication")
-                @NotNull
+            @TemplateProperty(label = "Keystore location", group = "authentication") @NotNull
                 String keystoreLocation,
-            @TemplateProperty(
-                    label = "Keystore password",
-                    tooltip = "The password to access the keystore",
-                    group = "authentication")
-                @NotNull
+            @TemplateProperty(label = "Keystore password", group = "authentication") @NotNull
                 String keystorePassword,
             @TemplateProperty(
                     label = "Certificate alias",
@@ -298,11 +286,7 @@ public record SoapConnectorInput(
                     group = "authentication")
                 @NotNull
                 String alias,
-            @TemplateProperty(
-                    label = "Certificate password",
-                    tooltip = "The password to access the certificate",
-                    group = "authentication")
-                @NotNull
+            @TemplateProperty(label = "Certificate password", group = "authentication") @NotNull
                 String password)
             implements Certificate {
           @Override


### PR DESCRIPTION
Part of #7470. One of 8 review-sized slices of the `description` → `tooltip` migration (originally the umbrella PR #7651, split per review feedback for reviewability).

**Priority:** `tooltip` > `placeholder` > `description`. Field hints move to `tooltip=`; always-visible `description=` is kept only for value-constraints, `Note:`/`Warning:` markers, and genuinely critical guidance.

**Connectors in this slice:** camunda-message (send message), JDBC, Email (SMTP/IMAP/POP3), Automation Anywhere, SOAP, SendGrid, Box.

Templates are regenerated from the migrated Java `@TemplateProperty` sources.