### PR TITLE
feat(element-template-generator): emit property description as tooltip

### DIFF
--- a/element-template-generator/annotations/src/main/java/io/camunda/connector/generator/java/annotation/TemplateProperty.java
+++ b/element-template-generator/annotations/src/main/java/io/camunda/connector/generator/java/annotation/TemplateProperty.java
@@ -48,7 +48,15 @@ public @interface TemplateProperty {
   /** Custom binding name of the property */
   PropertyBinding binding() default @PropertyBinding(name = "");
 
-  /** Description of the property */
+  /**
+   * Help text for the property.
+   *
+   * <p>As of <a href="https://github.com/camunda/connectors/issues/7470">#7470</a> the generator
+   * emits this value as a {@link #tooltip()} (shown on hover) rather than an always-visible
+   * description. Set {@link #tooltip()} explicitly to override; an explicit tooltip always wins. To
+   * keep an always-visible description for a specific property, edit the generated template
+   * manually.
+   */
   String description() default "";
 
   /** Whether the property should be marked as optional in the element template */

--- a/element-template-generator/core/src/main/java/io/camunda/connector/generator/dsl/PropertyBuilder.java
+++ b/element-template-generator/core/src/main/java/io/camunda/connector/generator/dsl/PropertyBuilder.java
@@ -65,8 +65,21 @@ public abstract class PropertyBuilder {
     return this;
   }
 
+  /**
+   * Sets the property help text.
+   *
+   * <p>As of <a href="https://github.com/camunda/connectors/issues/7470">#7470</a> the generator
+   * emits property help text as a {@code tooltip} (shown on hover) instead of an always-visible
+   * {@code description}. Any value passed here is therefore mapped to {@link #tooltip(String)},
+   * unless an explicit tooltip has already been set (an explicit tooltip always wins). To keep an
+   * always-visible description for a specific property, edit the generated template manually.
+   */
   public PropertyBuilder description(String description) {
-    this.description = description;
+    if (description != null
+        && !description.isBlank()
+        && (this.tooltip == null || this.tooltip.isBlank())) {
+      this.tooltip = description;
+    }
     return this;
   }
 

--- a/element-template-generator/core/src/test/java/io/camunda/connector/generator/java/OutboundClassBasedTemplateGeneratorTest.java
+++ b/element-template-generator/core/src/test/java/io/camunda/connector/generator/java/OutboundClassBasedTemplateGeneratorTest.java
@@ -496,7 +496,9 @@ public class OutboundClassBasedTemplateGeneratorTest extends BaseTest {
       assertThat(property.isOptional()).isFalse();
       assertThat(property.getLabel()).isEqualTo("Annotated and renamed string property");
       assertThat(property.getGroup()).isEqualTo("group1");
-      assertThat(property.getDescription()).isEqualTo("description");
+      // #7470: description= is emitted as a tooltip; an explicit tooltip= wins over description=
+      assertThat(property.getDescription()).isNull();
+      assertThat(property.getTooltip()).isEqualTo("tooltip");
       assertThat(property.getFeel()).isEqualTo(FeelMode.optional);
       assertThat(property.getBinding()).isEqualTo(new PropertyBinding.ZeebeInput("customBinding"));
       assertThat(property.getConstraints().notEmpty()).isTrue();
@@ -1164,7 +1166,8 @@ public class OutboundClassBasedTemplateGeneratorTest extends BaseTest {
 
       assertThat(resourceId).isInstanceOf(StringProperty.class);
       assertThat(resourceId.getLabel()).isEqualTo("Form ID");
-      assertThat(resourceId.getDescription())
+      // #7470: annotation description= is emitted as a tooltip
+      assertThat(resourceId.getTooltip())
           .isEqualTo("Select a form to render as an adaptive card");
       assertThat(resourceId.getGroup()).isEqualTo("form");
       assertThat(((ZeebeLinkedResource) resourceId.getBinding()).linkName())
@@ -1391,7 +1394,8 @@ public class OutboundClassBasedTemplateGeneratorTest extends BaseTest {
 
       assertThat(resourceId).isInstanceOf(StringProperty.class);
       assertThat(resourceId.getLabel()).isEqualTo("Form ID");
-      assertThat(resourceId.getDescription())
+      // #7470: annotation description= is emitted as a tooltip
+      assertThat(resourceId.getTooltip())
           .isEqualTo("Select a form to render as an adaptive card");
       assertThat(resourceId.getGroup()).isEqualTo("form");
       assertThat(resourceId.getCondition()).isNull();

--- a/element-template-generator/core/src/test/resources/test-element-template.json
+++ b/element-template-generator/core/src/test/resources/test-element-template.json
@@ -49,7 +49,7 @@
     },
     {
       "label": "Username",
-      "description": "The username for authentication.",
+      "tooltip": "The username for authentication.",
       "constraints": {
         "notEmpty": true
       },
@@ -63,7 +63,7 @@
     },
     {
       "label": "Token",
-      "description": "The token for authentication.",
+      "tooltip": "The token for authentication.",
       "constraints": {
         "notEmpty": true
       },
@@ -77,7 +77,7 @@
     },
     {
       "label": "Type",
-      "description": "The type of message to compose",
+      "tooltip": "The type of message to compose",
       "group": "compose",
       "binding": {
         "name": "compose.type",
@@ -112,7 +112,7 @@
     },
     {
       "label": "Topic",
-      "description": "The topic of the message",
+      "tooltip": "The topic of the message",
       "feel": "optional",
       "group": "compose",
       "binding": {
@@ -155,7 +155,7 @@
     },
     {
       "label": "Result Variable",
-      "description": "Name of variable to store the response in",
+      "tooltip": "Name of variable to store the response in",
       "feel": "optional",
       "group": "output",
       "binding": {
@@ -166,7 +166,7 @@
     },
     {
       "label": "Result Expression",
-      "description": "Expression to map the response into process variables",
+      "tooltip": "Expression to map the response into process variables",
       "feel": "required",
       "group": "output",
       "binding": {
@@ -177,7 +177,7 @@
     },
     {
       "label": "Error Expression",
-      "description": "Expression to handle errors. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/\" target=\"_blank\">documentation</a>.",
+      "tooltip": "Expression to handle errors. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/\" target=\"_blank\">documentation</a>.",
       "feel": "required",
       "group": "errors",
       "binding": {


### PR DESCRIPTION
Part of #7470 — the **generator** follow-up (issue item 1), addressing @ztefanie's review point 6 ("do the generator first / do it in the generator so all fields are consistent").

## What this does
The generator now emits property-level help text as a **`tooltip`** (hover) instead of an always-visible **`description`**. The change is at a single chokepoint — [`PropertyBuilder.description()`](element-template-generator/core/src/main/java/io/camunda/connector/generator/dsl/PropertyBuilder.java) — so **every** generation path is covered:
- the Java `@TemplateProperty` annotation processor (all annotated connectors),
- the HTTP DSL (`FactoryUtils` / `PropertyUtil`),
- hard-coded DSL property builders.

### Rules
- An explicit `tooltip=` **always wins** over `description=`.
- Connector/template-level description (the `ElementTemplate` description) is **unchanged** — only property help text moves.
- To keep an always-visible `description` for a specific property, edit the generated template manually (per the agreed policy: auto-map by default, manual opt-out).

## Why this approach
Connector authors keep writing `description=` as they always have and get tooltip-first templates for free on regeneration — no per-field annotation churn. This is the mechanical/consistent counterpart to the hand-curated wording in the split migration PRs (#7651 + siblings).

## Scope / follow-up
- This PR is **generator + tests only**. Regenerating all connector templates so the committed JSON reflects the new output is deliberately left as a follow-up to keep this reviewable.
- Tests updated to assert the new behavior (`OutboundClassBasedTemplateGeneratorTest`, `ElementTemplateSerializationTest` + resource). `element-template-generator/core` suite: **196 passing**.

## Note on the annotation
`@TemplateProperty#description()` is kept (Javadoc updated to document the mapping) rather than removed, to avoid breaking every existing annotation. It now behaves as a tooltip source.