### PR TITLE
fix(e2e): fix inbound e2e tests not able to boot spring context due to multiple cache manager beans

### DIFF
--- a/connectors-e2e-test/connectors-e2e-test-base/src/main/java/io/camunda/connector/e2e/inbound/InboundConnectorTestConfiguration.java
+++ b/connectors-e2e-test/connectors-e2e-test-base/src/main/java/io/camunda/connector/e2e/inbound/InboundConnectorTestConfiguration.java
@@ -24,6 +24,7 @@ import io.camunda.connector.runtime.inbound.executable.InboundExecutableRegistry
 import io.camunda.connector.runtime.inbound.state.ProcessDefinitionInspector;
 import java.time.Duration;
 import java.util.Objects;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.cache.CacheManager;
 import org.springframework.context.annotation.Bean;
@@ -33,7 +34,8 @@ public class InboundConnectorTestConfiguration {
 
   @Bean
   public InboundConnectorTestHelper inboundConnectorTestHelper(
-      CacheManager cacheManager, InboundExecutableRegistry executableRegistry) {
+      @Qualifier("processDefinitionCacheManager") CacheManager cacheManager,
+      InboundExecutableRegistry executableRegistry) {
     return new InboundConnectorTestHelper(cacheManager, executableRegistry);
   }
 


### PR DESCRIPTION
## Description

#7568 introduced a new `CacheManager secretKeyCache` bean, which breaks the e2e test context when not specifying a qualifier due to multiple `CacheManager` beans available on the context.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #

## Checklist

- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest
  release, as this branch will be rebased onto main before the next release. Example backport labels:
    - `backport stable/8.8`: for changes that should be included in the next 8.8.x release.
    - **or** `backport release-8.8.7`: for changes that should be included in the specific release 8.8.7, and this
      *release has already been created*. The release branch will be merged back into stable/8.8 later, so the change
      will be included in future 8.8.x releases as well.
- [ ] Tests/Integration tests for the changes have been added if applicable.
- [ ] If the change requires a documentation update, it has been added to the appropriate section in the documentation.


