### PR TITLE
fix: bump tomcat-embed-core to 10.1.56 (stable/8.8)

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -90,6 +90,7 @@ limitations under the License.</license.inlineheader>
     <version.hamcrest>3.0</version.hamcrest>
 
     <version.spring-boot>3.5.16</version.spring-boot>
+    <tomcat.version>10.1.56</tomcat.version>
     <version.spring-cloud-gcp-starter-logging>7.4.9</version.spring-cloud-gcp-starter-logging>
     <version.logback>1.5.37</version.logback>
 


### PR DESCRIPTION
## Summary

Bumps `org.apache.tomcat.embed:tomcat-embed-core` from `10.1.55` to `10.1.56` by overriding the `tomcat.version` property in `parent/pom.xml`.

Security fix. Details in the internal tracking issue: camunda/team-connectors#1239