### PR TITLE
ci: use local post-failure-feedback action (stable/8.8)

### DIFF
--- a/.github/actions/post-failure-feedback/action.yml
+++ b/.github/actions/post-failure-feedback/action.yml
@@ -1,0 +1,76 @@
+name: Post AlwaysGreen failure feedback
+description: >
+  Render one standardised AlwaysGreen failure message (Verdict / Evidence /
+  Next steps) and post it to the job summary, the PR (upserted), and Slack.
+  Best-effort — never fails the calling job. See the CI Failure Feedback Standard
+  in team-test-automation/docs/ci-failure-feedback-standard.md.
+
+inputs:
+  failure_category:
+    description: "infra | test-infra | flaky | product | test | external | unknown"
+    required: true
+  stage:
+    description: "Pipeline stage, e.g. helm-integration / saas-e2e"
+    required: true
+  owner_team:
+    description: "Team that owns triage for this stage"
+    required: false
+    default: "unknown"
+  run_url:
+    description: "URL of the failing run"
+    required: false
+    default: ""
+  status:
+    description: "failure | cancelled"
+    required: false
+    default: "failure"
+  evidence:
+    description: "Optional free-text evidence (failing step, key log line)"
+    required: false
+    default: ""
+  repo:
+    description: "owner/repo of the failing run (defaults to the calling repo)"
+    required: false
+    default: ""
+  pr:
+    description: >
+      PR number, or a merge_group head_ref to extract it from
+      (refs/heads/gh-readonly-queue/<base>/pr-<N>-<sha>). Empty to skip the PR comment.
+    required: false
+    default: ""
+  cookbook_url:
+    description: "Debugging cookbook link"
+    required: false
+    default: "https://github.com/camunda/c8-cross-component-e2e-tests/blob/main/docs/ci-debugging-cookbook.md"
+  slack_channel:
+    description: "Slack channel id/name for the proactive message (empty to skip)"
+    required: false
+    default: ""
+  slack_bot_token:
+    description: "Slack bot token (empty to skip Slack)"
+    required: false
+    default: ""
+  github_token:
+    description: "Token with PR write access (empty to skip the PR comment)"
+    required: false
+    default: ""
+
+runs:
+  using: composite
+  steps:
+    - name: Render & post failure feedback
+      shell: bash
+      env:
+        FB_CATEGORY: ${{ inputs.failure_category }}
+        FB_STAGE: ${{ inputs.stage }}
+        FB_OWNER: ${{ inputs.owner_team }}
+        FB_RUN_URL: ${{ inputs.run_url }}
+        FB_STATUS: ${{ inputs.status }}
+        FB_EVIDENCE: ${{ inputs.evidence }}
+        FB_REPO: ${{ inputs.repo || github.repository }}
+        FB_PR: ${{ inputs.pr }}
+        FB_COOKBOOK_URL: ${{ inputs.cookbook_url }}
+        FB_SLACK_CHANNEL: ${{ inputs.slack_channel }}
+        SLACK_BOT_TOKEN: ${{ inputs.slack_bot_token }}
+        GH_TOKEN: ${{ inputs.github_token }}
+      run: node "$GITHUB_ACTION_PATH/feedback.mjs"

--- a/.github/actions/post-failure-feedback/feedback.mjs
+++ b/.github/actions/post-failure-feedback/feedback.mjs
@@ -1,0 +1,237 @@
+// AlwaysGreen developer feedback — render one standard failure message and post
+// it to the job summary, the PR (upserted), and Slack. Dependency-free.
+//
+// Inputs via env (set by action.yml):
+//   FB_STAGE, FB_CATEGORY, FB_OWNER, FB_RUN_URL, FB_STATUS  (the classification contract)
+//   FB_EVIDENCE        optional free-text evidence (e.g. failing step name)
+//   FB_REPO            owner/repo of the failing run (for links)
+//   FB_PR              PR number, or a merge_group head_ref to extract it from, or empty
+//   FB_COOKBOOK_URL    debugging cookbook link
+//   FB_SLACK_CHANNEL   Slack channel id/name (optional → skip Slack)
+//   GH_TOKEN           token with PR write on FB_REPO (optional → skip PR comment)
+//   SLACK_BOT_TOKEN    Slack bot token (optional → skip Slack)
+
+import {execFile} from 'node:child_process';
+import {promisify} from 'node:util';
+import {appendFile} from 'node:fs/promises';
+
+const exec = promisify(execFile);
+const env = (k, d = '') => (process.env[k] ?? d).trim();
+
+const MARKER = '<!-- alwaysgreen-feedback -->'; // upsert anchor
+const ASK = 'https://camunda.slack.com/archives/C0AQ378VBEV'; // #ask-alwaysgreen
+const RELIABILITY =
+  'https://camunda.slack.com/archives/C0AK0AVKRL0'; // #alwaysgreen-reliability
+
+const CATALOG = {
+  product: {
+    title: 'Real failure — likely your change',
+    emoji: '🔴',
+    steps: [
+      'Open the failing job below and read the logs / screenshots.',
+      'Reproduce locally, fix, and re-push.',
+    ],
+  },
+  flaky: {
+    title: 'Likely a flaky test — probably not your change',
+    emoji: '🟡',
+    steps: [
+      'Re-run the failed job.',
+      'If it reproduces, file a flaky-test issue (label `flaky`) and ping the owner team.',
+    ],
+  },
+  infra: {
+    title: 'Infrastructure failure — not your code',
+    emoji: '🟠',
+    steps: [
+      'Re-run the failed job.',
+      `If it persists, ping <${RELIABILITY}|#alwaysgreen-reliability> — the owner team triages cluster/runner issues.`,
+    ],
+  },
+  'test-infra': {
+    title: 'Test infrastructure issue — not your code',
+    emoji: '🟠',
+    steps: [
+      'Re-run the failed job.',
+      `If it persists, ping the owner team — the test environment (cluster, login endpoint) may need attention.`,
+    ],
+  },
+  external: {
+    title: 'External dependency failure (registry / Harbor / marketplace)',
+    emoji: '🟠',
+    steps: [
+      "Check the dependency's status, then re-run.",
+      'Sustained outage → ping the owner team.',
+    ],
+  },
+  test: {
+    title: 'Test / automation bug',
+    emoji: '🟣',
+    steps: [
+      'Owned by Test Automation — not a product regression.',
+      `Link this run in <${ASK}|#ask-alwaysgreen>.`,
+    ],
+  },
+  unknown: {
+    title: 'Needs triage',
+    emoji: '⚪',
+    steps: [
+      'Open the run and follow the debugging cookbook.',
+      `Ask in <${ASK}|#ask-alwaysgreen> if the cause is unclear.`,
+    ],
+  },
+};
+
+function model() {
+  const category = (env('FB_CATEGORY') || 'unknown').toLowerCase();
+  const c = CATALOG[category] || CATALOG.unknown;
+  // Resolve PR number: explicit number, or extract from a merge_group head_ref
+  // refs/heads/gh-readonly-queue/<base>/pr-<N>-<sha>.
+  let pr = env('FB_PR');
+  const m = pr.match(/pr-(\d+)-/);
+  if (m) pr = m[1];
+  if (!/^\d+$/.test(pr)) pr = '';
+  return {
+    category,
+    ...c,
+    stage: env('FB_STAGE', 'unknown'),
+    owner: env('FB_OWNER', 'unknown'),
+    status: env('FB_STATUS', 'failure'),
+    runUrl: env('FB_RUN_URL'),
+    evidence: env('FB_EVIDENCE'),
+    repo: env('FB_REPO'),
+    cookbook: env('FB_COOKBOOK_URL'),
+    pr,
+  };
+}
+
+// ── Renderers (same content, per-surface formatting) ──
+function markdown(m) {
+  const ev = m.evidence || `Failing stage \`${m.stage}\` — see the run.`;
+  const steps = m.steps.map((s) => `- ${slackToMd(s)}`).join('\n');
+  const links = [
+    m.runUrl && `[Run](${m.runUrl})`,
+    m.cookbook && `[Debugging cookbook](${m.cookbook})`,
+    `[#ask-alwaysgreen](${ASK})`,
+  ]
+    .filter(Boolean)
+    .join(' · ');
+  return `${MARKER}
+### ${m.emoji} AlwaysGreen — ${m.title}
+**Stage:** \`${m.stage}\` · **Category:** \`${m.category}\` · **Owner:** ${m.owner}
+
+**Evidence:** ${ev}
+
+**Next steps:**
+${steps}
+
+${links}`;
+}
+
+// Slack mrkdwn (links are <url|text>; bold is *text*)
+const slackToMd = (s) => s.replace(/<([^|>]+)\|([^>]+)>/g, '[$2]($1)');
+function slackText(m) {
+  const ev = m.evidence || `Failing stage \`${m.stage}\` — see the run.`;
+  const steps = m.steps.map((s) => `• ${s}`).join('\n');
+  const prLink = m.pr && m.repo ? ` · <https://github.com/${m.repo}/pull/${m.pr}|PR #${m.pr}>` : '';
+  const links = [
+    m.runUrl && `<${m.runUrl}|Run>`,
+    m.cookbook && `<${m.cookbook}|Cookbook>`,
+    `<${ASK}|#ask-alwaysgreen>`,
+  ]
+    .filter(Boolean)
+    .join(' · ');
+  return `${m.emoji} *AlwaysGreen — ${m.title}*\n*Stage:* \`${m.stage}\` · *Category:* \`${m.category}\` · *Owner:* ${m.owner}${prLink}\n*Evidence:* ${ev}\n*Next steps:*\n${steps}\n${links}`;
+}
+
+const gh = (args) => exec('gh', args, {maxBuffer: 64 * 1024 * 1024});
+
+async function postSummary(md) {
+  const f = process.env.GITHUB_STEP_SUMMARY;
+  if (!f) return;
+  await appendFile(f, `\n${md}\n`);
+  console.log('[feedback] wrote job summary');
+}
+
+// Upsert: one bot comment per PR, updated on re-runs (find by MARKER).
+async function upsertPrComment(m, md) {
+  if (!m.pr || !m.repo || !env('GH_TOKEN')) {
+    console.log('[feedback] PR comment skipped (no pr/repo/token)');
+    return;
+  }
+  try {
+    const {stdout} = await gh([
+      'api',
+      `repos/${m.repo}/issues/${m.pr}/comments`,
+      '--paginate',
+      '--jq',
+      '.[] | {id, body}',
+    ]);
+    const existing = stdout
+      .split('\n')
+      .filter(Boolean)
+      .map((l) => JSON.parse(l))
+      .find((c) => (c.body || '').includes(MARKER));
+    if (existing) {
+      await gh([
+        'api',
+        '--method',
+        'PATCH',
+        `repos/${m.repo}/issues/comments/${existing.id}`,
+        '-f',
+        `body=${md}`,
+      ]);
+      console.log(`[feedback] updated PR #${m.pr} comment ${existing.id}`);
+    } else {
+      await gh([
+        'api',
+        '--method',
+        'POST',
+        `repos/${m.repo}/issues/${m.pr}/comments`,
+        '-f',
+        `body=${md}`,
+      ]);
+      console.log(`[feedback] created PR #${m.pr} comment`);
+    }
+  } catch (e) {
+    console.error(`[feedback] PR comment failed: ${e.message || e}`);
+  }
+}
+
+async function postSlack(m) {
+  const channel = env('FB_SLACK_CHANNEL');
+  const token = env('SLACK_BOT_TOKEN');
+  if (!channel || !token) {
+    console.log('[feedback] Slack skipped (no channel/token)');
+    return;
+  }
+  try {
+    const res = await fetch('https://slack.com/api/chat.postMessage', {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json; charset=utf-8',
+      },
+      body: JSON.stringify({channel, text: slackText(m)}),
+    });
+    const j = await res.json();
+    if (!j.ok) throw new Error(j.error || 'unknown');
+    console.log(`[feedback] posted to Slack ${channel}`);
+  } catch (e) {
+    console.error(`[feedback] Slack post failed: ${e.message || e}`);
+  }
+}
+
+async function main() {
+  const m = model();
+  const md = markdown(m);
+  await postSummary(md);
+  await upsertPrComment(m, md);
+  await postSlack(m);
+}
+
+main().catch((e) => {
+  console.error(e);
+  // Feedback is best-effort — never fail the CI job because of it.
+  process.exit(0);
+});

--- a/.github/workflows/MERGE_QUEUE_HELM_TEST.yaml
+++ b/.github/workflows/MERGE_QUEUE_HELM_TEST.yaml
@@ -200,7 +200,7 @@ jobs:
           repositories: connectors
       - name: Post AlwaysGreen failure feedback
         continue-on-error: true
-        uses: camunda/c8-cross-component-e2e-tests/.github/actions/post-failure-feedback@main
+        uses: ./.github/actions/post-failure-feedback
         with:
           failure_category: unknown
           stage: sm-e2e-helm


### PR DESCRIPTION
## Summary

- Copies the `post-failure-feedback` composite action locally into `.github/actions/post-failure-feedback/`
- Updates `MERGE_QUEUE_HELM_TEST.yaml` to use `uses: ./.github/actions/post-failure-feedback` instead of the cross-repo reference that fails with "Unable to resolve action, not found"

## Test plan
- [ ] Verify CI runs pick up the local action successfully on next merge queue trigger

🤖 Generated with [Claude Code](https://claude.com/claude-code)