### PR TITLE
fix(agentic-ai): treat 404 on agent-instance writes as non-retryable

### DIFF
--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/agentinstance/AgentInstanceErrorClassifier.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/agentinstance/AgentInstanceErrorClassifier.java
@@ -10,32 +10,19 @@ import io.camunda.client.api.command.ClientHttpException;
 import io.camunda.connector.agenticai.common.util.retry.ErrorClassifier;
 import java.io.IOException;
 
-public final class AgentInstanceErrorClassifier implements ErrorClassifier {
-
-  /** For create: 404 is retryable (idempotent re-create against a transient lookup race). */
-  public static final AgentInstanceErrorClassifier FOR_CREATE =
-      new AgentInstanceErrorClassifier(true);
-
-  /**
-   * For update: 404 is retryable. A just-created agent instance may not yet be visible to follow-up
-   * API calls due to eventual consistency, so a transient 404 should be retried rather than failing
-   * the job.
-   */
-  public static final AgentInstanceErrorClassifier FOR_UPDATE =
-      new AgentInstanceErrorClassifier(true);
-
-  /**
-   * For history item creation: 404 is retryable for the same eventual-consistency reason as {@link
-   * #FOR_UPDATE}.
-   */
-  public static final AgentInstanceErrorClassifier FOR_HISTORY_ITEM =
-      new AgentInstanceErrorClassifier(true);
-
-  private final boolean notFoundIsRetryable;
-
-  private AgentInstanceErrorClassifier(boolean notFoundIsRetryable) {
-    this.notFoundIsRetryable = notFoundIsRetryable;
-  }
+/**
+ * Shared classifier for the agent-instance write endpoints (create, update, history item creation).
+ * All three are {@code x-eventually-consistent: false} and are validated against primary processing
+ * state, with Zeebe's key-based partition routing guaranteeing a create is visible to the same
+ * partition before its key is ever returned to the caller. A {@code 404} from update/history means
+ * the referenced agent instance genuinely doesn't exist (wrong/stale key, or since
+ * completed/terminated); from create it means the referenced element instance doesn't exist. Either
+ * way it reflects a genuinely missing entity rather than a not-yet-visible record, so it is
+ * classified as permanent along with the other 4xx responses. {@code 429} is the exception: it
+ * signals rate limiting rather than a semantic error, so it is retried like a 5xx.
+ */
+public enum AgentInstanceErrorClassifier implements ErrorClassifier {
+  INSTANCE;
 
   @Override
   public Decision classify(Throwable t) {
@@ -43,14 +30,11 @@ public final class AgentInstanceErrorClassifier implements ErrorClassifier {
     while (current != null) {
       if (current instanceof ClientHttpException httpEx) {
         int status = httpEx.code();
-        if (status == 404) {
-          return notFoundIsRetryable ? Decision.RETRYABLE : Decision.PERMANENT;
-        }
-        if (status >= 400 && status < 500) {
-          return Decision.PERMANENT;
-        }
-        if (status >= 500) {
+        if (status == 429 || status >= 500) {
           return Decision.RETRYABLE;
+        }
+        if (status >= 400) {
+          return Decision.PERMANENT;
         }
       }
 

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/agentinstance/CamundaAgentInstanceClient.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/agentinstance/CamundaAgentInstanceClient.java
@@ -62,7 +62,7 @@ public class CamundaAgentInstanceClient implements AgentInstanceClient {
   public AgentInstanceKey create(AgentExecutionContext agentExecutionContext) {
     return CamundaApiRetry.execute(
         () -> executeCreate(agentExecutionContext),
-        AgentInstanceErrorClassifier.FOR_CREATE,
+        AgentInstanceErrorClassifier.INSTANCE,
         retriesProperties.maxRetries(),
         retriesProperties.initialRetryDelay(),
         this::buildCreateException,
@@ -110,7 +110,7 @@ public class CamundaAgentInstanceClient implements AgentInstanceClient {
           executeUpdate(executionContext, agentInstanceKey.value(), request);
           return null;
         },
-        AgentInstanceErrorClassifier.FOR_UPDATE,
+        AgentInstanceErrorClassifier.INSTANCE,
         retriesProperties.maxRetries(),
         retriesProperties.initialRetryDelay(),
         this::buildUpdateException,
@@ -230,7 +230,7 @@ public class CamundaAgentInstanceClient implements AgentInstanceClient {
               executionContext, agentInstanceKey, role, content, iteration, toolCalls, metrics);
           return null;
         },
-        AgentInstanceErrorClassifier.FOR_HISTORY_ITEM,
+        AgentInstanceErrorClassifier.INSTANCE,
         retriesProperties.maxRetries(),
         retriesProperties.initialRetryDelay(),
         this::buildHistoryItemException,

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/agentinstance/AgentInstanceErrorClassifierTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/agentinstance/AgentInstanceErrorClassifierTest.java
@@ -21,49 +21,23 @@ class AgentInstanceErrorClassifierTest {
 
   @ParameterizedTest
   @MethodSource("retryableExceptions")
-  void forCreate_shouldClassifyAsRetryable(Throwable exception) {
-    assertThat(AgentInstanceErrorClassifier.FOR_CREATE.classify(exception)).isEqualTo(RETRYABLE);
+  void shouldClassifyAsRetryable(Throwable exception) {
+    assertThat(AgentInstanceErrorClassifier.INSTANCE.classify(exception)).isEqualTo(RETRYABLE);
   }
 
   @ParameterizedTest
   @MethodSource("permanentExceptions")
-  void forCreate_shouldClassifyAsPermanent(Throwable exception) {
-    assertThat(AgentInstanceErrorClassifier.FOR_CREATE.classify(exception)).isEqualTo(PERMANENT);
-  }
-
-  @ParameterizedTest
-  @MethodSource("retryableExceptions")
-  void forUpdate_shouldClassifyAsRetryable(Throwable exception) {
-    assertThat(AgentInstanceErrorClassifier.FOR_UPDATE.classify(exception)).isEqualTo(RETRYABLE);
-  }
-
-  @ParameterizedTest
-  @MethodSource("permanentExceptions")
-  void forUpdate_shouldClassifyAsPermanent(Throwable exception) {
-    assertThat(AgentInstanceErrorClassifier.FOR_UPDATE.classify(exception)).isEqualTo(PERMANENT);
-  }
-
-  @ParameterizedTest
-  @MethodSource("retryableExceptions")
-  void forHistoryItem_shouldClassifyAsRetryable(Throwable exception) {
-    assertThat(AgentInstanceErrorClassifier.FOR_HISTORY_ITEM.classify(exception))
-        .isEqualTo(RETRYABLE);
-  }
-
-  @ParameterizedTest
-  @MethodSource("permanentExceptions")
-  void forHistoryItem_shouldClassifyAsPermanent(Throwable exception) {
-    assertThat(AgentInstanceErrorClassifier.FOR_HISTORY_ITEM.classify(exception))
-        .isEqualTo(PERMANENT);
+  void shouldClassifyAsPermanent(Throwable exception) {
+    assertThat(AgentInstanceErrorClassifier.INSTANCE.classify(exception)).isEqualTo(PERMANENT);
   }
 
   static Stream<Throwable> retryableExceptions() {
     return Stream.of(
-        new ClientHttpException(404, "Not Found"),
+        new ClientHttpException(429, "Too Many Requests"),
         new ClientHttpException(500, "Internal Server Error"),
         new ClientHttpException(502, "Bad Gateway"),
         new ClientHttpException(503, "Service Unavailable"),
-        new RuntimeException("wrapped", new ClientHttpException(404, "Not Found")),
+        new RuntimeException("wrapped", new ClientHttpException(429, "Too Many Requests")),
         new IOException("connection refused"),
         new InterruptedIOException("timeout"),
         new RuntimeException(new IOException("transport")));
@@ -74,8 +48,10 @@ class AgentInstanceErrorClassifierTest {
         new ClientHttpException(400, "Bad Request"),
         new ClientHttpException(401, "Unauthorized"),
         new ClientHttpException(403, "Forbidden"),
+        new ClientHttpException(404, "Not Found"),
         new ClientHttpException(409, "Conflict"),
         new RuntimeException("wrapped", new ClientHttpException(400, "Bad Request")),
+        new RuntimeException("wrapped", new ClientHttpException(404, "Not Found")),
         new RuntimeException("unknown"),
         new IllegalArgumentException("bad arg"));
   }

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/agentinstance/CamundaAgentInstanceClientTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/agentinstance/CamundaAgentInstanceClientTest.java
@@ -202,7 +202,7 @@ class CamundaAgentInstanceClientTest {
     void shouldReturnKeyAndRecordOneSleepWhenRetryableErrorPrecedesSuccess() {
       givenCreateCommandWithMaxModelCalls();
       when(step5.execute())
-          .thenThrow(new ClientHttpException(404, "Not Found"))
+          .thenThrow(new ClientHttpException(503, "Service Unavailable"))
           .thenReturn(response);
       when(response.getAgentInstanceKey()).thenReturn(999L);
 
@@ -212,6 +212,25 @@ class CamundaAgentInstanceClientTest {
       assertThat(recordedSleeps).hasSize(1);
       assertThat(recordedSleeps).containsExactly(Duration.ofSeconds(1));
       verify(camundaClient, times(2)).newCreateAgentInstanceCommand();
+    }
+
+    @Test
+    void shouldThrowConnectorExceptionImmediatelyForHttp404PermanentError() {
+      // given: a 404 from the create endpoint (x-eventually-consistent: false) means the
+      // referenced element instance genuinely doesn't exist, not a not-yet-visible record
+      givenCreateCommandWithMaxModelCalls();
+      when(step5.execute()).thenThrow(new ClientHttpException(404, "Not Found"));
+
+      assertThatThrownBy(() -> client.create(TestAgentExecutionContext.withLimits()))
+          .isInstanceOfSatisfying(
+              ConnectorException.class,
+              e ->
+                  assertThat(e.getErrorCode())
+                      .isEqualTo(ERROR_CODE_AGENT_INSTANCE_CREATION_FAILED));
+
+      // Only 1 attempt, no sleeps
+      assertThat(recordedSleeps).isEmpty();
+      verify(camundaClient, times(1)).newCreateAgentInstanceCommand();
     }
 
     @Test
@@ -325,13 +344,15 @@ class CamundaAgentInstanceClientTest {
     }
 
     @Test
-    void shouldRetry404ForUpdateDueToEventualConsistency() {
-      // given: a freshly created agent instance may not yet be visible to the update call
+    void shouldThrowConnectorExceptionImmediatelyForHttp404PermanentError() {
+      // given: the update endpoint is x-eventually-consistent: false and Zeebe key-based
+      // partition routing guarantees the create is visible before the key is returned, so a 404
+      // means the agent instance genuinely doesn't exist rather than being not-yet-visible
       givenUpdateCommand();
       final var agentInstanceKey = AgentInstanceKey.of(AGENT_INSTANCE_KEY);
       when(updateCommandStep2.execute()).thenThrow(new ClientHttpException(404, "Not Found"));
 
-      // when / then: 404 is retryable for update → retries are exhausted before failing
+      // when / then: 404 is permanent for update → fails immediately, no retries
       assertThatThrownBy(
               () ->
                   client.update(
@@ -342,8 +363,8 @@ class CamundaAgentInstanceClientTest {
               ConnectorException.class,
               e -> assertThat(e.getErrorCode()).isEqualTo(ERROR_CODE_AGENT_INSTANCE_UPDATE_FAILED));
 
-      assertThat(recordedSleeps).hasSize(4);
-      verify(camundaClient, times(5)).newUpdateAgentInstanceCommand(AGENT_INSTANCE_KEY);
+      assertThat(recordedSleeps).isEmpty();
+      verify(camundaClient, times(1)).newUpdateAgentInstanceCommand(AGENT_INSTANCE_KEY);
     }
 
     @Test

--- a/connectors/agentic-ai/docs/reference/ai-agent.md
+++ b/connectors/agentic-ai/docs/reference/ai-agent.md
@@ -1517,10 +1517,15 @@ connector behavior, element template properties, or data model shapes, update th
 ## 23. Agent Instance Integration
 
 The agent reports its lifecycle to the engine's **agent instance** API via `AgentInstanceClient`
-(`CamundaAgentInstanceClient`). All calls silently skip when the `agentInstanceKey` is `null` (agents
-that pre-date the feature) and retry transient failures via `CamundaApiRetry`. A `404` is treated as
-**retryable** for updates and history items, because a freshly created agent instance may not yet be
-visible to follow-up calls (eventual consistency).
+(`CamundaAgentInstanceClient`). Update and history calls silently skip when the `agentInstanceKey` is
+`null` (agents that pre-date the feature); create has no such key to check, since it produces one. All
+calls retry transient failures via `CamundaApiRetry`. A `404` is treated as **permanent** (not
+retried) for create, update, and history items: all three write endpoints are
+`x-eventually-consistent: false` and are validated against primary processing state, with Zeebe's
+key-based partition routing guaranteeing the create is visible to the same partition before the key
+is ever returned to the caller. For update/history a `404` means the agent instance genuinely doesn't
+exist, not that it isn't visible yet; for create it means the referenced element instance doesn't
+exist.
 
 ### Status & metrics
 


### PR DESCRIPTION
## Description

The create/update/history endpoints for agent instances are all `x-eventually-consistent: false` and validate against primary processing state (not an ES/OS projection), and Zeebe key-based partition routing guarantees a created record is visible before its key is returned to the caller. A 404 from these endpoints therefore reflects a genuinely missing instance, not an eventual-consistency lag, so retrying it only delays surfacing a real error.

Collapses AgentInstanceErrorClassifier into a single stateless singleton (404 now falls under the existing generic 4xx-is-permanent branch), removing the notFoundIsRetryable toggle and the three now-identical `FOR_*` variants.
## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #7598 

## Checklist

- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest
  release, as this branch will be rebased onto main before the next release. Example backport labels:
    - `backport stable/8.8`: for changes that should be included in the next 8.8.x release.
    - **or** `backport release-8.8.7`: for changes that should be included in the specific release 8.8.7, and this
      *release has already been created*. The release branch will be merged back into stable/8.8 later, so the change
      will be included in future 8.8.x releases as well.
- [ ] Tests/Integration tests for the changes have been added if applicable.
- [ ] If the change requires a documentation update, it has been added to the appropriate section in the documentation.


