### PR TITLE
chore: add GCP and AWS registry URLs to PR Docker image comment

### DIFF
--- a/.github/workflows/BUILD_PR_DOCKER_IMAGES.yml
+++ b/.github/workflows/BUILD_PR_DOCKER_IMAGES.yml
@@ -171,6 +171,17 @@ jobs:
               '- `' + reg + '/connectors:' + tag + '`',
               '- `' + reg + '/connectors-bundle:' + tag + '`',
               '- `' + reg + '/connectors-bundle-saas:' + tag + '`',
+              '',
+              '**To use the SaaS bundle on a cluster:**',
+              '',
+              '_GCP cluster:_',
+              '```',
+              'europe-docker.pkg.dev/camunda-saas-registry/harbor/team-connectors/connectors-bundle-saas:' + tag,
+              '```',
+              '_AWS cluster (replace `<WORKER_REGION>`, e.g. `eu-central-1`):_',
+              '```',
+              '390403865336.dkr.ecr.<WORKER_REGION>.amazonaws.com/team-connectors/connectors-bundle-saas:' + tag,
+              '```',
             ].join('\n');
             await github.rest.issues.createComment({
               owner: context.repo.owner,


### PR DESCRIPTION
## Description

When the `docker-images-required` label triggers a PR image build, the resulting PR comment now includes ready-to-use image pull URLs for both GCP and AWS clusters, so it's easy to deploy the built SaaS bundle without having to manually construct the registry paths.

Added to the comment:
- **GCP**: `europe-docker.pkg.dev/camunda-saas-registry/harbor/team-connectors/connectors-bundle-saas:<tag>`
- **AWS**: `390403865336.dkr.ecr.<WORKER_REGION>.amazonaws.com/team-connectors/connectors-bundle-saas:<tag>`

## Related issues

closes #

## Checklist

- [ ] Backport labels are added if these code changes should be backported.
- [ ] Tests/Integration tests for the changes have been added if applicable.
- [ ] If the change requires a documentation update, it has been added to the appropriate section in the documentation.
