### PR TITLE
refactor(webhook): reject deprecated responseBodyExpression at deployment

### DIFF
--- a/connectors-e2e-test/connectors-e2e-test-http/src/test/resources/webhook_connector.bpmn
+++ b/connectors-e2e-test/connectors-e2e-test-http/src/test/resources/webhook_connector.bpmn
@@ -21,7 +21,7 @@
           <zeebe:property name="inbound.auth.apiKeyLocator" value="=split(request.headers.authorization, &#34; &#34;)[2]" />
           <zeebe:property name="correlationKeyExpression" value="=request.body.correlationKey" />
           <zeebe:property name="resultExpression" value="={correlationKey: request.body.correlationKey, webhookExecuted: request.body.webhookExecuted, queryParam: request.params.value}" />
-          <zeebe:property name="inbound.responseBodyExpression" value="={correlationKey: request.body.correlationKey}" />
+          <zeebe:property name="inbound.responseExpression" value="={body: {correlationKey: request.body.correlationKey}}" />
         </zeebe:properties>
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_0iberio</bpmn:incoming>

--- a/connectors/webhook/src/main/java/io/camunda/connector/inbound/HttpWebhookExecutable.java
+++ b/connectors/webhook/src/main/java/io/camunda/connector/inbound/HttpWebhookExecutable.java
@@ -12,6 +12,7 @@ import io.camunda.connector.api.annotation.InboundConnector;
 import io.camunda.connector.api.error.ConnectorInputException;
 import io.camunda.connector.api.inbound.Health;
 import io.camunda.connector.api.inbound.InboundConnectorContext;
+import io.camunda.connector.api.inbound.ProcessElement;
 import io.camunda.connector.api.inbound.webhook.MappedHttpRequest;
 import io.camunda.connector.api.inbound.webhook.WebhookConnectorException;
 import io.camunda.connector.api.inbound.webhook.WebhookConnectorExecutable;
@@ -33,6 +34,7 @@ import io.camunda.connector.inbound.signature.HMACVerifier;
 import io.camunda.connector.inbound.utils.HttpMethods;
 import io.camunda.connector.inbound.utils.HttpWebhookUtil;
 import java.util.Map;
+import java.util.Objects;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -107,15 +109,13 @@ public class HttpWebhookExecutable implements WebhookConnectorExecutable {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(HttpWebhookExecutable.class);
 
-  /** Wrapper key under which the element-scoped inbound properties are nested. */
-  private static final String INBOUND_PROPERTIES_KEY = "inbound";
-
   /**
-   * Legacy, deprecated response property, superseded by {@code responseExpression}. Its presence on
-   * a deployed element is rejected at activation time (see {@link
-   * #rejectDeprecatedResponseBodyExpression}).
+   * Raw (flattened) key of the legacy, deprecated response property, superseded by {@code
+   * responseExpression}. Its presence on any deployed element is rejected at activation time (see
+   * {@link #rejectDeprecatedResponseBodyExpression}).
    */
-  private static final String LEGACY_RESPONSE_BODY_EXPRESSION_KEY = "responseBodyExpression";
+  private static final String LEGACY_RESPONSE_BODY_EXPRESSION_PROPERTY =
+      "inbound.responseBodyExpression";
 
   private WebhookConnectorProperties props;
   private WebhookAuthorizationHandler<?> authChecker;
@@ -137,19 +137,32 @@ public class HttpWebhookExecutable implements WebhookConnectorExecutable {
 
   /**
    * Fails webhook deployment (activation) when the legacy, deprecated {@code
-   * responseBodyExpression} property is present on the element. It was superseded by {@code
-   * responseExpression} — which can return a full HTTP response — and removed from element
+   * responseBodyExpression} property is present on <em>any</em> element. It was superseded by
+   * {@code responseExpression} — which can return a full HTTP response — and removed from element
    * templates long ago, but was still silently honored at runtime. Deployments must migrate to
    * {@code responseExpression}.
+   *
+   * <p>Every element is inspected, not just the representative one exposed by {@link
+   * InboundConnectorContext#getProperties()}: element-scoped response properties are excluded from
+   * deduplication, so elements sharing a single executable may each carry a different (or legacy)
+   * response expression, and the runtime honors the one from the element that actually matched.
    *
    * <p>Throwing here causes the runtime to report the connector as {@code DOWN} with this message,
    * which surfaces in the Manage &amp; Run UI. See
    * https://github.com/camunda/connectors/issues/7468.
    */
   private static void rejectDeprecatedResponseBodyExpression(InboundConnectorContext context) {
-    if (context.getProperties().get(INBOUND_PROPERTIES_KEY) instanceof Map<?, ?> inbound
-        && inbound.get(LEGACY_RESPONSE_BODY_EXPRESSION_KEY) instanceof String expression
-        && !expression.isBlank()) {
+    var definition = context.getDefinition();
+    if (definition == null) {
+      return;
+    }
+    boolean anyElementUsesLegacyProperty =
+        definition.elements().stream()
+            .map(ProcessElement::properties)
+            .filter(Objects::nonNull)
+            .map(properties -> properties.get(LEGACY_RESPONSE_BODY_EXPRESSION_PROPERTY))
+            .anyMatch(expression -> expression != null && !expression.isBlank());
+    if (anyElementUsesLegacyProperty) {
       throw new ConnectorInputException(
           "The webhook property 'responseBodyExpression' is deprecated and no longer supported. "
               + "Replace it with 'responseExpression', which returns a full HTTP response, e.g. "

--- a/connectors/webhook/src/main/java/io/camunda/connector/inbound/HttpWebhookExecutable.java
+++ b/connectors/webhook/src/main/java/io/camunda/connector/inbound/HttpWebhookExecutable.java
@@ -9,6 +9,7 @@ package io.camunda.connector.inbound;
 import static io.camunda.connector.inbound.signature.HMACSwitchCustomerChoice.enabled;
 
 import io.camunda.connector.api.annotation.InboundConnector;
+import io.camunda.connector.api.error.ConnectorInputException;
 import io.camunda.connector.api.inbound.Health;
 import io.camunda.connector.api.inbound.InboundConnectorContext;
 import io.camunda.connector.api.inbound.webhook.MappedHttpRequest;
@@ -106,6 +107,16 @@ public class HttpWebhookExecutable implements WebhookConnectorExecutable {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(HttpWebhookExecutable.class);
 
+  /** Wrapper key under which the element-scoped inbound properties are nested. */
+  private static final String INBOUND_PROPERTIES_KEY = "inbound";
+
+  /**
+   * Legacy, deprecated response property, superseded by {@code responseExpression}. Its presence on
+   * a deployed element is rejected at activation time (see {@link
+   * #rejectDeprecatedResponseBodyExpression}).
+   */
+  private static final String LEGACY_RESPONSE_BODY_EXPRESSION_KEY = "responseBodyExpression";
+
   private WebhookConnectorProperties props;
   private WebhookAuthorizationHandler<?> authChecker;
   private InboundConnectorContext context;
@@ -114,6 +125,7 @@ public class HttpWebhookExecutable implements WebhookConnectorExecutable {
   @Override
   public void activate(InboundConnectorContext context) {
     this.context = context;
+    rejectDeprecatedResponseBodyExpression(context);
     var wrappedProps = context.bindProperties(WebhookConnectorPropertiesWrapper.class);
     props = new WebhookConnectorProperties(wrappedProps);
     authChecker = WebhookAuthorizationHandler.getHandlerForAuth(props.auth());
@@ -121,6 +133,29 @@ public class HttpWebhookExecutable implements WebhookConnectorExecutable {
         new HMACVerifier(
             props.hmacScopes(), props.hmacHeader(), props.hmacSecret(), props.hmacAlgorithm());
     context.reportHealth(Health.up());
+  }
+
+  /**
+   * Fails webhook deployment (activation) when the legacy, deprecated {@code
+   * responseBodyExpression} property is present on the element. It was superseded by {@code
+   * responseExpression} — which can return a full HTTP response — and removed from element
+   * templates long ago, but was still silently honored at runtime. Deployments must migrate to
+   * {@code responseExpression}.
+   *
+   * <p>Throwing here causes the runtime to report the connector as {@code DOWN} with this message,
+   * which surfaces in the Manage &amp; Run UI. See
+   * https://github.com/camunda/connectors/issues/7468.
+   */
+  private static void rejectDeprecatedResponseBodyExpression(InboundConnectorContext context) {
+    if (context.getProperties().get(INBOUND_PROPERTIES_KEY) instanceof Map<?, ?> inbound
+        && inbound.get(LEGACY_RESPONSE_BODY_EXPRESSION_KEY) instanceof String expression
+        && !expression.isBlank()) {
+      throw new ConnectorInputException(
+          "The webhook property 'responseBodyExpression' is deprecated and no longer supported. "
+              + "Replace it with 'responseExpression', which returns a full HTTP response, e.g. "
+              + "'={body: ..., statusCode: 200, headers: {...}}'. See "
+              + "https://docs.camunda.io/docs/components/connectors/protocol/http-webhook/ for details.");
+    }
   }
 
   @Override

--- a/connectors/webhook/src/main/java/io/camunda/connector/inbound/model/DynamicWebhookProperties.java
+++ b/connectors/webhook/src/main/java/io/camunda/connector/inbound/model/DynamicWebhookProperties.java
@@ -37,7 +37,9 @@ public record DynamicWebhookProperties(
             optional = true)
         Function<WebhookResultContext, WebhookHttpResponse> responseExpression,
     // Legacy body-only expression, superseded by responseExpression (which can produce a full HTTP
-    // response). Retained only for backward compatibility.
+    // response). Deprecated and rejected at deployment time (see
+    // HttpWebhookExecutable#rejectDeprecatedResponseBodyExpression, issue #7468); the runtime
+    // fallback below is retained for backward compatibility until removal is completed in 8.10.
     @Deprecated @TemplateProperty(ignore = true)
         Function<WebhookResultContext, Object> responseBodyExpression) {
 

--- a/connectors/webhook/src/test/java/io/camunda/connector/inbound/HttpWebhookExecutableTest.java
+++ b/connectors/webhook/src/test/java/io/camunda/connector/inbound/HttpWebhookExecutableTest.java
@@ -17,6 +17,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import io.camunda.connector.api.error.ConnectorInputException;
 import io.camunda.connector.api.inbound.CorrelationResult;
 import io.camunda.connector.api.inbound.InboundConnectorContext;
 import io.camunda.connector.api.inbound.ProcessElement;
@@ -95,6 +96,62 @@ class HttpWebhookExecutableTest {
         new WebhookResultContext(
             new MappedHttpRequest(Map.of(), Map.of(), Map.of()), Map.of(), null);
     assertNull(result.response().apply(resultContext));
+  }
+
+  @Test
+  void activate_deprecatedResponseBodyExpression_failsDeploymentWithMigrationHint() {
+    InboundConnectorContext ctx =
+        InboundConnectorContextBuilder.create()
+            .properties(
+                Map.of(
+                    "inbound",
+                    Map.of(
+                        "context", "webhookContext",
+                        "method", "any",
+                        "auth", Map.of("type", "NONE"),
+                        "responseBodyExpression", "={\"foo\": \"bar\"}")))
+            .build();
+
+    var exception = catchException(() -> testObject.activate(ctx));
+
+    assertThat(exception)
+        .isInstanceOf(ConnectorInputException.class)
+        .hasMessageContaining("responseBodyExpression")
+        .hasMessageContaining("responseExpression");
+  }
+
+  @Test
+  void activate_blankResponseBodyExpression_doesNotFailDeployment() {
+    InboundConnectorContext ctx =
+        InboundConnectorContextBuilder.create()
+            .properties(
+                Map.of(
+                    "inbound",
+                    Map.of(
+                        "context", "webhookContext",
+                        "method", "any",
+                        "auth", Map.of("type", "NONE"),
+                        "responseBodyExpression", "   ")))
+            .build();
+
+    assertThat(catchException(() -> testObject.activate(ctx))).isNull();
+  }
+
+  @Test
+  void activate_responseExpressionOnly_doesNotFailDeployment() {
+    InboundConnectorContext ctx =
+        InboundConnectorContextBuilder.create()
+            .properties(
+                Map.of(
+                    "inbound",
+                    Map.of(
+                        "context", "webhookContext",
+                        "method", "any",
+                        "auth", Map.of("type", "NONE"),
+                        "responseExpression", "={body: request.body}")))
+            .build();
+
+    assertThat(catchException(() -> testObject.activate(ctx))).isNull();
   }
 
   @Test

--- a/connectors/webhook/src/test/java/io/camunda/connector/inbound/HttpWebhookExecutableTest.java
+++ b/connectors/webhook/src/test/java/io/camunda/connector/inbound/HttpWebhookExecutableTest.java
@@ -20,6 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import io.camunda.connector.api.error.ConnectorInputException;
 import io.camunda.connector.api.inbound.CorrelationResult;
 import io.camunda.connector.api.inbound.InboundConnectorContext;
+import io.camunda.connector.api.inbound.InboundConnectorDefinition;
 import io.camunda.connector.api.inbound.ProcessElement;
 import io.camunda.connector.api.inbound.webhook.*;
 import io.camunda.connector.inbound.model.DynamicWebhookProperties;
@@ -101,16 +102,9 @@ class HttpWebhookExecutableTest {
   @Test
   void activate_deprecatedResponseBodyExpression_failsDeploymentWithMigrationHint() {
     InboundConnectorContext ctx =
-        InboundConnectorContextBuilder.create()
-            .properties(
-                Map.of(
-                    "inbound",
-                    Map.of(
-                        "context", "webhookContext",
-                        "method", "any",
-                        "auth", Map.of("type", "NONE"),
-                        "responseBodyExpression", "={\"foo\": \"bar\"}")))
-            .build();
+        contextWithElements(
+            elementWithRawProperties(
+                Map.of("inbound.responseBodyExpression", "={\"foo\": \"bar\"}")));
 
     var exception = catchException(() -> testObject.activate(ctx));
 
@@ -121,18 +115,26 @@ class HttpWebhookExecutableTest {
   }
 
   @Test
+  void activate_deprecatedResponseBodyExpressionOnNonFirstDeduplicatedElement_failsDeployment() {
+    // The representative (first) element only uses responseExpression; a second element in the same
+    // deduplication group carries the legacy property. Deployment must still fail, even though
+    // context.getProperties() only reflects the first element.
+    InboundConnectorContext ctx =
+        contextWithElements(
+            elementWithRawProperties(Map.of("inbound.responseExpression", "={body: request.body}")),
+            elementWithRawProperties(
+                Map.of("inbound.responseBodyExpression", "={\"foo\": \"bar\"}")));
+
+    var exception = catchException(() -> testObject.activate(ctx));
+
+    assertThat(exception).isInstanceOf(ConnectorInputException.class);
+  }
+
+  @Test
   void activate_blankResponseBodyExpression_doesNotFailDeployment() {
     InboundConnectorContext ctx =
-        InboundConnectorContextBuilder.create()
-            .properties(
-                Map.of(
-                    "inbound",
-                    Map.of(
-                        "context", "webhookContext",
-                        "method", "any",
-                        "auth", Map.of("type", "NONE"),
-                        "responseBodyExpression", "   ")))
-            .build();
+        contextWithElements(
+            elementWithRawProperties(Map.of("inbound.responseBodyExpression", "   ")));
 
     assertThat(catchException(() -> testObject.activate(ctx))).isNull();
   }
@@ -140,18 +142,33 @@ class HttpWebhookExecutableTest {
   @Test
   void activate_responseExpressionOnly_doesNotFailDeployment() {
     InboundConnectorContext ctx =
-        InboundConnectorContextBuilder.create()
-            .properties(
-                Map.of(
-                    "inbound",
-                    Map.of(
-                        "context", "webhookContext",
-                        "method", "any",
-                        "auth", Map.of("type", "NONE"),
-                        "responseExpression", "={body: request.body}")))
-            .build();
+        contextWithElements(
+            elementWithRawProperties(
+                Map.of("inbound.responseExpression", "={body: request.body}")));
 
     assertThat(catchException(() -> testObject.activate(ctx))).isNull();
+  }
+
+  private static ProcessElement elementWithRawProperties(Map<String, String> rawProperties) {
+    var element = Mockito.mock(ProcessElement.class);
+    Mockito.when(element.properties()).thenReturn(rawProperties);
+    return element;
+  }
+
+  private static InboundConnectorContext contextWithElements(ProcessElement... elements) {
+    var definition =
+        new InboundConnectorDefinition(
+            "io.camunda:webhook:1", "<default>", "dedup-id", List.of(elements));
+    return InboundConnectorContextBuilder.create()
+        .properties(
+            Map.of(
+                "inbound",
+                Map.of(
+                    "context", "webhookContext",
+                    "method", "any",
+                    "auth", Map.of("type", "NONE"))))
+        .definition(definition)
+        .build();
   }
 
   @Test


### PR DESCRIPTION
## Description

`responseBodyExpression` was the original webhook response property, superseded by the more generic `responseExpression` in 8.6 and removed from element templates ~2 years ago. It was still silently honored at runtime, with no deprecation path, no user-facing validation, and no removal timeline.

This PR formally deprecates it by **failing webhook deployment** when a deployed element still carries `responseBodyExpression`:

- `HttpWebhookExecutable.activate(...)` now rejects the property with a clear, actionable `ConnectorInputException`. The runtime reports the connector as `DOWN` with this message, which surfaces in the **Manage & Run UI**.
- The error message points users to the migration path: replace `responseBodyExpression` with `responseExpression`, which can return a full HTTP response (`={body: ..., statusCode: 200, headers: {...}}`).
- Blank/empty leftover values are tolerated to avoid false positives.
- Diagrams using `responseExpression` (or no response expression) are unaffected.

The runtime fallback in `resolveResponse` that honors the legacy property is intentionally left in place for backward compatibility; its removal is targeted for the 8.10 removal step described in the issue.

### Acceptance criteria

- [x] Deploying a webhook with `responseBodyExpression` produces a validation error visible in the Manage & Run UI
- [x] The error message clearly explains the migration path to `responseExpression`
- [x] Diagrams using `responseExpression` (or no response expression) are unaffected

## Related issues

closes #7468

## Checklist

- [ ] Backport labels are added if these code changes should be backported. This is a new deprecation targeted at 8.10, so no backport is expected.
- [x] Tests/Integration tests for the changes have been added if applicable.
- [ ] If the change requires a documentation update, it has been added to the appropriate section in the documentation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)