### PR TITLE
[Backport stable/8.9] chore: add GCP and AWS registry URLs to PR Docker image comment

### DIFF
--- a/.github/workflows/BUILD_PR_DOCKER_IMAGES.yml
+++ b/.github/workflows/BUILD_PR_DOCKER_IMAGES.yml
@@ -1,0 +1,191 @@
+---
+name: Build PR Docker Images
+on:
+  pull_request:
+    types: [ labeled, synchronize ]
+
+# One run per PR + trigger; a new push (or re-add of the label) cancels the in-flight
+# build, but unrelated labeled events (e.g. deploy-preview) get their own group and
+# don't cancel a running image build.
+concurrency:
+  group: build-pr-docker-images-${{ github.event.pull_request.number }}-${{ github.event.label.name || github.event.action }}
+  cancel-in-progress: true
+
+jobs:
+  build-images:
+    name: Build & publish PR Docker images
+    # gcp runner to match the heavier Maven + multi-arch Docker build in DEPLOY_SNAPSHOTS
+    runs-on: gcp-core-2-default
+    permissions:
+      contents: read
+    # Run when the docker-images-required label is added, or on any push to a PR that already has it.
+    # Skip fork PRs: pull_request runs from forks don't get repository secrets (Vault/registry creds).
+    if: |
+      github.event.pull_request.state != 'closed' &&
+      github.event.pull_request.head.repo.full_name == github.repository && (
+        github.event.label.name == 'docker-images-required' ||
+        (github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'docker-images-required'))
+      )
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          # build the PR's actual code, not the synthetic merge ref
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Import Secrets
+        id: secrets
+        uses: hashicorp/vault-action@v4.0.0
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          exportEnv: false # we rely on step outputs, no need for environment variables
+          secrets: |
+            secret/data/products/connectors/ci/nexus USER | CI_NEXUS_USR;
+            secret/data/products/connectors/ci/nexus PASSWORD | CI_NEXUS_PSW;
+            secret/data/products/connectors/ci/common ARTIFACTORY_USR | CI_HARBOR_USR;
+            secret/data/products/connectors/ci/common ARTIFACTORY_PSW | CI_HARBOR_PSW;
+            secret/data/products/connectors/ci/common REGISTRY_MINIMUS_PSW;
+            secret/data/products/connectors/ci/common GITHUB_APP_ID;
+            secret/data/products/connectors/ci/common GITHUB_APP_PRIVATE_KEY;
+
+      - name: Generate a GitHub token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ steps.secrets.outputs.GITHUB_APP_ID }}
+          private-key: ${{ steps.secrets.outputs.GITHUB_APP_PRIVATE_KEY }}
+
+      - name: Restore cache
+        uses: actions/cache@v6
+        continue-on-error: true # cache failures should not fail the build
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+
+      - uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: '21.0.9'
+
+      # Use CI Nexus as co-located pull-through cache for Maven artifacts via ~/.m2/settings.xml
+      - name: 'Create settings.xml'
+        uses: s4u/maven-settings-action@v4.0.0
+        with:
+          githubServer: false
+          servers: |
+            [{
+               "id": "camunda-nexus",
+               "username": "${{ steps.secrets.outputs.CI_NEXUS_USR }}",
+               "password": "${{ steps.secrets.outputs.CI_NEXUS_PSW }}"
+             }]
+          mirrors: '[{"url": "https://repository.nexus.camunda.cloud/content/groups/internal/", "id": "camunda-nexus", "mirrorOf": "*,!shibboleth,!confluent", "name": "camunda Nexus"}]'
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+
+      - name: Install element templates CLI
+        run: npm install --global element-templates-cli
+
+      # Skip tests AND checks: we just need runnable images, not verification
+      - name: Package Connectors (skip tests & checks)
+        env:
+          PROJECTS: connector-runtime/connector-runtime-application,bundle/default-bundle,bundle/camunda-saas-bundle
+        run: ./mvnw -B compile generate-sources package -DskipTests -DskipChecks --projects "${PROJECTS}" --also-make
+
+      - name: Compute image tag
+        id: tag
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          BASE_VERSION=$(./mvnw help:evaluate -Dexpression=project.version -q -DforceStdout)
+          BASE_VERSION="${BASE_VERSION%-SNAPSHOT}"
+          TAG="${BASE_VERSION}-pr${PR_NUMBER}-run${GITHUB_RUN_ID}-a${GITHUB_RUN_ATTEMPT}"
+          echo "::notice::PR image tag: ${TAG}"
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v4
+        with:
+          platforms: 'arm64,arm'
+
+      - name: Set up Docker Build
+        uses: docker/setup-buildx-action@v4
+
+      - name: Login to Harbor
+        uses: docker/login-action@v4
+        with:
+          registry: registry.camunda.cloud
+          username: ${{ steps.secrets.outputs.CI_HARBOR_USR }}
+          password: ${{ steps.secrets.outputs.CI_HARBOR_PSW }}
+
+      - name: Login to Minimus
+        uses: docker/login-action@v4
+        with:
+          registry: reg.mini.dev
+          username: minimus
+          password: ${{ steps.secrets.outputs.REGISTRY_MINIMUS_PSW }}
+
+      - name: Build and Push Docker Image - connector-runtime
+        uses: docker/build-push-action@v7
+        with:
+          context: connector-runtime/connector-runtime-application/
+          push: true
+          tags: registry.camunda.cloud/team-connectors/connectors:${{ steps.tag.outputs.tag }}
+          platforms: linux/amd64,linux/arm64
+          provenance: false
+
+      - name: Build and Push Docker Image - bundle-default
+        uses: docker/build-push-action@v7
+        with:
+          context: bundle/default-bundle/
+          push: true
+          tags: registry.camunda.cloud/team-connectors/connectors-bundle:${{ steps.tag.outputs.tag }}
+          platforms: linux/amd64,linux/arm64
+          provenance: false
+
+      - name: Build and Push Docker Image - bundle-saas
+        uses: docker/build-push-action@v7
+        with:
+          context: bundle/camunda-saas-bundle/
+          push: true
+          tags: registry.camunda.cloud/team-connectors/connectors-bundle-saas:${{ steps.tag.outputs.tag }}
+          platforms: linux/amd64,linux/arm64
+          provenance: false
+
+      # github-script (Node) instead of gh CLI: the gcp runner has no gh binary
+      - name: Comment image tags on PR
+        uses: actions/github-script@v9
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+          script: |
+            const tag = '${{ steps.tag.outputs.tag }}';
+            const reg = 'registry.camunda.cloud/team-connectors';
+            const body = [
+              ':whale: PR Docker images published to Harbor:',
+              '- `' + reg + '/connectors:' + tag + '`',
+              '- `' + reg + '/connectors-bundle:' + tag + '`',
+              '- `' + reg + '/connectors-bundle-saas:' + tag + '`',
+              '',
+              '**To use the SaaS bundle on a cluster:**',
+              '',
+              '_GCP cluster:_',
+              '```',
+              'europe-docker.pkg.dev/camunda-saas-registry/harbor/team-connectors/connectors-bundle-saas:' + tag,
+              '```',
+              '_AWS cluster (replace `<WORKER_REGION>`, e.g. `eu-central-1`):_',
+              '```',
+              '390403865336.dkr.ecr.<WORKER_REGION>.amazonaws.com/team-connectors/connectors-bundle-saas:' + tag,
+              '```',
+            ].join('\n');
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: ${{ github.event.pull_request.number }},
+              body,
+            });


### PR DESCRIPTION
Backport of #7792 to `stable/8.9`.

Conflict resolved: `BUILD_PR_DOCKER_IMAGES.yml` did not exist in `stable/8.9` (it was added to `main` after the branch was cut). The file was added in full as part of this backport.