### PR TITLE
ci: split javadoc and format checks into parallel jobs in TEST_FEATURE_BRANCH

### DIFF
--- a/.github/workflows/TEST_FEATURE_BRANCH.yml
+++ b/.github/workflows/TEST_FEATURE_BRANCH.yml
@@ -13,11 +13,10 @@ on:
   merge_group:
     branches: [ main ]
 
-# Prevent duplicate runs when a push triggers both the push and pull_request events
-# for the same commit. Both events share the same commit SHA, so they land in the
-# same concurrency group and the second one cancels the first.
+# Cancel stale runs of the same type (push-on-push, PR-on-PR) without
+# letting push and pull_request events cancel each other.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.head.sha || github.sha }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/TEST_FEATURE_BRANCH.yml
+++ b/.github/workflows/TEST_FEATURE_BRANCH.yml
@@ -111,7 +111,7 @@ jobs:
 
       # Build and test (format and javadoc run in parallel jobs)
       - name: Build Connectors
-        run: ./mvnw --batch-mode -U clean test -Dquickly
+        run: ./mvnw --batch-mode -U clean test -Dquickly -T 1C
 
       - name: Publish Test Report
         if: always() && steps.internal.outputs.internal == 'true'

--- a/.github/workflows/TEST_FEATURE_BRANCH.yml
+++ b/.github/workflows/TEST_FEATURE_BRANCH.yml
@@ -13,6 +13,13 @@ on:
   merge_group:
     branches: [ main ]
 
+# Prevent duplicate runs when a push triggers both the push and pull_request events
+# for the same commit. Both events share the same commit SHA, so they land in the
+# same concurrency group and the second one cancels the first.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.head.sha || github.sha }}
+  cancel-in-progress: true
+
 jobs:
   run-tests:
 

--- a/.github/workflows/TEST_FEATURE_BRANCH.yml
+++ b/.github/workflows/TEST_FEATURE_BRANCH.yml
@@ -232,8 +232,11 @@ jobs:
             ]
           mirrors: '[{"url": "https://repository.nexus.camunda.cloud/content/groups/internal/", "id": "camunda-nexus", "mirrorOf": "*,!confluent,!shibboleth", "name": "camunda Nexus"}]'
 
+      - name: Install element-template-generator plugin
+        run: ./mvnw --batch-mode install -pl element-template-generator/maven-plugin -am -DskipTests -Dquickly
+
       - name: Check Javadoc
-        run: ./mvnw --batch-mode -U compile javadoc:javadoc -Dquickly
+        run: ./mvnw --batch-mode compile javadoc:javadoc -Dquickly
 
   check-format:
 

--- a/.github/workflows/TEST_FEATURE_BRANCH.yml
+++ b/.github/workflows/TEST_FEATURE_BRANCH.yml
@@ -303,5 +303,8 @@ jobs:
             ]
           mirrors: '[{"url": "https://repository.nexus.camunda.cloud/content/groups/internal/", "id": "camunda-nexus", "mirrorOf": "*,!confluent,!shibboleth", "name": "camunda Nexus"}]'
 
+      - name: Install element-template-generator plugin
+        run: ./mvnw --batch-mode install -pl element-template-generator/maven-plugin -am -DskipTests -Dquickly
+
       - name: Check Format
-        run: ./mvnw --batch-mode -U validate -PcheckFormat -Dquickly
+        run: ./mvnw --batch-mode validate -PcheckFormat -Dquickly

--- a/.github/workflows/TEST_FEATURE_BRANCH.yml
+++ b/.github/workflows/TEST_FEATURE_BRANCH.yml
@@ -103,9 +103,9 @@ jobs:
             ]
           mirrors: '[{"url": "https://repository.nexus.camunda.cloud/content/groups/internal/", "id": "camunda-nexus", "mirrorOf": "*,!confluent,!shibboleth", "name": "camunda Nexus"}]'
 
-      # Build
+      # Build and test (format and javadoc run in parallel jobs)
       - name: Build Connectors
-        run: ./mvnw --batch-mode -U clean test javadoc:javadoc -PcheckFormat -Dquickly
+        run: ./mvnw --batch-mode -U clean test -Dquickly
 
       - name: Publish Test Report
         if: always() && steps.internal.outputs.internal == 'true'
@@ -149,3 +149,159 @@ jobs:
         run: |
           ./mvnw --batch-mode -pl element-template-generator/validator -am package -DskipTests
           ./element-template-generator/validator/target/appassembler/bin/element-template-validator
+
+  check-javadoc:
+
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
+
+      - name: Set internal build flag
+        id: internal
+        run: |
+          if [ "${{ github.repository_owner }}" = "camunda" ]; then
+            if [ "${{ github.event_name }}" = "pull_request" ]; then
+              if [ "${{ github.event.pull_request.head.repo.fork }}" = "false" ]; then
+                echo "internal=true" >> $GITHUB_OUTPUT
+              else
+                echo "internal=false" >> $GITHUB_OUTPUT
+              fi
+            else
+              echo "internal=true" >> $GITHUB_OUTPUT
+            fi
+          else
+            echo "internal=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Restore cache
+        uses: actions/cache@v6
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}-${{ steps.internal.outputs.internal == 'true' && 'internal' || 'external' }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+
+      - uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: '21.0.9'
+
+      - name: Import Nexus Secrets (internal only)
+        if: ${{ steps.internal.outputs.internal == 'true' }}
+        id: secrets
+        uses: hashicorp/vault-action@v4.0.0
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          exportEnv: false
+          secrets: |
+            secret/data/products/connectors/ci/nexus USER | CI_NEXUS_USR;
+            secret/data/products/connectors/ci/nexus PASSWORD | CI_NEXUS_PSW;
+            secret/data/github.com/organizations/camunda MAVEN_CENTRAL_DEPLOYMENT_USR;
+            secret/data/github.com/organizations/camunda MAVEN_CENTRAL_DEPLOYMENT_PSW;
+            secret/data/github.com/organizations/camunda MAVEN_CENTRAL_GPG_SIGNING_KEY_PASSPHRASE;
+            secret/data/github.com/organizations/camunda MAVEN_CENTRAL_GPG_SIGNING_KEY_SEC;
+
+      - name: Create internal Maven settings.xml (Nexus mirror)
+        if: ${{ steps.internal.outputs.internal == 'true' }}
+        uses: s4u/maven-settings-action@v4.0.0
+        with:
+          githubServer: false
+          servers: |
+            [{
+               "id": "camunda-nexus",
+               "username": "${{ steps.secrets.outputs.CI_NEXUS_USR }}",
+               "password": "${{ steps.secrets.outputs.CI_NEXUS_PSW }}"
+             },
+            {
+               "id": "central",
+               "username": "${{ steps.secrets.outputs.MAVEN_CENTRAL_DEPLOYMENT_USR }}",
+               "password": "${{ steps.secrets.outputs.MAVEN_CENTRAL_DEPLOYMENT_PSW }}"
+             }
+            ]
+          mirrors: '[{"url": "https://repository.nexus.camunda.cloud/content/groups/internal/", "id": "camunda-nexus", "mirrorOf": "*,!confluent,!shibboleth", "name": "camunda Nexus"}]'
+
+      - name: Check Javadoc
+        run: ./mvnw --batch-mode -U compile javadoc:javadoc -Dquickly
+
+  check-format:
+
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
+
+      - name: Set internal build flag
+        id: internal
+        run: |
+          if [ "${{ github.repository_owner }}" = "camunda" ]; then
+            if [ "${{ github.event_name }}" = "pull_request" ]; then
+              if [ "${{ github.event.pull_request.head.repo.fork }}" = "false" ]; then
+                echo "internal=true" >> $GITHUB_OUTPUT
+              else
+                echo "internal=false" >> $GITHUB_OUTPUT
+              fi
+            else
+              echo "internal=true" >> $GITHUB_OUTPUT
+            fi
+          else
+            echo "internal=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Restore cache
+        uses: actions/cache@v6
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}-${{ steps.internal.outputs.internal == 'true' && 'internal' || 'external' }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+
+      - uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: '21.0.9'
+
+      - name: Import Nexus Secrets (internal only)
+        if: ${{ steps.internal.outputs.internal == 'true' }}
+        id: secrets
+        uses: hashicorp/vault-action@v4.0.0
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          exportEnv: false
+          secrets: |
+            secret/data/products/connectors/ci/nexus USER | CI_NEXUS_USR;
+            secret/data/products/connectors/ci/nexus PASSWORD | CI_NEXUS_PSW;
+            secret/data/github.com/organizations/camunda MAVEN_CENTRAL_DEPLOYMENT_USR;
+            secret/data/github.com/organizations/camunda MAVEN_CENTRAL_DEPLOYMENT_PSW;
+            secret/data/github.com/organizations/camunda MAVEN_CENTRAL_GPG_SIGNING_KEY_PASSPHRASE;
+            secret/data/github.com/organizations/camunda MAVEN_CENTRAL_GPG_SIGNING_KEY_SEC;
+
+      - name: Create internal Maven settings.xml (Nexus mirror)
+        if: ${{ steps.internal.outputs.internal == 'true' }}
+        uses: s4u/maven-settings-action@v4.0.0
+        with:
+          githubServer: false
+          servers: |
+            [{
+               "id": "camunda-nexus",
+               "username": "${{ steps.secrets.outputs.CI_NEXUS_USR }}",
+               "password": "${{ steps.secrets.outputs.CI_NEXUS_PSW }}"
+             },
+            {
+               "id": "central",
+               "username": "${{ steps.secrets.outputs.MAVEN_CENTRAL_DEPLOYMENT_USR }}",
+               "password": "${{ steps.secrets.outputs.MAVEN_CENTRAL_DEPLOYMENT_PSW }}"
+             }
+            ]
+          mirrors: '[{"url": "https://repository.nexus.camunda.cloud/content/groups/internal/", "id": "camunda-nexus", "mirrorOf": "*,!confluent,!shibboleth", "name": "camunda Nexus"}]'
+
+      - name: Check Format
+        run: ./mvnw --batch-mode -U validate -PcheckFormat -Dquickly


### PR DESCRIPTION
## Description

Splits the monolithic `Build Connectors` step in `TEST_FEATURE_BRANCH.yml` into three parallel jobs to improve CI feedback speed:

- **`build`** — `clean test -Dquickly` (tests only, slow tests skipped via `@SlowTest`)
- **`check-javadoc`** — `compile javadoc:javadoc -Dquickly`
- **`check-format`** — `validate -PcheckFormat -Dquickly`

Previously, javadoc generation and format checks blocked the test run in a single sequential step. Now they run concurrently, reducing overall wall-clock time for the workflow.

## Related issues

closes #

## Checklist

- [ ] Backport labels are added if these code changes should be backported.
- [ ] Tests/Integration tests for the changes have been added if applicable.
- [ ] If the change requires a documentation update, it has been added to the appropriate section in the documentation.
