### PR TITLE
fix(agentic-ai): map non-map tool results to OBJECT history content

### DIFF
--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/agentinstance/AgentInstanceHistoryMapper.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/agentinstance/AgentInstanceHistoryMapper.java
@@ -184,13 +184,7 @@ public class AgentInstanceHistoryMapper {
     return List.of(objectHistoryContent(resultContent));
   }
 
-  /**
-   * Maps any non-string content value to an {@code OBJECT} history block. The engine's {@link
-   * AgentInstanceHistoryContent#object(Object)} accepts arbitrary JSON values (maps, lists,
-   * numbers, ...), so structured tool results such as a JSON array are preserved as {@code OBJECT}
-   * rather than being flattened to {@code TEXT}. String content is routed to {@code TEXT} by the
-   * callers before reaching here.
-   */
+  // preserves arbitrary JSON values (maps, lists, numbers) as OBJECT rather than flattening to TEXT
   private AgentInstanceHistoryContent objectHistoryContent(Object value) {
     return AgentInstanceHistoryContent.object(value);
   }

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/agentinstance/AgentInstanceHistoryMapper.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/agentinstance/AgentInstanceHistoryMapper.java
@@ -184,7 +184,6 @@ public class AgentInstanceHistoryMapper {
     return List.of(objectHistoryContent(resultContent));
   }
 
-  // preserves arbitrary JSON values (maps, lists, numbers) as OBJECT rather than flattening to TEXT
   private AgentInstanceHistoryContent objectHistoryContent(Object value) {
     return AgentInstanceHistoryContent.object(value);
   }

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/agentinstance/AgentInstanceHistoryMapper.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/agentinstance/AgentInstanceHistoryMapper.java
@@ -6,11 +6,8 @@
  */
 package io.camunda.connector.agenticai.aiagent.agentinstance;
 
-import static io.camunda.connector.agenticai.aiagent.agent.AgentErrorCodes.ERROR_CODE_AGENT_INSTANCE_HISTORY_ITEM_FAILED;
 import static java.util.Objects.requireNonNullElse;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.client.api.command.AgentInstanceHistoryContent;
 import io.camunda.client.api.command.AgentInstanceHistoryMetrics;
 import io.camunda.client.api.command.AgentInstanceHistoryToolCall;
@@ -35,7 +32,6 @@ import io.camunda.connector.api.document.Document;
 import io.camunda.connector.api.document.DocumentMetadata;
 import io.camunda.connector.api.document.DocumentReference.CamundaDocumentReference;
 import io.camunda.connector.api.document.DocumentReference.ExternalDocumentReference;
-import io.camunda.connector.api.error.ConnectorException;
 import io.camunda.connector.document.jackson.DocumentReferenceModel.ExternalDocumentReferenceModel;
 import java.util.List;
 import java.util.Map;
@@ -51,12 +47,9 @@ import org.jspecify.annotations.Nullable;
  */
 public class AgentInstanceHistoryMapper {
 
-  private final ObjectMapper objectMapper;
   private final GatewayToolHandlerRegistry gatewayToolHandlers;
 
-  public AgentInstanceHistoryMapper(
-      ObjectMapper objectMapper, GatewayToolHandlerRegistry gatewayToolHandlers) {
-    this.objectMapper = objectMapper;
+  public AgentInstanceHistoryMapper(GatewayToolHandlerRegistry gatewayToolHandlers) {
     this.gatewayToolHandlers = gatewayToolHandlers;
   }
 
@@ -176,7 +169,7 @@ public class AgentInstanceHistoryMapper {
   private AgentInstanceHistoryContent toHistoryContent(Content content) {
     return switch (content) {
       case TextContent textContent -> AgentInstanceHistoryContent.text(textContent.text());
-      case ObjectContent objectContent -> objectOrText(objectContent.content());
+      case ObjectContent objectContent -> objectHistoryContent(objectContent.content());
       case DocumentContent documentContent -> documentHistoryContent(documentContent);
     };
   }
@@ -188,33 +181,18 @@ public class AgentInstanceHistoryMapper {
     if (resultContent instanceof String s) {
       return StringUtils.isBlank(s) ? List.of() : List.of(AgentInstanceHistoryContent.text(s));
     }
-    return List.of(objectOrText(resultContent));
+    return List.of(objectHistoryContent(resultContent));
   }
 
-  @SuppressWarnings("unchecked")
-  private AgentInstanceHistoryContent objectOrText(Object value) {
-    if (value instanceof Map<?, ?> map) {
-      return AgentInstanceHistoryContent.object((Map<String, Object>) map);
-    }
-    try {
-      return AgentInstanceHistoryContent.object(objectMapper.convertValue(value, Map.class));
-    } catch (IllegalArgumentException e) {
-      return AgentInstanceHistoryContent.text(toJson(value));
-    }
-  }
-
-  private String toJson(Object value) {
-    if (value instanceof String s) {
-      return s;
-    }
-    try {
-      return objectMapper.writeValueAsString(value);
-    } catch (JsonProcessingException e) {
-      throw new ConnectorException(
-          ERROR_CODE_AGENT_INSTANCE_HISTORY_ITEM_FAILED,
-          "Failed to serialize history item content: " + e.getMessage(),
-          e);
-    }
+  /**
+   * Maps any non-string content value to an {@code OBJECT} history block. The engine's {@link
+   * AgentInstanceHistoryContent#object(Object)} accepts arbitrary JSON values (maps, lists,
+   * numbers, ...), so structured tool results such as a JSON array are preserved as {@code OBJECT}
+   * rather than being flattened to {@code TEXT}. String content is routed to {@code TEXT} by the
+   * callers before reaching here.
+   */
+  private AgentInstanceHistoryContent objectHistoryContent(Object value) {
+    return AgentInstanceHistoryContent.object(value);
   }
 
   private AgentInstanceHistoryContent documentHistoryContent(DocumentContent documentContent) {
@@ -241,7 +219,7 @@ public class AgentInstanceHistoryMapper {
       throw new IllegalArgumentException(
           "External document reference requires both url and name for a history item");
     }
-    return objectOrText(new ExternalDocumentReferenceModel(ref.url(), ref.name()));
+    return objectHistoryContent(new ExternalDocumentReferenceModel(ref.url(), ref.name()));
   }
 
   private DocumentReferenceResponseImpl toDocumentReferenceResponse(

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/autoconfigure/AgenticAiConnectorsAutoConfiguration.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/autoconfigure/AgenticAiConnectorsAutoConfiguration.java
@@ -180,9 +180,8 @@ public class AgenticAiConnectorsAutoConfiguration {
   @Bean
   @ConditionalOnMissingBean
   public AgentInstanceHistoryMapper aiAgentInstanceHistoryMapper(
-      @ConnectorsObjectMapper ObjectMapper objectMapper,
       GatewayToolHandlerRegistry gatewayToolHandlers) {
-    return new AgentInstanceHistoryMapper(objectMapper, gatewayToolHandlers);
+    return new AgentInstanceHistoryMapper(gatewayToolHandlers);
   }
 
   @Bean

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/agentinstance/CamundaAgentInstanceClientTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/agentinstance/CamundaAgentInstanceClientTest.java
@@ -21,7 +21,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.command.AgentInstanceHistoryContent;
 import io.camunda.client.api.command.AgentInstanceHistoryMetrics;
@@ -118,7 +117,7 @@ class CamundaAgentInstanceClientTest {
   @BeforeEach
   void setUp() {
     recordedSleeps = new ArrayList<>();
-    var historyMapper = new AgentInstanceHistoryMapper(new ObjectMapper(), gatewayToolHandlers);
+    var historyMapper = new AgentInstanceHistoryMapper(gatewayToolHandlers);
     var toolMapper = new AgentInstanceToolMapper(gatewayToolHandlers);
     client =
         new CamundaAgentInstanceClient(
@@ -785,7 +784,40 @@ class CamundaAgentInstanceClientTest {
           .singleElement()
           .isInstanceOfSatisfying(
               AgentInstanceHistoryContent.ObjectContent.class,
-              object -> assertThat(object.getObject()).containsEntry("key", "value"));
+              object -> assertThat(object.getObject()).isEqualTo(Map.of("key", "value")));
+    }
+
+    @Test
+    void shouldMapNonMapObjectContentToObjectBlock() {
+      givenHistoryCommand();
+
+      // given: a list-shaped object result (e.g. a "list users" tool), which must be preserved as
+      // OBJECT content rather than being flattened to TEXT (#7626)
+      final var users = List.of("alice", "bob");
+      final var turn =
+          new AgentConversationTurn(
+              1,
+              List.of(
+                  UserMessage.builder()
+                      .content(List.of(ObjectContent.objectContent(users)))
+                      .build()),
+              null,
+              AgentMetrics.empty());
+
+      // when
+      client.createHistoryForInputMessages(
+          TestAgentExecutionContext.withLimits(),
+          AgentInstanceKey.of(AGENT_INSTANCE_KEY),
+          turn,
+          Optional.empty());
+
+      // then
+      verify(historyCommand).content(contentCaptor.capture());
+      assertThat(contentCaptor.getValue())
+          .singleElement()
+          .isInstanceOfSatisfying(
+              AgentInstanceHistoryContent.ObjectContent.class,
+              object -> assertThat(object.getObject()).isEqualTo(users));
     }
 
     @Test

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/agentinstance/CamundaAgentInstanceClientTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/agentinstance/CamundaAgentInstanceClientTest.java
@@ -791,8 +791,7 @@ class CamundaAgentInstanceClientTest {
     void shouldMapNonMapObjectContentToObjectBlock() {
       givenHistoryCommand();
 
-      // given: a list-shaped object result (e.g. a "list users" tool), which must be preserved as
-      // OBJECT content rather than being flattened to TEXT (#7626)
+      // given: a list-shaped object result (e.g. a "list users" tool) mapped to OBJECT content
       final var users = List.of("alice", "bob");
       final var turn =
           new AgentConversationTurn(


### PR DESCRIPTION
## Description

Non-map tool results (e.g. the `List users` tool returning a JSON array) were stored as `TEXT` in the agent-instance history instead of `OBJECT`, because `AgentInstanceHistoryMapper` coerced values to a `Map` and fell back to `TEXT` for anything else. The client API `AgentInstanceHistoryContent.object(...)` now accepts any `Object`, so the value is mapped straight through as `OBJECT` and Operate can render it as JSON.

This also fixes the `main` build: `ObjectContent.getObject()` now returns `Object` (was `Map`), which broke the `containsEntry` assertion in `CamundaAgentInstanceClientTest`. The unused `ObjectMapper` dependency and JSON fallback are removed, and a regression test for list content is added.

## Related issues

closes #7626

## Checklist

- [ ] Backport labels are added if these code changes should be backported.
- [x] Tests/Integration tests for the changes have been added if applicable.
- [x] If the change requires a documentation update, it has been added to the appropriate section in the documentation.

