### PR TITLE
[backport stable/8.8] ci: split javadoc and format checks into parallel jobs in TEST_FEATURE_BRANCH

### DIFF
--- a/.github/workflows/TEST_FEATURE_BRANCH.yml
+++ b/.github/workflows/TEST_FEATURE_BRANCH.yml
@@ -8,6 +8,12 @@ on:
   merge_group:
     branches: [ main ]
 
+# Cancel stale runs of the same type (push-on-push, PR-on-PR) without
+# letting push and pull_request events cancel each other.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   run-tests:
 
@@ -62,8 +68,9 @@ jobs:
       - name: Install element templates CLI
         run: npm install --global element-templates-cli@$(jq -r '.devDependencies["element-templates-cli"]' .github/workflows/package.json)
 
+      # Build and test (format check runs in a parallel job)
       - name: Build Connectors
-        run: ./mvnw --batch-mode clean test -PcheckFormat -Dquickly
+        run: ./mvnw --batch-mode clean test -Dquickly -T 1C
 
       - name: Publish Test Report
         if: always()
@@ -101,4 +108,52 @@ jobs:
           fi
         shell: bash
 
+  check-format:
 
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Import Secrets
+        id: secrets
+        uses: hashicorp/vault-action@v3.4.0
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          exportEnv: false # we rely on step outputs, no need for environment variables
+          secrets: |
+            secret/data/products/connectors/ci/common ARTIFACTORY_USR | CI_LDAP_USER;
+            secret/data/products/connectors/ci/common ARTIFACTORY_PSW | CI_LDAP_PASSWORD;
+
+      - name: Restore cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+
+      - uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: '21.0.9'
+
+      - name: 'Create settings.xml'
+        uses: s4u/maven-settings-action@v4.0.0
+        with:
+          githubServer: false
+          servers: |
+            [{
+               "id": "camunda-nexus",
+               "username": "${{ steps.secrets.outputs.CI_LDAP_USER }}",
+               "password": "${{ steps.secrets.outputs.CI_LDAP_PASSWORD }}"
+             }]
+          mirrors: '[{"url": "https://repository.nexus.camunda.cloud/content/groups/internal/", "id": "camunda-nexus", "mirrorOf": "*,!confluent,!shibboleth", "name": "camunda Nexus"}]'
+
+      - name: Install element-template-generator plugin
+        run: ./mvnw --batch-mode install -pl element-template-generator/maven-plugin -am -DskipTests -Dquickly
+
+      - name: Check Format
+        run: ./mvnw --batch-mode validate -PcheckFormat -Dquickly


### PR DESCRIPTION
## Description

Manual backport of #7797 to `stable/8.8`. The automated backport failed to cherry-pick because `TEST_FEATURE_BRANCH.yml` has diverged significantly between `main` and `stable/8.8` (different action versions/steps, and no javadoc check present at all on this branch).

Since `stable/8.8`'s `Build Connectors` step never ran `javadoc:javadoc` (only `-PcheckFormat`), this backport only splits the format check into a parallel `check-format` job — there's no javadoc check to split out. It also carries over the concurrency-group and `-T 1C` parallel-build improvements from the original PR, adapted to this branch's existing action versions and secrets.

## Related issues

Backport of #7797

## Checklist

- [x] Tests/Integration tests for the changes have been added if applicable. (N/A — CI workflow only)
- [ ] If the change requires a documentation update, it has been added to the appropriate section in the documentation.


---
_Generated by [Claude Code](https://claude.ai/code/session_011cxLaRW3x7AX43M2MWLrP5)_