### PR TITLE
[backport stable/8.9] ci: split javadoc and format checks into parallel jobs in TEST_FEATURE_BRANCH

### DIFF
--- a/.github/workflows/TEST_FEATURE_BRANCH.yml
+++ b/.github/workflows/TEST_FEATURE_BRANCH.yml
@@ -13,6 +13,12 @@ on:
   merge_group:
     branches: [ main ]
 
+# Cancel stale runs of the same type (push-on-push, PR-on-PR) without
+# letting push and pull_request events cancel each other.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   run-tests:
 
@@ -103,9 +109,9 @@ jobs:
             ]
           mirrors: '[{"url": "https://repository.nexus.camunda.cloud/content/groups/internal/", "id": "camunda-nexus", "mirrorOf": "*,!confluent,!shibboleth", "name": "camunda Nexus"}]'
 
-      # Build
+      # Build and test (format and javadoc run in parallel jobs)
       - name: Build Connectors
-        run: ./mvnw --batch-mode -U clean test javadoc:javadoc -PcheckFormat -Dquickly
+        run: ./mvnw --batch-mode -U clean test -Dquickly -T 1C
 
       - name: Publish Test Report
         if: always() && steps.internal.outputs.internal == 'true'
@@ -144,3 +150,165 @@ jobs:
             exit 1
           fi
         shell: bash
+
+  check-javadoc:
+
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
+
+      - name: Set internal build flag
+        id: internal
+        run: |
+          if [ "${{ github.repository_owner }}" = "camunda" ]; then
+            if [ "${{ github.event_name }}" = "pull_request" ]; then
+              if [ "${{ github.event.pull_request.head.repo.fork }}" = "false" ]; then
+                echo "internal=true" >> $GITHUB_OUTPUT
+              else
+                echo "internal=false" >> $GITHUB_OUTPUT
+              fi
+            else
+              echo "internal=true" >> $GITHUB_OUTPUT
+            fi
+          else
+            echo "internal=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Restore cache
+        uses: actions/cache@v5
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}-${{ steps.internal.outputs.internal == 'true' && 'internal' || 'external' }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+
+      - uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: '21.0.9'
+
+      - name: Import Nexus Secrets (internal only)
+        if: ${{ steps.internal.outputs.internal == 'true' }}
+        id: secrets
+        uses: hashicorp/vault-action@v3.4.0
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          exportEnv: false
+          secrets: |
+            secret/data/products/connectors/ci/common ARTIFACTORY_USR;
+            secret/data/products/connectors/ci/common ARTIFACTORY_PSW;
+            secret/data/github.com/organizations/camunda MAVEN_CENTRAL_DEPLOYMENT_USR;
+            secret/data/github.com/organizations/camunda MAVEN_CENTRAL_DEPLOYMENT_PSW;
+            secret/data/github.com/organizations/camunda MAVEN_CENTRAL_GPG_SIGNING_KEY_PASSPHRASE;
+            secret/data/github.com/organizations/camunda MAVEN_CENTRAL_GPG_SIGNING_KEY_SEC;
+
+      - name: Create internal Maven settings.xml (Nexus mirror)
+        if: ${{ steps.internal.outputs.internal == 'true' }}
+        uses: s4u/maven-settings-action@v4.0.0
+        with:
+          githubServer: false
+          servers: |
+            [{
+               "id": "camunda-nexus",
+               "username": "${{ steps.secrets.outputs.ARTIFACTORY_USR }}",
+               "password": "${{ steps.secrets.outputs.ARTIFACTORY_PSW }}"
+             },
+            {
+               "id": "central",
+               "username": "${{ steps.secrets.outputs.MAVEN_CENTRAL_DEPLOYMENT_USR }}",
+               "password": "${{ steps.secrets.outputs.MAVEN_CENTRAL_DEPLOYMENT_PSW }}"
+             }
+            ]
+          mirrors: '[{"url": "https://repository.nexus.camunda.cloud/content/groups/internal/", "id": "camunda-nexus", "mirrorOf": "*,!confluent,!shibboleth", "name": "camunda Nexus"}]'
+
+      - name: Install element-template-generator plugin
+        run: ./mvnw --batch-mode install -pl element-template-generator/maven-plugin -am -DskipTests -Dquickly
+
+      - name: Check Javadoc
+        run: ./mvnw --batch-mode compile javadoc:javadoc -Dquickly
+
+  check-format:
+
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
+
+      - name: Set internal build flag
+        id: internal
+        run: |
+          if [ "${{ github.repository_owner }}" = "camunda" ]; then
+            if [ "${{ github.event_name }}" = "pull_request" ]; then
+              if [ "${{ github.event.pull_request.head.repo.fork }}" = "false" ]; then
+                echo "internal=true" >> $GITHUB_OUTPUT
+              else
+                echo "internal=false" >> $GITHUB_OUTPUT
+              fi
+            else
+              echo "internal=true" >> $GITHUB_OUTPUT
+            fi
+          else
+            echo "internal=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Restore cache
+        uses: actions/cache@v5
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}-${{ steps.internal.outputs.internal == 'true' && 'internal' || 'external' }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+
+      - uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: '21.0.9'
+
+      - name: Import Nexus Secrets (internal only)
+        if: ${{ steps.internal.outputs.internal == 'true' }}
+        id: secrets
+        uses: hashicorp/vault-action@v3.4.0
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          exportEnv: false
+          secrets: |
+            secret/data/products/connectors/ci/common ARTIFACTORY_USR;
+            secret/data/products/connectors/ci/common ARTIFACTORY_PSW;
+            secret/data/github.com/organizations/camunda MAVEN_CENTRAL_DEPLOYMENT_USR;
+            secret/data/github.com/organizations/camunda MAVEN_CENTRAL_DEPLOYMENT_PSW;
+            secret/data/github.com/organizations/camunda MAVEN_CENTRAL_GPG_SIGNING_KEY_PASSPHRASE;
+            secret/data/github.com/organizations/camunda MAVEN_CENTRAL_GPG_SIGNING_KEY_SEC;
+
+      - name: Create internal Maven settings.xml (Nexus mirror)
+        if: ${{ steps.internal.outputs.internal == 'true' }}
+        uses: s4u/maven-settings-action@v4.0.0
+        with:
+          githubServer: false
+          servers: |
+            [{
+               "id": "camunda-nexus",
+               "username": "${{ steps.secrets.outputs.ARTIFACTORY_USR }}",
+               "password": "${{ steps.secrets.outputs.ARTIFACTORY_PSW }}"
+             },
+            {
+               "id": "central",
+               "username": "${{ steps.secrets.outputs.MAVEN_CENTRAL_DEPLOYMENT_USR }}",
+               "password": "${{ steps.secrets.outputs.MAVEN_CENTRAL_DEPLOYMENT_PSW }}"
+             }
+            ]
+          mirrors: '[{"url": "https://repository.nexus.camunda.cloud/content/groups/internal/", "id": "camunda-nexus", "mirrorOf": "*,!confluent,!shibboleth", "name": "camunda Nexus"}]'
+
+      - name: Install element-template-generator plugin
+        run: ./mvnw --batch-mode install -pl element-template-generator/maven-plugin -am -DskipTests -Dquickly
+
+      - name: Check Format
+        run: ./mvnw --batch-mode validate -PcheckFormat -Dquickly


### PR DESCRIPTION
## Description

Manual backport of #7797 to `stable/8.9`. The automated backport failed to cherry-pick because `TEST_FEATURE_BRANCH.yml` has diverged from `main` on action versions and secret names (e.g. `actions/checkout@v6` vs `v7`, `hashicorp/vault-action@v3.4.0` vs `v4.0.0`, `ARTIFACTORY_USR`/`PSW` vs `CI_NEXUS_USR`/`PSW`), and this branch doesn't yet have the `Validate element templates` step that main gained separately.

This backport applies the same conceptual change as the original PR — moving `javadoc:javadoc` and `-PcheckFormat` out of the main `Build Connectors` step into dedicated parallel `check-javadoc` and `check-format` jobs, plus the concurrency group and `-T 1C` parallel-build flag — using this branch's existing action versions and secret names.

## Related issues

Backport of #7797

## Checklist

- [x] Tests/Integration tests for the changes have been added if applicable. (N/A — CI workflow only)
- [ ] If the change requires a documentation update, it has been added to the appropriate section in the documentation.


---
_Generated by [Claude Code](https://claude.ai/code/session_011cxLaRW3x7AX43M2MWLrP5)_