### PR TITLE
fix(ci): Fix release workflow runner for e2e test step

### DIFF
--- a/.github/workflows/RELEASE.yaml
+++ b/.github/workflows/RELEASE.yaml
@@ -195,7 +195,7 @@ jobs:
   e2e-tests:
     needs: setup
     name: Run E2E tests
-    runs-on: ubuntu-latest
+    runs-on: gcp-core-8-default
     permissions:
       contents: read
       checks: write


### PR DESCRIPTION
## Description

Since version 8.10 the CPT runtime utilizes more resources, thus the agentic-ai e2e tests currently require `gcp-core-8-default` as a runner.

Add it to the `e2e-test` step.

