### PR TITLE
fix(slack-inbound): fix HMAC failure for form-urlencoded webhooks (Slack Interactivity)

### DIFF
--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/webhook/InboundWebhookRestController.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/webhook/InboundWebhookRestController.java
@@ -56,6 +56,7 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.Part;
 import java.io.IOException;
+import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
 import org.slf4j.Logger;
@@ -67,7 +68,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.util.HtmlUtils;
 
@@ -147,11 +147,15 @@ public class InboundWebhookRestController {
   public ResponseEntity<?> inbound(
       @PathVariable(value = "context") String context,
       @RequestHeader Map<String, String> headers,
-      @RequestParam(required = false) Map<String, String> params,
       HttpServletRequest httpServletRequest)
       throws IOException {
     LOG.trace("Received inbound hook on {}", context);
+    // Body must be read before any call that triggers form-parameter parsing (e.g.
+    // getParameterMap).
+    // For application/x-www-form-urlencoded requests, Tomcat consumes the input stream when
+    // getParameterMap() is invoked, which would leave rawBody empty and break HMAC verification.
     byte[] bodyAsByteArray = httpServletRequest.getInputStream().readAllBytes();
+    Map<String, String> params = extractQueryParams(httpServletRequest.getQueryString());
 
     return webhookConnectorRegistry
         .getActiveWebhook(context)
@@ -477,6 +481,21 @@ public class InboundWebhookRestController {
     }
 
     return sb.toString();
+  }
+
+  private static Map<String, String> extractQueryParams(String queryString) {
+    if (queryString == null || queryString.isBlank()) {
+      return emptyMap();
+    }
+    return Arrays.stream(queryString.split("&"))
+        .map(pair -> pair.split("=", 2))
+        .filter(parts -> parts.length > 0 && !parts[0].isBlank())
+        .collect(
+            toMap(
+                parts -> URLDecoder.decode(parts[0], StandardCharsets.UTF_8),
+                parts ->
+                    parts.length > 1 ? URLDecoder.decode(parts[1], StandardCharsets.UTF_8) : "",
+                (a, b) -> a));
   }
 
   private static boolean isMultipartRequest(WebhookProcessingPayload payload) {

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/inbound/webhook/InboundWebhookRestControllerTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/inbound/webhook/InboundWebhookRestControllerTest.java
@@ -65,14 +65,11 @@ class InboundWebhookRestControllerTest {
     request.setServerName("example.com");
     request.setServerPort(443);
     request.setRequestURI("/inbound/myPath");
+    request.setQueryString("token=secret-token&q=visible");
     request.setMethod("POST");
     request.setContent("a".repeat(1005).getBytes(StandardCharsets.UTF_8));
 
-    controller.inbound(
-        "myPath",
-        Map.of("authorization", "******", "x-test", "visible"),
-        Map.of("token", "secret-token", "q", "visible"),
-        request);
+    controller.inbound("myPath", Map.of("authorization", "******", "x-test", "visible"), request);
 
     var latestActivity = latestActivity(activityLogRegistry, connector.id());
     assertThat(latestActivity.message())
@@ -105,7 +102,7 @@ class InboundWebhookRestControllerTest {
             "file", "test.txt", "text/plain", "top secret file contents".getBytes()));
     request.setContent("top secret file contents".getBytes(StandardCharsets.UTF_8));
 
-    controller.inbound("myPath", new HashMap<>(), new HashMap<>(), request);
+    controller.inbound("myPath", new HashMap<>(), request);
 
     var latestActivity = latestActivity(activityLogRegistry, connector.id());
     assertThat(latestActivity.message())

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/inbound/webhook/InboundWebhookRestControllerTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/inbound/webhook/InboundWebhookRestControllerTest.java
@@ -21,6 +21,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 
 import io.camunda.client.CamundaClient;
 import io.camunda.connector.api.error.ConnectorInputException;
@@ -45,10 +46,14 @@ import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.mock.web.MockMultipartHttpServletRequest;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
 class InboundWebhookRestControllerTest {
 
@@ -110,6 +115,64 @@ class InboundWebhookRestControllerTest {
         .contains("/inbound/myPath")
         .contains("Body: (omitted for multipart request)")
         .doesNotContain("top secret file contents");
+  }
+
+  @Test
+  void shouldPreserveRawBodyForFormUrlEncodedRequest() throws Exception {
+    // Regression test for: @RequestParam in the controller caused Spring MVC to call
+    // getParameterMap() before the method body, consuming the servlet input stream for
+    // application/x-www-form-urlencoded requests. rawBody() then returned empty bytes,
+    // breaking HMAC verification for Slack Interactivity (block_actions) payloads.
+    //
+    // This test goes through the full Spring MVC dispatch via MockMvc so that
+    // Spring actually resolves method parameters — the condition that triggered the bug.
+
+    var rawBodyCaptor = new AtomicReference<byte[]>();
+
+    var executable = mock(WebhookConnectorExecutable.class);
+    var webhookResult = mock(WebhookResult.class);
+    when(webhookResult.request()).thenReturn(new MappedHttpRequest(Map.of(), Map.of(), Map.of()));
+    when(executable.triggerWebhook(any(WebhookProcessingPayload.class)))
+        .thenAnswer(
+            inv -> {
+              rawBodyCaptor.set(((WebhookProcessingPayload) inv.getArgument(0)).rawBody());
+              return webhookResult;
+            });
+
+    var correlationHandler = mock(InboundCorrelationHandler.class);
+    when(correlationHandler.correlate(anyList(), any()))
+        .thenThrow(new ConnectorInputException("invalid input"));
+
+    var details = webhookDefinition("processA", 1, "myPath");
+    var context =
+        new InboundConnectorContextImpl(
+            new NullSecretProvider(),
+            new DefaultValidationProvider(),
+            details,
+            correlationHandler,
+            e -> {},
+            ConnectorsObjectMapperSupplier.getCopy(),
+            new ActivityLogRegistry(),
+            mock(CamundaClient.class));
+
+    var registry = new WebhookConnectorRegistry();
+    registry.register(
+        new RegisteredExecutable.Activated(
+            executable, context, ExecutableId.fromDeduplicationId(details.deduplicationId())));
+
+    MockMvc mockMvc =
+        MockMvcBuilders.standaloneSetup(new InboundWebhookRestController(registry)).build();
+
+    String formBody = "payload=%7B%22type%22%3A%22block_actions%22%7D";
+    mockMvc.perform(
+        post("/inbound/myPath")
+            .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+            .content(formBody));
+
+    assertThat(rawBodyCaptor.get())
+        .isNotNull()
+        .isNotEmpty()
+        .isEqualTo(formBody.getBytes(StandardCharsets.UTF_8));
   }
 
   private static io.camunda.connector.api.inbound.Activity latestActivity(

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/inbound/WebhookControllerTestExceptionZeebeTest.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/inbound/WebhookControllerTestExceptionZeebeTest.java
@@ -254,7 +254,6 @@ class WebhookControllerTestExceptionZeebeTest {
             webhookContext,
             ExecutableId.fromDeduplicationId("random")));
 
-    return controller.inbound(
-        "myPath", new HashMap<>(), new HashMap<>(), new MockHttpServletRequest());
+    return controller.inbound("myPath", new HashMap<>(), new MockHttpServletRequest());
   }
 }

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/inbound/WebhookControllerTestZeebeTest.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/inbound/WebhookControllerTestZeebeTest.java
@@ -126,8 +126,7 @@ class WebhookControllerTestZeebeTest {
     deployProcess("processA");
 
     ResponseEntity<?> responseEntity =
-        controller.inbound(
-            "myPath", new HashMap<>(), new HashMap<>(), new MockHttpServletRequest());
+        controller.inbound("myPath", new HashMap<>(), new MockHttpServletRequest());
 
     assertEquals(200, responseEntity.getStatusCode().value());
     assertNull(responseEntity.getBody());
@@ -168,8 +167,7 @@ class WebhookControllerTestZeebeTest {
 
     ResponseEntity<Map> responseEntity =
         (ResponseEntity<Map>)
-            controller.inbound(
-                "myPath", new HashMap<>(), new HashMap<>(), new MockHttpServletRequest());
+            controller.inbound("myPath", new HashMap<>(), new MockHttpServletRequest());
 
     assertEquals(201, responseEntity.getStatusCode().value());
     assertEquals("valueResponse", responseEntity.getBody().get("keyResponse"));
@@ -212,8 +210,7 @@ class WebhookControllerTestZeebeTest {
             ExecutableId.fromDeduplicationId("random")));
 
     ResponseEntity<?> responseEntity =
-        controller.inbound(
-            "myPath", new HashMap<>(), new HashMap<>(), new MockHttpServletRequest());
+        controller.inbound("myPath", new HashMap<>(), new MockHttpServletRequest());
 
     assertEquals(422, responseEntity.getStatusCode().value());
     assertNotNull(responseEntity.getBody());
@@ -253,8 +250,7 @@ class WebhookControllerTestZeebeTest {
             ExecutableId.fromDeduplicationId("random")));
 
     ResponseEntity<?> responseEntity =
-        controller.inbound(
-            "myPath", new HashMap<>(), new HashMap<>(), new MockHttpServletRequest());
+        controller.inbound("myPath", new HashMap<>(), new MockHttpServletRequest());
 
     assertEquals(200, responseEntity.getStatusCode().value());
     assertNotNull(responseEntity.getBody());
@@ -296,8 +292,7 @@ class WebhookControllerTestZeebeTest {
             ExecutableId.fromDeduplicationId("random")));
 
     ResponseEntity<?> responseEntity =
-        controller.inbound(
-            "myPath", new HashMap<>(), new HashMap<>(), new MockHttpServletRequest());
+        controller.inbound("myPath", new HashMap<>(), new MockHttpServletRequest());
 
     assertEquals(200, responseEntity.getStatusCode().value());
     assertNotNull(responseEntity.getBody());
@@ -337,8 +332,7 @@ class WebhookControllerTestZeebeTest {
 
     ResponseEntity<Map> responseEntity =
         (ResponseEntity<Map>)
-            controller.inbound(
-                "myPath", new HashMap<>(), new HashMap<>(), new MockHttpServletRequest());
+            controller.inbound("myPath", new HashMap<>(), new MockHttpServletRequest());
 
     assertEquals(200, responseEntity.getStatusCode().value());
 
@@ -374,8 +368,7 @@ class WebhookControllerTestZeebeTest {
     deployProcess("processB");
 
     ResponseEntity<?> responseEntity =
-        controller.inbound(
-            "myPath", new HashMap<>(), new HashMap<>(), new MockHttpServletRequest());
+        controller.inbound("myPath", new HashMap<>(), new MockHttpServletRequest());
     assertEquals(500, responseEntity.getStatusCode().value());
   }
 
@@ -407,8 +400,7 @@ class WebhookControllerTestZeebeTest {
     deployProcess("processA");
 
     ResponseEntity<?> responseEntity =
-        controller.inbound(
-            "myPath", new HashMap<>(), new HashMap<>(), new MockHttpServletRequest());
+        controller.inbound("myPath", new HashMap<>(), new MockHttpServletRequest());
 
     assertEquals(500, responseEntity.getStatusCode().value());
   }
@@ -443,8 +435,7 @@ class WebhookControllerTestZeebeTest {
 
     ResponseEntity<FeelExpressionErrorResponse> responseEntity =
         (ResponseEntity<FeelExpressionErrorResponse>)
-            controller.inbound(
-                "myPath", new HashMap<>(), new HashMap<>(), new MockHttpServletRequest());
+            controller.inbound("myPath", new HashMap<>(), new MockHttpServletRequest());
 
     assertEquals(422, responseEntity.getStatusCode().value());
     assertEquals("reason", responseEntity.getBody().reason());
@@ -490,8 +481,7 @@ class WebhookControllerTestZeebeTest {
 
     ResponseEntity<Map> responseEntity =
         (ResponseEntity<Map>)
-            controller.inbound(
-                "myPath", new HashMap<>(), new HashMap<>(), new MockHttpServletRequest());
+            controller.inbound("myPath", new HashMap<>(), new MockHttpServletRequest());
 
     assertEquals(200, responseEntity.getStatusCode().value());
     assertNull(responseEntity.getBody().get("keyResponse"));
@@ -541,8 +531,7 @@ class WebhookControllerTestZeebeTest {
 
     ResponseEntity<CorrelationResult.Success.ProcessInstanceCreated> responseEntity =
         (ResponseEntity<CorrelationResult.Success.ProcessInstanceCreated>)
-            controller.inbound(
-                "myPath", new HashMap<>(), new HashMap<>(), new MockHttpServletRequest());
+            controller.inbound("myPath", new HashMap<>(), new MockHttpServletRequest());
 
     assertEquals(200, responseEntity.getStatusCode().value());
     assertEquals(1L, responseEntity.getBody().processInstanceKey());
@@ -587,8 +576,7 @@ class WebhookControllerTestZeebeTest {
     deployProcess("processA");
 
     ResponseEntity<?> responseEntity =
-        controller.inbound(
-            "myPath", new HashMap<>(), new HashMap<>(), new MockHttpServletRequest());
+        controller.inbound("myPath", new HashMap<>(), new MockHttpServletRequest());
 
     assertEquals(200, responseEntity.getStatusCode().value());
     assertNull(responseEntity.getBody());
@@ -626,8 +614,7 @@ class WebhookControllerTestZeebeTest {
     MockHttpServletRequest headRequest = new MockHttpServletRequest();
     headRequest.setMethod("HEAD");
 
-    ResponseEntity<?> responseEntity =
-        controller.inbound("myPath", new HashMap<>(), new HashMap<>(), headRequest);
+    ResponseEntity<?> responseEntity = controller.inbound("myPath", new HashMap<>(), headRequest);
 
     assertEquals(200, responseEntity.getStatusCode().value());
   }
@@ -665,8 +652,7 @@ class WebhookControllerTestZeebeTest {
     request.setContentType("application/json");
     request.setContent("{\"key\": \"value\", \"nested\": {\"foo\": \"bar\"}}".getBytes());
 
-    ResponseEntity<?> responseEntity =
-        controller.inbound("myPath", new HashMap<>(), new HashMap<>(), request);
+    ResponseEntity<?> responseEntity = controller.inbound("myPath", new HashMap<>(), request);
 
     assertEquals(200, responseEntity.getStatusCode().value());
   }
@@ -710,8 +696,7 @@ class WebhookControllerTestZeebeTest {
         new MockMultipartFile("file", "test.txt", "text/plain", "file content here".getBytes());
     request.addFile(file);
 
-    ResponseEntity<?> responseEntity =
-        controller.inbound("myPath", new HashMap<>(), new HashMap<>(), request);
+    ResponseEntity<?> responseEntity = controller.inbound("myPath", new HashMap<>(), request);
 
     assertEquals(200, responseEntity.getStatusCode().value());
   }
@@ -749,8 +734,7 @@ class WebhookControllerTestZeebeTest {
     request.setContentType("application/x-www-form-urlencoded");
     request.setContent("field1=value1&field2=value2&special=%26%3D%3F".getBytes());
 
-    ResponseEntity<?> responseEntity =
-        controller.inbound("myPath", new HashMap<>(), new HashMap<>(), request);
+    ResponseEntity<?> responseEntity = controller.inbound("myPath", new HashMap<>(), request);
 
     assertEquals(200, responseEntity.getStatusCode().value());
   }
@@ -788,8 +772,7 @@ class WebhookControllerTestZeebeTest {
     request.setContentType("application/xml");
     request.setContent("<?xml version=\"1.0\"?><root><element>value</element></root>".getBytes());
 
-    ResponseEntity<?> responseEntity =
-        controller.inbound("myPath", new HashMap<>(), new HashMap<>(), request);
+    ResponseEntity<?> responseEntity = controller.inbound("myPath", new HashMap<>(), request);
 
     assertEquals(200, responseEntity.getStatusCode().value());
   }
@@ -827,8 +810,7 @@ class WebhookControllerTestZeebeTest {
     request.setContentType("text/plain");
     request.setContent("This is plain text content for the webhook".getBytes());
 
-    ResponseEntity<?> responseEntity =
-        controller.inbound("myPath", new HashMap<>(), new HashMap<>(), request);
+    ResponseEntity<?> responseEntity = controller.inbound("myPath", new HashMap<>(), request);
 
     assertEquals(200, responseEntity.getStatusCode().value());
   }
@@ -867,8 +849,7 @@ class WebhookControllerTestZeebeTest {
     byte[] binaryContent = new byte[] {0x00, 0x01, 0x02, 0x03, (byte) 0xFF, (byte) 0xFE};
     request.setContent(binaryContent);
 
-    ResponseEntity<?> responseEntity =
-        controller.inbound("myPath", new HashMap<>(), new HashMap<>(), request);
+    ResponseEntity<?> responseEntity = controller.inbound("myPath", new HashMap<>(), request);
 
     assertEquals(200, responseEntity.getStatusCode().value());
   }

--- a/connectors/slack/src/main/java/io/camunda/connector/slack/inbound/SlackInboundWebhookExecutable.java
+++ b/connectors/slack/src/main/java/io/camunda/connector/slack/inbound/SlackInboundWebhookExecutable.java
@@ -194,7 +194,7 @@ public class SlackInboundWebhookExecutable implements WebhookConnectorExecutable
           URLDecoder.decode(new String(rawBody, StandardCharsets.UTF_8), StandardCharsets.UTF_8);
       return Arrays.stream(bodyAsString.split("&"))
           .filter(Objects::nonNull)
-          .map(param -> param.split("="))
+          .map(param -> param.split("=", 2))
           .collect(Collectors.toMap(param -> param[0], param -> param.length == 1 ? "" : param[1]));
     } else {
       // Do our best to parse to JSON (throws exception otherwise)


### PR DESCRIPTION
Closes #7814

## Summary

- **Primary fix**: Remove `@RequestParam Map<String, String> params` from `InboundWebhookRestController.inbound()`. Spring was calling `getParameterMap()` to resolve this parameter before the method body ran, which consumed the servlet input stream for `application/x-www-form-urlencoded` requests. `getInputStream().readAllBytes()` then returned `[]`, so HMAC was computed on `""` instead of the actual body — a guaranteed failure for Slack Interactivity (block_actions) payloads.
- Query params are now extracted from `httpServletRequest.getQueryString()` only, so FEEL expressions referencing `params` in other connectors continue to work.
- **Secondary fix**: `param.split("=")` → `param.split("=", 2)` in `SlackInboundWebhookExecutable.bodyAsMap` to prevent truncation of form values whose decoded content contains `=` (e.g. base64 data).

## Why Events API was unaffected

`application/json` bodies are never parsed by Spring's `@RequestParam` resolution, so the input stream remained intact for JSON requests.

## Test plan

- [ ] All existing unit and integration tests pass (updated to match new 3-arg controller signature)
- [ ] Manually verify: Slack Interactivity button click reaches the connector and HMAC validates correctly
- [ ] Manually verify: Slack Events API (`app_mention`) still works
- [ ] Manually verify: Slash Commands still work
- [ ] Manually verify: webhooks using query-string `params` in FEEL expressions still receive correct values

🤖 Generated with [Claude Code](https://claude.com/claude-code)