### PR TITLE
fix(ci): Merge queue concurrency handling in TEST_FEATURE_BRANCH workflow should not fail for multiple parallel workflows

### DIFF
--- a/.github/workflows/TEST_FEATURE_BRANCH.yml
+++ b/.github/workflows/TEST_FEATURE_BRANCH.yml
@@ -10,13 +10,16 @@ on:
     branches:
       - '**'
       - '!main'
+      - '!gh-readonly-queue/**'
   merge_group:
     branches: [ main ]
 
 # Cancel stale runs of the same type (push-on-push, PR-on-PR) without
-# letting push and pull_request events cancel each other.
+# letting push and pull_request events cancel each other. Merge-queue runs
+# are keyed on the merge group's head ref so entries queued behind others
+# don't collide into the same group and get cancelled.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.merge_group.head_ref || github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## Description

Updates the test feature branch workflow to properly handle GitHub merge queue runs:

1. **Exclude merge queue branches**: Added `!gh-readonly-queue/**` to the branch filter to prevent duplicate workflow runs when pull requests are queued for merging.

2. **Fix concurrency group keying**: Updated the concurrency group to use `github.event.merge_group.head_ref` for merge queue runs, ensuring that queued merge requests don't collide with each other and get incorrectly cancelled. Previously, all merge queue runs would use the same concurrency group, causing later queued items to cancel earlier ones.

3. **Improved documentation**: Enhanced the concurrency comment to explain the merge queue behavior.

These changes ensure that:
- Merge queue runs are properly isolated from each other
- Stale runs are still cancelled appropriately for push and pull request events
- The workflow behaves correctly with GitHub's merge queue feature

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #

## Checklist

- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest
  release, as this branch will be rebased onto main before the next release. Example backport labels:
    - `backport stable/8.8`: for changes that should be included in the next 8.8.x release.
    - **or** `backport release-8.8.7`: for changes that should be included in the specific release 8.8.7, and this
      *release has already been created*. The release branch will be merged back into stable/8.8 later, so the change
      will be included in future 8.8.x releases as well.
- [ ] Tests/Integration tests for the changes have been added if applicable.
- [ ] If the change requires a documentation update, it has been added to the appropriate section in the documentation.

https://claude.ai/code/session_0165om9LXaTd3dgiaXxht4an