### PR TITLE
feat(native-operations): add steps/presets to flat ET-only connectors (#7344)

### DIFF
--- a/connectors/blue-prism/element-templates/blue-prism-connector.json
+++ b/connectors/blue-prism/element-templates/blue-prism-connector.json
@@ -505,7 +505,7 @@
       "id": "version",
       "label": "Version",
       "description": "Version of the element template",
-      "value": "4",
+      "value": "6",
       "group": "connector",
       "binding": {
         "key": "elementTemplateVersion",

--- a/connectors/blue-prism/element-templates/versioned/blue-prism-connector-5.json
+++ b/connectors/blue-prism/element-templates/versioned/blue-prism-connector-5.json
@@ -2,7 +2,7 @@
   "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
   "name": "Blue Prism Outbound Connector",
   "id": "io.camunda.connectors.BluePrism.v1",
-  "version": 6,
+  "version": 5,
   "engines": {
     "camunda": "^8.3"
   },
@@ -562,46 +562,6 @@
         "oneOf": [
           "createItemInQueue"
         ]
-      }
-    }
-  ],
-  "steps": [
-    {
-      "name": "Get item from a queue by ID",
-      "description": "Fetch a single work queue item from Blue Prism using its queue item ID.",
-      "keywords": [
-        "get queue item",
-        "fetch item by id",
-        "read work queue item",
-        "retrieve queue item",
-        "lookup item"
-      ],
-      "presetId": "operationType_getItemFromQueueById"
-    },
-    {
-      "name": "Create work queue item",
-      "description": "Add a new item to a Blue Prism work queue with the given data, priority, and status.",
-      "keywords": [
-        "create queue item",
-        "add work item",
-        "add item to queue",
-        "new work queue item",
-        "enqueue item"
-      ],
-      "presetId": "operationType_createItemInQueue"
-    }
-  ],
-  "presets": [
-    {
-      "id": "operationType_getItemFromQueueById",
-      "properties": {
-        "operationType": "getItemFromQueueById"
-      }
-    },
-    {
-      "id": "operationType_createItemInQueue",
-      "properties": {
-        "operationType": "createItemInQueue"
       }
     }
   ],

--- a/connectors/blue-prism/element-templates/versioned/blue-prism-connector-5.json
+++ b/connectors/blue-prism/element-templates/versioned/blue-prism-connector-5.json
@@ -505,7 +505,7 @@
       "id": "version",
       "label": "Version",
       "description": "Version of the element template",
-      "value": "4",
+      "value": "5",
       "group": "connector",
       "binding": {
         "key": "elementTemplateVersion",

--- a/connectors/easy-post/element-templates/easy-post-connector.json
+++ b/connectors/easy-post/element-templates/easy-post-connector.json
@@ -1077,7 +1077,7 @@
     },
     {
       "name": "Buy a shipment",
-      "description": "Purchase a shipping label for a shipment using a selected rate.",
+      "description": "Purchase a shipping label in EasyPost for a shipment using a selected rate.",
       "keywords": [
         "buy shipment",
         "purchase label",
@@ -1101,7 +1101,7 @@
     },
     {
       "name": "Retrieve a tracker by ID",
-      "description": "Retrieve tracking information for a shipment using its tracker ID.",
+      "description": "Retrieve tracking information from EasyPost for a shipment using its tracker ID.",
       "keywords": [
         "retrieve tracker",
         "track shipment",

--- a/connectors/easy-post/element-templates/easy-post-connector.json
+++ b/connectors/easy-post/element-templates/easy-post-connector.json
@@ -1005,7 +1005,7 @@
       "id": "version",
       "label": "Version",
       "description": "Version of the element template",
-      "value": "5",
+      "value": "7",
       "group": "connector",
       "binding": {
         "key": "elementTemplateVersion",

--- a/connectors/easy-post/element-templates/versioned/easy-post-connector-6.json
+++ b/connectors/easy-post/element-templates/versioned/easy-post-connector-6.json
@@ -1005,7 +1005,7 @@
       "id": "version",
       "label": "Version",
       "description": "Version of the element template",
-      "value": "5",
+      "value": "6",
       "group": "connector",
       "binding": {
         "key": "elementTemplateVersion",

--- a/connectors/easy-post/element-templates/versioned/easy-post-connector-6.json
+++ b/connectors/easy-post/element-templates/versioned/easy-post-connector-6.json
@@ -2,7 +2,7 @@
   "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
   "name": "Easy Post Outbound Connector",
   "id": "io.camunda.connectors.EasyPost.v1",
-  "version": 7,
+  "version": 6,
   "engines": {
     "camunda": "^8.3"
   },
@@ -1036,118 +1036,6 @@
         "type": "zeebe:taskHeader"
       },
       "type": "Hidden"
-    }
-  ],
-  "steps": [
-    {
-      "name": "Create an address",
-      "description": "Create a new address in EasyPost from recipient and location details.",
-      "keywords": [
-        "create address",
-        "add address",
-        "new address",
-        "recipient address",
-        "shipping address"
-      ],
-      "presetId": "operationType_createAddress"
-    },
-    {
-      "name": "Create a parcel",
-      "description": "Create a new parcel in EasyPost with weight and dimension details.",
-      "keywords": [
-        "create parcel",
-        "add parcel",
-        "new package",
-        "parcel dimensions",
-        "package weight"
-      ],
-      "presetId": "operationType_createParcel"
-    },
-    {
-      "name": "Create a shipment",
-      "description": "Create a shipment in EasyPost linking origin, destination, and parcel.",
-      "keywords": [
-        "create shipment",
-        "new shipment",
-        "prepare shipment",
-        "shipping rates",
-        "origin destination"
-      ],
-      "presetId": "operationType_createShipment"
-    },
-    {
-      "name": "Buy a shipment",
-      "description": "Purchase a shipping label for a shipment using a selected rate.",
-      "keywords": [
-        "buy shipment",
-        "purchase label",
-        "buy shipping label",
-        "pay for shipment",
-        "select rate"
-      ],
-      "presetId": "operationType_buyShipment"
-    },
-    {
-      "name": "Verify a created address",
-      "description": "Verify a previously created address by its EasyPost address ID.",
-      "keywords": [
-        "verify address",
-        "validate address",
-        "check address",
-        "confirm address",
-        "address verification"
-      ],
-      "presetId": "operationType_verifyAddressById"
-    },
-    {
-      "name": "Retrieve a tracker by ID",
-      "description": "Retrieve tracking information for a shipment using its tracker ID.",
-      "keywords": [
-        "retrieve tracker",
-        "track shipment",
-        "tracking status",
-        "get tracker",
-        "shipment tracking"
-      ],
-      "presetId": "operationType_retrieveTracker"
-    }
-  ],
-  "presets": [
-    {
-      "id": "operationType_createAddress",
-      "properties": {
-        "operationType": "createAddress"
-      }
-    },
-    {
-      "id": "operationType_createParcel",
-      "properties": {
-        "operationType": "createParcel"
-      }
-    },
-    {
-      "id": "operationType_createShipment",
-      "properties": {
-        "operationType": "createShipment"
-      }
-    },
-    {
-      "id": "operationType_buyShipment",
-      "properties": {
-        "operationType": "buyShipment"
-      }
-    },
-    {
-      "id": "operationType_verifyAddressById",
-      "properties": {
-        "operationType": "verifyAddressById"
-      }
-    },
-    {
-      "id": "operationType_retrieveTracker",
-      "properties": {
-        "operationType": "retrieveTracker"
-      }
     }
   ],
   "icon": {

--- a/connectors/google-maps-platform/element-templates/google-maps-platform-connector.json
+++ b/connectors/google-maps-platform/element-templates/google-maps-platform-connector.json
@@ -542,7 +542,7 @@
   "steps": [
     {
       "name": "Validate address",
-      "description": "Validate and standardize a postal address using the Google Maps Address Validation service.",
+      "description": "Validate and standardize a postal address with Google Maps Platform.",
       "keywords": [
         "address",
         "validate",
@@ -554,7 +554,7 @@
     },
     {
       "name": "Get place ID",
-      "description": "Look up the Google Maps place ID for a given address or location.",
+      "description": "Look up the place ID for a given address or location using Google Maps Platform.",
       "keywords": [
         "place",
         "place id",
@@ -566,7 +566,7 @@
     },
     {
       "name": "Calculate distance",
-      "description": "Calculate the distance and travel time between origin and destination points.",
+      "description": "Calculate the distance and travel time between origin and destination points with Google Maps Platform.",
       "keywords": [
         "distance",
         "route",

--- a/connectors/google-maps-platform/element-templates/google-maps-platform-connector.json
+++ b/connectors/google-maps-platform/element-templates/google-maps-platform-connector.json
@@ -518,7 +518,7 @@
       "id": "version",
       "label": "Version",
       "description": "Version of the element template",
-      "value": "4",
+      "value": "7",
       "group": "connector",
       "binding": {
         "key": "elementTemplateVersion",

--- a/connectors/google-maps-platform/element-templates/versioned/google-maps-platform-connector-6.json
+++ b/connectors/google-maps-platform/element-templates/versioned/google-maps-platform-connector-6.json
@@ -518,7 +518,7 @@
       "id": "version",
       "label": "Version",
       "description": "Version of the element template",
-      "value": "4",
+      "value": "6",
       "group": "connector",
       "binding": {
         "key": "elementTemplateVersion",

--- a/connectors/google-maps-platform/element-templates/versioned/google-maps-platform-connector-6.json
+++ b/connectors/google-maps-platform/element-templates/versioned/google-maps-platform-connector-6.json
@@ -2,7 +2,7 @@
   "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
   "name": "Google Maps Platform Outbound Connector",
   "id": "io.camunda.connectors.GoogleMapsPlatform.v1",
-  "version": 7,
+  "version": 6,
   "engines": {
     "camunda": "^8.3"
   },
@@ -537,64 +537,6 @@
         "type": "zeebe:taskHeader"
       },
       "type": "Hidden"
-    }
-  ],
-  "steps": [
-    {
-      "name": "Validate address",
-      "description": "Validate and standardize a postal address using the Google Maps Address Validation service.",
-      "keywords": [
-        "address",
-        "validate",
-        "verify",
-        "standardize",
-        "postal"
-      ],
-      "presetId": "operationType_validateAddress"
-    },
-    {
-      "name": "Get place ID",
-      "description": "Look up the Google Maps place ID for a given address or location.",
-      "keywords": [
-        "place",
-        "place id",
-        "lookup",
-        "geocode",
-        "location"
-      ],
-      "presetId": "operationType_getPlaceID"
-    },
-    {
-      "name": "Calculate distance",
-      "description": "Calculate the distance and travel time between origin and destination points.",
-      "keywords": [
-        "distance",
-        "route",
-        "travel time",
-        "directions",
-        "matrix"
-      ],
-      "presetId": "operationType_calculateDistance"
-    }
-  ],
-  "presets": [
-    {
-      "id": "operationType_validateAddress",
-      "properties": {
-        "operationType": "validateAddress"
-      }
-    },
-    {
-      "id": "operationType_getPlaceID",
-      "properties": {
-        "operationType": "getPlaceID"
-      }
-    },
-    {
-      "id": "operationType_calculateDistance",
-      "properties": {
-        "operationType": "calculateDistance"
-      }
     }
   ],
   "icon": {

--- a/connectors/microsoft/azure-open-ai/element-templates/azure-open-ai-connector.json
+++ b/connectors/microsoft/azure-open-ai/element-templates/azure-open-ai-connector.json
@@ -1288,7 +1288,7 @@
       "id": "version",
       "label": "Version",
       "description": "Version of the element template",
-      "value": "2",
+      "value": "4",
       "group": "connector",
       "binding": {
         "key": "elementTemplateVersion",

--- a/connectors/microsoft/azure-open-ai/element-templates/versioned/azure-open-ai-connector-3.json
+++ b/connectors/microsoft/azure-open-ai/element-templates/versioned/azure-open-ai-connector-3.json
@@ -1288,7 +1288,7 @@
       "id": "version",
       "label": "Version",
       "description": "Version of the element template",
-      "value": "2",
+      "value": "3",
       "group": "connector",
       "binding": {
         "key": "elementTemplateVersion",

--- a/connectors/microsoft/azure-open-ai/element-templates/versioned/azure-open-ai-connector-3.json
+++ b/connectors/microsoft/azure-open-ai/element-templates/versioned/azure-open-ai-connector-3.json
@@ -16,7 +16,7 @@
     "text generation"
   ],
   "documentationRef": "https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/azure-open-ai/",
-  "version": 4,
+  "version": 3,
   "engines": {
     "camunda": "^8.6"
   },
@@ -32,12 +32,12 @@
   },
   "groups": [
     {
-      "id": "operation",
-      "label": "Operation"
-    },
-    {
       "id": "authentication",
       "label": "Authentication"
+    },
+    {
+      "id": "operation",
+      "label": "Operation"
     },
     {
       "id": "parameters",
@@ -1307,62 +1307,6 @@
         "type": "zeebe:taskHeader"
       },
       "type": "Hidden"
-    }
-  ],
-  "steps": [
-    {
-      "name": "Completion",
-      "description": "Generate a text completion for a given prompt using an Azure OpenAI model.",
-      "keywords": [
-        "completion",
-        "text generation",
-        "prompt",
-        "GPT"
-      ],
-      "presetId": "operation_completion"
-    },
-    {
-      "name": "Chat completion",
-      "description": "Generate a chat completion from a sequence of messages using an Azure OpenAI chat model.",
-      "keywords": [
-        "chat completion",
-        "conversation",
-        "messages",
-        "assistant"
-      ],
-      "presetId": "operation_chatCompletion"
-    },
-    {
-      "name": "Completions extension",
-      "description": "Generate a chat completion augmented with your own data sources using the Azure OpenAI completions extension.",
-      "keywords": [
-        "completions extension",
-        "own data",
-        "retrieval",
-        "data source",
-        "grounding"
-      ],
-      "presetId": "operation_completionsExtension"
-    }
-  ],
-  "presets": [
-    {
-      "id": "operation_completion",
-      "properties": {
-        "operation": "completion"
-      }
-    },
-    {
-      "id": "operation_chatCompletion",
-      "properties": {
-        "operation": "chatCompletion"
-      }
-    },
-    {
-      "id": "operation_completionsExtension",
-      "properties": {
-        "operation": "completionsExtension"
-      }
     }
   ],
   "icon": {

--- a/connectors/microsoft/mail/element-templates/microsoft-office365-mail-connector.json
+++ b/connectors/microsoft/mail/element-templates/microsoft-office365-mail-connector.json
@@ -961,7 +961,7 @@
       "id": "version",
       "label": "Version",
       "description": "Version of the element template",
-      "value": "4",
+      "value": "6",
       "group": "connector",
       "binding": {
         "key": "elementTemplateVersion",

--- a/connectors/microsoft/mail/element-templates/microsoft-office365-mail-connector.json
+++ b/connectors/microsoft/mail/element-templates/microsoft-office365-mail-connector.json
@@ -985,7 +985,7 @@
   "steps": [
     {
       "name": "Get user's folders",
-      "description": "List the mail folders in a user's mailbox",
+      "description": "List the mail folders in a user's mailbox with Microsoft 365 Mail",
       "keywords": [
         "list mail folders",
         "get folders",
@@ -997,7 +997,7 @@
     },
     {
       "name": "Create mail folder for user",
-      "description": "Create a new mail folder in a user's mailbox",
+      "description": "Create a new mail folder in a user's mailbox with Microsoft 365 Mail",
       "keywords": [
         "create mail folder",
         "new folder",
@@ -1009,7 +1009,7 @@
     },
     {
       "name": "Get user's messages",
-      "description": "List the email messages in a user's mailbox",
+      "description": "List the email messages in a user's mailbox with Microsoft 365 Mail",
       "keywords": [
         "list messages",
         "get messages",
@@ -1021,7 +1021,7 @@
     },
     {
       "name": "Send mail on behalf of user",
-      "description": "Send an email message on behalf of a user",
+      "description": "Send an email message on behalf of a user with Microsoft 365 Mail",
       "keywords": [
         "send mail",
         "send email",

--- a/connectors/microsoft/mail/element-templates/versioned/microsoft-office365-mail-connector-5.json
+++ b/connectors/microsoft/mail/element-templates/versioned/microsoft-office365-mail-connector-5.json
@@ -961,7 +961,7 @@
       "id": "version",
       "label": "Version",
       "description": "Version of the element template",
-      "value": "4",
+      "value": "5",
       "group": "connector",
       "binding": {
         "key": "elementTemplateVersion",

--- a/connectors/microsoft/mail/element-templates/versioned/microsoft-office365-mail-connector-5.json
+++ b/connectors/microsoft/mail/element-templates/versioned/microsoft-office365-mail-connector-5.json
@@ -16,7 +16,7 @@
     "email notification"
   ],
   "documentationRef": "https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/microsoft-o365-mail/",
-  "version": 6,
+  "version": 5,
   "engines": {
     "camunda": "^8.4"
   },
@@ -32,16 +32,16 @@
   },
   "groups": [
     {
-      "id": "operation",
-      "label": "Operation"
-    },
-    {
       "id": "server",
       "label": "Server"
     },
     {
       "id": "authentication",
       "label": "Authentication"
+    },
+    {
+      "id": "operation",
+      "label": "Operation"
     },
     {
       "id": "requestBody",
@@ -980,82 +980,6 @@
         "type": "zeebe:taskHeader"
       },
       "type": "Hidden"
-    }
-  ],
-  "steps": [
-    {
-      "name": "Get user's folders",
-      "description": "List the mail folders in a user's mailbox",
-      "keywords": [
-        "list mail folders",
-        "get folders",
-        "mailbox folders",
-        "browse folders",
-        "inbox folders"
-      ],
-      "presetId": "operationId_users.ListMailFolders"
-    },
-    {
-      "name": "Create mail folder for user",
-      "description": "Create a new mail folder in a user's mailbox",
-      "keywords": [
-        "create mail folder",
-        "new folder",
-        "add folder",
-        "make folder",
-        "organize mailbox"
-      ],
-      "presetId": "operationId_users.CreateMailFolders"
-    },
-    {
-      "name": "Get user's messages",
-      "description": "List the email messages in a user's mailbox",
-      "keywords": [
-        "list messages",
-        "get messages",
-        "read emails",
-        "fetch mail",
-        "inbox messages"
-      ],
-      "presetId": "operationId_users.ListMessages"
-    },
-    {
-      "name": "Send mail on behalf of user",
-      "description": "Send an email message on behalf of a user",
-      "keywords": [
-        "send mail",
-        "send email",
-        "compose email",
-        "deliver message",
-        "email notification"
-      ],
-      "presetId": "operationId_users.user.sendMail"
-    }
-  ],
-  "presets": [
-    {
-      "id": "operationId_users.ListMailFolders",
-      "properties": {
-        "operationId": "users.ListMailFolders"
-      }
-    },
-    {
-      "id": "operationId_users.CreateMailFolders",
-      "properties": {
-        "operationId": "users.CreateMailFolders"
-      }
-    },
-    {
-      "id": "operationId_users.ListMessages",
-      "properties": {
-        "operationId": "users.ListMessages"
-      }
-    },
-    {
-      "id": "operationId_users.user.sendMail",
-      "properties": {
-        "operationId": "users.user.sendMail"
-      }
     }
   ],
   "icon": {

--- a/connectors/openai/element-templates/openai-connector.json
+++ b/connectors/openai/element-templates/openai-connector.json
@@ -431,7 +431,7 @@
       "id": "version",
       "label": "Version",
       "description": "Version of the element template",
-      "value": "6",
+      "value": "8",
       "group": "connector",
       "binding": {
         "key": "elementTemplateVersion",

--- a/connectors/openai/element-templates/openai-connector.json
+++ b/connectors/openai/element-templates/openai-connector.json
@@ -455,7 +455,7 @@
   "steps": [
     {
       "name": "Chat",
-      "description": "Generate a chat completion response from an OpenAI GPT model",
+      "description": "Generate a chat completion response using OpenAI",
       "keywords": [
         "chat completion",
         "generate text",
@@ -467,7 +467,7 @@
     },
     {
       "name": "Moderation",
-      "description": "Analyze text for policy violations using the OpenAI moderation API",
+      "description": "Analyze text for policy violations with OpenAI",
       "keywords": [
         "content moderation",
         "moderate text",

--- a/connectors/openai/element-templates/versioned/openai-connector-7.json
+++ b/connectors/openai/element-templates/versioned/openai-connector-7.json
@@ -427,7 +427,7 @@
       "id": "version",
       "label": "Version",
       "description": "Version of the element template",
-      "value": "6",
+      "value": "7",
       "group": "connector",
       "binding": {
         "key": "elementTemplateVersion",

--- a/connectors/openai/element-templates/versioned/openai-connector-7.json
+++ b/connectors/openai/element-templates/versioned/openai-connector-7.json
@@ -2,7 +2,7 @@
   "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
   "name": "OpenAI Outbound Connector",
   "id": "io.camunda.connectors.OpenAI.v1",
-  "version": 8,
+  "version": 7,
   "engines": {
     "camunda": "^8.3"
   },
@@ -36,10 +36,6 @@
     "value": "bpmn:ServiceTask"
   },
   "groups": [
-    {
-      "id": "operation",
-      "label": "Operation"
-    },
     {
       "id": "authentication",
       "label": "Authentication"
@@ -116,7 +112,7 @@
     },
     {
       "label": "Operation",
-      "group": "operation",
+      "group": "input",
       "description": "OpenAI API operation",
       "type": "Dropdown",
       "id": "operation",
@@ -450,46 +446,6 @@
         "type": "zeebe:taskHeader"
       },
       "type": "Hidden"
-    }
-  ],
-  "steps": [
-    {
-      "name": "Chat",
-      "description": "Generate a chat completion response from an OpenAI GPT model",
-      "keywords": [
-        "chat completion",
-        "generate text",
-        "GPT",
-        "prompt",
-        "conversation"
-      ],
-      "presetId": "operation_chat"
-    },
-    {
-      "name": "Moderation",
-      "description": "Analyze text for policy violations using the OpenAI moderation API",
-      "keywords": [
-        "content moderation",
-        "moderate text",
-        "policy check",
-        "flag content",
-        "safety filter"
-      ],
-      "presetId": "operation_moderation"
-    }
-  ],
-  "presets": [
-    {
-      "id": "operation_chat",
-      "properties": {
-        "operation": "chat"
-      }
-    },
-    {
-      "id": "operation_moderation",
-      "properties": {
-        "operation": "moderation"
-      }
     }
   ]
 }

--- a/connectors/twilio/element-templates/twilio-connector.json
+++ b/connectors/twilio/element-templates/twilio-connector.json
@@ -756,7 +756,7 @@
       "id": "version",
       "label": "Version",
       "description": "Version of the element template",
-      "value": "6",
+      "value": "8",
       "group": "connector",
       "binding": {
         "key": "elementTemplateVersion",

--- a/connectors/twilio/element-templates/versioned/twilio-connector-7.json
+++ b/connectors/twilio/element-templates/versioned/twilio-connector-7.json
@@ -756,7 +756,7 @@
       "id": "version",
       "label": "Version",
       "description": "Version of the element template",
-      "value": "6",
+      "value": "7",
       "group": "connector",
       "binding": {
         "key": "elementTemplateVersion",

--- a/connectors/twilio/element-templates/versioned/twilio-connector-7.json
+++ b/connectors/twilio/element-templates/versioned/twilio-connector-7.json
@@ -2,7 +2,7 @@
   "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
   "name": "Twilio Outbound Connector",
   "id": "io.camunda.connectors.Twilio.v1",
-  "version": 8,
+  "version": 7,
   "engines": {
     "camunda": "^8.9"
   },
@@ -775,82 +775,6 @@
         "type": "zeebe:taskHeader"
       },
       "type": "Hidden"
-    }
-  ],
-  "steps": [
-    {
-      "name": "Send a SMS",
-      "description": "Send an SMS text message to a recipient's phone number using Twilio",
-      "keywords": [
-        "send SMS",
-        "text message",
-        "SMS",
-        "send text",
-        "notify"
-      ],
-      "presetId": "operationType_sendSms"
-    },
-    {
-      "name": "Send a WhatsApp message",
-      "description": "Send a WhatsApp message, either free form or from a template, using Twilio",
-      "keywords": [
-        "send WhatsApp",
-        "WhatsApp message",
-        "WhatsApp",
-        "messaging",
-        "notification"
-      ],
-      "presetId": "operationType_sendWhatsApp"
-    },
-    {
-      "name": "Get message",
-      "description": "Retrieve information about a specific message by its message SID from Twilio",
-      "keywords": [
-        "get message",
-        "retrieve message",
-        "message details",
-        "message SID",
-        "lookup message"
-      ],
-      "presetId": "operationType_getMessage"
-    },
-    {
-      "name": "List messages",
-      "description": "List messages from your Twilio account with optional filters such as date, sender, and recipient",
-      "keywords": [
-        "list messages",
-        "list SMS",
-        "message history",
-        "filter messages",
-        "retrieve messages"
-      ],
-      "presetId": "operationType_listMessages"
-    }
-  ],
-  "presets": [
-    {
-      "id": "operationType_sendSms",
-      "properties": {
-        "operationType": "sendSms"
-      }
-    },
-    {
-      "id": "operationType_sendWhatsApp",
-      "properties": {
-        "operationType": "sendWhatsApp"
-      }
-    },
-    {
-      "id": "operationType_getMessage",
-      "properties": {
-        "operationType": "getMessage"
-      }
-    },
-    {
-      "id": "operationType_listMessages",
-      "properties": {
-        "operationType": "listMessages"
-      }
     }
   ]
 }

--- a/connectors/uipath/element-templates/uipath-connector.json
+++ b/connectors/uipath/element-templates/uipath-connector.json
@@ -590,7 +590,7 @@
       "id": "version",
       "label": "Version",
       "description": "Version of the element template",
-      "value": "5",
+      "value": "7",
       "group": "connector",
       "binding": {
         "key": "elementTemplateVersion",

--- a/connectors/uipath/element-templates/versioned/uipath-connector-6.json
+++ b/connectors/uipath/element-templates/versioned/uipath-connector-6.json
@@ -590,7 +590,7 @@
       "id": "version",
       "label": "Version",
       "description": "Version of the element template",
-      "value": "5",
+      "value": "6",
       "group": "connector",
       "binding": {
         "key": "elementTemplateVersion",

--- a/connectors/uipath/element-templates/versioned/uipath-connector-6.json
+++ b/connectors/uipath/element-templates/versioned/uipath-connector-6.json
@@ -2,7 +2,7 @@
   "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
   "name": "UiPath Outbound Connector",
   "id": "io.camunda.connectors.UIPath.v1",
-  "version": 7,
+  "version": 6,
   "engines": {
     "camunda": "^8.3"
   },
@@ -609,46 +609,6 @@
         "type": "zeebe:taskHeader"
       },
       "type": "Hidden"
-    }
-  ],
-  "steps": [
-    {
-      "name": "Add queue item",
-      "description": "Add a new queue item to a UiPath Orchestrator queue",
-      "keywords": [
-        "add queue item",
-        "create queue item",
-        "enqueue item",
-        "submit to queue",
-        "new queue entry"
-      ],
-      "presetId": "operationType_addQueueItem"
-    },
-    {
-      "name": "Get queue item result by ID",
-      "description": "Retrieve the result and status of a UiPath queue item by its ID",
-      "keywords": [
-        "get queue item",
-        "queue item result",
-        "fetch item by id",
-        "queue item status",
-        "retrieve queue item"
-      ],
-      "presetId": "operationType_getItemById"
-    }
-  ],
-  "presets": [
-    {
-      "id": "operationType_addQueueItem",
-      "properties": {
-        "operationType": "addQueueItem"
-      }
-    },
-    {
-      "id": "operationType_getItemById",
-      "properties": {
-        "operationType": "getItemById"
-      }
     }
   ]
 }

--- a/connectors/whatsapp/element-templates/versioned/whatsapp-connector-4.json
+++ b/connectors/whatsapp/element-templates/versioned/whatsapp-connector-4.json
@@ -303,7 +303,7 @@
       "id": "version",
       "label": "Version",
       "description": "Version of the element template",
-      "value": "3",
+      "value": "4",
       "group": "connector",
       "binding": {
         "key": "elementTemplateVersion",

--- a/connectors/whatsapp/element-templates/versioned/whatsapp-connector-4.json
+++ b/connectors/whatsapp/element-templates/versioned/whatsapp-connector-4.json
@@ -2,7 +2,7 @@
   "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
   "name": "WhatsApp Business Outbound Connector",
   "id": "io.camunda.connectors.WhatsApp.v1",
-  "version": 5,
+  "version": 4,
   "engines": {
     "camunda": "^8.3"
   },
@@ -31,10 +31,6 @@
     "value": "bpmn:ServiceTask"
   },
   "groups": [
-    {
-      "id": "operation",
-      "label": "Operation"
-    },
     {
       "id": "authentication",
       "label": "Authentication"
@@ -110,7 +106,7 @@
     {
       "label": "Message type",
       "description": "Choose message type you wish to send.  <a href='https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/whatsapp/' target='_blank'>See documentation</a>",
-      "group": "operation",
+      "group": "input",
       "id": "messageType",
       "type": "Dropdown",
       "value": "plainText",
@@ -326,46 +322,6 @@
         "type": "zeebe:taskHeader"
       },
       "type": "Hidden"
-    }
-  ],
-  "steps": [
-    {
-      "name": "Send plain text message",
-      "description": "Send a plain text WhatsApp message to a recipient's phone number",
-      "keywords": [
-        "send plain text",
-        "text message",
-        "send message",
-        "chat notification",
-        "notify recipient"
-      ],
-      "presetId": "messageType_plainText"
-    },
-    {
-      "name": "Send message template",
-      "description": "Send a pre-approved WhatsApp message template with optional header and body variables",
-      "keywords": [
-        "send message template",
-        "template message",
-        "approved template",
-        "notification template",
-        "structured message"
-      ],
-      "presetId": "messageType_messageTemplate"
-    }
-  ],
-  "presets": [
-    {
-      "id": "messageType_plainText",
-      "properties": {
-        "messageType": "plainText"
-      }
-    },
-    {
-      "id": "messageType_messageTemplate",
-      "properties": {
-        "messageType": "messageTemplate"
-      }
     }
   ]
 }

--- a/connectors/whatsapp/element-templates/whatsapp-connector.json
+++ b/connectors/whatsapp/element-templates/whatsapp-connector.json
@@ -331,7 +331,7 @@
   "steps": [
     {
       "name": "Send plain text message",
-      "description": "Send a plain text WhatsApp message to a recipient's phone number",
+      "description": "Send a plain text message to a recipient's phone number via WhatsApp",
       "keywords": [
         "send plain text",
         "text message",
@@ -343,7 +343,7 @@
     },
     {
       "name": "Send message template",
-      "description": "Send a pre-approved WhatsApp message template with optional header and body variables",
+      "description": "Send a pre-approved message template with optional header and body variables via WhatsApp",
       "keywords": [
         "send message template",
         "template message",

--- a/connectors/whatsapp/element-templates/whatsapp-connector.json
+++ b/connectors/whatsapp/element-templates/whatsapp-connector.json
@@ -307,7 +307,7 @@
       "id": "version",
       "label": "Version",
       "description": "Version of the element template",
-      "value": "3",
+      "value": "5",
       "group": "connector",
       "binding": {
         "key": "elementTemplateVersion",

--- a/element-template-generator/validator/src/main/java/io/camunda/connector/validator/core/OperationMetadataIgnoreList.java
+++ b/element-template-generator/validator/src/main/java/io/camunda/connector/validator/core/OperationMetadataIgnoreList.java
@@ -41,16 +41,12 @@ public final class OperationMetadataIgnoreList {
           "aws-sns",
           "aws-sqs",
           "aws-textract",
-          "azure-open-ai",
-          "blue-prism",
-          "easy-post",
           "email-inbound",
           "email-message-start-event",
           "github",
           "gitlab",
           "google-drive",
           "google-gemini",
-          "google-maps-platform",
           "http",
           "hubspot",
           "hugging-face",
@@ -58,8 +54,6 @@ public final class OperationMetadataIgnoreList {
           "idp-extraction",
           "jdbc",
           "kafka",
-          "mail",
-          "openai",
           "operate",
           "orchestration",
           "power-automate",
@@ -70,10 +64,8 @@ public final class OperationMetadataIgnoreList {
           "servicenow",
           "slack-inbound",
           "soap",
-          "twilio",
-          "uipath",
-          "webhook",
-          "whatsapp");
+          "twilio-webhook",
+          "webhook");
 
   /**
    * Returns true if the given template file lives under any connector directory on the ignore list,


### PR DESCRIPTION
## Description

Part of the native operations epic (product-hub#3403). Follow-up to #7630 (which covered all Java connectors), this PR adds `steps` + `presets` metadata to the **flat / single-level** element-template-only (ET-only) connectors so Modeler's native operations search/discovery UI can browse and preset-select operations.

### Connectors updated (9)

| Connector | Ops | Version | Notes |
|---|---|---|---|
| blue-prism | 2 | 5→6 | |
| easy-post | 6 | 6→7 | |
| google-maps-platform | 3 | 6→7 | |
| microsoft/azure-open-ai | 3 | 3→4 | reordered `operation` group to first |
| microsoft/mail | 4 | 5→6 | reordered `operation` group to first |
| openai | 2 | 7→8 | created `operation` group, moved dropdown into it |
| twilio | 4 | 7→8 | `whatsappMessageType` sub-dropdown intentionally excluded |
| uipath | 2 | 6→7 | |
| whatsapp | 2 | 4→5 | created `operation` group, moved dropdown into it |

### Per connector

- Added top-level `steps` + `presets` arrays (preset property keys = the operation dropdown's `id`, values = choice values).
- Bumped `@ElementTemplate` version and saved the previous version as a `versioned/` snapshot.
- Ensured the operation dropdown lives in the `operation` UI group and that group is ordered first.
- Removed the connector from `OperationMetadataIgnoreList`; replaced the broad `twilio` entry with `twilio-webhook` so the inbound webhook templates stay exempt while `twilio-connector.json` is validated.

The remaining complex two-level ET-only connectors (asana, github, gitlab, hubspot, salesforce, servicenow) will follow in a separate PR.
