### PR TITLE
feat: expose messageName in inbound connector ProcessElementWithRuntimeData response (#7813)

### DIFF
--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/ProcessElementWithRuntimeData.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/ProcessElementWithRuntimeData.java
@@ -24,6 +24,7 @@ import java.util.Map;
 public record ProcessElementWithRuntimeData(
     String bpmnProcessId,
     String processName,
+    String messageName,
     int version,
     long processDefinitionKey,
     String elementId,
@@ -42,6 +43,7 @@ public record ProcessElementWithRuntimeData(
       String tenantId) {
     this(
         bpmnProcessId,
+        null,
         null,
         version,
         processDefinitionKey,

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextImplTest.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextImplTest.java
@@ -28,9 +28,6 @@ import io.camunda.client.api.command.EvaluateExpressionCommandStep1.EvaluateExpr
 import io.camunda.client.api.response.EvaluateExpressionResponse;
 import io.camunda.connector.api.annotation.FEEL;
 import io.camunda.connector.api.inbound.ActivityLogTag;
-import io.camunda.connector.api.inbound.CorrelationRequest;
-import io.camunda.connector.api.inbound.CorrelationResult;
-import io.camunda.connector.api.inbound.ElementTemplateDetails;
 import io.camunda.connector.api.inbound.Health;
 import io.camunda.connector.api.inbound.Severity;
 import io.camunda.connector.api.secret.SecretProvider;
@@ -40,7 +37,6 @@ import io.camunda.connector.runtime.core.FooBarSecretProvider;
 import io.camunda.connector.runtime.core.TestObjectMapperSupplier;
 import io.camunda.connector.runtime.core.inbound.InboundConnectorContextImplTest.TestPropertiesClass.InnerObject;
 import io.camunda.connector.runtime.core.inbound.activitylog.ActivityLogRegistry;
-import io.camunda.connector.runtime.core.inbound.correlation.InboundCorrelationHandler;
 import io.camunda.connector.runtime.core.inbound.correlation.MessageCorrelationPoint.StandaloneMessageCorrelationPoint;
 import io.camunda.connector.runtime.core.inbound.details.InboundConnectorDetails;
 import io.camunda.connector.runtime.core.inbound.details.InboundConnectorDetails.ValidInboundConnectorDetails;
@@ -123,50 +119,6 @@ class InboundConnectorContextImplTest {
               return step2;
             });
     return camundaClient;
-  }
-
-  @Test
-  void bindProperties_fromActivatedElement_bindsThatElementsProperties() {
-    // given a context whose correlation activates a specific element carrying its own raw
-    // properties. Issue #6684: element-scoped binding must use the element that actually matched,
-    // not the executable's shared/first element.
-    var definition = getInboundConnectorDefinition(Map.of("stringMap", "={}"));
-    var activatedElement =
-        new ProcessElementWithRuntimeData(
-            "bool",
-            null,
-            null,
-            0,
-            0,
-            "activated",
-            null,
-            null,
-            "<default>",
-            new ElementTemplateDetails("t", "1", "icon"),
-            Map.of("stringMap", "={\"from\":\"activated-element\"}"));
-    var correlationHandler = mock(InboundCorrelationHandler.class);
-    when(correlationHandler.correlate(any(), any()))
-        .thenReturn(
-            new CorrelationResult.Success.ProcessInstanceCreated(
-                activatedElement, 1L, "<default>"));
-    var context =
-        new InboundConnectorContextImpl(
-            secretProvider,
-            (e) -> {},
-            definition,
-            correlationHandler,
-            (e) -> {},
-            mapper,
-            activityLogRegistry,
-            camundaClient);
-
-    // when
-    var result = context.correlate(CorrelationRequest.builder().variables(Map.of()).build());
-
-    // then the Success binds the ACTIVATED element's own properties, not the context's
-    assertThat(result).isInstanceOf(CorrelationResult.Success.class);
-    var bound = ((CorrelationResult.Success) result).bindProperties(TestPropertiesClass.class);
-    assertThat(bound.getStringMap()).containsEntry("from", "activated-element");
   }
 
   @Test

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextImplTest.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextImplTest.java
@@ -28,6 +28,9 @@ import io.camunda.client.api.command.EvaluateExpressionCommandStep1.EvaluateExpr
 import io.camunda.client.api.response.EvaluateExpressionResponse;
 import io.camunda.connector.api.annotation.FEEL;
 import io.camunda.connector.api.inbound.ActivityLogTag;
+import io.camunda.connector.api.inbound.CorrelationRequest;
+import io.camunda.connector.api.inbound.CorrelationResult;
+import io.camunda.connector.api.inbound.ElementTemplateDetails;
 import io.camunda.connector.api.inbound.Health;
 import io.camunda.connector.api.inbound.Severity;
 import io.camunda.connector.api.secret.SecretProvider;
@@ -37,6 +40,7 @@ import io.camunda.connector.runtime.core.FooBarSecretProvider;
 import io.camunda.connector.runtime.core.TestObjectMapperSupplier;
 import io.camunda.connector.runtime.core.inbound.InboundConnectorContextImplTest.TestPropertiesClass.InnerObject;
 import io.camunda.connector.runtime.core.inbound.activitylog.ActivityLogRegistry;
+import io.camunda.connector.runtime.core.inbound.correlation.InboundCorrelationHandler;
 import io.camunda.connector.runtime.core.inbound.correlation.MessageCorrelationPoint.StandaloneMessageCorrelationPoint;
 import io.camunda.connector.runtime.core.inbound.details.InboundConnectorDetails;
 import io.camunda.connector.runtime.core.inbound.details.InboundConnectorDetails.ValidInboundConnectorDetails;
@@ -119,6 +123,50 @@ class InboundConnectorContextImplTest {
               return step2;
             });
     return camundaClient;
+  }
+
+  @Test
+  void bindProperties_fromActivatedElement_bindsThatElementsProperties() {
+    // given a context whose correlation activates a specific element carrying its own raw
+    // properties. Issue #6684: element-scoped binding must use the element that actually matched,
+    // not the executable's shared/first element.
+    var definition = getInboundConnectorDefinition(Map.of("stringMap", "={}"));
+    var activatedElement =
+        new ProcessElementWithRuntimeData(
+            "bool",
+            null,
+            null,
+            0,
+            0,
+            "activated",
+            null,
+            null,
+            "<default>",
+            new ElementTemplateDetails("t", "1", "icon"),
+            Map.of("stringMap", "={\"from\":\"activated-element\"}"));
+    var correlationHandler = mock(InboundCorrelationHandler.class);
+    when(correlationHandler.correlate(any(), any()))
+        .thenReturn(
+            new CorrelationResult.Success.ProcessInstanceCreated(
+                activatedElement, 1L, "<default>"));
+    var context =
+        new InboundConnectorContextImpl(
+            secretProvider,
+            (e) -> {},
+            definition,
+            correlationHandler,
+            (e) -> {},
+            mapper,
+            activityLogRegistry,
+            camundaClient);
+
+    // when
+    var result = context.correlate(CorrelationRequest.builder().variables(Map.of()).build());
+
+    // then the Success binds the ACTIVATED element's own properties, not the context's
+    assertThat(result).isInstanceOf(CorrelationResult.Success.class);
+    var bound = ((CorrelationResult.Success) result).bindProperties(TestPropertiesClass.class);
+    assertThat(bound.getStringMap()).containsEntry("from", "activated-element");
   }
 
   @Test

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/state/ProcessDefinitionInspector.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/state/ProcessDefinitionInspector.java
@@ -25,6 +25,7 @@ import io.camunda.connector.api.inbound.ElementTemplateDetails;
 import io.camunda.connector.runtime.core.error.InvalidInboundConnectorDefinitionException;
 import io.camunda.connector.runtime.core.inbound.InboundConnectorElement;
 import io.camunda.connector.runtime.core.inbound.ProcessElementWithRuntimeData;
+import io.camunda.connector.runtime.core.inbound.correlation.MessageCorrelationPoint;
 import io.camunda.connector.runtime.core.inbound.correlation.MessageCorrelationPoint.BoundaryEventCorrelationPoint;
 import io.camunda.connector.runtime.core.inbound.correlation.MessageCorrelationPoint.StandaloneMessageCorrelationPoint;
 import io.camunda.connector.runtime.core.inbound.correlation.MessageStartEventCorrelationPoint;
@@ -151,6 +152,12 @@ public class ProcessDefinitionInspector {
         continue;
       }
       ProcessCorrelationPoint target = optionalTarget.get();
+      String messageName =
+          switch (target) {
+            case MessageCorrelationPoint mcp -> mcp.messageName();
+            case MessageStartEventCorrelationPoint msecp -> msecp.messageName();
+            default -> null;
+          };
 
       var rawProperties = getRawProperties(element);
       if (rawProperties == null || !rawProperties.containsKey(INBOUND_TYPE_KEYWORD)) {
@@ -162,6 +169,7 @@ public class ProcessDefinitionInspector {
           new ProcessElementWithRuntimeData(
               process.getId(),
               process.getName(),
+              messageName,
               version.version(),
               version.processDefinitionKey(),
               element.getId(),

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/inbound/importer/ProcessDefinitionInspectorUtilTests.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/inbound/importer/ProcessDefinitionInspectorUtilTests.java
@@ -56,6 +56,9 @@ public class ProcessDefinitionInspectorUtilTests {
     var inboundConnectors = fromModel("multi-webhook-collaboration.bpmn", "process2");
     assertEquals(1, inboundConnectors.size());
     assertEquals("intermediate_event", inboundConnectors.getFirst().element().elementId());
+    assertEquals(
+        "af13ccea-2581-45b1-928d-165edbc1af8f",
+        inboundConnectors.getFirst().element().messageName());
   }
 
   @Test
@@ -77,6 +80,9 @@ public class ProcessDefinitionInspectorUtilTests {
     var inboundConnectors = fromModel("single-webhook-boundary.bpmn", "BoundaryEventTest");
     assertEquals(1, inboundConnectors.size());
     assertEquals("boundary_event", inboundConnectors.getFirst().element().elementId());
+    assertEquals(
+        "c97ca438-b051-49db-b007-f897574daceb",
+        inboundConnectors.getFirst().element().messageName());
   }
 
   @Test

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/inbound/InboundInstancesRestControllerTest.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/inbound/InboundInstancesRestControllerTest.java
@@ -37,6 +37,7 @@ import io.camunda.connector.runtime.app.TestConnectorRuntimeApplication;
 import io.camunda.connector.runtime.core.inbound.ExecutableId;
 import io.camunda.connector.runtime.core.inbound.InboundConnectorElement;
 import io.camunda.connector.runtime.core.inbound.ProcessElementWithRuntimeData;
+import io.camunda.connector.runtime.core.inbound.correlation.MessageCorrelationPoint.BoundaryEventCorrelationPoint;
 import io.camunda.connector.runtime.core.inbound.correlation.MessageCorrelationPoint.StandaloneMessageCorrelationPoint;
 import io.camunda.connector.runtime.inbound.controller.ActiveInboundConnectorResponse;
 import io.camunda.connector.runtime.inbound.executable.ActiveExecutableQuery;
@@ -65,9 +66,13 @@ class InboundInstancesRestControllerTest {
 
   private static final String TYPE_1 = "webhook";
 
+  private static final String MESSAGE_NAME_1 = "myMessage";
+  private static final String MESSAGE_NAME_BOUNDARY = "boundaryMessage";
+
   private static final ExecutableId RANDOM_ID_1 = ExecutableId.fromDeduplicationId("theid1");
   private static final ExecutableId RANDOM_ID_2 = ExecutableId.fromDeduplicationId("theid2");
   private static final ExecutableId RANDOM_ID_3 = ExecutableId.fromDeduplicationId("theid3");
+  private static final ExecutableId RANDOM_ID_4 = ExecutableId.fromDeduplicationId("theid4");
   private static final String TYPE_2 = "anotherType";
 
   private final Health health1 = Health.up();
@@ -108,8 +113,19 @@ class InboundInstancesRestControllerTest {
                               new InboundConnectorElement(
                                   Map.of("inbound.context", "myPath", "inbound.type", TYPE_1),
                                   new StandaloneMessageCorrelationPoint(
-                                      "myPath", "=expression", "=myPath", null),
-                                  new ProcessElementWithRuntimeData("ProcessA", 1, 1, "", ""))),
+                                      MESSAGE_NAME_1, "=expression", "=myPath", null),
+                                  new ProcessElementWithRuntimeData(
+                                      "ProcessA",
+                                      null,
+                                      MESSAGE_NAME_1,
+                                      1,
+                                      1,
+                                      "",
+                                      null,
+                                      null,
+                                      "",
+                                      new ElementTemplateDetails("Test", "1", "icon"),
+                                      Map.of()))),
                           health1,
                           Collections.emptyList(),
                           System.currentTimeMillis()),
@@ -160,6 +176,38 @@ class InboundInstancesRestControllerTest {
                                   .withTag("myTag2")
                                   .withMessage("myMessage2")
                                   .build()),
+                          System.currentTimeMillis()),
+                      new ActiveExecutableResponse(
+                          RANDOM_ID_4,
+                          AnotherExecutable.class,
+                          List.of(
+                              new InboundConnectorElement(
+                                  Map.of(
+                                      "inbound.other.prop",
+                                      "boundaryValue",
+                                      "inbound.type",
+                                      TYPE_2),
+                                  new BoundaryEventCorrelationPoint(
+                                      MESSAGE_NAME_BOUNDARY,
+                                      "=key",
+                                      null,
+                                      null,
+                                      new BoundaryEventCorrelationPoint.Activity(
+                                          "task1", "Task 1")),
+                                  new ProcessElementWithRuntimeData(
+                                      "ProcessD",
+                                      null,
+                                      MESSAGE_NAME_BOUNDARY,
+                                      1,
+                                      1,
+                                      "boundaryElem",
+                                      null,
+                                      null,
+                                      "",
+                                      new ElementTemplateDetails("Test", "1", "icon"),
+                                      Map.of()))),
+                          Health.up(),
+                          Collections.emptyList(),
                           System.currentTimeMillis()))
                   .filter(response -> matchesQuery(response, query))
                   .toList();
@@ -189,11 +237,13 @@ class InboundInstancesRestControllerTest {
     var instance2 = instance.get(1);
     assertEquals(TYPE_2, instance2.connectorId());
     assertEquals("AnotherType", instance2.connectorName());
-    assertEquals(2, instance2.instances().size());
+    assertEquals(3, instance2.instances().size());
     assertEquals(RANDOM_ID_2, instance2.instances().get(0).executableId());
     assertEquals("ProcessB", instance2.instances().get(0).elements().getFirst().bpmnProcessId());
     assertEquals(RANDOM_ID_3, instance2.instances().get(1).executableId());
     assertEquals("ProcessC", instance2.instances().get(1).elements().getFirst().bpmnProcessId());
+    assertEquals(RANDOM_ID_4, instance2.instances().get(2).executableId());
+    assertEquals("ProcessD", instance2.instances().get(2).elements().getFirst().bpmnProcessId());
   }
 
   @Test
@@ -254,6 +304,7 @@ class InboundInstancesRestControllerTest {
             .readValue(response, ActiveInboundConnectorResponse.class);
     assertEquals(RANDOM_ID_1, executable.executableId());
     assertEquals("ProcessA", executable.elements().getFirst().bpmnProcessId());
+    assertEquals(MESSAGE_NAME_1, executable.elements().getFirst().messageName());
   }
 
   @Test
@@ -359,6 +410,25 @@ class InboundInstancesRestControllerTest {
             .readValue(response, ActiveInboundConnectorResponse.class);
     assertEquals(RANDOM_ID_1, executable.executableId());
     assertEquals("ProcessA", executable.elements().getFirst().bpmnProcessId());
+    assertEquals(MESSAGE_NAME_1, executable.elements().getFirst().messageName());
+  }
+
+  @Test
+  public void shouldReturnMessageName_forBoundaryEvent() throws Exception {
+    var response =
+        mockMvc
+            .perform(get("/inbound-instances/executables/" + RANDOM_ID_4.getId()))
+            .andExpect(status().isOk())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+
+    ActiveInboundConnectorResponse executable =
+        ConnectorsObjectMapperSupplier.getCopy()
+            .readValue(response, ActiveInboundConnectorResponse.class);
+    assertEquals(RANDOM_ID_4, executable.executableId());
+    assertEquals("ProcessD", executable.elements().getFirst().bpmnProcessId());
+    assertEquals(MESSAGE_NAME_BOUNDARY, executable.elements().getFirst().messageName());
   }
 
   @Test


### PR DESCRIPTION
Backport of #7813 to `release-8.10.0-alpha3`.

## Conflicts resolved

- `ProcessElementWithRuntimeData.java`: added `String messageName` field (without `@Nullable` annotation since jspecify is not a dependency on this release branch)
- `InboundConnectorContextImplTest.java`: included the `bindProperties_fromActivatedElement_bindsThatElementsProperties` test with its required imports (`CorrelationRequest`, `CorrelationResult`, `ElementTemplateDetails`, `InboundCorrelationHandler`)