### PR TITLE
Bump camunda client 8.10.0-alpha3

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -70,7 +70,7 @@ limitations under the License.</license.inlineheader>
     <nexus.release.repository>https://artifacts.camunda.com/artifactory/connectors/</nexus.release.repository>
 
     <!-- Camunda internal libraries -->
-    <version.camunda>8.10.0-alpha3-rc2</version.camunda>
+    <version.camunda>8.10.0-alpha3</version.camunda>
     <version.feel-engine>1.21.0</version.feel-engine>
     <version.camunda-xml-model>7.24.0</version.camunda-xml-model>
 


### PR DESCRIPTION
## Description

Bump `version.camunda` from `8.10.0-alpha3-rc2` to `8.10.0-alpha3` in `parent/pom.xml`.

## Related issues

closes #

## Checklist

- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest release, as this branch will be rebased onto main before the next release.
- [ ] Tests/Integration tests for the changes have been added if applicable.
- [ ] If the change requires a documentation update, it has been added to the appropriate section in the documentation.