### PR TITLE
feat(saas): report App Integrations connector availability per cluster

### DIFF
--- a/bundle/camunda-saas-bundle/pom.xml
+++ b/bundle/camunda-saas-bundle/pom.xml
@@ -110,6 +110,11 @@
     </dependency>
 
     <dependency>
+      <groupId>dev.failsafe</groupId>
+      <artifactId>failsafe</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>camunda-client-java</artifactId>
     </dependency>

--- a/bundle/camunda-saas-bundle/pom.xml
+++ b/bundle/camunda-saas-bundle/pom.xml
@@ -110,11 +110,6 @@
     </dependency>
 
     <dependency>
-      <groupId>dev.failsafe</groupId>
-      <artifactId>failsafe</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>camunda-client-java</artifactId>
     </dependency>

--- a/bundle/camunda-saas-bundle/src/main/java/io/camunda/connector/runtime/saas/AppIntegrationsClient.java
+++ b/bundle/camunda-saas-bundle/src/main/java/io/camunda/connector/runtime/saas/AppIntegrationsClient.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.runtime.saas;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpRequest.BodyPublishers;
+import java.net.http.HttpResponse;
+import java.net.http.HttpResponse.BodyHandlers;
+import java.time.Duration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+/**
+ * Talks to the App Integrations backend to (de)register this SaaS cluster.
+ *
+ * <p>{@code registerCluster} performs a single {@code PUT} (settings present) or {@code DELETE}
+ * (settings absent) against {@code /api/connector/{orgId}/{clusterId}}, authenticated with the
+ * shared {@code APP_INTEGRATIONS_CONNECTOR_SECRET} sent in the {@code X-API-KEY} header. It never
+ * throws — the returned {@link RegistrationOutcome} tells the caller whether the failure was
+ * transient and worth retrying. Scheduling/retrying is the caller's concern (see {@link
+ * AppIntegrationsClusterRegistration}).
+ *
+ * <p>{@code APP_INTEGRATIONS_BASE_URL} and {@code APP_INTEGRATIONS_CONNECTOR_SECRET} are
+ * fleet-level values that address and authenticate the endpoint (including the disable/{@code
+ * DELETE} case).
+ */
+@Component
+public class AppIntegrationsClient {
+
+  /** Outcome of a registration attempt, telling the caller whether to retry. */
+  public enum RegistrationOutcome {
+    /** Reported successfully, or failed permanently — do not retry. */
+    DONE,
+    /** Transient failure — the caller should retry later. */
+    RETRY
+  }
+
+  static final String API_KEY_HEADER = "X-API-KEY";
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(AppIntegrationsClient.class);
+  private static final Duration TIMEOUT = Duration.ofSeconds(10);
+
+  private final String baseUrl;
+  private final String apiKey;
+  private final HttpClient httpClient;
+
+  @Autowired
+  public AppIntegrationsClient(
+      @Value("${APP_INTEGRATIONS_BASE_URL:}") String baseUrl,
+      @Value("${APP_INTEGRATIONS_CONNECTOR_SECRET:}") String apiKey) {
+    this(baseUrl, apiKey, HttpClient.newBuilder().connectTimeout(TIMEOUT).build());
+  }
+
+  AppIntegrationsClient(String baseUrl, String apiKey, HttpClient httpClient) {
+    this.baseUrl = baseUrl;
+    this.apiKey = apiKey;
+    this.httpClient = httpClient;
+  }
+
+  /** Whether the fleet-level endpoint configuration (base URL and API key) is available. */
+  boolean isConfigured() {
+    return isPresent(baseUrl) && isPresent(apiKey);
+  }
+
+  /**
+   * Registers ({@code settingsPresent}) or deregisters the cluster with the App Integrations
+   * backend. Never throws.
+   */
+  RegistrationOutcome registerCluster(
+      String organizationId, String clusterId, boolean settingsPresent) {
+    var method = settingsPresent ? "PUT" : "DELETE";
+
+    final HttpRequest request;
+    try {
+      var uri =
+          URI.create(
+              baseUrl.replaceAll("/+$", "") + "/api/connector/" + organizationId + "/" + clusterId);
+      request =
+          HttpRequest.newBuilder(uri)
+              .timeout(TIMEOUT)
+              .header(API_KEY_HEADER, apiKey)
+              .method(method, BodyPublishers.noBody())
+              .build();
+    } catch (RuntimeException e) {
+      // A malformed base URL (or invalid org/cluster id) is a misconfiguration that a retry cannot
+      // fix, so stop rather than loop.
+      LOGGER.warn(
+          "Cannot build App Integrations registration request for base URL '{}': {}",
+          baseUrl,
+          e.getMessage());
+      return RegistrationOutcome.DONE;
+    }
+
+    try {
+      HttpResponse<String> response = httpClient.send(request, BodyHandlers.ofString());
+      int status = response.statusCode();
+      if (status < 400) {
+        LOGGER.info(
+            "Reported App Integrations availability: {} {} -> {}", method, request.uri(), status);
+        return RegistrationOutcome.DONE;
+      }
+      if (status < 500) {
+        // Client error — retrying will not help.
+        LOGGER.warn(
+            "App Integrations cluster registration ({} {}) returned client error {}; giving up",
+            method,
+            request.uri(),
+            status);
+        return RegistrationOutcome.DONE;
+      }
+      LOGGER.warn(
+          "App Integrations cluster registration ({} {}) returned {}; will retry",
+          method,
+          request.uri(),
+          status);
+      return RegistrationOutcome.RETRY;
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      LOGGER.warn(
+          "Interrupted while reporting App Integrations availability ({} {})",
+          method,
+          request.uri());
+      return RegistrationOutcome.DONE;
+    } catch (Exception e) {
+      LOGGER.warn(
+          "Failed to report App Integrations availability ({} {}); will retry: {}",
+          method,
+          request.uri(),
+          e.getMessage());
+      return RegistrationOutcome.RETRY;
+    }
+  }
+
+  private static boolean isPresent(String value) {
+    return value != null && !value.isBlank();
+  }
+}

--- a/bundle/camunda-saas-bundle/src/main/java/io/camunda/connector/runtime/saas/AppIntegrationsClient.java
+++ b/bundle/camunda-saas-bundle/src/main/java/io/camunda/connector/runtime/saas/AppIntegrationsClient.java
@@ -34,12 +34,12 @@ import org.springframework.stereotype.Component;
  *
  * <p>{@code registerCluster} performs a single {@code PUT} (settings present) or {@code DELETE}
  * (settings absent) against {@code /api/connector/{orgId}/{clusterId}}, authenticated with the
- * shared {@code APP_INTEGRATIONS_CONNECTOR_SECRET} sent in the {@code X-API-KEY} header. It never
+ * shared {@code APP_INTEGRATIONS_CONNECTOR_API_KEY} sent in the {@code X-API-KEY} header. It never
  * throws — the returned {@link RegistrationOutcome} tells the caller whether the failure was
  * transient and worth retrying. Scheduling/retrying is the caller's concern (see {@link
  * AppIntegrationsClusterRegistration}).
  *
- * <p>{@code APP_INTEGRATIONS_BASE_URL} and {@code APP_INTEGRATIONS_CONNECTOR_SECRET} are
+ * <p>{@code APP_INTEGRATIONS_BASE_URL} and {@code APP_INTEGRATIONS_CONNECTOR_API_KEY} are
  * fleet-level values that address and authenticate the endpoint (including the disable/{@code
  * DELETE} case).
  */
@@ -66,7 +66,7 @@ public class AppIntegrationsClient {
   @Autowired
   public AppIntegrationsClient(
       @Value("${APP_INTEGRATIONS_BASE_URL:}") String baseUrl,
-      @Value("${APP_INTEGRATIONS_CONNECTOR_SECRET:}") String apiKey) {
+      @Value("${APP_INTEGRATIONS_CONNECTOR_API_KEY:}") String apiKey) {
     this(baseUrl, apiKey, HttpClient.newBuilder().connectTimeout(TIMEOUT).build());
   }
 

--- a/bundle/camunda-saas-bundle/src/main/java/io/camunda/connector/runtime/saas/AppIntegrationsClusterRegistration.java
+++ b/bundle/camunda-saas-bundle/src/main/java/io/camunda/connector/runtime/saas/AppIntegrationsClusterRegistration.java
@@ -16,12 +16,7 @@
  */
 package io.camunda.connector.runtime.saas;
 
-import java.net.URI;
-import java.net.http.HttpClient;
-import java.net.http.HttpRequest;
-import java.net.http.HttpRequest.BodyPublishers;
-import java.net.http.HttpResponse;
-import java.net.http.HttpResponse.BodyHandlers;
+import io.camunda.connector.runtime.saas.AppIntegrationsClient.RegistrationOutcome;
 import java.time.Duration;
 import java.time.Instant;
 import org.slf4j.Logger;
@@ -35,194 +30,107 @@ import org.springframework.scheduling.TaskScheduler;
 import org.springframework.stereotype.Component;
 
 /**
- * Reports this SaaS cluster's App Integrations connector availability to the App Integrations
- * backend when the runtime starts.
+ * Reports this SaaS cluster's App Integrations connector availability when the runtime starts.
  *
- * <p>If the App Integrations connector settings are provisioned for the cluster, the runtime
- * registers the cluster with {@code PUT /api/connector/{orgId}/{clusterId}}; otherwise it
- * deregisters it with {@code DELETE /api/connector/{orgId}/{clusterId}}. Both requests are
- * authenticated with a shared API key ({@code APP_INTEGRATIONS_CONNECTOR_SECRET}) sent in the
- * {@code X-API-KEY} header — no OAuth client is built here.
+ * <p>On {@link ApplicationReadyEvent} it schedules a one-time task (off the startup thread) that
+ * delegates the actual HTTP call to {@link AppIntegrationsClient}. When the client reports a
+ * transient failure the task reschedules itself with a capped exponential backoff, so the runtime
+ * keeps trying until the report succeeds (or fails permanently). Nothing here can prevent the
+ * runtime from starting.
  *
- * <p>{@code APP_INTEGRATIONS_BASE_URL} and {@code APP_INTEGRATIONS_CONNECTOR_SECRET} are
- * fleet-level values that address and authenticate the reporting endpoint (including the
- * disable/{@code DELETE} case). "Settings present" therefore refers to the per-cluster connector
- * configuration, detected by the presence of the connector's OAuth client credentials.
- *
- * <p>The report runs off the startup thread as a one-time scheduled task. A transient failure (I/O
- * error or {@code 5xx}) reschedules the task with a capped exponential backoff, so the runtime
- * keeps trying until the report succeeds. A client error ({@code 4xx}) is treated as permanent and
- * is not retried. Nothing here can prevent the runtime from starting.
+ * <p>The report registers the cluster when the App Integrations connector is provisioned for it and
+ * deregisters it otherwise. "Settings present" is detected by the presence of the connector's
+ * per-cluster OAuth client credentials.
  */
 @Component
 @Profile("!test")
 public class AppIntegrationsClusterRegistration {
 
-  static final String API_KEY_HEADER = "X-API-KEY";
-
   private static final Logger LOGGER =
       LoggerFactory.getLogger(AppIntegrationsClusterRegistration.class);
-  private static final Duration TIMEOUT = Duration.ofSeconds(10);
   private static final Duration INITIAL_RETRY_DELAY = Duration.ofSeconds(5);
   private static final Duration MAX_RETRY_DELAY = Duration.ofMinutes(5);
 
-  private final String baseUrl;
-  private final String apiKey;
+  private final AppIntegrationsClient client;
+  private final TaskScheduler taskScheduler;
   private final boolean settingsPresent;
   private final String organizationId;
   private final String clusterId;
-  private final HttpClient httpClient;
-  private final TaskScheduler taskScheduler;
   private final Duration initialRetryDelay;
   private final Duration maxRetryDelay;
 
   @Autowired
   public AppIntegrationsClusterRegistration(
-      @Value("${APP_INTEGRATIONS_BASE_URL:}") String baseUrl,
-      @Value("${APP_INTEGRATIONS_CONNECTOR_SECRET:}") String apiKey,
+      AppIntegrationsClient client,
+      TaskScheduler taskScheduler,
       @Value("${APP_INTEGRATIONS_OAUTH_CLIENT_ID:}") String oauthClientId,
       @Value("${APP_INTEGRATIONS_OAUTH_CLIENT_SECRET:}") String oauthClientSecret,
       @Value("${camunda.connector.cloud.organization.id:}") String organizationId,
-      @Value("${camunda.client.cloud.clusterId:}") String clusterId,
-      TaskScheduler taskScheduler) {
+      @Value("${camunda.client.cloud.clusterId:}") String clusterId) {
     this(
-        baseUrl,
-        apiKey,
+        client,
+        taskScheduler,
         // The App Integrations connector is provisioned for this cluster when its per-cluster OAuth
         // client credentials are present.
         isPresent(oauthClientId) && isPresent(oauthClientSecret),
         organizationId,
         clusterId,
-        HttpClient.newBuilder().connectTimeout(TIMEOUT).build(),
-        taskScheduler,
         INITIAL_RETRY_DELAY,
         MAX_RETRY_DELAY);
   }
 
   AppIntegrationsClusterRegistration(
-      String baseUrl,
-      String apiKey,
+      AppIntegrationsClient client,
+      TaskScheduler taskScheduler,
       boolean settingsPresent,
       String organizationId,
-      String clusterId,
-      HttpClient httpClient,
-      TaskScheduler taskScheduler) {
+      String clusterId) {
     // Convenience for tests: short retry delays so the backoff numbers stay small.
     this(
-        baseUrl,
-        apiKey,
+        client,
+        taskScheduler,
         settingsPresent,
         organizationId,
         clusterId,
-        httpClient,
-        taskScheduler,
         Duration.ofMillis(1),
         Duration.ofMillis(10));
   }
 
   AppIntegrationsClusterRegistration(
-      String baseUrl,
-      String apiKey,
+      AppIntegrationsClient client,
+      TaskScheduler taskScheduler,
       boolean settingsPresent,
       String organizationId,
       String clusterId,
-      HttpClient httpClient,
-      TaskScheduler taskScheduler,
       Duration initialRetryDelay,
       Duration maxRetryDelay) {
-    this.baseUrl = baseUrl;
-    this.apiKey = apiKey;
+    this.client = client;
+    this.taskScheduler = taskScheduler;
     this.settingsPresent = settingsPresent;
     this.organizationId = organizationId;
     this.clusterId = clusterId;
-    this.httpClient = httpClient;
-    this.taskScheduler = taskScheduler;
     this.initialRetryDelay = initialRetryDelay;
     this.maxRetryDelay = maxRetryDelay;
   }
 
   @EventListener(ApplicationReadyEvent.class)
   public void reportAvailability() {
-    if (!isPresent(baseUrl)
-        || !isPresent(apiKey)
-        || !isPresent(organizationId)
-        || !isPresent(clusterId)) {
+    if (!client.isConfigured() || !isPresent(organizationId) || !isPresent(clusterId)) {
       LOGGER.info(
-          "Skipping App Integrations cluster registration: base URL, API key, organization id or "
-              + "cluster id is not configured");
+          "Skipping App Integrations cluster registration: endpoint configuration, organization id "
+              + "or cluster id is not available");
       return;
     }
-
-    // Build the request up front so a malformed base URL (or invalid org/cluster id) fails fast
-    // here rather than escaping the startup thread or looping forever on the scheduler.
-    final HttpRequest request;
-    var method = settingsPresent ? "PUT" : "DELETE";
-    try {
-      var uri =
-          URI.create(
-              baseUrl.replaceAll("/+$", "") + "/api/connector/" + organizationId + "/" + clusterId);
-      request =
-          HttpRequest.newBuilder(uri)
-              .timeout(TIMEOUT)
-              .header(API_KEY_HEADER, apiKey)
-              .method(method, BodyPublishers.noBody())
-              .build();
-    } catch (RuntimeException e) {
-      LOGGER.warn(
-          "Skipping App Integrations cluster registration: cannot build request for base URL '{}': {}",
-          baseUrl,
-          e.getMessage());
-      return;
-    }
-
-    // Run off the startup thread; retry transient failures until the report succeeds.
-    taskScheduler.schedule(() -> attempt(request, method, initialRetryDelay), Instant.now());
+    taskScheduler.schedule(() -> attempt(initialRetryDelay), Instant.now());
   }
 
-  private void attempt(HttpRequest request, String method, Duration retryDelay) {
-    try {
-      HttpResponse<String> response = httpClient.send(request, BodyHandlers.ofString());
-      int status = response.statusCode();
-      if (status < 400) {
-        LOGGER.info(
-            "Reported App Integrations availability: {} {} -> {}", method, request.uri(), status);
-        return;
-      }
-      if (status < 500) {
-        // Client error — retrying will not help, so stop.
-        LOGGER.warn(
-            "App Integrations cluster registration ({} {}) returned client error {}; giving up",
-            method,
-            request.uri(),
-            status);
-        return;
-      }
-      LOGGER.warn(
-          "App Integrations cluster registration ({} {}) returned {}; retrying in {}",
-          method,
-          request.uri(),
-          status,
-          retryDelay);
-    } catch (InterruptedException e) {
-      Thread.currentThread().interrupt();
-      LOGGER.warn(
-          "Interrupted while reporting App Integrations availability ({} {})",
-          method,
-          request.uri());
-      return;
-    } catch (Exception e) {
-      LOGGER.warn(
-          "Failed to report App Integrations availability ({} {}); retrying in {}: {}",
-          method,
-          request.uri(),
-          retryDelay,
-          e.getMessage());
+  private void attempt(Duration retryDelay) {
+    if (client.registerCluster(organizationId, clusterId, settingsPresent)
+        == RegistrationOutcome.RETRY) {
+      var doubled = retryDelay.multipliedBy(2);
+      var nextDelay = doubled.compareTo(maxRetryDelay) > 0 ? maxRetryDelay : doubled;
+      taskScheduler.schedule(() -> attempt(nextDelay), Instant.now().plus(retryDelay));
     }
-
-    var doubled = retryDelay.multipliedBy(2);
-    var nextDelay = doubled.compareTo(maxRetryDelay) > 0 ? maxRetryDelay : doubled;
-    taskScheduler.schedule(
-        () -> attempt(request, method, nextDelay), Instant.now().plus(retryDelay));
   }
 
   private static boolean isPresent(String value) {

--- a/bundle/camunda-saas-bundle/src/main/java/io/camunda/connector/runtime/saas/AppIntegrationsClusterRegistration.java
+++ b/bundle/camunda-saas-bundle/src/main/java/io/camunda/connector/runtime/saas/AppIntegrationsClusterRegistration.java
@@ -16,9 +16,6 @@
  */
 package io.camunda.connector.runtime.saas;
 
-import dev.failsafe.Failsafe;
-import dev.failsafe.RetryPolicy;
-import java.io.IOException;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
@@ -26,6 +23,7 @@ import java.net.http.HttpRequest.BodyPublishers;
 import java.net.http.HttpResponse;
 import java.net.http.HttpResponse.BodyHandlers;
 import java.time.Duration;
+import java.time.Instant;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -33,6 +31,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.context.annotation.Profile;
 import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.TaskScheduler;
 import org.springframework.stereotype.Component;
 
 /**
@@ -49,6 +48,11 @@ import org.springframework.stereotype.Component;
  * fleet-level values that address and authenticate the reporting endpoint (including the
  * disable/{@code DELETE} case). "Settings present" therefore refers to the per-cluster connector
  * configuration, detected by the presence of the connector's OAuth client credentials.
+ *
+ * <p>The report runs off the startup thread as a one-time scheduled task. A transient failure (I/O
+ * error or {@code 5xx}) reschedules the task with a capped exponential backoff, so the runtime
+ * keeps trying until the report succeeds. A client error ({@code 4xx}) is treated as permanent and
+ * is not retried. Nothing here can prevent the runtime from starting.
  */
 @Component
 @Profile("!test")
@@ -59,8 +63,8 @@ public class AppIntegrationsClusterRegistration {
   private static final Logger LOGGER =
       LoggerFactory.getLogger(AppIntegrationsClusterRegistration.class);
   private static final Duration TIMEOUT = Duration.ofSeconds(10);
-  private static final int MAX_RETRIES = 3;
-  private static final Duration RETRY_DELAY = Duration.ofSeconds(2);
+  private static final Duration INITIAL_RETRY_DELAY = Duration.ofSeconds(5);
+  private static final Duration MAX_RETRY_DELAY = Duration.ofMinutes(5);
 
   private final String baseUrl;
   private final String apiKey;
@@ -68,8 +72,9 @@ public class AppIntegrationsClusterRegistration {
   private final String organizationId;
   private final String clusterId;
   private final HttpClient httpClient;
-  private final int maxRetries;
-  private final Duration retryDelay;
+  private final TaskScheduler taskScheduler;
+  private final Duration initialRetryDelay;
+  private final Duration maxRetryDelay;
 
   @Autowired
   public AppIntegrationsClusterRegistration(
@@ -78,7 +83,8 @@ public class AppIntegrationsClusterRegistration {
       @Value("${APP_INTEGRATIONS_OAUTH_CLIENT_ID:}") String oauthClientId,
       @Value("${APP_INTEGRATIONS_OAUTH_CLIENT_SECRET:}") String oauthClientSecret,
       @Value("${camunda.connector.cloud.organization.id:}") String organizationId,
-      @Value("${camunda.client.cloud.clusterId:}") String clusterId) {
+      @Value("${camunda.client.cloud.clusterId:}") String clusterId,
+      TaskScheduler taskScheduler) {
     this(
         baseUrl,
         apiKey,
@@ -88,27 +94,9 @@ public class AppIntegrationsClusterRegistration {
         organizationId,
         clusterId,
         HttpClient.newBuilder().connectTimeout(TIMEOUT).build(),
-        MAX_RETRIES,
-        RETRY_DELAY);
-  }
-
-  AppIntegrationsClusterRegistration(
-      String baseUrl,
-      String apiKey,
-      boolean settingsPresent,
-      String organizationId,
-      String clusterId,
-      HttpClient httpClient) {
-    // Convenience for tests: short retry delay so the retry path runs quickly.
-    this(
-        baseUrl,
-        apiKey,
-        settingsPresent,
-        organizationId,
-        clusterId,
-        httpClient,
-        2,
-        Duration.ofMillis(1));
+        taskScheduler,
+        INITIAL_RETRY_DELAY,
+        MAX_RETRY_DELAY);
   }
 
   AppIntegrationsClusterRegistration(
@@ -118,16 +106,39 @@ public class AppIntegrationsClusterRegistration {
       String organizationId,
       String clusterId,
       HttpClient httpClient,
-      int maxRetries,
-      Duration retryDelay) {
+      TaskScheduler taskScheduler) {
+    // Convenience for tests: short retry delays so the backoff numbers stay small.
+    this(
+        baseUrl,
+        apiKey,
+        settingsPresent,
+        organizationId,
+        clusterId,
+        httpClient,
+        taskScheduler,
+        Duration.ofMillis(1),
+        Duration.ofMillis(10));
+  }
+
+  AppIntegrationsClusterRegistration(
+      String baseUrl,
+      String apiKey,
+      boolean settingsPresent,
+      String organizationId,
+      String clusterId,
+      HttpClient httpClient,
+      TaskScheduler taskScheduler,
+      Duration initialRetryDelay,
+      Duration maxRetryDelay) {
     this.baseUrl = baseUrl;
     this.apiKey = apiKey;
     this.settingsPresent = settingsPresent;
     this.organizationId = organizationId;
     this.clusterId = clusterId;
     this.httpClient = httpClient;
-    this.maxRetries = maxRetries;
-    this.retryDelay = retryDelay;
+    this.taskScheduler = taskScheduler;
+    this.initialRetryDelay = initialRetryDelay;
+    this.maxRetryDelay = maxRetryDelay;
   }
 
   @EventListener(ApplicationReadyEvent.class)
@@ -142,62 +153,76 @@ public class AppIntegrationsClusterRegistration {
       return;
     }
 
-    var uri =
-        URI.create(
-            baseUrl.replaceAll("/+$", "") + "/api/connector/" + organizationId + "/" + clusterId);
+    // Build the request up front so a malformed base URL (or invalid org/cluster id) fails fast
+    // here rather than escaping the startup thread or looping forever on the scheduler.
+    final HttpRequest request;
     var method = settingsPresent ? "PUT" : "DELETE";
-    var request =
-        HttpRequest.newBuilder(uri)
-            .timeout(TIMEOUT)
-            .header(API_KEY_HEADER, apiKey)
-            .method(method, BodyPublishers.noBody())
-            .build();
-
-    // Retry transient failures (I/O errors and 5xx responses) with a bounded, backing-off policy,
-    // mirroring the Failsafe usage elsewhere in the runtime. Client errors (4xx) are not retried.
-    RetryPolicy<HttpResponse<String>> retryPolicy =
-        RetryPolicy.<HttpResponse<String>>builder()
-            .handle(IOException.class)
-            .handleResultIf(response -> response != null && response.statusCode() >= 500)
-            .withBackoff(retryDelay, retryDelay.multipliedBy(8))
-            .withMaxRetries(maxRetries)
-            .onRetry(
-                event ->
-                    LOGGER.warn(
-                        "Retrying App Integrations cluster registration ({} {}) after attempt {} failed",
-                        method,
-                        uri,
-                        event.getAttemptCount()))
-            .build();
-
     try {
-      HttpResponse<String> response =
-          Failsafe.with(retryPolicy).get(() -> httpClient.send(request, BodyHandlers.ofString()));
-      if (response.statusCode() >= 400) {
-        LOGGER.warn(
-            "App Integrations cluster registration ({} {}) returned status {}",
-            method,
-            uri,
-            response.statusCode());
-      } else {
+      var uri =
+          URI.create(
+              baseUrl.replaceAll("/+$", "") + "/api/connector/" + organizationId + "/" + clusterId);
+      request =
+          HttpRequest.newBuilder(uri)
+              .timeout(TIMEOUT)
+              .header(API_KEY_HEADER, apiKey)
+              .method(method, BodyPublishers.noBody())
+              .build();
+    } catch (RuntimeException e) {
+      LOGGER.warn(
+          "Skipping App Integrations cluster registration: cannot build request for base URL '{}': {}",
+          baseUrl,
+          e.getMessage());
+      return;
+    }
+
+    // Run off the startup thread; retry transient failures until the report succeeds.
+    taskScheduler.schedule(() -> attempt(request, method, initialRetryDelay), Instant.now());
+  }
+
+  private void attempt(HttpRequest request, String method, Duration retryDelay) {
+    try {
+      HttpResponse<String> response = httpClient.send(request, BodyHandlers.ofString());
+      int status = response.statusCode();
+      if (status < 400) {
         LOGGER.info(
-            "Reported App Integrations availability: {} {} -> {}",
-            method,
-            uri,
-            response.statusCode());
+            "Reported App Integrations availability: {} {} -> {}", method, request.uri(), status);
+        return;
       }
-    } catch (Exception e) {
-      // Never let a reporting failure prevent the runtime from starting.
-      if (e instanceof InterruptedException || e.getCause() instanceof InterruptedException) {
-        Thread.currentThread().interrupt();
+      if (status < 500) {
+        // Client error — retrying will not help, so stop.
+        LOGGER.warn(
+            "App Integrations cluster registration ({} {}) returned client error {}; giving up",
+            method,
+            request.uri(),
+            status);
+        return;
       }
       LOGGER.warn(
-          "Failed to report App Integrations availability ({} {}): {}",
+          "App Integrations cluster registration ({} {}) returned {}; retrying in {}",
           method,
-          uri,
-          e.getMessage(),
-          e);
+          request.uri(),
+          status,
+          retryDelay);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      LOGGER.warn(
+          "Interrupted while reporting App Integrations availability ({} {})",
+          method,
+          request.uri());
+      return;
+    } catch (Exception e) {
+      LOGGER.warn(
+          "Failed to report App Integrations availability ({} {}); retrying in {}: {}",
+          method,
+          request.uri(),
+          retryDelay,
+          e.getMessage());
     }
+
+    var doubled = retryDelay.multipliedBy(2);
+    var nextDelay = doubled.compareTo(maxRetryDelay) > 0 ? maxRetryDelay : doubled;
+    taskScheduler.schedule(
+        () -> attempt(request, method, nextDelay), Instant.now().plus(retryDelay));
   }
 
   private static boolean isPresent(String value) {

--- a/bundle/camunda-saas-bundle/src/main/java/io/camunda/connector/runtime/saas/AppIntegrationsClusterRegistration.java
+++ b/bundle/camunda-saas-bundle/src/main/java/io/camunda/connector/runtime/saas/AppIntegrationsClusterRegistration.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.runtime.saas;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpRequest.BodyPublishers;
+import java.net.http.HttpResponse;
+import java.net.http.HttpResponse.BodyHandlers;
+import java.time.Duration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.annotation.Profile;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+/**
+ * Reports this SaaS cluster's App Integrations connector availability to the App Integrations
+ * backend when the runtime starts.
+ *
+ * <p>If the App Integrations connector settings are provisioned for the cluster, the runtime
+ * registers the cluster with {@code PUT /api/connector/{orgId}/{clusterId}}; otherwise it
+ * deregisters it with {@code DELETE /api/connector/{orgId}/{clusterId}}. Both requests are
+ * authenticated with a shared API key ({@code APP_INTEGRATIONS_SECRET}) sent in the {@code
+ * X-API-KEY} header — no OAuth client is built here.
+ *
+ * <p>{@code APP_INTEGRATIONS_BASE_URL} and {@code APP_INTEGRATIONS_SECRET} are fleet-level values
+ * that address and authenticate the reporting endpoint (including the disable/{@code DELETE} case).
+ * "Settings present" therefore refers to the per-cluster connector configuration, detected by the
+ * presence of the connector's OAuth client credentials.
+ */
+@Component
+@Profile("!test")
+public class AppIntegrationsClusterRegistration {
+
+  static final String API_KEY_HEADER = "X-API-KEY";
+
+  private static final Logger LOGGER =
+      LoggerFactory.getLogger(AppIntegrationsClusterRegistration.class);
+  private static final Duration TIMEOUT = Duration.ofSeconds(10);
+
+  private final String baseUrl;
+  private final String apiKey;
+  private final boolean settingsPresent;
+  private final String organizationId;
+  private final String clusterId;
+  private final HttpClient httpClient;
+
+  @Autowired
+  public AppIntegrationsClusterRegistration(
+      @Value("${APP_INTEGRATIONS_BASE_URL:}") String baseUrl,
+      @Value("${APP_INTEGRATIONS_SECRET:}") String apiKey,
+      @Value("${APP_INTEGRATIONS_OAUTH_CLIENT_ID:}") String oauthClientId,
+      @Value("${APP_INTEGRATIONS_OAUTH_CLIENT_SECRET:}") String oauthClientSecret,
+      @Value("${camunda.connector.cloud.organization.id:}") String organizationId,
+      @Value("${camunda.client.cloud.clusterId:}") String clusterId) {
+    this(
+        baseUrl,
+        apiKey,
+        // The App Integrations connector is provisioned for this cluster when its per-cluster OAuth
+        // client credentials are present.
+        isPresent(oauthClientId) && isPresent(oauthClientSecret),
+        organizationId,
+        clusterId,
+        HttpClient.newBuilder().connectTimeout(TIMEOUT).build());
+  }
+
+  AppIntegrationsClusterRegistration(
+      String baseUrl,
+      String apiKey,
+      boolean settingsPresent,
+      String organizationId,
+      String clusterId,
+      HttpClient httpClient) {
+    this.baseUrl = baseUrl;
+    this.apiKey = apiKey;
+    this.settingsPresent = settingsPresent;
+    this.organizationId = organizationId;
+    this.clusterId = clusterId;
+    this.httpClient = httpClient;
+  }
+
+  @EventListener(ApplicationReadyEvent.class)
+  public void reportAvailability() {
+    if (!isPresent(baseUrl)
+        || !isPresent(apiKey)
+        || !isPresent(organizationId)
+        || !isPresent(clusterId)) {
+      LOGGER.info(
+          "Skipping App Integrations cluster registration: base URL, API key, organization id or "
+              + "cluster id is not configured");
+      return;
+    }
+
+    var uri =
+        URI.create(
+            baseUrl.replaceAll("/+$", "") + "/api/connector/" + organizationId + "/" + clusterId);
+    var method = settingsPresent ? "PUT" : "DELETE";
+    try {
+      var request =
+          HttpRequest.newBuilder(uri)
+              .timeout(TIMEOUT)
+              .header(API_KEY_HEADER, apiKey)
+              .method(method, BodyPublishers.noBody())
+              .build();
+      HttpResponse<String> response = httpClient.send(request, BodyHandlers.ofString());
+      if (response.statusCode() >= 400) {
+        LOGGER.warn(
+            "App Integrations cluster registration ({} {}) returned status {}",
+            method,
+            uri,
+            response.statusCode());
+      } else {
+        LOGGER.info(
+            "Reported App Integrations availability: {} {} -> {}",
+            method,
+            uri,
+            response.statusCode());
+      }
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      LOGGER.warn(
+          "Interrupted while reporting App Integrations availability ({} {})", method, uri, e);
+    } catch (Exception e) {
+      // Never let a reporting failure prevent the runtime from starting.
+      LOGGER.warn(
+          "Failed to report App Integrations availability ({} {}): {}",
+          method,
+          uri,
+          e.getMessage(),
+          e);
+    }
+  }
+
+  private static boolean isPresent(String value) {
+    return value != null && !value.isBlank();
+  }
+}

--- a/bundle/camunda-saas-bundle/src/main/java/io/camunda/connector/runtime/saas/AppIntegrationsClusterRegistration.java
+++ b/bundle/camunda-saas-bundle/src/main/java/io/camunda/connector/runtime/saas/AppIntegrationsClusterRegistration.java
@@ -16,6 +16,9 @@
  */
 package io.camunda.connector.runtime.saas;
 
+import dev.failsafe.Failsafe;
+import dev.failsafe.RetryPolicy;
+import java.io.IOException;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
@@ -56,6 +59,8 @@ public class AppIntegrationsClusterRegistration {
   private static final Logger LOGGER =
       LoggerFactory.getLogger(AppIntegrationsClusterRegistration.class);
   private static final Duration TIMEOUT = Duration.ofSeconds(10);
+  private static final int MAX_RETRIES = 3;
+  private static final Duration RETRY_DELAY = Duration.ofSeconds(2);
 
   private final String baseUrl;
   private final String apiKey;
@@ -63,6 +68,8 @@ public class AppIntegrationsClusterRegistration {
   private final String organizationId;
   private final String clusterId;
   private final HttpClient httpClient;
+  private final int maxRetries;
+  private final Duration retryDelay;
 
   @Autowired
   public AppIntegrationsClusterRegistration(
@@ -80,7 +87,9 @@ public class AppIntegrationsClusterRegistration {
         isPresent(oauthClientId) && isPresent(oauthClientSecret),
         organizationId,
         clusterId,
-        HttpClient.newBuilder().connectTimeout(TIMEOUT).build());
+        HttpClient.newBuilder().connectTimeout(TIMEOUT).build(),
+        MAX_RETRIES,
+        RETRY_DELAY);
   }
 
   AppIntegrationsClusterRegistration(
@@ -90,12 +99,35 @@ public class AppIntegrationsClusterRegistration {
       String organizationId,
       String clusterId,
       HttpClient httpClient) {
+    // Convenience for tests: short retry delay so the retry path runs quickly.
+    this(
+        baseUrl,
+        apiKey,
+        settingsPresent,
+        organizationId,
+        clusterId,
+        httpClient,
+        2,
+        Duration.ofMillis(1));
+  }
+
+  AppIntegrationsClusterRegistration(
+      String baseUrl,
+      String apiKey,
+      boolean settingsPresent,
+      String organizationId,
+      String clusterId,
+      HttpClient httpClient,
+      int maxRetries,
+      Duration retryDelay) {
     this.baseUrl = baseUrl;
     this.apiKey = apiKey;
     this.settingsPresent = settingsPresent;
     this.organizationId = organizationId;
     this.clusterId = clusterId;
     this.httpClient = httpClient;
+    this.maxRetries = maxRetries;
+    this.retryDelay = retryDelay;
   }
 
   @EventListener(ApplicationReadyEvent.class)
@@ -114,14 +146,33 @@ public class AppIntegrationsClusterRegistration {
         URI.create(
             baseUrl.replaceAll("/+$", "") + "/api/connector/" + organizationId + "/" + clusterId);
     var method = settingsPresent ? "PUT" : "DELETE";
+    var request =
+        HttpRequest.newBuilder(uri)
+            .timeout(TIMEOUT)
+            .header(API_KEY_HEADER, apiKey)
+            .method(method, BodyPublishers.noBody())
+            .build();
+
+    // Retry transient failures (I/O errors and 5xx responses) with a bounded, backing-off policy,
+    // mirroring the Failsafe usage elsewhere in the runtime. Client errors (4xx) are not retried.
+    RetryPolicy<HttpResponse<String>> retryPolicy =
+        RetryPolicy.<HttpResponse<String>>builder()
+            .handle(IOException.class)
+            .handleResultIf(response -> response != null && response.statusCode() >= 500)
+            .withBackoff(retryDelay, retryDelay.multipliedBy(8))
+            .withMaxRetries(maxRetries)
+            .onRetry(
+                event ->
+                    LOGGER.warn(
+                        "Retrying App Integrations cluster registration ({} {}) after attempt {} failed",
+                        method,
+                        uri,
+                        event.getAttemptCount()))
+            .build();
+
     try {
-      var request =
-          HttpRequest.newBuilder(uri)
-              .timeout(TIMEOUT)
-              .header(API_KEY_HEADER, apiKey)
-              .method(method, BodyPublishers.noBody())
-              .build();
-      HttpResponse<String> response = httpClient.send(request, BodyHandlers.ofString());
+      HttpResponse<String> response =
+          Failsafe.with(retryPolicy).get(() -> httpClient.send(request, BodyHandlers.ofString()));
       if (response.statusCode() >= 400) {
         LOGGER.warn(
             "App Integrations cluster registration ({} {}) returned status {}",
@@ -135,12 +186,11 @@ public class AppIntegrationsClusterRegistration {
             uri,
             response.statusCode());
       }
-    } catch (InterruptedException e) {
-      Thread.currentThread().interrupt();
-      LOGGER.warn(
-          "Interrupted while reporting App Integrations availability ({} {})", method, uri, e);
     } catch (Exception e) {
       // Never let a reporting failure prevent the runtime from starting.
+      if (e instanceof InterruptedException || e.getCause() instanceof InterruptedException) {
+        Thread.currentThread().interrupt();
+      }
       LOGGER.warn(
           "Failed to report App Integrations availability ({} {}): {}",
           method,

--- a/bundle/camunda-saas-bundle/src/main/java/io/camunda/connector/runtime/saas/AppIntegrationsClusterRegistration.java
+++ b/bundle/camunda-saas-bundle/src/main/java/io/camunda/connector/runtime/saas/AppIntegrationsClusterRegistration.java
@@ -42,13 +42,13 @@ import org.springframework.stereotype.Component;
  * <p>If the App Integrations connector settings are provisioned for the cluster, the runtime
  * registers the cluster with {@code PUT /api/connector/{orgId}/{clusterId}}; otherwise it
  * deregisters it with {@code DELETE /api/connector/{orgId}/{clusterId}}. Both requests are
- * authenticated with a shared API key ({@code APP_INTEGRATIONS_SECRET}) sent in the {@code
- * X-API-KEY} header — no OAuth client is built here.
+ * authenticated with a shared API key ({@code APP_INTEGRATIONS_CONNECTOR_SECRET}) sent in the
+ * {@code X-API-KEY} header — no OAuth client is built here.
  *
- * <p>{@code APP_INTEGRATIONS_BASE_URL} and {@code APP_INTEGRATIONS_SECRET} are fleet-level values
- * that address and authenticate the reporting endpoint (including the disable/{@code DELETE} case).
- * "Settings present" therefore refers to the per-cluster connector configuration, detected by the
- * presence of the connector's OAuth client credentials.
+ * <p>{@code APP_INTEGRATIONS_BASE_URL} and {@code APP_INTEGRATIONS_CONNECTOR_SECRET} are
+ * fleet-level values that address and authenticate the reporting endpoint (including the
+ * disable/{@code DELETE} case). "Settings present" therefore refers to the per-cluster connector
+ * configuration, detected by the presence of the connector's OAuth client credentials.
  */
 @Component
 @Profile("!test")
@@ -74,7 +74,7 @@ public class AppIntegrationsClusterRegistration {
   @Autowired
   public AppIntegrationsClusterRegistration(
       @Value("${APP_INTEGRATIONS_BASE_URL:}") String baseUrl,
-      @Value("${APP_INTEGRATIONS_SECRET:}") String apiKey,
+      @Value("${APP_INTEGRATIONS_CONNECTOR_SECRET:}") String apiKey,
       @Value("${APP_INTEGRATIONS_OAUTH_CLIENT_ID:}") String oauthClientId,
       @Value("${APP_INTEGRATIONS_OAUTH_CLIENT_SECRET:}") String oauthClientSecret,
       @Value("${camunda.connector.cloud.organization.id:}") String organizationId,

--- a/bundle/camunda-saas-bundle/src/test/java/io/camunda/connector/runtime/saas/AppIntegrationsClientTest.java
+++ b/bundle/camunda-saas-bundle/src/test/java/io/camunda/connector/runtime/saas/AppIntegrationsClientTest.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.runtime.saas;
+
+import static io.camunda.connector.runtime.saas.AppIntegrationsClient.API_KEY_HEADER;
+import static io.camunda.connector.runtime.saas.AppIntegrationsClient.RegistrationOutcome.DONE;
+import static io.camunda.connector.runtime.saas.AppIntegrationsClient.RegistrationOutcome.RETRY;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import io.camunda.connector.runtime.saas.AppIntegrationsClient.RegistrationOutcome;
+import java.io.IOException;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+class AppIntegrationsClientTest {
+
+  private static final String BASE_URL = "https://app-integrations.example.com";
+  private static final String API_KEY = "secret-key";
+  private static final String ORG_ID = "org-1";
+  private static final String CLUSTER_ID = "cluster-1";
+  private static final String EXPECTED_URI =
+      "https://app-integrations.example.com/api/connector/org-1/cluster-1";
+
+  private HttpClient httpClient;
+
+  @BeforeEach
+  void setUp() {
+    httpClient = mock(HttpClient.class);
+  }
+
+  @Test
+  void sendsPutWithApiKeyWhenSettingsPresent() throws Exception {
+    stubResponse(200);
+
+    RegistrationOutcome outcome = client().registerCluster(ORG_ID, CLUSTER_ID, true);
+
+    HttpRequest request = capturedRequest();
+    assertThat(request.method()).isEqualTo("PUT");
+    assertThat(request.uri()).hasToString(EXPECTED_URI);
+    assertThat(request.headers().firstValue(API_KEY_HEADER)).contains(API_KEY);
+    assertThat(outcome).isEqualTo(DONE);
+  }
+
+  @Test
+  void sendsDeleteWhenSettingsAbsent() throws Exception {
+    stubResponse(200);
+
+    client().registerCluster(ORG_ID, CLUSTER_ID, false);
+
+    assertThat(capturedRequest().method()).isEqualTo("DELETE");
+  }
+
+  @Test
+  void trimsTrailingSlashesFromBaseUrl() throws Exception {
+    stubResponse(200);
+
+    new AppIntegrationsClient(BASE_URL + "///", API_KEY, httpClient)
+        .registerCluster(ORG_ID, CLUSTER_ID, true);
+
+    assertThat(capturedRequest().uri()).hasToString(EXPECTED_URI);
+  }
+
+  @Test
+  void successfulResponseIsDone() throws Exception {
+    stubResponse(204);
+    assertThat(client().registerCluster(ORG_ID, CLUSTER_ID, true)).isEqualTo(DONE);
+  }
+
+  @Test
+  void clientErrorIsDoneAndNotRetried() throws Exception {
+    stubResponse(404);
+    assertThat(client().registerCluster(ORG_ID, CLUSTER_ID, true)).isEqualTo(DONE);
+  }
+
+  @Test
+  void serverErrorIsRetryable() throws Exception {
+    stubResponse(503);
+    assertThat(client().registerCluster(ORG_ID, CLUSTER_ID, true)).isEqualTo(RETRY);
+  }
+
+  @Test
+  void ioErrorIsRetryable() throws Exception {
+    doThrow(new IOException("boom")).when(httpClient).send(any(HttpRequest.class), any());
+    assertThat(client().registerCluster(ORG_ID, CLUSTER_ID, true)).isEqualTo(RETRY);
+  }
+
+  @Test
+  void malformedBaseUrlIsDoneWithoutSending() {
+    RegistrationOutcome outcome =
+        new AppIntegrationsClient("http://space in url", API_KEY, httpClient)
+            .registerCluster(ORG_ID, CLUSTER_ID, true);
+
+    assertThat(outcome).isEqualTo(DONE);
+    verifyNoInteractions(httpClient);
+  }
+
+  @Test
+  void isConfiguredReflectsBaseUrlAndApiKey() {
+    assertThat(new AppIntegrationsClient(BASE_URL, API_KEY, httpClient).isConfigured()).isTrue();
+    assertThat(new AppIntegrationsClient("", API_KEY, httpClient).isConfigured()).isFalse();
+    assertThat(new AppIntegrationsClient(BASE_URL, "  ", httpClient).isConfigured()).isFalse();
+  }
+
+  private AppIntegrationsClient client() {
+    return new AppIntegrationsClient(BASE_URL, API_KEY, httpClient);
+  }
+
+  private void stubResponse(int status) throws Exception {
+    HttpResponse<?> response = mock(HttpResponse.class);
+    when(response.statusCode()).thenReturn(status);
+    doReturn(response).when(httpClient).send(any(HttpRequest.class), any());
+  }
+
+  private HttpRequest capturedRequest() throws Exception {
+    ArgumentCaptor<HttpRequest> captor = ArgumentCaptor.forClass(HttpRequest.class);
+    verify(httpClient).send(captor.capture(), any());
+    return captor.getValue();
+  }
+}

--- a/bundle/camunda-saas-bundle/src/test/java/io/camunda/connector/runtime/saas/AppIntegrationsClusterRegistrationTest.java
+++ b/bundle/camunda-saas-bundle/src/test/java/io/camunda/connector/runtime/saas/AppIntegrationsClusterRegistrationTest.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.runtime.saas;
+
+import static io.camunda.connector.runtime.saas.AppIntegrationsClusterRegistration.API_KEY_HEADER;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+class AppIntegrationsClusterRegistrationTest {
+
+  private static final String BASE_URL = "https://app-integrations.example.com";
+  private static final String API_KEY = "secret-key";
+  private static final String ORG_ID = "org-1";
+  private static final String CLUSTER_ID = "cluster-1";
+  private static final String EXPECTED_URI =
+      "https://app-integrations.example.com/api/connector/org-1/cluster-1";
+
+  private HttpClient httpClient;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    httpClient = mock(HttpClient.class);
+    HttpResponse<?> response = mock(HttpResponse.class);
+    when(response.statusCode()).thenReturn(200);
+    doReturn(response).when(httpClient).send(any(HttpRequest.class), any());
+  }
+
+  @Test
+  void sendsPutWithApiKeyWhenSettingsPresent() throws Exception {
+    registration(true).reportAvailability();
+
+    HttpRequest request = capturedRequest();
+    assertThat(request.method()).isEqualTo("PUT");
+    assertThat(request.uri()).hasToString(EXPECTED_URI);
+    assertThat(request.headers().firstValue(API_KEY_HEADER)).contains(API_KEY);
+  }
+
+  @Test
+  void sendsDeleteWhenSettingsAbsent() throws Exception {
+    registration(false).reportAvailability();
+
+    HttpRequest request = capturedRequest();
+    assertThat(request.method()).isEqualTo("DELETE");
+    assertThat(request.uri()).hasToString(EXPECTED_URI);
+    assertThat(request.headers().firstValue(API_KEY_HEADER)).contains(API_KEY);
+  }
+
+  @Test
+  void skipsWhenBaseUrlMissing() {
+    new AppIntegrationsClusterRegistration("", API_KEY, true, ORG_ID, CLUSTER_ID, httpClient)
+        .reportAvailability();
+    verifyNoInteractions(httpClient);
+  }
+
+  @Test
+  void skipsWhenApiKeyMissing() {
+    new AppIntegrationsClusterRegistration(BASE_URL, "  ", true, ORG_ID, CLUSTER_ID, httpClient)
+        .reportAvailability();
+    verifyNoInteractions(httpClient);
+  }
+
+  @Test
+  void skipsWhenOrgIdMissing() {
+    new AppIntegrationsClusterRegistration(BASE_URL, API_KEY, true, null, CLUSTER_ID, httpClient)
+        .reportAvailability();
+    verifyNoInteractions(httpClient);
+  }
+
+  @Test
+  void skipsWhenClusterIdMissing() {
+    new AppIntegrationsClusterRegistration(BASE_URL, API_KEY, true, ORG_ID, null, httpClient)
+        .reportAvailability();
+    verifyNoInteractions(httpClient);
+  }
+
+  @Test
+  void trimsTrailingSlashesFromBaseUrl() throws Exception {
+    new AppIntegrationsClusterRegistration(
+            BASE_URL + "///", API_KEY, true, ORG_ID, CLUSTER_ID, httpClient)
+        .reportAvailability();
+    assertThat(capturedRequest().uri()).hasToString(EXPECTED_URI);
+  }
+
+  @Test
+  void doesNotThrowWhenHttpCallFails() throws Exception {
+    doThrow(new IOException("boom")).when(httpClient).send(any(HttpRequest.class), any());
+    assertThatCode(() -> registration(true).reportAvailability()).doesNotThrowAnyException();
+  }
+
+  private AppIntegrationsClusterRegistration registration(boolean settingsPresent) {
+    return new AppIntegrationsClusterRegistration(
+        BASE_URL, API_KEY, settingsPresent, ORG_ID, CLUSTER_ID, httpClient);
+  }
+
+  private HttpRequest capturedRequest() throws Exception {
+    ArgumentCaptor<HttpRequest> captor = ArgumentCaptor.forClass(HttpRequest.class);
+    verify(httpClient).send(captor.capture(), any());
+    return captor.getValue();
+  }
+}

--- a/bundle/camunda-saas-bundle/src/test/java/io/camunda/connector/runtime/saas/AppIntegrationsClusterRegistrationTest.java
+++ b/bundle/camunda-saas-bundle/src/test/java/io/camunda/connector/runtime/saas/AppIntegrationsClusterRegistrationTest.java
@@ -23,6 +23,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
@@ -116,9 +117,58 @@ class AppIntegrationsClusterRegistrationTest {
     assertThatCode(() -> registration(true).reportAvailability()).doesNotThrowAnyException();
   }
 
+  @Test
+  void retriesTransientIoErrorThenSucceeds() throws Exception {
+    HttpResponse<?> ok = responseWithStatus(200);
+    doThrow(new IOException("transient"))
+        .doReturn(ok)
+        .when(httpClient)
+        .send(any(HttpRequest.class), any());
+
+    registration(true).reportAvailability();
+
+    verify(httpClient, times(2)).send(any(HttpRequest.class), any());
+  }
+
+  @Test
+  void retriesServerErrorThenSucceeds() throws Exception {
+    HttpResponse<?> serverError = responseWithStatus(503);
+    HttpResponse<?> ok = responseWithStatus(200);
+    doReturn(serverError).doReturn(ok).when(httpClient).send(any(HttpRequest.class), any());
+
+    registration(true).reportAvailability();
+
+    verify(httpClient, times(2)).send(any(HttpRequest.class), any());
+  }
+
+  @Test
+  void doesNotRetryClientError() throws Exception {
+    HttpResponse<?> clientError = responseWithStatus(404);
+    doReturn(clientError).when(httpClient).send(any(HttpRequest.class), any());
+
+    registration(true).reportAvailability();
+
+    verify(httpClient, times(1)).send(any(HttpRequest.class), any());
+  }
+
+  @Test
+  void givesUpAfterExhaustingRetries() throws Exception {
+    doThrow(new IOException("boom")).when(httpClient).send(any(HttpRequest.class), any());
+
+    // Default test constructor allows 2 retries, i.e. 3 attempts in total.
+    assertThatCode(() -> registration(true).reportAvailability()).doesNotThrowAnyException();
+    verify(httpClient, times(3)).send(any(HttpRequest.class), any());
+  }
+
   private AppIntegrationsClusterRegistration registration(boolean settingsPresent) {
     return new AppIntegrationsClusterRegistration(
         BASE_URL, API_KEY, settingsPresent, ORG_ID, CLUSTER_ID, httpClient);
+  }
+
+  private static HttpResponse<?> responseWithStatus(int status) {
+    HttpResponse<?> response = mock(HttpResponse.class);
+    when(response.statusCode()).thenReturn(status);
+    return response;
   }
 
   private HttpRequest capturedRequest() throws Exception {

--- a/bundle/camunda-saas-bundle/src/test/java/io/camunda/connector/runtime/saas/AppIntegrationsClusterRegistrationTest.java
+++ b/bundle/camunda-saas-bundle/src/test/java/io/camunda/connector/runtime/saas/AppIntegrationsClusterRegistrationTest.java
@@ -18,7 +18,6 @@ package io.camunda.connector.runtime.saas;
 
 import static io.camunda.connector.runtime.saas.AppIntegrationsClusterRegistration.API_KEY_HEADER;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
@@ -32,9 +31,12 @@ import java.io.IOException;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.time.Instant;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
+import org.springframework.scheduling.TaskScheduler;
 
 class AppIntegrationsClusterRegistrationTest {
 
@@ -46,18 +48,27 @@ class AppIntegrationsClusterRegistrationTest {
       "https://app-integrations.example.com/api/connector/org-1/cluster-1";
 
   private HttpClient httpClient;
+  private TaskScheduler scheduler;
 
   @BeforeEach
-  void setUp() throws Exception {
+  void setUp() {
     httpClient = mock(HttpClient.class);
-    HttpResponse<?> response = mock(HttpResponse.class);
-    when(response.statusCode()).thenReturn(200);
-    doReturn(response).when(httpClient).send(any(HttpRequest.class), any());
+    scheduler = mock(TaskScheduler.class);
+  }
+
+  @Test
+  void schedulesReportOnStartupWithoutBlocking() {
+    registration(true).reportAvailability();
+
+    verify(scheduler, times(1)).schedule(any(Runnable.class), any(Instant.class));
+    verifyNoInteractions(httpClient);
   }
 
   @Test
   void sendsPutWithApiKeyWhenSettingsPresent() throws Exception {
+    stubResponse(200);
     registration(true).reportAvailability();
+    runScheduledTasks(1).get(0).run();
 
     HttpRequest request = capturedRequest();
     assertThat(request.method()).isEqualTo("PUT");
@@ -67,7 +78,9 @@ class AppIntegrationsClusterRegistrationTest {
 
   @Test
   void sendsDeleteWhenSettingsAbsent() throws Exception {
+    stubResponse(200);
     registration(false).reportAvailability();
+    runScheduledTasks(1).get(0).run();
 
     HttpRequest request = capturedRequest();
     assertThat(request.method()).isEqualTo("DELETE");
@@ -76,49 +89,108 @@ class AppIntegrationsClusterRegistrationTest {
   }
 
   @Test
-  void skipsWhenBaseUrlMissing() {
-    new AppIntegrationsClusterRegistration("", API_KEY, true, ORG_ID, CLUSTER_ID, httpClient)
+  void trimsTrailingSlashesFromBaseUrl() throws Exception {
+    stubResponse(200);
+    new AppIntegrationsClusterRegistration(
+            BASE_URL + "///", API_KEY, true, ORG_ID, CLUSTER_ID, httpClient, scheduler)
         .reportAvailability();
+    runScheduledTasks(1).get(0).run();
+
+    assertThat(capturedRequest().uri()).hasToString(EXPECTED_URI);
+  }
+
+  @Test
+  void skipsWhenBaseUrlMissing() {
+    new AppIntegrationsClusterRegistration(
+            "", API_KEY, true, ORG_ID, CLUSTER_ID, httpClient, scheduler)
+        .reportAvailability();
+    verifyNoInteractions(scheduler);
     verifyNoInteractions(httpClient);
   }
 
   @Test
   void skipsWhenApiKeyMissing() {
-    new AppIntegrationsClusterRegistration(BASE_URL, "  ", true, ORG_ID, CLUSTER_ID, httpClient)
+    new AppIntegrationsClusterRegistration(
+            BASE_URL, "  ", true, ORG_ID, CLUSTER_ID, httpClient, scheduler)
         .reportAvailability();
+    verifyNoInteractions(scheduler);
     verifyNoInteractions(httpClient);
   }
 
   @Test
   void skipsWhenOrgIdMissing() {
-    new AppIntegrationsClusterRegistration(BASE_URL, API_KEY, true, null, CLUSTER_ID, httpClient)
+    new AppIntegrationsClusterRegistration(
+            BASE_URL, API_KEY, true, null, CLUSTER_ID, httpClient, scheduler)
         .reportAvailability();
+    verifyNoInteractions(scheduler);
     verifyNoInteractions(httpClient);
   }
 
   @Test
   void skipsWhenClusterIdMissing() {
-    new AppIntegrationsClusterRegistration(BASE_URL, API_KEY, true, ORG_ID, null, httpClient)
+    new AppIntegrationsClusterRegistration(
+            BASE_URL, API_KEY, true, ORG_ID, null, httpClient, scheduler)
         .reportAvailability();
+    verifyNoInteractions(scheduler);
     verifyNoInteractions(httpClient);
   }
 
   @Test
-  void trimsTrailingSlashesFromBaseUrl() throws Exception {
+  void skipsWhenBaseUrlIsMalformed() {
     new AppIntegrationsClusterRegistration(
-            BASE_URL + "///", API_KEY, true, ORG_ID, CLUSTER_ID, httpClient)
+            "http://space in url", API_KEY, true, ORG_ID, CLUSTER_ID, httpClient, scheduler)
         .reportAvailability();
-    assertThat(capturedRequest().uri()).hasToString(EXPECTED_URI);
+    // A malformed base URL fails fast on the startup thread: nothing is scheduled or sent, and no
+    // exception escapes.
+    verifyNoInteractions(scheduler);
+    verifyNoInteractions(httpClient);
   }
 
   @Test
-  void doesNotThrowWhenHttpCallFails() throws Exception {
-    doThrow(new IOException("boom")).when(httpClient).send(any(HttpRequest.class), any());
-    assertThatCode(() -> registration(true).reportAvailability()).doesNotThrowAnyException();
+  void reschedulesOnTransientIoError() throws Exception {
+    doThrow(new IOException("transient")).when(httpClient).send(any(HttpRequest.class), any());
+
+    registration(true).reportAvailability();
+    runScheduledTasks(1).get(0).run();
+
+    // First attempt failed -> a retry was scheduled.
+    verify(scheduler, times(2)).schedule(any(Runnable.class), any(Instant.class));
   }
 
   @Test
-  void retriesTransientIoErrorThenSucceeds() throws Exception {
+  void reschedulesOnServerError() throws Exception {
+    stubResponse(503);
+
+    registration(true).reportAvailability();
+    runScheduledTasks(1).get(0).run();
+
+    verify(scheduler, times(2)).schedule(any(Runnable.class), any(Instant.class));
+  }
+
+  @Test
+  void doesNotRescheduleOnClientError() throws Exception {
+    stubResponse(404);
+
+    registration(true).reportAvailability();
+    runScheduledTasks(1).get(0).run();
+
+    // Only the initial schedule; a 4xx is treated as permanent.
+    verify(scheduler, times(1)).schedule(any(Runnable.class), any(Instant.class));
+    verify(httpClient, times(1)).send(any(HttpRequest.class), any());
+  }
+
+  @Test
+  void doesNotRescheduleOnSuccess() throws Exception {
+    stubResponse(200);
+
+    registration(true).reportAvailability();
+    runScheduledTasks(1).get(0).run();
+
+    verify(scheduler, times(1)).schedule(any(Runnable.class), any(Instant.class));
+  }
+
+  @Test
+  void retriesUntilItSucceeds() throws Exception {
     HttpResponse<?> ok = responseWithStatus(200);
     doThrow(new IOException("transient"))
         .doReturn(ok)
@@ -126,49 +198,36 @@ class AppIntegrationsClusterRegistrationTest {
         .send(any(HttpRequest.class), any());
 
     registration(true).reportAvailability();
+    List<Runnable> tasks = runScheduledTasks(1);
+    tasks.get(0).run(); // fails, reschedules
+    runScheduledTasks(2).get(1).run(); // succeeds, no further reschedule
 
+    verify(scheduler, times(2)).schedule(any(Runnable.class), any(Instant.class));
     verify(httpClient, times(2)).send(any(HttpRequest.class), any());
-  }
-
-  @Test
-  void retriesServerErrorThenSucceeds() throws Exception {
-    HttpResponse<?> serverError = responseWithStatus(503);
-    HttpResponse<?> ok = responseWithStatus(200);
-    doReturn(serverError).doReturn(ok).when(httpClient).send(any(HttpRequest.class), any());
-
-    registration(true).reportAvailability();
-
-    verify(httpClient, times(2)).send(any(HttpRequest.class), any());
-  }
-
-  @Test
-  void doesNotRetryClientError() throws Exception {
-    HttpResponse<?> clientError = responseWithStatus(404);
-    doReturn(clientError).when(httpClient).send(any(HttpRequest.class), any());
-
-    registration(true).reportAvailability();
-
-    verify(httpClient, times(1)).send(any(HttpRequest.class), any());
-  }
-
-  @Test
-  void givesUpAfterExhaustingRetries() throws Exception {
-    doThrow(new IOException("boom")).when(httpClient).send(any(HttpRequest.class), any());
-
-    // Default test constructor allows 2 retries, i.e. 3 attempts in total.
-    assertThatCode(() -> registration(true).reportAvailability()).doesNotThrowAnyException();
-    verify(httpClient, times(3)).send(any(HttpRequest.class), any());
   }
 
   private AppIntegrationsClusterRegistration registration(boolean settingsPresent) {
     return new AppIntegrationsClusterRegistration(
-        BASE_URL, API_KEY, settingsPresent, ORG_ID, CLUSTER_ID, httpClient);
+        BASE_URL, API_KEY, settingsPresent, ORG_ID, CLUSTER_ID, httpClient, scheduler);
+  }
+
+  private void stubResponse(int status) throws Exception {
+    doReturn(responseWithStatus(status)).when(httpClient).send(any(HttpRequest.class), any());
   }
 
   private static HttpResponse<?> responseWithStatus(int status) {
     HttpResponse<?> response = mock(HttpResponse.class);
     when(response.statusCode()).thenReturn(status);
     return response;
+  }
+
+  /**
+   * Captures the tasks scheduled so far (expects exactly {@code expectedCount}) without running.
+   */
+  private List<Runnable> runScheduledTasks(int expectedCount) {
+    ArgumentCaptor<Runnable> captor = ArgumentCaptor.forClass(Runnable.class);
+    verify(scheduler, times(expectedCount)).schedule(captor.capture(), any(Instant.class));
+    return captor.getAllValues();
   }
 
   private HttpRequest capturedRequest() throws Exception {

--- a/bundle/camunda-saas-bundle/src/test/java/io/camunda/connector/runtime/saas/AppIntegrationsClusterRegistrationTest.java
+++ b/bundle/camunda-saas-bundle/src/test/java/io/camunda/connector/runtime/saas/AppIntegrationsClusterRegistrationTest.java
@@ -16,21 +16,18 @@
  */
 package io.camunda.connector.runtime.saas;
 
-import static io.camunda.connector.runtime.saas.AppIntegrationsClusterRegistration.API_KEY_HEADER;
-import static org.assertj.core.api.Assertions.assertThat;
+import static io.camunda.connector.runtime.saas.AppIntegrationsClient.RegistrationOutcome.DONE;
+import static io.camunda.connector.runtime.saas.AppIntegrationsClient.RegistrationOutcome.RETRY;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.doThrow;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
-import java.io.IOException;
-import java.net.http.HttpClient;
-import java.net.http.HttpRequest;
-import java.net.http.HttpResponse;
 import java.time.Instant;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
@@ -40,126 +37,63 @@ import org.springframework.scheduling.TaskScheduler;
 
 class AppIntegrationsClusterRegistrationTest {
 
-  private static final String BASE_URL = "https://app-integrations.example.com";
-  private static final String API_KEY = "secret-key";
   private static final String ORG_ID = "org-1";
   private static final String CLUSTER_ID = "cluster-1";
-  private static final String EXPECTED_URI =
-      "https://app-integrations.example.com/api/connector/org-1/cluster-1";
 
-  private HttpClient httpClient;
+  private AppIntegrationsClient client;
   private TaskScheduler scheduler;
 
   @BeforeEach
   void setUp() {
-    httpClient = mock(HttpClient.class);
+    client = mock(AppIntegrationsClient.class);
     scheduler = mock(TaskScheduler.class);
+    when(client.isConfigured()).thenReturn(true);
   }
 
   @Test
-  void schedulesReportOnStartupWithoutBlocking() {
+  void schedulesReportOnStartupWithoutCallingClient() {
     registration(true).reportAvailability();
 
     verify(scheduler, times(1)).schedule(any(Runnable.class), any(Instant.class));
-    verifyNoInteractions(httpClient);
+    verify(client, never()).registerCluster(any(), any(), anyBoolean());
   }
 
   @Test
-  void sendsPutWithApiKeyWhenSettingsPresent() throws Exception {
-    stubResponse(200);
+  void skipsWhenClientNotConfigured() {
+    when(client.isConfigured()).thenReturn(false);
+
     registration(true).reportAvailability();
-    runScheduledTasks(1).get(0).run();
 
-    HttpRequest request = capturedRequest();
-    assertThat(request.method()).isEqualTo("PUT");
-    assertThat(request.uri()).hasToString(EXPECTED_URI);
-    assertThat(request.headers().firstValue(API_KEY_HEADER)).contains(API_KEY);
-  }
-
-  @Test
-  void sendsDeleteWhenSettingsAbsent() throws Exception {
-    stubResponse(200);
-    registration(false).reportAvailability();
-    runScheduledTasks(1).get(0).run();
-
-    HttpRequest request = capturedRequest();
-    assertThat(request.method()).isEqualTo("DELETE");
-    assertThat(request.uri()).hasToString(EXPECTED_URI);
-    assertThat(request.headers().firstValue(API_KEY_HEADER)).contains(API_KEY);
-  }
-
-  @Test
-  void trimsTrailingSlashesFromBaseUrl() throws Exception {
-    stubResponse(200);
-    new AppIntegrationsClusterRegistration(
-            BASE_URL + "///", API_KEY, true, ORG_ID, CLUSTER_ID, httpClient, scheduler)
-        .reportAvailability();
-    runScheduledTasks(1).get(0).run();
-
-    assertThat(capturedRequest().uri()).hasToString(EXPECTED_URI);
-  }
-
-  @Test
-  void skipsWhenBaseUrlMissing() {
-    new AppIntegrationsClusterRegistration(
-            "", API_KEY, true, ORG_ID, CLUSTER_ID, httpClient, scheduler)
-        .reportAvailability();
     verifyNoInteractions(scheduler);
-    verifyNoInteractions(httpClient);
-  }
-
-  @Test
-  void skipsWhenApiKeyMissing() {
-    new AppIntegrationsClusterRegistration(
-            BASE_URL, "  ", true, ORG_ID, CLUSTER_ID, httpClient, scheduler)
-        .reportAvailability();
-    verifyNoInteractions(scheduler);
-    verifyNoInteractions(httpClient);
   }
 
   @Test
   void skipsWhenOrgIdMissing() {
-    new AppIntegrationsClusterRegistration(
-            BASE_URL, API_KEY, true, null, CLUSTER_ID, httpClient, scheduler)
+    new AppIntegrationsClusterRegistration(client, scheduler, true, null, CLUSTER_ID)
         .reportAvailability();
     verifyNoInteractions(scheduler);
-    verifyNoInteractions(httpClient);
   }
 
   @Test
   void skipsWhenClusterIdMissing() {
-    new AppIntegrationsClusterRegistration(
-            BASE_URL, API_KEY, true, ORG_ID, null, httpClient, scheduler)
+    new AppIntegrationsClusterRegistration(client, scheduler, true, ORG_ID, "  ")
         .reportAvailability();
     verifyNoInteractions(scheduler);
-    verifyNoInteractions(httpClient);
   }
 
   @Test
-  void skipsWhenBaseUrlIsMalformed() {
-    new AppIntegrationsClusterRegistration(
-            "http://space in url", API_KEY, true, ORG_ID, CLUSTER_ID, httpClient, scheduler)
-        .reportAvailability();
-    // A malformed base URL fails fast on the startup thread: nothing is scheduled or sent, and no
-    // exception escapes.
-    verifyNoInteractions(scheduler);
-    verifyNoInteractions(httpClient);
-  }
+  void passesSettingsPresentToClient() {
+    when(client.registerCluster(any(), any(), anyBoolean())).thenReturn(DONE);
 
-  @Test
-  void reschedulesOnTransientIoError() throws Exception {
-    doThrow(new IOException("transient")).when(httpClient).send(any(HttpRequest.class), any());
-
-    registration(true).reportAvailability();
+    registration(false).reportAvailability();
     runScheduledTasks(1).get(0).run();
 
-    // First attempt failed -> a retry was scheduled.
-    verify(scheduler, times(2)).schedule(any(Runnable.class), any(Instant.class));
+    verify(client).registerCluster(ORG_ID, CLUSTER_ID, false);
   }
 
   @Test
-  void reschedulesOnServerError() throws Exception {
-    stubResponse(503);
+  void reschedulesWhenClientReportsRetry() {
+    when(client.registerCluster(eq(ORG_ID), eq(CLUSTER_ID), anyBoolean())).thenReturn(RETRY);
 
     registration(true).reportAvailability();
     runScheduledTasks(1).get(0).run();
@@ -168,20 +102,8 @@ class AppIntegrationsClusterRegistrationTest {
   }
 
   @Test
-  void doesNotRescheduleOnClientError() throws Exception {
-    stubResponse(404);
-
-    registration(true).reportAvailability();
-    runScheduledTasks(1).get(0).run();
-
-    // Only the initial schedule; a 4xx is treated as permanent.
-    verify(scheduler, times(1)).schedule(any(Runnable.class), any(Instant.class));
-    verify(httpClient, times(1)).send(any(HttpRequest.class), any());
-  }
-
-  @Test
-  void doesNotRescheduleOnSuccess() throws Exception {
-    stubResponse(200);
+  void doesNotRescheduleWhenClientReportsDone() {
+    when(client.registerCluster(eq(ORG_ID), eq(CLUSTER_ID), anyBoolean())).thenReturn(DONE);
 
     registration(true).reportAvailability();
     runScheduledTasks(1).get(0).run();
@@ -190,49 +112,28 @@ class AppIntegrationsClusterRegistrationTest {
   }
 
   @Test
-  void retriesUntilItSucceeds() throws Exception {
-    HttpResponse<?> ok = responseWithStatus(200);
-    doThrow(new IOException("transient"))
-        .doReturn(ok)
-        .when(httpClient)
-        .send(any(HttpRequest.class), any());
+  void retriesUntilDone() {
+    when(client.registerCluster(eq(ORG_ID), eq(CLUSTER_ID), anyBoolean()))
+        .thenReturn(RETRY)
+        .thenReturn(DONE);
 
     registration(true).reportAvailability();
-    List<Runnable> tasks = runScheduledTasks(1);
-    tasks.get(0).run(); // fails, reschedules
-    runScheduledTasks(2).get(1).run(); // succeeds, no further reschedule
+    runScheduledTasks(1).get(0).run(); // RETRY -> reschedules
+    runScheduledTasks(2).get(1).run(); // DONE -> no further reschedule
 
     verify(scheduler, times(2)).schedule(any(Runnable.class), any(Instant.class));
-    verify(httpClient, times(2)).send(any(HttpRequest.class), any());
+    verify(client, times(2)).registerCluster(ORG_ID, CLUSTER_ID, true);
   }
 
   private AppIntegrationsClusterRegistration registration(boolean settingsPresent) {
     return new AppIntegrationsClusterRegistration(
-        BASE_URL, API_KEY, settingsPresent, ORG_ID, CLUSTER_ID, httpClient, scheduler);
+        client, scheduler, settingsPresent, ORG_ID, CLUSTER_ID);
   }
 
-  private void stubResponse(int status) throws Exception {
-    doReturn(responseWithStatus(status)).when(httpClient).send(any(HttpRequest.class), any());
-  }
-
-  private static HttpResponse<?> responseWithStatus(int status) {
-    HttpResponse<?> response = mock(HttpResponse.class);
-    when(response.statusCode()).thenReturn(status);
-    return response;
-  }
-
-  /**
-   * Captures the tasks scheduled so far (expects exactly {@code expectedCount}) without running.
-   */
+  /** Captures the tasks scheduled so far (expects exactly {@code expectedCount}). */
   private List<Runnable> runScheduledTasks(int expectedCount) {
     ArgumentCaptor<Runnable> captor = ArgumentCaptor.forClass(Runnable.class);
     verify(scheduler, times(expectedCount)).schedule(captor.capture(), any(Instant.class));
     return captor.getAllValues();
-  }
-
-  private HttpRequest capturedRequest() throws Exception {
-    ArgumentCaptor<HttpRequest> captor = ArgumentCaptor.forClass(HttpRequest.class);
-    verify(httpClient).send(captor.capture(), any());
-    return captor.getValue();
   }
 }


### PR DESCRIPTION
## Description

Reports each SaaS cluster's **App Integrations connector availability** to the App Integrations
backend when the connectors SaaS runtime starts.

A new component (`AppIntegrationsClusterRegistration`) in `bundle/camunda-saas-bundle` listens for
`ApplicationReadyEvent` and calls the App Integrations backend:

- **Settings present** (the connector is provisioned for the cluster) → `PUT {APP_INTEGRATIONS_BASE_URL}/api/connector/{orgId}/{clusterId}`
- **Settings absent** → `DELETE {APP_INTEGRATIONS_BASE_URL}/api/connector/{orgId}/{clusterId}`

`orgId` / `clusterId` come from `camunda.connector.cloud.organization.id` and
`camunda.client.cloud.clusterId`. Both requests are authenticated with a shared, always-available
API key sent in the `X-API-KEY` header (`APP_INTEGRATIONS_CONNECTOR_API_KEY`) — no OAuth client is built in
the SaaS runtime. The call uses the JDK `HttpClient`.

The report runs off the startup thread as a one-time task on the injected `TaskScheduler`. On a
transient failure (I/O error or `5xx`) it reschedules itself with a capped exponential backoff
(5s → 5min), so the runtime keeps retrying until the report succeeds. A client error (`4xx`) is
treated as permanent and is not retried. The request (including URI) is built up front inside a
guard, so a malformed base URL is skipped with a log rather than escaping startup or looping
forever. Nothing here can prevent the runtime from starting.

### Design notes

- `APP_INTEGRATIONS_BASE_URL` and `APP_INTEGRATIONS_CONNECTOR_API_KEY` are fleet-level values that address and
  authenticate the reporting endpoint (including the disable/`DELETE` case), so they are treated as
  always available.
- "Settings present" refers to the **per-cluster** connector configuration and is detected by the
  presence of the connector's OAuth client credentials (`APP_INTEGRATIONS_OAUTH_CLIENT_ID` /
  `APP_INTEGRATIONS_OAUTH_CLIENT_SECRET`).
- Reporting is skipped (and logged) when the base URL, API key, org id, or cluster id is missing.
- Any failure while reporting is caught and logged; it never prevents the runtime from starting.
- The component is excluded from the `test` profile, mirroring the other SaaS runtime configuration
  classes.

This runtime code does not depend on the App Integrations connector module (#7588) at compile time
— it only reads environment configuration and makes an HTTP call. The backend endpoint and the
`APP_INTEGRATIONS_BASE_URL` / `APP_INTEGRATIONS_CONNECTOR_API_KEY` provisioning are out of scope for this PR.

## Related issues

closes #7832

## Checklist

- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest
  release, as this branch will be rebased onto main before the next release. Example backport labels:
    - `backport stable/8.8`: for changes that should be included in the next 8.8.x release.
    - **or** `backport release-8.8.7`: for changes that should be included in the specific release 8.8.7, and this
      *release has already been created*. The release branch will be merged back into stable/8.8 later, so the change
      will be included in future 8.8.x releases as well.
- [x] Tests/Integration tests for the changes have been added if applicable.
- [ ] If the change requires a documentation update, it has been added to the appropriate section in the documentation.

