### PR TITLE
feat: add multi-instance forwarding to connector metrics APIs

### DIFF
--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/controller/InboundConnectorRestController.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/controller/InboundConnectorRestController.java
@@ -22,46 +22,29 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import io.camunda.connector.runtime.inbound.executable.*;
 import io.camunda.connector.runtime.instances.InstanceAwareModel;
 import io.camunda.connector.runtime.instances.service.InstanceForwardingRouter;
-import io.camunda.connector.runtime.metrics.ConnectorMetricsAggregator;
-import io.camunda.connector.runtime.metrics.InboundConnectorMetrics;
-import io.micrometer.core.instrument.MeterRegistry;
 import jakarta.servlet.http.HttpServletRequest;
 import java.util.Collection;
 import java.util.List;
-import java.util.Optional;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
 public class InboundConnectorRestController {
 
-  private static final Logger LOG = LoggerFactory.getLogger(InboundConnectorRestController.class);
-
   private final InboundExecutableRegistry executableRegistry;
   private final ConnectorDataMapper connectorDataMapper = new ConnectorDataMapper();
   private final InstanceForwardingRouter instanceForwardingRouter;
-  // null when MeterRegistry is not in the application context (e.g. no Actuator)
-  private final MeterRegistry meterRegistry;
 
   @Value("${camunda.connector.hostname:${HOSTNAME:localhost}}")
   private String hostname;
 
   public InboundConnectorRestController(
       InboundExecutableRegistry executableRegistry,
-      InstanceForwardingRouter instanceForwardingRouter,
-      Optional<MeterRegistry> meterRegistry) {
+      InstanceForwardingRouter instanceForwardingRouter) {
     this.executableRegistry = executableRegistry;
     this.instanceForwardingRouter = instanceForwardingRouter;
-    this.meterRegistry = meterRegistry.orElse(null);
-    if (this.meterRegistry == null) {
-      LOG.warn(
-          "No MeterRegistry bean found — inbound metrics endpoints will return empty results. "
-              + "Add spring-boot-starter-actuator to enable metrics.");
-    }
   }
 
   @GetMapping("/inbound")
@@ -127,22 +110,5 @@ public class InboundConnectorRestController {
         .stream()
         .map(connectorDataMapper::createActiveInboundConnectorResponse)
         .collect(Collectors.toList());
-  }
-
-  /** Returns aggregated inbound connector metrics across all connector types. */
-  @GetMapping("/inbound/metrics")
-  public InboundConnectorMetrics getMetrics() {
-    return ConnectorMetricsAggregator.inbound(meterRegistry, null);
-  }
-
-  /**
-   * Returns inbound connector metrics for a specific connector type.
-   *
-   * @param connectorType connector type (e.g. {@code io.camunda:webhook:1})
-   */
-  @GetMapping("/inbound/metrics/{connectorType}")
-  public InboundConnectorMetrics getMetricsByType(
-      @PathVariable(name = "connectorType") String connectorType) {
-    return ConnectorMetricsAggregator.inbound(meterRegistry, connectorType);
   }
 }

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/controller/InboundInstancesRestController.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/controller/InboundInstancesRestController.java
@@ -24,9 +24,14 @@ import io.camunda.connector.runtime.inbound.executable.*;
 import io.camunda.connector.runtime.instances.InstanceAwareModel;
 import io.camunda.connector.runtime.instances.service.InboundInstancesService;
 import io.camunda.connector.runtime.instances.service.InstanceForwardingRouter;
+import io.camunda.connector.runtime.metrics.ConnectorMetricsAggregator;
+import io.camunda.connector.runtime.metrics.InboundConnectorMetrics;
+import io.micrometer.core.instrument.MeterRegistry;
 import jakarta.servlet.http.HttpServletRequest;
 import java.util.List;
 import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.web.bind.annotation.*;
 
@@ -41,17 +46,28 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/inbound-instances")
 public class InboundInstancesRestController {
 
+  private static final Logger LOG = LoggerFactory.getLogger(InboundInstancesRestController.class);
+
   private final InstanceForwardingRouter instanceForwardingRouter;
   private final InboundInstancesService inboundInstancesService;
+  // null when MeterRegistry is not in the application context (e.g. no Actuator)
+  private final MeterRegistry meterRegistry;
 
   @Value("${camunda.connector.hostname:${HOSTNAME:localhost}}")
   private String hostname;
 
   public InboundInstancesRestController(
       InstanceForwardingRouter instanceForwardingRouter,
-      InboundInstancesService inboundInstancesService) {
+      InboundInstancesService inboundInstancesService,
+      Optional<MeterRegistry> meterRegistry) {
     this.instanceForwardingRouter = instanceForwardingRouter;
     this.inboundInstancesService = inboundInstancesService;
+    this.meterRegistry = meterRegistry.orElse(null);
+    if (this.meterRegistry == null) {
+      LOG.warn(
+          "No MeterRegistry bean found — inbound metrics endpoints will return empty results. "
+              + "Add spring-boot-starter-actuator to enable metrics.");
+    }
   }
 
   @GetMapping()
@@ -132,5 +148,34 @@ public class InboundInstancesRestController {
                 new TypeReference<>() {}))
         .orElseThrow(
             () -> new DataNotFoundException(ActiveInboundConnectorResponse.class, executableId));
+  }
+
+  /** Returns aggregated inbound connector metrics across all connector types. */
+  @GetMapping("/metrics")
+  public List<InboundConnectorMetrics> getMetrics(
+      HttpServletRequest request,
+      @RequestHeader(name = X_CAMUNDA_FORWARDED_FOR, required = false) String forwardedFor) {
+    return instanceForwardingRouter.forwardToInstancesAndReduceOrLocal(
+        request,
+        forwardedFor,
+        () -> List.of(ConnectorMetricsAggregator.inbound(meterRegistry, null, hostname)),
+        new TypeReference<>() {});
+  }
+
+  /**
+   * Returns inbound connector metrics for a specific connector type.
+   *
+   * @param connectorType connector type (e.g. {@code io.camunda:webhook:1})
+   */
+  @GetMapping("/metrics/{connectorType}")
+  public List<InboundConnectorMetrics> getMetricsByType(
+      HttpServletRequest request,
+      @RequestHeader(name = X_CAMUNDA_FORWARDED_FOR, required = false) String forwardedFor,
+      @PathVariable(name = "connectorType") String connectorType) {
+    return instanceForwardingRouter.forwardToInstancesAndReduceOrLocal(
+        request,
+        forwardedFor,
+        () -> List.of(ConnectorMetricsAggregator.inbound(meterRegistry, connectorType, hostname)),
+        new TypeReference<>() {});
   }
 }

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/controller/InboundInstancesRestController.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/controller/InboundInstancesRestController.java
@@ -158,7 +158,10 @@ public class InboundInstancesRestController {
     return instanceForwardingRouter.forwardToInstancesAndReduceOrLocal(
         request,
         forwardedFor,
-        () -> List.of(ConnectorMetricsAggregator.inbound(meterRegistry, null, hostname)),
+        () ->
+            meterRegistry == null
+                ? List.of()
+                : List.of(ConnectorMetricsAggregator.inbound(meterRegistry, null, hostname)),
         new TypeReference<>() {});
   }
 
@@ -175,7 +178,11 @@ public class InboundInstancesRestController {
     return instanceForwardingRouter.forwardToInstancesAndReduceOrLocal(
         request,
         forwardedFor,
-        () -> List.of(ConnectorMetricsAggregator.inbound(meterRegistry, connectorType, hostname)),
+        () ->
+            meterRegistry == null
+                ? List.of()
+                : List.of(
+                    ConnectorMetricsAggregator.inbound(meterRegistry, connectorType, hostname)),
         new TypeReference<>() {});
   }
 }

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/instances/reducer/ReducerRegistry.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/instances/reducer/ReducerRegistry.java
@@ -20,6 +20,8 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import io.camunda.connector.runtime.inbound.controller.ActiveInboundConnectorResponse;
 import io.camunda.connector.runtime.inbound.executable.ConnectorInstances;
 import io.camunda.connector.runtime.instances.InstanceAwareModel;
+import io.camunda.connector.runtime.metrics.InboundConnectorMetrics;
+import io.camunda.connector.runtime.metrics.OutboundConnectorMetrics;
 import io.camunda.connector.runtime.outbound.controller.OutboundConnectorResponse;
 import java.lang.reflect.Type;
 import java.util.Collection;
@@ -52,6 +54,12 @@ public class ReducerRegistry {
         Reducers.mergeListsReducer());
     reducers.put(
         new TypeReference<List<OutboundConnectorResponse>>() {}.getType(),
+        Reducers.mergeListsReducer());
+    reducers.put(
+        new TypeReference<List<OutboundConnectorMetrics>>() {}.getType(),
+        Reducers.mergeListsReducer());
+    reducers.put(
+        new TypeReference<List<InboundConnectorMetrics>>() {}.getType(),
         Reducers.mergeListsReducer());
   }
 

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/metrics/ConnectorMetricsAggregator.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/metrics/ConnectorMetricsAggregator.java
@@ -42,19 +42,22 @@ public final class ConnectorMetricsAggregator {
 
   /**
    * Returns outbound metrics for a specific connector type, or aggregated totals across all types
-   * when {@code connectorType} is {@code null} or blank.
+   * when {@code connectorType} is {@code null} or blank. {@code runtimeId} identifies the runtime
+   * node that produced these metrics.
    */
-  public static OutboundConnectorMetrics outbound(MeterRegistry registry, String connectorType) {
+  public static OutboundConnectorMetrics outbound(
+      MeterRegistry registry, String connectorType, String runtimeId) {
     if (registry == null) {
-      return new OutboundConnectorMetrics(null, null, null);
+      return new OutboundConnectorMetrics(runtimeId, null, null, null);
     }
     if (connectorType != null && !connectorType.isBlank()) {
-      return buildOutbound(registry, connectorType);
+      return buildOutbound(registry, connectorType, runtimeId);
     }
-    return buildOutboundAggregate(registry);
+    return buildOutboundAggregate(registry, runtimeId);
   }
 
-  private static OutboundConnectorMetrics buildOutboundAggregate(MeterRegistry registry) {
+  private static OutboundConnectorMetrics buildOutboundAggregate(
+      MeterRegistry registry, String runtimeId) {
     Set<String> types = discoverTypes(registry, null, allOutboundMetricNames());
 
     long completed = 0, failed = 0, bpmnError = 0;
@@ -122,6 +125,7 @@ public final class ConnectorMetricsAggregator {
             : null;
 
     return new OutboundConnectorMetrics(
+        runtimeId,
         new OutboundConnectorMetrics.Runtime(readRuntimeUptime(registry)),
         new OutboundConnectorMetrics.Job(
             completed,
@@ -133,7 +137,8 @@ public final class ConnectorMetricsAggregator {
         new OutboundConnectorMetrics.Worker(jobsActivated, jobsHandled, streamRecreations));
   }
 
-  private static OutboundConnectorMetrics buildOutbound(MeterRegistry registry, String type) {
+  private static OutboundConnectorMetrics buildOutbound(
+      MeterRegistry registry, String type, String runtimeId) {
     OutboundConnectorMetrics.ExecutionTime executionTime = buildExecutionTime(registry, type);
     Instant lastCompleted =
         epochMsToInstant(
@@ -143,6 +148,7 @@ public final class ConnectorMetricsAggregator {
             readGauge(registry, ConnectorMetrics.Outbound.METRIC_NAME_LAST_FAILED, type));
 
     return new OutboundConnectorMetrics(
+        runtimeId,
         new OutboundConnectorMetrics.Runtime(readRuntimeUptime(registry)),
         new OutboundConnectorMetrics.Job(
             sumCounterByAction(
@@ -211,19 +217,22 @@ public final class ConnectorMetricsAggregator {
 
   /**
    * Returns inbound metrics for a specific connector type, or aggregated totals across all types
-   * when {@code connectorType} is {@code null} or blank.
+   * when {@code connectorType} is {@code null} or blank. {@code runtimeId} identifies the runtime
+   * node that produced these metrics.
    */
-  public static InboundConnectorMetrics inbound(MeterRegistry registry, String connectorType) {
+  public static InboundConnectorMetrics inbound(
+      MeterRegistry registry, String connectorType, String runtimeId) {
     if (registry == null) {
-      return new InboundConnectorMetrics(null, null, null);
+      return new InboundConnectorMetrics(runtimeId, null, null, null);
     }
     if (connectorType != null && !connectorType.isBlank()) {
-      return buildInbound(registry, connectorType);
+      return buildInbound(registry, connectorType, runtimeId);
     }
-    return buildInboundAggregate(registry);
+    return buildInboundAggregate(registry, runtimeId);
   }
 
-  private static InboundConnectorMetrics buildInboundAggregate(MeterRegistry registry) {
+  private static InboundConnectorMetrics buildInboundAggregate(
+      MeterRegistry registry, String runtimeId) {
     Set<String> types = discoverTypes(registry, null, allInboundMetricNames());
 
     long activated = 0, deactivated = 0, activationFailed = 0;
@@ -285,6 +294,7 @@ public final class ConnectorMetricsAggregator {
     }
 
     return new InboundConnectorMetrics(
+        runtimeId,
         new InboundConnectorMetrics.Runtime(readRuntimeUptime(registry)),
         new InboundConnectorMetrics.Activation(
             activated, deactivated, activationFailed, epochMsToInstant(maxLastActivated)),
@@ -296,8 +306,10 @@ public final class ConnectorMetricsAggregator {
             epochMsToInstant(maxLastTriggered)));
   }
 
-  private static InboundConnectorMetrics buildInbound(MeterRegistry registry, String type) {
+  private static InboundConnectorMetrics buildInbound(
+      MeterRegistry registry, String type, String runtimeId) {
     return new InboundConnectorMetrics(
+        runtimeId,
         new InboundConnectorMetrics.Runtime(readRuntimeUptime(registry)),
         new InboundConnectorMetrics.Activation(
             sumCounterByAction(

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/metrics/InboundConnectorMetrics.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/metrics/InboundConnectorMetrics.java
@@ -22,12 +22,14 @@ import java.time.Instant;
 /**
  * Aggregated inbound connector metrics, grouped into three sections.
  *
+ * @param runtimeId hostname of the runtime node that reported these metrics
  * @param runtime process-level runtime information
  * @param activation activation lifecycle counters and last-activity timestamp
  * @param trigger correlation / trigger counters and last-activity timestamp
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
-public record InboundConnectorMetrics(Runtime runtime, Activation activation, Trigger trigger) {
+public record InboundConnectorMetrics(
+    String runtimeId, Runtime runtime, Activation activation, Trigger trigger) {
 
   /**
    * @param uptimeSeconds number of seconds the runtime process has been running

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/metrics/OutboundConnectorMetrics.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/metrics/OutboundConnectorMetrics.java
@@ -22,12 +22,13 @@ import java.time.Instant;
 /**
  * Aggregated outbound connector metrics, grouped into three sections.
  *
+ * @param runtimeId hostname of the runtime node that reported these metrics
  * @param runtime process-level runtime information
  * @param job job execution counters, timing, and last-activity timestamps
  * @param worker Zeebe job-worker level counters
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
-public record OutboundConnectorMetrics(Runtime runtime, Job job, Worker worker) {
+public record OutboundConnectorMetrics(String runtimeId, Runtime runtime, Job job, Worker worker) {
 
   /**
    * @param uptimeSeconds number of seconds the runtime process has been running

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/controller/OutboundConnectorsRestController.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/controller/OutboundConnectorsRestController.java
@@ -98,7 +98,10 @@ public class OutboundConnectorsRestController {
     return instanceForwardingRouter.forwardToInstancesAndReduceOrLocal(
         request,
         forwardedFor,
-        () -> List.of(ConnectorMetricsAggregator.outbound(meterRegistry, null, hostname)),
+        () ->
+            meterRegistry == null
+                ? List.of()
+                : List.of(ConnectorMetricsAggregator.outbound(meterRegistry, null, hostname)),
         new TypeReference<>() {});
   }
 
@@ -115,7 +118,11 @@ public class OutboundConnectorsRestController {
     return instanceForwardingRouter.forwardToInstancesAndReduceOrLocal(
         request,
         forwardedFor,
-        () -> List.of(ConnectorMetricsAggregator.outbound(meterRegistry, connectorType, hostname)),
+        () ->
+            meterRegistry == null
+                ? List.of()
+                : List.of(
+                    ConnectorMetricsAggregator.outbound(meterRegistry, connectorType, hostname)),
         new TypeReference<>() {});
   }
 }

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/controller/OutboundConnectorsRestController.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/controller/OutboundConnectorsRestController.java
@@ -92,8 +92,14 @@ public class OutboundConnectorsRestController {
 
   /** Returns aggregated outbound connector metrics across all connector types. */
   @GetMapping("/metrics")
-  public OutboundConnectorMetrics getMetrics() {
-    return ConnectorMetricsAggregator.outbound(meterRegistry, null);
+  public List<OutboundConnectorMetrics> getMetrics(
+      HttpServletRequest request,
+      @RequestHeader(name = X_CAMUNDA_FORWARDED_FOR, required = false) String forwardedFor) {
+    return instanceForwardingRouter.forwardToInstancesAndReduceOrLocal(
+        request,
+        forwardedFor,
+        () -> List.of(ConnectorMetricsAggregator.outbound(meterRegistry, null, hostname)),
+        new TypeReference<>() {});
   }
 
   /**
@@ -102,8 +108,14 @@ public class OutboundConnectorsRestController {
    * @param connectorType connector type (e.g. {@code io.camunda:http-json:1})
    */
   @GetMapping("/metrics/{connectorType}")
-  public OutboundConnectorMetrics getMetricsByType(
+  public List<OutboundConnectorMetrics> getMetricsByType(
+      HttpServletRequest request,
+      @RequestHeader(name = X_CAMUNDA_FORWARDED_FOR, required = false) String forwardedFor,
       @PathVariable(name = "connectorType") String connectorType) {
-    return ConnectorMetricsAggregator.outbound(meterRegistry, connectorType);
+    return instanceForwardingRouter.forwardToInstancesAndReduceOrLocal(
+        request,
+        forwardedFor,
+        () -> List.of(ConnectorMetricsAggregator.outbound(meterRegistry, connectorType, hostname)),
+        new TypeReference<>() {});
   }
 }

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/instances/reducer/ReducerRegistryTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/instances/reducer/ReducerRegistryTest.java
@@ -20,6 +20,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import io.camunda.connector.runtime.inbound.executable.ConnectorInstances;
+import io.camunda.connector.runtime.metrics.InboundConnectorMetrics;
+import io.camunda.connector.runtime.metrics.OutboundConnectorMetrics;
 import io.camunda.connector.runtime.outbound.controller.OutboundConnectorResponse;
 import java.util.List;
 import org.junit.jupiter.api.Test;
@@ -60,6 +62,19 @@ public class ReducerRegistryTest {
     var reducer = reducerRegistry.getReducer(targetClass);
 
     // then
+    assertThat(reducer).isNotNull();
+  }
+
+  @Test
+  public void shouldReturnReducer_forOutboundConnectorMetricsList() {
+    var reducer =
+        reducerRegistry.getReducer(new TypeReference<List<OutboundConnectorMetrics>>() {});
+    assertThat(reducer).isNotNull();
+  }
+
+  @Test
+  public void shouldReturnReducer_forInboundConnectorMetricsList() {
+    var reducer = reducerRegistry.getReducer(new TypeReference<List<InboundConnectorMetrics>>() {});
     assertThat(reducer).isNotNull();
   }
 }

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/inbound/InboundConnectorRestControllerTest.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/inbound/InboundConnectorRestControllerTest.java
@@ -22,6 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import io.camunda.connector.jackson.ConnectorsObjectMapperSupplier;
 import io.camunda.connector.runtime.app.TestConnectorRuntimeApplication;
 import io.camunda.connector.runtime.inbound.executable.InboundExecutableRegistry;
@@ -31,6 +32,7 @@ import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.time.Instant;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -65,15 +67,16 @@ class InboundConnectorRestControllerTest {
 
     var response =
         mockMvc
-            .perform(get("/inbound/metrics/" + type))
+            .perform(get("/inbound-instances/metrics/" + type))
             .andExpect(status().isOk())
             .andReturn()
             .getResponse()
             .getContentAsString();
 
-    InboundConnectorMetrics m =
-        ConnectorsObjectMapperSupplier.getCopy().readValue(response, InboundConnectorMetrics.class);
+    List<InboundConnectorMetrics> metrics =
+        ConnectorsObjectMapperSupplier.getCopy().readValue(response, new TypeReference<>() {});
 
+    InboundConnectorMetrics m = metrics.getFirst();
     assertEquals(3L, m.activation().activated());
     assertEquals(0L, m.activation().deactivated());
     assertEquals(1L, m.activation().activationFailed());
@@ -102,15 +105,16 @@ class InboundConnectorRestControllerTest {
 
     var response =
         mockMvc
-            .perform(get("/inbound/metrics/" + type))
+            .perform(get("/inbound-instances/metrics/" + type))
             .andExpect(status().isOk())
             .andReturn()
             .getResponse()
             .getContentAsString();
 
-    InboundConnectorMetrics m =
-        ConnectorsObjectMapperSupplier.getCopy().readValue(response, InboundConnectorMetrics.class);
+    List<InboundConnectorMetrics> metrics =
+        ConnectorsObjectMapperSupplier.getCopy().readValue(response, new TypeReference<>() {});
 
+    InboundConnectorMetrics m = metrics.getFirst();
     assertEquals(10L, m.trigger().triggered());
     assertEquals(9L, m.trigger().correlated());
     assertEquals(0L, m.trigger().correlationFailed());
@@ -134,16 +138,16 @@ class InboundConnectorRestControllerTest {
 
     var response =
         mockMvc
-            .perform(get("/inbound/metrics/" + typeA))
+            .perform(get("/inbound-instances/metrics/" + typeA))
             .andExpect(status().isOk())
             .andReturn()
             .getResponse()
             .getContentAsString();
 
-    InboundConnectorMetrics m =
-        ConnectorsObjectMapperSupplier.getCopy().readValue(response, InboundConnectorMetrics.class);
+    List<InboundConnectorMetrics> metrics =
+        ConnectorsObjectMapperSupplier.getCopy().readValue(response, new TypeReference<>() {});
 
-    assertEquals(5L, m.activation().activated());
+    assertEquals(5L, metrics.getFirst().activation().activated());
   }
 
   @Test
@@ -157,16 +161,16 @@ class InboundConnectorRestControllerTest {
 
     var response =
         mockMvc
-            .perform(get("/inbound/metrics/" + type))
+            .perform(get("/inbound-instances/metrics/" + type))
             .andExpect(status().isOk())
             .andReturn()
             .getResponse()
             .getContentAsString();
 
-    InboundConnectorMetrics m =
-        ConnectorsObjectMapperSupplier.getCopy().readValue(response, InboundConnectorMetrics.class);
+    List<InboundConnectorMetrics> metrics =
+        ConnectorsObjectMapperSupplier.getCopy().readValue(response, new TypeReference<>() {});
 
-    assertEquals(4L, m.activation().activated());
+    assertEquals(4L, metrics.getFirst().activation().activated());
   }
 
   @Test
@@ -179,15 +183,16 @@ class InboundConnectorRestControllerTest {
 
     var response =
         mockMvc
-            .perform(get("/inbound/metrics/" + type))
+            .perform(get("/inbound-instances/metrics/" + type))
             .andExpect(status().isOk())
             .andReturn()
             .getResponse()
             .getContentAsString();
 
-    InboundConnectorMetrics m =
-        ConnectorsObjectMapperSupplier.getCopy().readValue(response, InboundConnectorMetrics.class);
+    List<InboundConnectorMetrics> metrics =
+        ConnectorsObjectMapperSupplier.getCopy().readValue(response, new TypeReference<>() {});
 
+    InboundConnectorMetrics m = metrics.getFirst();
     assertEquals(Instant.ofEpochMilli(epochMs), m.activation().lastActivated());
     assertNull(m.trigger().lastTriggered());
   }
@@ -202,15 +207,16 @@ class InboundConnectorRestControllerTest {
 
     var response =
         mockMvc
-            .perform(get("/inbound/metrics/" + type))
+            .perform(get("/inbound-instances/metrics/" + type))
             .andExpect(status().isOk())
             .andReturn()
             .getResponse()
             .getContentAsString();
 
-    InboundConnectorMetrics m =
-        ConnectorsObjectMapperSupplier.getCopy().readValue(response, InboundConnectorMetrics.class);
+    List<InboundConnectorMetrics> metrics =
+        ConnectorsObjectMapperSupplier.getCopy().readValue(response, new TypeReference<>() {});
 
+    InboundConnectorMetrics m = metrics.getFirst();
     assertNull(m.activation().lastActivated());
     assertEquals(Instant.ofEpochMilli(epochMs), m.trigger().lastTriggered());
   }
@@ -232,16 +238,16 @@ class InboundConnectorRestControllerTest {
 
     var response =
         mockMvc
-            .perform(get("/inbound/metrics"))
+            .perform(get("/inbound-instances/metrics"))
             .andExpect(status().isOk())
             .andReturn()
             .getResponse()
             .getContentAsString();
 
-    InboundConnectorMetrics m =
-        ConnectorsObjectMapperSupplier.getCopy().readValue(response, InboundConnectorMetrics.class);
+    List<InboundConnectorMetrics> metrics =
+        ConnectorsObjectMapperSupplier.getCopy().readValue(response, new TypeReference<>() {});
 
     // activated must include at least the 8 (5+3) we just registered
-    assertTrue(m.activation().activated() >= 8L);
+    assertTrue(metrics.getFirst().activation().activated() >= 8L);
   }
 }

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/inbound/InboundEndpointTest.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/inbound/InboundEndpointTest.java
@@ -35,11 +35,9 @@ import io.camunda.connector.runtime.inbound.controller.InboundConnectorRestContr
 import io.camunda.connector.runtime.inbound.executable.ActiveExecutableResponse;
 import io.camunda.connector.runtime.inbound.executable.InboundExecutableRegistry;
 import io.camunda.connector.runtime.instances.service.LocalInstanceForwardingRouter;
-import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.jupiter.api.Test;
 
@@ -86,10 +84,7 @@ public class InboundEndpointTest {
                     System.currentTimeMillis())));
 
     InboundConnectorRestController statusController =
-        new InboundConnectorRestController(
-            executableRegistry,
-            new LocalInstanceForwardingRouter(),
-            Optional.of(new SimpleMeterRegistry()));
+        new InboundConnectorRestController(executableRegistry, new LocalInstanceForwardingRouter());
 
     var response = statusController.getActiveInboundConnectors(null, null, null);
     assertEquals(1, response.size());
@@ -116,10 +111,7 @@ public class InboundEndpointTest {
                     System.currentTimeMillis())));
 
     InboundConnectorRestController statusController =
-        new InboundConnectorRestController(
-            executableRegistry,
-            new LocalInstanceForwardingRouter(),
-            Optional.of(new SimpleMeterRegistry()));
+        new InboundConnectorRestController(executableRegistry, new LocalInstanceForwardingRouter());
 
     var response = statusController.getActiveInboundConnectors(null, null, null);
     assertEquals(1, response.size());

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/outbound/OutboundConnectorsRestControllerTest.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/outbound/OutboundConnectorsRestControllerTest.java
@@ -197,10 +197,11 @@ class OutboundConnectorsRestControllerTest {
             .getResponse()
             .getContentAsString();
 
-    OutboundConnectorMetrics m =
-        ConnectorsObjectMapperSupplier.getCopy()
-            .readValue(response, OutboundConnectorMetrics.class);
+    List<OutboundConnectorMetrics> metrics =
+        ConnectorsObjectMapperSupplier.getCopy().readValue(response, new TypeReference<>() {});
 
+    OutboundConnectorMetrics m = metrics.getFirst();
+    assertEquals("localhost", m.runtimeId());
     assertEquals(10L, m.job().completed());
     assertEquals(2L, m.job().failed());
     assertEquals(1L, m.job().bpmnError());
@@ -230,10 +231,10 @@ class OutboundConnectorsRestControllerTest {
             .getResponse()
             .getContentAsString();
 
-    OutboundConnectorMetrics worker =
-        ConnectorsObjectMapperSupplier.getCopy()
-            .readValue(response, OutboundConnectorMetrics.class);
+    List<OutboundConnectorMetrics> metrics =
+        ConnectorsObjectMapperSupplier.getCopy().readValue(response, new TypeReference<>() {});
 
+    OutboundConnectorMetrics worker = metrics.getFirst();
     assertEquals(5L, worker.worker().jobsActivated());
     assertEquals(4L, worker.worker().jobsHandled());
     assertEquals(1L, worker.worker().streamRecreations());
@@ -260,11 +261,10 @@ class OutboundConnectorsRestControllerTest {
             .getResponse()
             .getContentAsString();
 
-    OutboundConnectorMetrics m =
-        ConnectorsObjectMapperSupplier.getCopy()
-            .readValue(response, OutboundConnectorMetrics.class);
+    List<OutboundConnectorMetrics> metrics =
+        ConnectorsObjectMapperSupplier.getCopy().readValue(response, new TypeReference<>() {});
 
-    assertEquals(3L, m.worker().jobsActivated());
+    assertEquals(3L, metrics.getFirst().worker().jobsActivated());
   }
 
   @Test
@@ -283,11 +283,10 @@ class OutboundConnectorsRestControllerTest {
             .getResponse()
             .getContentAsString();
 
-    OutboundConnectorMetrics m =
-        ConnectorsObjectMapperSupplier.getCopy()
-            .readValue(response, OutboundConnectorMetrics.class);
+    List<OutboundConnectorMetrics> metrics =
+        ConnectorsObjectMapperSupplier.getCopy().readValue(response, new TypeReference<>() {});
 
-    assertEquals(6L, m.worker().jobsActivated());
+    assertEquals(6L, metrics.getFirst().worker().jobsActivated());
   }
 
   @Test
@@ -311,11 +310,10 @@ class OutboundConnectorsRestControllerTest {
             .getResponse()
             .getContentAsString();
 
-    OutboundConnectorMetrics m =
-        ConnectorsObjectMapperSupplier.getCopy()
-            .readValue(response, OutboundConnectorMetrics.class);
+    List<OutboundConnectorMetrics> metrics =
+        ConnectorsObjectMapperSupplier.getCopy().readValue(response, new TypeReference<>() {});
 
     // jobsActivated must include at least the 10 (3+7) we just registered
-    assertTrue(m.worker().jobsActivated() >= 10L);
+    assertTrue(metrics.getFirst().worker().jobsActivated() >= 10L);
   }
 }


### PR DESCRIPTION
## Description

The connector metrics endpoints previously returned a single aggregated object from the local instance only, bypassing the `instanceForwardingRouter`. In a multi-instance deployment, this meant each runtime node only reported its own metrics with no way to get a global view.

This PR wires the metrics APIs into the existing instance-forwarding infrastructure, so a request to any node collects and returns metrics from all nodes — one entry per instance, identified by a new `runtimeId` field.

### Changes

**`OutboundConnectorMetrics` / `InboundConnectorMetrics`**
- Added `runtimeId` (hostname of the reporting runtime) as a top-level field, consistent with `OutboundConnectorResponse`.

**`ConnectorMetricsAggregator`**
- `outbound()` and `inbound()` now accept a `runtimeId` parameter that is embedded in the returned object.

**Outbound metrics (`GET /outbound/metrics`, `GET /outbound/metrics/{connectorType}`)**
- Now delegate to `instanceForwardingRouter.forwardToInstancesAndReduceOrLocal()`.
- Return `List<OutboundConnectorMetrics>` — one entry per runtime instance — instead of a single aggregated object.

**Inbound metrics — moved to `InboundInstancesRestController`**
- Endpoints relocated from `InboundConnectorRestController` (`/inbound/metrics`) to `InboundInstancesRestController` (`/inbound-instances/metrics`), consistent with where all other instance-aware inbound endpoints live.
- Same forwarding pattern, returning `List<InboundConnectorMetrics>`.

**`InboundConnectorRestController` cleanup**
- Removed `meterRegistry`, `LOG`, and the two metrics endpoints. The constructor no longer takes `Optional<MeterRegistry>`.

**Tests**
- Updated to deserialise `List<>` responses from the metrics endpoints.
- Added assertion on the new `runtimeId` field (`"localhost"` in single-instance tests).
- Inbound metrics tests now use the `/inbound-instances/metrics` paths.
- Fixed `InboundEndpointTest` direct constructor calls.

## Related issues

closes #

## Checklist

- [x] Backport labels are added if these code changes should be backported.
- [x] Tests/Integration tests for the changes have been added if applicable.
- [ ] If the change requires a documentation update, it has been added to the appropriate section in the documentation.
