### PR TITLE
refactor(agentic-ai): store last iteration key in agent context metadata

### DIFF
--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/jobworker/BaseAiAgentJobWorkerTest.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/jobworker/BaseAiAgentJobWorkerTest.java
@@ -159,6 +159,7 @@ public abstract class BaseAiAgentJobWorkerTest extends BaseAiAgentTest {
                 .isReady()
                 .hasAgentInstanceKey()
                 .hasMetrics(new AgentMetrics(1, new AgentMetrics.TokenUsage(10, 20), 0))
+                .hasLastIterationKey(1)
                 .satisfies(agentResponseAssertions));
 
     assertThat(userFeedbackJobWorkerCounter.get()).isEqualTo(1);
@@ -249,6 +250,7 @@ public abstract class BaseAiAgentJobWorkerTest extends BaseAiAgentTest {
             JobWorkerAgentResponseAssert.assertThat(agentResponse)
                 .isReady()
                 .hasMetrics(new AgentMetrics(3, new AgentMetrics.TokenUsage(121, 242), 3))
+                .hasLastIterationKey(3)
                 .satisfies(agentResponseAssertions));
 
     assertThat(userFeedbackJobWorkerCounter.get()).isEqualTo(2);

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/outboundconnector/BaseAiAgentConnectorTest.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/outboundconnector/BaseAiAgentConnectorTest.java
@@ -156,6 +156,7 @@ public abstract class BaseAiAgentConnectorTest extends BaseAiAgentTest {
                 .hasNoToolCalls()
                 .hasAgentInstanceKey()
                 .hasMetrics(new AgentMetrics(1, new AgentMetrics.TokenUsage(10, 20), 0))
+                .hasLastIterationKey(1)
                 .satisfies(agentResponseAssertions));
 
     assertThat(userFeedbackJobWorkerCounter.get()).isEqualTo(1);
@@ -247,6 +248,7 @@ public abstract class BaseAiAgentConnectorTest extends BaseAiAgentTest {
                 .isReady()
                 .hasNoToolCalls()
                 .hasMetrics(new AgentMetrics(3, new AgentMetrics.TokenUsage(121, 242), 3))
+                .hasLastIterationKey(3)
                 .satisfies(agentResponseAssertions));
 
     assertThat(userFeedbackJobWorkerCounter.get()).isEqualTo(2);

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/assertj/AgentResponseAssert.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/assertj/AgentResponseAssert.java
@@ -122,4 +122,13 @@ public class AgentResponseAssert extends AbstractAssert<AgentResponseAssert, Age
     Assertions.assertThat(actual.context().metadata().agentInstanceKey()).isNotNull().isPositive();
     return this;
   }
+
+  public AgentResponseAssert hasLastIterationKey(int expectedLastIterationKey) {
+    isNotNull();
+    Assertions.assertThat(actual.context()).isNotNull();
+    Assertions.assertThat(actual.context().metadata()).isNotNull();
+    Assertions.assertThat(actual.context().metadata().lastIterationKey())
+        .isEqualTo(expectedLastIterationKey);
+    return this;
+  }
 }

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/assertj/JobWorkerAgentResponseAssert.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/assertj/JobWorkerAgentResponseAssert.java
@@ -119,4 +119,13 @@ public class JobWorkerAgentResponseAssert
     Assertions.assertThat(actual.context().metadata().agentInstanceKey()).isNotNull().isPositive();
     return this;
   }
+
+  public JobWorkerAgentResponseAssert hasLastIterationKey(int expectedLastIterationKey) {
+    isNotNull();
+    Assertions.assertThat(actual.context()).isNotNull();
+    Assertions.assertThat(actual.context().metadata()).isNotNull();
+    Assertions.assertThat(actual.context().metadata().lastIterationKey())
+        .isEqualTo(expectedLastIterationKey);
+    return this;
+  }
 }

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/AgentConversation.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/AgentConversation.java
@@ -191,14 +191,16 @@ public final class AgentConversation {
 
   /**
    * Produces an updated {@link AgentContext} with cumulative metrics from all turns ingested in
-   * this invocation applied on top of the base context metrics.
+   * this invocation applied on top of the base context metrics, and {@code lastIterationKey}
+   * stamped to the current turn's key once it has been ingested.
    */
   public AgentContext toAgentContext() {
     var withMetrics = currentContext.withMetrics(totalMetrics());
     var metadata = currentContext.metadata();
-    return metadata == null
-        ? withMetrics
-        : withMetrics.withMetadata(metadata.withLastIterationKey(currentTurn.iterationKey()));
+    if (metadata == null || currentTurn.assistantMessage() == null) {
+      return withMetrics;
+    }
+    return withMetrics.withMetadata(metadata.withLastIterationKey(currentTurn.iterationKey()));
   }
 
   /** Returns the last completed turn, or empty if no turns have been completed yet. */

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/AgentConversation.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/AgentConversation.java
@@ -17,6 +17,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Immutable domain aggregate representing the agent's full conversation across all turns.
@@ -28,6 +30,8 @@ import org.jspecify.annotations.Nullable;
  * and completed by {@link #ingest}.
  */
 public final class AgentConversation {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(AgentConversation.class);
 
   private final AgentConfiguration configuration;
   private final AgentContext currentContext;
@@ -68,10 +72,35 @@ public final class AgentConversation {
       PreviousConversation previousConversation,
       @Nullable SystemMessage systemMessage,
       List<Message> inputMessages) {
-    int nextKey = previousConversation.turns().size() + 1;
+    int nextKey = nextIterationKey(agentContext, previousConversation);
     var currentTurn = new AgentConversationTurn(nextKey, inputMessages, null, AgentMetrics.empty());
     return new AgentConversation(
         configuration, agentContext, systemMessage, previousConversation.turns(), currentTurn);
+  }
+
+  /**
+   * Determines the next turn's iterationKey. The stored {@code lastIterationKey} on the agent
+   * context metadata is authoritative when present; the reconstructed turn count is used as a
+   * fallback (pre-feature conversations, or right after a process definition migration reset) and
+   * to cross-validate the stored value, logging a warning on drift instead of failing silently.
+   */
+  private static int nextIterationKey(
+      AgentContext agentContext, PreviousConversation previousConversation) {
+    var metadata = agentContext.metadata();
+    var storedLastIterationKey = metadata != null ? metadata.lastIterationKey() : null;
+    int reconstructedCount = previousConversation.turns().size();
+
+    if (storedLastIterationKey == null) {
+      return reconstructedCount + 1;
+    }
+
+    if (storedLastIterationKey != reconstructedCount) {
+      LOGGER.warn(
+          "Turn reconstruction drift detected: stored lastIterationKey={} but reconstructed {} turn(s) from history",
+          storedLastIterationKey,
+          reconstructedCount);
+    }
+    return storedLastIterationKey + 1;
   }
 
   /**
@@ -165,7 +194,11 @@ public final class AgentConversation {
    * this invocation applied on top of the base context metrics.
    */
   public AgentContext toAgentContext() {
-    return currentContext.withMetrics(totalMetrics());
+    var withMetrics = currentContext.withMetrics(totalMetrics());
+    var metadata = currentContext.metadata();
+    return metadata == null
+        ? withMetrics
+        : withMetrics.withMetadata(metadata.withLastIterationKey(currentTurn.iterationKey()));
   }
 
   /** Returns the last completed turn, or empty if no turns have been completed yet. */

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/AgentMetadata.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/AgentMetadata.java
@@ -16,14 +16,20 @@ import org.jspecify.annotations.Nullable;
  * @param processDefinitionKey The key of the process definition this agent was initialized with
  * @param processInstanceKey The key of the process instance this agent is executing in
  * @param agentInstanceKey The key of the agent instance created on the engine, if any
+ * @param lastIterationKey The highest turn iterationKey persisted so far, if any. Authoritative
+ *     counter for the next turn's iterationKey; absent for conversations created before this field
+ *     was introduced, or right after a process definition migration reset.
  */
 @AgenticAiRecord
 public record AgentMetadata(
-    Long processDefinitionKey, Long processInstanceKey, @Nullable Long agentInstanceKey)
+    Long processDefinitionKey,
+    Long processInstanceKey,
+    @Nullable Long agentInstanceKey,
+    @Nullable Integer lastIterationKey)
     implements AgentMetadataBuilder.With {
 
   public static AgentMetadata of(JobContext jobContext) {
     return new AgentMetadata(
-        jobContext.getProcessDefinitionKey(), jobContext.getProcessInstanceKey(), null);
+        jobContext.getProcessDefinitionKey(), jobContext.getProcessInstanceKey(), null, null);
   }
 }

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/agent/AgentInitializerTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/agent/AgentInitializerTest.java
@@ -99,7 +99,7 @@ class AgentInitializerTest {
     private static final Long PROCESS_DEFINITION_KEY = 123456789L;
     private static final Long PROCESS_INSTANCE_KEY = 987654321L;
     private static final AgentMetadata EXECUTION_METADATA =
-        new AgentMetadata(PROCESS_DEFINITION_KEY, PROCESS_INSTANCE_KEY, null);
+        new AgentMetadata(PROCESS_DEFINITION_KEY, PROCESS_INSTANCE_KEY, null, null);
 
     @BeforeEach
     void setUp() {
@@ -146,7 +146,7 @@ class AgentInitializerTest {
       final var result = agentInitializer.initializeAgent(executionContext);
 
       final var expectedMetadata =
-          new AgentMetadata(PROCESS_DEFINITION_KEY, PROCESS_INSTANCE_KEY, 12345L);
+          new AgentMetadata(PROCESS_DEFINITION_KEY, PROCESS_INSTANCE_KEY, 12345L, null);
       assertThat(result)
           .isInstanceOfSatisfying(
               ReadyToConverse.class,
@@ -189,7 +189,7 @@ class AgentInitializerTest {
     private static final AgentContext AGENT_CONTEXT =
         AgentContext.empty()
             .withProperty("hello", "world")
-            .withMetadata(new AgentMetadata(123456789L, 987654321L, 99999L));
+            .withMetadata(new AgentMetadata(123456789L, 987654321L, 99999L, null));
 
     @BeforeEach
     void setUp() {
@@ -494,7 +494,7 @@ class AgentInitializerTest {
       final var result = agentInitializer.initializeAgent(executionContext);
 
       final var expectedMetadata =
-          new AgentMetadata(MIGRATED_PROCESS_DEFINITION_KEY, PROCESS_INSTANCE_KEY, null);
+          new AgentMetadata(MIGRATED_PROCESS_DEFINITION_KEY, PROCESS_INSTANCE_KEY, null, null);
       assertThat(result)
           .isInstanceOfSatisfying(
               ReadyToConverse.class,
@@ -507,7 +507,7 @@ class AgentInitializerTest {
     @Test
     void shouldTriggerToolUpdateWhenProcessDefinitionKeyChanged() {
       final var originalMetadata =
-          new AgentMetadata(ORIGINAL_PROCESS_DEFINITION_KEY, PROCESS_INSTANCE_KEY, null);
+          new AgentMetadata(ORIGINAL_PROCESS_DEFINITION_KEY, PROCESS_INSTANCE_KEY, null, null);
       final var agentContext =
           AgentContext.empty()
               .withState(AgentState.READY)
@@ -525,7 +525,7 @@ class AgentInitializerTest {
       final var result = agentInitializer.initializeAgent(executionContext);
 
       final var expectedMetadata =
-          new AgentMetadata(MIGRATED_PROCESS_DEFINITION_KEY, PROCESS_INSTANCE_KEY, null);
+          new AgentMetadata(MIGRATED_PROCESS_DEFINITION_KEY, PROCESS_INSTANCE_KEY, null, null);
       assertThat(result)
           .isInstanceOfSatisfying(
               ReadyToConverse.class,
@@ -538,7 +538,7 @@ class AgentInitializerTest {
     @Test
     void shouldSkipToolUpdateWhenProcessDefinitionKeyMatches() {
       final var metadata =
-          new AgentMetadata(ORIGINAL_PROCESS_DEFINITION_KEY, PROCESS_INSTANCE_KEY, null);
+          new AgentMetadata(ORIGINAL_PROCESS_DEFINITION_KEY, PROCESS_INSTANCE_KEY, null, null);
       final var agentContext =
           AgentContext.empty()
               .withState(AgentState.READY)
@@ -594,7 +594,7 @@ class AgentInitializerTest {
     @Test
     void shouldSkipAgentInstanceCreationWhenKeyAlreadyPresent() {
       final var existingMetadata =
-          new AgentMetadata(PROCESS_DEFINITION_KEY, PROCESS_INSTANCE_KEY, 99L);
+          new AgentMetadata(PROCESS_DEFINITION_KEY, PROCESS_INSTANCE_KEY, 99L, null);
       final var agentContext =
           AgentContext.empty().withState(AgentState.INITIALIZING).withMetadata(existingMetadata);
       when(executionContext.initialAgentContext()).thenReturn(agentContext);
@@ -610,7 +610,7 @@ class AgentInitializerTest {
     @Test
     void shouldSkipAgentInstanceCreationOnMissingAgentInstanceKeyInExistingAgentContext() {
       final var existingMetadata =
-          new AgentMetadata(PROCESS_DEFINITION_KEY, PROCESS_INSTANCE_KEY, null);
+          new AgentMetadata(PROCESS_DEFINITION_KEY, PROCESS_INSTANCE_KEY, null, null);
       // one step ahead of the initialization state
       final var agentContext =
           AgentContext.empty().withState(AgentState.TOOL_DISCOVERY).withMetadata(existingMetadata);
@@ -645,7 +645,8 @@ class AgentInitializerTest {
 
     @Test
     void shouldResolveCompletedAtBeforeDispatchingAndUseTheResolvedResults() {
-      final var metadata = new AgentMetadata(PROCESS_DEFINITION_KEY, PROCESS_INSTANCE_KEY, null);
+      final var metadata =
+          new AgentMetadata(PROCESS_DEFINITION_KEY, PROCESS_INSTANCE_KEY, null, null);
       final var agentContext =
           AgentContext.empty()
               .withState(AgentState.READY)

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/model/AgentConversationTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/model/AgentConversationTest.java
@@ -183,6 +183,27 @@ class AgentConversationTest {
   }
 
   @Test
+  void toAgentContext_doesNotStampLastIterationKey_whileTurnPending() {
+    var contextWithStoredKey =
+        AgentContext.builder()
+            .state(AgentState.READY)
+            .metadata(new AgentMetadata(1L, 1L, null, 4))
+            .build();
+    var history = TurnReconstructor.reconstruct(List.of());
+    var conv =
+        AgentConversation.rehydrate(
+            CONFIG,
+            contextWithStoredKey,
+            history,
+            systemMessage("sys"),
+            List.of(userMessage("hi")));
+
+    assertThat(conv.currentTurn().assistantMessage()).isNull();
+    var ctx = conv.toAgentContext();
+    assertThat(ctx.metadata().lastIterationKey()).isEqualTo(4);
+  }
+
+  @Test
   void toAgentContext_leavesMetadataNull_whenAbsent() {
     var conv =
         rehydrate(List.of(), List.of(userMessage("hi")))

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/model/AgentConversationTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/model/AgentConversationTest.java
@@ -52,6 +52,48 @@ class AgentConversationTest {
   }
 
   @Test
+  void rehydrate_usesStoredLastIterationKey_whenPresent() {
+    // stored key (5) disagrees with the reconstructed count (1 turn) on purpose: the stored value
+    // must win regardless
+    var contextWithStoredKey =
+        AgentContext.builder()
+            .state(AgentState.READY)
+            .metadata(new AgentMetadata(1L, 1L, null, 5))
+            .build();
+    var storedMessages = List.<Message>of(userMessage("hi"), assistantMessage("hello"));
+    var history = TurnReconstructor.reconstruct(storedMessages);
+    var conv =
+        AgentConversation.rehydrate(
+            CONFIG,
+            contextWithStoredKey,
+            history,
+            systemMessage("sys"),
+            List.of(userMessage("next")));
+
+    assertThat(conv.currentTurn().iterationKey()).isEqualTo(6);
+  }
+
+  @Test
+  void rehydrate_fallsBackToReconstructedCount_whenStoredKeyAbsent() {
+    var contextWithMetadataNoKey =
+        AgentContext.builder()
+            .state(AgentState.READY)
+            .metadata(new AgentMetadata(1L, 1L, null, null))
+            .build();
+    var storedMessages = List.<Message>of(userMessage("hi"), assistantMessage("hello"));
+    var history = TurnReconstructor.reconstruct(storedMessages);
+    var conv =
+        AgentConversation.rehydrate(
+            CONFIG,
+            contextWithMetadataNoKey,
+            history,
+            systemMessage("sys"),
+            List.of(userMessage("next")));
+
+    assertThat(conv.currentTurn().iterationKey()).isEqualTo(2);
+  }
+
+  @Test
   void rehydrate_createsPendingTurn_withInputMessages() {
     var inputMessages = List.<Message>of(userMessage("hello"));
     var conv = rehydrate(List.of(), inputMessages);
@@ -117,6 +159,37 @@ class AgentConversationTest {
             .ingest(assistantMessage("hello"), new AgentMetrics(1, new TokenUsage(10, 5), 0));
     var ctx = conv.toAgentContext();
     assertThat(ctx.metrics().modelCalls()).isEqualTo(1);
+  }
+
+  @Test
+  void toAgentContext_stampsLastIterationKeyOnMetadata() {
+    var contextWithMetadata =
+        AgentContext.builder()
+            .state(AgentState.READY)
+            .metadata(new AgentMetadata(1L, 1L, null, null))
+            .build();
+    var history = TurnReconstructor.reconstruct(List.of());
+    var conv =
+        AgentConversation.rehydrate(
+                CONFIG,
+                contextWithMetadata,
+                history,
+                systemMessage("sys"),
+                List.of(userMessage("hi")))
+            .ingest(assistantMessage("hello"), AgentMetrics.empty());
+
+    var ctx = conv.toAgentContext();
+    assertThat(ctx.metadata().lastIterationKey()).isEqualTo(1);
+  }
+
+  @Test
+  void toAgentContext_leavesMetadataNull_whenAbsent() {
+    var conv =
+        rehydrate(List.of(), List.of(userMessage("hi")))
+            .ingest(assistantMessage("hello"), AgentMetrics.empty());
+
+    var ctx = conv.toAgentContext();
+    assertThat(ctx.metadata()).isNull();
   }
 
   @Test

--- a/connectors/agentic-ai/docs/reference/ai-agent.md
+++ b/connectors/agentic-ai/docs/reference/ai-agent.md
@@ -349,8 +349,8 @@ invocation and transformed through copy-on-write methods.
 - `window(int size)`: applies `MessageWindowFilter.apply(allMessages(), size)` and returns a
   read-only `ConversationSnapshot`.
 - `toAgentContext()`: reduces back to the serialized `AgentContext`, incrementing the durable
-  `AgentContext.metrics` by the current turn's delta and stamping `AgentMetadata.lastIterationKey`
-  with the current turn's `iterationKey` (when metadata is present).
+  `AgentContext.metrics` by the current turn's delta and, once the current turn has been `ingest`ed,
+  stamping `AgentMetadata.lastIterationKey` with its `iterationKey` (when metadata is present).
 - `totalMetrics()`: returns the durable `AgentContext.metrics()` plus the current turn's delta —
   **not** a sum over the reconstructed turns, which always carry `AgentMetrics.empty()`. The
   model-call limit check (`BaseAgentRequestHandler.throwIfLimitsReached`) relies on this cumulative

--- a/connectors/agentic-ai/docs/reference/ai-agent.md
+++ b/connectors/agentic-ai/docs/reference/ai-agent.md
@@ -349,7 +349,8 @@ invocation and transformed through copy-on-write methods.
 - `window(int size)`: applies `MessageWindowFilter.apply(allMessages(), size)` and returns a
   read-only `ConversationSnapshot`.
 - `toAgentContext()`: reduces back to the serialized `AgentContext`, incrementing the durable
-  `AgentContext.metrics` by the current turn's delta.
+  `AgentContext.metrics` by the current turn's delta and stamping `AgentMetadata.lastIterationKey`
+  with the current turn's `iterationKey` (when metadata is present).
 - `totalMetrics()`: returns the durable `AgentContext.metrics()` plus the current turn's delta —
   **not** a sum over the reconstructed turns, which always carry `AgentMetrics.empty()`. The
   model-call limit check (`BaseAgentRequestHandler.throwIfLimitsReached`) relies on this cumulative
@@ -360,12 +361,20 @@ invocation and transformed through copy-on-write methods.
 AgentMetrics metrics)`. `iterationKey` is 1-based across the agent lifetime; the turn is pending
 while `assistantMessage == null`.
 
+The next turn's `iterationKey` is determined by `AgentConversation.rehydrate()`:
+`AgentMetadata.lastIterationKey` (persisted by `toAgentContext()`, see above) is authoritative when
+present. The reconstructed turn count is used as a fallback when it's absent (pre-feature
+conversations, or right after a process definition migration reset — `AgentInitializerImpl` replaces
+metadata wholesale on migration) and, when a stored key is present, to cross-validate against it:
+a mismatch is logged as a warning (reconstruction drift), not thrown.
+
 `TurnReconstructor.reconstruct(messages)` (`...aiagent.model`) rebuilds the turn list and the
 optional system message from the persisted flat message list: the leading `SystemMessage` (if any)
 is split off, and the remaining body is grouped by `AssistantMessage` boundaries. All reconstructed
 turns carry `AgentMetrics.empty()` — per-invocation metrics are computed live from the current
 turn, not read from history. This provides backward compatibility with existing conversations
-without a data migration.
+without a data migration, and is now also the cross-validation source for `iterationKey` drift
+detection described above.
 
 `ConversationSnapshot` (record, `...aiagent.memory`) is the transient, windowed, read-only view sent
 to the LLM: `(List<Message> messages, List<ToolDefinition> toolDefinitions)`.


### PR DESCRIPTION
## Description

Persists `iterationKey` on `AgentMetadata.lastIterationKey` so it's authoritative across turns, instead of re-deriving it by scanning stored messages. The reconstructed turn count is now only used as a fallback and to cross-validate (a mismatch is logged as a warning).

## Related issues

closes #7624

## Checklist

- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest
  release, as this branch will be rebased onto main before the next release. Example backport labels:
    - `backport stable/8.8`: for changes that should be included in the next 8.8.x release.
    - **or** `backport release-8.8.7`: for changes that should be included in the specific release 8.8.7, and this
      *release has already been created*. The release branch will be merged back into stable/8.8 later, so the change
      will be included in future 8.8.x releases as well.
- [x] Tests/Integration tests for the changes have been added if applicable.
- [x] If the change requires a documentation update, it has been added to the appropriate section in the documentation.