### PR TITLE
fix(csv): validate headers for object-based CSV write input

### DIFF
--- a/connectors/csv/src/main/java/io/camunda/connector/csv/CsvUtils.java
+++ b/connectors/csv/src/main/java/io/camunda/connector/csv/CsvUtils.java
@@ -6,6 +6,7 @@
  */
 package io.camunda.connector.csv;
 
+import io.camunda.connector.api.error.ConnectorInputException;
 import io.camunda.connector.csv.model.CsvFormat;
 import io.camunda.connector.csv.model.ReadCsvRequest;
 import io.camunda.connector.csv.model.ReadCsvResult;
@@ -65,6 +66,10 @@ public class CsvUtils {
         if (record instanceof List<?> listValues) {
           printer.printRecord(listValues);
         } else if (record instanceof Map<?, ?> mapValues) {
+          if (!headersDefined(format)) {
+            throw new ConnectorInputException(
+                "Headers must be defined when writing object-based (Map) records to CSV.");
+          }
           var row = format.headers().stream().map(mapValues::get).toList();
           printer.printRecord(row);
         } else {

--- a/connectors/csv/src/test/java/io/camunda/connector/csv/CsvConnectorTests.java
+++ b/connectors/csv/src/test/java/io/camunda/connector/csv/CsvConnectorTests.java
@@ -10,6 +10,7 @@ import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
 
+import io.camunda.connector.api.error.ConnectorInputException;
 import io.camunda.connector.csv.model.*;
 import io.camunda.connector.csv.model.ReadCsvRequest.RowType;
 import io.camunda.connector.runtime.test.outbound.OutboundConnectorContextBuilder;
@@ -195,6 +196,28 @@ public class CsvConnectorTests {
     assertNotNull(result);
     assertEquals(
         "name,role\r\nSimon,Engineering Manager\r\nMathias,Backend Engineer\r\n", result.content());
+  }
+
+  @Test
+  public void testWriteObjectsWithoutHeadersThrows() {
+    var context = OutboundConnectorContextBuilder.create().build();
+    var nullHeaders =
+        new WriteCsvRequest(
+            asList(Map.of("name", "Simon", "role", "Engineering Manager")),
+            false,
+            new CsvFormat(",", true, null));
+    assertThatThrownBy(() -> connector.writeCsv(nullHeaders, context))
+        .isInstanceOf(ConnectorInputException.class)
+        .hasMessageContaining("Headers must be defined");
+
+    var emptyHeaders =
+        new WriteCsvRequest(
+            asList(Map.of("name", "Simon", "role", "Engineering Manager")),
+            false,
+            new CsvFormat(",", true, List.of()));
+    assertThatThrownBy(() -> connector.writeCsv(emptyHeaders, context))
+        .isInstanceOf(ConnectorInputException.class)
+        .hasMessageContaining("Headers must be defined");
   }
 
   private static List<Map<String, Object>> toList(ReadCsvResult result) {


### PR DESCRIPTION
## Description

Writing a CSV with `WriteCsv` threw a `NullPointerException` in `CsvUtils.createCsv` when the input `data` was a `List<Map>` and `format.headers` was not configured (`null`). Setting `headers` to `[]` didn't throw but silently produced empty rows.

Headers are required for object-based (Map) input, so this now throws a meaningful `ConnectorInputException` for both `null` and empty headers instead of an NPE / silent bad output.

Fixes #7529

## Changes
- `CsvUtils.createCsv`: guard Map records with `headersDefined(format)`, throwing `ConnectorInputException` when headers are missing.
- Added test covering null and empty headers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)