### PR TITLE
feat(agentic-ai): chat model SPI + LangChain4j bridge (own the LLM layer, Phase 0)

### DIFF
--- a/connectors/agentic-ai/AGENTS.md
+++ b/connectors/agentic-ai/AGENTS.md
@@ -41,7 +41,7 @@ Deep architecture lives in the reference docs, linked instead of copied:
 | Tool completion, partial results, no-op completion                       | [§9](docs/reference/ai-agent.md#9-tool-completion)                                      |
 | Concurrency & race conditions (supersession, store-ahead-of-Zeebe)       | [§10](docs/reference/ai-agent.md#10-concurrency)                                        |
 | Event handling (sub-process only)                                        | [§11](docs/reference/ai-agent.md#11-event-handling)                                     |
-| Framework abstraction & LangChain4J converter chain                      | [§12](docs/reference/ai-agent.md#12-framework-abstraction)                              |
+| Chat model SPI & LangChain4J bridge implementation                       | [§12](docs/reference/ai-agent.md#12-framework-abstraction)                              |
 | System prompt composition / contributors                                 | [§13](docs/reference/ai-agent.md#13-system-prompt-composition)                          |
 | Response handling (text / JSON / full message)                           | [§14](docs/reference/ai-agent.md#14-response-handling)                                  |
 | Error codes                                                              | [§15](docs/reference/ai-agent.md#15-error-codes)                                        |
@@ -121,7 +121,10 @@ suite will enforce (epic #7537):
 
 - **Framework-agnostic core.** Only `aiagent/framework/langchain4j/**` may import `dev.langchain4j.*`.
   The agent core (`aiagent/agent`, `aiagent/model`, `aiagent/memory`, the root `model/`) stays
-  framework-neutral.
+  framework-neutral. `aiagent/framework/api/**` is the provider-neutral chat model SPI
+  (`ChatModelApi`, `ChatModelApiFactory`, `ChatModelApiRegistry`, …) and must import no vendor SDK;
+  future native chat model implementations live under their own `aiagent/framework/<provider>/**`
+  package, each importing only its own vendor SDK.
 - **Domain types never leak framework types.** The domain `Message` / `ToolCall` / `Content` model
   (`io.camunda.connector.agenticai.model.*`) is translated to/from LangChain4J only through the
   converter chain (`ChatMessageConverter`, `ToolSpecificationConverter`, and friends).

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/agent/BaseAgentRequestHandler.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/agent/BaseAgentRequestHandler.java
@@ -13,7 +13,9 @@ import io.camunda.connector.agenticai.aiagent.agent.AgentInitializationResult.Re
 import io.camunda.connector.agenticai.aiagent.agentinstance.AgentInstanceClient;
 import io.camunda.connector.agenticai.aiagent.agentinstance.AgentInstanceKey;
 import io.camunda.connector.agenticai.aiagent.agentinstance.AgentInstanceUpdateRequest;
-import io.camunda.connector.agenticai.aiagent.framework.AiFrameworkAdapter;
+import io.camunda.connector.agenticai.aiagent.framework.api.ChatModelApiRegistry;
+import io.camunda.connector.agenticai.aiagent.framework.api.ChatModelRequest;
+import io.camunda.connector.agenticai.aiagent.framework.api.ProviderChatModelApiConfiguration;
 import io.camunda.connector.agenticai.aiagent.memory.conversation.ConversationSession;
 import io.camunda.connector.agenticai.aiagent.memory.conversation.ConversationStore;
 import io.camunda.connector.agenticai.aiagent.memory.conversation.ConversationStoreRegistry;
@@ -53,7 +55,7 @@ public abstract class BaseAgentRequestHandler<
   private final AgentInitializer agentInitializer;
   private final ConversationStoreRegistry conversationStoreRegistry;
   private final AgentConversationTurnInputComposer agentInputComposer;
-  private final AiFrameworkAdapter<?> framework;
+  private final ChatModelApiRegistry chatModelApiRegistry;
   private final SystemPromptComposer systemPromptComposer;
   private final AgentResponseHandler responseHandler;
   private final AgentInstanceClient agentInstanceClient;
@@ -62,14 +64,14 @@ public abstract class BaseAgentRequestHandler<
       AgentInitializer agentInitializer,
       ConversationStoreRegistry conversationStoreRegistry,
       AgentConversationTurnInputComposer agentInputComposer,
-      AiFrameworkAdapter<?> framework,
+      ChatModelApiRegistry chatModelApiRegistry,
       SystemPromptComposer systemPromptComposer,
       AgentResponseHandler responseHandler,
       AgentInstanceClient agentInstanceClient) {
     this.agentInitializer = agentInitializer;
     this.conversationStoreRegistry = conversationStoreRegistry;
     this.agentInputComposer = agentInputComposer;
-    this.framework = framework;
+    this.chatModelApiRegistry = chatModelApiRegistry;
     this.systemPromptComposer = systemPromptComposer;
     this.responseHandler = responseHandler;
     this.agentInstanceClient = agentInstanceClient;
@@ -158,12 +160,16 @@ public abstract class BaseAgentRequestHandler<
         conversation.lastTurn(),
         OffsetDateTime.now());
 
-    LOGGER.debug("Executing chat request with AI framework");
-    final var chatResponse =
-        framework.executeMeasuringTime(
-            executionContext, conversation.window(agentConfiguration.contextWindowSize()));
+    LOGGER.debug("Executing chat request");
+    final var chatModel =
+        chatModelApiRegistry.resolve(
+            new ProviderChatModelApiConfiguration(executionContext.configuration().provider()));
+    final var chatResult =
+        chatModel.call(
+            new ChatModelRequest(
+                executionContext, conversation.window(agentConfiguration.contextWindowSize())));
     final var updatedConversation =
-        conversation.ingest(chatResponse.assistantMessage(), chatResponse.metrics());
+        conversation.ingest(chatResult.assistantMessage(), chatResult.metrics());
 
     agentInstanceClient.createHistoryForAssistantMessage(
         executionContext,

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/agent/JobWorkerAgentRequestHandler.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/agent/JobWorkerAgentRequestHandler.java
@@ -10,7 +10,7 @@ import io.camunda.connector.agenticai.aiagent.AiAgentJobWorker;
 import io.camunda.connector.agenticai.aiagent.AiAgentSubProcessConnectorResponse;
 import io.camunda.connector.agenticai.aiagent.AiAgentSubProcessConnectorResponse.ToolCallElementActivation;
 import io.camunda.connector.agenticai.aiagent.agentinstance.AgentInstanceClient;
-import io.camunda.connector.agenticai.aiagent.framework.AiFrameworkAdapter;
+import io.camunda.connector.agenticai.aiagent.framework.api.ChatModelApiRegistry;
 import io.camunda.connector.agenticai.aiagent.memory.conversation.ConversationStoreRegistry;
 import io.camunda.connector.agenticai.aiagent.model.AgentConversation;
 import io.camunda.connector.agenticai.aiagent.model.AgentResponse;
@@ -35,7 +35,7 @@ public class JobWorkerAgentRequestHandler
       AgentInitializer agentInitializer,
       ConversationStoreRegistry conversationStoreRegistry,
       AgentConversationTurnInputComposer agentInputComposer,
-      AiFrameworkAdapter<?> framework,
+      ChatModelApiRegistry chatModelApiRegistry,
       SystemPromptComposer systemPromptComposer,
       AgentResponseHandler responseHandler,
       AgentInstanceClient agentInstanceClient) {
@@ -43,7 +43,7 @@ public class JobWorkerAgentRequestHandler
         agentInitializer,
         conversationStoreRegistry,
         agentInputComposer,
-        framework,
+        chatModelApiRegistry,
         systemPromptComposer,
         responseHandler,
         agentInstanceClient);

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/agent/OutboundConnectorAgentRequestHandler.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/agent/OutboundConnectorAgentRequestHandler.java
@@ -8,7 +8,7 @@ package io.camunda.connector.agenticai.aiagent.agent;
 
 import io.camunda.connector.agenticai.aiagent.AiAgentTaskConnectorResponse;
 import io.camunda.connector.agenticai.aiagent.agentinstance.AgentInstanceClient;
-import io.camunda.connector.agenticai.aiagent.framework.AiFrameworkAdapter;
+import io.camunda.connector.agenticai.aiagent.framework.api.ChatModelApiRegistry;
 import io.camunda.connector.agenticai.aiagent.memory.conversation.ConversationStoreRegistry;
 import io.camunda.connector.agenticai.aiagent.model.AgentConversation;
 import io.camunda.connector.agenticai.aiagent.model.AgentResponse;
@@ -25,7 +25,7 @@ public class OutboundConnectorAgentRequestHandler
       AgentInitializer agentInitializer,
       ConversationStoreRegistry conversationStoreRegistry,
       AgentConversationTurnInputComposer agentInputComposer,
-      AiFrameworkAdapter<?> framework,
+      ChatModelApiRegistry chatModelApiRegistry,
       SystemPromptComposer systemPromptComposer,
       AgentResponseHandler responseHandler,
       AgentInstanceClient agentInstanceClient) {
@@ -33,7 +33,7 @@ public class OutboundConnectorAgentRequestHandler
         agentInitializer,
         conversationStoreRegistry,
         agentInputComposer,
-        framework,
+        chatModelApiRegistry,
         systemPromptComposer,
         responseHandler,
         agentInstanceClient);

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/agentinstance/AgentInstanceHistoryMapper.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/agentinstance/AgentInstanceHistoryMapper.java
@@ -24,6 +24,7 @@ import io.camunda.connector.agenticai.aiagent.model.message.UserMessage;
 import io.camunda.connector.agenticai.aiagent.model.message.content.Content;
 import io.camunda.connector.agenticai.aiagent.model.message.content.DocumentContent;
 import io.camunda.connector.agenticai.aiagent.model.message.content.ObjectContent;
+import io.camunda.connector.agenticai.aiagent.model.message.content.ReasoningContent;
 import io.camunda.connector.agenticai.aiagent.model.message.content.TextContent;
 import io.camunda.connector.agenticai.aiagent.model.tool.ToolCall;
 import io.camunda.connector.agenticai.aiagent.model.tool.ToolCallResult;
@@ -197,6 +198,9 @@ public class AgentInstanceHistoryMapper {
       case TextContent textContent -> AgentInstanceHistoryContent.text(textContent.text());
       case ObjectContent objectContent -> objectHistoryContent(objectContent.content());
       case DocumentContent documentContent -> documentHistoryContent(documentContent);
+      // Agent instance history has no dedicated reasoning content block yet; surface it as an
+      // object block for now (follow-up: team decision).
+      case ReasoningContent reasoningContent -> objectHistoryContent(reasoningContent);
     };
   }
 

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/ChatModelApiRegistryImpl.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/ChatModelApiRegistryImpl.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.agenticai.aiagent.framework;
+
+import io.camunda.connector.agenticai.aiagent.agent.AgentErrorCodes;
+import io.camunda.connector.agenticai.aiagent.framework.api.ChatModelApi;
+import io.camunda.connector.agenticai.aiagent.framework.api.ChatModelApiConfiguration;
+import io.camunda.connector.agenticai.aiagent.framework.api.ChatModelApiFactory;
+import io.camunda.connector.agenticai.aiagent.framework.api.ChatModelApiRegistry;
+import io.camunda.connector.api.error.ConnectorException;
+import java.util.Comparator;
+import java.util.List;
+
+/**
+ * Resolves the {@link ChatModelApi} for a given {@link ChatModelApiConfiguration} by asking the
+ * registered {@link ChatModelApiFactory} instances, in {@link ChatModelApiFactory#getOrder()}
+ * precedence, which of them supports it.
+ */
+public class ChatModelApiRegistryImpl implements ChatModelApiRegistry {
+
+  private final List<ChatModelApiFactory> factories;
+
+  public ChatModelApiRegistryImpl(List<ChatModelApiFactory> factories) {
+    this.factories =
+        factories.stream().sorted(Comparator.comparingInt(ChatModelApiFactory::getOrder)).toList();
+  }
+
+  @Override
+  public ChatModelApi resolve(ChatModelApiConfiguration configuration) {
+    return factories.stream()
+        .filter(factory -> factory.supports(configuration))
+        .findFirst()
+        .orElseThrow(
+            () ->
+                new ConnectorException(
+                    AgentErrorCodes.ERROR_CODE_FAILED_MODEL_CALL,
+                    "No chat model registered for configuration: " + configuration))
+        .create(configuration);
+  }
+}

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/api/ChatModelApi.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/api/ChatModelApi.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.agenticai.aiagent.framework.api;
+
+/**
+ * Per-provider chat model. A single {@link #call(ChatModelRequest)} invocation performs exactly one
+ * round-trip against the provider; implementations must not run their own internal (vendor)
+ * tool-calling auto-loop.
+ */
+public interface ChatModelApi {
+
+  ChatModelResult call(ChatModelRequest request);
+}

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/api/ChatModelApiConfiguration.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/api/ChatModelApiConfiguration.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.agenticai.aiagent.framework.api;
+
+/**
+ * Neutral, connector-agnostic descriptor a {@link ChatModelApiFactory} inspects to decide whether
+ * it can serve a request and to build a {@link ChatModelApi}. Today the only implementation wraps a
+ * {@link io.camunda.connector.agenticai.aiagent.model.request.provider.ProviderConfiguration}; new
+ * connector variants and custom providers contribute their own implementations.
+ */
+public interface ChatModelApiConfiguration {}

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/api/ChatModelApiFactory.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/api/ChatModelApiFactory.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.agenticai.aiagent.framework.api;
+
+/** Builds a {@link ChatModelApi} for the chat model configurations it supports. */
+public interface ChatModelApiFactory {
+
+  int DEFAULT_ORDER = 0;
+
+  /** Whether this factory can serve the given configuration. */
+  boolean supports(ChatModelApiConfiguration configuration);
+
+  /**
+   * Builds the chat model. Only called when {@link #supports(ChatModelApiConfiguration)} is true.
+   */
+  ChatModelApi create(ChatModelApiConfiguration configuration);
+
+  /**
+   * Selection precedence when multiple factories support a configuration: lowest value wins. The
+   * LangChain4j bridge returns the lowest precedence so any native implementation overrides it.
+   *
+   * @return The order value (default: {@link #DEFAULT_ORDER})
+   */
+  default int getOrder() {
+    return DEFAULT_ORDER;
+  }
+}

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/api/ChatModelApiRegistry.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/api/ChatModelApiRegistry.java
@@ -1,0 +1,13 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.agenticai.aiagent.framework.api;
+
+/** Resolves the {@link ChatModelApi} responsible for a given {@link ChatModelApiConfiguration}. */
+public interface ChatModelApiRegistry {
+
+  ChatModelApi resolve(ChatModelApiConfiguration configuration);
+}

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/api/ChatModelRequest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/api/ChatModelRequest.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.agenticai.aiagent.framework.api;
+
+import io.camunda.connector.agenticai.aiagent.memory.ConversationSnapshot;
+import io.camunda.connector.agenticai.aiagent.model.AgentExecutionContext;
+
+/** What a {@link ChatModelApi} needs for one round-trip against a provider. */
+public record ChatModelRequest(
+    AgentExecutionContext executionContext, ConversationSnapshot snapshot) {}

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/api/ChatModelResult.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/api/ChatModelResult.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.agenticai.aiagent.framework.api;
+
+import io.camunda.connector.agenticai.aiagent.model.AgentMetrics;
+import io.camunda.connector.agenticai.aiagent.model.message.AssistantMessage;
+
+/**
+ * The outcome of a single round-trip performed by a {@link ChatModelApi}: the assistant message
+ * produced for the turn and its metrics ({@code modelCalls}, {@code tokenUsage}, {@code toolCalls},
+ * and the measured {@code executionTime}).
+ */
+public record ChatModelResult(AssistantMessage assistantMessage, AgentMetrics metrics) {}

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/api/ProviderChatModelApiConfiguration.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/api/ProviderChatModelApiConfiguration.java
@@ -1,0 +1,13 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.agenticai.aiagent.framework.api;
+
+import io.camunda.connector.agenticai.aiagent.model.request.provider.ProviderConfiguration;
+
+/** {@link ChatModelApiConfiguration} backed by a built-in {@link ProviderConfiguration}. */
+public record ProviderChatModelApiConfiguration(ProviderConfiguration providerConfiguration)
+    implements ChatModelApiConfiguration {}

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/api/package-info.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/api/package-info.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+@NullMarked
+package io.camunda.connector.agenticai.aiagent.framework.api;
+
+import org.jspecify.annotations.NullMarked;

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/ChatMessageConverterImpl.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/ChatMessageConverterImpl.java
@@ -15,10 +15,12 @@ import dev.langchain4j.data.message.ToolExecutionResultMessage;
 import dev.langchain4j.internal.Json;
 import dev.langchain4j.model.chat.response.ChatResponse;
 import dev.langchain4j.model.chat.response.ChatResponseMetadata;
+import dev.langchain4j.model.output.FinishReason;
 import dev.langchain4j.model.output.TokenUsage;
 import io.camunda.connector.agenticai.aiagent.framework.langchain4j.tool.ToolCallConverter;
 import io.camunda.connector.agenticai.aiagent.model.message.AssistantMessage;
 import io.camunda.connector.agenticai.aiagent.model.message.AssistantMessageBuilder;
+import io.camunda.connector.agenticai.aiagent.model.message.StopReason;
 import io.camunda.connector.agenticai.aiagent.model.message.SystemMessage;
 import io.camunda.connector.agenticai.aiagent.model.message.ToolCallResultMessage;
 import io.camunda.connector.agenticai.aiagent.model.message.UserMessage;
@@ -133,10 +135,21 @@ public class ChatMessageConverterImpl implements ChatMessageConverter {
     final var builder = AssistantMessage.builder();
 
     if (chatResponse.metadata() != null) {
+      final var responseMetadata = chatResponse.metadata();
       builder.metadata(
           Map.of(
               "timestamp", ZonedDateTime.now(),
-              "framework", serializedChatResponseMetadata(chatResponse.metadata())));
+              "framework", serializedChatResponseMetadata(responseMetadata)));
+
+      Optional.ofNullable(responseMetadata.modelName())
+          .filter(StringUtils::isNotBlank)
+          .ifPresent(builder::modelId);
+      Optional.ofNullable(responseMetadata.id())
+          .filter(StringUtils::isNotBlank)
+          .ifPresent(builder::messageId);
+      Optional.ofNullable(responseMetadata.finishReason())
+          .map(ChatMessageConverterImpl::toStopReason)
+          .ifPresent(builder::stopReason);
     }
 
     final var aiMessage = chatResponse.aiMessage();
@@ -150,6 +163,16 @@ public class ChatMessageConverterImpl implements ChatMessageConverter {
     builder.toolCalls(toolCalls);
 
     return builder;
+  }
+
+  private static StopReason toStopReason(FinishReason finishReason) {
+    return switch (finishReason) {
+      case STOP -> StopReason.STOP;
+      case LENGTH -> StopReason.LENGTH;
+      case TOOL_EXECUTION -> StopReason.TOOL_USE;
+      case CONTENT_FILTER -> StopReason.CONTENT_FILTERED;
+      case OTHER -> StopReason.UNKNOWN;
+    };
   }
 
   protected Map<String, Object> serializedChatResponseMetadata(

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/ContentConverterImpl.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/ContentConverterImpl.java
@@ -12,6 +12,7 @@ import io.camunda.connector.agenticai.aiagent.framework.langchain4j.document.Doc
 import io.camunda.connector.agenticai.aiagent.model.message.content.Content;
 import io.camunda.connector.agenticai.aiagent.model.message.content.DocumentContent;
 import io.camunda.connector.agenticai.aiagent.model.message.content.ObjectContent;
+import io.camunda.connector.agenticai.aiagent.model.message.content.ReasoningContent;
 import io.camunda.connector.agenticai.aiagent.model.message.content.TextContent;
 import java.util.Objects;
 import org.jspecify.annotations.Nullable;
@@ -37,6 +38,11 @@ public class ContentConverterImpl implements ContentConverter {
       case ObjectContent objectContent ->
           new dev.langchain4j.data.message.TextContent(
               Objects.requireNonNull(convertToString(objectContent.content())));
+      case ReasoningContent reasoningContent ->
+          // LangChain4J has no wire representation for provider-opaque reasoning content; this
+          // legacy framework path is not expected to round-trip it (follow-up: team decision).
+          throw new UnsupportedOperationException(
+              "Reasoning content is not supported by the LangChain4J framework abstraction");
     };
   }
 

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/Langchain4JChatModelApi.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/Langchain4JChatModelApi.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.agenticai.aiagent.framework.langchain4j;
+
+import io.camunda.connector.agenticai.aiagent.framework.api.ChatModelApi;
+import io.camunda.connector.agenticai.aiagent.framework.api.ChatModelRequest;
+import io.camunda.connector.agenticai.aiagent.framework.api.ChatModelResult;
+
+/** Bridges the existing LangChain4J framework adapter behind the {@link ChatModelApi} SPI. */
+public class Langchain4JChatModelApi implements ChatModelApi {
+
+  private final Langchain4JAiFrameworkAdapter adapter;
+
+  public Langchain4JChatModelApi(Langchain4JAiFrameworkAdapter adapter) {
+    this.adapter = adapter;
+  }
+
+  @Override
+  public ChatModelResult call(ChatModelRequest request) {
+    final var response =
+        adapter.executeMeasuringTime(request.executionContext(), request.snapshot());
+    return new ChatModelResult(response.assistantMessage(), response.metrics());
+  }
+}

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/Langchain4JChatModelApiFactory.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/Langchain4JChatModelApiFactory.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.agenticai.aiagent.framework.langchain4j;
+
+import io.camunda.connector.agenticai.aiagent.framework.api.ChatModelApi;
+import io.camunda.connector.agenticai.aiagent.framework.api.ChatModelApiConfiguration;
+import io.camunda.connector.agenticai.aiagent.framework.api.ChatModelApiFactory;
+import io.camunda.connector.agenticai.aiagent.framework.api.ProviderChatModelApiConfiguration;
+
+/**
+ * Lowest-precedence bridge factory routing every built-in {@link ProviderChatModelApiConfiguration}
+ * through the LangChain4J adapter. Serves every built-in provider configuration until native {@link
+ * ChatModelApi} implementations are introduced and override it per provider.
+ */
+public class Langchain4JChatModelApiFactory implements ChatModelApiFactory {
+
+  /** Low precedence: native implementations register below this to override the bridge. */
+  static final int ORDER = 1000;
+
+  private final Langchain4JAiFrameworkAdapter adapter;
+
+  public Langchain4JChatModelApiFactory(Langchain4JAiFrameworkAdapter adapter) {
+    this.adapter = adapter;
+  }
+
+  @Override
+  public boolean supports(ChatModelApiConfiguration configuration) {
+    return configuration instanceof ProviderChatModelApiConfiguration;
+  }
+
+  @Override
+  public ChatModelApi create(ChatModelApiConfiguration configuration) {
+    return new Langchain4JChatModelApi(adapter);
+  }
+
+  @Override
+  public int getOrder() {
+    return ORDER;
+  }
+}

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/configuration/AgenticAiLangchain4JFrameworkConfiguration.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/configuration/AgenticAiLangchain4JFrameworkConfiguration.java
@@ -13,6 +13,7 @@ import io.camunda.connector.agenticai.aiagent.framework.langchain4j.ChatModelFac
 import io.camunda.connector.agenticai.aiagent.framework.langchain4j.ContentConverter;
 import io.camunda.connector.agenticai.aiagent.framework.langchain4j.ContentConverterImpl;
 import io.camunda.connector.agenticai.aiagent.framework.langchain4j.Langchain4JAiFrameworkAdapter;
+import io.camunda.connector.agenticai.aiagent.framework.langchain4j.Langchain4JChatModelApiFactory;
 import io.camunda.connector.agenticai.aiagent.framework.langchain4j.document.DocumentToContentConverter;
 import io.camunda.connector.agenticai.aiagent.framework.langchain4j.document.DocumentToContentConverterImpl;
 import io.camunda.connector.agenticai.aiagent.framework.langchain4j.jsonschema.JsonSchemaConverter;
@@ -88,5 +89,12 @@ public class AgenticAiLangchain4JFrameworkConfiguration {
       JsonSchemaConverter jsonSchemaConverter) {
     return new Langchain4JAiFrameworkAdapter(
         chatModelFactory, chatMessageConverter, toolSpecificationConverter, jsonSchemaConverter);
+  }
+
+  @Bean
+  @ConditionalOnMissingBean
+  public Langchain4JChatModelApiFactory langchain4JChatModelApiFactory(
+      Langchain4JAiFrameworkAdapter langchain4JAiFrameworkAdapter) {
+    return new Langchain4JChatModelApiFactory(langchain4JAiFrameworkAdapter);
   }
 }

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/AgentMetrics.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/AgentMetrics.java
@@ -73,21 +73,42 @@ public record AgentMetrics(
   @JsonPOJOBuilder(withPrefix = "")
   public static class AgentMetricsJacksonProxyBuilder extends AgentMetricsBuilder {}
 
+  /**
+   * Token usage for a model interaction.
+   *
+   * <p>Aggregation semantics: {@code cacheReadTokenCount} and {@code cacheCreationTokenCount} are
+   * subsets already counted within {@code inputTokenCount}; {@code reasoningTokenCount} is a subset
+   * already counted within {@code outputTokenCount}. {@link #totalTokenCount()} is therefore {@code
+   * input + output} and never double-counts. Populated per-round by the native provider
+   * implementations.
+   */
   @AgenticAiRecord
   @JsonDeserialize(builder = TokenUsage.AgentMetricsTokenUsageJacksonProxyBuilder.class)
-  public record TokenUsage(int inputTokenCount, int outputTokenCount)
+  public record TokenUsage(
+      int inputTokenCount,
+      int outputTokenCount,
+      @JsonInclude(JsonInclude.Include.NON_DEFAULT) int cacheReadTokenCount,
+      @JsonInclude(JsonInclude.Include.NON_DEFAULT) int cacheCreationTokenCount,
+      @JsonInclude(JsonInclude.Include.NON_DEFAULT) int reasoningTokenCount)
       implements AgentMetricsTokenUsageBuilder.With {
+
+    public TokenUsage(int inputTokenCount, int outputTokenCount) {
+      this(inputTokenCount, outputTokenCount, 0, 0, 0);
+    }
 
     public int totalTokenCount() {
       return inputTokenCount + outputTokenCount;
     }
 
-    public TokenUsage add(TokenUsage tokenUsage) {
+    public TokenUsage add(TokenUsage other) {
       return with(
-          builder ->
-              builder
-                  .inputTokenCount(builder.inputTokenCount() + tokenUsage.inputTokenCount())
-                  .outputTokenCount(builder.outputTokenCount() + tokenUsage.outputTokenCount()));
+          b ->
+              b.inputTokenCount(b.inputTokenCount() + other.inputTokenCount())
+                  .outputTokenCount(b.outputTokenCount() + other.outputTokenCount())
+                  .cacheReadTokenCount(b.cacheReadTokenCount() + other.cacheReadTokenCount())
+                  .cacheCreationTokenCount(
+                      b.cacheCreationTokenCount() + other.cacheCreationTokenCount())
+                  .reasoningTokenCount(b.reasoningTokenCount() + other.reasoningTokenCount()));
     }
 
     public static TokenUsage empty() {

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/message/AssistantMessage.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/message/AssistantMessage.java
@@ -21,6 +21,9 @@ import org.jspecify.annotations.Nullable;
 public record AssistantMessage(
     @JsonInclude(JsonInclude.Include.NON_EMPTY) List<Content> content,
     @JsonInclude(JsonInclude.Include.NON_EMPTY) List<ToolCall> toolCalls,
+    @JsonInclude(JsonInclude.Include.NON_NULL) @Nullable String modelId,
+    @JsonInclude(JsonInclude.Include.NON_NULL) @Nullable String messageId,
+    @JsonInclude(JsonInclude.Include.NON_NULL) @Nullable StopReason stopReason,
     @JsonInclude(JsonInclude.Include.NON_EMPTY) @Nullable Map<String, Object> metadata)
     implements AssistantMessageBuilder.With, Message, ContentMessage {
 

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/message/StopReason.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/message/StopReason.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.agenticai.aiagent.model.message;
+
+/**
+ * Provider-neutral, normalized finish reason. Diagnostics + a thin predicate surface only — never
+ * load-bearing for control flow (that keys off {@link AssistantMessage#hasToolCalls()}). The raw
+ * vendor value is always preserved in {@link AssistantMessage#metadata()}. Do NOT exhaustively
+ * switch on this enum: it is part of the persisted message contract, so new values must remain
+ * non-breaking. Continuation states (e.g. Anthropic {@code pause_turn}) are NOT represented here —
+ * see the {@code Continuation} chat result. See ADR 009 §3.
+ */
+public enum StopReason {
+  STOP,
+  LENGTH,
+  TOOL_USE,
+  CONTENT_FILTERED,
+  GUARDRAIL,
+  ERROR,
+  ABORTED,
+  UNKNOWN
+}

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/message/content/Content.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/message/content/Content.java
@@ -14,8 +14,10 @@ import java.util.Map;
 @JsonSubTypes({
   @JsonSubTypes.Type(value = TextContent.class, name = "text"),
   @JsonSubTypes.Type(value = DocumentContent.class, name = "document"),
-  @JsonSubTypes.Type(value = ObjectContent.class, name = "object")
+  @JsonSubTypes.Type(value = ObjectContent.class, name = "object"),
+  @JsonSubTypes.Type(value = ReasoningContent.class, name = "reasoning")
 })
-public sealed interface Content permits TextContent, DocumentContent, ObjectContent {
+public sealed interface Content
+    permits TextContent, DocumentContent, ObjectContent, ReasoningContent {
   Map<String, Object> metadata();
 }

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/message/content/ReasoningContent.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/message/content/ReasoningContent.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.agenticai.aiagent.model.message.content;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import java.util.Map;
+import org.jspecify.annotations.Nullable;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record ReasoningContent(
+    @JsonInclude(JsonInclude.Include.NON_EMPTY) @Nullable String text,
+    @JsonInclude(JsonInclude.Include.NON_NULL) @Nullable Object providerPayload,
+    @JsonInclude(JsonInclude.Include.NON_EMPTY) @Nullable Map<String, Object> metadata)
+    implements Content {
+
+  public static ReasoningContent reasoningContent(String text) {
+    return new ReasoningContent(text, null, null);
+  }
+}

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/autoconfigure/AgenticAiConnectorsAutoConfiguration.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/autoconfigure/AgenticAiConnectorsAutoConfiguration.java
@@ -42,7 +42,9 @@ import io.camunda.connector.agenticai.aiagent.agentinstance.AgentInstanceClient;
 import io.camunda.connector.agenticai.aiagent.agentinstance.AgentInstanceHistoryMapper;
 import io.camunda.connector.agenticai.aiagent.agentinstance.AgentInstanceToolMapper;
 import io.camunda.connector.agenticai.aiagent.agentinstance.CamundaAgentInstanceClient;
-import io.camunda.connector.agenticai.aiagent.framework.AiFrameworkAdapter;
+import io.camunda.connector.agenticai.aiagent.framework.ChatModelApiRegistryImpl;
+import io.camunda.connector.agenticai.aiagent.framework.api.ChatModelApiFactory;
+import io.camunda.connector.agenticai.aiagent.framework.api.ChatModelApiRegistry;
 import io.camunda.connector.agenticai.aiagent.framework.langchain4j.ChatModelHttpProxySupport;
 import io.camunda.connector.agenticai.aiagent.framework.langchain4j.configuration.AgenticAiLangchain4JFrameworkConfiguration;
 import io.camunda.connector.agenticai.aiagent.memory.conversation.ConversationStore;
@@ -288,6 +290,13 @@ public class AgenticAiConnectorsAutoConfiguration {
 
   @Bean
   @ConditionalOnMissingBean
+  public ChatModelApiRegistry chatModelApiRegistry(
+      List<ChatModelApiFactory> chatModelApiFactories) {
+    return new ChatModelApiRegistryImpl(chatModelApiFactories);
+  }
+
+  @Bean
+  @ConditionalOnMissingBean
   @ConditionalOnBooleanProperty(
       value = "camunda.connector.agenticai.aiagent.outbound-connector.enabled",
       matchIfMissing = true)
@@ -295,7 +304,7 @@ public class AgenticAiConnectorsAutoConfiguration {
       AgentInitializer agentInitializer,
       ConversationStoreRegistry conversationStoreRegistry,
       AgentConversationTurnInputComposer agentConversationTurnInputComposer,
-      AiFrameworkAdapter<?> aiFrameworkAdapter,
+      ChatModelApiRegistry chatModelApiRegistry,
       SystemPromptComposer systemPromptComposer,
       AgentResponseHandler responseHandler,
       AgentInstanceClient agentInstanceClient) {
@@ -303,7 +312,7 @@ public class AgenticAiConnectorsAutoConfiguration {
         agentInitializer,
         conversationStoreRegistry,
         agentConversationTurnInputComposer,
-        aiFrameworkAdapter,
+        chatModelApiRegistry,
         systemPromptComposer,
         responseHandler,
         agentInstanceClient);
@@ -329,7 +338,7 @@ public class AgenticAiConnectorsAutoConfiguration {
       AgentInitializer agentInitializer,
       ConversationStoreRegistry conversationStoreRegistry,
       AgentConversationTurnInputComposer agentConversationTurnInputComposer,
-      AiFrameworkAdapter<?> aiFrameworkAdapter,
+      ChatModelApiRegistry chatModelApiRegistry,
       SystemPromptComposer systemPromptComposer,
       AgentResponseHandler responseHandler,
       AgentInstanceClient agentInstanceClient) {
@@ -337,7 +346,7 @@ public class AgenticAiConnectorsAutoConfiguration {
         agentInitializer,
         conversationStoreRegistry,
         agentConversationTurnInputComposer,
-        aiFrameworkAdapter,
+        chatModelApiRegistry,
         systemPromptComposer,
         responseHandler,
         agentInstanceClient);

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/agent/AgentResponseHandlerTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/agent/AgentResponseHandlerTest.java
@@ -231,7 +231,11 @@ class AgentResponseHandlerTest {
 
     static Stream<AssistantMessage> emptyAssistantMessages() {
       return Stream.of(
-          new AssistantMessage(List.of(), List.of(), Map.of()),
+          AssistantMessage.builder()
+              .content(List.of())
+              .toolCalls(List.of())
+              .metadata(Map.of())
+              .build(),
           assistantMessage(List.of(DocumentContent.documentContent(mock(Document.class)))));
     }
   }

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/agent/JobWorkerAgentRequestHandlerTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/agent/JobWorkerAgentRequestHandlerTest.java
@@ -34,9 +34,10 @@ import io.camunda.connector.agenticai.aiagent.agent.AgentInitializationResult.Di
 import io.camunda.connector.agenticai.aiagent.agent.AgentInitializationResult.ReadyToConverse;
 import io.camunda.connector.agenticai.aiagent.agentinstance.AgentInstanceClient;
 import io.camunda.connector.agenticai.aiagent.agentinstance.AgentInstanceUpdateRequest;
-import io.camunda.connector.agenticai.aiagent.framework.AiFrameworkAdapter;
-import io.camunda.connector.agenticai.aiagent.framework.AiFrameworkChatResponse;
-import io.camunda.connector.agenticai.aiagent.memory.ConversationSnapshot;
+import io.camunda.connector.agenticai.aiagent.framework.api.ChatModelApi;
+import io.camunda.connector.agenticai.aiagent.framework.api.ChatModelApiRegistry;
+import io.camunda.connector.agenticai.aiagent.framework.api.ChatModelRequest;
+import io.camunda.connector.agenticai.aiagent.framework.api.ChatModelResult;
 import io.camunda.connector.agenticai.aiagent.memory.conversation.ConversationStore;
 import io.camunda.connector.agenticai.aiagent.memory.conversation.ConversationStoreRegistry;
 import io.camunda.connector.agenticai.aiagent.memory.conversation.inprocess.InProcessConversationContext;
@@ -91,7 +92,8 @@ class JobWorkerAgentRequestHandlerTest {
   @Mock private AgentInitializer agentInitializer;
   @Mock private ConversationStoreRegistry conversationStoreRegistry;
   @Mock private AgentConversationTurnInputComposer agentInputComposer;
-  @Mock private AiFrameworkAdapter<?> framework;
+  @Mock private ChatModelApiRegistry chatModelApiRegistry;
+  @Mock private ChatModelApi chatModelApi;
   @Mock private SystemPromptComposer systemPromptComposer;
   @Mock private AgentResponseHandler responseHandler;
   @Mock private AgentInstanceClient agentInstanceClient;
@@ -99,7 +101,7 @@ class JobWorkerAgentRequestHandlerTest {
   @Mock(answer = Answers.RETURNS_DEEP_STUBS)
   private JobWorkerAgentExecutionContext agentExecutionContext;
 
-  @Captor private ArgumentCaptor<ConversationSnapshot> snapshotCaptor;
+  @Captor private ArgumentCaptor<ChatModelRequest> chatModelRequestCaptor;
   @Captor private ArgumentCaptor<AgentConversationTurn> turnCaptor;
 
   @InjectMocks private JobWorkerAgentRequestHandler requestHandler;
@@ -149,7 +151,7 @@ class JobWorkerAgentRequestHandlerTest {
     assertThat(response.responseValue().toolCalls())
         .containsExactly(ToolCallProcessVariable.from(toolDiscoveryToolCalls.getFirst()));
 
-    verifyNoInteractions(agentInputComposer, framework, responseHandler);
+    verifyNoInteractions(agentInputComposer, chatModelApiRegistry, responseHandler);
   }
 
   @Test
@@ -212,7 +214,7 @@ class JobWorkerAgentRequestHandlerTest {
     assertThat(response.responseValue()).isNull();
     assertThat(response.completionConditionFulfilled()).isFalse();
 
-    verifyNoInteractions(agentInputComposer, framework, responseHandler);
+    verifyNoInteractions(agentInputComposer, chatModelApiRegistry, responseHandler);
   }
 
   @Test
@@ -242,7 +244,9 @@ class JobWorkerAgentRequestHandlerTest {
     assertThat(agentResponse.context()).isEqualTo(response.variables().get("agentContext"));
     assertThat(agentResponse.context().state()).isEqualTo(AgentState.READY);
     assertThat(agentResponse.context().metrics())
-        .isEqualTo(new AgentMetrics(1, new TokenUsage(10, 20), 0));
+        .isEqualTo(
+            new AgentMetrics(
+                1, TokenUsage.builder().inputTokenCount(10).outputTokenCount(20).build(), 0));
     assertThat(agentResponse.context().conversation())
         .isNotNull()
         .isInstanceOfSatisfying(
@@ -255,7 +259,8 @@ class JobWorkerAgentRequestHandlerTest {
     assertThat(response.elementActivations()).isEmpty();
 
     // snapshot is captured before the assistant message is ingested
-    assertThat(snapshotCaptor.getValue().messages()).containsExactly(SYSTEM_MESSAGE, USER_MESSAGE);
+    assertThat(chatModelRequestCaptor.getValue().snapshot().messages())
+        .containsExactly(SYSTEM_MESSAGE, USER_MESSAGE);
   }
 
   @Test
@@ -282,7 +287,9 @@ class JobWorkerAgentRequestHandlerTest {
     assertThat(agentResponse).isNotNull();
     assertThat(agentResponse.context().state()).isEqualTo(AgentState.READY);
     assertThat(agentResponse.context().metrics())
-        .isEqualTo(new AgentMetrics(1, new TokenUsage(10, 20), 2));
+        .isEqualTo(
+            new AgentMetrics(
+                1, TokenUsage.builder().inputTokenCount(10).outputTokenCount(20).build(), 2));
     assertThat(agentResponse.context().conversation())
         .isNotNull()
         .isInstanceOfSatisfying(
@@ -351,7 +358,9 @@ class JobWorkerAgentRequestHandlerTest {
     assertThat(agentResponse.context()).isEqualTo(response.variables().get("agentContext"));
     assertThat(agentResponse.context().state()).isEqualTo(AgentState.READY);
     assertThat(agentResponse.context().metrics())
-        .isEqualTo(new AgentMetrics(1, new TokenUsage(10, 20), 0));
+        .isEqualTo(
+            new AgentMetrics(
+                1, TokenUsage.builder().inputTokenCount(10).outputTokenCount(20).build(), 0));
     assertThat(agentResponse.context().conversation())
         .isNotNull()
         .isInstanceOfSatisfying(
@@ -377,7 +386,7 @@ class JobWorkerAgentRequestHandlerTest {
     assertThat(response.cancelRemainingInstances()).isFalse();
     assertThat(response.elementActivations()).isEmpty();
 
-    verifyNoInteractions(framework);
+    verifyNoInteractions(chatModelApiRegistry);
   }
 
   @Test
@@ -392,7 +401,7 @@ class JobWorkerAgentRequestHandlerTest {
     assertThat(response.completionConditionFulfilled()).isFalse();
     assertThat(response.cancelRemainingInstances()).isFalse();
 
-    verifyNoInteractions(framework);
+    verifyNoInteractions(chatModelApiRegistry);
   }
 
   @Test
@@ -432,7 +441,11 @@ class JobWorkerAgentRequestHandlerTest {
             eq(
                 AgentInstanceUpdateRequest.builder()
                     .status(AgentInstanceUpdateStatus.TOOL_CALLING)
-                    .delta(new AgentMetrics(1, new TokenUsage(10, 20), 2))
+                    .delta(
+                        new AgentMetrics(
+                            1,
+                            TokenUsage.builder().inputTokenCount(10).outputTokenCount(20).build(),
+                            2))
                     .build()));
     verifyNoMoreInteractions(agentInstanceClient);
   }
@@ -470,7 +483,11 @@ class JobWorkerAgentRequestHandlerTest {
             eq(
                 AgentInstanceUpdateRequest.builder()
                     .status(AgentInstanceUpdateStatus.IDLE)
-                    .delta(new AgentMetrics(1, new TokenUsage(10, 20), 0))
+                    .delta(
+                        new AgentMetrics(
+                            1,
+                            TokenUsage.builder().inputTokenCount(10).outputTokenCount(20).build(),
+                            0))
                     .build()));
     verifyHistoryItemsCreated(assistantMessage);
     verifyNoMoreInteractions(agentInstanceClient);
@@ -519,7 +536,11 @@ class JobWorkerAgentRequestHandlerTest {
             eq(
                 AgentInstanceUpdateRequest.builder()
                     .status(AgentInstanceUpdateStatus.IDLE)
-                    .delta(new AgentMetrics(1, new TokenUsage(10, 20), 0))
+                    .delta(
+                        new AgentMetrics(
+                            1,
+                            TokenUsage.builder().inputTokenCount(10).outputTokenCount(20).build(),
+                            0))
                     .build()));
     verifyNoMoreInteractions(agentInstanceClient);
   }
@@ -562,7 +583,11 @@ class JobWorkerAgentRequestHandlerTest {
             any(),
             eq(
                 AgentInstanceUpdateRequest.builder()
-                    .delta(new AgentMetrics(1, new TokenUsage(10, 20), 0))
+                    .delta(
+                        new AgentMetrics(
+                            1,
+                            TokenUsage.builder().inputTokenCount(10).outputTokenCount(20).build(),
+                            0))
                     .build()));
     verifyNoMoreInteractions(agentInstanceClient);
   }
@@ -587,7 +612,8 @@ class JobWorkerAgentRequestHandlerTest {
             InProcessConversationContext.class,
             c -> assertThat(c.messages()).containsExactly(USER_MESSAGE, assistantMessage));
     // no system message is sent to the LLM either
-    assertThat(snapshotCaptor.getValue().messages()).containsExactly(USER_MESSAGE);
+    assertThat(chatModelRequestCaptor.getValue().snapshot().messages())
+        .containsExactly(USER_MESSAGE);
   }
 
   @Test
@@ -624,7 +650,7 @@ class JobWorkerAgentRequestHandlerTest {
                     .isEqualTo(AgentErrorCodes.ERROR_CODE_MAXIMUM_NUMBER_OF_MODEL_CALLS_REACHED));
 
     // limit is checked before the LLM call — no chat request is issued
-    verifyNoInteractions(framework);
+    verifyNoInteractions(chatModelApiRegistry);
   }
 
   private void mockSystemPrompt() {
@@ -684,23 +710,12 @@ class JobWorkerAgentRequestHandlerTest {
     final var metrics =
         new AgentMetrics(
             1,
-            new TokenUsage(10, 20),
+            TokenUsage.builder().inputTokenCount(10).outputTokenCount(20).build(),
             assistantMessage.toolCalls() == null ? 0 : assistantMessage.toolCalls().size(),
             EXECUTION_TIME);
-    doReturn(
-            new TestFrameworkChatResponse(
-                assistantMessage, metrics, Map.of("message", assistantMessage)))
-        .when(framework)
-        .executeMeasuringTime(eq(agentExecutionContext), snapshotCaptor.capture());
-  }
-
-  private record TestFrameworkChatResponse(
-      AssistantMessage assistantMessage, AgentMetrics metrics, Map<String, Object> rawChatResponse)
-      implements AiFrameworkChatResponse<Map<String, Object>> {
-    @Override
-    public TestFrameworkChatResponse withExecutionTimeMetrics(Duration executionTime) {
-      return new TestFrameworkChatResponse(
-          assistantMessage, metrics.withExecutionTime(executionTime), rawChatResponse);
-    }
+    doReturn(chatModelApi).when(chatModelApiRegistry).resolve(any());
+    doReturn(new ChatModelResult(assistantMessage, metrics))
+        .when(chatModelApi)
+        .call(chatModelRequestCaptor.capture());
   }
 }

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/agent/OutboundConnectorAgentRequestHandlerTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/agent/OutboundConnectorAgentRequestHandlerTest.java
@@ -29,9 +29,10 @@ import io.camunda.connector.agenticai.aiagent.agent.AgentInitializationResult.Di
 import io.camunda.connector.agenticai.aiagent.agent.AgentInitializationResult.ReadyToConverse;
 import io.camunda.connector.agenticai.aiagent.agentinstance.AgentInstanceClient;
 import io.camunda.connector.agenticai.aiagent.agentinstance.AgentInstanceUpdateRequest;
-import io.camunda.connector.agenticai.aiagent.framework.AiFrameworkAdapter;
-import io.camunda.connector.agenticai.aiagent.framework.AiFrameworkChatResponse;
-import io.camunda.connector.agenticai.aiagent.memory.ConversationSnapshot;
+import io.camunda.connector.agenticai.aiagent.framework.api.ChatModelApi;
+import io.camunda.connector.agenticai.aiagent.framework.api.ChatModelApiRegistry;
+import io.camunda.connector.agenticai.aiagent.framework.api.ChatModelRequest;
+import io.camunda.connector.agenticai.aiagent.framework.api.ChatModelResult;
 import io.camunda.connector.agenticai.aiagent.memory.conversation.ConversationStoreRegistry;
 import io.camunda.connector.agenticai.aiagent.memory.conversation.inprocess.InProcessConversationContext;
 import io.camunda.connector.agenticai.aiagent.memory.conversation.inprocess.InProcessConversationStore;
@@ -55,7 +56,6 @@ import io.camunda.connector.api.error.ConnectorException;
 import io.camunda.connector.api.outbound.JobCompletionFailure;
 import java.time.Duration;
 import java.util.List;
-import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -81,13 +81,14 @@ class OutboundConnectorAgentRequestHandlerTest {
   @Mock private AgentInitializer agentInitializer;
   @Mock private ConversationStoreRegistry conversationStoreRegistry;
   @Mock private AgentConversationTurnInputComposer agentInputComposer;
-  @Mock private AiFrameworkAdapter<?> framework;
+  @Mock private ChatModelApiRegistry chatModelApiRegistry;
+  @Mock private ChatModelApi chatModelApi;
   @Mock private SystemPromptComposer systemPromptComposer;
   @Mock private AgentResponseHandler responseHandler;
   @Mock private AgentInstanceClient agentInstanceClient;
   @Mock private OutboundConnectorAgentExecutionContext agentExecutionContext;
 
-  @Captor private ArgumentCaptor<ConversationSnapshot> snapshotCaptor;
+  @Captor private ArgumentCaptor<ChatModelRequest> chatModelRequestCaptor;
 
   @InjectMocks private OutboundConnectorAgentRequestHandler requestHandler;
 
@@ -115,7 +116,7 @@ class OutboundConnectorAgentRequestHandlerTest {
     assertThat(response.agentResponse().toolCalls())
         .containsExactly(ToolCallProcessVariable.from(toolDiscoveryToolCalls.getFirst()));
 
-    verifyNoInteractions(agentInputComposer, framework, responseHandler);
+    verifyNoInteractions(agentInputComposer, chatModelApiRegistry, responseHandler);
   }
 
   @Test
@@ -177,7 +178,7 @@ class OutboundConnectorAgentRequestHandlerTest {
     final var response = requestHandler.handleRequest(agentExecutionContext);
     assertThat(response.agentResponse()).isNull();
 
-    verifyNoInteractions(agentInputComposer, framework, responseHandler);
+    verifyNoInteractions(agentInputComposer, chatModelApiRegistry, responseHandler);
   }
 
   @Test
@@ -201,13 +202,16 @@ class OutboundConnectorAgentRequestHandlerTest {
     final var response = requestHandler.handleRequest(agentExecutionContext);
 
     // snapshot is captured before the assistant message is ingested
-    assertThat(snapshotCaptor.getValue().messages()).containsExactly(SYSTEM_MESSAGE, USER_MESSAGE);
+    assertThat(chatModelRequestCaptor.getValue().snapshot().messages())
+        .containsExactly(SYSTEM_MESSAGE, USER_MESSAGE);
 
     var agentResponse = response.agentResponse();
     assertThat(agentResponse).isNotNull();
     assertThat(agentResponse.context().state()).isEqualTo(AgentState.READY);
     assertThat(agentResponse.context().metrics())
-        .isEqualTo(new AgentMetrics(1, new TokenUsage(10, 20), 0));
+        .isEqualTo(
+            new AgentMetrics(
+                1, TokenUsage.builder().inputTokenCount(10).outputTokenCount(20).build(), 0));
     assertThat(agentResponse.context().conversation())
         .isNotNull()
         .isInstanceOfSatisfying(
@@ -237,13 +241,16 @@ class OutboundConnectorAgentRequestHandlerTest {
 
     final var response = requestHandler.handleRequest(agentExecutionContext);
 
-    assertThat(snapshotCaptor.getValue().messages()).containsExactly(SYSTEM_MESSAGE, USER_MESSAGE);
+    assertThat(chatModelRequestCaptor.getValue().snapshot().messages())
+        .containsExactly(SYSTEM_MESSAGE, USER_MESSAGE);
 
     var agentResponse = response.agentResponse();
     assertThat(agentResponse).isNotNull();
     assertThat(agentResponse.context().state()).isEqualTo(AgentState.READY);
     assertThat(agentResponse.context().metrics())
-        .isEqualTo(new AgentMetrics(1, new TokenUsage(10, 20), 2));
+        .isEqualTo(
+            new AgentMetrics(
+                1, TokenUsage.builder().inputTokenCount(10).outputTokenCount(20).build(), 2));
     assertThat(agentResponse.context().conversation())
         .isNotNull()
         .isInstanceOfSatisfying(
@@ -277,7 +284,7 @@ class OutboundConnectorAgentRequestHandlerTest {
                       "Agent cannot proceed as no user message content (user message, tool call results) is left to add.");
             });
 
-    verifyNoInteractions(framework, agentInstanceClient);
+    verifyNoInteractions(chatModelApiRegistry, agentInstanceClient);
   }
 
   @Test
@@ -308,7 +315,7 @@ class OutboundConnectorAgentRequestHandlerTest {
                     .isEqualTo(AgentErrorCodes.ERROR_CODE_MAXIMUM_NUMBER_OF_MODEL_CALLS_REACHED));
 
     // limit is checked before the LLM call — no chat request is issued
-    verifyNoInteractions(framework);
+    verifyNoInteractions(chatModelApiRegistry);
   }
 
   @Test
@@ -343,7 +350,11 @@ class OutboundConnectorAgentRequestHandlerTest {
             eq(
                 AgentInstanceUpdateRequest.builder()
                     .status(AgentInstanceUpdateStatus.IDLE)
-                    .delta(new AgentMetrics(1, new TokenUsage(10, 20), 0))
+                    .delta(
+                        new AgentMetrics(
+                            1,
+                            TokenUsage.builder().inputTokenCount(10).outputTokenCount(20).build(),
+                            0))
                     .build()));
     verifyHistoryItemsCreated();
     verifyNoMoreInteractions(agentInstanceClient);
@@ -385,7 +396,11 @@ class OutboundConnectorAgentRequestHandlerTest {
             eq(
                 AgentInstanceUpdateRequest.builder()
                     .status(AgentInstanceUpdateStatus.TOOL_CALLING)
-                    .delta(new AgentMetrics(1, new TokenUsage(10, 20), 2))
+                    .delta(
+                        new AgentMetrics(
+                            1,
+                            TokenUsage.builder().inputTokenCount(10).outputTokenCount(20).build(),
+                            2))
                     .build()));
     verifyHistoryItemsCreated();
     verifyNoMoreInteractions(agentInstanceClient);
@@ -419,7 +434,11 @@ class OutboundConnectorAgentRequestHandlerTest {
             eq(
                 AgentInstanceUpdateRequest.builder()
                     .status(AgentInstanceUpdateStatus.IDLE)
-                    .delta(new AgentMetrics(1, new TokenUsage(10, 20), 0))
+                    .delta(
+                        new AgentMetrics(
+                            1,
+                            TokenUsage.builder().inputTokenCount(10).outputTokenCount(20).build(),
+                            0))
                     .build()));
   }
 
@@ -480,23 +499,12 @@ class OutboundConnectorAgentRequestHandlerTest {
     final var metrics =
         new AgentMetrics(
             1,
-            new TokenUsage(10, 20),
+            TokenUsage.builder().inputTokenCount(10).outputTokenCount(20).build(),
             assistantMessage.toolCalls() == null ? 0 : assistantMessage.toolCalls().size(),
             EXECUTION_TIME);
-    doReturn(
-            new TestFrameworkChatResponse(
-                assistantMessage, metrics, Map.of("message", assistantMessage)))
-        .when(framework)
-        .executeMeasuringTime(eq(agentExecutionContext), snapshotCaptor.capture());
-  }
-
-  private record TestFrameworkChatResponse(
-      AssistantMessage assistantMessage, AgentMetrics metrics, Map<String, Object> rawChatResponse)
-      implements AiFrameworkChatResponse<Map<String, Object>> {
-    @Override
-    public TestFrameworkChatResponse withExecutionTimeMetrics(Duration executionTime) {
-      return new TestFrameworkChatResponse(
-          assistantMessage, metrics.withExecutionTime(executionTime), rawChatResponse);
-    }
+    doReturn(chatModelApi).when(chatModelApiRegistry).resolve(any());
+    doReturn(new ChatModelResult(assistantMessage, metrics))
+        .when(chatModelApi)
+        .call(chatModelRequestCaptor.capture());
   }
 }

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/framework/ChatModelApiRegistryImplTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/framework/ChatModelApiRegistryImplTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.agenticai.aiagent.framework;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+
+import io.camunda.connector.agenticai.aiagent.agent.AgentErrorCodes;
+import io.camunda.connector.agenticai.aiagent.framework.api.ChatModelApi;
+import io.camunda.connector.agenticai.aiagent.framework.api.ChatModelApiConfiguration;
+import io.camunda.connector.agenticai.aiagent.framework.api.ChatModelApiFactory;
+import io.camunda.connector.agenticai.aiagent.framework.api.ProviderChatModelApiConfiguration;
+import io.camunda.connector.agenticai.aiagent.model.request.provider.AnthropicProviderConfiguration;
+import io.camunda.connector.agenticai.aiagent.model.request.provider.AnthropicProviderConfiguration.AnthropicAuthentication;
+import io.camunda.connector.agenticai.aiagent.model.request.provider.AnthropicProviderConfiguration.AnthropicConnection;
+import io.camunda.connector.agenticai.aiagent.model.request.provider.AnthropicProviderConfiguration.AnthropicModel;
+import io.camunda.connector.api.error.ConnectorException;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class ChatModelApiRegistryImplTest {
+
+  @Test
+  void resolvesChatModelFromSupportingFactory() {
+    final var chatModel = mock(ChatModelApi.class);
+    final var factory = stubFactory(true, chatModel, ChatModelApiFactory.DEFAULT_ORDER);
+
+    final var registry = new ChatModelApiRegistryImpl(List.of(factory));
+
+    assertThat(registry.resolve(validProviderConfiguration())).isSameAs(chatModel);
+  }
+
+  @Test
+  void higherPrecedenceFactoryOverridesLowerPrecedenceFactory() {
+    final var lowPrecedenceChatModel = mock(ChatModelApi.class);
+    final var lowPrecedenceFactory = stubFactory(true, lowPrecedenceChatModel, Integer.MAX_VALUE);
+
+    final var highPrecedenceChatModel = mock(ChatModelApi.class);
+    final var highPrecedenceFactory =
+        stubFactory(true, highPrecedenceChatModel, ChatModelApiFactory.DEFAULT_ORDER);
+
+    // register the low-precedence factory first to ensure ordering, not registration order, wins
+    final var registry =
+        new ChatModelApiRegistryImpl(List.of(lowPrecedenceFactory, highPrecedenceFactory));
+
+    assertThat(registry.resolve(validProviderConfiguration())).isSameAs(highPrecedenceChatModel);
+  }
+
+  @Test
+  void throwsWhenNoFactorySupportsConfiguration() {
+    final var factory =
+        stubFactory(false, mock(ChatModelApi.class), ChatModelApiFactory.DEFAULT_ORDER);
+    final var registry = new ChatModelApiRegistryImpl(List.of(factory));
+
+    assertThatThrownBy(() -> registry.resolve(validProviderConfiguration()))
+        .isInstanceOf(ConnectorException.class)
+        .satisfies(
+            e ->
+                assertThat(((ConnectorException) e).getErrorCode())
+                    .isEqualTo(AgentErrorCodes.ERROR_CODE_FAILED_MODEL_CALL));
+  }
+
+  @Test
+  void throwsWhenRegistryIsEmpty() {
+    final var registry = new ChatModelApiRegistryImpl(List.of());
+
+    assertThatThrownBy(() -> registry.resolve(validProviderConfiguration()))
+        .isInstanceOf(ConnectorException.class)
+        .satisfies(
+            e ->
+                assertThat(((ConnectorException) e).getErrorCode())
+                    .isEqualTo(AgentErrorCodes.ERROR_CODE_FAILED_MODEL_CALL));
+  }
+
+  private static ChatModelApiFactory stubFactory(
+      boolean supports, ChatModelApi chatModel, int order) {
+    return new ChatModelApiFactory() {
+      @Override
+      public boolean supports(ChatModelApiConfiguration configuration) {
+        return supports;
+      }
+
+      @Override
+      public ChatModelApi create(ChatModelApiConfiguration configuration) {
+        return chatModel;
+      }
+
+      @Override
+      public int getOrder() {
+        return order;
+      }
+    };
+  }
+
+  private static ChatModelApiConfiguration validProviderConfiguration() {
+    return new ProviderChatModelApiConfiguration(
+        new AnthropicProviderConfiguration(
+            new AnthropicConnection(
+                null,
+                new AnthropicAuthentication("api-key"),
+                null,
+                new AnthropicModel("claude", null))));
+  }
+}

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/Langchain4JChatModelApiTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/Langchain4JChatModelApiTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.agenticai.aiagent.framework.langchain4j;
+
+import static io.camunda.connector.agenticai.aiagent.model.message.content.TextContent.textContent;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.camunda.connector.agenticai.aiagent.framework.api.ChatModelRequest;
+import io.camunda.connector.agenticai.aiagent.framework.api.ChatModelResult;
+import io.camunda.connector.agenticai.aiagent.framework.api.ProviderChatModelApiConfiguration;
+import io.camunda.connector.agenticai.aiagent.memory.ConversationSnapshot;
+import io.camunda.connector.agenticai.aiagent.model.AgentExecutionContext;
+import io.camunda.connector.agenticai.aiagent.model.AgentMetrics;
+import io.camunda.connector.agenticai.aiagent.model.message.AssistantMessage;
+import io.camunda.connector.agenticai.aiagent.model.request.provider.AnthropicProviderConfiguration;
+import io.camunda.connector.agenticai.aiagent.model.request.provider.AnthropicProviderConfiguration.AnthropicAuthentication;
+import io.camunda.connector.agenticai.aiagent.model.request.provider.AnthropicProviderConfiguration.AnthropicConnection;
+import io.camunda.connector.agenticai.aiagent.model.request.provider.AnthropicProviderConfiguration.AnthropicModel;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class Langchain4JChatModelApiTest {
+
+  @Mock private AgentExecutionContext executionContext;
+  @Mock private ConversationSnapshot snapshot;
+  @Mock private Langchain4JAiFrameworkAdapter adapter;
+
+  @Test
+  void wrapsAdapterResponseAsResult() {
+    final var msg = AssistantMessage.builder().content(List.of(textContent("hi"))).build();
+    final var metrics = new AgentMetrics(1, AgentMetrics.TokenUsage.empty(), 0);
+    final var response = mock(Langchain4JAiFrameworkChatResponse.class);
+    when(response.assistantMessage()).thenReturn(msg);
+    when(response.metrics()).thenReturn(metrics);
+    when(adapter.executeMeasuringTime(any(), any())).thenReturn(response);
+
+    final var api = new Langchain4JChatModelApi(adapter);
+    final var result = api.call(new ChatModelRequest(executionContext, snapshot));
+
+    assertThat(result).isEqualTo(new ChatModelResult(msg, metrics));
+  }
+
+  @Test
+  void factorySupportsAnyProviderChatModelApiConfigurationAtLowPrecedence() {
+    final var factory = new Langchain4JChatModelApiFactory(adapter);
+
+    final var configuration =
+        new ProviderChatModelApiConfiguration(
+            new AnthropicProviderConfiguration(
+                new AnthropicConnection(
+                    null,
+                    new AnthropicAuthentication("api-key"),
+                    null,
+                    new AnthropicModel("claude", null))));
+
+    assertThat(factory.supports(configuration)).isTrue();
+    assertThat(factory.getOrder()).isEqualTo(Langchain4JChatModelApiFactory.ORDER);
+    assertThat(factory.create(configuration)).isInstanceOf(Langchain4JChatModelApi.class);
+  }
+}

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/memory/conversation/awsagentcore/AwsAgentCoreConversationStoreReasoningRoundTripTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/memory/conversation/awsagentcore/AwsAgentCoreConversationStoreReasoningRoundTripTest.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.agenticai.aiagent.memory.conversation.awsagentcore;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.connector.agenticai.aiagent.memory.conversation.ConversationStoreRequest;
+import io.camunda.connector.agenticai.aiagent.memory.conversation.awsagentcore.AwsAgentCoreConversationStore.BedrockAgentCoreClientFactory;
+import io.camunda.connector.agenticai.aiagent.memory.conversation.awsagentcore.mapping.AwsAgentCoreConversationMapper;
+import io.camunda.connector.agenticai.aiagent.model.AgentConfiguration;
+import io.camunda.connector.agenticai.aiagent.model.AgentContext;
+import io.camunda.connector.agenticai.aiagent.model.AgentExecutionContext;
+import io.camunda.connector.agenticai.aiagent.model.message.AssistantMessage;
+import io.camunda.connector.agenticai.aiagent.model.message.Message;
+import io.camunda.connector.agenticai.aiagent.model.message.content.ReasoningContent;
+import io.camunda.connector.agenticai.aiagent.model.message.content.TextContent;
+import io.camunda.connector.agenticai.aiagent.model.request.MemoryConfiguration;
+import io.camunda.connector.agenticai.aiagent.model.request.MemoryStorageConfiguration.AwsAgentCoreMemoryStorageConfiguration;
+import io.camunda.connector.agenticai.testutil.TestObjectMapperSupplier;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.core.pagination.sync.SdkIterable;
+import software.amazon.awssdk.services.bedrockagentcore.BedrockAgentCoreClient;
+import software.amazon.awssdk.services.bedrockagentcore.model.CreateEventRequest;
+import software.amazon.awssdk.services.bedrockagentcore.model.CreateEventResponse;
+import software.amazon.awssdk.services.bedrockagentcore.model.Event;
+import software.amazon.awssdk.services.bedrockagentcore.model.ListEventsRequest;
+import software.amazon.awssdk.services.bedrockagentcore.paginators.ListEventsIterable;
+
+/**
+ * Verifies that {@link ReasoningContent}, including its opaque {@code providerPayload}, survives a
+ * store-and-load round trip through the AWS AgentCore conversation store and its bespoke {@link
+ * AwsAgentCoreConversationMapper}.
+ *
+ * <p>This test mirrors {@link AwsAgentCoreConversationStoreTest}'s mocked-client setup (no live AWS
+ * calls) and feeds the payload captured from {@code createEvent} back into a mocked {@code
+ * listEventsPaginator} response to simulate the load path.
+ */
+@ExtendWith(MockitoExtension.class)
+class AwsAgentCoreConversationStoreReasoningRoundTripTest {
+
+  private static final String MEMORY_ID = "test-memory-id";
+  private static final String ACTOR_ID = "test-actor-id";
+  private static final String SESSION_ID = "test-session-id";
+
+  @Mock private BedrockAgentCoreClient bedrockClient;
+  @Mock private BedrockAgentCoreClientFactory clientFactory;
+  @Mock private AgentExecutionContext executionContext;
+  @Mock private ListEventsIterable listEventsIterable;
+
+  @Captor private ArgumentCaptor<CreateEventRequest> createEventRequestCaptor;
+
+  private AwsAgentCoreConversationStore store;
+  private AwsAgentCoreMemoryStorageConfiguration config;
+
+  @BeforeEach
+  void setUp() {
+    var authentication =
+        new AwsAgentCoreMemoryStorageConfiguration.AwsAgentCoreAuthentication
+            .AwsStaticCredentialsAuthentication("test-access-key", "test-secret-key");
+    config =
+        new AwsAgentCoreMemoryStorageConfiguration(
+            "us-east-1", null, authentication, MEMORY_ID, ACTOR_ID);
+    when(executionContext.configuration())
+        .thenReturn(configWithMemory(new MemoryConfiguration(config, 20)));
+    when(clientFactory.createClient(config)).thenReturn(bedrockClient);
+
+    var conversationMapper = new AwsAgentCoreConversationMapper(TestObjectMapperSupplier.INSTANCE);
+
+    store = new AwsAgentCoreConversationStore(clientFactory, conversationMapper);
+  }
+
+  private static AgentConfiguration configWithMemory(MemoryConfiguration memory) {
+    return new AgentConfiguration(null, null, null, memory, null, null, null);
+  }
+
+  @Test
+  void reasoningContentSurvivesStoreAndLoad() {
+    final var assistant =
+        AssistantMessage.builder()
+            .content(
+                List.of(
+                    new ReasoningContent("why", Map.of("signature", "sig-xyz"), null),
+                    TextContent.textContent("answer")))
+            .build();
+
+    final var agentContext =
+        AgentContext.builder()
+            .conversation(
+                AwsAgentCoreConversationContext.builder(SESSION_ID)
+                    .memoryId(MEMORY_ID)
+                    .actorId(ACTOR_ID)
+                    .build())
+            .build();
+
+    mockListEventsResponse(List.of());
+    when(bedrockClient.createEvent(any(CreateEventRequest.class)))
+        .thenReturn(
+            CreateEventResponse.builder().event(Event.builder().eventId("evt-1").build()).build());
+
+    AgentContext updatedAgentContext;
+    try (var session = store.createSession(executionContext, agentContext)) {
+      session.loadMessages(agentContext);
+
+      List<Message> messages = List.of(assistant);
+      var updatedConversation =
+          session.storeMessages(agentContext, ConversationStoreRequest.of(messages));
+      updatedAgentContext = agentContext.withConversation(updatedConversation);
+    }
+
+    // simulate the AgentCore backend by feeding the payload we just "wrote" back on the next load
+    verify(bedrockClient).createEvent(createEventRequestCaptor.capture());
+    final var createdRequest = createEventRequestCaptor.getValue();
+
+    final var replayedEvent =
+        Event.builder()
+            .eventTimestamp(Instant.now())
+            .payload(createdRequest.payload())
+            .metadata(createdRequest.metadata())
+            .build();
+    mockListEventsResponse(List.of(replayedEvent));
+
+    try (var session = store.createSession(executionContext, updatedAgentContext)) {
+      var loadResult = session.loadMessages(updatedAgentContext);
+
+      assertThat(loadResult.messages()).hasSize(1);
+      var restored = (AssistantMessage) loadResult.messages().get(0);
+      assertThat(restored.content()).containsExactlyElementsOf(assistant.content());
+
+      var restoredReasoning = (ReasoningContent) restored.content().get(0);
+      assertThat(restoredReasoning.text()).isEqualTo("why");
+      assertThat(restoredReasoning.providerPayload()).isEqualTo(Map.of("signature", "sig-xyz"));
+    }
+  }
+
+  private void mockListEventsResponse(List<Event> events) {
+    final SdkIterable<Event> eventsIterable = events::iterator;
+    when(listEventsIterable.events()).thenReturn(eventsIterable);
+    when(bedrockClient.listEventsPaginator(any(ListEventsRequest.class)))
+        .thenReturn(listEventsIterable);
+  }
+}

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/model/AgentMetricsTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/model/AgentMetricsTest.java
@@ -10,6 +10,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.connector.agenticai.aiagent.model.AgentMetrics.TokenUsage;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
@@ -53,24 +54,33 @@ class AgentMetricsTest {
   @Test
   void withTokenUsage() {
     final var initialMetrics = AgentMetrics.empty();
-    final var updatedMetrics = initialMetrics.withTokenUsage(new TokenUsage(10, 20));
+    final var updatedMetrics =
+        initialMetrics.withTokenUsage(
+            TokenUsage.builder().inputTokenCount(10).outputTokenCount(20).build());
 
     assertThat(updatedMetrics).isNotEqualTo(initialMetrics);
     assertThat(initialMetrics.tokenUsage()).isEqualTo(EMPTY_METRICS.tokenUsage());
 
-    assertThat(updatedMetrics.tokenUsage()).isEqualTo(new TokenUsage(10, 20));
+    assertThat(updatedMetrics.tokenUsage())
+        .isEqualTo(TokenUsage.builder().inputTokenCount(10).outputTokenCount(20).build());
     assertThat(updatedMetrics.tokenUsage().totalTokenCount()).isEqualTo(30);
   }
 
   @Test
   void incrementTokenUsage() {
-    final var initialMetrics = AgentMetrics.empty().withTokenUsage(new TokenUsage(10, 20));
-    final var updatedMetrics = initialMetrics.incrementTokenUsage(new TokenUsage(1, 2));
+    final var initialMetrics =
+        AgentMetrics.empty()
+            .withTokenUsage(TokenUsage.builder().inputTokenCount(10).outputTokenCount(20).build());
+    final var updatedMetrics =
+        initialMetrics.incrementTokenUsage(
+            TokenUsage.builder().inputTokenCount(1).outputTokenCount(2).build());
 
     assertThat(updatedMetrics).isNotEqualTo(initialMetrics);
-    assertThat(initialMetrics.tokenUsage()).isEqualTo(new TokenUsage(10, 20));
+    assertThat(initialMetrics.tokenUsage())
+        .isEqualTo(TokenUsage.builder().inputTokenCount(10).outputTokenCount(20).build());
 
-    assertThat(updatedMetrics.tokenUsage()).isEqualTo(new TokenUsage(11, 22));
+    assertThat(updatedMetrics.tokenUsage())
+        .isEqualTo(TokenUsage.builder().inputTokenCount(11).outputTokenCount(22).build());
     assertThat(updatedMetrics.tokenUsage().totalTokenCount()).isEqualTo(33);
   }
 
@@ -98,16 +108,123 @@ class AgentMetricsTest {
 
   @Test
   void addAgentMetrics() {
-    final var a = new AgentMetrics(2, new TokenUsage(30, 70), 1);
-    final var b = new AgentMetrics(3, new TokenUsage(100, 200), 2);
+    final var a =
+        new AgentMetrics(
+            2, TokenUsage.builder().inputTokenCount(30).outputTokenCount(70).build(), 1);
+    final var b =
+        new AgentMetrics(
+            3, TokenUsage.builder().inputTokenCount(100).outputTokenCount(200).build(), 2);
 
     final var sum = a.add(b);
 
     assertThat(sum.modelCalls()).isEqualTo(5);
-    assertThat(sum.tokenUsage()).isEqualTo(new TokenUsage(130, 270));
+    assertThat(sum.tokenUsage())
+        .isEqualTo(TokenUsage.builder().inputTokenCount(130).outputTokenCount(270).build());
     assertThat(sum.toolCalls()).isEqualTo(3);
     // operands are left untouched
-    assertThat(a).isEqualTo(new AgentMetrics(2, new TokenUsage(30, 70), 1));
+    assertThat(a)
+        .isEqualTo(
+            new AgentMetrics(
+                2, TokenUsage.builder().inputTokenCount(30).outputTokenCount(70).build(), 1));
+  }
+
+  @Test
+  void incrementTokenUsageCarriesCacheAndReasoningDimensions() {
+    final var initialMetrics =
+        AgentMetrics.empty()
+            .withTokenUsage(
+                TokenUsage.builder()
+                    .inputTokenCount(100)
+                    .outputTokenCount(40)
+                    .cacheReadTokenCount(60)
+                    .cacheCreationTokenCount(10)
+                    .reasoningTokenCount(25)
+                    .build());
+    final var updatedMetrics =
+        initialMetrics.incrementTokenUsage(
+            TokenUsage.builder()
+                .inputTokenCount(50)
+                .outputTokenCount(20)
+                .cacheReadTokenCount(30)
+                .cacheCreationTokenCount(0)
+                .reasoningTokenCount(5)
+                .build());
+
+    assertThat(updatedMetrics.tokenUsage())
+        .isEqualTo(
+            TokenUsage.builder()
+                .inputTokenCount(150)
+                .outputTokenCount(60)
+                .cacheReadTokenCount(90)
+                .cacheCreationTokenCount(10)
+                .reasoningTokenCount(30)
+                .build());
+    // cache/reasoning are subsets of input/output, so they are not added on top of the total
+    assertThat(updatedMetrics.tokenUsage().totalTokenCount()).isEqualTo(210);
+  }
+
+  @Test
+  void tokenUsageOmitsZeroCacheAndReasoningDimensionsWhenSerialized() throws Exception {
+    final var mapper = new ObjectMapper();
+
+    final var withoutExtras = TokenUsage.builder().inputTokenCount(10).outputTokenCount(20).build();
+    final var json = mapper.writeValueAsString(withoutExtras);
+    assertThat(json)
+        .contains("inputTokenCount", "outputTokenCount")
+        .doesNotContain("cacheReadTokenCount", "cacheCreationTokenCount", "reasoningTokenCount");
+
+    // absent dimensions default back to zero on deserialization
+    assertThat(mapper.readValue(json, TokenUsage.class)).isEqualTo(withoutExtras);
+
+    final var withExtras =
+        TokenUsage.builder()
+            .inputTokenCount(10)
+            .outputTokenCount(20)
+            .cacheReadTokenCount(5)
+            .reasoningTokenCount(3)
+            .build();
+    assertThat(mapper.writeValueAsString(withExtras))
+        .contains("cacheReadTokenCount", "reasoningTokenCount");
+  }
+
+  @Test
+  void tokenUsageWithoutCacheAndReasoningLeavesDimensionsAtZero() {
+    final var tokenUsage = TokenUsage.builder().inputTokenCount(10).outputTokenCount(20).build();
+
+    assertThat(tokenUsage.cacheReadTokenCount()).isZero();
+    assertThat(tokenUsage.cacheCreationTokenCount()).isZero();
+    assertThat(tokenUsage.reasoningTokenCount()).isZero();
+    assertThat(tokenUsage.totalTokenCount()).isEqualTo(30);
+  }
+
+  @Test
+  void tokenUsageCarriesCacheAndReasoningDimensionsAndAggregates() {
+    var a =
+        AgentMetrics.TokenUsage.builder()
+            .inputTokenCount(100)
+            .outputTokenCount(40)
+            .cacheReadTokenCount(60)
+            .cacheCreationTokenCount(10)
+            .reasoningTokenCount(25)
+            .build();
+    var b =
+        AgentMetrics.TokenUsage.builder()
+            .inputTokenCount(50)
+            .outputTokenCount(20)
+            .cacheReadTokenCount(30)
+            .cacheCreationTokenCount(0)
+            .reasoningTokenCount(5)
+            .build();
+
+    var sum = a.add(b);
+
+    assertThat(sum.inputTokenCount()).isEqualTo(150);
+    assertThat(sum.outputTokenCount()).isEqualTo(60);
+    assertThat(sum.cacheReadTokenCount()).isEqualTo(90);
+    assertThat(sum.cacheCreationTokenCount()).isEqualTo(10);
+    assertThat(sum.reasoningTokenCount()).isEqualTo(30);
+    assertThat(sum.totalTokenCount())
+        .isEqualTo(210); // cache/reasoning are subsets, not added on top
   }
 
   @ParameterizedTest

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/model/message/AssistantMessageTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/model/message/AssistantMessageTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.agenticai.aiagent.model.message;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.connector.agenticai.aiagent.model.message.content.TextContent;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class AssistantMessageTest {
+
+  @Test
+  void carriesStopReasonAndModelIdentityAndRoundTrips() throws Exception {
+    var mapper = new ObjectMapper();
+    var msg =
+        AssistantMessage.builder()
+            .content(List.of(TextContent.textContent("hi")))
+            .modelId("claude-opus-4-8")
+            .messageId("msg_123")
+            .stopReason(StopReason.STOP)
+            .metadata(Map.of("rawStopReason", "end_turn"))
+            .build();
+
+    var restored = mapper.readValue(mapper.writeValueAsString(msg), AssistantMessage.class);
+
+    assertThat(restored.modelId()).isEqualTo("claude-opus-4-8");
+    assertThat(restored.messageId()).isEqualTo("msg_123");
+    assertThat(restored.stopReason()).isEqualTo(StopReason.STOP);
+    assertThat(restored.metadata()).containsEntry("rawStopReason", "end_turn");
+    assertThat(restored.hasToolCalls()).isFalse();
+  }
+}

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/model/message/content/ReasoningContentTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/model/message/content/ReasoningContentTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.agenticai.aiagent.model.message.content;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class ReasoningContentTest {
+  private final ObjectMapper mapper = new ObjectMapper();
+
+  @Test
+  void roundTripsOpaquePayloadVerbatim() throws Exception {
+    var original =
+        new ReasoningContent(
+            "summary text",
+            Map.of("signature", "abc123", "encrypted", "opaque-blob"),
+            Map.of("provider", "anthropic"));
+
+    var json = mapper.writeValueAsString(original);
+    var restored = mapper.readValue(json, Content.class);
+
+    assertThat(restored).isInstanceOf(ReasoningContent.class);
+    assertThat(restored).isEqualTo(original);
+  }
+}

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/autoconfigure/AgenticAiConnectorsAutoConfigurationTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/autoconfigure/AgenticAiConnectorsAutoConfigurationTest.java
@@ -27,12 +27,14 @@ import io.camunda.connector.agenticai.aiagent.agent.AgentToolsResolver;
 import io.camunda.connector.agenticai.aiagent.agent.JobWorkerAgentRequestHandler;
 import io.camunda.connector.agenticai.aiagent.agent.OutboundConnectorAgentRequestHandler;
 import io.camunda.connector.agenticai.aiagent.agentinstance.AgentInstanceClient;
+import io.camunda.connector.agenticai.aiagent.framework.api.ChatModelApiRegistry;
 import io.camunda.connector.agenticai.aiagent.framework.langchain4j.ChatMessageConverter;
 import io.camunda.connector.agenticai.aiagent.framework.langchain4j.ChatModelFactory;
 import io.camunda.connector.agenticai.aiagent.framework.langchain4j.ChatModelHttpProxySupport;
 import io.camunda.connector.agenticai.aiagent.framework.langchain4j.CloseableChatModel;
 import io.camunda.connector.agenticai.aiagent.framework.langchain4j.ContentConverter;
 import io.camunda.connector.agenticai.aiagent.framework.langchain4j.Langchain4JAiFrameworkAdapter;
+import io.camunda.connector.agenticai.aiagent.framework.langchain4j.Langchain4JChatModelApiFactory;
 import io.camunda.connector.agenticai.aiagent.framework.langchain4j.document.DocumentToContentConverter;
 import io.camunda.connector.agenticai.aiagent.framework.langchain4j.jsonschema.JsonSchemaConverter;
 import io.camunda.connector.agenticai.aiagent.framework.langchain4j.provider.AnthropicChatModelProvider;
@@ -104,7 +106,8 @@ class AgenticAiConnectorsAutoConfigurationTest {
           AiAgentFunction.class,
           JobWorkerAgentRequestHandler.class,
           AiAgentJobWorker.class,
-          AgentInstanceClient.class);
+          AgentInstanceClient.class,
+          ChatModelApiRegistry.class);
 
   private static final List<Class<?>> LANGCHAIN4J_BEANS =
       List.of(
@@ -123,7 +126,8 @@ class AgenticAiConnectorsAutoConfigurationTest {
           JsonSchemaConverter.class,
           ToolSpecificationConverter.class,
           ChatMessageConverter.class,
-          Langchain4JAiFrameworkAdapter.class);
+          Langchain4JAiFrameworkAdapter.class,
+          Langchain4JChatModelApiFactory.class);
 
   // this will need to be updated in case we support different frameworks
   private static final List<Class<?>> ALL_BEANS =

--- a/connectors/agentic-ai/docs/adr-009-implementation-plan.md
+++ b/connectors/agentic-ai/docs/adr-009-implementation-plan.md
@@ -1,0 +1,929 @@
+# Own the LLM Layer — Implementation Plan (ADR 009)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the LangChain4j-backed `AiFrameworkAdapter` with a provider-neutral chat SPI dispatched to native implementations over the vendor Java SDKs, while preserving today's BPMN orchestration core and existing element templates.
+
+**Architecture:** A new chat SPI (`ChatModelApi` drivers behind a `ChatModelApiRegistry`, invoked through a thin `ChatModelInvoker` seam) replaces the single `AiFrameworkAdapter` call in the request handler. Each driver performs exactly one provider round-trip and returns a `Completed | Continuation` result; the invoker owns a bounded continuation loop that emits per-round metrics/events. LangChain4j becomes one bridge driver, kept default-on until native parity, then opt-in. Design decisions are fixed in [ADR 009](adr/009-own-the-llm-layer.md); read it first.
+
+**Tech Stack:** Java 21, Spring Boot auto-configuration, Jackson (`@AgenticAiRecord` + generated record builders), JUnit 5 + Mockito + AssertJ, vendor SDKs (`com.anthropic:anthropic-java`, `com.openai:openai-java`, AWS SDK v2 `bedrockruntime`, `com.google.genai:google-genai`).
+
+## Global Constraints
+
+- **Build:** `mvn clean install -f connectors/agentic-ai/pom.xml`. If deviating, `mvn spotless:apply -f connectors/agentic-ai/pom.xml` and `mvn license:format -f connectors/agentic-ai/pom.xml` must run clean (pre-commit hooks enforce these).
+- **Separate e2e module (MANDATORY on every task):** `connectors-e2e-test/connectors-e2e-test-agentic-ai` is a DIFFERENT Maven module that depends on the built `connector-agentic-ai` artifact and constructs domain types directly (e.g. `new AgentMetrics.TokenUsage(...)`, `new AssistantMessage(...)`). `mvn ... -f connectors/agentic-ai/pom.xml` does NOT compile it, so any change to a shared model/record's constructor arity, a sealed hierarchy, or serialization silently breaks it. **After any task that touches `model/**` (records, enums, sealed interfaces) or serialization, you MUST also run `mvn test-compile -pl connectors-e2e-test/connectors-e2e-test-agentic-ai -am -f pom.xml` (from repo root) and fix every construction/assertion site there in the SAME commit.** Because this module resolves `connector-agentic-ai` from `~/.m2`, first (re)install it: `mvn -T8C clean install -DskipTests` (whole project) or at least `mvn install -f connectors/agentic-ai/pom.xml -DskipTests`; beware stale timestamped remote snapshots winning resolution — use `-am` so the e2e module builds against the just-built classes.
+- **Null safety:** all production code is `@NullMarked` per package; annotate absent values with `@Nullable` (`org.jspecify.annotations`). Never suppress null errors.
+- **Framework-agnostic core (invariant):** only `aiagent/framework/langchain4j/**` may import `dev.langchain4j.*`. Native drivers under `aiagent/framework/<provider>/**` may import their own vendor SDK only.
+- **Interface + `*Impl` convention:** public collaborators are interfaces in the package root with a single `*Impl` alongside; wire impls as Spring beans, depend on the interface.
+- **Records:** follow the module pattern — `@AgenticAiRecord`, `@JsonDeserialize(builder = X.XJacksonProxyBuilder.class)`, `@JsonPOJOBuilder(withPrefix = "")` proxy builder. Plain sealed-interface value records (e.g. `Content` subtypes) follow `TextContent` (no builder).
+- **Commits:** Conventional Commits (`feat(agentic-ai): …`, `test(agentic-ai): …`, `refactor(agentic-ai): …`, `docs(agentic-ai): …`). Frequent, one deliverable per commit.
+- **Do not push** without explicit confirmation.
+- **Module root for paths below:** `connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai` (abbreviated `…/agenticai`). Tests mirror under `.../src/test/java/...`. E2E tests live in the separate `connectors-e2e-test/connectors-e2e-test-agentic-ai` module and require `element-templates-cli` on PATH.
+- **ADR immutability:** ADR 009 may be revised only within this epic's PRs; after merge, supersede via a new ADR.
+
+---
+
+## Phase Roadmap (green-build checkpoints)
+
+Each phase ends green (`mvn clean install -f connectors/agentic-ai/pom.xml` + relevant e2e) and is independently reviewable. Only **Phase 0** is broken into bite-sized tasks below; Phases 1–3 get their detailed task breakdown when their predecessor lands (their fine-grained code depends on APIs settled earlier).
+
+### Phase 0 — Domain model + SPI skeleton + bridge cutover + de-risk spike
+
+Additive and behaviour-identical. After this phase every chat call routes through the new SPI with LangChain4j as the only (bridge) implementation; existing e2e behaviour is unchanged; element templates untouched.
+
+> **Re-scoped 2026-07-07 (post PR #7847 review).** Phase 0 is trimmed to the *minimal* behaviour-identical SPI + bridge. Three pieces that were built here but are **unused on the Phase-0 branch** were pulled out and moved to where they are actually exercised: (1) the continuation loop — `ChatModelInvoker`/`ChatModelInvokerImpl`, `ContinuationState`, `ChatModelResult.Continuation`, `ChatModelRoundListener` (the bridge never continues) → rebuilt in Phase 1 as a **turn-based** model (each `pause_turn` round is a real appended assistant turn; no continuation parameter); (2) `ToolCallResult.contentBlocks` (only a native provider implementation reads it) → the persisted block-list redesign + backward-compatible migration moves to Phase 2; (3) the confusing singular `ChatModelApiFactory.providerType()` removed (registry dispatches on the plural `providerTypes()`). Terminology: a `ChatModelApi` is a **"chat model"**; concrete classes are **"provider implementations"** (the word "driver" is retired).
+
+- **Deliverables:** opaque-carrying `Content` subtype + store round-trip spike; `AssistantMessage.{modelId, messageId, stopReason}` + `StopReason`; `TokenUsage` cache/reasoning dimensions (+ 2-arg convenience constructor); chat SPI (`ChatModelApi` — one `call(ChatModelRequest)` → `ChatModelResult`, `ChatModelApiFactory`, `ChatModelApiRegistry`) + impls; LangChain4j bridge implementation; request handler calls the registry directly (no invoker seam).
+- **Test plan:** unit tests per task (below); regression e2e in `connectors-e2e-test-agentic-ai` (`*ApiAiAgentJobWorker*` wire-format tests + a tool-calling test) must stay green.
+- **Verification:** `mvn clean install -f connectors/agentic-ai/pom.xml` then `mvn test -pl connectors-e2e-test/connectors-e2e-test-agentic-ai -Dtest='*ApiAiAgentJobWorker*'`.
+
+### Phase 1 (#7212) — Native implementations, all five wire formats
+
+- **Deliverables:** internal normalized provider model `(wireFormat, backend, apiFamily)` + resolver mapping existing discriminators (templates frozen); registry dispatch by `WireFormat` (bridge as the catch-all fallback); native `ChatModelApi` provider implementations: Anthropic-messages (direct) **first**, then OpenAI completions + responses, Bedrock Converse (non-Anthropic), Google GenAI, Anthropic cloud backends (Bedrock / Vertex / Foundry); **turn-based continuation** built here (Anthropic `pause_turn`: each round is a real appended assistant turn, looped internally by the request handler — no `ContinuationState` parameter; faithful re-serialization via the opaque provider-payload from Phase 0's `ReasoningContent` round-trip); deterministic tools/system serialization; **HTTP transport/proxy parity per provider** (prefer JDK `HttpClient`, fall back e.g. OkHttp where needed — reuse the parity baseline in `framework/langchain4j/ChatModelHttpProxySupport.java`); implementation-level cache/reasoning token capture. LangChain4j demoted to opt-in once parity proven; bridge still covers any not-yet-native discriminator.
+- **Files (indicative):** `framework/anthropic/**`, `framework/openai/**`, `framework/bedrock/**`, `framework/google/**`, `framework/api/provider/**` (normalized model + resolver); pom SDK deps `@ConditionalOnClass`.
+- **Test plan:** per-driver unit tests; wire-format e2e regression per provider under `connectors-e2e-test-agentic-ai/.../wireformat/` (extend the existing WireMock wire-format harness); a `pause_turn` continuation e2e for Anthropic.
+- **Checkpoint:** each driver lands as its own green-build unit; L4J default flips off only after all five pass parity.
+
+### Phase 2 (#7214) — Capability matrix + multimodal tool results
+
+- **Deliverables:** cascading, specificity-weighted capability matrix (§4 of ADR 009) resolved per request, with resolution **debuggable** (log contributing layers); minimal initial properties (modalities, max output, context window where read); native multimodal tool-result emission per provider implementation; native-vs-fallback routing of tool-result documents; **`ToolCallResult` block-content redesign** (moved here from Phase 0): the persisted tool-call-result model becomes a list of content blocks while the process-returned result stays a single `content` object, with a **backward-compatible deserializer** lifting a legacy scalar/object `content` into a single-element block list (same pattern as the `Message.id` pre-upgrade marker + the `properties` `@JsonAnySetter` proxy builder) — no engine migration, pure serialization-compat, with round-trip BC tests; **converge tool-result rendering on the existing `<doc/>` scheme** (`model/message/content/DocumentReferenceXmlTag`), not a competing `<document/>` tag; keep the window/snapshot seam pluggable for compaction.
+- **Files (indicative):** `framework/capabilities/**` (matrix, resolver, bundled `model-capabilities.yaml`), `framework/strategy/ToolCallResultStrategy*`, per-driver multimodal emission.
+- **Test plan:** matrix resolution unit tests (specificity, merge, tie-break); multimodal tool-result e2e (image + PDF) per capable driver; fallback path e2e for non-multimodal.
+
+### Phase 3 (#7213) — New connector types + config restructure + custom-provider SPI
+
+- **Deliverables:** new "AI Agent Task" / "AI Agent Sub-process" connector types + element templates with wire-format-first config (backend + apiFamily selectors, consolidated OpenAI, `googleGenAi`, Anthropic backends); custom-provider SPI; old connector types become deprecated input-rewrite shims delegating to the internal normalized model; element-template version bump + README per `AGENTS.md`. **All breaking UX changes isolated here.**
+- **Sequencing constraint:** the `bedrock` + Claude-model → Anthropic-backend migration must ship paired with (or gated behind) the native Anthropic cloud backends from Phase 1, or it breaks existing Claude-on-Bedrock users.
+- **Test plan:** deserializer/shim migration unit tests (legacy config → internal model); new-connector-type e2e; element-template generation diff review.
+
+### Cross-cutting (all phases)
+
+- **Agent-instance API gap register:** maintain the table in ADR 009 → "Agent-instance API gap register" as gaps are hit; degrade-and-mark (omit unrepresentable content/metrics from history emission, log + code comment + register entry). **Definition of Done for the epic** includes the consolidated requirements summary for the agent-instance history/metrics API.
+- **Docs:** update `docs/reference/ai-agent.md` §12 (framework abstraction) and §25 (extension points) as the SPI lands; keep `AGENTS.md` invariants current.
+
+---
+
+## Phase 0 — Detailed Tasks
+
+> Package prefix `io.camunda.connector.agenticai.aiagent`. Paths below are relative to `…/agenticai`. New SPI types live under `framework/api/` (framework-neutral — no vendor imports).
+
+### Task 0.1: Add `ReasoningContent` opaque-carrying content type
+
+Proves the domain model can carry provider-opaque content losslessly. First consumer is reasoning (#7669, deferred), but the type + round-trip is Phase 0 structural groundwork.
+
+**Files:**
+- Create: `model/message/content/ReasoningContent.java`
+- Modify: `model/message/content/Content.java` (add permit + `@JsonSubTypes`)
+- Test: `model/message/content/ReasoningContentTest.java`
+
+**Interfaces:**
+- Produces: `ReasoningContent(@Nullable String text, @Nullable Object providerPayload, @Nullable Map<String,Object> metadata) implements Content` — `providerPayload` holds opaque vendor data (signature / encrypted reasoning / raw block) round-tripped verbatim; `text` is optional human-readable summary.
+
+- [ ] **Step 1: Write the failing test**
+
+```java
+// ReasoningContentTest.java
+package io.camunda.connector.agenticai.aiagent.model.message.content;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class ReasoningContentTest {
+  private final ObjectMapper mapper = new ObjectMapper();
+
+  @Test
+  void roundTripsOpaquePayloadVerbatim() throws Exception {
+    var original =
+        new ReasoningContent(
+            "summary text",
+            Map.of("signature", "abc123", "encrypted", "opaque-blob"),
+            Map.of("provider", "anthropic"));
+
+    var json = mapper.writeValueAsString(original);
+    var restored = mapper.readValue(json, Content.class);
+
+    assertThat(restored).isInstanceOf(ReasoningContent.class);
+    assertThat(restored).isEqualTo(original);
+    assertThat(json).contains("\"type\":\"reasoning\"");
+  }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `mvn test -f connectors/agentic-ai/pom.xml -Dtest=ReasoningContentTest`
+Expected: FAIL — `ReasoningContent` does not exist / cannot deserialize type `reasoning`.
+
+- [ ] **Step 3: Create `ReasoningContent`**
+
+```java
+// ReasoningContent.java
+package io.camunda.connector.agenticai.aiagent.model.message.content;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import java.util.Map;
+import org.jspecify.annotations.Nullable;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record ReasoningContent(
+    @JsonInclude(JsonInclude.Include.NON_EMPTY) @Nullable String text,
+    @JsonInclude(JsonInclude.Include.NON_NULL) @Nullable Object providerPayload,
+    @JsonInclude(JsonInclude.Include.NON_EMPTY) @Nullable Map<String, Object> metadata)
+    implements Content {
+
+  public static ReasoningContent reasoningContent(String text) {
+    return new ReasoningContent(text, null, null);
+  }
+}
+```
+
+- [ ] **Step 4: Register the subtype in `Content`**
+
+Modify `Content.java`: add the import, the `@JsonSubTypes.Type`, and the `permits` entry.
+
+```java
+@JsonSubTypes({
+  @JsonSubTypes.Type(value = TextContent.class, name = "text"),
+  @JsonSubTypes.Type(value = DocumentContent.class, name = "document"),
+  @JsonSubTypes.Type(value = ObjectContent.class, name = "object"),
+  @JsonSubTypes.Type(value = ReasoningContent.class, name = "reasoning")
+})
+public sealed interface Content
+    permits TextContent, DocumentContent, ObjectContent, ReasoningContent {
+  Map<String, Object> metadata();
+}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `mvn test -f connectors/agentic-ai/pom.xml -Dtest=ReasoningContentTest`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/message/content/ReasoningContent.java \
+        connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/message/content/Content.java \
+        connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/model/message/content/ReasoningContentTest.java
+git commit -m "feat(agentic-ai): add ReasoningContent opaque-carrying content type"
+```
+
+### Task 0.2: De-risk spike — opaque content round-trips through all conversation stores
+
+Proves `ReasoningContent` survives persistence + reload through the in-process, document, and AWS AgentCore stores. **If the AgentCore mapping cannot represent it, do not fix it here** — record the gap in the ADR 009 gap register and raise it with the user; the spike's job is to surface it now.
+
+**Files:**
+- Test: `memory/conversation/inprocess/InProcessConversationStoreReasoningRoundTripTest.java`
+- Test: `memory/conversation/document/DocumentConversationStoreReasoningRoundTripTest.java`
+- Test: `memory/conversation/awsagentcore/AwsAgentCoreConversationStoreReasoningRoundTripTest.java`
+
+**Interfaces:**
+- Consumes: `ConversationStore.createSession(executionContext, agentContext)`; `ConversationSession.storeMessages(...)` / `loadMessages(agentContext)`; `ReasoningContent` (Task 0.1).
+
+- [ ] **Step 1: Locate each store's existing test to mirror its setup**
+
+Run: `ls connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/memory/conversation/`
+Expected: existing per-store test classes to copy fixture/setup from (mock `AgentExecutionContext`, build an `AgentContext`).
+
+- [ ] **Step 2: Write the failing round-trip test (in-process first)**
+
+```java
+// InProcessConversationStoreReasoningRoundTripTest.java  (mirror the existing in-process store test's setup)
+@Test
+void reasoningContentSurvivesStoreAndLoad() {
+  var assistant =
+      AssistantMessage.builder()
+          .content(
+              List.of(
+                  new ReasoningContent(
+                      "why", Map.of("signature", "sig-xyz"), null),
+                  TextContent.textContent("answer")))
+          .build();
+
+  try (var session = store.createSession(executionContext, agentContext)) {
+    var ref = session.storeMessages(agentContext, ConversationStoreRequest.of(List.of(assistant)));
+    var reloaded = session.loadMessages(agentContext.withConversation(ref.conversationContext())).messages();
+
+    assertThat(reloaded).hasSize(1);
+    var restored = (AssistantMessage) reloaded.get(0);
+    assertThat(restored.content()).containsExactlyElementsOf(assistant.content());
+  }
+}
+```
+
+> Adapt `store`, `executionContext`, `agentContext`, and the `withConversation`/pointer plumbing to each store's actual test fixture (copy from the sibling test found in Step 1). The assertion — opaque `providerPayload` survives verbatim — is the invariant.
+
+- [ ] **Step 3: Run it — in-process expected PASS, then replicate for document + AgentCore**
+
+Run: `mvn test -f connectors/agentic-ai/pom.xml -Dtest='*ConversationStoreReasoningRoundTripTest'`
+Expected: in-process + document PASS. **AgentCore:** if it FAILS (mapping drops `providerPayload`), stop — do not patch the mapper.
+
+- [ ] **Step 4: If AgentCore fails, record the gap (do not fix)**
+
+Add a row to the gap register table in `docs/adr/009-own-the-llm-layer.md` (§ Agent-instance API gap register — reuse for store-mapping gaps too, or add a short "Store-mapping gaps" note): describe what AgentCore cannot round-trip, mark the test `@Disabled("gap: AgentCore mapping cannot represent opaque reasoning payload — see ADR 009")`, and surface it to the user. Otherwise leave all three enabled.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/memory/conversation/
+git commit -m "test(agentic-ai): de-risk opaque content round-trip across conversation stores"
+```
+
+### Task 0.3: `StopReason` enum + `AssistantMessage` fields
+
+**Files:**
+- Create: `model/message/StopReason.java`
+- Modify: `model/message/AssistantMessage.java` (add `modelId`, `messageId`, `stopReason`)
+- Test: `model/message/AssistantMessageTest.java` (extend or create)
+
+**Interfaces:**
+- Produces: `enum StopReason { STOP, LENGTH, TOOL_USE, CONTENT_FILTERED, GUARDRAIL, ERROR, ABORTED, UNKNOWN }`; `AssistantMessage` gains `@Nullable String modelId`, `@Nullable String messageId`, `@Nullable StopReason stopReason`. Raw vendor value stays in `metadata`. **No `usage`** — per-turn usage stays on `AgentConversationTurn` via `AgentMetrics.tokenUsage`.
+
+- [ ] **Step 1: Write the failing test**
+
+```java
+// AssistantMessageTest.java
+@Test
+void carriesStopReasonAndModelIdentityAndRoundTrips() throws Exception {
+  var mapper = new ObjectMapper();
+  var msg =
+      AssistantMessage.builder()
+          .content(List.of(TextContent.textContent("hi")))
+          .modelId("claude-opus-4-8")
+          .messageId("msg_123")
+          .stopReason(StopReason.STOP)
+          .metadata(Map.of("rawStopReason", "end_turn"))
+          .build();
+
+  var restored = mapper.readValue(mapper.writeValueAsString(msg), AssistantMessage.class);
+
+  assertThat(restored.modelId()).isEqualTo("claude-opus-4-8");
+  assertThat(restored.messageId()).isEqualTo("msg_123");
+  assertThat(restored.stopReason()).isEqualTo(StopReason.STOP);
+  assertThat(restored.metadata()).containsEntry("rawStopReason", "end_turn");
+  assertThat(restored.hasToolCalls()).isFalse();
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `mvn test -f connectors/agentic-ai/pom.xml -Dtest=AssistantMessageTest`
+Expected: FAIL — builder has no `modelId`/`messageId`/`stopReason`.
+
+- [ ] **Step 3: Create `StopReason`**
+
+```java
+// StopReason.java
+package io.camunda.connector.agenticai.aiagent.model.message;
+
+/**
+ * Provider-neutral, normalized finish reason. Diagnostics + a thin predicate surface only — never
+ * load-bearing for control flow (that keys off {@link AssistantMessage#hasToolCalls()}). The raw
+ * vendor value is always preserved in {@link AssistantMessage#metadata()}. Do NOT exhaustively
+ * switch on this enum: it is part of the persisted message contract, so new values must remain
+ * non-breaking. Continuation states (e.g. Anthropic {@code pause_turn}) are NOT represented here —
+ * see the {@code Continuation} chat result. See ADR 009 §3.
+ */
+public enum StopReason {
+  STOP,
+  LENGTH,
+  TOOL_USE,
+  CONTENT_FILTERED,
+  GUARDRAIL,
+  ERROR,
+  ABORTED,
+  UNKNOWN
+}
+```
+
+- [ ] **Step 4: Add the fields to `AssistantMessage`**
+
+Add three record components (keep existing `content`, `toolCalls`, `metadata`); annotate with `@JsonInclude(JsonInclude.Include.NON_NULL) @Nullable`. The `@AgenticAiRecord` builder + proxy builder regenerate automatically.
+
+```java
+public record AssistantMessage(
+    @JsonInclude(JsonInclude.Include.NON_EMPTY) List<Content> content,
+    @JsonInclude(JsonInclude.Include.NON_EMPTY) List<ToolCall> toolCalls,
+    @JsonInclude(JsonInclude.Include.NON_NULL) @Nullable String modelId,
+    @JsonInclude(JsonInclude.Include.NON_NULL) @Nullable String messageId,
+    @JsonInclude(JsonInclude.Include.NON_NULL) @Nullable StopReason stopReason,
+    @JsonInclude(JsonInclude.Include.NON_EMPTY) @Nullable Map<String, Object> metadata)
+    implements AssistantMessageBuilder.With, Message, ContentMessage {
+  // hasToolCalls(), builder(), proxy builder unchanged
+}
+```
+
+- [ ] **Step 5: Fix compile fallout at construction sites**
+
+Run: `mvn test-compile -f connectors/agentic-ai/pom.xml`
+Expected: compile errors only where `new AssistantMessage(...)` is called positionally (converters/tests). Fix each to use `AssistantMessage.builder()...build()` or the new arity. The LangChain4j `ChatMessageConverterImpl.toAssistantMessage(...)` is the main production site — set `modelId`/`stopReason` from the L4J response where available, else leave null (bridge parity; full mapping lands per-driver in Phase 1).
+
+- [ ] **Step 6: Run test to verify it passes**
+
+Run: `mvn test -f connectors/agentic-ai/pom.xml -Dtest=AssistantMessageTest`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add -A && git commit -m "feat(agentic-ai): add StopReason and modelId/messageId/stopReason to AssistantMessage"
+```
+
+### Task 0.4: `TokenUsage` cache + reasoning dimensions
+
+**Files:**
+- Modify: `model/AgentMetrics.java` (nested `TokenUsage` record)
+- Test: `model/AgentMetricsTest.java` (extend or create)
+
+**Interfaces:**
+- Produces: `TokenUsage(int inputTokenCount, int outputTokenCount, int cacheReadTokenCount, int cacheCreationTokenCount, int reasoningTokenCount)`. **Aggregation semantics (documented on the record):** `cacheReadTokenCount` and `cacheCreationTokenCount` are subsets *already included in* `inputTokenCount`; `reasoningTokenCount` is a subset *already included in* `outputTokenCount`. `totalTokenCount()` stays `input + output` (no double count). `add()` sums all five component-wise.
+
+- [ ] **Step 1: Write the failing test**
+
+```java
+// AgentMetricsTest.java
+@Test
+void tokenUsageCarriesCacheAndReasoningDimensionsAndAggregates() {
+  var a = AgentMetrics.TokenUsage.builder()
+      .inputTokenCount(100).outputTokenCount(40)
+      .cacheReadTokenCount(60).cacheCreationTokenCount(10).reasoningTokenCount(25).build();
+  var b = AgentMetrics.TokenUsage.builder()
+      .inputTokenCount(50).outputTokenCount(20)
+      .cacheReadTokenCount(30).cacheCreationTokenCount(0).reasoningTokenCount(5).build();
+
+  var sum = a.add(b);
+
+  assertThat(sum.inputTokenCount()).isEqualTo(150);
+  assertThat(sum.outputTokenCount()).isEqualTo(60);
+  assertThat(sum.cacheReadTokenCount()).isEqualTo(90);
+  assertThat(sum.cacheCreationTokenCount()).isEqualTo(10);
+  assertThat(sum.reasoningTokenCount()).isEqualTo(30);
+  // cache/reasoning are subsets of input/output — not added on top
+  assertThat(sum.totalTokenCount()).isEqualTo(210);
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `mvn test -f connectors/agentic-ai/pom.xml -Dtest=AgentMetricsTest`
+Expected: FAIL — builder has no cache/reasoning setters.
+
+- [ ] **Step 3: Extend the `TokenUsage` record**
+
+Add the three components with the documented semantics; extend `add()`; keep `totalTokenCount()` as `input + output`; keep `empty()`. Two-arg construction sites keep working via the builder — but the record's canonical constructor arity changes, so update the `empty()`/`builder()` usages if positional.
+
+```java
+/**
+ * Token usage for a model interaction.
+ *
+ * <p>Aggregation semantics: {@code cacheReadTokenCount} and {@code cacheCreationTokenCount} are
+ * subsets already counted within {@code inputTokenCount}; {@code reasoningTokenCount} is a subset
+ * already counted within {@code outputTokenCount}. {@link #totalTokenCount()} is therefore
+ * {@code input + output} and never double-counts. Populated per-round by the native drivers.
+ */
+@AgenticAiRecord
+@JsonDeserialize(builder = TokenUsage.AgentMetricsTokenUsageJacksonProxyBuilder.class)
+public record TokenUsage(
+    int inputTokenCount,
+    int outputTokenCount,
+    int cacheReadTokenCount,
+    int cacheCreationTokenCount,
+    int reasoningTokenCount)
+    implements AgentMetricsTokenUsageBuilder.With {
+
+  public int totalTokenCount() {
+    return inputTokenCount + outputTokenCount;
+  }
+
+  public TokenUsage add(TokenUsage o) {
+    return with(
+        b ->
+            b.inputTokenCount(b.inputTokenCount() + o.inputTokenCount())
+                .outputTokenCount(b.outputTokenCount() + o.outputTokenCount())
+                .cacheReadTokenCount(b.cacheReadTokenCount() + o.cacheReadTokenCount())
+                .cacheCreationTokenCount(b.cacheCreationTokenCount() + o.cacheCreationTokenCount())
+                .reasoningTokenCount(b.reasoningTokenCount() + o.reasoningTokenCount()));
+  }
+
+  public static TokenUsage empty() {
+    return builder().build();
+  }
+
+  public static AgentMetricsTokenUsageBuilder builder() {
+    return AgentMetricsTokenUsageBuilder.builder();
+  }
+
+  @JsonPOJOBuilder(withPrefix = "")
+  public static class AgentMetricsTokenUsageJacksonProxyBuilder
+      extends AgentMetricsTokenUsageBuilder {}
+}
+```
+
+- [ ] **Step 4: Fix construction fallout**
+
+Run: `mvn test-compile -f connectors/agentic-ai/pom.xml`
+Expected: fix any positional `new TokenUsage(in, out)` sites (e.g. the L4J adapter's `tokenUsage(...)` helper uses the builder already — leave cache/reasoning at default 0 for the bridge). Persisted old JSON without the new fields deserializes fine (defaults 0).
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `mvn test -f connectors/agentic-ai/pom.xml -Dtest=AgentMetricsTest`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add -A && git commit -m "feat(agentic-ai): add cache/reasoning token dimensions to TokenUsage"
+```
+
+### Task 0.5: `ToolCallResult.contentBlocks`
+
+> **REVERTED (2026-07-07, post-review).** `contentBlocks` was removed from Phase 0 — it had no reader on the Phase-0 branch. The block-content redesign (persisted block list + BC deserializer + migration) moves to Phase 2; see the Phase 2 deliverables above.
+
+**Files:**
+- Modify: `model/tool/ToolCallResult.java` (add `@Nullable List<Content> contentBlocks`)
+- Test: `model/tool/ToolCallResultTest.java` (extend or create)
+
+**Interfaces:**
+- Produces: `ToolCallResult` gains `@JsonInclude(NON_EMPTY) @Nullable List<Content> contentBlocks` — structured multimodal tool-result content (consumed by Phase 2 native emission and by document flow #7781). `content` (the opaque `Object`) stays for backward compatibility.
+
+- [ ] **Step 1: Write the failing test**
+
+```java
+// ToolCallResultTest.java
+@Test
+void carriesContentBlocksAndRoundTrips() throws Exception {
+  var mapper = new ObjectMapper();
+  var result =
+      ToolCallResult.builder()
+          .id("call_1").name("search")
+          .contentBlocks(List.of(TextContent.textContent("found it")))
+          .build();
+
+  var restored = mapper.readValue(mapper.writeValueAsString(result), ToolCallResult.class);
+
+  assertThat(restored.contentBlocks()).hasSize(1);
+  assertThat(restored.contentBlocks().get(0)).isEqualTo(TextContent.textContent("found it"));
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `mvn test -f connectors/agentic-ai/pom.xml -Dtest=ToolCallResultTest`
+Expected: FAIL — no `contentBlocks`.
+
+- [ ] **Step 3: Add the component**
+
+Insert `@JsonInclude(JsonInclude.Include.NON_EMPTY) @Nullable List<Content> contentBlocks` into the `ToolCallResult` record (before `properties`, which must stay last because of its `@JsonAnySetter`/`@JsonAnyGetter`). Keep the existing proxy builder.
+
+- [ ] **Step 4: Fix construction fallout & run**
+
+Run: `mvn test -f connectors/agentic-ai/pom.xml -Dtest=ToolCallResultTest`
+Expected: PASS (fix positional constructor sites via builder if any).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A && git commit -m "feat(agentic-ai): add contentBlocks to ToolCallResult"
+```
+
+### Task 0.6: Chat SPI interfaces
+
+Framework-neutral. No vendor imports.
+
+**Files:**
+- Create: `framework/api/ChatModelRequest.java`, `framework/api/ContinuationState.java`, `framework/api/ChatModelResult.java`, `framework/api/ChatModelRoundListener.java`, `framework/api/ChatModelApi.java`, `framework/api/ChatModelApiFactory.java`, `framework/api/ChatModelApiRegistry.java`, `framework/api/ChatModelInvoker.java`, `framework/api/ChatModelInvocationResult.java`
+- Test: `framework/api/ChatModelResultTest.java`
+
+**Interfaces:**
+- Produces (the SPI other tasks consume):
+
+```java
+// ChatModelRequest.java — what a driver needs for one round-trip
+public record ChatModelRequest(AgentExecutionContext executionContext, ConversationSnapshot snapshot) {}
+
+// ContinuationState.java — opaque, provider-specific resume marker
+public interface ContinuationState {}
+
+// ChatModelResult.java — tagged single-round outcome
+public sealed interface ChatModelResult {
+  AssistantMessage message();
+  AgentMetrics metrics(); // per-round: modelCalls=1 + this round's tokenUsage + toolCalls
+  record Completed(AssistantMessage message, AgentMetrics metrics) implements ChatModelResult {}
+  record Continuation(AssistantMessage message, AgentMetrics metrics, ContinuationState resumeState)
+      implements ChatModelResult {}
+}
+
+// ChatModelRoundListener.java — per-round observability hook (Phase 0: NOOP)
+public interface ChatModelRoundListener {
+  ChatModelRoundListener NOOP = (round, result) -> {};
+  void onRound(int round, ChatModelResult result);
+}
+
+// ChatModelApi.java — per-provider driver; ONE round-trip per call, no vendor auto-loop
+public interface ChatModelApi {
+  ChatModelResult call(ChatModelRequest request, @Nullable ContinuationState continuation);
+}
+
+// ChatModelApiFactory.java — builds a driver from a provider configuration
+public interface ChatModelApiFactory<C extends ProviderConfiguration> {
+  String providerType();
+  default List<String> providerTypes() { return List.of(providerType()); }
+  Class<C> configurationType();
+  ChatModelApi create(C configuration);
+}
+
+// ChatModelApiRegistry.java — dispatch by discriminator
+public interface ChatModelApiRegistry {
+  ChatModelApi resolve(ProviderConfiguration configuration);
+}
+
+// ChatModelInvocationResult.java — what the invoker returns to the request handler (mirrors AiFrameworkChatResponse)
+public record ChatModelInvocationResult(AssistantMessage assistantMessage, AgentMetrics metrics) {}
+
+// ChatModelInvoker.java — the seam that replaces AiFrameworkAdapter
+public interface ChatModelInvoker {
+  ChatModelInvocationResult invoke(AgentExecutionContext executionContext, ConversationSnapshot snapshot);
+}
+```
+
+- [ ] **Step 1: Write the failing test (sealed result exhaustiveness)**
+
+```java
+// ChatModelResultTest.java
+@Test
+void resultVariantsExposeMessageAndMetrics() {
+  var msg = AssistantMessage.builder().content(List.of(TextContent.textContent("x"))).build();
+  var metrics = new AgentMetrics(1, AgentMetrics.TokenUsage.empty(), 0);
+
+  ChatModelResult completed = new ChatModelResult.Completed(msg, metrics);
+  ChatModelResult continuation =
+      new ChatModelResult.Continuation(msg, metrics, new ContinuationState() {});
+
+  assertThat(completed.message()).isSameAs(msg);
+  assertThat(continuation.metrics()).isSameAs(metrics);
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `mvn test -f connectors/agentic-ai/pom.xml -Dtest=ChatModelResultTest`
+Expected: FAIL — types do not exist.
+
+- [ ] **Step 3: Create all SPI files** as shown in the Interfaces block above (one file each, `@NullMarked` package with a `package-info.java` for `framework/api`). `message()`/`metrics()` on the sealed interface are satisfied by the record components.
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `mvn test -f connectors/agentic-ai/pom.xml -Dtest=ChatModelResultTest`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A && git commit -m "feat(agentic-ai): add chat model SPI interfaces (framework/api)"
+```
+
+### Task 0.7: Registry + invoker impls (continuation loop + per-round metrics)
+
+> **RE-SCOPED (2026-07-07, post-review).** Only `ChatModelApiRegistryImpl` remains in Phase 0. `ChatModelInvokerImpl` + the continuation loop / `ChatModelRoundListener` were removed (the bridge never continues); the turn-based continuation model is built in Phase 1. The registry dispatches on `providerTypes()` in Phase 0 and is re-worked to `WireFormat` dispatch in Phase 1.
+
+**Files:**
+- Create: `framework/ChatModelApiRegistryImpl.java`, `framework/ChatModelInvokerImpl.java`
+- Test: `framework/ChatModelInvokerImplTest.java`, `framework/ChatModelApiRegistryImplTest.java`
+
+**Interfaces:**
+- Consumes: `ChatModelApi`, `ChatModelApiFactory`, `ChatModelResult`, `ChatModelRoundListener`, `ChatModelInvoker` (Task 0.6); `AgentExecutionContext.configuration().provider()`.
+- Produces: `ChatModelInvokerImpl(ChatModelApiRegistry, ChatModelRoundListener, int maxContinuations)`; `ChatModelApiRegistryImpl(List<ChatModelApiFactory<?>>)` — fail-loud on duplicate `providerType`.
+
+- [ ] **Step 1: Write the failing invoker test (loop + summed metrics + guard)**
+
+```java
+// ChatModelInvokerImplTest.java
+@Test
+void loopsOnContinuationAndSumsPerRoundMetrics() {
+  var msg1 = AssistantMessage.builder().content(List.of(TextContent.textContent("thinking"))).build();
+  var msg2 = AssistantMessage.builder().content(List.of(TextContent.textContent("done"))).build();
+  var m = new AgentMetrics(1, new AgentMetrics.TokenUsage(10, 5, 0, 0, 0), 0);
+
+  var driver = mock(ChatModelApi.class);
+  when(driver.call(any(), isNull()))
+      .thenReturn(new ChatModelResult.Continuation(msg1, m, new ContinuationState() {}));
+  when(driver.call(any(), notNull()))
+      .thenReturn(new ChatModelResult.Completed(msg2, m));
+
+  var registry = mock(ChatModelApiRegistry.class);
+  when(registry.resolve(any())).thenReturn(driver);
+
+  var invoker = new ChatModelInvokerImpl(registry, ChatModelRoundListener.NOOP, 5);
+  var result = invoker.invoke(executionContext, snapshot);
+
+  assertThat(result.assistantMessage()).isSameAs(msg2);          // terminal message returned
+  assertThat(result.metrics().modelCalls()).isEqualTo(2);         // both rounds counted
+  assertThat(result.metrics().tokenUsage().inputTokenCount()).isEqualTo(20);
+  assertThat(result.metrics().executionTime()).isNotNull();       // whole loop timed
+}
+
+@Test
+void throwsWhenMaxContinuationsExceeded() {
+  var msg = AssistantMessage.builder().content(List.of(TextContent.textContent("x"))).build();
+  var m = new AgentMetrics(1, AgentMetrics.TokenUsage.empty(), 0);
+  var driver = mock(ChatModelApi.class);
+  when(driver.call(any(), any()))
+      .thenReturn(new ChatModelResult.Continuation(msg, m, new ContinuationState() {}));
+  var registry = mock(ChatModelApiRegistry.class);
+  when(registry.resolve(any())).thenReturn(driver);
+
+  var invoker = new ChatModelInvokerImpl(registry, ChatModelRoundListener.NOOP, 3);
+
+  assertThatThrownBy(() -> invoker.invoke(executionContext, snapshot))
+      .isInstanceOf(ConnectorException.class);
+}
+```
+
+> Set up `executionContext` (Mockito mock; `configuration().provider()` returns any `ProviderConfiguration`) and `snapshot` (mock `ConversationSnapshot`) in `@BeforeEach`.
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `mvn test -f connectors/agentic-ai/pom.xml -Dtest=ChatModelInvokerImplTest`
+Expected: FAIL — `ChatModelInvokerImpl` does not exist.
+
+- [ ] **Step 3: Implement the invoker**
+
+```java
+// ChatModelInvokerImpl.java
+public class ChatModelInvokerImpl implements ChatModelInvoker {
+  private final ChatModelApiRegistry registry;
+  private final ChatModelRoundListener roundListener;
+  private final int maxContinuations;
+
+  public ChatModelInvokerImpl(
+      ChatModelApiRegistry registry, ChatModelRoundListener roundListener, int maxContinuations) {
+    this.registry = registry;
+    this.roundListener = roundListener;
+    this.maxContinuations = maxContinuations;
+  }
+
+  @Override
+  public ChatModelInvocationResult invoke(
+      AgentExecutionContext executionContext, ConversationSnapshot snapshot) {
+    final var driver = registry.resolve(executionContext.configuration().provider());
+    final var request = new ChatModelRequest(executionContext, snapshot);
+    final long start = System.nanoTime();
+
+    ContinuationState continuation = null;
+    AgentMetrics aggregate = AgentMetrics.empty();
+    int round = 0;
+    while (true) {
+      final var result = driver.call(request, continuation);
+      aggregate = aggregate.add(result.metrics());
+      roundListener.onRound(round, result);
+      if (result instanceof ChatModelResult.Completed completed) {
+        final var timed = aggregate.withExecutionTime(Duration.ofNanos(System.nanoTime() - start));
+        return new ChatModelInvocationResult(completed.message(), timed);
+      }
+      continuation = ((ChatModelResult.Continuation) result).resumeState();
+      if (++round > maxContinuations) {
+        throw new ConnectorException(
+            AgentErrorCodes.ERROR_CODE_FAILED_MODEL_CALL,
+            "Provider continuation exceeded maxContinuations (%d)".formatted(maxContinuations));
+      }
+    }
+  }
+}
+```
+
+> Note: `AgentMetrics.add(...)` does not accumulate `executionTime` (per its javadoc), so timing the whole loop and setting it once via `withExecutionTime(...)` is correct. Continuation rounds re-send the same windowed `request`; provider-specific resume detail rides `ContinuationState`.
+
+- [ ] **Step 4: Implement the registry**
+
+```java
+// ChatModelApiRegistryImpl.java
+public class ChatModelApiRegistryImpl implements ChatModelApiRegistry {
+  private final Map<String, ChatModelApiFactory<?>> factoriesByType;
+
+  public ChatModelApiRegistryImpl(List<ChatModelApiFactory<?>> factories) {
+    this.factoriesByType = new HashMap<>();
+    for (var f : factories) {
+      for (var type : f.providerTypes()) {
+        var prev = factoriesByType.putIfAbsent(type, f);
+        if (prev != null) {
+          throw new IllegalStateException(
+              "Duplicate ChatModelApiFactory for providerType '%s': %s and %s"
+                  .formatted(type, prev.getClass(), f.getClass()));
+        }
+      }
+    }
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public ChatModelApi resolve(ProviderConfiguration configuration) {
+    var factory = factoriesByType.get(configuration.providerType());
+    if (factory == null) {
+      throw new ConnectorException(
+          AgentErrorCodes.ERROR_CODE_FAILED_MODEL_CALL,
+          "No chat model provider registered for '%s'".formatted(configuration.providerType()));
+    }
+    if (!factory.configurationType().isInstance(configuration)) {
+      throw new IllegalStateException(
+          "Configuration %s does not match factory expected type %s"
+              .formatted(configuration.getClass(), factory.configurationType()));
+    }
+    return ((ChatModelApiFactory<ProviderConfiguration>) factory).create(configuration);
+  }
+}
+```
+
+- [ ] **Step 5: Write + run the registry test (duplicate fail-loud, resolve, unknown)**
+
+Add `ChatModelApiRegistryImplTest` asserting: resolve returns the created driver; duplicate `providerType` throws `IllegalStateException` at construction; unknown discriminator throws `ConnectorException`.
+
+Run: `mvn test -f connectors/agentic-ai/pom.xml -Dtest='ChatModelInvokerImplTest,ChatModelApiRegistryImplTest'`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add -A && git commit -m "feat(agentic-ai): add chat model registry and invoker with continuation loop"
+```
+
+### Task 0.8: LangChain4j bridge driver
+
+Wrap the existing `Langchain4JAiFrameworkAdapter` behind a `ChatModelApi`. L4J has no continuation, so it always returns `Completed`.
+
+**Files:**
+- Create: `framework/langchain4j/Langchain4JChatModelApi.java`, `framework/langchain4j/Langchain4JChatModelApiFactory.java`
+- Test: `framework/langchain4j/Langchain4JChatModelApiTest.java`
+
+**Interfaces:**
+- Consumes: `Langchain4JAiFrameworkAdapter.executeChatRequest(ctx, snapshot)` (returns `AiFrameworkChatResponse` with `assistantMessage()` + `metrics()`); `ChatModelApi`, `ChatModelApiFactory`, `ChatModelResult` (Task 0.6).
+- Produces: a factory claiming all six existing discriminators (`anthropic`, `bedrock`, `azureOpenAi`, `googleVertexAi`, `openai`, `openaiCompatible`) so every provider routes through the bridge in Phase 0.
+
+- [ ] **Step 1: Write the failing test**
+
+```java
+// Langchain4JChatModelApiTest.java
+@Test
+void wrapsAdapterResponseAsCompletedResult() {
+  var msg = AssistantMessage.builder().content(List.of(TextContent.textContent("hi"))).build();
+  var metrics = new AgentMetrics(1, AgentMetrics.TokenUsage.empty(), 0);
+  var adapter = mock(Langchain4JAiFrameworkAdapter.class);
+  when(adapter.executeChatRequest(any(), any())).thenReturn(chatResponseOf(msg, metrics));
+
+  var api = new Langchain4JChatModelApi(adapter);
+  var result = api.call(new ChatModelRequest(executionContext, snapshot), null);
+
+  assertThat(result).isInstanceOf(ChatModelResult.Completed.class);
+  assertThat(result.message()).isSameAs(msg);
+  assertThat(result.metrics()).isSameAs(metrics);
+}
+```
+
+> `chatResponseOf(...)` returns a stub `AiFrameworkChatResponse` (a small test double or a Mockito mock returning `assistantMessage()`/`metrics()`).
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `mvn test -f connectors/agentic-ai/pom.xml -Dtest=Langchain4JChatModelApiTest`
+Expected: FAIL — type missing.
+
+- [ ] **Step 3: Implement driver + factory**
+
+```java
+// Langchain4JChatModelApi.java
+public class Langchain4JChatModelApi implements ChatModelApi {
+  private final Langchain4JAiFrameworkAdapter adapter;
+
+  public Langchain4JChatModelApi(Langchain4JAiFrameworkAdapter adapter) {
+    this.adapter = adapter;
+  }
+
+  @Override
+  public ChatModelResult call(ChatModelRequest request, @Nullable ContinuationState continuation) {
+    var response = adapter.executeChatRequest(request.executionContext(), request.snapshot());
+    return new ChatModelResult.Completed(response.assistantMessage(), response.metrics());
+  }
+}
+```
+
+```java
+// Langchain4JChatModelApiFactory.java — bridge claims all built-in discriminators
+public class Langchain4JChatModelApiFactory implements ChatModelApiFactory<ProviderConfiguration> {
+  private final Langchain4JAiFrameworkAdapter adapter;
+
+  public Langchain4JChatModelApiFactory(Langchain4JAiFrameworkAdapter adapter) {
+    this.adapter = adapter;
+  }
+
+  @Override public String providerType() { return "langchain4j"; }
+
+  @Override
+  public List<String> providerTypes() {
+    return List.of("anthropic", "bedrock", "azureOpenAi", "googleVertexAi", "openai", "openaiCompatible");
+  }
+
+  @Override public Class<ProviderConfiguration> configurationType() { return ProviderConfiguration.class; }
+
+  @Override public ChatModelApi create(ProviderConfiguration configuration) {
+    return new Langchain4JChatModelApi(adapter);
+  }
+}
+```
+
+> Confirm the six discriminator string constants against `AnthropicProviderConfiguration.ANTHROPIC_ID` etc. and use those constants rather than string literals.
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `mvn test -f connectors/agentic-ai/pom.xml -Dtest=Langchain4JChatModelApiTest`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A && git commit -m "feat(agentic-ai): add LangChain4j bridge chat model driver"
+```
+
+### Task 0.9: Cut the request handler over to `ChatModelInvoker`
+
+> **RE-SCOPED (2026-07-07, post-review).** The handler cuts over to `ChatModelApiRegistry` directly (`registry.resolve(provider).call(request)`), not to a `ChatModelInvoker` seam. The bridge implementation calls `AiFrameworkAdapter.executeMeasuringTime(...)`, so metrics keep their measured `executionTime`. Still a behaviour-identical swap of the single LLM call.
+
+Behaviour-identical swap of the single LLM call. This is the phase's integration checkpoint.
+
+**Files:**
+- Modify: `aiagent/agent/BaseAgentRequestHandler.java` (field + call site)
+- Modify: `aiagent/framework/langchain4j/configuration/AgenticAiLangchain4JFrameworkConfiguration.java` (register bridge factory bean)
+- Modify: `autoconfigure/AgenticAiConnectorsAutoConfiguration.java` (register `ChatModelApiRegistry` + `ChatModelInvoker` beans; inject invoker into the request handlers)
+- Modify: `aiagent/agent/OutboundConnectorAgentRequestHandlerTest.java`, `aiagent/agent/JobWorkerAgentRequestHandlerTest.java` (mock `ChatModelInvoker` instead of `AiFrameworkAdapter`)
+
+**Interfaces:**
+- Consumes: `ChatModelInvoker.invoke(ctx, snapshot)` (Task 0.6/0.7); `ChatModelApiRegistryImpl`, `Langchain4JChatModelApiFactory` (Task 0.7/0.8).
+
+- [ ] **Step 1: Update the handler tests first (red)**
+
+In both handler tests, replace the `AiFrameworkAdapter` mock with a `ChatModelInvoker` mock:
+```java
+when(chatModelInvoker.invoke(any(), any()))
+    .thenReturn(new ChatModelInvocationResult(assistantMessage, metrics));
+```
+Run: `mvn test -f connectors/agentic-ai/pom.xml -Dtest='OutboundConnectorAgentRequestHandlerTest,JobWorkerAgentRequestHandlerTest'`
+Expected: FAIL to compile — handler still takes `AiFrameworkAdapter`.
+
+- [ ] **Step 2: Swap the field and call site in `BaseAgentRequestHandler`**
+
+Replace the `AiFrameworkAdapter<?> framework` constructor param/field with `ChatModelInvoker chatModelInvoker`. Change the call site in `proceed(...)`:
+```java
+final var result = chatModelInvoker.invoke(executionContext, conversation.window(agentConfiguration.contextWindowSize()));
+final var updatedConversation = conversation.ingest(result.assistantMessage(), result.metrics());
+```
+Propagate the constructor change to `JobWorkerAgentRequestHandler` and `OutboundConnectorAgentRequestHandler` subclasses.
+
+- [ ] **Step 3: Register beans**
+
+In `AgenticAiLangchain4JFrameworkConfiguration`, add a `@Bean Langchain4JChatModelApiFactory` (depends on the existing `Langchain4JAiFrameworkAdapter` bean). In `AgenticAiConnectorsAutoConfiguration`, add `@Bean ChatModelApiRegistry chatModelApiRegistry(List<ChatModelApiFactory<?>> factories)` → `new ChatModelApiRegistryImpl(factories)` and `@Bean ChatModelInvoker chatModelInvoker(ChatModelApiRegistry registry)` → `new ChatModelInvokerImpl(registry, ChatModelRoundListener.NOOP, <maxContinuations default, e.g. 10>)`. Inject `ChatModelInvoker` into the request-handler bean definitions instead of `AiFrameworkAdapter`.
+
+- [ ] **Step 4: Run unit tests (green)**
+
+Run: `mvn test -f connectors/agentic-ai/pom.xml`
+Expected: PASS. Fix any remaining construction sites.
+
+- [ ] **Step 5: Run wire-format e2e regression (parity gate)**
+
+Run:
+```bash
+mvn install -pl connectors/agentic-ai -DskipTests -f pom.xml
+mvn test -pl connectors-e2e-test/connectors-e2e-test-agentic-ai -Dtest='*ApiAiAgentJobWorker*'
+```
+Expected: PASS — behaviour identical to before the cutover. (Requires `element-templates-cli` on PATH.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add -A && git commit -m "refactor(agentic-ai): route chat requests through ChatModelInvoker (LangChain4j bridge)"
+```
+
+### Task 0.10: Docs — record the SPI in the module reference
+
+**Files:**
+- Modify: `docs/reference/ai-agent.md` (§12 framework abstraction: describe `ChatModelApi`/registry/invoker as the seam, LangChain4j as bridge driver; §25 extension points: adding a provider = implement `ChatModelApiFactory`)
+- Modify: `AGENTS.md` (invariants: native drivers under `framework/<provider>/**` import only their vendor SDK; framework-agnostic-core wording updated to allow `framework/api/**` as neutral)
+
+- [ ] **Step 1: Update `ai-agent.md` §12 and §25** with the SPI description and the "add a provider" playbook (implement `ChatModelApiFactory`, register a bean; capabilities + native emission arrive in Phases 1–2).
+
+- [ ] **Step 2: Update `AGENTS.md`** framework-agnostic-core invariant to name `framework/api/**` as the neutral SPI package and `framework/<provider>/**` as vendor-scoped.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add -A && git commit -m "docs(agentic-ai): document chat model SPI and provider extension point"
+```
+
+---
+
+## Self-review checklist (before executing)
+
+- **Spec coverage:** every ADR 009 decision (§1 seam, §2 continuation, §3 StopReason, §4 matrix, §5 domain model, §6 config, §7 bridge, §8 transport) maps to a Phase task or a roadmap phase. Phase 0 covers §1/§2/§3/§5/§7; §4 → Phase 2; §6 → Phases 1+3; §8 → Phase 1.
+- **Gap register:** Task 0.2 wires the first entry path; the epic DoD requires the consolidated agent-instance API requirements summary.
+- **Cross-module e2e:** every model/serialization task (0.1, 0.3, 0.4, 0.5, and any later record-shape change) must test-compile `connectors-e2e-test-agentic-ai` (`-am` from repo root) and fix construction sites there in the same commit — the module builds outside `connectors/agentic-ai/pom.xml`. Task 0.4's `TokenUsage` arity change was the first to hit this.
+- **Type consistency:** `ChatModelResult`, `ChatModelInvocationResult`, `ChatModelInvoker`, `ChatModelApiRegistry`, `ChatModelApiFactory`, `TokenUsage` (5 components), `StopReason` (8 values) are used with identical names/signatures across Tasks 0.6–0.9.

--- a/connectors/agentic-ai/docs/adr/009-own-the-llm-layer.md
+++ b/connectors/agentic-ai/docs/adr/009-own-the-llm-layer.md
@@ -1,0 +1,334 @@
+# Own the LLM layer
+
+* Deciders: Agentic AI Team
+* Date: Jul 6, 2026
+
+## Status
+
+**Proposed**
+
+Tracks epic [#7211](https://github.com/camunda/connectors/issues/7211) and its three sub-epics:
+[#7212](https://github.com/camunda/connectors/issues/7212) (native provider implementations),
+[#7213](https://github.com/camunda/connectors/issues/7213) (connector types + provider-config restructure),
+[#7214](https://github.com/camunda/connectors/issues/7214) (capability matrix + multimodal tool results).
+
+Supersedes the hackdays reference on PR [#7151](https://github.com/camunda/connectors/pull/7151),
+which is a proof of concept, not the shape we land.
+
+## Context and Problem Statement
+
+The agentic-ai module reaches every LLM through a single `AiFrameworkAdapter` backed by LangChain4j.
+That framework's lowest-common-denominator data model blocks features providers support natively —
+multimodal tool results, signed/opaque reasoning continuations, granular prompt caching, cache and
+reasoning token attribution, provider-native server-side tools, and lossless wire formats for Claude
+on AWS / GCP / Azure. Closing these gaps upstream is bounded by LangChain4j's release cadence, and
+several of them (single-content-block assistant messages, flat tool-result content) are structural.
+
+Do we keep building on LangChain4j, or own the provider layer end-to-end while preserving today's
+BPMN orchestration core (the distributed agent loop, conversation memory, gateway tools, the
+`AgentConversation` turn aggregate)?
+
+## Decision Drivers
+
+* **Native feature access** — reach provider-native capabilities (multimodal tool results, reasoning,
+  caching, server-side tools) without waiting on an intermediary framework.
+* **Provider fidelity** — a provider-neutral SPI that never leaks vendor vocabulary, but round-trips
+  provider-opaque content (reasoning/thinking blocks, signatures, compaction blocks, server-tool
+  blocks) losslessly.
+* **Capability awareness** — the agent knows each `(model, backend)` tuple's real modalities, limits,
+  and feature support at request time.
+* **HTTP transport parity** — full control over the HTTP client, especially **outbound proxy
+  configuration**, at parity with today (same driver as [ADR 001](001-replace-mcp-client-framework.md)).
+* **Preserve the orchestration core** — the request handler, memory, gateway tools, and the ADR-007
+  turn aggregate stay intact. This is an LLM-seam replacement, not an orchestration rewrite.
+* **No user disruption** — existing element templates and saved configurations keep working unchanged;
+  breaking changes land only on new connector types.
+* **Extensibility** — a custom-provider SPI, and structural groundwork so follow-ups (reasoning,
+  caching, compaction, server-side tools, document flow) attach without breaking changes.
+
+## Considered Options
+
+1. **Extend LangChain4j upstream** and keep building on it.
+2. **Build a thin per-provider HTTP layer** ourselves.
+3. **Native provider implementations over the official vendor Java SDKs**, behind a provider-neutral
+   SPI, with LangChain4j demoted to an opt-in bridge.
+
+## Decision Outcome
+
+Chosen option: **Option 3 — native provider implementations over the vendor SDKs.**
+
+We replace the LangChain4j-backed `AiFrameworkAdapter` with a provider-neutral chat SPI, dispatched
+by a registry to native implementations built on the official vendor Java SDKs (Anthropic, OpenAI,
+AWS Bedrock, Google GenAI). LangChain4j remains available as an opt-in bridge implementation and as a
+customization escape hatch, never regressing coverage during the transition.
+
+The rest of this section states the architecture and the principles that constrain it. Type names are
+**indicative** — the ADR fixes roles and contracts, not final identifiers.
+
+### 1. The chat SPI replaces the LLM seam, not the orchestrator
+
+The core request handler keeps owning the BPMN-level job: initialization, memory load, input
+composition, limit checks, agent-instance updates, and job completion. The **only** thing that
+changes for the request handler is what sits behind its single LLM call. Today:
+
+```java
+final var chatResponse = framework.executeMeasuringTime(executionContext, conversation.window(...));
+final var updatedConversation = conversation.ingest(chatResponse.assistantMessage(), chatResponse.metrics());
+```
+
+The seam contract — `(executionContext, windowed snapshot) → (assistantMessage, per-turn metrics)` —
+is preserved. Behind it, a **`ChatModelApiRegistry`** dispatches to a **`ChatModelApi`**
+implementation, built by a **`ChatModelApiFactory`**.
+
+**Metrics ingestion stays in the `AgentConversation` aggregate** (ADR 007), via
+`conversation.ingest(assistantMessage, metrics)`. The PoC's idea of a `ChatClient` that *owns* the
+metric update is explicitly dropped — ADR 007 already owns it. The `ChatModelApi` therefore stays
+thin: it performs one provider round-trip and returns `(assistantMessage, per-turn metrics)`; the
+request handler ingests the result and owns any multi-round loop (below).
+
+### 2. Provider implementations do exactly one round-trip; our code owns every loop
+
+A single logical assistant turn may require several provider round-trips (e.g. Anthropic
+`pause_turn` while a server-side tool runs). **Every round-trip goes through our code**, never a
+hidden vendor-SDK auto-loop, so metrics, tracing, and events are emitted per round.
+
+* A `ChatModelApi` performs **one** provider round-trip per `call(...)` and returns the resulting
+  `AssistantMessage`. The vendor SDK's tool-runner / auto-continuation loop is **not** used.
+* When a provider pauses a turn mid-flight (Anthropic `pause_turn`), the interim assistant message
+  is **appended to the conversation as a real turn** and the request handler re-invokes the chat
+  model to resume. This is a **turn-based loop owned by the request handler**, not an opaque
+  resume-state threaded back through `call(...)`: each round is an ordinary persisted turn with its
+  own per-round metrics and events, and the sequence of interim turns is the elaboration of one
+  logical assistant response.
+* Provider-opaque content produced across those rounds (reasoning/thinking blocks, signatures) rides
+  on the message itself (§5) and is re-emitted unchanged on the next round, so no server-side-tool
+  vocabulary enters the provider-neutral SPI.
+
+The turn-based loop is a general primitive: the same request-handler-driven re-invocation later
+underpins agent-driven compaction ([#7401](https://github.com/camunda/connectors/issues/7401)). This
+epic **builds the primitive but ships no server-side-tool feature.**
+
+### 3. `StopReason` is diagnostics, never load-bearing
+
+The continue/stop decision is `!conversation.currentTurn().hasToolCalls()` — derived from the tool
+calls, never from a finish reason. A normalized `StopReason` therefore exists for **provider-neutral
+diagnostics plus a thin predicate surface only**:
+
+```
+STOP | LENGTH | TOOL_USE | CONTENT_FILTERED | GUARDRAIL | ERROR | ABORTED | UNKNOWN
+```
+
+* The **raw vendor value is always preserved** in `AssistantMessage.metadata`. Normalization for
+  logic, raw string for diagnosability/audit.
+* **`UNKNOWN` is the mandatory fallback** — unrecognized vendor values map to it, so adding a provider
+  is a mapping change, never a domain-model change.
+* **No exhaustive switching on `StopReason`** — control flow keys off `hasToolCalls()`; error handling
+  uses a small predicate (is this a terminal model-side error?), not a value-by-value switch. The
+  enum is part of the persisted `AssistantMessage` contract, so exhaustive switches would make every
+  new value a breaking change.
+* `pause_turn` and other mid-turn pauses are handled by the turn-based loop (§2), **never** by
+  `StopReason`.
+* Ratified taxonomy decisions: keep `GUARDRAIL` distinct from `CONTENT_FILTERED` — an extra value is
+  effectively free given the no-exhaustive-switching rule, avoids an information-losing normalization,
+  and lets providers that separate the two map faithfully (Bedrock `guardrail_intervened` → `GUARDRAIL`
+  vs. `content_filtered` → `CONTENT_FILTERED`). Anthropic `refusal` maps to `CONTENT_FILTERED` (a
+  model-side content refusal, not a separate guardrail layer).
+
+### 4. Capability matrix — lean, keyed on `(apiFamily, backend, model)`
+
+A configuration-driven matrix advertises each tuple's capabilities, resolved at request time by a
+**cascading, specificity-weighted selector model** (CSS-like) rather than the PoC's whole-entry
+longest-match:
+
+* Config is expressed as **layers**, each matching on any subset of dimensions — e.g. all Anthropic
+  (`provider=anthropic`), then Sonnet models (`provider=anthropic, model=*sonnet*`), then Sonnet on
+  Bedrock (`provider=anthropic, model=*sonnet*, backend=bedrock`).
+* Resolution **merges properties across all matching layers** (property-level cascade, not whole-entry
+  replacement), so a broad layer sets defaults and narrower layers override individual properties.
+* **Specificity = how many/how precisely dimensions match** (more matched dimensions → more weight,
+  exact match outweighs glob); the highest-specificity layer wins **per property**. On specificity
+  ties, **later-declared wins**. A connector-level override is the highest-specificity layer; bundled
+  conservative defaults are the lowest (base) layer.
+* **Initial properties are minimal** — only what this epic consumes: input/output modalities (drive
+  multimodal tool-result routing), max output tokens, and context-window size where the window seam
+  reads it.
+* The **schema is designed to grow flags without breaking**; each follow-up adds its own
+  (`supports_reasoning`, `supports_prompt_caching`, `supports_server_side_tools`, …). We do **not**
+  pre-load flags for features we are not shipping.
+
+### 5. Domain-model extensions (structural groundwork)
+
+Additive, and locked in early because retrofitting them is a breaking change to the persisted memory
+format and the message model:
+
+* `AssistantMessage` gains `modelId`, `messageId`, `stopReason`. **Not `usage`** — per-turn token
+  usage is already modeled on `AgentConversationTurn` via `AgentMetrics.tokenUsage`, and each round
+  of the turn-based loop (§2) is its own turn carrying its own usage; adding usage to the message
+  would duplicate it.
+* **Opaque-carrying content** — reasoning/thinking blocks, signatures, encrypted reasoning items, and
+  compaction-shaped blocks are stored as **provider-opaque payload**, not lossily flattened to text.
+  This content must round-trip losslessly through the domain model, **all** conversation stores, and
+  the window/snapshot, and be re-emitted unchanged on the next round. This opaque-carrying content is
+  what the turn-based loop (§2) replays across rounds; it is the prerequisite for reasoning
+  ([#7669](https://github.com/camunda/connectors/issues/7669)), compaction (#7401), and server-side
+  tools.
+* `ToolCallResult` gains `contentBlocks` (consumed by native multimodal emission and by document flow,
+  [#7781](https://github.com/camunda/connectors/issues/7781)).
+* `TokenUsage` gains **cache and reasoning token dimensions with documented aggregation semantics**
+  (whether `cacheRead` is included-in or separate-from input, `reasoning` in or out of output).
+  Captured at the provider-implementation level as each native usage-mapper is written — the SDKs already return them,
+  and nailing the semantics once avoids a cross-cutting retrofit. Carried through `AgentMetrics`.
+
+### 6. Provider configuration — restructure internally now, break UX only on new connector types
+
+* **Phase 1 introduces an internal normalized provider model** `(wireFormat, backend, apiFamily)` that
+  the native factory dispatches on. Today's existing discriminators map into it via a resolver
+  (`bedrock` + Claude model → Anthropic wire format, BEDROCK backend; `azureOpenAi` → OpenAI wire
+  format, Foundry backend; `openai` → OpenAI wire format, Completions default; `googleVertexAi` →
+  Google wire format, Vertex backend). **The user-facing `ProviderConfiguration` types are not
+  restructured, so the generated element templates stay byte-identical — no migration for existing
+  users.**
+* **The wire-format-first UX and all breaking changes land only on new connector types** ("AI Agent
+  Task" / "AI Agent Sub-process") in Phase 3, with backend + apiFamily selectors, consolidated OpenAI,
+  `googleGenAi`, Anthropic backends, and the custom-provider SPI. Old connector types become
+  **deprecated input-rewrite shims** that delegate to the internal model — largely the resolver from
+  Phase 1.
+* New opt-in features (reasoning/caching config, server-side tools) surface on the new connector types;
+  existing templates stay frozen.
+
+### 7. LangChain4j demoted to an opt-in bridge
+
+The bridge wraps the existing `AiFrameworkAdapter` behind a `ChatModelApi`, covering any provider not
+yet native so **coverage never regresses**. LangChain4j stays default-on until native parity is
+proven, then becomes opt-in (off by default), and remains a customization escape hatch (user-supplied
+`dev.langchain4j.model.chat.ChatModel`). The framework-agnostic-core invariant holds: only
+`framework/langchain4j/**` imports `dev.langchain4j.*`.
+
+**Planned:** extract the LangChain4j bridge into a **dedicated module** later, as part of the broader
+split of the core domain model into its own module — isolating the `dev.langchain4j.*` dependency at
+the module boundary (and enforceable by the future ArchUnit suite, epic
+[#7537](https://github.com/camunda/connectors/issues/7537)). Out of scope for this epic; noted so the
+package layout chosen here doesn't fight that move.
+
+### 8. HTTP transport / proxy parity is first-class
+
+**Proper outbound-proxy support at parity with today is the hard requirement**; the specific HTTP
+client is not. Transport configuration (proxy, timeouts, TLS) is a first-class Phase 1 concern per
+provider — not a deferred follow-up. Prefer the JDK `java.net.http.HttpClient` where the SDK supports
+it; fall back to another sensible client (e.g. OkHttp) per provider where necessary to get correct
+proxy behavior.
+
+### Positive Consequences
+
+* Native provider features become reachable without upstream dependency.
+* Provider-opaque content round-trips losslessly, unblocking reasoning, caching, compaction, and
+  server-side tools as clean follow-ups.
+* Existing users are undisturbed; breaking changes are quarantined to new connector types.
+* One turn-based loop serves `pause_turn` and agent-driven compaction.
+
+### Negative Consequences
+
+* Five native wire-format implementations to build and maintain (mitigated by the bridge covering
+  gaps and by shared SPI/serialization infrastructure).
+* Two provider-config shapes coexist during the deprecation window (legacy templates + new connector
+  types), bridged by the input-rewrite shims.
+* The engine-side agent-instance history/metrics API cannot represent all native output (see
+  [Agent-instance API gap register](#agent-instance-api-gap-register)); we degrade and document rather
+  than block.
+
+## Pros and Cons of the Options
+
+### Option 1: Extend LangChain4j upstream
+
+* Good, because no new provider code and known patterns.
+* Bad, because gated by upstream release cadence.
+* Bad, because several gaps are structural (single-content-block assistant messages, flat tool-result
+  content) and unlikely to close without breaking upstream changes.
+
+### Option 2: Thin per-provider HTTP layer
+
+* Good, because full control over the wire.
+* Bad, because it re-implements what the vendor SDKs already do well (auth, signing, retries,
+  streaming, schema derivation) across four providers.
+
+### Option 3: Native implementations over vendor SDKs (chosen)
+
+* Good, because full control over transport (proxy) and access to native features.
+* Good, because the SDKs handle auth/signing/retries/streaming.
+* Good, because the bridge lets us migrate provider-by-provider without regression.
+* Bad, because more provider code to maintain and a coexistence window.
+
+## Implementation Approach
+
+Side-by-side migration behind the SPI; the bridge guarantees no regression. Phases stay within the
+epic's filed structure. Detailed per-phase breakdown, file lists, and test plans live in the
+[implementation plan](../adr-009-implementation-plan.md).
+
+* **Phase 0 — domain model + SPI skeleton + bridge cutover.** Additive, behaviour-identical: domain
+  extensions (§5), the chat SPI interfaces + registry, LangChain4j wired as the first bridge
+  implementation. Element templates untouched. **Includes a de-risking spike** proving opaque-block
+  round-trip through the in-process, document, and AWS AgentCore conversation stores.
+* **Phase 1 (#7212) — native implementations, all five wire formats.** Anthropic-messages (direct)
+  first (unblocks the follow-up server-tool work), then OpenAI (completions + responses), Bedrock
+  Converse, Google GenAI, and Anthropic cloud backends (Bedrock / Vertex / Foundry). Dispatched from
+  the internal normalized model (§6) mapped from existing discriminators — templates frozen. Lands the
+  request-handler-owned turn-based loop with per-round metrics/events (§2), deterministic
+  tools/system serialization, HTTP transport/proxy parity (§8), and provider-level token-dimension
+  capture (§5). LangChain4j demoted to opt-in once parity is proven.
+* **Phase 2 (#7214) — capability matrix + multimodal tool results.** The lean matrix (§4), native
+  multimodal emission, and native-vs-fallback tool-result routing. Tool-result rendering **converges
+  on the existing `<doc/>` scheme** (`DocumentReferenceXmlTag`), not a competing `<document/>` tag, to
+  avoid a reconciliation debt for #7781. Keeps the window/snapshot seam pluggable for compaction.
+* **Phase 3 (#7213) — new connector types + config restructure + custom-provider SPI.** Wire-format-
+  first templates with backend/apiFamily selectors; old connector types become deprecated shims;
+  custom-provider SPI. All breaking UX changes isolated here. Element-template version bump per
+  `AGENTS.md`.
+
+### Out of scope (follow-ups this epic prepares for)
+
+* **Reasoning configuration** ([#7669](https://github.com/camunda/connectors/issues/7669)) — config/UX
+  deferred; opaque reasoning-content round-trip and reasoning token dimensions are groundwork here.
+* **Prompt caching** ([#7668](https://github.com/camunda/connectors/issues/7668)) — config/UX deferred;
+  cache token dimensions and deterministic prefix serialization are groundwork here.
+* **Memory compaction** ([#7401](https://github.com/camunda/connectors/issues/7401)) — consumes the
+  turn-based loop (§2), the pluggable window seam, capability context-window sizes, and opaque
+  compaction-block round-trip.
+* **Provider-native server-side tools** (Claude code execution + skills) — consumes the turn-based
+  loop (§2) and a future `supports_server_side_tools` matrix flag; config surfaces on the new
+  connector types.
+* **Document flow & awareness** ([#7781](https://github.com/camunda/connectors/issues/7781)) — consumes
+  `ToolCallResult.contentBlocks`, native multimodal emission, and the `<doc/>` convergence.
+
+## Agent-instance API gap register
+
+The engine-side agent-instance **history/metrics** API (consumed in the request handler via
+`createHistoryForInputMessages` / `createHistoryForAssistantMessage` / `notifyMetrics`) cannot
+represent all native-provider output end-to-end — reasoning content, provider-opaque blocks, and the
+new token dimensions. Convention for the whole epic:
+
+* **Degrade, never fail** — omit unrepresentable content/metrics from the emitted history/metrics
+  (e.g. strip opaque blocks before building the history entry). The job completes; conversation memory
+  keeps full fidelity.
+* **Mark loudly** — every omission gets a code comment, a log line, and an entry in a living gap
+  register (this section, kept current through the epic).
+* **Consolidate at the end** — a **requirements summary for the agent-instance history/metrics API** is
+  part of the epic's Definition of Done: the concrete list of what that API must support to represent
+  native output faithfully. That summary is the handoff to whoever owns that API.
+
+| Gap | Native output not representable | Workaround | Phase surfaced |
+|-----|----------------------------------|------------|----------------|
+| `ReasoningContent` → history | No dedicated reasoning/opaque history content block; `providerPayload` (signature / encrypted reasoning) has no faithful representation | `AgentInstanceHistoryMapper` maps it to a generic **object** history block (marked with a code comment). Latent in Phase 0 — no driver emits `ReasoningContent` yet (reasoning config deferred to #7669); exercised once a native driver produces it | 0 (code site), 1+ (exercised) |
+
+## References
+
+* Epic [#7211](https://github.com/camunda/connectors/issues/7211) and sub-epics
+  [#7212](https://github.com/camunda/connectors/issues/7212),
+  [#7213](https://github.com/camunda/connectors/issues/7213),
+  [#7214](https://github.com/camunda/connectors/issues/7214).
+* Hackdays reference PR [#7151](https://github.com/camunda/connectors/pull/7151).
+* [ADR 001 — MCP client framework](001-replace-mcp-client-framework.md) (transport/proxy precedent).
+* [ADR 006 — data-driven agent initialization](006-data-driven-agent-initialization.md),
+  [ADR 007 — agent conversation turn aggregate](007-agent-conversation-turn-aggregate.md).
+* [ADR 004 — document handling in tool call results](004-document-handling-in-tool-call-results.md)
+  and PR [#6999](https://github.com/camunda/connectors/pull/6999).
+* Implementation plan: [adr-009-implementation-plan.md](../adr-009-implementation-plan.md).

--- a/connectors/agentic-ai/docs/reference/ai-agent.md
+++ b/connectors/agentic-ai/docs/reference/ai-agent.md
@@ -26,7 +26,7 @@ For A2A integration details, see [`a2a.md`](a2a.md).
 9. [What Happens When Tools Complete](#9-tool-completion)
 10. [Concurrency Challenges & Race Conditions](#10-concurrency)
 11. [Event Handling](#11-event-handling)
-12. [Framework Abstraction & Converter Chain (LangChain4J)](#12-framework-abstraction)
+12. [Chat Model SPI & Framework Abstraction (LangChain4J Bridge)](#12-framework-abstraction)
 13. [System Prompt Composition](#13-system-prompt-composition)
 14. [Response Handling](#14-response-handling)
 15. [Error Codes](#15-error-codes)
@@ -860,9 +860,86 @@ Events create their payload in `toolCallResult`:
 
 <a id="12-framework-abstraction"></a>
 
-## 12. Framework Abstraction & Converter Chain (LangChain4J)
+## 12. Chat Model SPI & Framework Abstraction (LangChain4J Bridge)
 
-### Interface
+### Chat Model SPI (the seam)
+
+The provider-neutral chat SPI, package `io.camunda.connector.agenticai.aiagent.framework.api`, is
+what `BaseAgentRequestHandler.proceed()` calls to reach the LLM. It replaces the previous direct call
+to `AiFrameworkAdapter.executeMeasuringTime` — that adapter now lives one layer down, as an internal
+detail of the LangChain4J bridge implementation (see below), not the top-level seam. See
+[ADR 009 §1–§2](../adr/009-own-the-llm-layer.md) for the full design rationale.
+
+```java
+public interface ChatModelApiRegistry {
+    ChatModelApi resolve(ChatModelApiConfiguration configuration);
+}
+
+public interface ChatModelApi {
+    ChatModelResult call(ChatModelRequest request);
+}
+
+public record ChatModelResult(AssistantMessage message, AgentMetrics metrics) {}
+
+public interface ChatModelApiConfiguration {}  // neutral, connector-agnostic config seam
+
+public interface ChatModelApiFactory {
+    boolean supports(ChatModelApiConfiguration configuration);
+    ChatModelApi create(ChatModelApiConfiguration configuration);
+    default int getOrder() { return 0; }  // lower wins; bridge is lowest
+}
+```
+
+- **`ChatModelApi`** is a per-provider **chat model**. A single `call(request)` performs **exactly one**
+  provider round-trip — implementations must not run their own vendor-SDK tool-calling auto-loop — and
+  returns a `ChatModelResult(assistantMessage, per-turn metrics)`. The metrics carry the measured
+  `executionTime` for the call.
+- **`ChatModelApiConfiguration`** is the neutral descriptor the registry dispatches on — deliberately
+  **not** the sealed `ProviderConfiguration`, so the chat-model layer stays connector-agnostic. Phase 0
+  ships one impl, `ProviderChatModelApiConfiguration`, wrapping the built-in provider config; a second
+  connector variant or a custom provider contributes its own impl.
+- **`ChatModelApiFactory`** decides via `supports(...)` whether it can serve a configuration and
+  `create(...)`s the chat model; `getOrder()` sets selection precedence (mirrors
+  `SystemPromptContributor#getOrder()`).
+- **`ChatModelApiRegistry`** (`ChatModelApiRegistryImpl`) collects every `ChatModelApiFactory` bean,
+  sorts by `getOrder()`, and returns the **first** whose `supports(...)` is true — else fails loud with
+  `ConnectorException(ERROR_CODE_FAILED_MODEL_CALL)`. This is how providers move to native **one at a
+  time**: a native factory `supports()` its config at higher precedence than the lowest-precedence
+  LangChain4j bridge, which `supports()` every `ProviderChatModelApiConfiguration`.
+- **`BaseAgentRequestHandler.proceed()`** wraps the request's provider config and resolves+calls
+  directly — `registry.resolve(new ProviderChatModelApiConfiguration(config.provider())).call(...)` —
+  then ingests the returned `(assistantMessage, metrics)`, the same contract the old adapter returned.
+
+> **A `call(...)` is a single provider round-trip.** The chat model SPI has no continuation loop or
+> invoker seam — the LangChain4J bridge completes a turn in one round, and the request handler owns the
+> agentic loop. Multi-round provider turns (e.g. Anthropic `pause_turn`) are out of scope of the SPI
+> itself; see [ADR 009](../adr/009-own-the-llm-layer.md) for the planned turn-based handling.
+
+`ChatModelApiRegistry` is registered as a bean in `AgenticAiConnectorsAutoConfiguration`;
+`List<ChatModelApiFactory>` is auto-collected by Spring, so adding a factory bean anywhere on the
+classpath registers it with no other wiring change (see [§25.4](#254-add-a-native-chat-model-implementation)).
+
+### The LangChain4J Bridge Implementation
+
+In Phase 0, LangChain4J is demoted to **one `ChatModelApi` implementation** behind the SPI above, not
+the top-level abstraction:
+
+- **`Langchain4JChatModelApi`** wraps the pre-existing `Langchain4JAiFrameworkAdapter` (see below),
+  calls its `executeMeasuringTime(...)` (so the returned metrics carry the measured `executionTime`),
+  and returns a completed `ChatModelResult` — LangChain4J has no continuation concept.
+- **`Langchain4JChatModelApiFactory`** `supports()` every `ProviderChatModelApiConfiguration` and
+  registers at the **lowest precedence** (`getOrder()` = `Integer.MAX_VALUE`), so every built-in
+  provider routes through this one bridge in Phase 0. Native provider implementations override it
+  per-provider in later phases (ADR 009 Phase 1) by `supports()`-ing their own config at a higher
+  precedence; the bridge stays the fallback until native parity is proven for a given provider
+  (ADR 009 §7).
+- Registered as a bean in `AgenticAiLangchain4JFrameworkConfiguration`.
+
+#### `AiFrameworkAdapter` (bridge-internal)
+
+`AiFrameworkAdapter` is the pre-existing LangChain4J-era interface. It is no longer the seam the
+request handler calls directly — it is now purely an internal collaborator of
+`Langchain4JChatModelApi`:
 
 ```java
 public interface AiFrameworkAdapter<R extends AiFrameworkChatResponse<?>> {
@@ -871,18 +948,17 @@ public interface AiFrameworkAdapter<R extends AiFrameworkChatResponse<?>> {
 ```
 
 The adapter receives a read-only `ConversationSnapshot` (the windowed message list plus the tool
-definitions) and returns a response. `BaseAgentRequestHandler` builds the snapshot via
-`conversation.window(configuration.contextWindowSize())` and passes it to the adapter.
-
-The agent core is framework-agnostic. `AiFrameworkAdapter` abstracts:
+definitions) and returns a response. `Langchain4JChatModelApi.call(...)` invokes it (via
+`executeMeasuringTime`) and wraps the result as a `ChatModelResult`. `AiFrameworkAdapter` abstracts:
 - Converting internal message models to framework-specific formats
 - Calling the LLM
 - Converting the framework response back to internal models
-- Updating `AgentContext` with metrics (model calls, token usage)
+- Reporting metrics (model calls, tool calls, token usage) for the round
 
 ### LangChain4J Implementation
 
-The current (and only) implementation uses LangChain4J:
+The current (and only) `AiFrameworkAdapter` implementation, `Langchain4JAiFrameworkAdapter`, uses
+LangChain4J:
 - Configured via `AgenticAiLangchain4JFrameworkConfiguration`
 - Supports multiple providers: Anthropic, OpenAI, AWS Bedrock, Google Vertex AI, Azure OpenAI, OpenAI Compatible
 - **Does NOT use LangChain4J's built-in tool execution** — tool calls are returned as data, execution happens via BPMN
@@ -1610,14 +1686,18 @@ them so violations fail the build. Until then, enforcement is by review, so resp
 
 ### I1. The agent core is framework-agnostic
 
-Only the LangChain4J adapter package may depend on LangChain4J.
+Only the LangChain4J bridge package may depend on LangChain4J.
 
 - **Rule**: nothing outside `io.camunda.connector.agenticai.aiagent.framework.langchain4j.**` may
   import `dev.langchain4j.*`. The agent core (`aiagent/agent`, `aiagent/model`, `aiagent/memory`, the
   root `model/`, `adhoctoolsschema/`, `tool/`) stays framework-neutral.
-- **Why**: the LLM framework is an SPI (`AiFrameworkAdapter`, see [§12](#12-framework-abstraction)).
-  Keeping LangChain4J behind the adapter means it can be replaced without touching orchestration,
-  memory, or the data model.
+  `aiagent.framework.api.**` is the provider-neutral chat model SPI (`ChatModelApi`,
+  `ChatModelApiFactory`, `ChatModelApiRegistry`, …) and must not import any vendor SDK either; future
+  native chat model implementations live under their own `aiagent.framework.<provider>.**` package,
+  each importing only its own vendor SDK.
+- **Why**: the LLM framework sits behind an SPI (`ChatModelApi` / `ChatModelApiRegistry`, see
+  [§12](#12-framework-abstraction)). Keeping LangChain4J behind the bridge implementation means it — or
+  any other provider SDK — can be replaced without touching orchestration, memory, or the data model.
 - **Verify**: `grep -rl "import dev.langchain4j" --include="*.java"
   connector-agentic-ai/src/main/java/io/camunda/connector/agenticai | grep -v /framework/langchain4j/` returns nothing.
 
@@ -1645,12 +1725,13 @@ pervasive, so follow the nearest existing pair.
 Add capability by implementing an SPI and registering a bean. Do not modify the core to special-case
 a new provider, store, or contributor. The SPIs:
 
-| SPI                       | Add a…                          | Where to start      |
-|---------------------------|---------------------------------|---------------------|
-| `ChatModelProvider<T>`    | LLM provider                    | [§25.1](#251-add-an-llm-provider) |
-| `SystemPromptContributor` | system-prompt contribution      | [§25.2](#252-add-a-systempromptcontributor) |
-| `ConversationStore`       | conversation memory backend     | [§25.3](#253-add-a-conversationstore) |
-| `GatewayToolHandler`      | multi-tool gateway (MCP/A2A)    | [§19](#19-gateway-tool-pattern) |
+| SPI                       | Add a…                                     | Where to start      |
+|---------------------------|---------------------------------------------|---------------------|
+| `ChatModelApiFactory`     | native chat model implementation            | [§25.4](#254-add-a-native-chat-model-implementation) |
+| `ChatModelProvider<T>`    | LangChain4J-backed LLM provider (bridge-internal) | [§25.1](#251-add-an-llm-provider) |
+| `SystemPromptContributor` | system-prompt contribution                  | [§25.2](#252-add-a-systempromptcontributor) |
+| `ConversationStore`       | conversation memory backend                 | [§25.3](#253-add-a-conversationstore) |
+| `GatewayToolHandler`      | multi-tool gateway (MCP/A2A)                | [§19](#19-gateway-tool-pattern) |
 
 ### I5. Conversation stores follow the write-ahead, pointer-based contract
 
@@ -1676,9 +1757,13 @@ reference implementation and its wiring for the current exact procedure, and res
 ### 25.1 Add an LLM provider
 
 Implement `ChatModelProvider<T extends ProviderConfiguration>` and add the matching
-`ProviderConfiguration` subtype. The `ChatModelProviderRegistry` selects providers by `type()`.
-Reference implementation: `AnthropicChatModelProvider` with `AnthropicProviderConfiguration`. The
-strategy is the only place that may touch `dev.langchain4j` (invariant I1).
+`ProviderConfiguration` subtype. This configures the **LangChain4J bridge implementation** specifically
+(see [§12](#12-framework-abstraction)) — it builds the LangChain4J `ChatModel` consumed by
+`Langchain4JAiFrameworkAdapter`, not a `ChatModelApi` directly. For a provider that bypasses
+LangChain4J entirely, see [§25.4](#254-add-a-native-chat-model-implementation). The `ChatModelProviderRegistry`
+selects providers by `type()`. Reference implementation: `AnthropicChatModelProvider` with
+`AnthropicProviderConfiguration`. The strategy is the only place that may touch `dev.langchain4j`
+(invariant I1).
 
 <a id="252-add-a-systempromptcontributor"></a>
 
@@ -1697,3 +1782,20 @@ write-ahead, pointer-based storage contract in [§6](#6-conversation-memory) (in
 `ConversationStoreRegistryImpl` selects the store by `type()`. Reference implementation: the in-process
 store (`InProcessConversationStore` and its session/context). For a custom store outside this module,
 see [camunda-agentic-ai-customizations](https://github.com/maff/camunda-agentic-ai-customizations).
+
+<a id="254-add-a-native-chat-model-implementation"></a>
+
+### 25.4 Add a native chat model implementation
+
+Implement `ChatModelApiFactory` and its `ChatModelApi` (see [§12](#12-framework-abstraction)):
+`supports(...)` declares which `ChatModelApiConfiguration`s the factory serves, `create(...)` builds a
+chat model whose `call(...)` performs exactly one provider round-trip (never the vendor SDK's own
+tool-calling loop), and `getOrder()` sets precedence (the default outranks the lowest-precedence
+bridge). Register it as a Spring bean; `ChatModelApiRegistry` sorts factories by `getOrder()` and picks
+the first that `supports()` the configuration. Reference implementation: `Langchain4JChatModelApiFactory`
+/ `Langchain4JChatModelApi` — the lowest-precedence bridge serving every
+`ProviderChatModelApiConfiguration`. A native implementation for one provider `supports()` that
+provider's config at default precedence; the bridge covers the rest. Only the vendor-scoped package
+may import that vendor's SDK — keep a native chat model in its own `aiagent.framework.<provider>.**`
+package (invariant I1). Custom providers follow the same shape with their own `ChatModelApiConfiguration`
+implementation (analogous to the memory `custom` store).


### PR DESCRIPTION
Part of #7211 — first step of ADR-009 (`connectors/agentic-ai/docs/adr/009-own-the-llm-layer.md`).

Closes #7216.
Closes #7215.

Introduces a provider-neutral **chat model SPI** as the LLM seam and routes the agent request handler through it, with LangChain4j as the sole bridge implementation. **Behaviour-identical** — no new provider dependency; every provider still runs via LangChain4j.

**Chat model SPI** (`framework/api`)
- `ChatModelApi` — one provider round-trip: `(executionContext, snapshot) → (assistantMessage, metrics)`.
- `ChatModelApiFactory` — capability-based dispatch: `supports(config)` + `getOrder()` (lowest value wins; no provider enum).
- `ChatModelApiRegistry` — sorts factories by order, first `supports` match wins.
- `ChatModelApiConfiguration` — connector-neutral seam; `ProviderChatModelApiConfiguration` wraps today's `ProviderConfiguration`.

**LangChain4j bridge** — `Langchain4JChatModelApiFactory` supports any provider config at low precedence (order `1000`), so a native implementation can override per-provider with no bridge edits. The request handler is cut over from `AiFrameworkAdapter` to the registry.

**Domain groundwork** (additive; persisted format locked in early)
- `ReasoningContent` — opaque provider payload that round-trips losslessly through the conversation stores.
- `AssistantMessage` gains `modelId`, `messageId`, `stopReason`.
- `TokenUsage` gains cache/reasoning dimensions (serialized only when non-zero).

Native provider implementations (Anthropic first), turn-based multi-round handling (`pause_turn`), and multimodal tool results follow in later phases. Module build + agentic-ai e2e green.
