### PR TITLE
ci: verify element template JSON files are in sync with Java source

### DIFF
--- a/.github/workflows/TEST_FEATURE_BRANCH.yml
+++ b/.github/workflows/TEST_FEATURE_BRANCH.yml
@@ -113,8 +113,30 @@ jobs:
           mirrors: '[{"url": "https://repository.nexus.camunda.cloud/content/groups/internal/", "id": "camunda-nexus", "mirrorOf": "*,!confluent,!shibboleth", "name": "camunda Nexus"}]'
 
       # Build and test (format and javadoc run in parallel jobs)
+      # The build above regenerates all element template JSON files as part of
+      # the `process-classes` phase (element-template-generator-maven-plugin),
+      # writing them back into each connector's element-templates/ source dir.
       - name: Build Connectors
         run: ./mvnw --batch-mode -U clean test -Dquickly -T 1C
+
+      # Fail if the regenerated templates differ from what's committed. This is a
+      # diff check only — CI never commits or modifies files. Versioned snapshots
+      # (element-templates/versioned/) are intentionally excluded, as they are
+      # pinned and not overwritten on regeneration.
+      - name: Verify element templates are in sync with Java source
+        run: |
+          CHANGED=$(git diff --name-only -- '*element-templates*.json' ':(exclude)*/versioned/*')
+          if [ -n "$CHANGED" ]; then
+            echo "❌ Element templates are out of sync with their Java source."
+            echo "   Run 'mvn install' (or 'mvn process-classes') locally and commit the regenerated templates."
+            echo ""
+            echo "Affected files:"
+            echo "$CHANGED"
+            echo ""
+            git diff -- '*element-templates*.json' ':(exclude)*/versioned/*'
+            exit 1
+          fi
+          echo "✅ All element templates match their Java source."
 
       - name: Publish Test Report
         if: always() && steps.internal.outputs.internal == 'true'

--- a/.github/workflows/TEST_FEATURE_BRANCH.yml
+++ b/.github/workflows/TEST_FEATURE_BRANCH.yml
@@ -125,7 +125,11 @@ jobs:
       # pinned and not overwritten on regeneration.
       - name: Verify element templates are in sync with Java source
         run: |
-          CHANGED=$(git diff --name-only -- '*element-templates*.json' ':(exclude)*/versioned/*')
+          set -euo pipefail
+          # --porcelain reports both modified tracked files AND new untracked
+          # ones, so a Java change that produces a brand-new template is caught
+          # too — not just edits to existing templates.
+          CHANGED=$(git status --porcelain -- '*element-templates*.json' ':(exclude)*/versioned/*')
           if [ -n "$CHANGED" ]; then
             echo "❌ Element templates are out of sync with their Java source."
             echo "   Run 'mvn install' (or 'mvn process-classes') locally and commit the regenerated templates."

--- a/.github/workflows/TEST_FEATURE_BRANCH.yml
+++ b/.github/workflows/TEST_FEATURE_BRANCH.yml
@@ -126,21 +126,28 @@ jobs:
       - name: Verify element templates are in sync with Java source
         run: |
           set -euo pipefail
-          # --porcelain reports both modified tracked files AND new untracked
-          # ones, so a Java change that produces a brand-new template is caught
-          # too — not just edits to existing templates.
-          CHANGED=$(git status --porcelain -- '*element-templates*.json' ':(exclude)*/versioned/*')
-          if [ -n "$CHANGED" ]; then
+          # Directory-anchored pathspecs: root templates and hybrid/ variants,
+          # excluding pinned versioned/ snapshots.
+          PATHSPEC=(
+            '*/element-templates/*.json'
+            '*/element-templates/hybrid/*.json'
+            ':(exclude)*/element-templates/versioned/*'
+          )
+          # Register intent-to-add for any brand-new (untracked) generated
+          # templates so a single `git diff` reports — with content — both
+          # modified and newly created files. This stages no file content.
+          git add -N -- "${PATHSPEC[@]}"
+          if git diff --quiet -- "${PATHSPEC[@]}"; then
+            echo "✅ All element templates match their Java source."
+          else
             echo "❌ Element templates are out of sync with their Java source."
             echo "   Run 'mvn install' (or 'mvn process-classes') locally and commit the regenerated templates."
             echo ""
-            echo "Affected files:"
-            echo "$CHANGED"
+            git diff --stat -- "${PATHSPEC[@]}"
             echo ""
-            git diff -- '*element-templates*.json' ':(exclude)*/versioned/*'
+            git diff -- "${PATHSPEC[@]}"
             exit 1
           fi
-          echo "✅ All element templates match their Java source."
 
       - name: Publish Test Report
         if: always() && steps.internal.outputs.internal == 'true'


### PR DESCRIPTION
## Description

Adds a CI safeguard that verifies the generated element template JSON files are in sync with the Java source they're generated from. Closes #7770.

Rather than adding a separate job that re-runs `mvn install`, this plugs into the existing `run-tests` job in `TEST_FEATURE_BRANCH.yml`. That job already runs `./mvnw clean test`, which passes through the `process-classes` phase — the phase the `element-template-generator-maven-plugin`'s `generate-templates` goal is bound to (via `connectors/pom.xml` `pluginManagement`). So every template is already regenerated in place as part of the existing build; the new step is just a `git diff` afterward, which is essentially free.

## What it does

- After `Build Connectors`, a new **Verify element templates are in sync with Java source** step diffs the regenerated element template JSON against what's committed.
- Fails the job if any template differs, printing the affected files and full diff.
- **Diff check only** — CI never commits or modifies files (per the acceptance criteria and the Slack discussion).
- Versioned snapshots (`element-templates/versioned/`) are intentionally excluded, since they are pinned and not overwritten on regeneration.

## Notes / verification

- The generator Mojo has no `skip` parameter and `-Dquickly` is not referenced anywhere, so generation always runs.
- Spotless only formats `.gitignore`/Java/pom files, never the JSON — and the diff is scoped to JSON regardless, so no false positives.
- The Maven build cache only skips regeneration when inputs are unchanged, in which case templates wouldn't drift anyway.
- The git pathspec (`'*element-templates*.json' ':(exclude)*/versioned/*'`) was tested against the real repo: it catches root + `hybrid/` templates, ignores `versioned/`, and a versioned-only change produces no diff.

## Acceptance criteria

- [x] CI regenerates the element template JSON files (via the existing build) and diffs them against the committed versions.
- [x] CI fails if any generated JSON file differs from what's committed.
- [x] CI does **not** commit or otherwise modify files — it only reports/fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
