### PR TITLE
fix: Rename iteration method to loopIteration in client

### DIFF
--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/agentinstance/CamundaAgentInstanceClient.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/agentinstance/CamundaAgentInstanceClient.java
@@ -273,7 +273,7 @@ public class CamundaAgentInstanceClient implements AgentInstanceClient {
             .role(role)
             .content(content)
             .producedAt(producedAt)
-            .iteration(iteration);
+            .loopIteration(iteration);
 
     if (toolCalls != null && !toolCalls.isEmpty()) {
       cmd = cmd.toolCalls(toolCalls);

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/agentinstance/CamundaAgentInstanceClientTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/agentinstance/CamundaAgentInstanceClientTest.java
@@ -553,7 +553,7 @@ class CamundaAgentInstanceClientTest {
       verify(historyCommand).elementInstanceKey(ELEMENT_INSTANCE_KEY);
       verify(historyCommand).jobKey(JOB_KEY);
       verify(historyCommand).role(AgentInstanceHistoryRole.USER);
-      verify(historyCommand).iteration(3);
+      verify(historyCommand).loopIteration(3);
       verify(historyCommand).producedAt(TURN_INGESTION_TIMESTAMP);
       verify(historyCommand).content(contentCaptor.capture());
       verify(historyCommand, never()).toolCalls(any());
@@ -630,7 +630,7 @@ class CamundaAgentInstanceClientTest {
       // it to the originating tool call. The first result carries its content block; the second has
       // no content, yielding an empty (now valid) content list rather than a placeholder block.
       verify(historyCommand, times(2)).role(AgentInstanceHistoryRole.TOOL_RESULT);
-      verify(historyCommand, times(2)).iteration(1);
+      verify(historyCommand, times(2)).loopIteration(1);
       verify(historyCommand, times(2)).execute();
 
       // each result's own completedAt is used, not the shared turn ingestion timestamp
@@ -869,7 +869,7 @@ class CamundaAgentInstanceClientTest {
 
       // then
       verify(historyCommand).role(AgentInstanceHistoryRole.ASSISTANT);
-      verify(historyCommand).iteration(2);
+      verify(historyCommand).loopIteration(2);
       verify(historyCommand).producedAt(TURN_INGESTION_TIMESTAMP);
 
       final ArgumentCaptor<List<AgentInstanceHistoryToolCall>> toolCallsCaptor =


### PR DESCRIPTION
This pull request updates the terminology in the agent instance history logic and its corresponding tests to use `loopIteration` instead of `iteration`. This change improves clarity and consistency in how iteration data is represented and referenced throughout the codebase.

**Terminology update in agent history logic and tests:**

* Replaced the use of `.iteration` with `.loopIteration` when creating history items in `CamundaAgentInstanceClient.java` to clarify the meaning of the iteration field.
* Updated all related test verifications in `CamundaAgentInstanceClientTest.java` to check for `.loopIteration` instead of `.iteration`, ensuring tests align with the new terminology:
  - In `shouldCreateUserHistoryItemBeforeChat`
  - In `shouldCreateOneToolResultHistoryItemPerResultBeforeChat`
  - In `shouldCreateAssistantHistoryItemWithToolCallsAndMetricsAfterChat`