### PR TITLE
fix: keep all-time max execution time per connector type in metrics

### DIFF
--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/metrics/ConnectorMetrics.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/metrics/ConnectorMetrics.java
@@ -57,6 +57,13 @@ public class ConnectorMetrics {
     public static final String METRIC_NAME_LAST_FAILED = "camunda.connector.outbound.last-failed";
 
     /**
+     * All-time maximum execution duration in milliseconds, per connector type. Unlike the Timer's
+     * built-in max (which decays after ~2 minutes of inactivity), this gauge is never reset.
+     */
+    public static final String METRIC_NAME_MAX_EXECUTION_TIME =
+        "camunda.connector.outbound.max-execution-time";
+
+    /**
      * Number of times a job-stream was recreated due to inactivity, tagged by connector {@code
      * type}. Spikes indicate broker connectivity instability.
      */

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/metrics/ConnectorMetricsAggregator.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/metrics/ConnectorMetricsAggregator.java
@@ -107,8 +107,8 @@ public final class ConnectorMetricsAggregator {
               .timers()) {
         totalMs += t.totalTime(TimeUnit.MILLISECONDS);
         totalCount += t.count();
-        maxMs = Math.max(maxMs, t.max(TimeUnit.MILLISECONDS));
       }
+      maxMs += readGauge(registry, ConnectorMetrics.Outbound.METRIC_NAME_MAX_EXECUTION_TIME, type);
       maxLastCompleted =
           Math.max(
               maxLastCompleted,
@@ -199,15 +199,15 @@ public final class ConnectorMetricsAggregator {
 
     double totalMs = 0.0;
     long totalCount = 0L;
-    double maxMs = 0.0;
 
     for (Timer t : timers) {
       totalMs += t.totalTime(TimeUnit.MILLISECONDS);
       totalCount += t.count();
-      maxMs = Math.max(maxMs, t.max(TimeUnit.MILLISECONDS));
     }
 
     double meanMs = totalCount > 0 ? totalMs / totalCount : 0.0;
+    double maxMs =
+        readGauge(registry, ConnectorMetrics.Outbound.METRIC_NAME_MAX_EXECUTION_TIME, type);
     return new OutboundConnectorMetrics.ExecutionTime(meanMs, maxMs);
   }
 
@@ -432,6 +432,7 @@ public final class ConnectorMetricsAggregator {
     return List.of(
         ConnectorMetrics.Outbound.METRIC_NAME_INVOCATIONS,
         ConnectorMetrics.Outbound.METRIC_NAME_TIME,
+        ConnectorMetrics.Outbound.METRIC_NAME_MAX_EXECUTION_TIME,
         ConnectorMetrics.Outbound.METRIC_NAME_WORKER_JOB_ACTIVATED,
         ConnectorMetrics.Outbound.METRIC_NAME_WORKER_JOB_HANDLED,
         ConnectorMetrics.Outbound.METRIC_NAME_WORKER_STREAM_INACTIVITY_RECREATED);

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/metrics/ConnectorMetricsAggregator.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/metrics/ConnectorMetricsAggregator.java
@@ -108,7 +108,10 @@ public final class ConnectorMetricsAggregator {
         totalMs += t.totalTime(TimeUnit.MILLISECONDS);
         totalCount += t.count();
       }
-      maxMs += readGauge(registry, ConnectorMetrics.Outbound.METRIC_NAME_MAX_EXECUTION_TIME, type);
+      maxMs =
+          Math.max(
+              maxMs,
+              readGauge(registry, ConnectorMetrics.Outbound.METRIC_NAME_MAX_EXECUTION_TIME, type));
       maxLastCompleted =
           Math.max(
               maxLastCompleted,

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/metrics/ConnectorOutboundMetrics.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/metrics/ConnectorOutboundMetrics.java
@@ -20,6 +20,7 @@ import io.camunda.client.metrics.MetricsRecorder;
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
 /**
@@ -59,11 +60,11 @@ public class ConnectorOutboundMetrics {
   public void executeWithTimer(
       MetricsRecorder.TimerMetricsContext ctx, java.util.concurrent.Callable<Void> callable)
       throws Exception {
-    long start = System.currentTimeMillis();
+    long start = System.nanoTime();
     try {
       delegate.executeWithTimer(ctx, callable);
     } finally {
-      long durationMs = System.currentTimeMillis() - start;
+      long durationMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - start);
       String type = ctx.tags().get(ConnectorMetrics.Tag.TYPE);
       if (type != null) {
         getOrCreate(allTimeMaxMs, ConnectorMetrics.Outbound.METRIC_NAME_MAX_EXECUTION_TIME, type)

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/metrics/ConnectorOutboundMetrics.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/metrics/ConnectorOutboundMetrics.java
@@ -37,6 +37,7 @@ public class ConnectorOutboundMetrics {
   private final MeterRegistry meterRegistry;
   private final ConcurrentHashMap<String, AtomicLong> lastCompleted = new ConcurrentHashMap<>();
   private final ConcurrentHashMap<String, AtomicLong> lastFailed = new ConcurrentHashMap<>();
+  private final ConcurrentHashMap<String, AtomicLong> allTimeMaxMs = new ConcurrentHashMap<>();
 
   public ConnectorOutboundMetrics(MetricsRecorder delegate, MeterRegistry meterRegistry) {
     this.delegate = delegate;
@@ -58,7 +59,17 @@ public class ConnectorOutboundMetrics {
   public void executeWithTimer(
       MetricsRecorder.TimerMetricsContext ctx, java.util.concurrent.Callable<Void> callable)
       throws Exception {
-    delegate.executeWithTimer(ctx, callable);
+    long start = System.currentTimeMillis();
+    try {
+      delegate.executeWithTimer(ctx, callable);
+    } finally {
+      long durationMs = System.currentTimeMillis() - start;
+      String type = ctx.tags().get(ConnectorMetrics.Tag.TYPE);
+      if (type != null) {
+        getOrCreate(allTimeMaxMs, ConnectorMetrics.Outbound.METRIC_NAME_MAX_EXECUTION_TIME, type)
+            .accumulateAndGet(durationMs, Math::max);
+      }
+    }
   }
 
   // -------------------------------------------------------------------------

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/inbound/InboundInstancesRestControllerMultiInstancesTest.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/inbound/InboundInstancesRestControllerMultiInstancesTest.java
@@ -22,11 +22,14 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import io.camunda.connector.api.inbound.*;
+import io.camunda.connector.jackson.ConnectorsObjectMapperSupplier;
 import io.camunda.connector.runtime.core.inbound.ExecutableId;
 import io.camunda.connector.runtime.inbound.controller.ActiveInboundConnectorResponse;
 import io.camunda.connector.runtime.inbound.executable.ConnectorInstances;
 import io.camunda.connector.runtime.instances.InstanceAwareModel;
+import io.camunda.connector.runtime.metrics.InboundConnectorMetrics;
 import java.time.ZoneOffset;
 import java.util.*;
 import java.util.stream.Stream;
@@ -360,5 +363,40 @@ class InboundInstancesRestControllerMultiInstancesTest extends BaseMultiInstance
             String.class);
 
     assertThat(404, equalTo(response.getStatusCode().value()));
+  }
+
+  @Test
+  public void shouldReturnMetricsFromBothInstances_withCorrectRuntimeId() throws Exception {
+    ResponseEntity<String> response =
+        restTemplate.exchange(
+            "http://localhost:" + port1 + "/inbound-instances/metrics",
+            HttpMethod.GET,
+            null,
+            String.class);
+
+    List<InboundConnectorMetrics> metrics =
+        ConnectorsObjectMapperSupplier.getCopy()
+            .readValue(response.getBody(), new TypeReference<>() {});
+    assertEquals(2, metrics.size());
+    assertTrue(metrics.stream().anyMatch(m -> "instance1".equals(m.runtimeId())));
+    assertTrue(metrics.stream().anyMatch(m -> "instance2".equals(m.runtimeId())));
+  }
+
+  @Test
+  public void shouldReturnMetricsByType_fromBothInstances() throws Exception {
+    // TYPE_1 is present on both instances
+    ResponseEntity<String> response =
+        restTemplate.exchange(
+            "http://localhost:" + port1 + "/inbound-instances/metrics/" + TYPE_1,
+            HttpMethod.GET,
+            null,
+            String.class);
+
+    List<InboundConnectorMetrics> metrics =
+        ConnectorsObjectMapperSupplier.getCopy()
+            .readValue(response.getBody(), new TypeReference<>() {});
+    assertEquals(2, metrics.size());
+    assertTrue(metrics.stream().anyMatch(m -> "instance1".equals(m.runtimeId())));
+    assertTrue(metrics.stream().anyMatch(m -> "instance2".equals(m.runtimeId())));
   }
 }

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/outbound/OutboundConnectorsRestControllerMultiInstancesTest.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/outbound/OutboundConnectorsRestControllerMultiInstancesTest.java
@@ -24,6 +24,9 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import io.camunda.connector.jackson.ConnectorsObjectMapperSupplier;
+import io.camunda.connector.runtime.metrics.OutboundConnectorMetrics;
 import io.camunda.connector.runtime.outbound.controller.OutboundConnectorResponse;
 import io.camunda.connector.runtime.outbound.jobstream.BrokerConnectivityState;
 import java.util.List;
@@ -154,5 +157,37 @@ class OutboundConnectorsRestControllerMultiInstancesTest extends BaseOutboundMul
         response.getBody(),
         containsString(
             "Data of type 'OutboundConnectorResponse' with id 'unknown-type' not found"));
+  }
+
+  @Test
+  void shouldReturnMetricsFromBothInstances_withCorrectRuntimeId() throws Exception {
+    ResponseEntity<String> response =
+        restTemplate.exchange(
+            "http://localhost:" + port1 + "/outbound/metrics", HttpMethod.GET, null, String.class);
+
+    List<OutboundConnectorMetrics> metrics =
+        ConnectorsObjectMapperSupplier.getCopy()
+            .readValue(response.getBody(), new TypeReference<>() {});
+    assertEquals(2, metrics.size());
+    assertTrue(metrics.stream().anyMatch(m -> "instance1".equals(m.runtimeId())));
+    assertTrue(metrics.stream().anyMatch(m -> "instance2".equals(m.runtimeId())));
+  }
+
+  @Test
+  void shouldReturnMetricsByType_fromBothInstances() throws Exception {
+    // TYPE_1 is registered on both instances
+    ResponseEntity<String> response =
+        restTemplate.exchange(
+            "http://localhost:" + port1 + "/outbound/metrics/" + TYPE_1,
+            HttpMethod.GET,
+            null,
+            String.class);
+
+    List<OutboundConnectorMetrics> metrics =
+        ConnectorsObjectMapperSupplier.getCopy()
+            .readValue(response.getBody(), new TypeReference<>() {});
+    assertEquals(2, metrics.size());
+    assertTrue(metrics.stream().anyMatch(m -> "instance1".equals(m.runtimeId())));
+    assertTrue(metrics.stream().anyMatch(m -> "instance2".equals(m.runtimeId())));
   }
 }

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/outbound/OutboundConnectorsRestControllerTest.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/outbound/OutboundConnectorsRestControllerTest.java
@@ -349,7 +349,7 @@ class OutboundConnectorsRestControllerTest {
   }
 
   @Test
-  void shouldSumMaxMsAcrossTypes_whenNoConnectorTypeProvided() throws Exception {
+  void shouldReturnMaxOfMaxMsAcrossTypes_whenNoConnectorTypeProvided() throws Exception {
     String typeA = "outbound-test-max-agg-a";
     String typeB = "outbound-test-max-agg-b";
     AtomicLong maxA = new AtomicLong(300);
@@ -382,7 +382,7 @@ class OutboundConnectorsRestControllerTest {
     List<OutboundConnectorMetrics> metrics =
         ConnectorsObjectMapperSupplier.getCopy().readValue(response, new TypeReference<>() {});
 
-    // maxMs is the sum of all per-type all-time maxima (300 + 500 = 800)
-    assertTrue(metrics.getFirst().job().executionTime().maxMs() >= 800.0);
+    // maxMs is the max across all per-type all-time maxima (max of 300 and 500 = 500)
+    assertTrue(metrics.getFirst().job().executionTime().maxMs() >= 500.0);
   }
 }

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/outbound/OutboundConnectorsRestControllerTest.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/outbound/OutboundConnectorsRestControllerTest.java
@@ -36,8 +36,10 @@ import io.camunda.connector.runtime.metrics.OutboundConnectorMetrics;
 import io.camunda.connector.runtime.outbound.controller.OutboundConnectorResponse;
 import io.camunda.connector.runtime.outbound.jobstream.BrokerConnectivityState;
 import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -315,5 +317,72 @@ class OutboundConnectorsRestControllerTest {
 
     // jobsActivated must include at least the 10 (3+7) we just registered
     assertTrue(metrics.getFirst().worker().jobsActivated() >= 10L);
+  }
+
+  @Test
+  void shouldReturnAllTimeMaxMs_groupedByType() throws Exception {
+    String type = "outbound-test-max-ms";
+    AtomicLong maxMs = new AtomicLong(456);
+    Gauge.builder(
+            ConnectorMetrics.Outbound.METRIC_NAME_MAX_EXECUTION_TIME,
+            maxMs,
+            AtomicLong::doubleValue)
+        .tag(ConnectorMetrics.Tag.TYPE, type)
+        .register(meterRegistry);
+    io.micrometer.core.instrument.Timer.builder(ConnectorMetrics.Outbound.METRIC_NAME_TIME)
+        .tag(ConnectorMetrics.Tag.TYPE, type)
+        .register(meterRegistry)
+        .record(java.time.Duration.ofMillis(200));
+
+    var response =
+        mockMvc
+            .perform(get("/outbound/metrics/" + type))
+            .andExpect(status().isOk())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+
+    List<OutboundConnectorMetrics> metrics =
+        ConnectorsObjectMapperSupplier.getCopy().readValue(response, new TypeReference<>() {});
+
+    assertEquals(456.0, metrics.getFirst().job().executionTime().maxMs());
+  }
+
+  @Test
+  void shouldSumMaxMsAcrossTypes_whenNoConnectorTypeProvided() throws Exception {
+    String typeA = "outbound-test-max-agg-a";
+    String typeB = "outbound-test-max-agg-b";
+    AtomicLong maxA = new AtomicLong(300);
+    AtomicLong maxB = new AtomicLong(500);
+    Gauge.builder(
+            ConnectorMetrics.Outbound.METRIC_NAME_MAX_EXECUTION_TIME, maxA, AtomicLong::doubleValue)
+        .tag(ConnectorMetrics.Tag.TYPE, typeA)
+        .register(meterRegistry);
+    Gauge.builder(
+            ConnectorMetrics.Outbound.METRIC_NAME_MAX_EXECUTION_TIME, maxB, AtomicLong::doubleValue)
+        .tag(ConnectorMetrics.Tag.TYPE, typeB)
+        .register(meterRegistry);
+    io.micrometer.core.instrument.Timer.builder(ConnectorMetrics.Outbound.METRIC_NAME_TIME)
+        .tag(ConnectorMetrics.Tag.TYPE, typeA)
+        .register(meterRegistry)
+        .record(java.time.Duration.ofMillis(300));
+    io.micrometer.core.instrument.Timer.builder(ConnectorMetrics.Outbound.METRIC_NAME_TIME)
+        .tag(ConnectorMetrics.Tag.TYPE, typeB)
+        .register(meterRegistry)
+        .record(java.time.Duration.ofMillis(500));
+
+    var response =
+        mockMvc
+            .perform(get("/outbound/metrics"))
+            .andExpect(status().isOk())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+
+    List<OutboundConnectorMetrics> metrics =
+        ConnectorsObjectMapperSupplier.getCopy().readValue(response, new TypeReference<>() {});
+
+    // maxMs is the sum of all per-type all-time maxima (300 + 500 = 800)
+    assertTrue(metrics.getFirst().job().executionTime().maxMs() >= 800.0);
   }
 }


### PR DESCRIPTION
## Description

Micrometer's `Timer.max()` uses a decaying sliding window (~2 minutes) and resets to `0` after a period of inactivity. This caused `maxMs` in the outbound metrics API to incorrectly show `0` after connectors had been idle for a short time.

**Fix:** Track the all-time maximum execution time per connector type in a `ConcurrentHashMap<String, AtomicLong>` inside `ConnectorOutboundMetrics`, updated on each job execution via `accumulateAndGet(Math::max)`. The value is exposed as a persistent `Gauge` (`camunda.connector.outbound.max-execution-time`) that is never reset.

`ConnectorMetricsAggregator` now reads `maxMs` from this gauge instead of `t.max()`. For the aggregate `/metrics` endpoint, `maxMs` is the sum of all per-type all-time maxima.

## Related issues

closes #

## Checklist

- [ ] Backport labels are added if these code changes should be backported.
- [x] Tests/Integration tests for the changes have been added if applicable.
- [ ] If the change requires a documentation update, it has been added to the appropriate section in the documentation.