### PR TITLE
fix(logging): improve exception messages in activity logs

### DIFF
--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextImpl.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextImpl.java
@@ -158,16 +158,14 @@ public class InboundConnectorContextImpl extends AbstractConnectorContext
           activity ->
               activity
                   .withSeverity(Severity.ERROR)
-                  .withMessage(
-                      "Failed to evaluate FEEL expression: "
-                          + feelEngineWrapperException.getMessage()));
+                  .withMessage("Failed to evaluate FEEL expression", feelEngineWrapperException));
       return new CorrelationResult.Failure.Other(feelEngineWrapperException);
     } catch (Exception exception) {
       log(
           activity ->
               activity
                   .withSeverity(Severity.ERROR)
-                  .withMessage("Failed to correlate inbound event: " + exception.getMessage()));
+                  .withMessage("Failed to correlate inbound event", exception));
       LOG.error("Failed to correlate inbound event", exception);
       return new CorrelationResult.Failure.Other(exception);
     }

--- a/connector-sdk/core/pom.xml
+++ b/connector-sdk/core/pom.xml
@@ -31,6 +31,18 @@
           <groupId>org.jspecify</groupId>
           <artifactId>jspecify</artifactId>
       </dependency>
+
+      <dependency>
+          <groupId>org.junit.jupiter</groupId>
+          <artifactId>junit-jupiter</artifactId>
+          <scope>test</scope>
+      </dependency>
+
+      <dependency>
+          <groupId>org.assertj</groupId>
+          <artifactId>assertj-core</artifactId>
+          <scope>test</scope>
+      </dependency>
   </dependencies>
 
 </project>

--- a/connector-sdk/core/src/main/java/io/camunda/connector/api/inbound/ActivityBuilder.java
+++ b/connector-sdk/core/src/main/java/io/camunda/connector/api/inbound/ActivityBuilder.java
@@ -106,9 +106,18 @@ public class ActivityBuilder {
     StringWriter sw = new StringWriter();
     PrintWriter pw = new PrintWriter(sw);
     exception.printStackTrace(pw);
-    if (message == null) {
-      return sw.toString();
+
+    StringBuilder result = new StringBuilder();
+    if (message != null && !message.isEmpty()) {
+      result.append(message).append("\n");
     }
-    return message + "\n" + sw;
+    // The exception message usually carries the most meaningful information, so surface it
+    // explicitly in addition to the stack trace.
+    String exceptionMessage = exception.getMessage();
+    if (exceptionMessage != null && !exceptionMessage.isEmpty()) {
+      result.append(exceptionMessage).append("\n");
+    }
+    result.append(sw);
+    return result.toString();
   }
 }

--- a/connector-sdk/core/src/test/java/io/camunda/connector/api/inbound/ActivityBuilderTest.java
+++ b/connector-sdk/core/src/test/java/io/camunda/connector/api/inbound/ActivityBuilderTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.api.inbound;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class ActivityBuilderTest {
+
+  @Test
+  void withMessageAndException_includesMessageExceptionMessageAndStackTrace() {
+    var exception = new IllegalStateException("Something went wrong");
+
+    var activity = Activity.newBuilder().withMessage("Operation failed", exception).build();
+
+    assertThat(activity.message())
+        .startsWith("Operation failed\nSomething went wrong\n")
+        .contains("java.lang.IllegalStateException: Something went wrong")
+        .contains("at io.camunda.connector.api.inbound.ActivityBuilderTest");
+  }
+
+  @Test
+  void withException_includesExceptionMessageAndStackTrace() {
+    var exception = new IllegalStateException("Something went wrong");
+
+    var activity = Activity.newBuilder().withMessage(exception).build();
+
+    assertThat(activity.message())
+        .startsWith("Something went wrong\n")
+        .contains("java.lang.IllegalStateException: Something went wrong")
+        .contains("at io.camunda.connector.api.inbound.ActivityBuilderTest");
+  }
+
+  @Test
+  void withException_whenExceptionMessageIsNull_fallsBackToStackTraceOnly() {
+    var exception = new IllegalStateException();
+
+    var activity = Activity.newBuilder().withMessage(exception).build();
+
+    assertThat(activity.message())
+        .startsWith("java.lang.IllegalStateException")
+        .contains("at io.camunda.connector.api.inbound.ActivityBuilderTest");
+  }
+
+  @Test
+  void withMessageAndException_whenExceptionMessageIsNull_keepsCustomMessageAndStackTrace() {
+    var exception = new IllegalStateException();
+
+    var activity = Activity.newBuilder().withMessage("Operation failed", exception).build();
+
+    assertThat(activity.message())
+        .startsWith("Operation failed\njava.lang.IllegalStateException")
+        .contains("at io.camunda.connector.api.inbound.ActivityBuilderTest");
+  }
+
+  @Test
+  void withMessageOnly_returnsMessageUnchanged() {
+    var activity = Activity.newBuilder().withMessage("Just a message").build();
+
+    assertThat(activity.message()).isEqualTo("Just a message");
+  }
+}

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/a2a/client/inbound/polling/task/A2aPollingTask.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/a2a/client/inbound/polling/task/A2aPollingTask.java
@@ -148,8 +148,7 @@ public class A2aPollingTask implements Runnable, AutoCloseable {
               activity
                   .withSeverity(Severity.ERROR)
                   .withTag("a2a-polling")
-                  .withMessage(
-                      "Failed to poll A2A task %s: %s".formatted(task.id(), e.getMessage())));
+                  .withMessage("Failed to poll A2A task %s".formatted(task.id()), e));
     }
   }
 
@@ -163,7 +162,7 @@ public class A2aPollingTask implements Runnable, AutoCloseable {
               activity
                   .withSeverity(Severity.ERROR)
                   .withTag("a2a-polling-runtime-properties")
-                  .withMessage("Failed to bind A2A polling runtime properties: " + e.getMessage()));
+                  .withMessage("Failed to bind A2A polling runtime properties", e));
     }
 
     return null;
@@ -181,7 +180,7 @@ public class A2aPollingTask implements Runnable, AutoCloseable {
               activity
                   .withSeverity(Severity.ERROR)
                   .withTag("a2a-polling-response")
-                  .withMessage("Error loading A2A client response: " + e.getMessage()));
+                  .withMessage("Error loading A2A client response", e));
     }
 
     return null;
@@ -205,7 +204,7 @@ public class A2aPollingTask implements Runnable, AutoCloseable {
                 activity
                     .withSeverity(Severity.ERROR)
                     .withTag("a2a-polling-client")
-                    .withMessage("Failed to create A2A client: " + e.getMessage()));
+                    .withMessage("Failed to create A2A client", e));
       }
     }
 

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/a2a/client/inbound/webhook/A2aClientWebhookExecutable.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/a2a/client/inbound/webhook/A2aClientWebhookExecutable.java
@@ -131,7 +131,7 @@ public class A2aClientWebhookExecutable implements WebhookConnectorExecutable {
               activity
                   .withSeverity(Severity.ERROR)
                   .withTag("a2a-webhook-request")
-                  .withMessage("Error deserializing A2A Webhook payload: " + e.getMessage()));
+                  .withMessage("Error deserializing A2A Webhook payload", e));
       throw new RuntimeException(e);
     }
   }

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/a2a/client/inbound/polling/task/A2aPollingTaskTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/a2a/client/inbound/polling/task/A2aPollingTaskTest.java
@@ -9,7 +9,6 @@ package io.camunda.connector.agenticai.a2a.client.inbound.polling.task;
 import static io.camunda.connector.agenticai.aiagent.model.message.content.TextContent.textContent;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
-import static org.assertj.core.api.Assertions.tuple;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.assertArg;
 import static org.mockito.ArgumentMatchers.eq;
@@ -197,12 +196,14 @@ class A2aPollingTaskTest {
     verify(processInstanceContext, never()).correlate(any());
     assertThat(loggedActivities)
         .hasSize(1)
-        .extracting(Activity::severity, Activity::tag, Activity::message)
-        .containsExactly(
-            tuple(
-                Severity.ERROR,
-                "a2a-polling-runtime-properties",
-                "Failed to bind A2A polling runtime properties: Binding failed"));
+        .first()
+        .satisfies(
+            activity -> {
+              assertThat(activity.severity()).isEqualTo(Severity.ERROR);
+              assertThat(activity.tag()).isEqualTo("a2a-polling-runtime-properties");
+              assertThat(activity.message())
+                  .startsWith("Failed to bind A2A polling runtime properties\nBinding failed");
+            });
   }
 
   @Test
@@ -227,7 +228,7 @@ class A2aPollingTaskTest {
               assertThat(activity.severity()).isEqualTo(Severity.ERROR);
               assertThat(activity.tag()).isEqualTo("a2a-polling-response");
               assertThat(activity.message())
-                  .startsWith("Error loading A2A client response: Unrecognized token 'invalid'");
+                  .startsWith("Error loading A2A client response\nUnrecognized token 'invalid'");
             });
   }
 
@@ -295,12 +296,14 @@ class A2aPollingTaskTest {
     verify(processInstanceContext, never()).correlate(any());
     assertThat(loggedActivities)
         .hasSize(1)
-        .extracting(Activity::severity, Activity::tag, Activity::message)
-        .containsExactly(
-            tuple(
-                Severity.ERROR,
-                "a2a-polling-client",
-                "Failed to create A2A client: Fetching agent card failed"));
+        .first()
+        .satisfies(
+            activity -> {
+              assertThat(activity.severity()).isEqualTo(Severity.ERROR);
+              assertThat(activity.tag()).isEqualTo("a2a-polling-client");
+              assertThat(activity.message())
+                  .startsWith("Failed to create A2A client\nFetching agent card failed");
+            });
   }
 
   @Test
@@ -319,12 +322,14 @@ class A2aPollingTaskTest {
     verify(processInstanceContext, never()).correlate(any());
     assertThat(loggedActivities)
         .hasSize(1)
-        .extracting(Activity::severity, Activity::tag, Activity::message)
-        .containsExactly(
-            tuple(
-                Severity.ERROR,
-                "a2a-polling-client",
-                "Failed to create A2A client: Creating client failed"));
+        .first()
+        .satisfies(
+            activity -> {
+              assertThat(activity.severity()).isEqualTo(Severity.ERROR);
+              assertThat(activity.tag()).isEqualTo("a2a-polling-client");
+              assertThat(activity.message())
+                  .startsWith("Failed to create A2A client\nCreating client failed");
+            });
   }
 
   @Test
@@ -344,12 +349,14 @@ class A2aPollingTaskTest {
     verify(processInstanceContext, never()).correlate(any());
     assertThat(loggedActivities)
         .hasSize(1)
-        .extracting(Activity::severity, Activity::tag, Activity::message)
-        .containsExactly(
-            tuple(
-                Severity.ERROR,
-                "a2a-polling",
-                "Failed to poll A2A task task-123: Fetching task failed"));
+        .first()
+        .satisfies(
+            activity -> {
+              assertThat(activity.severity()).isEqualTo(Severity.ERROR);
+              assertThat(activity.tag()).isEqualTo("a2a-polling");
+              assertThat(activity.message())
+                  .startsWith("Failed to poll A2A task task-123\nFetching task failed");
+            });
   }
 
   @Test

--- a/connectors/aws/aws-sqs/src/main/java/io/camunda/connector/inbound/SqsQueueConsumer.java
+++ b/connectors/aws/aws-sqs/src/main/java/io/camunda/connector/inbound/SqsQueueConsumer.java
@@ -82,7 +82,7 @@ public class SqsQueueConsumer implements Runnable {
                 activity
                     .withSeverity(Severity.WARNING)
                     .withTag(ActivityLogTag.MESSAGE)
-                    .withMessage("NACK - failed to correlate event : " + e.getMessage()));
+                    .withMessage("NACK - failed to correlate event", e));
       }
     } while (queueConsumerActive.get());
     LOGGER.info("Stopping SQS consumer for queue {}", properties.getQueue().url());

--- a/connectors/email/src/main/java/io/camunda/connector/email/client/jakarta/inbound/JakartaEmailListener.java
+++ b/connectors/email/src/main/java/io/camunda/connector/email/client/jakarta/inbound/JakartaEmailListener.java
@@ -70,7 +70,7 @@ public class JakartaEmailListener implements EmailListener {
                     activity
                         .withSeverity(Severity.ERROR)
                         .withTag("Context creation")
-                        .withMessage(throwable.getMessage()));
+                        .withMessage(throwable));
           } else context.reportHealth(Health.up());
         });
   }

--- a/connectors/email/src/main/java/io/camunda/connector/email/client/jakarta/inbound/PollingManager.java
+++ b/connectors/email/src/main/java/io/camunda/connector/email/client/jakarta/inbound/PollingManager.java
@@ -100,7 +100,7 @@ public class PollingManager {
               activity
                   .withSeverity(Severity.ERROR)
                   .withTag("Connection error")
-                  .withMessage(exception.getMessage()));
+                  .withMessage(exception));
       throw new EmailConnectorException(exception);
     } catch (MessagingException e) {
       try {
@@ -178,11 +178,7 @@ public class PollingManager {
       // All exception are caught at highest level, ensuring the scheduler never stops, and continue
       // polling indefinitely
       this.connectorContext.log(
-          activity ->
-              activity
-                  .withSeverity(Severity.ERROR)
-                  .withTag("mail-polling")
-                  .withMessage(e.getMessage()));
+          activity -> activity.withSeverity(Severity.ERROR).withTag("mail-polling").withMessage(e));
       this.connectorContext.reportHealth(Health.down());
     }
   }

--- a/connectors/kafka/src/main/java/io/camunda/connector/kafka/inbound/KafkaConnectorConsumer.java
+++ b/connectors/kafka/src/main/java/io/camunda/connector/kafka/inbound/KafkaConnectorConsumer.java
@@ -124,7 +124,7 @@ public class KafkaConnectorConsumer {
               activity
                   .withSeverity(Severity.ERROR)
                   .withTag(ActivityLogTag.CONSUMER)
-                  .withMessage("Failed to initialize connector: " + ex.getMessage(), ex));
+                  .withMessage("Failed to initialize connector", ex));
       context.reportHealth(Health.down(ex));
       throw ex;
     }

--- a/connectors/kafka/src/main/java/io/camunda/connector/kafka/inbound/KafkaExecutable.java
+++ b/connectors/kafka/src/main/java/io/camunda/connector/kafka/inbound/KafkaExecutable.java
@@ -156,7 +156,7 @@ public class KafkaExecutable implements InboundConnectorExecutable<InboundConnec
               activity
                   .withSeverity(Severity.ERROR)
                   .withTag(ActivityLogTag.CONSUMER)
-                  .withMessage("Subscription activation failed: " + ex.getMessage()));
+                  .withMessage("Subscription activation failed", ex));
       context.reportHealth(Health.down(ex));
       throw ex;
     }

--- a/connectors/microsoft/email-inbound/src/main/java/io/camunda/connector/microsoft/email/MsEmailInboundExecutable.java
+++ b/connectors/microsoft/email-inbound/src/main/java/io/camunda/connector/microsoft/email/MsEmailInboundExecutable.java
@@ -102,8 +102,7 @@ public class MsEmailInboundExecutable
               activity
                   .withSeverity(Severity.ERROR)
                   .withTag(ActivityLogTag.CONSUMER)
-                  .withMessage(
-                      "Microsoft O365 Email connector activation failed: " + e.getMessage()));
+                  .withMessage("Microsoft O365 Email connector activation failed", e));
       context.reportHealth(Health.down(e));
       throw e;
     }

--- a/connectors/slack/src/main/java/io/camunda/connector/slack/inbound/SlackInboundWebhookExecutable.java
+++ b/connectors/slack/src/main/java/io/camunda/connector/slack/inbound/SlackInboundWebhookExecutable.java
@@ -145,7 +145,7 @@ public class SlackInboundWebhookExecutable implements WebhookConnectorExecutable
                 activity
                     .withSeverity(Severity.ERROR)
                     .withTag("JSON Parsing")
-                    .withMessage("Failed to parse 'payload' as JSON: " + e.getMessage()));
+                    .withMessage("Failed to parse 'payload' as JSON", e));
       }
       return new SlackWebhookProcessingResult(
           new MappedHttpRequest(
@@ -206,9 +206,7 @@ public class SlackInboundWebhookExecutable implements WebhookConnectorExecutable
                 activity
                     .withSeverity(Severity.ERROR)
                     .withTag("JSON Parsing")
-                    .withMessage(
-                        "Failed to parse JSON from raw body due to an IOException: "
-                            + e.getMessage()));
+                    .withMessage("Failed to parse JSON from raw body due to an IOException", e));
         throw new RuntimeException(e);
       }
     }


### PR DESCRIPTION
This pull request improves error logging across several connectors by enhancing how exception details are included in activity log messages. Instead of logging only the exception message, the full exception (including stack trace) is now attached, making debugging easier. The changes also add or update tests to verify the new logging behavior and add test dependencies to the build configuration.

### Error Logging Improvements

* Updated all usages of `activity.withMessage(...)` in connector implementations to pass the exception object instead of just its message. This ensures that the full exception details, including stack traces, are available in logs for easier troubleshooting. (`A2aPollingTask.java`, `A2aClientWebhookExecutable.java`, `SqsQueueConsumer.java`, `JakartaEmailListener.java`, `PollingManager.java`, `KafkaConnectorConsumer.java`, `KafkaExecutable.java`, `MsEmailInboundExecutable.java`, `SlackInboundWebhookExecutable.java`, `InboundConnectorContextImpl.java`) [[1]](diffhunk://#diff-a1fbe81a5bf89ce2f00a2a34a57c572fedc8a1ea8c646387c2864cbf73201903L151-R151) [[2]](diffhunk://#diff-a1fbe81a5bf89ce2f00a2a34a57c572fedc8a1ea8c646387c2864cbf73201903L166-R165) [[3]](diffhunk://#diff-a1fbe81a5bf89ce2f00a2a34a57c572fedc8a1ea8c646387c2864cbf73201903L184-R183) [[4]](diffhunk://#diff-a1fbe81a5bf89ce2f00a2a34a57c572fedc8a1ea8c646387c2864cbf73201903L208-R207) [[5]](diffhunk://#diff-3d5db5b07ed2b5f1d0640d169fbb3416a9ca54672201a3f022a56515cc5e184cL134-R134) [[6]](diffhunk://#diff-48ea2950de67607ca0a20bb07321d60077b89fd663af2eb24b0024b2c584c979L85-R85) [[7]](diffhunk://#diff-d2a092cc8fea376a8229020710e3898c0ae9851c712998e0423fe15c0adb7476L73-R73) [[8]](diffhunk://#diff-862ae7b59094e8847e5128b12d4c4d9eec18c96f81966ab2f4f84730f2532433L103-R103) [[9]](diffhunk://#diff-862ae7b59094e8847e5128b12d4c4d9eec18c96f81966ab2f4f84730f2532433L181-R181) [[10]](diffhunk://#diff-7bb02c8e5c3467f044031580b3a6987a954ea2df783708b517a5126d82d67197L127-R127) [[11]](diffhunk://#diff-f50de58642f511dd1fd63fba66b96de2618a8898ef6833e559e6a885508d33e8L159-R159) [[12]](diffhunk://#diff-f892a435e4065d1a5e5ed333069bc09ba0d37b7ba4fe873d72187bb6d38a72e5L105-R105) [[13]](diffhunk://#diff-e7b21e1577538f3a85e48e3952581bf485a65fd671fd17804a89559602fcfd4fL148-R148) [[14]](diffhunk://#diff-e7b21e1577538f3a85e48e3952581bf485a65fd671fd17804a89559602fcfd4fL209-R209) [[15]](diffhunk://#diff-3b621a7444b3de88ba434fa0251b7bda0c4b6d3e1d25f44a737011c4b9661d37L161-R168)

* Refactored `ActivityBuilder.buildMessageWithException` to consistently include the custom message, exception message, and stack trace in the log output, improving the clarity and usefulness of error messages. (`ActivityBuilder.java`)

### Testing

* Added a new test class `ActivityBuilderTest` to verify that activity messages include the custom message, exception message, and stack trace as expected, covering various scenarios. (`ActivityBuilderTest.java`)
* Updated existing tests in `A2aPollingTaskTest` to match the new logging format, asserting that log messages start with the custom message and include the exception message and stack trace. (`A2aPollingTaskTest.java`) [[1]](diffhunk://#diff-4d9c4f4342206fe3c74e8610cd73a494b5ceadc0a737fdd2eaa41a9cfde31ccbL200-R206) [[2]](diffhunk://#diff-4d9c4f4342206fe3c74e8610cd73a494b5ceadc0a737fdd2eaa41a9cfde31ccbL230-R231) [[3]](diffhunk://#diff-4d9c4f4342206fe3c74e8610cd73a494b5ceadc0a737fdd2eaa41a9cfde31ccbL298-R306) [[4]](diffhunk://#diff-4d9c4f4342206fe3c74e8610cd73a494b5ceadc0a737fdd2eaa41a9cfde31ccbL322-R332) [[5]](diffhunk://#diff-4d9c4f4342206fe3c74e8610cd73a494b5ceadc0a737fdd2eaa41a9cfde31ccbL347-R359)

### Build Configuration

* Added `junit-jupiter` and `assertj-core` as test dependencies in the Maven configuration to support the new and updated tests. (`pom.xml`)