### PR TITLE
chore(metrics): add cache hit/miss metrics for process-definition inspection

### DIFF
--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/InboundConnectorRuntimeConfiguration.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/InboundConnectorRuntimeConfiguration.java
@@ -186,12 +186,13 @@ public class InboundConnectorRuntimeConfiguration {
   @Bean
   public ProcessDefinitionInspector processDefinitionInspector(
       SearchQueryClient searchQueryClient,
-      @Qualifier("processDefinitionCacheManager") CacheManager cacheManager) {
+      @Qualifier("processDefinitionCacheManager") CacheManager cacheManager,
+      ConnectorsInboundMetrics connectorsInboundMetrics) {
     Cache cache =
         Objects.requireNonNull(
             cacheManager.getCache(ProcessDefinitionInspector.PROCESS_DEFINITION_CACHE_NAME),
             "processDefinitions cache must be configured");
-    return new ProcessDefinitionInspector(searchQueryClient, cache);
+    return new ProcessDefinitionInspector(searchQueryClient, cache, connectorsInboundMetrics);
   }
 
   @Bean

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/state/ProcessDefinitionInspector.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/state/ProcessDefinitionInspector.java
@@ -100,7 +100,7 @@ public class ProcessDefinitionInspector {
       throw new IllegalArgumentException("processDefinitionCache must not be null");
     }
     this.processDefinitionCache = processDefinitionCache;
-this.metrics = java.util.Objects.requireNonNull(metrics, "metrics must not be null");
+    this.metrics = java.util.Objects.requireNonNull(metrics, "metrics must not be null");
   }
 
   public List<InboundConnectorElement> findInboundConnectors(

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/state/ProcessDefinitionInspector.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/state/ProcessDefinitionInspector.java
@@ -34,6 +34,7 @@ import io.camunda.connector.runtime.core.inbound.correlation.StartEventCorrelati
 import io.camunda.connector.runtime.inbound.search.SearchQueryClient;
 import io.camunda.connector.runtime.inbound.state.model.DeployedVersionRef;
 import io.camunda.connector.runtime.inbound.state.model.ProcessDefinitionRef;
+import io.camunda.connector.runtime.metrics.ConnectorsInboundMetrics;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.model.bpmn.instance.BaseElement;
 import io.camunda.zeebe.model.bpmn.instance.BoundaryEvent;
@@ -56,6 +57,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -87,28 +89,43 @@ public class ProcessDefinitionInspector {
 
   private final SearchQueryClient searchQueryClient;
   private final Cache processDefinitionCache;
+  private final ConnectorsInboundMetrics metrics;
 
   public ProcessDefinitionInspector(
-      SearchQueryClient searchQueryClient, Cache processDefinitionCache) {
+      SearchQueryClient searchQueryClient,
+      Cache processDefinitionCache,
+      ConnectorsInboundMetrics metrics) {
     this.searchQueryClient = searchQueryClient;
     if (processDefinitionCache == null) {
       throw new IllegalArgumentException("processDefinitionCache must not be null");
     }
     this.processDefinitionCache = processDefinitionCache;
+    this.metrics = metrics;
   }
 
   public List<InboundConnectorElement> findInboundConnectors(
       ProcessDefinitionRef identifier, long processDefinitionKey) {
 
-    return processDefinitionCache.get(
-        processDefinitionKey,
-        () -> {
-          LOG.debug(
-              "Cache miss for process {} (key {}), fetching and parsing BPMN model.",
-              identifier.bpmnProcessId(),
-              processDefinitionKey);
-          return fetchAndParseConnectors(identifier, processDefinitionKey);
-        });
+    // The value loader only runs on a cache miss, so it doubles as our hit/miss signal.
+    AtomicBoolean cacheMiss = new AtomicBoolean(false);
+    List<InboundConnectorElement> connectors =
+        processDefinitionCache.get(
+            processDefinitionKey,
+            () -> {
+              cacheMiss.set(true);
+              LOG.debug(
+                  "Cache miss for process {} (key {}), fetching and parsing BPMN model.",
+                  identifier.bpmnProcessId(),
+                  processDefinitionKey);
+              return fetchAndParseConnectors(identifier, processDefinitionKey);
+            });
+
+    if (cacheMiss.get()) {
+      metrics.increaseProcessDefinitionCacheMiss();
+    } else {
+      metrics.increaseProcessDefinitionCacheHit();
+    }
+    return connectors;
   }
 
   private List<InboundConnectorElement> fetchAndParseConnectors(

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/state/ProcessDefinitionInspector.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/state/ProcessDefinitionInspector.java
@@ -100,7 +100,7 @@ public class ProcessDefinitionInspector {
       throw new IllegalArgumentException("processDefinitionCache must not be null");
     }
     this.processDefinitionCache = processDefinitionCache;
-    this.metrics = metrics;
+this.metrics = java.util.Objects.requireNonNull(metrics, "metrics must not be null");
   }
 
   public List<InboundConnectorElement> findInboundConnectors(

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/metrics/ConnectorMetrics.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/metrics/ConnectorMetrics.java
@@ -29,6 +29,7 @@ public class ConnectorMetrics {
     public static final String TYPE = "type";
     public static final String ACTION = "action";
     public static final String ELEMENT_TEMPLATE_VERSION = "elementTemplateVersion";
+    public static final String RESULT = "result";
   }
 
   public static class Outbound {
@@ -85,6 +86,20 @@ public class ConnectorMetrics {
     public static final String METRIC_NAME_TRIGGERS = "camunda.connector.inbound.triggers";
     public static final String METRIC_NAME_INBOUND_PROCESS_DEFINITIONS_CHECKED =
         "camunda.connector.inbound.process-definitions-checked";
+
+    /**
+     * Number of process-definition inspection cache lookups, tagged by {@code result} ({@code hit}
+     * or {@code miss}). A high miss rate suggests the cache size (configured via {@code
+     * camunda.connector.inbound.process-definition-cache.max-size}) is too small.
+     */
+    public static final String METRIC_NAME_PROCESS_DEFINITION_CACHE_ACCESSES =
+        "camunda.connector.inbound.process-definition-cache.accesses";
+
+    /** Value of the {@code result} tag for a process-definition cache hit. */
+    public static final String RESULT_CACHE_HIT = "hit";
+
+    /** Value of the {@code result} tag for a process-definition cache miss. */
+    public static final String RESULT_CACHE_MISS = "miss";
 
     /**
      * Epoch-millisecond timestamp of the last successful activation, per connector type. Value is

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/metrics/ConnectorsInboundMetrics.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/metrics/ConnectorsInboundMetrics.java
@@ -31,9 +31,19 @@ public class ConnectorsInboundMetrics {
   private final Map<String, Counter> activationCounter = new ConcurrentHashMap<>();
   private final Map<String, AtomicLong> lastActivatedGauges = new ConcurrentHashMap<>();
   private final Map<String, AtomicLong> lastTriggeredGauges = new ConcurrentHashMap<>();
+  private final Counter processDefinitionCacheHitCounter;
+  private final Counter processDefinitionCacheMissCounter;
 
   public ConnectorsInboundMetrics(MeterRegistry meterRegistry) {
     this.meterRegistry = meterRegistry;
+    this.processDefinitionCacheHitCounter =
+        Counter.builder(ConnectorMetrics.Inbound.METRIC_NAME_PROCESS_DEFINITION_CACHE_ACCESSES)
+            .tag(ConnectorMetrics.Tag.RESULT, ConnectorMetrics.Inbound.RESULT_CACHE_HIT)
+            .register(meterRegistry);
+    this.processDefinitionCacheMissCounter =
+        Counter.builder(ConnectorMetrics.Inbound.METRIC_NAME_PROCESS_DEFINITION_CACHE_ACCESSES)
+            .tag(ConnectorMetrics.Tag.RESULT, ConnectorMetrics.Inbound.RESULT_CACHE_MISS)
+            .register(meterRegistry);
   }
 
   public void increaseActivation(InboundConnectorElement connectorElement) {
@@ -147,6 +157,16 @@ public class ConnectorsInboundMetrics {
                     .tag(ConnectorMetrics.Tag.ELEMENT_TEMPLATE_VERSION, result.version())
                     .register(meterRegistry))
         .increment();
+  }
+
+  /** Records a hit on the process-definition inspection cache. */
+  public void increaseProcessDefinitionCacheHit() {
+    processDefinitionCacheHitCounter.increment();
+  }
+
+  /** Records a miss on the process-definition inspection cache. */
+  public void increaseProcessDefinitionCacheMiss() {
+    processDefinitionCacheMissCounter.increment();
   }
 
   private void recordLastActivated(String type) {

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/inbound/importer/ProcessDefinitionInspectorUtilTests.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/inbound/importer/ProcessDefinitionInspectorUtilTests.java
@@ -26,7 +26,9 @@ import io.camunda.connector.runtime.core.inbound.InboundConnectorElement;
 import io.camunda.connector.runtime.inbound.search.SearchQueryClient;
 import io.camunda.connector.runtime.inbound.state.ProcessDefinitionInspector;
 import io.camunda.connector.runtime.inbound.state.model.ProcessDefinitionRef;
+import io.camunda.connector.runtime.metrics.ConnectorsInboundMetrics;
 import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.io.FileInputStream;
 import java.util.List;
 import org.junit.jupiter.api.Assertions;
@@ -134,7 +136,8 @@ public class ProcessDefinitionInspectorUtilTests {
       var inspector =
           new ProcessDefinitionInspector(
               searchQueryClientMock,
-              cacheManager.getCache(ProcessDefinitionInspector.PROCESS_DEFINITION_CACHE_NAME));
+              cacheManager.getCache(ProcessDefinitionInspector.PROCESS_DEFINITION_CACHE_NAME),
+              new ConnectorsInboundMetrics(new SimpleMeterRegistry()));
       var modelFile = ResourceUtils.getFile("classpath:bpmn/" + fileName);
       var model = Bpmn.readModelFromStream(new FileInputStream(modelFile));
       var processDefinitionID = new ProcessDefinitionRef(processId, "tenant1");

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/inbound/state/ProcessDefinitionInspectorCacheMetricsTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/inbound/state/ProcessDefinitionInspectorCacheMetricsTest.java
@@ -51,10 +51,12 @@ class ProcessDefinitionInspectorCacheMetricsTest {
   @BeforeEach
   void setUp() throws Exception {
     searchQueryClient = mock(SearchQueryClient.class);
-    BpmnModelInstance model =
-        Bpmn.readModelFromStream(
-            new FileInputStream(
-                ResourceUtils.getFile("classpath:bpmn/single-webhook-collaboration.bpmn")));
+    BpmnModelInstance model;
+    try (FileInputStream inputStream =
+        new FileInputStream(
+            ResourceUtils.getFile("classpath:bpmn/single-webhook-collaboration.bpmn"))) {
+      model = Bpmn.readModelFromStream(inputStream);
+    }
     when(searchQueryClient.getProcessModel(PROCESS_DEFINITION_KEY)).thenReturn(model);
     var processDefinition = mock(ProcessDefinition.class);
     when(processDefinition.getVersion()).thenReturn(1);

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/inbound/state/ProcessDefinitionInspectorCacheMetricsTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/inbound/state/ProcessDefinitionInspectorCacheMetricsTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.runtime.inbound.state;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.client.api.search.response.ProcessDefinition;
+import io.camunda.connector.runtime.inbound.search.SearchQueryClient;
+import io.camunda.connector.runtime.inbound.state.model.ProcessDefinitionRef;
+import io.camunda.connector.runtime.metrics.ConnectorMetrics;
+import io.camunda.connector.runtime.metrics.ConnectorsInboundMetrics;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.io.FileInputStream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.cache.Cache;
+import org.springframework.cache.caffeine.CaffeineCacheManager;
+import org.springframework.cache.support.NoOpCacheManager;
+import org.springframework.util.ResourceUtils;
+
+class ProcessDefinitionInspectorCacheMetricsTest {
+
+  private static final ProcessDefinitionRef PROCESS_REF =
+      new ProcessDefinitionRef("process", "tenant1");
+  private static final long PROCESS_DEFINITION_KEY = 1L;
+
+  private SearchQueryClient searchQueryClient;
+  private SimpleMeterRegistry meterRegistry;
+  private ConnectorsInboundMetrics metrics;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    searchQueryClient = mock(SearchQueryClient.class);
+    BpmnModelInstance model =
+        Bpmn.readModelFromStream(
+            new FileInputStream(
+                ResourceUtils.getFile("classpath:bpmn/single-webhook-collaboration.bpmn")));
+    when(searchQueryClient.getProcessModel(PROCESS_DEFINITION_KEY)).thenReturn(model);
+    var processDefinition = mock(ProcessDefinition.class);
+    when(processDefinition.getVersion()).thenReturn(1);
+    when(searchQueryClient.getProcessDefinition(PROCESS_DEFINITION_KEY))
+        .thenReturn(processDefinition);
+
+    meterRegistry = new SimpleMeterRegistry();
+    metrics = new ConnectorsInboundMetrics(meterRegistry);
+  }
+
+  @Test
+  void recordsMissThenHitForRepeatedLookupsOfSameKey() {
+    var inspector = new ProcessDefinitionInspector(searchQueryClient, caffeineCache(), metrics);
+
+    inspector.findInboundConnectors(PROCESS_REF, PROCESS_DEFINITION_KEY);
+    inspector.findInboundConnectors(PROCESS_REF, PROCESS_DEFINITION_KEY);
+    inspector.findInboundConnectors(PROCESS_REF, PROCESS_DEFINITION_KEY);
+
+    assertThat(cacheAccessCount(ConnectorMetrics.Inbound.RESULT_CACHE_MISS)).isEqualTo(1.0);
+    assertThat(cacheAccessCount(ConnectorMetrics.Inbound.RESULT_CACHE_HIT)).isEqualTo(2.0);
+    // BPMN model is only fetched on the miss, subsequent lookups are served from cache.
+    verify(searchQueryClient, times(1)).getProcessModel(PROCESS_DEFINITION_KEY);
+  }
+
+  @Test
+  void countsEveryLookupAsMissWhenCachingIsDisabled() {
+    Cache noOpCache =
+        new NoOpCacheManager().getCache(ProcessDefinitionInspector.PROCESS_DEFINITION_CACHE_NAME);
+    var inspector = new ProcessDefinitionInspector(searchQueryClient, noOpCache, metrics);
+
+    inspector.findInboundConnectors(PROCESS_REF, PROCESS_DEFINITION_KEY);
+    inspector.findInboundConnectors(PROCESS_REF, PROCESS_DEFINITION_KEY);
+
+    assertThat(cacheAccessCount(ConnectorMetrics.Inbound.RESULT_CACHE_MISS)).isEqualTo(2.0);
+    assertThat(cacheAccessCount(ConnectorMetrics.Inbound.RESULT_CACHE_HIT)).isEqualTo(0.0);
+  }
+
+  private Cache caffeineCache() {
+    return new CaffeineCacheManager(ProcessDefinitionInspector.PROCESS_DEFINITION_CACHE_NAME)
+        .getCache(ProcessDefinitionInspector.PROCESS_DEFINITION_CACHE_NAME);
+  }
+
+  private double cacheAccessCount(String result) {
+    return meterRegistry
+        .get(ConnectorMetrics.Inbound.METRIC_NAME_PROCESS_DEFINITION_CACHE_ACCESSES)
+        .tag(ConnectorMetrics.Tag.RESULT, result)
+        .counter()
+        .count();
+  }
+}


### PR DESCRIPTION
This pull request introduces metrics to track cache hits and misses for process definition inspection in the inbound connector runtime. The main goal is to provide observability into the effectiveness of the process definition cache, which can help in tuning cache size and diagnosing performance issues. The changes include new metric definitions, instrumentation of cache access in the core logic, and corresponding tests.

**Metrics and Observability Enhancements:**

* Added new metrics to track process definition cache hits and misses, including metric names and result tags in `ConnectorMetrics` (`RESULT_CACHE_HIT`, `RESULT_CACHE_MISS`, `METRIC_NAME_PROCESS_DEFINITION_CACHE_ACCESSES`). [[1]](diffhunk://#diff-4214a31c513bfdf1bb67a023a266af1546bd30e47c7b7b049d9d8b422d939a1dR32) [[2]](diffhunk://#diff-4214a31c513bfdf1bb67a023a266af1546bd30e47c7b7b049d9d8b422d939a1dR90-R103)
* Updated `ConnectorsInboundMetrics` to register and increment counters for cache hits and misses, and exposed methods to record these events. [[1]](diffhunk://#diff-ab595c78af82def265a39d61744d448c89e437c050f2c689d056d6bf4e3a3a92R34-R46) [[2]](diffhunk://#diff-ab595c78af82def265a39d61744d448c89e437c050f2c689d056d6bf4e3a3a92R162-R171)

**Instrumentation of Core Logic:**

* Modified `ProcessDefinitionInspector` to accept a `ConnectorsInboundMetrics` instance, and instrumented the cache lookup logic to record hits and misses using the new metrics. [[1]](diffhunk://#diff-c991386122ca94c1c78a9a32a8e0dcaac5b077cb16d55a7634fc9e6d6d3ab95dR37) [[2]](diffhunk://#diff-c991386122ca94c1c78a9a32a8e0dcaac5b077cb16d55a7634fc9e6d6d3ab95dR60) [[3]](diffhunk://#diff-c991386122ca94c1c78a9a32a8e0dcaac5b077cb16d55a7634fc9e6d6d3ab95dR92-R128) [[4]](diffhunk://#diff-a3a55d8400a31bac71ec78a1887007574903f2135ba0663621f4094e613264b2L189-R195)

**Testing and Validation:**

* Added `ProcessDefinitionInspectorCacheMetricsTest` to verify correct counting of cache hits and misses under both normal and cache-disabled scenarios.
* Updated existing tests to provide a `ConnectorsInboundMetrics` instance to `ProcessDefinitionInspector`. [[1]](diffhunk://#diff-106fe7c6c6ca6a3278bba34be99371a082ebd2782d6ddf00b3b349ae4291a3dbR29-R31) [[2]](diffhunk://#diff-106fe7c6c6ca6a3278bba34be99371a082ebd2782d6ddf00b3b349ae4291a3dbL137-R140)

These changes improve observability of cache behavior, making it easier to monitor and tune cache effectiveness in production environments.