### PR TITLE
feat(salesforce): support the Salesforce Composite API

### DIFF
--- a/connectors/salesforce/element-templates/salesforce-connector.json
+++ b/connectors/salesforce/element-templates/salesforce-connector.json
@@ -244,7 +244,8 @@
         "property" : "salesforceOperationType",
         "oneOf" : [
           "sObject",
-          "soqlQuery"
+          "soqlQuery",
+          "composite"
         ],
         "type" : "simple"
       },

--- a/connectors/salesforce/element-templates/salesforce-connector.json
+++ b/connectors/salesforce/element-templates/salesforce-connector.json
@@ -785,29 +785,29 @@
     {
       "id" : "sObject_get",
       "properties" : {
-        "interactionType" : "get",
-        "salesforceOperationType" : "sObject"
+        "salesforceOperationType" : "sObject",
+        "interactionType" : "get"
       }
     },
     {
       "id" : "sObject_post",
       "properties" : {
-        "interactionType" : "post",
-        "salesforceOperationType" : "sObject"
+        "salesforceOperationType" : "sObject",
+        "interactionType" : "post"
       }
     },
     {
       "id" : "sObject_patch",
       "properties" : {
-        "interactionType" : "patch",
-        "salesforceOperationType" : "sObject"
+        "salesforceOperationType" : "sObject",
+        "interactionType" : "patch"
       }
     },
     {
       "id" : "sObject_delete",
       "properties" : {
-        "interactionType" : "delete",
-        "salesforceOperationType" : "sObject"
+        "salesforceOperationType" : "sObject",
+        "interactionType" : "delete"
       }
     },
     {

--- a/connectors/salesforce/element-templates/salesforce-connector.json
+++ b/connectors/salesforce/element-templates/salesforce-connector.json
@@ -206,7 +206,7 @@
         "name" : "salesforceInteractionType",
         "type" : "zeebe:input"
       },
-      "tooltip" : "sObject records to create, get, update, or delete a record; SOQL Query to run a Salesforce Object Query Language query; Apex REST to invoke a custom Apex REST endpoint; Composite Request to batch multiple sObject sub-requests into a single call.",
+      "tooltip" : "sObject records to create, get, update, or delete a record; SOQL Query to run a Salesforce Object Query Language query; Apex REST to invoke a custom Apex REST endpoint; Composite Request to batch multiple Salesforce API sub-requests (sObject, SOQL, or Apex REST) into a single call.",
       "type" : "Dropdown",
       "choices" : [
         {
@@ -890,7 +890,7 @@
     },
     {
       "name" : "Composite request",
-      "description" : "Batch multiple Salesforce sObject sub-requests into a single call",
+      "description" : "Batch multiple Salesforce API sub-requests (sObject, SOQL, or Apex REST) into a single call",
       "keywords" : [
         "composite request",
         "batch request",
@@ -904,29 +904,29 @@
     {
       "id" : "sObject_get",
       "properties" : {
-        "interactionType" : "get",
-        "salesforceOperationType" : "sObject"
+        "salesforceOperationType" : "sObject",
+        "interactionType" : "get"
       }
     },
     {
       "id" : "sObject_post",
       "properties" : {
-        "interactionType" : "post",
-        "salesforceOperationType" : "sObject"
+        "salesforceOperationType" : "sObject",
+        "interactionType" : "post"
       }
     },
     {
       "id" : "sObject_patch",
       "properties" : {
-        "interactionType" : "patch",
-        "salesforceOperationType" : "sObject"
+        "salesforceOperationType" : "sObject",
+        "interactionType" : "patch"
       }
     },
     {
       "id" : "sObject_delete",
       "properties" : {
-        "interactionType" : "delete",
-        "salesforceOperationType" : "sObject"
+        "salesforceOperationType" : "sObject",
+        "interactionType" : "delete"
       }
     },
     {

--- a/connectors/salesforce/element-templates/salesforce-connector.json
+++ b/connectors/salesforce/element-templates/salesforce-connector.json
@@ -206,7 +206,7 @@
         "name" : "salesforceInteractionType",
         "type" : "zeebe:input"
       },
-      "tooltip" : "sObject records to create, get, update, or delete a record; SOQL Query to run a Salesforce Object Query Language query; Apex REST to invoke a custom Apex REST endpoint; Composite Request to batch multiple Salesforce API sub-requests (sObject, SOQL, or Apex REST) into a single call.",
+      "tooltip" : "sObject records to create, get, update, or delete a record; SOQL Query to run a Salesforce Object Query Language query; Apex REST to invoke a custom Apex REST endpoint; Composite Request to batch any combination of Salesforce REST API calls into a single request.",
       "type" : "Dropdown",
       "choices" : [
         {
@@ -890,7 +890,7 @@
     },
     {
       "name" : "Composite request",
-      "description" : "Batch multiple Salesforce API sub-requests (sObject, SOQL, or Apex REST) into a single call",
+      "description" : "Batch any combination of Salesforce REST API calls into a single request",
       "keywords" : [
         "composite request",
         "batch request",

--- a/connectors/salesforce/element-templates/salesforce-connector.json
+++ b/connectors/salesforce/element-templates/salesforce-connector.json
@@ -785,29 +785,29 @@
     {
       "id" : "sObject_get",
       "properties" : {
-        "salesforceOperationType" : "sObject",
-        "interactionType" : "get"
+        "interactionType" : "get",
+        "salesforceOperationType" : "sObject"
       }
     },
     {
       "id" : "sObject_post",
       "properties" : {
-        "salesforceOperationType" : "sObject",
-        "interactionType" : "post"
+        "interactionType" : "post",
+        "salesforceOperationType" : "sObject"
       }
     },
     {
       "id" : "sObject_patch",
       "properties" : {
-        "salesforceOperationType" : "sObject",
-        "interactionType" : "patch"
+        "interactionType" : "patch",
+        "salesforceOperationType" : "sObject"
       }
     },
     {
       "id" : "sObject_delete",
       "properties" : {
-        "salesforceOperationType" : "sObject",
-        "interactionType" : "delete"
+        "interactionType" : "delete",
+        "salesforceOperationType" : "sObject"
       }
     },
     {

--- a/connectors/salesforce/element-templates/salesforce-connector.json
+++ b/connectors/salesforce/element-templates/salesforce-connector.json
@@ -19,7 +19,7 @@
     "account"
   ],
   "documentationRef" : "https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/salesforce/",
-  "version" : 7,
+  "version" : 8,
   "category" : {
     "id" : "connectors",
     "name" : "Connectors"
@@ -206,7 +206,7 @@
         "name" : "salesforceInteractionType",
         "type" : "zeebe:input"
       },
-      "tooltip" : "sObject records to create, get, update, or delete a record; SOQL Query to run a Salesforce Object Query Language query; Apex REST to invoke a custom Apex REST endpoint.",
+      "tooltip" : "sObject records to create, get, update, or delete a record; SOQL Query to run a Salesforce Object Query Language query; Apex REST to invoke a custom Apex REST endpoint; Composite Request to batch multiple sObject sub-requests into a single call.",
       "type" : "Dropdown",
       "choices" : [
         {
@@ -220,6 +220,10 @@
         {
           "name" : "Apex REST",
           "value" : "apexRest"
+        },
+        {
+          "name" : "Composite Request",
+          "value" : "composite"
         }
       ]
     },
@@ -612,6 +616,110 @@
       "type" : "String"
     },
     {
+      "id" : "allOrNone",
+      "label" : "All or none",
+      "value" : true,
+      "feel" : "optional",
+      "group" : "operation",
+      "binding" : {
+        "name" : "allOrNone",
+        "type" : "zeebe:input"
+      },
+      "condition" : {
+        "property" : "salesforceOperationType",
+        "equals" : "composite",
+        "type" : "simple"
+      },
+      "tooltip" : "Roll back all sub-requests if any of them fails. If disabled, sub-requests are processed independently.",
+      "type" : "Boolean"
+    },
+    {
+      "id" : "collateSubrequests",
+      "label" : "Collate subrequests",
+      "value" : false,
+      "feel" : "optional",
+      "group" : "operation",
+      "binding" : {
+        "name" : "collateSubrequests",
+        "type" : "zeebe:input"
+      },
+      "condition" : {
+        "property" : "salesforceOperationType",
+        "equals" : "composite",
+        "type" : "simple"
+      },
+      "tooltip" : "Batch compatible subrequests together where possible.",
+      "type" : "Boolean"
+    },
+    {
+      "id" : "compositeRequest",
+      "label" : "Subrequests",
+      "constraints" : {
+        "notEmpty" : true
+      },
+      "feel" : "required",
+      "group" : "operation",
+      "binding" : {
+        "name" : "compositeRequest",
+        "type" : "zeebe:input"
+      },
+      "condition" : {
+        "property" : "salesforceOperationType",
+        "equals" : "composite",
+        "type" : "simple"
+      },
+      "tooltip" : "FEEL list of subrequests, each a context with \"method\", \"url\", \"referenceId\", and optional \"body\" entries. See the <a href=\"https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/resources_composite.htm\" target=\"_blank\">Composite API reference</a>. Reference an earlier subrequest's result by its \"referenceId\" in a later subrequest's \"url\" or \"body\".",
+      "type" : "Text"
+    },
+    {
+      "id" : "methodComposite",
+      "label" : "Method",
+      "value" : "post",
+      "group" : "operation",
+      "binding" : {
+        "name" : "method",
+        "type" : "zeebe:input"
+      },
+      "condition" : {
+        "property" : "salesforceOperationType",
+        "equals" : "composite",
+        "type" : "simple"
+      },
+      "type" : "Hidden"
+    },
+    {
+      "id" : "urlComposite",
+      "label" : "URL",
+      "value" : "=baseUrl + \"/services/data/\" + apiVersion + \"/composite\"",
+      "group" : "operation",
+      "binding" : {
+        "name" : "url",
+        "type" : "zeebe:input"
+      },
+      "condition" : {
+        "property" : "salesforceOperationType",
+        "equals" : "composite",
+        "type" : "simple"
+      },
+      "type" : "Hidden"
+    },
+    {
+      "id" : "bodyComposite",
+      "label" : "Request body",
+      "value" : "={\n  allOrNone: allOrNone,\n  collateSubrequests: collateSubrequests,\n  compositeRequest: compositeRequest\n}",
+      "group" : "operation",
+      "binding" : {
+        "name" : "body",
+        "type" : "zeebe:input"
+      },
+      "condition" : {
+        "property" : "salesforceOperationType",
+        "equals" : "composite",
+        "type" : "simple"
+      },
+      "type" : "Hidden"
+    },
+    {
       "id" : "connectionTimeoutInSeconds",
       "label" : "Connection timeout",
       "optional" : true,
@@ -636,7 +744,7 @@
       "id" : "version",
       "label" : "Version",
       "description" : "Version of the element template",
-      "value" : "7",
+      "value" : "8",
       "group" : "connector",
       "binding" : {
         "key" : "elementTemplateVersion",
@@ -779,35 +887,46 @@
         "invoke apex"
       ],
       "presetId" : "apexRest"
+    },
+    {
+      "name" : "Composite request",
+      "description" : "Batch multiple sObject sub-requests into a single call",
+      "keywords" : [
+        "composite request",
+        "batch request",
+        "bulk operations",
+        "multiple sub-requests"
+      ],
+      "presetId" : "composite"
     }
   ],
   "presets" : [
     {
       "id" : "sObject_get",
       "properties" : {
-        "salesforceOperationType" : "sObject",
-        "interactionType" : "get"
+        "interactionType" : "get",
+        "salesforceOperationType" : "sObject"
       }
     },
     {
       "id" : "sObject_post",
       "properties" : {
-        "salesforceOperationType" : "sObject",
-        "interactionType" : "post"
+        "interactionType" : "post",
+        "salesforceOperationType" : "sObject"
       }
     },
     {
       "id" : "sObject_patch",
       "properties" : {
-        "salesforceOperationType" : "sObject",
-        "interactionType" : "patch"
+        "interactionType" : "patch",
+        "salesforceOperationType" : "sObject"
       }
     },
     {
       "id" : "sObject_delete",
       "properties" : {
-        "salesforceOperationType" : "sObject",
-        "interactionType" : "delete"
+        "interactionType" : "delete",
+        "salesforceOperationType" : "sObject"
       }
     },
     {
@@ -820,6 +939,12 @@
       "id" : "apexRest",
       "properties" : {
         "salesforceOperationType" : "apexRest"
+      }
+    },
+    {
+      "id" : "composite",
+      "properties" : {
+        "salesforceOperationType" : "composite"
       }
     }
   ],

--- a/connectors/salesforce/element-templates/versioned/salesforce-connector-7.json
+++ b/connectors/salesforce/element-templates/versioned/salesforce-connector-7.json
@@ -19,7 +19,7 @@
     "account"
   ],
   "documentationRef" : "https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/salesforce/",
-  "version" : 8,
+  "version" : 7,
   "category" : {
     "id" : "connectors",
     "name" : "Connectors"
@@ -206,7 +206,7 @@
         "name" : "salesforceInteractionType",
         "type" : "zeebe:input"
       },
-      "tooltip" : "sObject records to create, get, update, or delete a record; SOQL Query to run a Salesforce Object Query Language query; Apex REST to invoke a custom Apex REST endpoint; Composite Request to batch multiple sObject sub-requests into a single call.",
+      "tooltip" : "sObject records to create, get, update, or delete a record; SOQL Query to run a Salesforce Object Query Language query; Apex REST to invoke a custom Apex REST endpoint.",
       "type" : "Dropdown",
       "choices" : [
         {
@@ -220,10 +220,6 @@
         {
           "name" : "Apex REST",
           "value" : "apexRest"
-        },
-        {
-          "name" : "Composite Request",
-          "value" : "composite"
         }
       ]
     },
@@ -616,110 +612,6 @@
       "type" : "String"
     },
     {
-      "id" : "allOrNone",
-      "label" : "All or none",
-      "value" : true,
-      "feel" : "optional",
-      "group" : "operation",
-      "binding" : {
-        "name" : "allOrNone",
-        "type" : "zeebe:input"
-      },
-      "condition" : {
-        "property" : "salesforceOperationType",
-        "equals" : "composite",
-        "type" : "simple"
-      },
-      "tooltip" : "Roll back all sub-requests if any of them fails. If disabled, sub-requests are processed independently.",
-      "type" : "Boolean"
-    },
-    {
-      "id" : "collateSubrequests",
-      "label" : "Collate subrequests",
-      "value" : false,
-      "feel" : "optional",
-      "group" : "operation",
-      "binding" : {
-        "name" : "collateSubrequests",
-        "type" : "zeebe:input"
-      },
-      "condition" : {
-        "property" : "salesforceOperationType",
-        "equals" : "composite",
-        "type" : "simple"
-      },
-      "tooltip" : "Batch compatible subrequests together where possible.",
-      "type" : "Boolean"
-    },
-    {
-      "id" : "compositeRequest",
-      "label" : "Subrequests",
-      "constraints" : {
-        "notEmpty" : true
-      },
-      "feel" : "required",
-      "group" : "operation",
-      "binding" : {
-        "name" : "compositeRequest",
-        "type" : "zeebe:input"
-      },
-      "condition" : {
-        "property" : "salesforceOperationType",
-        "equals" : "composite",
-        "type" : "simple"
-      },
-      "tooltip" : "FEEL list of subrequests, each a context with \"method\", \"url\", \"referenceId\", and optional \"body\" entries. See the <a href=\"https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/resources_composite.htm\" target=\"_blank\">Composite API reference</a>. Reference an earlier subrequest's result by its \"referenceId\" in a later subrequest's \"url\" or \"body\".",
-      "type" : "Text"
-    },
-    {
-      "id" : "methodComposite",
-      "label" : "Method",
-      "value" : "post",
-      "group" : "operation",
-      "binding" : {
-        "name" : "method",
-        "type" : "zeebe:input"
-      },
-      "condition" : {
-        "property" : "salesforceOperationType",
-        "equals" : "composite",
-        "type" : "simple"
-      },
-      "type" : "Hidden"
-    },
-    {
-      "id" : "urlComposite",
-      "label" : "URL",
-      "value" : "=baseUrl + \"/services/data/\" + apiVersion + \"/composite\"",
-      "group" : "operation",
-      "binding" : {
-        "name" : "url",
-        "type" : "zeebe:input"
-      },
-      "condition" : {
-        "property" : "salesforceOperationType",
-        "equals" : "composite",
-        "type" : "simple"
-      },
-      "type" : "Hidden"
-    },
-    {
-      "id" : "bodyComposite",
-      "label" : "Request body",
-      "value" : "={\n  allOrNone: allOrNone,\n  collateSubrequests: collateSubrequests,\n  compositeRequest: compositeRequest\n}",
-      "group" : "operation",
-      "binding" : {
-        "name" : "body",
-        "type" : "zeebe:input"
-      },
-      "condition" : {
-        "property" : "salesforceOperationType",
-        "equals" : "composite",
-        "type" : "simple"
-      },
-      "type" : "Hidden"
-    },
-    {
       "id" : "connectionTimeoutInSeconds",
       "label" : "Connection timeout",
       "optional" : true,
@@ -744,7 +636,7 @@
       "id" : "version",
       "label" : "Version",
       "description" : "Version of the element template",
-      "value" : "8",
+      "value" : "7",
       "group" : "connector",
       "binding" : {
         "key" : "elementTemplateVersion",
@@ -887,46 +779,35 @@
         "invoke apex"
       ],
       "presetId" : "apexRest"
-    },
-    {
-      "name" : "Composite request",
-      "description" : "Batch multiple Salesforce sObject sub-requests into a single call",
-      "keywords" : [
-        "composite request",
-        "batch request",
-        "bulk operations",
-        "multiple sub-requests"
-      ],
-      "presetId" : "composite"
     }
   ],
   "presets" : [
     {
       "id" : "sObject_get",
       "properties" : {
-        "interactionType" : "get",
-        "salesforceOperationType" : "sObject"
+        "salesforceOperationType" : "sObject",
+        "interactionType" : "get"
       }
     },
     {
       "id" : "sObject_post",
       "properties" : {
-        "interactionType" : "post",
-        "salesforceOperationType" : "sObject"
+        "salesforceOperationType" : "sObject",
+        "interactionType" : "post"
       }
     },
     {
       "id" : "sObject_patch",
       "properties" : {
-        "interactionType" : "patch",
-        "salesforceOperationType" : "sObject"
+        "salesforceOperationType" : "sObject",
+        "interactionType" : "patch"
       }
     },
     {
       "id" : "sObject_delete",
       "properties" : {
-        "interactionType" : "delete",
-        "salesforceOperationType" : "sObject"
+        "salesforceOperationType" : "sObject",
+        "interactionType" : "delete"
       }
     },
     {
@@ -939,12 +820,6 @@
       "id" : "apexRest",
       "properties" : {
         "salesforceOperationType" : "apexRest"
-      }
-    },
-    {
-      "id" : "composite",
-      "properties" : {
-        "salesforceOperationType" : "composite"
       }
     }
   ],

--- a/connectors/salesforce/src/test/java/io/camunda/connector/salesforce/GenerateElementTemplate.java
+++ b/connectors/salesforce/src/test/java/io/camunda/connector/salesforce/GenerateElementTemplate.java
@@ -457,7 +457,9 @@ public class GenerateElementTemplate {
                 .binding(new ZeebeInput("apiVersion"))
                 .value("v58.0")
                 .constraints(PropertyConstraints.builder().notEmpty(true).build())
-                .condition(new OneOf("salesforceOperationType", List.of("sObject", "soqlQuery")))
+                .condition(
+                    new OneOf(
+                        "salesforceOperationType", List.of("sObject", "soqlQuery", "composite")))
                 .build(),
             DropdownProperty.builder()
                 .choices(

--- a/connectors/salesforce/src/test/java/io/camunda/connector/salesforce/GenerateElementTemplate.java
+++ b/connectors/salesforce/src/test/java/io/camunda/connector/salesforce/GenerateElementTemplate.java
@@ -809,7 +809,7 @@ public class GenerateElementTemplate {
             "apexRest"),
         new LeafStep(
             "Composite request",
-            "Batch multiple sObject sub-requests into a single call",
+            "Batch multiple Salesforce sObject sub-requests into a single call",
             List.of(
                 "composite request", "batch request", "bulk operations", "multiple sub-requests"),
             "composite"));

--- a/connectors/salesforce/src/test/java/io/camunda/connector/salesforce/GenerateElementTemplate.java
+++ b/connectors/salesforce/src/test/java/io/camunda/connector/salesforce/GenerateElementTemplate.java
@@ -445,7 +445,7 @@ public class GenerateElementTemplate {
                 .id("salesforceOperationType")
                 .label("Salesforce operation type")
                 .tooltip(
-                    "sObject records to create, get, update, or delete a record; SOQL Query to run a Salesforce Object Query Language query; Apex REST to invoke a custom Apex REST endpoint; Composite Request to batch multiple Salesforce API sub-requests (sObject, SOQL, or Apex REST) into a single call.")
+                    "sObject records to create, get, update, or delete a record; SOQL Query to run a Salesforce Object Query Language query; Apex REST to invoke a custom Apex REST endpoint; Composite Request to batch any combination of Salesforce REST API calls into a single request.")
                 .group("operation")
                 .binding(new ZeebeInput("salesforceInteractionType"))
                 .build(),
@@ -809,7 +809,7 @@ public class GenerateElementTemplate {
             "apexRest"),
         new LeafStep(
             "Composite request",
-            "Batch multiple Salesforce API sub-requests (sObject, SOQL, or Apex REST) into a single call",
+            "Batch any combination of Salesforce REST API calls into a single request",
             List.of(
                 "composite request", "batch request", "bulk operations", "multiple sub-requests"),
             "composite"));

--- a/connectors/salesforce/src/test/java/io/camunda/connector/salesforce/GenerateElementTemplate.java
+++ b/connectors/salesforce/src/test/java/io/camunda/connector/salesforce/GenerateElementTemplate.java
@@ -445,7 +445,7 @@ public class GenerateElementTemplate {
                 .id("salesforceOperationType")
                 .label("Salesforce operation type")
                 .tooltip(
-                    "sObject records to create, get, update, or delete a record; SOQL Query to run a Salesforce Object Query Language query; Apex REST to invoke a custom Apex REST endpoint; Composite Request to batch multiple sObject sub-requests into a single call.")
+                    "sObject records to create, get, update, or delete a record; SOQL Query to run a Salesforce Object Query Language query; Apex REST to invoke a custom Apex REST endpoint; Composite Request to batch multiple Salesforce API sub-requests (sObject, SOQL, or Apex REST) into a single call.")
                 .group("operation")
                 .binding(new ZeebeInput("salesforceInteractionType"))
                 .build(),
@@ -809,7 +809,7 @@ public class GenerateElementTemplate {
             "apexRest"),
         new LeafStep(
             "Composite request",
-            "Batch multiple Salesforce sObject sub-requests into a single call",
+            "Batch multiple Salesforce API sub-requests (sObject, SOQL, or Apex REST) into a single call",
             List.of(
                 "composite request", "batch request", "bulk operations", "multiple sub-requests"),
             "composite"));

--- a/connectors/salesforce/src/test/java/io/camunda/connector/salesforce/GenerateElementTemplate.java
+++ b/connectors/salesforce/src/test/java/io/camunda/connector/salesforce/GenerateElementTemplate.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.core.util.DefaultIndenter;
 import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
+import io.camunda.connector.generator.dsl.BooleanProperty;
 import io.camunda.connector.generator.dsl.CommonProperties;
 import io.camunda.connector.generator.dsl.DropdownProperty;
 import io.camunda.connector.generator.dsl.DropdownProperty.DropdownChoice;
@@ -181,7 +182,7 @@ public class GenerateElementTemplate {
         builder
             .id("io.camunda.connectors.Salesforce.v1")
             .name("Salesforce Outbound Connector")
-            .version(7)
+            .version(8)
             .category(ElementTemplateCategory.CONNECTORS)
             .documentationRef(
                 "https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/salesforce/")
@@ -439,11 +440,12 @@ public class GenerateElementTemplate {
                     List.of(
                         new DropdownChoice("sObject records", "sObject"),
                         new DropdownChoice("SOQL Query", "soqlQuery"),
-                        new DropdownChoice("Apex REST", "apexRest")))
+                        new DropdownChoice("Apex REST", "apexRest"),
+                        new DropdownChoice("Composite Request", "composite")))
                 .id("salesforceOperationType")
                 .label("Salesforce operation type")
                 .tooltip(
-                    "sObject records to create, get, update, or delete a record; SOQL Query to run a Salesforce Object Query Language query; Apex REST to invoke a custom Apex REST endpoint.")
+                    "sObject records to create, get, update, or delete a record; SOQL Query to run a Salesforce Object Query Language query; Apex REST to invoke a custom Apex REST endpoint; Composite Request to batch multiple sObject sub-requests into a single call.")
                 .group("operation")
                 .binding(new ZeebeInput("salesforceInteractionType"))
                 .build(),
@@ -624,6 +626,63 @@ public class GenerateElementTemplate {
                     new AllMatch(
                         new OneOf("apexRestMethod", List.of("post", "patch", "put")),
                         new Equals("salesforceOperationType", "apexRest")))
+                .build(),
+            BooleanProperty.builder()
+                .id("allOrNone")
+                .label("All or none")
+                .tooltip(
+                    "Roll back all sub-requests if any of them fails. If disabled, sub-requests are processed independently.")
+                .group("operation")
+                .feel(FeelMode.optional)
+                .value(true)
+                .binding(new ZeebeInput("allOrNone"))
+                .condition(new Equals("salesforceOperationType", "composite"))
+                .build(),
+            BooleanProperty.builder()
+                .id("collateSubrequests")
+                .label("Collate subrequests")
+                .tooltip("Batch compatible subrequests together where possible.")
+                .group("operation")
+                .feel(FeelMode.optional)
+                .value(false)
+                .binding(new ZeebeInput("collateSubrequests"))
+                .condition(new Equals("salesforceOperationType", "composite"))
+                .build(),
+            TextProperty.builder()
+                .id("compositeRequest")
+                .label("Subrequests")
+                .tooltip(
+                    "FEEL list of subrequests, each a context with \"method\", \"url\", \"referenceId\", and optional \"body\" entries. See the <a href=\"https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/resources_composite.htm\" target=\"_blank\">Composite API reference</a>. Reference an earlier subrequest's result by its \"referenceId\" in a later subrequest's \"url\" or \"body\".")
+                .group("operation")
+                .feel(FeelMode.required)
+                .binding(new ZeebeInput("compositeRequest"))
+                .condition(new Equals("salesforceOperationType", "composite"))
+                .constraints(PropertyConstraints.builder().notEmpty(true).build())
+                .build(),
+            HiddenProperty.builder()
+                .id("methodComposite")
+                .label("Method")
+                .group("operation")
+                .value("post")
+                .binding(new ZeebeInput("method"))
+                .condition(new Equals("salesforceOperationType", "composite"))
+                .build(),
+            HiddenProperty.builder()
+                .id("urlComposite")
+                .label("URL")
+                .group("operation")
+                .binding(new ZeebeInput("url"))
+                .value("=baseUrl + \"/services/data/\" + apiVersion + \"/composite\"")
+                .condition(new Equals("salesforceOperationType", "composite"))
+                .build(),
+            HiddenProperty.builder()
+                .id("bodyComposite")
+                .label("Request body")
+                .group("operation")
+                .binding(new ZeebeInput("body"))
+                .value(
+                    "={\n  allOrNone: allOrNone,\n  collateSubrequests: collateSubrequests,\n  compositeRequest: compositeRequest\n}")
+                .condition(new Equals("salesforceOperationType", "composite"))
                 .build())
         .build();
   }
@@ -660,7 +719,7 @@ public class GenerateElementTemplate {
         .id("connector")
         .label("Connector")
         .properties(
-            CommonProperties.version(7L)
+            CommonProperties.version(8L)
                 .binding(new ZeebeTaskHeader("elementTemplateVersion"))
                 .build(),
             CommonProperties.id("io.camunda.connectors.Salesforce.v1")
@@ -747,7 +806,13 @@ public class GenerateElementTemplate {
             "Apex REST",
             "Invoke a custom Salesforce Apex REST endpoint",
             List.of("apex rest", "custom endpoint", "apex class", "invoke apex"),
-            "apexRest"));
+            "apexRest"),
+        new LeafStep(
+            "Composite request",
+            "Batch multiple sObject sub-requests into a single call",
+            List.of(
+                "composite request", "batch request", "bulk operations", "multiple sub-requests"),
+            "composite"));
   }
 
   private static List<Preset> buildPresets() {
@@ -765,7 +830,8 @@ public class GenerateElementTemplate {
             "sObject_delete",
             java.util.Map.of("salesforceOperationType", "sObject", "interactionType", "delete")),
         new Preset("soqlQuery", java.util.Map.of("salesforceOperationType", "soqlQuery")),
-        new Preset("apexRest", java.util.Map.of("salesforceOperationType", "apexRest")));
+        new Preset("apexRest", java.util.Map.of("salesforceOperationType", "apexRest")),
+        new Preset("composite", java.util.Map.of("salesforceOperationType", "composite")));
   }
 
   private static final String SALESFORCE_ICON =


### PR DESCRIPTION
## Summary

Stacked on #7958 — targets that branch, not `main`.

Processes that create related Salesforce records in sequence (e.g. Account → Contact → Opportunity) incur one connector call per record today, with no way to roll back all of them if one fails.

Adds a fourth operation type, `composite`:
- `allOrNone` (default `true`) — roll back all sub-requests if any fails
- `collateSubrequests` (default `false`) — let Salesforce batch compatible sub-requests
- `compositeRequest` — FEEL list of subrequests, each a context with `method`/`url`/`referenceId`/optional `body`; later sub-requests can reference an earlier one's result by `referenceId`
- Fixed `POST {baseUrl}/services/data/{apiVersion}/composite`, body assembled from the three fields above
- The full `compositeResponse` is available through the existing result-variable/result-expression mapping like any other response — no new output wiring needed since composite's underlying method is `post`

Closes #7874

## Test plan

- [x] `mvn -pl connectors/salesforce -am verify` — full build green
- [x] `element-template-validator` — 621/621 templates, 0 findings
- [x] Verified generated JSON wiring for every new property (allOrNone/collateSubrequests/compositeRequest/method/url/body) by hand

🤖 Generated with [Claude Code](https://claude.com/claude-code)