### PR TITLE
fix(job): handle interrupted job evaluation gracefully 

### DIFF
--- a/connector-runtime/connector-feel/src/main/java/io/camunda/connector/feel/FeelEngineWrapperException.java
+++ b/connector-runtime/connector-feel/src/main/java/io/camunda/connector/feel/FeelEngineWrapperException.java
@@ -45,7 +45,9 @@ public class FeelEngineWrapperException extends RuntimeException {
   }
 
   private static String formatContext(final Object context) {
-    return context instanceof Object[] array ? Arrays.deepToString(array) : String.valueOf(context);
+    final String formatted =
+        context instanceof Object[] array ? Arrays.deepToString(array) : String.valueOf(context);
+    return formatted.length() > 2000 ? formatted.substring(0, 2000) + "...(truncated)" : formatted;
   }
 
   public String getReason() {

--- a/connector-runtime/connector-feel/src/main/java/io/camunda/connector/feel/FeelEngineWrapperException.java
+++ b/connector-runtime/connector-feel/src/main/java/io/camunda/connector/feel/FeelEngineWrapperException.java
@@ -16,6 +16,8 @@
  */
 package io.camunda.connector.feel;
 
+import java.util.Arrays;
+
 /** Exception class indicating issues in a {@link LocalFeelExpressionEvaluator} call */
 public class FeelEngineWrapperException extends RuntimeException {
 
@@ -36,10 +38,14 @@ public class FeelEngineWrapperException extends RuntimeException {
     super(
         String.format(
             "Failed to evaluate expression '%s' in context '%s'. Reason: %s",
-            expression, context, reason),
+            expression, formatContext(context), reason),
         throwable);
     this.reason = reason;
     this.expression = expression;
+  }
+
+  private static String formatContext(final Object context) {
+    return context instanceof Object[] array ? Arrays.deepToString(array) : String.valueOf(context);
   }
 
   public String getReason() {

--- a/connector-runtime/connector-feel/src/main/java/io/camunda/connector/feel/LocalFeelExpressionEvaluator.java
+++ b/connector-runtime/connector-feel/src/main/java/io/camunda/connector/feel/LocalFeelExpressionEvaluator.java
@@ -126,7 +126,7 @@ public class LocalFeelExpressionEvaluator implements FeelExpressionEvaluator {
     try {
       return (T) evaluateInternal(expression, variables);
     } catch (Exception e) {
-      throw new FeelEngineWrapperException(e.getMessage(), expression, variables, e);
+      throw wrapEvaluationException(e, expression, variables);
     }
   }
 
@@ -187,8 +187,29 @@ public class LocalFeelExpressionEvaluator implements FeelExpressionEvaluator {
         return resultToJson(result);
       } else return null;
     } catch (Exception e) {
-      throw new FeelEngineWrapperException(e.getMessage(), expression, variables, e);
+      throw wrapEvaluationException(e, expression, variables);
     }
+  }
+
+  /**
+   * feel-engine's cooperative cancellation ({@code FeelInterpreter.eval}) checks {@code
+   * Thread.interrupted()} on every AST node and throws a bare, message-less {@link
+   * InterruptedException} when the job-handling thread was interrupted (e.g. runtime shutdown while
+   * a job was in flight). Wrapping it like any other evaluation failure produces a misleading
+   * "Reason: null" incident, so it is special-cased here with a clear reason and the thread's
+   * interrupt status is restored for callers further up the stack to observe.
+   */
+  private static FeelEngineWrapperException wrapEvaluationException(
+      final Exception e, final String expression, final Object[] variables) {
+    if (e instanceof InterruptedException) {
+      Thread.currentThread().interrupt();
+      return new FeelEngineWrapperException(
+          "the evaluating thread was interrupted, likely because the connector runtime is shutting down",
+          expression,
+          variables,
+          e);
+    }
+    return new FeelEngineWrapperException(e.getMessage(), expression, variables, e);
   }
 
   private Object evaluateInternal(final String expression, final Object[] variables) {

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/SpringConnectorJobHandler.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/SpringConnectorJobHandler.java
@@ -267,7 +267,8 @@ public class SpringConnectorJobHandler implements JobHandler {
                 + "completion before the interrupt was noticed, so reassignment will re-execute it "
                 + "- verify the connector's side effects are idempotent before relying on this",
             job.getKey(),
-            job.getTenantId());
+            job.getTenantId(),
+            ex);
         return;
       }
       CompletableFuture<CommandOutcome> failJobRequest =

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/SpringConnectorJobHandler.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/SpringConnectorJobHandler.java
@@ -253,6 +253,23 @@ public class SpringConnectorJobHandler implements JobHandler {
               handleConnectorError(client, job, context, finalResult, error, counterMetricsContext),
           () -> handleFinalResult(client, job, context, finalResult, counterMetricsContext));
     } catch (Exception ex) {
+      if (Thread.currentThread().isInterrupted()) {
+        // the job-handling thread was interrupted (e.g. runtime shutdown) while evaluating the
+        // error expression; leave the job alone rather than raising an incident so Zeebe's
+        // activation timeout reassigns it, same as if the worker had been killed outright.
+        // NOTE: the connector call preceding this evaluation has already run to completion, so
+        // reassignment will re-invoke the connector from scratch - any non-idempotent side effect
+        // (HTTP call, message send, LLM call, etc.) it performed may be executed a second time.
+        LOGGER.error(
+            "Job {} for tenant {} was interrupted while evaluating its error expression, likely "
+                + "because the runtime is shutting down; abandoning the job so Zeebe's activation "
+                + "timeout reassigns it. WARNING: the connector call for this job already ran to "
+                + "completion before the interrupt was noticed, so reassignment will re-execute it "
+                + "- verify the connector's side effects are idempotent before relying on this",
+            job.getKey(),
+            job.getTenantId());
+        return;
+      }
       CompletableFuture<CommandOutcome> failJobRequest =
           failJob(
               client,

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/job/SpringConnectorJobHandlerTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/job/SpringConnectorJobHandlerTest.java
@@ -32,6 +32,7 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import io.camunda.client.api.command.FailJobCommandStep1;
@@ -1472,6 +1473,36 @@ class SpringConnectorJobHandlerTest {
       assertThat(result.getErrorCode()).isNull();
       assertThat(result.getErrorMessage()).isNull();
       assertThat(result.getVariables()).isEmpty();
+    }
+
+    @Test
+    void shouldAbandonJob_WhenThreadInterruptedDuringErrorExpressionEvaluation() throws Exception {
+      // given: the job-handling thread was interrupted (e.g. runtime shutdown via
+      // JobWorkerExecutors.close()) right before error expression evaluation gets a chance to
+      // observe it - mirroring a downstream connector call that returned after being interrupted
+      var errorExpression = "if error != null then bpmnError(error.code, error.message) else null";
+      var jobHandler =
+          newConnectorJobHandler(
+              context -> {
+                throw new ConnectorException("1013", "exception message");
+              });
+      var jobClient = mock(JobClient.class);
+
+      // when
+      Thread.currentThread().interrupt();
+      try {
+        JobBuilder.create()
+            .withErrorExpressionHeader(errorExpression)
+            .useJobClient(jobClient)
+            .execute(jobHandler);
+      } finally {
+        // clear any leftover interrupt status so it doesn't leak into other tests
+        Thread.interrupted();
+      }
+
+      // then: no incident is raised - the job is abandoned so Zeebe's activation timeout
+      // reassigns it, instead of failing with a misleading "Reason: null" error
+      verifyNoInteractions(jobClient);
     }
   }
 


### PR DESCRIPTION
This pull request improves how the connector runtime handles thread interruptions during FEEL expression evaluation, especially during shutdown scenarios. It ensures that jobs are abandoned (not failed with misleading errors) if the evaluating thread is interrupted, and provides clearer error reporting and handling. The changes also add tests to verify this behavior.

**Error handling improvements:**

* Special-cased handling for `InterruptedException` in `LocalFeelExpressionEvaluator`: If the evaluating thread is interrupted (e.g., during shutdown), a clear error message is set and the thread's interrupt status is restored, instead of raising an exception with a null reason. (`LocalFeelExpressionEvaluator.java`, [connector-runtime/connector-feel/src/main/java/io/camunda/connector/feel/LocalFeelExpressionEvaluator.javaL190-R214](diffhunk://#diff-7f8107345fc744345e4d7f5a378b2f4b574a858e9311b0c6a44d638810b205d5L190-R214))
* The context in `FeelEngineWrapperException` is now formatted for readability, especially when it is an array. (`FeelEngineWrapperException.java`, [[1]](diffhunk://#diff-5bf0b180aeecd491b34c92ab0bdda755622d3d3915e08572dc80f8de431af497L39-R50) [[2]](diffhunk://#diff-5bf0b180aeecd491b34c92ab0bdda755622d3d3915e08572dc80f8de431af497R19-R20)

**Job handling logic:**

* In `SpringConnectorJobHandler`, if the thread is interrupted during error expression evaluation, the job is abandoned (not failed), so Zeebe's activation timeout will reassign it. This prevents non-informative incidents and warns about possible repeated side effects. (`SpringConnectorJobHandler.java`, [connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/SpringConnectorJobHandler.javaR256-R272](diffhunk://#diff-8b38a8d6fb32730135f037e1ad4796ceb31be7f7bea987d3b9db43f12831a573R256-R272))

**Testing:**

* Added a test to verify that jobs are abandoned (and not failed or retried) when the thread is interrupted during error expression evaluation. (`SpringConnectorJobHandlerTest.java`, [[1]](diffhunk://#diff-8feebaf7e017d530b4272075d0a9202430712165d900419f27a191f6ca0df2b2R1477-R1506) [[2]](diffhunk://#diff-8feebaf7e017d530b4272075d0a9202430712165d900419f27a191f6ca0df2b2R35)