### PR TITLE
fix(eventbridge): restore result payload lost in SDK v2 migration

### DIFF
--- a/connectors/aws/aws-eventbridge/pom.xml
+++ b/connectors/aws/aws-eventbridge/pom.xml
@@ -57,6 +57,11 @@
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>sdk-core</artifactId>
     </dependency>
+    <dependency>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>http-client-spi</artifactId>
+      <version>${version.aws-sdk2}</version>
+    </dependency>
 
   </dependencies>
 

--- a/connectors/aws/aws-eventbridge/src/main/java/io/camunda/connector/aws/eventbridge/EventBridgeFunction.java
+++ b/connectors/aws/aws-eventbridge/src/main/java/io/camunda/connector/aws/eventbridge/EventBridgeFunction.java
@@ -71,8 +71,7 @@ public class EventBridgeFunction implements OutboundConnectorFunction {
   public Object execute(OutboundConnectorContext context) throws JsonProcessingException {
     var eventBridgeRequest = context.bindVariables(AwsEventBridgeRequest.class);
     try (EventBridgeClient client = createEventBridgeClient(eventBridgeRequest)) {
-      return objectMapper.convertValue(
-          putEvents(client, eventBridgeRequest.getInput()), Object.class);
+      return EventBridgeResult.from(putEvents(client, eventBridgeRequest.getInput()));
     }
   }
 

--- a/connectors/aws/aws-eventbridge/src/main/java/io/camunda/connector/aws/eventbridge/EventBridgeResult.java
+++ b/connectors/aws/aws-eventbridge/src/main/java/io/camunda/connector/aws/eventbridge/EventBridgeResult.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.aws.eventbridge;
+
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import software.amazon.awssdk.awscore.AwsResponseMetadata;
+import software.amazon.awssdk.http.SdkHttpResponse;
+import software.amazon.awssdk.services.eventbridge.model.PutEventsResponse;
+
+/**
+ * Connector-owned result of an EventBridge {@code PutEvents} call.
+ *
+ * <p>The AWS SDK v2 model classes ({@link PutEventsResponse} and friends) expose fluent accessors
+ * ({@code entries()}, {@code failedEntryCount()}) rather than JavaBean getters. Serializing them
+ * directly with the connectors' {@code ObjectMapper} (which disables {@code FAIL_ON_EMPTY_BEANS})
+ * silently produced {@code {}}, dropping the partial-failure signal ({@code failedEntryCount}) and
+ * the per-entry {@code eventId}. This record maps the v2 response back into the exact JSON shape
+ * that the pre-v2 (AWS SDK v1) connector documented and returned, restoring that output contract.
+ */
+@JsonPropertyOrder({"sdkResponseMetadata", "sdkHttpMetadata", "failedEntryCount", "entries"})
+public record EventBridgeResult(
+    SdkResponseMetadata sdkResponseMetadata,
+    SdkHttpMetadata sdkHttpMetadata,
+    Integer failedEntryCount,
+    List<Entry> entries) {
+
+  /** Maps an AWS SDK v2 {@link PutEventsResponse} into the v1-shaped connector result. */
+  public static EventBridgeResult from(final PutEventsResponse response) {
+    return new EventBridgeResult(
+        SdkResponseMetadata.from(response.responseMetadata()),
+        SdkHttpMetadata.from(response.sdkHttpResponse()),
+        response.failedEntryCount(),
+        mapEntries(response.entries()));
+  }
+
+  private static List<Entry> mapEntries(
+      final List<software.amazon.awssdk.services.eventbridge.model.PutEventsResultEntry> entries) {
+    if (entries == null) {
+      return null;
+    }
+    return entries.stream().map(Entry::from).toList();
+  }
+
+  public record SdkResponseMetadata(String requestId) {
+    // v2 returns the literal "UNKNOWN" when AWS_REQUEST_ID is absent; v1 exposed null there
+    private static final String UNKNOWN_REQUEST_ID = "UNKNOWN";
+
+    static SdkResponseMetadata from(final AwsResponseMetadata metadata) {
+      if (metadata == null || UNKNOWN_REQUEST_ID.equals(metadata.requestId())) {
+        return null;
+      }
+      return new SdkResponseMetadata(metadata.requestId());
+    }
+  }
+
+  @JsonPropertyOrder({"httpHeaders", "httpStatusCode", "allHttpHeaders"})
+  public record SdkHttpMetadata(
+      Map<String, String> httpHeaders,
+      Integer httpStatusCode,
+      Map<String, List<String>> allHttpHeaders) {
+
+    static SdkHttpMetadata from(final SdkHttpResponse httpResponse) {
+      if (httpResponse == null) {
+        return null;
+      }
+      Map<String, List<String>> allHttpHeaders = new LinkedHashMap<>(httpResponse.headers());
+      Map<String, String> httpHeaders = new LinkedHashMap<>();
+      allHttpHeaders.forEach(
+          (name, values) ->
+              httpHeaders.put(name, values == null || values.isEmpty() ? null : values.get(0)));
+      return new SdkHttpMetadata(httpHeaders, httpResponse.statusCode(), allHttpHeaders);
+    }
+  }
+
+  @JsonPropertyOrder({"eventId", "errorCode", "errorMessage"})
+  public record Entry(String eventId, String errorCode, String errorMessage) {
+    static Entry from(
+        final software.amazon.awssdk.services.eventbridge.model.PutEventsResultEntry entry) {
+      return new Entry(entry.eventId(), entry.errorCode(), entry.errorMessage());
+    }
+  }
+}

--- a/connectors/aws/aws-eventbridge/src/main/java/io/camunda/connector/aws/eventbridge/EventBridgeResult.java
+++ b/connectors/aws/aws-eventbridge/src/main/java/io/camunda/connector/aws/eventbridge/EventBridgeResult.java
@@ -53,10 +53,11 @@ public record EventBridgeResult(
     private static final String UNKNOWN_REQUEST_ID = "UNKNOWN";
 
     static SdkResponseMetadata from(final AwsResponseMetadata metadata) {
-      if (metadata == null || UNKNOWN_REQUEST_ID.equals(metadata.requestId())) {
+      if (metadata == null) {
         return null;
       }
-      return new SdkResponseMetadata(metadata.requestId());
+      String requestId = metadata.requestId();
+      return new SdkResponseMetadata(UNKNOWN_REQUEST_ID.equals(requestId) ? null : requestId);
     }
   }
 

--- a/connectors/aws/aws-eventbridge/src/test/java/io/camunda/connector/aws/eventbridge/EventBridgeFunctionTest.java
+++ b/connectors/aws/aws-eventbridge/src/test/java/io/camunda/connector/aws/eventbridge/EventBridgeFunctionTest.java
@@ -18,13 +18,16 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.connector.api.error.ConnectorInputException;
 import io.camunda.connector.api.outbound.OutboundConnectorContext;
 import io.camunda.connector.aws.ObjectMapperSupplier;
+import io.camunda.connector.jackson.ConnectorsObjectMapperSupplier;
 import io.camunda.connector.runtime.test.outbound.OutboundConnectorContextBuilder;
 import io.camunda.connector.validation.impl.DefaultValidationProvider;
 import java.io.File;
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -34,6 +37,8 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import software.amazon.awssdk.auth.credentials.AwsCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.awscore.DefaultAwsResponseMetadata;
+import software.amazon.awssdk.http.SdkHttpResponse;
 import software.amazon.awssdk.services.eventbridge.EventBridgeClient;
 import software.amazon.awssdk.services.eventbridge.model.PutEventsRequest;
 import software.amazon.awssdk.services.eventbridge.model.PutEventsRequestEntry;
@@ -66,6 +71,8 @@ class EventBridgeFunctionTest {
   private static final String SECRETS_INNER_DETAIL_VALUE = "INNER_DETAIL_VALUE";
 
   private static final String DETAIL_AS_STRING = "{\"key1\":{\"innerKey\":\"innerValue\"}}";
+  private static final String EVENT_ID = "0dcd8361-d287-b9eb-bbb2-a2512851c2bf";
+  private static final String REQUEST_ID = "929bf054-193b-48e6-ab80-3aeeb613b415";
 
   private EventBridgeFunction function;
   @Mock private AwsEventBridgeClientSupplier clientSupplier;
@@ -94,11 +101,22 @@ class EventBridgeFunctionTest {
         .thenReturn(client);
     when(client.putEvents(putEventsRequestArgumentCaptor.capture()))
         .thenReturn(
-            PutEventsResponse.builder().entries(PutEventsResultEntry.builder().build()).build());
+            PutEventsResponse.builder()
+                .failedEntryCount(0)
+                .entries(PutEventsResultEntry.builder().eventId(EVENT_ID).build())
+                .build());
     // When connector execute
     Object execute = function.execute(context);
-    // Then
-    assertThat(execute).isNotNull();
+    // Then the result carries the actual PutEvents outcome (regression guard: failedEntryCount and
+    // the per-entry eventId must survive the v2 -> connector-result mapping).
+    assertThat(execute).isInstanceOf(EventBridgeResult.class);
+    EventBridgeResult result = (EventBridgeResult) execute;
+    assertThat(result.failedEntryCount()).isZero();
+    assertThat(result.entries()).hasSize(1);
+    EventBridgeResult.Entry resultEntry = result.entries().get(0);
+    assertThat(resultEntry.eventId()).isEqualTo(EVENT_ID);
+    assertThat(resultEntry.errorCode()).isNull();
+    assertThat(resultEntry.errorMessage()).isNull();
 
     AwsCredentials credentials = credentialsProviderArgumentCaptor.getValue().resolveCredentials();
     assertThat(credentials.accessKeyId()).isEqualTo(ACCESS_KEY);
@@ -116,6 +134,86 @@ class EventBridgeFunctionTest {
     assertThat(entry.detailType()).isEqualTo(DETAIL_TYPE);
 
     assertThat(entry.detail()).isEqualTo(DETAIL_AS_STRING);
+  }
+
+  /**
+   * Golden-JSON shape test: the connector result, serialized with the real connectors {@link
+   * ObjectMapper}, must reproduce the output contract the connector documented before the AWS SDK
+   * v2 migration (see README). This is the template for verifying result serialization across the
+   * v2 migration effort: build a realistic v2 SDK response, map it through the connector, serialize
+   * with the production mapper, and diff the full JSON tree against the frozen expectation.
+   */
+  @Test
+  public void putEventsResult_serializesToDocumentedV1JsonShape() throws JsonProcessingException {
+    // Given a fully populated AWS SDK v2 PutEventsResponse, as returned by a live PutEvents call:
+    // one delivered entry (eventId), one failed entry (errorCode/errorMessage), a partial-failure
+    // count, request metadata and HTTP metadata.
+    var responseBuilder =
+        PutEventsResponse.builder()
+            .failedEntryCount(1)
+            .entries(
+                PutEventsResultEntry.builder().eventId(EVENT_ID).build(),
+                PutEventsResultEntry.builder()
+                    .errorCode("InternalFailure")
+                    .errorMessage("Internal Service Failure")
+                    .build());
+    responseBuilder.responseMetadata(
+        DefaultAwsResponseMetadata.create(Map.of("AWS_REQUEST_ID", REQUEST_ID)));
+    responseBuilder.sdkHttpResponse(
+        SdkHttpResponse.builder()
+            .statusCode(200)
+            .putHeader("Content-Length", "85")
+            .putHeader("Content-Type", "application/x-amz-json-1.1")
+            .putHeader("x-amzn-RequestId", REQUEST_ID)
+            .build());
+    PutEventsResponse response = responseBuilder.build();
+
+    // When the connector maps it and the runtime serializes the result with the production mapper
+    EventBridgeResult result = EventBridgeResult.from(response);
+    ObjectMapper productionMapper = ConnectorsObjectMapperSupplier.getCopy();
+    JsonNode actual = productionMapper.valueToTree(result);
+
+    // Then the JSON matches the pre-v2 (AWS SDK v1) output shape exactly, including explicit nulls.
+    String expectedJson =
+        """
+        {
+          "sdkResponseMetadata": {
+            "requestId": "929bf054-193b-48e6-ab80-3aeeb613b415"
+          },
+          "sdkHttpMetadata": {
+            "httpHeaders": {
+              "Content-Length": "85",
+              "Content-Type": "application/x-amz-json-1.1",
+              "x-amzn-RequestId": "929bf054-193b-48e6-ab80-3aeeb613b415"
+            },
+            "httpStatusCode": 200,
+            "allHttpHeaders": {
+              "Content-Length": ["85"],
+              "Content-Type": ["application/x-amz-json-1.1"],
+              "x-amzn-RequestId": ["929bf054-193b-48e6-ab80-3aeeb613b415"]
+            }
+          },
+          "failedEntryCount": 1,
+          "entries": [
+            {
+              "eventId": "0dcd8361-d287-b9eb-bbb2-a2512851c2bf",
+              "errorCode": null,
+              "errorMessage": null
+            },
+            {
+              "eventId": null,
+              "errorCode": "InternalFailure",
+              "errorMessage": "Internal Service Failure"
+            }
+          ]
+        }
+        """;
+    JsonNode expected = productionMapper.readTree(expectedJson);
+    assertThat(actual).isEqualTo(expected);
+    // Tree equality above is key-order-insensitive; also pin the serialized field order
+    // (@JsonPropertyOrder) to the documented v1 layout.
+    assertThat(productionMapper.writeValueAsString(result))
+        .isEqualTo(productionMapper.writeValueAsString(expected));
   }
 
   @ParameterizedTest()

--- a/connectors/aws/aws-eventbridge/src/test/java/io/camunda/connector/aws/eventbridge/EventBridgeFunctionTest.java
+++ b/connectors/aws/aws-eventbridge/src/test/java/io/camunda/connector/aws/eventbridge/EventBridgeFunctionTest.java
@@ -216,6 +216,25 @@ class EventBridgeFunctionTest {
         .isEqualTo(productionMapper.writeValueAsString(expected));
   }
 
+  /**
+   * v2 falls back to the literal request id {@code "UNKNOWN"} when {@code AWS_REQUEST_ID} is absent
+   * from the response metadata map; v1 exposed a {@code null} {@code requestId} in that case, with
+   * the {@code sdkResponseMetadata} object still present. Guards against collapsing the whole
+   * object to {@code null} instead of normalizing just the {@code requestId} field.
+   */
+  @Test
+  public void putEventsResult_normalizesUnknownRequestIdWithoutDroppingMetadataObject() {
+    var responseBuilder =
+        PutEventsResponse.builder()
+            .entries(PutEventsResultEntry.builder().eventId(EVENT_ID).build());
+    responseBuilder.responseMetadata(DefaultAwsResponseMetadata.create(Map.of()));
+
+    EventBridgeResult result = EventBridgeResult.from(responseBuilder.build());
+
+    assertThat(result.sdkResponseMetadata()).isNotNull();
+    assertThat(result.sdkResponseMetadata().requestId()).isNull();
+  }
+
   @ParameterizedTest()
   @MethodSource("validationTestCases")
   public void execute_shouldThrowExceptionWhenDataNotValid(String input) {


### PR DESCRIPTION
## Description

Since the AWS SDK v2 migration (#6681), the EventBridge outbound connector has returned an empty `{}` result variable: `EventBridgeFunction` passed the v2 `PutEventsResponse` through `objectMapper.convertValue(..., Object.class)`, and v2 model objects expose fluent accessors with no bean getters — with `FAIL_ON_EMPTY_BEANS` disabled in `ConnectorsObjectMapperSupplier`, the response silently serializes to `{}`. Users lost `failedEntryCount` (the only delivery-failure signal of the partial-failure PutEvents API — failures come back with HTTP 200) and `entries[].eventId`. Affects 8.10.0-alpha1+ only; no GA release. Neither the unit test (`isNotNull`) nor the e2e test (variable existence) could catch it.

**Fix:** map the v2 response into a connector-owned `EventBridgeResult` record reproducing the documented pre-migration JSON shape exactly — `sdkResponseMetadata.requestId`, `sdkHttpMetadata` (`httpHeaders`/`httpStatusCode`/`allHttpHeaders`), `failedEntryCount`, `entries[]` — with explicit nulls preserved and field order pinned. The v2 `"UNKNOWN"` requestId sentinel is normalized to `null` for v1 parity. Same pattern as the sibling connectors (`AwsLambdaResult`, `SqsConnectorResult`, `SnsConnectorResult`).

**Tests:**
- New golden-JSON test serializes the mapped result through the production ObjectMapper and asserts the exact JSON (tree + string, so field order is guarded). This test is the template for the result-shape fixtures planned across the remaining AWS SDK v2 migrations (#7968).
- `execute_shouldExecuteRequest` strengthened beyond `isNotNull`; verified it fails against the pre-fix code.
- `software.amazon.awssdk:http-client-spi` added to the pom (`EventBridgeResult` references `SdkHttpResponse`; required by `dependency:analyze-only`).

No element-template version bump: this restores the documented contract (README output shape is again accurate). A sweep of all other migrated AWS connectors (sqs, sns, lambda, s3, bedrock*) confirmed none share this pattern — EventBridge was the sole offender.

## Related issues

closes #7967

Related: #5419, camunda/product-hub#3581

## Checklist

- [x] Backport labels are added if these code changes should be backported. — not applicable: the regression exists only on `main`/8.10 alphas; no released branch is affected.
- [x] Tests/Integration tests for the changes have been added if applicable.
- [x] If the change requires a documentation update, it has been added to the appropriate section in the documentation. — none needed: the README's documented output shape is correct again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)