### PR TITLE
feat(agentic-ai): mark AI Agent sub-process element templates as tool containers

### DIFF
--- a/connectors/agentic-ai/connector-agentic-ai/bin/transform-ai-agent-job-worker-template.groovy
+++ b/connectors/agentic-ai/connector-agentic-ai/bin/transform-ai-agent-job-worker-template.groovy
@@ -139,6 +139,17 @@ def updatedProperties = []
             value: "={\n  id: toolCall._meta.id,\n  name: toolCall._meta.name,\n  content: toolCallResult,\n  completedAt: now()\n}",
             type: "Hidden"
         ])
+
+        // Mark the ad-hoc sub-process as an agentic tool container so linting rules
+        // (e.g. fromAi() validation) can detect it.
+        updatedProperties.add([
+            value: "true",
+            binding: [
+                name: "io.camunda.agenticai.toolContainer",
+                type: "zeebe:property"
+            ],
+            type: "Hidden"
+        ])
     } else if (property.id == "id") {
         property.value = "io.camunda.connectors.agenticai.aiagent.jobworker.v1"
         updatedProperties.add(property)

--- a/connectors/agentic-ai/connector-agentic-ai/element-templates/agenticai-aiagent-job-worker.json
+++ b/connectors/agentic-ai/connector-agentic-ai/element-templates/agenticai-aiagent-job-worker.json
@@ -96,6 +96,13 @@
     "value" : "={\n  id: toolCall._meta.id,\n  name: toolCall._meta.name,\n  content: toolCallResult,\n  completedAt: now()\n}",
     "type" : "Hidden"
   }, {
+    "value" : "true",
+    "binding" : {
+      "name" : "io.camunda.agenticai.toolContainer",
+      "type" : "zeebe:property"
+    },
+    "type" : "Hidden"
+  }, {
     "id" : "provider.type",
     "label" : "Provider",
     "description" : "Specify the LLM provider to use.",

--- a/connectors/agentic-ai/connector-agentic-ai/element-templates/hybrid/agenticai-aiagent-job-worker-hybrid.json
+++ b/connectors/agentic-ai/connector-agentic-ai/element-templates/hybrid/agenticai-aiagent-job-worker-hybrid.json
@@ -101,6 +101,13 @@
     "value" : "={\n  id: toolCall._meta.id,\n  name: toolCall._meta.name,\n  content: toolCallResult,\n  completedAt: now()\n}",
     "type" : "Hidden"
   }, {
+    "value" : "true",
+    "binding" : {
+      "name" : "io.camunda.agenticai.toolContainer",
+      "type" : "zeebe:property"
+    },
+    "type" : "Hidden"
+  }, {
     "id" : "provider.type",
     "label" : "Provider",
     "description" : "Specify the LLM provider to use.",

--- a/connectors/agentic-ai/connector-agentic-ai/element-templates/versioned/agenticai-aiagent-job-worker-10.json
+++ b/connectors/agentic-ai/connector-agentic-ai/element-templates/versioned/agenticai-aiagent-job-worker-10.json
@@ -96,6 +96,13 @@
     "value" : "={\n  id: toolCall._meta.id,\n  name: toolCall._meta.name,\n  content: toolCallResult\n}",
     "type" : "Hidden"
   }, {
+    "value" : "true",
+    "binding" : {
+      "name" : "io.camunda.agenticai.toolContainer",
+      "type" : "zeebe:property"
+    },
+    "type" : "Hidden"
+  }, {
     "id" : "provider.type",
     "label" : "Provider",
     "description" : "Specify the LLM provider to use.",

--- a/connectors/agentic-ai/connector-agentic-ai/element-templates/versioned/agenticai-aiagent-job-worker-3.json
+++ b/connectors/agentic-ai/connector-agentic-ai/element-templates/versioned/agenticai-aiagent-job-worker-3.json
@@ -98,6 +98,13 @@
     "value" : "={\n  id: toolCall._meta.id,\n  name: toolCall._meta.name,\n  content: toolCallResult\n}",
     "type" : "Hidden"
   }, {
+    "value" : "true",
+    "binding" : {
+      "name" : "io.camunda.agenticai.toolContainer",
+      "type" : "zeebe:property"
+    },
+    "type" : "Hidden"
+  }, {
     "id" : "provider.type",
     "label" : "Provider",
     "description" : "Specify the LLM provider to use.",

--- a/connectors/agentic-ai/connector-agentic-ai/element-templates/versioned/agenticai-aiagent-job-worker-4.json
+++ b/connectors/agentic-ai/connector-agentic-ai/element-templates/versioned/agenticai-aiagent-job-worker-4.json
@@ -98,6 +98,13 @@
     "value" : "={\n  id: toolCall._meta.id,\n  name: toolCall._meta.name,\n  content: toolCallResult\n}",
     "type" : "Hidden"
   }, {
+    "value" : "true",
+    "binding" : {
+      "name" : "io.camunda.agenticai.toolContainer",
+      "type" : "zeebe:property"
+    },
+    "type" : "Hidden"
+  }, {
     "id" : "provider.type",
     "label" : "Provider",
     "description" : "Specify the LLM provider to use.",

--- a/connectors/agentic-ai/connector-agentic-ai/element-templates/versioned/agenticai-aiagent-job-worker-5.json
+++ b/connectors/agentic-ai/connector-agentic-ai/element-templates/versioned/agenticai-aiagent-job-worker-5.json
@@ -98,6 +98,13 @@
     "value" : "={\n  id: toolCall._meta.id,\n  name: toolCall._meta.name,\n  content: toolCallResult\n}",
     "type" : "Hidden"
   }, {
+    "value" : "true",
+    "binding" : {
+      "name" : "io.camunda.agenticai.toolContainer",
+      "type" : "zeebe:property"
+    },
+    "type" : "Hidden"
+  }, {
     "id" : "provider.type",
     "label" : "Provider",
     "description" : "Specify the LLM provider to use.",

--- a/connectors/agentic-ai/connector-agentic-ai/element-templates/versioned/agenticai-aiagent-job-worker-6.json
+++ b/connectors/agentic-ai/connector-agentic-ai/element-templates/versioned/agenticai-aiagent-job-worker-6.json
@@ -98,6 +98,13 @@
     "value" : "={\n  id: toolCall._meta.id,\n  name: toolCall._meta.name,\n  content: toolCallResult\n}",
     "type" : "Hidden"
   }, {
+    "value" : "true",
+    "binding" : {
+      "name" : "io.camunda.agenticai.toolContainer",
+      "type" : "zeebe:property"
+    },
+    "type" : "Hidden"
+  }, {
     "id" : "provider.type",
     "label" : "Provider",
     "description" : "Specify the LLM provider to use.",

--- a/connectors/agentic-ai/connector-agentic-ai/element-templates/versioned/agenticai-aiagent-job-worker-7.json
+++ b/connectors/agentic-ai/connector-agentic-ai/element-templates/versioned/agenticai-aiagent-job-worker-7.json
@@ -98,6 +98,13 @@
     "value" : "={\n  id: toolCall._meta.id,\n  name: toolCall._meta.name,\n  content: toolCallResult\n}",
     "type" : "Hidden"
   }, {
+    "value" : "true",
+    "binding" : {
+      "name" : "io.camunda.agenticai.toolContainer",
+      "type" : "zeebe:property"
+    },
+    "type" : "Hidden"
+  }, {
     "id" : "provider.type",
     "label" : "Provider",
     "description" : "Specify the LLM provider to use.",


### PR DESCRIPTION
## Description

Adds the `io.camunda.agenticai.toolContainer` `zeebe:property` extension property to the AI Agent **Sub-process** (ad-hoc sub-process) element templates. The AI Agent Task (service task) flavor is not itself a tool container and does not carry this marker.

Applied to:
- The current (latest) job-worker template, plus its hybrid variant.
- All previously released `versioned/` job-worker template revisions, so the property is available regardless of which template version a process was modeled with.

Verified manually via `c8ctl element-template apply` against all outbound-connector (Task) and job-worker (Sub-process) templates — current, hybrid, and every versioned revision. Task templates apply without error and correctly omit the property; Sub-process templates apply without error and correctly include it.

## Related issues

closes #7882

## Checklist

- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest
  release, as this branch will be rebased onto main before the next release. Example backport labels:
    - `backport stable/8.8`: for changes that should be included in the next 8.8.x release.
    - **or** `backport release-8.8.7`: for changes that should be included in the specific release 8.8.7, and this
      *release has already been created*. The release branch will be merged back into stable/8.8 later, so the change
      will be included in future 8.8.x releases as well.
- [ ] Tests/Integration tests for the changes have been added if applicable.
- [ ] If the change requires a documentation update, it has been added to the appropriate section in the documentation.