### PR TITLE
fix(agentic-ai): reuse existing agent instance on 409 conflict

### DIFF
--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/agentinstance/CamundaAgentInstanceClient.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/agentinstance/CamundaAgentInstanceClient.java
@@ -15,6 +15,7 @@ import io.camunda.client.api.command.AgentInstanceHistoryContent;
 import io.camunda.client.api.command.AgentInstanceHistoryMetrics;
 import io.camunda.client.api.command.AgentInstanceHistoryToolCall;
 import io.camunda.client.api.command.CreateAgentHistoryItemCommandStep1.CreateAgentHistoryItemFinalCommandStep;
+import io.camunda.client.api.command.ProblemException;
 import io.camunda.client.api.command.UpdateAgentInstanceCommandStep1.UpdateAgentInstanceCommandStep2;
 import io.camunda.client.api.search.enums.AgentInstanceHistoryRole;
 import io.camunda.connector.agenticai.aiagent.model.AgentConversationTurn;
@@ -31,6 +32,7 @@ import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.regex.Pattern;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -38,6 +40,25 @@ import org.slf4j.LoggerFactory;
 public class CamundaAgentInstanceClient implements AgentInstanceClient {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(CamundaAgentInstanceClient.class);
+
+  private static final int HTTP_STATUS_CONFLICT = 409;
+
+  /**
+   * Matches the {@code detail} message of a {@code 409 ALREADY_EXISTS} response from {@code POST
+   * /agent-instances}, capturing the existing agent instance key.
+   *
+   * <p>The engine's {@code AgentInstanceCreateProcessor} documents this message as a stable
+   * contract: callers may parse it to extract the existing agent instance key, and wording changes
+   * that alter the position of the embedded keys are a breaking contract change that must be kept
+   * in sync with this pattern. The whole message is matched (not just a fragment), so an
+   * unparseable or unexpectedly worded detail fails to match rather than risking extraction of the
+   * wrong number.
+   */
+  private static final Pattern ALREADY_EXISTS_DETAIL_PATTERN =
+      Pattern.compile(
+          "Command 'CREATE' rejected with code 'ALREADY_EXISTS': Expected to associate element "
+              + "instance with key '\\d+' with an agent instance, but it is already associated "
+              + "with agent instance with key '(?<existingAgentInstanceKey>\\d+)'\\.");
 
   private final CamundaClient camundaClient;
   private final RetriesProperties retriesProperties;
@@ -90,10 +111,54 @@ public class CamundaAgentInstanceClient implements AgentInstanceClient {
     if (limits != null && limits.maxModelCalls() != null) {
       command = command.maxModelCalls(limits.maxModelCalls());
     }
-    final var key = AgentInstanceKey.of(command.execute().getAgentInstanceKey());
-    LOGGER.debug(
-        "Created agent instance {} for element instance {}", key.value(), elementInstanceKey);
-    return key;
+
+    try {
+      final var key = AgentInstanceKey.of(command.execute().getAgentInstanceKey());
+      LOGGER.debug(
+          "Created agent instance {} for element instance {}", key.value(), elementInstanceKey);
+      return key;
+    } catch (ProblemException e) {
+      if (e.code() == HTTP_STATUS_CONFLICT) {
+        return handleAgentInstanceCreationConflict(elementInstanceKey, e);
+      }
+      throw e;
+    }
+  }
+
+  /**
+   * Handles a {@code 409 ALREADY_EXISTS} response from a create attempt by falling back to the
+   * existing agent instance key embedded in the response {@code detail} message (there is no other
+   * way to recover it from this response). If the detail cannot be parsed, the conflict cannot be
+   * resolved and is raised as a failure instead of silently dropping the agent instance link.
+   */
+  private AgentInstanceKey handleAgentInstanceCreationConflict(
+      long elementInstanceKey, ProblemException e) {
+    final String detail = e.details().getDetail();
+    return parseExistingAgentInstanceKey(detail)
+        .map(
+            existingAgentInstanceKey -> {
+              LOGGER.debug(
+                  "Agent instance creation conflicted for element instance {}, reusing existing agent instance {}",
+                  elementInstanceKey,
+                  existingAgentInstanceKey);
+              return AgentInstanceKey.of(existingAgentInstanceKey);
+            })
+        .orElseThrow(
+            () ->
+                new IllegalStateException(
+                    "Agent instance creation for element instance %d conflicted (%d ALREADY_EXISTS), but the existing agent instance key could not be parsed from the response detail: %s"
+                        .formatted(elementInstanceKey, HTTP_STATUS_CONFLICT, detail),
+                    e));
+  }
+
+  private Optional<Long> parseExistingAgentInstanceKey(@Nullable String detail) {
+    if (detail == null) {
+      return Optional.empty();
+    }
+    final var matcher = ALREADY_EXISTS_DETAIL_PATTERN.matcher(detail);
+    return matcher.matches()
+        ? Optional.of(Long.parseLong(matcher.group("existingAgentInstanceKey")))
+        : Optional.empty();
   }
 
   @Override

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/agentinstance/CamundaAgentInstanceClientTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/agentinstance/CamundaAgentInstanceClientTest.java
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import io.camunda.client.CamundaClient;
+import io.camunda.client.api.ProblemDetail;
 import io.camunda.client.api.command.AgentInstanceHistoryContent;
 import io.camunda.client.api.command.AgentInstanceHistoryMetrics;
 import io.camunda.client.api.command.AgentInstanceHistoryToolCall;
@@ -29,6 +30,7 @@ import io.camunda.client.api.command.AgentInstanceUpdateStatus;
 import io.camunda.client.api.command.ClientHttpException;
 import io.camunda.client.api.command.CreateAgentInstanceCommandStep1;
 import io.camunda.client.api.command.CreateAgentInstanceCommandStep1.CreateAgentInstanceCommandStep5;
+import io.camunda.client.api.command.ProblemException;
 import io.camunda.client.api.command.UpdateAgentInstanceCommandStep1;
 import io.camunda.client.api.command.UpdateAgentInstanceCommandStep1.AgentTool;
 import io.camunda.client.api.command.UpdateAgentInstanceCommandStep1.UpdateAgentInstanceCommandStep2;
@@ -69,10 +71,14 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Answers;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
@@ -255,6 +261,65 @@ class CamundaAgentInstanceClientTest {
               Duration.ofSeconds(4),
               Duration.ofSeconds(8));
       verify(camundaClient, times(5)).newCreateAgentInstanceCommand();
+    }
+
+    @Test
+    void shouldReturnExistingAgentInstanceKeyOnConflictWithParseableDetail() {
+      // given: a 409 ALREADY_EXISTS response whose detail embeds the existing agent instance key
+      givenCreateCommandWithMaxModelCalls();
+      final var detail =
+          "Command 'CREATE' rejected with code 'ALREADY_EXISTS': Expected to associate element "
+              + "instance with key '77' with an agent instance, but it is already associated with "
+              + "agent instance with key '999'.";
+      when(step5.execute()).thenThrow(conflictException(detail));
+
+      // when
+      final AgentInstanceKey key = client.create(TestAgentExecutionContext.withLimits());
+
+      // then: the existing key is reused, no retry
+      assertThat(key).isEqualTo(AgentInstanceKey.of(999L));
+      assertThat(recordedSleeps).isEmpty();
+      verify(camundaClient, times(1)).newCreateAgentInstanceCommand();
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(
+        strings = {
+          // unrelated wording
+          "Some unrelated conflict message.",
+          // whole message must match, not just a fragment -- extra text before/after an
+          // otherwise well-formed detail must not be accepted
+          "extra prefix Command 'CREATE' rejected with code 'ALREADY_EXISTS': Expected to "
+              + "associate element instance with key '77' with an agent instance, but it is "
+              + "already associated with agent instance with key '999'. extra suffix",
+          // well-worded detail whose embedded key isn't numeric
+          "Command 'CREATE' rejected with code 'ALREADY_EXISTS': Expected to associate element "
+              + "instance with key '77' with an agent instance, but it is already associated "
+              + "with agent instance with key 'abc'."
+        })
+    void shouldThrowConnectorExceptionImmediatelyOnUnparseableConflictDetail(
+        @Nullable String detail) {
+      // given: a 409 ALREADY_EXISTS response whose detail doesn't match the expected contract
+      givenCreateCommandWithMaxModelCalls();
+      when(step5.execute()).thenThrow(conflictException(detail));
+
+      // when / then: the conflict cannot be resolved, so it fails permanently, no retry
+      assertThatThrownBy(() -> client.create(TestAgentExecutionContext.withLimits()))
+          .isInstanceOfSatisfying(
+              ConnectorException.class,
+              e ->
+                  assertThat(e.getErrorCode())
+                      .isEqualTo(ERROR_CODE_AGENT_INSTANCE_CREATION_FAILED));
+
+      assertThat(recordedSleeps).isEmpty();
+      verify(camundaClient, times(1)).newCreateAgentInstanceCommand();
+    }
+
+    private ProblemException conflictException(@Nullable String detail) {
+      final var problemDetail =
+          new ProblemDetail().setStatus(409).setTitle("ALREADY_EXISTS").setDetail(detail);
+      return new ProblemException(409, "Conflict", problemDetail);
     }
   }
 


### PR DESCRIPTION
## Description

Creating an agent instance for an element instance that already has one now returns `409 ALREADY_EXISTS` (camunda/camunda#57575) instead of an idempotent `200`. This handles that response by parsing the existing agent instance key out of the `detail` message of the `ProblemException` and reusing it, so the AI Agent falls back to the already-existing instance instead of failing.

The whole `detail` message is matched against the engine's documented contract (not just a fragment), so an unexpectedly worded or unparseable detail raises an error instead of risking extraction of the wrong key. All other errors (400, 404, 429, 5xx, etc.) keep their existing classification and retry behavior — unchanged by this PR.

No e2e test is included: the real `409` behavior isn't available until camunda/camunda#57956 (the engine-side change) merges. Unit tests cover the parsing contract (well-formed, unrelated wording, partial match, non-numeric key, null/empty detail) and the classifier/retry interaction (no retries on conflict, single attempt).

## Related issues

closes #7932

## Checklist

- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest
  release, as this branch will be rebased onto main before the next release. Example backport labels:
    - `backport stable/8.8`: for changes that should be included in the next 8.8.x release.
    - **or** `backport release-8.8.7`: for changes that should be included in the specific release 8.8.7, and this
      *release has already been created*. The release branch will be merged back into stable/8.8 later, so the change
      will be included in future 8.8.x releases as well.
- [x] Tests/Integration tests for the changes have been added if applicable.
- [ ] If the change requires a documentation update, it has been added to the appropriate section in the documentation.