### PR TITLE
test(sagemaker): pin result JSON shapes as golden fixtures

### DIFF
--- a/connectors/aws/aws-sagemaker/src/test/java/io/camunda/connector/sagemaker/caller/SageMakerAsyncCallerTest.java
+++ b/connectors/aws/aws-sagemaker/src/test/java/io/camunda/connector/sagemaker/caller/SageMakerAsyncCallerTest.java
@@ -13,13 +13,19 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.amazonaws.ResponseMetadata;
 import com.amazonaws.services.sagemakerruntime.AmazonSageMakerRuntimeAsync;
 import com.amazonaws.services.sagemakerruntime.model.InvokeEndpointAsyncRequest;
 import com.amazonaws.services.sagemakerruntime.model.InvokeEndpointAsyncResult;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.connector.api.error.ConnectorException;
 import io.camunda.connector.aws.ObjectMapperSupplier;
+import io.camunda.connector.jackson.ConnectorsObjectMapperSupplier;
+import io.camunda.connector.sagemaker.model.SageMakerAsyncResponse;
 import io.camunda.connector.sagemaker.model.SageMakerRequest;
+import java.util.Map;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -68,5 +74,64 @@ class SageMakerAsyncCallerTest {
         .thenThrow(new RuntimeException("Something went terribly wrong!"));
     Assertions.assertThrows(
         ConnectorException.class, () -> SageMakerAsyncCaller.ASYNC_CALLER.apply(runtime, request));
+  }
+
+  /**
+   * Golden-JSON shape test: the connector result, serialized with the real connectors {@link
+   * ObjectMapper}, must reproduce the JSON shape the async invocation path documented and returned
+   * before the AWS SDK v2 migration. This is the template for verifying result serialization across
+   * the v2 migration effort for aws-sagemaker: build a realistic AWS SDK v1 {@link
+   * InvokeEndpointAsyncResult} (as a live InvokeEndpointAsync call would populate it), map it
+   * through the real caller, serialize with the production mapper, and diff the full JSON tree
+   * against the frozen expectation.
+   */
+  @Test
+  public void invokeEndpointAsyncResult_serializesToDocumentedV1JsonShape()
+      throws JsonProcessingException {
+    // Given a fully populated InvokeEndpointAsyncResult, as returned by a live
+    // InvokeEndpointAsync call: output/failure S3 locations and the inference id.
+    var runtime = mock(AmazonSageMakerRuntimeAsync.class);
+    var mockedAwsCall = new InvokeEndpointAsyncResult();
+    mockedAwsCall.setOutputLocation("s3://result-bucket/result-object");
+    mockedAwsCall.setFailureLocation("s3://result-bucket/failures-object");
+    mockedAwsCall.setInferenceId("inference01");
+    // A live call also populates request/HTTP metadata inherited from AmazonWebServiceResult; set
+    // it here for realism even though the assertion below shows it never reaches the connector
+    // result.
+    mockedAwsCall.setSdkResponseMetadata(
+        new ResponseMetadata(
+            Map.of(ResponseMetadata.AWS_REQUEST_ID, "929bf054-193b-48e6-ab80-3aeeb613b415")));
+    when(runtime.invokeEndpointAsync(any(InvokeEndpointAsyncRequest.class)))
+        .thenReturn(mockedAwsCall);
+    var request =
+        ObjectMapperSupplier.getMapperInstance()
+            .readValue(ASYNC_EXECUTION_JSON, SageMakerRequest.class);
+
+    // When the connector maps it through the real caller
+    Object mapped = SageMakerAsyncCaller.ASYNC_CALLER.apply(runtime, request);
+
+    assertThat(mapped).isInstanceOf(SageMakerAsyncResponse.class);
+    ObjectMapper productionMapper = ConnectorsObjectMapperSupplier.getCopy();
+    JsonNode actual = productionMapper.valueToTree(mapped);
+
+    // Then the JSON matches the pre-v2 (SDK v1) async-invocation output shape exactly.
+    // sdkResponseMetadata/sdkHttpMetadata are ABSENT: SageMakerAsyncResponse only maps
+    // outputLocation/failureLocation/inferenceId, so any AWS request/HTTP metadata the SDK result
+    // carries (populated above) is silently dropped today -- intentional v1 behavior being pinned
+    // for the migration.
+    String expectedJson =
+        """
+        {
+          "outputLocation": "s3://result-bucket/result-object",
+          "failureLocation": "s3://result-bucket/failures-object",
+          "inferenceId": "inference01"
+        }
+        """;
+    JsonNode expected = productionMapper.readTree(expectedJson);
+    assertThat(actual).isEqualTo(expected);
+    // Tree equality above is key-order-insensitive; also pin the serialized field order to the
+    // documented v1 layout.
+    assertThat(productionMapper.writeValueAsString(mapped))
+        .isEqualTo(productionMapper.writeValueAsString(expected));
   }
 }

--- a/connectors/aws/aws-sagemaker/src/test/java/io/camunda/connector/sagemaker/caller/SageMakerAsyncCallerTest.java
+++ b/connectors/aws/aws-sagemaker/src/test/java/io/camunda/connector/sagemaker/caller/SageMakerAsyncCallerTest.java
@@ -14,6 +14,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.amazonaws.ResponseMetadata;
+import com.amazonaws.http.SdkHttpMetadata;
 import com.amazonaws.services.sagemakerruntime.AmazonSageMakerRuntimeAsync;
 import com.amazonaws.services.sagemakerruntime.model.InvokeEndpointAsyncRequest;
 import com.amazonaws.services.sagemakerruntime.model.InvokeEndpointAsyncResult;
@@ -96,11 +97,15 @@ class SageMakerAsyncCallerTest {
     mockedAwsCall.setFailureLocation("s3://result-bucket/failures-object");
     mockedAwsCall.setInferenceId("inference01");
     // A live call also populates request/HTTP metadata inherited from AmazonWebServiceResult; set
-    // it here for realism even though the assertion below shows it never reaches the connector
+    // both here for realism even though the assertion below shows neither reaches the connector
     // result.
     mockedAwsCall.setSdkResponseMetadata(
         new ResponseMetadata(
             Map.of(ResponseMetadata.AWS_REQUEST_ID, "929bf054-193b-48e6-ab80-3aeeb613b415")));
+    var sdkHttpMetadata = mock(SdkHttpMetadata.class);
+    when(sdkHttpMetadata.getHttpStatusCode()).thenReturn(200);
+    when(sdkHttpMetadata.getHttpHeaders()).thenReturn(Map.of("Content-Type", "application/json"));
+    mockedAwsCall.setSdkHttpMetadata(sdkHttpMetadata);
     when(runtime.invokeEndpointAsync(any(InvokeEndpointAsyncRequest.class)))
         .thenReturn(mockedAwsCall);
     var request =

--- a/connectors/aws/aws-sagemaker/src/test/java/io/camunda/connector/sagemaker/caller/SageMakerSyncCallerTest.java
+++ b/connectors/aws/aws-sagemaker/src/test/java/io/camunda/connector/sagemaker/caller/SageMakerSyncCallerTest.java
@@ -13,14 +13,21 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.amazonaws.ResponseMetadata;
 import com.amazonaws.services.sagemakerruntime.AmazonSageMakerRuntime;
 import com.amazonaws.services.sagemakerruntime.model.InvokeEndpointRequest;
 import com.amazonaws.services.sagemakerruntime.model.InvokeEndpointResult;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.connector.api.error.ConnectorException;
 import io.camunda.connector.aws.ObjectMapperSupplier;
+import io.camunda.connector.jackson.ConnectorsObjectMapperSupplier;
 import io.camunda.connector.sagemaker.model.SageMakerRequest;
+import io.camunda.connector.sagemaker.model.SageMakerSyncResponse;
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -78,5 +85,145 @@ class SageMakerSyncCallerTest {
         .thenThrow(new RuntimeException("Something went terribly wrong!"));
     Assertions.assertThrows(
         ConnectorException.class, () -> SageMakerSyncCaller.SYNC_REQUEST.apply(runtime, request));
+  }
+
+  /**
+   * Golden-JSON shape test: the connector result, serialized with the real connectors {@link
+   * ObjectMapper}, must reproduce the JSON shape the sync (real-time) invocation path documented
+   * and returned before the AWS SDK v2 migration. This is the template for verifying result
+   * serialization across the v2 migration effort for aws-sagemaker: build a realistic AWS SDK v1
+   * {@link InvokeEndpointResult} (as a live InvokeEndpoint call would populate it), map it through
+   * the real caller, serialize with the production mapper, and diff the full JSON tree against the
+   * frozen expectation.
+   */
+  @Test
+  public void invokeEndpointResult_jsonBody_serializesToDocumentedV1JsonShape()
+      throws JsonProcessingException {
+    // Given a fully populated InvokeEndpointResult with a JSON inference payload, as returned by a
+    // live InvokeEndpoint call against an "application/json" endpoint.
+    var runtime = mock(AmazonSageMakerRuntime.class);
+    var mockedAwsCall = new InvokeEndpointResult();
+    String jsonBody =
+        """
+        {"predictions":[{"label":"POSITIVE","score":0.9821},{"label":"NEGATIVE","score":0.0179}],"modelId":"text-classification-v3"}""";
+    mockedAwsCall.setBody(ByteBuffer.wrap(jsonBody.getBytes(StandardCharsets.UTF_8)));
+    mockedAwsCall.setContentType("application/json");
+    mockedAwsCall.setCustomAttributes("tenant-id=42;request-source=order-service");
+    mockedAwsCall.setInvokedProductionVariant("AllTraffic");
+    // A live call also populates request/HTTP metadata inherited from AmazonWebServiceResult; set
+    // it here for realism even though the assertion below shows it never reaches the connector
+    // result.
+    mockedAwsCall.setSdkResponseMetadata(
+        new ResponseMetadata(
+            Map.of(ResponseMetadata.AWS_REQUEST_ID, "929bf054-193b-48e6-ab80-3aeeb613b415")));
+    when(runtime.invokeEndpoint(any(InvokeEndpointRequest.class))).thenReturn(mockedAwsCall);
+    var request =
+        ObjectMapperSupplier.getMapperInstance()
+            .readValue(REAL_TIME_EXECUTION_JSON, SageMakerRequest.class);
+
+    // When the connector maps it through the real caller
+    Object mapped = SageMakerSyncCaller.SYNC_REQUEST.apply(runtime, request);
+
+    assertThat(mapped).isInstanceOf(SageMakerSyncResponse.class);
+    ObjectMapper productionMapper = ConnectorsObjectMapperSupplier.getCopy();
+    JsonNode actual = productionMapper.valueToTree(mapped);
+
+    // Then the JSON matches the pre-v2 (SDK v1) sync-invocation output shape exactly: an
+    // "application/json" body is parsed into a JSON object (not left as a string / base64) --
+    // intentional v1 behavior being pinned for the migration. Also note sdkResponseMetadata /
+    // sdkHttpMetadata are ABSENT: SageMakerSyncResponse only maps
+    // body/contentType/customAttributes/invokedProductionVariant, so any AWS request/HTTP
+    // metadata the SDK result carries (populated above) is silently dropped today.
+    String expectedJson =
+        """
+        {
+          "body": {
+            "predictions": [
+              {"label": "POSITIVE", "score": 0.9821},
+              {"label": "NEGATIVE", "score": 0.0179}
+            ],
+            "modelId": "text-classification-v3"
+          },
+          "contentType": "application/json",
+          "customAttributes": "tenant-id=42;request-source=order-service",
+          "invokedProductionVariant": "AllTraffic"
+        }
+        """;
+    JsonNode expected = productionMapper.readTree(expectedJson);
+    assertThat(actual).isEqualTo(expected);
+    // Tree equality above is key-order-insensitive; also pin the serialized field order to the
+    // documented v1 layout.
+    assertThat(productionMapper.writeValueAsString(mapped))
+        .isEqualTo(productionMapper.writeValueAsString(expected));
+  }
+
+  /**
+   * Edge-case golden-JSON test: when the response content type is not "application/json",
+   * mapResponseBody does not attempt to parse the body at all -- it just UTF-8-decodes the raw
+   * bytes into a plain string. Pin that distinction so the v2 migration doesn't accidentally start
+   * parsing (or base64-encoding) non-JSON payloads.
+   */
+  @Test
+  public void invokeEndpointResult_nonJsonBody_serializesAsPlainStringNotParsed()
+      throws JsonProcessingException {
+    // Given a live InvokeEndpoint call against a non-JSON ("text/plain") endpoint.
+    var runtime = mock(AmazonSageMakerRuntime.class);
+    var mockedAwsCall = new InvokeEndpointResult();
+    String textBody = "prediction: positive (0.98)";
+    mockedAwsCall.setBody(ByteBuffer.wrap(textBody.getBytes(StandardCharsets.UTF_8)));
+    mockedAwsCall.setContentType("text/plain");
+    mockedAwsCall.setInvokedProductionVariant("AllTraffic");
+    // customAttributes intentionally left unset -- the production mapper must serialize it as
+    // an explicit null below (unset bean property, FAIL_ON_EMPTY_BEANS disabled).
+    when(runtime.invokeEndpoint(any(InvokeEndpointRequest.class))).thenReturn(mockedAwsCall);
+    var request =
+        ObjectMapperSupplier.getMapperInstance()
+            .readValue(REAL_TIME_EXECUTION_JSON, SageMakerRequest.class);
+
+    Object mapped = SageMakerSyncCaller.SYNC_REQUEST.apply(runtime, request);
+
+    ObjectMapper productionMapper = ConnectorsObjectMapperSupplier.getCopy();
+    JsonNode actual = productionMapper.valueToTree(mapped);
+    String expectedJson =
+        """
+        {
+          "body": "prediction: positive (0.98)",
+          "contentType": "text/plain",
+          "customAttributes": null,
+          "invokedProductionVariant": "AllTraffic"
+        }
+        """;
+    JsonNode expected = productionMapper.readTree(expectedJson);
+    assertThat(actual).isEqualTo(expected);
+    assertThat(productionMapper.writeValueAsString(mapped))
+        .isEqualTo(productionMapper.writeValueAsString(expected));
+  }
+
+  /**
+   * Edge-case regression guard: an "application/json" response with an EMPTY body cannot be parsed
+   * as JSON. Today that surfaces as a {@link ConnectorException} wrapping the read failure (the
+   * caller's catch-all wraps the {@link RuntimeException} thrown while constructing {@link
+   * SageMakerSyncResponse}) rather than an empty/null result. This is intentional (if surprising)
+   * v1 behavior being pinned for the migration: a non-JSON empty body would NOT throw (see {@link
+   * #invokeEndpointResult_nonJsonBody_serializesAsPlainStringNotParsed}), so the mapping does
+   * distinguish "empty" from "non-JSON".
+   */
+  @Test
+  public void invokeEndpointResult_emptyBodyWithJsonContentType_throwsConnectorException()
+      throws JsonProcessingException {
+    var runtime = mock(AmazonSageMakerRuntime.class);
+    var mockedAwsCall = new InvokeEndpointResult();
+    mockedAwsCall.setBody(ByteBuffer.wrap(new byte[0]));
+    mockedAwsCall.setContentType("application/json");
+    when(runtime.invokeEndpoint(any(InvokeEndpointRequest.class))).thenReturn(mockedAwsCall);
+    var request =
+        ObjectMapperSupplier.getMapperInstance()
+            .readValue(REAL_TIME_EXECUTION_JSON, SageMakerRequest.class);
+
+    ConnectorException thrown =
+        Assertions.assertThrows(
+            ConnectorException.class,
+            () -> SageMakerSyncCaller.SYNC_REQUEST.apply(runtime, request));
+    assertThat(thrown.getCause()).hasMessageContaining("Error reading Sagemaker response.");
   }
 }

--- a/connectors/aws/aws-sagemaker/src/test/java/io/camunda/connector/sagemaker/caller/SageMakerSyncCallerTest.java
+++ b/connectors/aws/aws-sagemaker/src/test/java/io/camunda/connector/sagemaker/caller/SageMakerSyncCallerTest.java
@@ -14,6 +14,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.amazonaws.ResponseMetadata;
+import com.amazonaws.http.SdkHttpMetadata;
 import com.amazonaws.services.sagemakerruntime.AmazonSageMakerRuntime;
 import com.amazonaws.services.sagemakerruntime.model.InvokeEndpointRequest;
 import com.amazonaws.services.sagemakerruntime.model.InvokeEndpointResult;
@@ -111,11 +112,15 @@ class SageMakerSyncCallerTest {
     mockedAwsCall.setCustomAttributes("tenant-id=42;request-source=order-service");
     mockedAwsCall.setInvokedProductionVariant("AllTraffic");
     // A live call also populates request/HTTP metadata inherited from AmazonWebServiceResult; set
-    // it here for realism even though the assertion below shows it never reaches the connector
+    // both here for realism even though the assertion below shows neither reaches the connector
     // result.
     mockedAwsCall.setSdkResponseMetadata(
         new ResponseMetadata(
             Map.of(ResponseMetadata.AWS_REQUEST_ID, "929bf054-193b-48e6-ab80-3aeeb613b415")));
+    var sdkHttpMetadata = mock(SdkHttpMetadata.class);
+    when(sdkHttpMetadata.getHttpStatusCode()).thenReturn(200);
+    when(sdkHttpMetadata.getHttpHeaders()).thenReturn(Map.of("Content-Type", "application/json"));
+    mockedAwsCall.setSdkHttpMetadata(sdkHttpMetadata);
     when(runtime.invokeEndpoint(any(InvokeEndpointRequest.class))).thenReturn(mockedAwsCall);
     var request =
         ObjectMapperSupplier.getMapperInstance()
@@ -174,7 +179,8 @@ class SageMakerSyncCallerTest {
     mockedAwsCall.setContentType("text/plain");
     mockedAwsCall.setInvokedProductionVariant("AllTraffic");
     // customAttributes intentionally left unset -- the production mapper must serialize it as
-    // an explicit null below (unset bean property, FAIL_ON_EMPTY_BEANS disabled).
+    // an explicit null below: the mapper's default inclusion policy serializes null record
+    // components rather than omitting them (no NON_NULL/NON_ABSENT inclusion is configured).
     when(runtime.invokeEndpoint(any(InvokeEndpointRequest.class))).thenReturn(mockedAwsCall);
     var request =
         ObjectMapperSupplier.getMapperInstance()


### PR DESCRIPTION
## Description

Part of #7968 (AWS v1 -> v2 SDK migration): adds golden-JSON result-shape
fixture tests for the **aws-sagemaker** connector, pinning the exact JSON
the connector writes to process variables **today** (AWS SDK v1), so the
upcoming v2 migration can be verified against unchanged expectations.
Test-only change: no production code, element-template, or version changes.

Unlike the other v1 AWS connectors, `aws-sagemaker` already wraps its raw
SDK results in connector-owned records (`SageMakerSyncResponse` /
`SageMakerAsyncResponse`), so the top-level shape was already code-pinned —
but no existing test inspected the actual result *contents*, and in
particular the sync path's mapping of `InvokeEndpointResult`'s
`java.nio.ByteBuffer` body was completely untested. Investigated it
empirically and pinned what it actually does:

- an `"application/json"` body is parsed into a real JSON object/array
  (not left as a string, not base64-encoded)
- any other content type is UTF-8-decoded into a plain string, unparsed
- an empty body combined with `"application/json"` content type throws a
  `ConnectorException` wrapping the JSON-read failure, rather than
  producing an empty/null result — a real (if surprising) v1 quirk, now
  pinned as a regression guard
- `sdkResponseMetadata` / `sdkHttpMetadata` (inherited from
  `AmazonWebServiceResult`, which a live SDK v1 call does populate) are
  silently dropped by both response records today, since they only map
  their own explicit fields — documented in code comments so the v2
  migration doesn't accidentally start emitting them

Each test drives the real mapping path (`SageMakerSyncCaller.SYNC_REQUEST`
/ `SageMakerAsyncCaller.ASYNC_CALLER` against a mocked AWS SDK v1 runtime,
exactly as the existing caller tests do), serializes the result with the
production `ObjectMapper` (`ConnectorsObjectMapperSupplier`), and asserts
both `JsonNode` tree equality against a frozen expected-JSON text block
(key-order-insensitive) and exact `writeValueAsString` string equality
(pins field order), including explicit-`null` fields.

New tests added:
- `SageMakerSyncCallerTest#invokeEndpointResult_jsonBody_serializesToDocumentedV1JsonShape`
  — realistic JSON inference body, contentType, customAttributes,
  invokedProductionVariant
- `SageMakerSyncCallerTest#invokeEndpointResult_nonJsonBody_serializesAsPlainStringNotParsed`
  — edge case: non-JSON content type keeps the body as a plain string
- `SageMakerSyncCallerTest#invokeEndpointResult_emptyBodyWithJsonContentType_throwsConnectorException`
  — edge case: empty body + JSON content type throws
- `SageMakerAsyncCallerTest#invokeEndpointAsyncResult_serializesToDocumentedV1JsonShape`
  — outputLocation, failureLocation, inferenceId

## Related issues

Part of #7968

## Checklist

- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest
  release, as this branch will be rebased onto main before the next release. Example backport labels:
    - `backport stable/8.8`: for changes that should be included in the next 8.8.x release.
    - **or** `backport release-8.8.7`: for changes that should be included in the specific release 8.8.7, and this
      *release has already been created*. The release branch will be merged back into stable/8.8 later, so the change
      will be included in future 8.8.x releases as well.
- [x] Tests/Integration tests for the changes have been added if applicable.
- [ ] If the change requires a documentation update, it has been added to the appropriate section in the documentation.

Not applicable: this PR targets main/8.10 only, and adds test-only coverage with no documentation impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)