### PR TITLE
fix: improve error handling for interrupted job evaluation

### DIFF
--- a/connector-runtime/connector-feel/src/main/java/io/camunda/connector/feel/FeelEngineWrapperException.java
+++ b/connector-runtime/connector-feel/src/main/java/io/camunda/connector/feel/FeelEngineWrapperException.java
@@ -16,6 +16,8 @@
  */
 package io.camunda.connector.feel;
 
+import java.util.Arrays;
+
 /** Exception class indicating issues in a {@link LocalFeelExpressionEvaluator} call */
 public class FeelEngineWrapperException extends RuntimeException {
 
@@ -36,10 +38,16 @@ public class FeelEngineWrapperException extends RuntimeException {
     super(
         String.format(
             "Failed to evaluate expression '%s' in context '%s'. Reason: %s",
-            expression, context, reason),
+            expression, formatContext(context), reason),
         throwable);
     this.reason = reason;
     this.expression = expression;
+  }
+
+  private static String formatContext(final Object context) {
+    final String formatted =
+        context instanceof Object[] array ? Arrays.deepToString(array) : String.valueOf(context);
+    return formatted.length() > 2000 ? formatted.substring(0, 2000) + "...(truncated)" : formatted;
   }
 
   public String getReason() {

--- a/connector-runtime/connector-feel/src/main/java/io/camunda/connector/feel/LocalFeelExpressionEvaluator.java
+++ b/connector-runtime/connector-feel/src/main/java/io/camunda/connector/feel/LocalFeelExpressionEvaluator.java
@@ -126,7 +126,7 @@ public class LocalFeelExpressionEvaluator implements FeelExpressionEvaluator {
     try {
       return (T) evaluateInternal(expression, variables);
     } catch (Exception e) {
-      throw new FeelEngineWrapperException(e.getMessage(), expression, variables, e);
+      throw wrapEvaluationException(e, expression, variables);
     }
   }
 
@@ -187,8 +187,29 @@ public class LocalFeelExpressionEvaluator implements FeelExpressionEvaluator {
         return resultToJson(result);
       } else return null;
     } catch (Exception e) {
-      throw new FeelEngineWrapperException(e.getMessage(), expression, variables, e);
+      throw wrapEvaluationException(e, expression, variables);
     }
+  }
+
+  /**
+   * feel-engine's cooperative cancellation ({@code FeelInterpreter.eval}) checks {@code
+   * Thread.interrupted()} on every AST node and throws a bare, message-less {@link
+   * InterruptedException} when the job-handling thread was interrupted (e.g. runtime shutdown while
+   * a job was in flight). Wrapping it like any other evaluation failure produces a misleading
+   * "Reason: null" incident, so it is special-cased here with a clear reason and the thread's
+   * interrupt status is restored for callers further up the stack to observe.
+   */
+  private static FeelEngineWrapperException wrapEvaluationException(
+      final Exception e, final String expression, final Object[] variables) {
+    if (e instanceof InterruptedException) {
+      Thread.currentThread().interrupt();
+      return new FeelEngineWrapperException(
+          "the evaluating thread was interrupted, likely because the connector runtime is shutting down",
+          expression,
+          variables,
+          e);
+    }
+    return new FeelEngineWrapperException(e.getMessage(), expression, variables, e);
   }
 
   private Object evaluateInternal(final String expression, final Object[] variables) {

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/SpringConnectorJobHandler.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/SpringConnectorJobHandler.java
@@ -240,6 +240,24 @@ public class SpringConnectorJobHandler implements JobHandler {
           error -> handleBPMNError(client, job, error, counterMetricsContext),
           () -> handleSuccessResult(client, job, finalResult, counterMetricsContext));
     } catch (Exception ex) {
+      if (Thread.currentThread().isInterrupted()) {
+        // the job-handling thread was interrupted (e.g. runtime shutdown) while evaluating the
+        // error expression; leave the job alone rather than raising an incident so Zeebe's
+        // activation timeout reassigns it, same as if the worker had been killed outright.
+        // NOTE: the connector call preceding this evaluation has already run to completion, so
+        // reassignment will re-invoke the connector from scratch - any non-idempotent side effect
+        // (HTTP call, message send, LLM call, etc.) it performed may be executed a second time.
+        LOGGER.error(
+            "Job {} for tenant {} was interrupted while evaluating its error expression, likely "
+                + "because the runtime is shutting down; abandoning the job so Zeebe's activation "
+                + "timeout reassigns it. WARNING: the connector call for this job already ran to "
+                + "completion before the interrupt was noticed, so reassignment will re-execute it "
+                + "- verify the connector's side effects are idempotent before relying on this",
+            job.getKey(),
+            job.getTenantId(),
+            ex);
+        return;
+      }
       failJob(
           client,
           job,

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/job/SpringConnectorJobHandlerTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/job/SpringConnectorJobHandlerTest.java
@@ -30,6 +30,7 @@ import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import io.camunda.client.api.command.FailJobCommandStep1;
@@ -1403,6 +1404,36 @@ class SpringConnectorJobHandlerTest {
       assertThat(result.getErrorCode()).isNull();
       assertThat(result.getErrorMessage()).isNull();
       assertThat(result.getVariables()).isNull();
+    }
+
+    @Test
+    void shouldAbandonJob_WhenThreadInterruptedDuringErrorExpressionEvaluation() throws Exception {
+      // given: the job-handling thread was interrupted (e.g. runtime shutdown via
+      // JobWorkerExecutors.close()) right before error expression evaluation gets a chance to
+      // observe it - mirroring a downstream connector call that returned after being interrupted
+      var errorExpression = "if error != null then bpmnError(error.code, error.message) else null";
+      var jobHandler =
+          newConnectorJobHandler(
+              context -> {
+                throw new ConnectorException("1013", "exception message");
+              });
+      var jobClient = mock(JobClient.class);
+
+      // when
+      Thread.currentThread().interrupt();
+      try {
+        JobBuilder.create()
+            .withErrorExpressionHeader(errorExpression)
+            .useJobClient(jobClient)
+            .execute(jobHandler);
+      } finally {
+        // clear any leftover interrupt status so it doesn't leak into other tests
+        Thread.interrupted();
+      }
+
+      // then: no incident is raised - the job is abandoned so Zeebe's activation timeout
+      // reassigns it, instead of failing with a misleading "Reason: null" error
+      verifyNoInteractions(jobClient);
     }
   }
 


### PR DESCRIPTION
# BACKPORT

This pull request introduces improved handling for thread interruptions during FEEL expression evaluation, especially in scenarios where the connector runtime is shutting down. It ensures that jobs are abandoned (not failed) when interrupted, preventing misleading incidents and allowing for correct reassignment by Zeebe. The changes also add context formatting for error messages and extend test coverage for these cases.

**Error Handling Improvements**
* Added a special case in `LocalFeelExpressionEvaluator` to detect `InterruptedException` during FEEL evaluation, restoring the thread's interrupt status and providing a clear error reason, instead of a generic or null message.
* Updated `FeelEngineWrapperException` to format the context more readably and truncate overly long contexts in error messages. [[1]](diffhunk://#diff-5bf0b180aeecd491b34c92ab0bdda755622d3d3915e08572dc80f8de431af497R19-R20) [[2]](diffhunk://#diff-5bf0b180aeecd491b34c92ab0bdda755622d3d3915e08572dc80f8de431af497L39-R52)

**Job Handling Logic**
* Modified `SpringConnectorJobHandler` so that if the thread is interrupted during error expression evaluation, the job is abandoned (i.e., not failed or retried), allowing Zeebe's activation timeout to handle reassignment. This avoids misleading error incidents and warns about possible non-idempotent side effects.

**Test Coverage**
* Added a test to verify that when the thread is interrupted during error expression evaluation, the job client is not interacted with, confirming that the job is properly abandoned.
* Included `verifyNoInteractions` in test imports to support the new test.