### PR TITLE
feat(csv): add document input and response format dropdowns

### DIFF
--- a/connector-runtime/connector-runtime-test/src/main/java/io/camunda/connector/runtime/test/outbound/OutboundConnectorContextBuilder.java
+++ b/connector-runtime/connector-runtime-test/src/main/java/io/camunda/connector/runtime/test/outbound/OutboundConnectorContextBuilder.java
@@ -18,11 +18,15 @@ package io.camunda.connector.runtime.test.outbound;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.connector.api.document.Document;
 import io.camunda.connector.api.document.DocumentCreationRequest;
 import io.camunda.connector.api.document.DocumentFactory;
 import io.camunda.connector.api.document.DocumentReference;
+import io.camunda.connector.api.document.DocumentReturnChoice;
+import io.camunda.connector.api.document.DocumentReturnFormat;
+import io.camunda.connector.api.error.ConnectorInputException;
 import io.camunda.connector.api.outbound.JobContext;
 import io.camunda.connector.api.outbound.OutboundConnectorContext;
 import io.camunda.connector.api.secret.SecretProvider;
@@ -42,6 +46,7 @@ import io.camunda.connector.test.ConnectorContextTestUtil;
 import io.camunda.connector.test.MapSecretProvider;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 
 /** Test helper class for creating a {@link OutboundConnectorContext} with a fluent API. */
 public class OutboundConnectorContextBuilder {
@@ -241,6 +246,29 @@ public class OutboundConnectorContextBuilder {
     @Override
     public JobContext getJobContext() {
       return jobContext;
+    }
+
+    @Override
+    public Optional<DocumentReturnFormat> readDocumentReturnFormat() {
+      Object rawFormat = variables == null ? null : variables.get("documentReturnFormat");
+      if (rawFormat == null) {
+        return Optional.empty();
+      }
+      JsonNode formatNode = objectMapper.valueToTree(rawFormat);
+      String choiceText = formatNode.path("choice").asText(null);
+      if (choiceText == null || choiceText.isBlank()) {
+        return Optional.empty();
+      }
+      try {
+        return Optional.of(
+            new DocumentReturnFormat(
+                DocumentReturnChoice.valueOf(choiceText),
+                formatNode.path("encoding").asText(null)));
+      } catch (IllegalArgumentException e) {
+        throw new ConnectorInputException(
+            "documentReturnFormat.choice must be one of DOCUMENT, TEXT, JSON. Got: " + choiceText,
+            e);
+      }
     }
 
     @Override

--- a/connectors/csv/element-templates/csv-outbound-connector.json
+++ b/connectors/csv/element-templates/csv-outbound-connector.json
@@ -420,7 +420,7 @@
   }, {
     "id" : "writeCsv:documentReturnFormat",
     "label" : "Response format",
-    "value" : "DOCUMENT",
+    "value" : "TEXT",
     "group" : "operation",
     "binding" : {
       "name" : "documentReturnFormat.choice",

--- a/connectors/csv/element-templates/hybrid/csv-outbound-connector-hybrid.json
+++ b/connectors/csv/element-templates/hybrid/csv-outbound-connector-hybrid.json
@@ -4,7 +4,7 @@
   "id" : "io.camunda.connectors.csv-hybrid",
   "description" : "Read or write CSV documents — parse a CSV into structured records or render rows back into CSV.",
   "keywords" : [ "read CSV", "write CSV", "parse CSV", "export CSV", "import CSV", "tabular data", "data export", "spreadsheet" ],
-  "version" : 2,
+  "version" : 3,
   "category" : {
     "id" : "connectors",
     "name" : "Connectors"
@@ -14,7 +14,7 @@
     "value" : "bpmn:ServiceTask"
   },
   "engines" : {
-    "camunda" : "^8.8"
+    "camunda" : "^8.10"
   },
   "groups" : [ {
     "id" : "taskDefinitionType",
@@ -63,13 +63,12 @@
       "value" : "writeCsv"
     } ]
   }, {
-    "id" : "readCsv:data",
-    "label" : "Data",
-    "optional" : false,
-    "feel" : "optional",
+    "id" : "readCsv:document_documentSource",
+    "label" : "Document source",
+    "value" : "camunda",
     "group" : "operation",
     "binding" : {
-      "name" : "data",
+      "name" : "document_documentSource",
       "type" : "zeebe:input"
     },
     "condition" : {
@@ -79,8 +78,169 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "CSV as a document or text",
+    "tooltip" : "The CSV document to read.",
+    "type" : "Dropdown",
+    "choices" : [ {
+      "name" : "Camunda Document",
+      "value" : "camunda"
+    }, {
+      "name" : "Inline Content",
+      "value" : "inline"
+    }, {
+      "name" : "From URL",
+      "value" : "external"
+    } ]
+  }, {
+    "id" : "readCsv:document_camundaReference",
+    "label" : "Camunda document",
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "required",
+    "group" : "operation",
+    "binding" : {
+      "name" : "document_camundaReference",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "allMatch" : [ {
+        "property" : "operation",
+        "equals" : "readCsv",
+        "type" : "simple"
+      }, {
+        "property" : "readCsv:document_documentSource",
+        "equals" : "camunda",
+        "type" : "simple"
+      } ]
+    },
     "type" : "String"
+  }, {
+    "id" : "readCsv:document_inline_content",
+    "label" : "Content",
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "operation",
+    "binding" : {
+      "name" : "document_inline_content",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "allMatch" : [ {
+        "property" : "operation",
+        "equals" : "readCsv",
+        "type" : "simple"
+      }, {
+        "property" : "readCsv:document_documentSource",
+        "equals" : "inline",
+        "type" : "simple"
+      } ]
+    },
+    "type" : "String"
+  }, {
+    "id" : "readCsv:document_inline_fileName",
+    "label" : "File name",
+    "feel" : "optional",
+    "group" : "operation",
+    "binding" : {
+      "name" : "document_inline_fileName",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "allMatch" : [ {
+        "property" : "operation",
+        "equals" : "readCsv",
+        "type" : "simple"
+      }, {
+        "property" : "readCsv:document_documentSource",
+        "equals" : "inline",
+        "type" : "simple"
+      } ]
+    },
+    "type" : "String"
+  }, {
+    "id" : "readCsv:document_inline_contentType",
+    "label" : "Content type",
+    "feel" : "optional",
+    "group" : "operation",
+    "binding" : {
+      "name" : "document_inline_contentType",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "allMatch" : [ {
+        "property" : "operation",
+        "equals" : "readCsv",
+        "type" : "simple"
+      }, {
+        "property" : "readCsv:document_documentSource",
+        "equals" : "inline",
+        "type" : "simple"
+      } ]
+    },
+    "type" : "String"
+  }, {
+    "id" : "readCsv:document_external_url",
+    "label" : "URL",
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "operation",
+    "binding" : {
+      "name" : "document_external_url",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "allMatch" : [ {
+        "property" : "operation",
+        "equals" : "readCsv",
+        "type" : "simple"
+      }, {
+        "property" : "readCsv:document_documentSource",
+        "equals" : "external",
+        "type" : "simple"
+      } ]
+    },
+    "type" : "String"
+  }, {
+    "id" : "readCsv:document_external_fileName",
+    "label" : "File name",
+    "feel" : "optional",
+    "group" : "operation",
+    "binding" : {
+      "name" : "document_external_fileName",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "allMatch" : [ {
+        "property" : "operation",
+        "equals" : "readCsv",
+        "type" : "simple"
+      }, {
+        "property" : "readCsv:document_documentSource",
+        "equals" : "external",
+        "type" : "simple"
+      } ]
+    },
+    "type" : "String"
+  }, {
+    "id" : "readCsv:document",
+    "value" : "=if document_documentSource = \"camunda\" then document_camundaReference else if document_documentSource = \"inline\" then { \"camunda.document.type\": \"inline\", content: document_inline_content, name: document_inline_fileName, contentType: document_inline_contentType } else if document_documentSource = \"external\" then { \"camunda.document.type\": \"external\", url: document_external_url, name: document_external_fileName } else null",
+    "group" : "operation",
+    "binding" : {
+      "name" : "document",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "allMatch" : [ {
+        "property" : "operation",
+        "equals" : "readCsv",
+        "type" : "simple"
+      } ]
+    },
+    "type" : "Hidden"
   }, {
     "id" : "readCsv:format.delimiter",
     "label" : "Delimiter",
@@ -204,22 +364,6 @@
     },
     "type" : "String"
   }, {
-    "id" : "writeCsv:createDocument",
-    "label" : "Create document",
-    "group" : "operation",
-    "binding" : {
-      "name" : "createDocument",
-      "type" : "zeebe:input"
-    },
-    "condition" : {
-      "allMatch" : [ {
-        "property" : "operation",
-        "equals" : "writeCsv",
-        "type" : "simple"
-      } ]
-    },
-    "type" : "Boolean"
-  }, {
     "id" : "writeCsv:format.delimiter",
     "label" : "Delimiter",
     "optional" : false,
@@ -279,10 +423,58 @@
     "tooltip" : "Mapping of the columns if not included in the CSV itself in the first row.",
     "type" : "String"
   }, {
+    "id" : "writeCsv:documentReturnFormat",
+    "label" : "Response format",
+    "value" : "DOCUMENT",
+    "group" : "operation",
+    "binding" : {
+      "name" : "documentReturnFormat.choice",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "allMatch" : [ {
+        "property" : "operation",
+        "equals" : "writeCsv",
+        "type" : "simple"
+      } ]
+    },
+    "tooltip" : "How the rendered CSV should be returned. Document reference uploads it to the document store; as text returns the CSV inline as a String.",
+    "type" : "Dropdown",
+    "choices" : [ {
+      "name" : "Document reference",
+      "value" : "DOCUMENT"
+    }, {
+      "name" : "as text",
+      "value" : "TEXT"
+    } ]
+  }, {
+    "id" : "writeCsv:documentReturnFormatEncoding",
+    "label" : "Encoding",
+    "description" : "Character set used to decode the response. Default UTF-8.",
+    "value" : "UTF-8",
+    "feel" : "optional",
+    "group" : "operation",
+    "binding" : {
+      "name" : "documentReturnFormat.encoding",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "allMatch" : [ {
+        "property" : "operation",
+        "equals" : "writeCsv",
+        "type" : "simple"
+      }, {
+        "property" : "writeCsv:documentReturnFormat",
+        "equals" : "TEXT",
+        "type" : "simple"
+      } ]
+    },
+    "type" : "String"
+  }, {
     "id" : "version",
     "label" : "Version",
     "description" : "Version of the element template",
-    "value" : "2",
+    "value" : "3",
     "group" : "connector",
     "binding" : {
       "key" : "elementTemplateVersion",

--- a/connectors/csv/element-templates/hybrid/csv-outbound-connector-hybrid.json
+++ b/connectors/csv/element-templates/hybrid/csv-outbound-connector-hybrid.json
@@ -425,7 +425,7 @@
   }, {
     "id" : "writeCsv:documentReturnFormat",
     "label" : "Response format",
-    "value" : "DOCUMENT",
+    "value" : "TEXT",
     "group" : "operation",
     "binding" : {
       "name" : "documentReturnFormat.choice",

--- a/connectors/csv/element-templates/versioned/csv-outbound-connector-2.json
+++ b/connectors/csv/element-templates/versioned/csv-outbound-connector-2.json
@@ -4,7 +4,7 @@
   "id" : "io.camunda.connectors.csv",
   "description" : "Read or write CSV documents — parse a CSV into structured records or render rows back into CSV.",
   "keywords" : [ "read CSV", "write CSV", "parse CSV", "export CSV", "import CSV", "tabular data", "data export", "spreadsheet" ],
-  "version" : 3,
+  "version" : 2,
   "category" : {
     "id" : "connectors",
     "name" : "Connectors"
@@ -14,7 +14,7 @@
     "value" : "bpmn:ServiceTask"
   },
   "engines" : {
-    "camunda" : "^8.10"
+    "camunda" : "^8.8"
   },
   "groups" : [ {
     "id" : "operation",
@@ -58,67 +58,13 @@
       "value" : "writeCsv"
     } ]
   }, {
-    "id" : "readCsv:document_documentSource",
-    "label" : "Document source",
-    "value" : "camunda",
-    "group" : "operation",
-    "binding" : {
-      "name" : "document_documentSource",
-      "type" : "zeebe:input"
-    },
-    "condition" : {
-      "allMatch" : [ {
-        "property" : "operation",
-        "equals" : "readCsv",
-        "type" : "simple"
-      } ]
-    },
-    "tooltip" : "The CSV document to read.",
-    "type" : "Dropdown",
-    "choices" : [ {
-      "name" : "Camunda Document",
-      "value" : "camunda"
-    }, {
-      "name" : "Inline Content",
-      "value" : "inline"
-    }, {
-      "name" : "From URL",
-      "value" : "external"
-    } ]
-  }, {
-    "id" : "readCsv:document_camundaReference",
-    "label" : "Camunda document",
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "feel" : "required",
-    "group" : "operation",
-    "binding" : {
-      "name" : "document_camundaReference",
-      "type" : "zeebe:input"
-    },
-    "condition" : {
-      "allMatch" : [ {
-        "property" : "operation",
-        "equals" : "readCsv",
-        "type" : "simple"
-      }, {
-        "property" : "readCsv:document_documentSource",
-        "equals" : "camunda",
-        "type" : "simple"
-      } ]
-    },
-    "type" : "String"
-  }, {
-    "id" : "readCsv:document_inline_content",
-    "label" : "Content",
-    "constraints" : {
-      "notEmpty" : true
-    },
+    "id" : "readCsv:data",
+    "label" : "Data",
+    "optional" : false,
     "feel" : "optional",
     "group" : "operation",
     "binding" : {
-      "name" : "document_inline_content",
+      "name" : "data",
       "type" : "zeebe:input"
     },
     "condition" : {
@@ -126,116 +72,10 @@
         "property" : "operation",
         "equals" : "readCsv",
         "type" : "simple"
-      }, {
-        "property" : "readCsv:document_documentSource",
-        "equals" : "inline",
-        "type" : "simple"
       } ]
     },
+    "tooltip" : "CSV as a document or text",
     "type" : "String"
-  }, {
-    "id" : "readCsv:document_inline_fileName",
-    "label" : "File name",
-    "feel" : "optional",
-    "group" : "operation",
-    "binding" : {
-      "name" : "document_inline_fileName",
-      "type" : "zeebe:input"
-    },
-    "condition" : {
-      "allMatch" : [ {
-        "property" : "operation",
-        "equals" : "readCsv",
-        "type" : "simple"
-      }, {
-        "property" : "readCsv:document_documentSource",
-        "equals" : "inline",
-        "type" : "simple"
-      } ]
-    },
-    "type" : "String"
-  }, {
-    "id" : "readCsv:document_inline_contentType",
-    "label" : "Content type",
-    "feel" : "optional",
-    "group" : "operation",
-    "binding" : {
-      "name" : "document_inline_contentType",
-      "type" : "zeebe:input"
-    },
-    "condition" : {
-      "allMatch" : [ {
-        "property" : "operation",
-        "equals" : "readCsv",
-        "type" : "simple"
-      }, {
-        "property" : "readCsv:document_documentSource",
-        "equals" : "inline",
-        "type" : "simple"
-      } ]
-    },
-    "type" : "String"
-  }, {
-    "id" : "readCsv:document_external_url",
-    "label" : "URL",
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "feel" : "optional",
-    "group" : "operation",
-    "binding" : {
-      "name" : "document_external_url",
-      "type" : "zeebe:input"
-    },
-    "condition" : {
-      "allMatch" : [ {
-        "property" : "operation",
-        "equals" : "readCsv",
-        "type" : "simple"
-      }, {
-        "property" : "readCsv:document_documentSource",
-        "equals" : "external",
-        "type" : "simple"
-      } ]
-    },
-    "type" : "String"
-  }, {
-    "id" : "readCsv:document_external_fileName",
-    "label" : "File name",
-    "feel" : "optional",
-    "group" : "operation",
-    "binding" : {
-      "name" : "document_external_fileName",
-      "type" : "zeebe:input"
-    },
-    "condition" : {
-      "allMatch" : [ {
-        "property" : "operation",
-        "equals" : "readCsv",
-        "type" : "simple"
-      }, {
-        "property" : "readCsv:document_documentSource",
-        "equals" : "external",
-        "type" : "simple"
-      } ]
-    },
-    "type" : "String"
-  }, {
-    "id" : "readCsv:document",
-    "value" : "=if document_documentSource = \"camunda\" then document_camundaReference else if document_documentSource = \"inline\" then { \"camunda.document.type\": \"inline\", content: document_inline_content, name: document_inline_fileName, contentType: document_inline_contentType } else if document_documentSource = \"external\" then { \"camunda.document.type\": \"external\", url: document_external_url, name: document_external_fileName } else null",
-    "group" : "operation",
-    "binding" : {
-      "name" : "document",
-      "type" : "zeebe:input"
-    },
-    "condition" : {
-      "allMatch" : [ {
-        "property" : "operation",
-        "equals" : "readCsv",
-        "type" : "simple"
-      } ]
-    },
-    "type" : "Hidden"
   }, {
     "id" : "readCsv:format.delimiter",
     "label" : "Delimiter",
@@ -359,6 +199,22 @@
     },
     "type" : "String"
   }, {
+    "id" : "writeCsv:createDocument",
+    "label" : "Create document",
+    "group" : "operation",
+    "binding" : {
+      "name" : "createDocument",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "allMatch" : [ {
+        "property" : "operation",
+        "equals" : "writeCsv",
+        "type" : "simple"
+      } ]
+    },
+    "type" : "Boolean"
+  }, {
     "id" : "writeCsv:format.delimiter",
     "label" : "Delimiter",
     "optional" : false,
@@ -418,58 +274,10 @@
     "tooltip" : "Mapping of the columns if not included in the CSV itself in the first row.",
     "type" : "String"
   }, {
-    "id" : "writeCsv:documentReturnFormat",
-    "label" : "Response format",
-    "value" : "DOCUMENT",
-    "group" : "operation",
-    "binding" : {
-      "name" : "documentReturnFormat.choice",
-      "type" : "zeebe:input"
-    },
-    "condition" : {
-      "allMatch" : [ {
-        "property" : "operation",
-        "equals" : "writeCsv",
-        "type" : "simple"
-      } ]
-    },
-    "tooltip" : "How the rendered CSV should be returned. Document reference uploads it to the document store; as text returns the CSV inline as a String.",
-    "type" : "Dropdown",
-    "choices" : [ {
-      "name" : "Document reference",
-      "value" : "DOCUMENT"
-    }, {
-      "name" : "as text",
-      "value" : "TEXT"
-    } ]
-  }, {
-    "id" : "writeCsv:documentReturnFormatEncoding",
-    "label" : "Encoding",
-    "description" : "Character set used to decode the response. Default UTF-8.",
-    "value" : "UTF-8",
-    "feel" : "optional",
-    "group" : "operation",
-    "binding" : {
-      "name" : "documentReturnFormat.encoding",
-      "type" : "zeebe:input"
-    },
-    "condition" : {
-      "allMatch" : [ {
-        "property" : "operation",
-        "equals" : "writeCsv",
-        "type" : "simple"
-      }, {
-        "property" : "writeCsv:documentReturnFormat",
-        "equals" : "TEXT",
-        "type" : "simple"
-      } ]
-    },
-    "type" : "String"
-  }, {
     "id" : "version",
     "label" : "Version",
     "description" : "Version of the element template",
-    "value" : "3",
+    "value" : "2",
     "group" : "connector",
     "binding" : {
       "key" : "elementTemplateVersion",

--- a/connectors/csv/src/main/java/io/camunda/connector/csv/CsvConnector.java
+++ b/connectors/csv/src/main/java/io/camunda/connector/csv/CsvConnector.java
@@ -15,6 +15,8 @@ import io.camunda.connector.api.annotation.OutboundConnector;
 import io.camunda.connector.api.annotation.Variable;
 import io.camunda.connector.api.document.Document;
 import io.camunda.connector.api.document.DocumentCreationRequest;
+import io.camunda.connector.api.document.DocumentReturn;
+import io.camunda.connector.api.error.ConnectorInputException;
 import io.camunda.connector.api.outbound.OutboundConnectorContext;
 import io.camunda.connector.api.outbound.OutboundConnectorProvider;
 import io.camunda.connector.csv.model.*;
@@ -22,10 +24,12 @@ import io.camunda.connector.csv.model.ReadCsvRequest.RowType;
 import io.camunda.connector.generator.java.annotation.ElementTemplate;
 import io.camunda.connector.generator.java.annotation.FeelMode;
 import io.camunda.connector.generator.java.annotation.TemplateProperty;
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.io.StringReader;
+import java.io.Reader;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
@@ -37,8 +41,8 @@ import java.util.function.Function;
     id = "io.camunda.connectors.csv",
     description =
         "Read or write CSV documents — parse a CSV into structured records or render rows back into CSV.",
-    version = 2,
-    engineVersion = "^8.8",
+    version = 3,
+    engineVersion = "^8.10",
     keywords = {
       "read CSV",
       "write CSV",
@@ -67,17 +71,27 @@ public class CsvConnector implements OutboundConnectorProvider {
               feel = FeelMode.required)
           Function<Map<String, Object>, Object> mapper) {
     var rowType = Optional.ofNullable(request.rowType()).orElse(RowType.Object);
+    try (InputStream in = openStream(request);
+        Reader reader = new InputStreamReader(in, StandardCharsets.UTF_8)) {
+      return readCsvRequest(reader, request.format(), rowType, mapper);
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  /**
+   * Resolves the CSV byte source, preferring the new (element-template v3) {@code document} input
+   * and falling back to the legacy {@code data} variable (element-template <= 2), which may hold
+   * raw CSV text or a document reference. The returned stream is owned and closed by the caller.
+   */
+  private static InputStream openStream(ReadCsvRequest request) {
+    if (request.document() != null) {
+      return request.document().asInputStream();
+    }
     return switch (request.data()) {
-      case String csv -> readCsvRequest(new StringReader(csv), request.format(), rowType, mapper);
-      case Document csv -> {
-        try (InputStream csvInputStream = csv.asInputStream()) {
-          try (InputStreamReader reader = new InputStreamReader(csvInputStream)) {
-            yield readCsvRequest(reader, request.format(), rowType, mapper);
-          }
-        } catch (IOException e) {
-          throw new RuntimeException(e);
-        }
-      }
+      case String csv -> new ByteArrayInputStream(csv.getBytes(StandardCharsets.UTF_8));
+      case Document doc -> doc.asInputStream();
+      case null -> throw new ConnectorInputException("No CSV data provided");
       default ->
           throw new IllegalArgumentException(
               "Unsupported CSV data type: " + request.data().getClass().getSimpleName());
@@ -91,6 +105,23 @@ public class CsvConnector implements OutboundConnectorProvider {
       keywords = {"write csv", "export csv", "generate csv"})
   public Object writeCsv(@Variable WriteCsvRequest request, OutboundConnectorContext context) {
     var csv = createCsv(request.data(), request.format());
+    // New flow (element-template version >= 3): the runtime converts the payload according to the
+    // user's response-format dropdown choice, read from the job variables.
+    if (context.readDocumentReturnFormat().isPresent()) {
+      return DocumentReturn.of(
+          csv.getBytes(StandardCharsets.UTF_8),
+          "text/csv",
+          "result.csv",
+          (converted, choice) ->
+              switch (choice) {
+                case DOCUMENT -> new WriteCsvResult.Document((Document) converted);
+                case TEXT -> new WriteCsvResult.Value((String) converted);
+                case JSON ->
+                    throw new IllegalStateException(
+                        "JSON response format is not supported for CSV output");
+              });
+    }
+    // Legacy flow (element-template version <= 2): the createDocument boolean drives the output.
     if (request.createDocument()) {
       var documentCreationRequest =
           DocumentCreationRequest.from(csv.getBytes()).contentType("text/csv").build();

--- a/connectors/csv/src/main/java/io/camunda/connector/csv/CsvConnector.java
+++ b/connectors/csv/src/main/java/io/camunda/connector/csv/CsvConnector.java
@@ -76,7 +76,7 @@ public class CsvConnector implements OutboundConnectorProvider {
     try (InputStream in = openStream(request);
         Reader reader = new InputStreamReader(in, StandardCharsets.UTF_8)) {
       return readCsvRequest(reader, request.format(), rowType, mapper);
-    } catch (ConnectorException e) {
+    } catch (ConnectorException | ConnectorInputException e) {
       throw e;
     } catch (IOException e) {
       throw readRetryException(e);

--- a/connectors/csv/src/main/java/io/camunda/connector/csv/CsvConnector.java
+++ b/connectors/csv/src/main/java/io/camunda/connector/csv/CsvConnector.java
@@ -127,13 +127,11 @@ public class CsvConnector implements OutboundConnectorProvider {
   public Object writeCsv(@Variable WriteCsvRequest request, OutboundConnectorContext context) {
     var csv = createCsv(request.data(), request.format());
     return context.readDocumentReturnFormat().isPresent()
-        ? newFlow(csv)
-        : oldFlow(csv, request, context);
+        ? writeWithResponseFormat(csv)
+        : writeWithCreateDocumentFlag(csv, request, context);
   }
 
-  // New flow (element-template version >= 3): the runtime converts the payload per the user's
-  // response-format dropdown choice.
-  private static DocumentReturn<WriteCsvResult> newFlow(String csv) {
+  private static DocumentReturn<WriteCsvResult> writeWithResponseFormat(String csv) {
     return DocumentReturn.of(
         csv.getBytes(StandardCharsets.UTF_8),
         "text/csv",
@@ -148,8 +146,7 @@ public class CsvConnector implements OutboundConnectorProvider {
             });
   }
 
-  // Legacy flow (element-template version <= 2): the createDocument boolean drives the output.
-  private static WriteCsvResult oldFlow(
+  private static WriteCsvResult writeWithCreateDocumentFlag(
       String csv, WriteCsvRequest request, OutboundConnectorContext context) {
     if (request.createDocument()) {
       var documentCreationRequest =

--- a/connectors/csv/src/main/java/io/camunda/connector/csv/CsvConnector.java
+++ b/connectors/csv/src/main/java/io/camunda/connector/csv/CsvConnector.java
@@ -16,7 +16,9 @@ import io.camunda.connector.api.annotation.Variable;
 import io.camunda.connector.api.document.Document;
 import io.camunda.connector.api.document.DocumentCreationRequest;
 import io.camunda.connector.api.document.DocumentReturn;
+import io.camunda.connector.api.error.ConnectorException;
 import io.camunda.connector.api.error.ConnectorInputException;
+import io.camunda.connector.api.error.ConnectorRetryException;
 import io.camunda.connector.api.outbound.OutboundConnectorContext;
 import io.camunda.connector.api.outbound.OutboundConnectorProvider;
 import io.camunda.connector.csv.model.*;
@@ -75,15 +77,13 @@ public class CsvConnector implements OutboundConnectorProvider {
         Reader reader = new InputStreamReader(in, StandardCharsets.UTF_8)) {
       return readCsvRequest(reader, request.format(), rowType, mapper);
     } catch (IOException e) {
-      throw new RuntimeException(e);
+      throw ConnectorRetryException.builder()
+          .message("Failed to read CSV input: " + e.getMessage())
+          .cause(e)
+          .build();
     }
   }
 
-  /**
-   * Resolves the CSV byte source, preferring the new (element-template v3) {@code document} input
-   * and falling back to the legacy {@code data} variable (element-template <= 2), which may hold
-   * raw CSV text or a document reference. The returned stream is owned and closed by the caller.
-   */
   private static InputStream openStream(ReadCsvRequest request) {
     if (request.document() != null) {
       return request.document().asInputStream();
@@ -93,7 +93,7 @@ public class CsvConnector implements OutboundConnectorProvider {
       case Document doc -> doc.asInputStream();
       case null -> throw new ConnectorInputException("No CSV data provided");
       default ->
-          throw new IllegalArgumentException(
+          throw new ConnectorInputException(
               "Unsupported CSV data type: " + request.data().getClass().getSimpleName());
     };
   }
@@ -105,8 +105,6 @@ public class CsvConnector implements OutboundConnectorProvider {
       keywords = {"write csv", "export csv", "generate csv"})
   public Object writeCsv(@Variable WriteCsvRequest request, OutboundConnectorContext context) {
     var csv = createCsv(request.data(), request.format());
-    // New flow (element-template version >= 3): the runtime converts the payload according to the
-    // user's response-format dropdown choice, read from the job variables.
     if (context.readDocumentReturnFormat().isPresent()) {
       return DocumentReturn.of(
           csv.getBytes(StandardCharsets.UTF_8),
@@ -117,7 +115,7 @@ public class CsvConnector implements OutboundConnectorProvider {
                 case DOCUMENT -> new WriteCsvResult.Document((Document) converted);
                 case TEXT -> new WriteCsvResult.Value((String) converted);
                 case JSON ->
-                    throw new IllegalStateException(
+                    throw new ConnectorException(
                         "JSON response format is not supported for CSV output");
               });
     }

--- a/connectors/csv/src/main/java/io/camunda/connector/csv/CsvConnector.java
+++ b/connectors/csv/src/main/java/io/camunda/connector/csv/CsvConnector.java
@@ -31,6 +31,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
+import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.Optional;
@@ -76,33 +77,12 @@ public class CsvConnector implements OutboundConnectorProvider {
     try (InputStream in = openStream(request);
         Reader reader = new InputStreamReader(in, StandardCharsets.UTF_8)) {
       return readCsvRequest(reader, request.format(), rowType, mapper);
-    } catch (ConnectorException | ConnectorInputException e) {
-      throw e;
-    } catch (IOException e) {
-      throw readRetryException(e);
-    } catch (RuntimeException e) {
-      // CsvUtils wraps read failures as RuntimeException; retry only on an I/O root cause, else it
-      // is malformed input.
-      throw isCausedByIo(e)
-          ? readRetryException(e)
-          : new ConnectorInputException("Error reading CSV data", e);
+    } catch (IOException | UncheckedIOException e) {
+      throw ConnectorRetryException.builder()
+          .message("Failed to read CSV input: " + e.getMessage())
+          .cause(e)
+          .build();
     }
-  }
-
-  private static boolean isCausedByIo(Throwable e) {
-    for (Throwable t = e; t != null; t = t.getCause()) {
-      if (t instanceof IOException) {
-        return true;
-      }
-    }
-    return false;
-  }
-
-  private static ConnectorRetryException readRetryException(Throwable e) {
-    return ConnectorRetryException.builder()
-        .message("Failed to read CSV input: " + e.getMessage())
-        .cause(e)
-        .build();
   }
 
   private static InputStream openStream(ReadCsvRequest request) {

--- a/connectors/csv/src/main/java/io/camunda/connector/csv/CsvConnector.java
+++ b/connectors/csv/src/main/java/io/camunda/connector/csv/CsvConnector.java
@@ -76,12 +76,33 @@ public class CsvConnector implements OutboundConnectorProvider {
     try (InputStream in = openStream(request);
         Reader reader = new InputStreamReader(in, StandardCharsets.UTF_8)) {
       return readCsvRequest(reader, request.format(), rowType, mapper);
+    } catch (ConnectorException e) {
+      throw e;
     } catch (IOException e) {
-      throw ConnectorRetryException.builder()
-          .message("Failed to read CSV input: " + e.getMessage())
-          .cause(e)
-          .build();
+      throw readRetryException(e);
+    } catch (RuntimeException e) {
+      // CsvUtils wraps read failures as RuntimeException; retry only on an I/O root cause, else it
+      // is malformed input.
+      throw isCausedByIo(e)
+          ? readRetryException(e)
+          : new ConnectorInputException("Error reading CSV data", e);
     }
+  }
+
+  private static boolean isCausedByIo(Throwable e) {
+    for (Throwable t = e; t != null; t = t.getCause()) {
+      if (t instanceof IOException) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static ConnectorRetryException readRetryException(Throwable e) {
+    return ConnectorRetryException.builder()
+        .message("Failed to read CSV input: " + e.getMessage())
+        .cause(e)
+        .build();
   }
 
   private static InputStream openStream(ReadCsvRequest request) {

--- a/connectors/csv/src/main/java/io/camunda/connector/csv/CsvConnector.java
+++ b/connectors/csv/src/main/java/io/camunda/connector/csv/CsvConnector.java
@@ -126,28 +126,37 @@ public class CsvConnector implements OutboundConnectorProvider {
       keywords = {"write csv", "export csv", "generate csv"})
   public Object writeCsv(@Variable WriteCsvRequest request, OutboundConnectorContext context) {
     var csv = createCsv(request.data(), request.format());
-    if (context.readDocumentReturnFormat().isPresent()) {
-      return DocumentReturn.of(
-          csv.getBytes(StandardCharsets.UTF_8),
-          "text/csv",
-          "result.csv",
-          (converted, choice) ->
-              switch (choice) {
-                case DOCUMENT -> new WriteCsvResult.Document((Document) converted);
-                case TEXT -> new WriteCsvResult.Value((String) converted);
-                case JSON ->
-                    throw new ConnectorException(
-                        "JSON response format is not supported for CSV output");
-              });
-    }
-    // Legacy flow (element-template version <= 2): the createDocument boolean drives the output.
+    return context.readDocumentReturnFormat().isPresent()
+        ? newFlow(csv)
+        : oldFlow(csv, request, context);
+  }
+
+  // New flow (element-template version >= 3): the runtime converts the payload per the user's
+  // response-format dropdown choice.
+  private static DocumentReturn<WriteCsvResult> newFlow(String csv) {
+    return DocumentReturn.of(
+        csv.getBytes(StandardCharsets.UTF_8),
+        "text/csv",
+        "result.csv",
+        (converted, choice) ->
+            switch (choice) {
+              case DOCUMENT -> new WriteCsvResult.Document((Document) converted);
+              case TEXT -> new WriteCsvResult.Value((String) converted);
+              case JSON ->
+                  throw new ConnectorException(
+                      "JSON response format is not supported for CSV output");
+            });
+  }
+
+  // Legacy flow (element-template version <= 2): the createDocument boolean drives the output.
+  private static WriteCsvResult oldFlow(
+      String csv, WriteCsvRequest request, OutboundConnectorContext context) {
     if (request.createDocument()) {
       var documentCreationRequest =
           DocumentCreationRequest.from(csv.getBytes()).contentType("text/csv").build();
       var document = context.create(documentCreationRequest);
       return new WriteCsvResult.Document(document);
-    } else {
-      return new WriteCsvResult.Value(csv);
     }
+    return new WriteCsvResult.Value(csv);
   }
 }

--- a/connectors/csv/src/main/java/io/camunda/connector/csv/CsvUtils.java
+++ b/connectors/csv/src/main/java/io/camunda/connector/csv/CsvUtils.java
@@ -27,19 +27,16 @@ public class CsvUtils {
       Reader csvReader,
       CsvFormat format,
       ReadCsvRequest.RowType rowType,
-      Function<Map<String, Object>, Object> mapper) {
-    try {
-      var csvFormat = CsvUtils.buildFrom(format, rowType);
-      var csvParser = csvFormat.parse(csvReader);
-      return new ReadCsvResult(
-          csvParser.stream()
-              .map(record -> mapToRowType(record, rowType))
-              .map(row -> mapRecord(row, mapper))
-              .filter(Objects::nonNull)
-              .toList());
-    } catch (Throwable e) {
-      throw new RuntimeException("Error reading CSV data", e);
-    }
+      Function<Map<String, Object>, Object> mapper)
+      throws IOException {
+    var csvFormat = CsvUtils.buildFrom(format, rowType);
+    var csvParser = csvFormat.parse(csvReader);
+    return new ReadCsvResult(
+        csvParser.stream()
+            .map(record -> mapToRowType(record, rowType))
+            .map(row -> mapRecord(row, mapper))
+            .filter(Objects::nonNull)
+            .toList());
   }
 
   private static Object mapToRowType(CSVRecord record, ReadCsvRequest.RowType rowType) {

--- a/connectors/csv/src/main/java/io/camunda/connector/csv/model/ReadCsvRequest.java
+++ b/connectors/csv/src/main/java/io/camunda/connector/csv/model/ReadCsvRequest.java
@@ -6,15 +6,20 @@
  */
 package io.camunda.connector.csv.model;
 
-import io.camunda.connector.generator.java.annotation.FeelMode;
+import io.camunda.connector.api.document.Document;
+import io.camunda.connector.generator.java.annotation.TemplateDocumentProperty;
 import io.camunda.connector.generator.java.annotation.TemplateProperty;
 
 public record ReadCsvRequest(
-    @TemplateProperty(
-            label = "Data",
-            tooltip = "CSV as a document or text",
-            feel = FeelMode.optional)
-        Object data,
+    // Legacy input from element-template versions <= 2: raw CSV text or a document reference bound
+    // directly to `data`. Kept (but hidden) so old templates and already-running instances keep
+    // working under the new runtime. Superseded by the `document` input below.
+    @TemplateProperty(ignore = true) Object data,
+    @TemplateDocumentProperty(
+            id = "document",
+            binding = @TemplateProperty.PropertyBinding(name = "document"),
+            tooltip = "The CSV document to read.")
+        Document document,
     CsvFormat format,
     @TemplateProperty(
             label = "Row Type",

--- a/connectors/csv/src/main/java/io/camunda/connector/csv/model/ReadCsvRequest.java
+++ b/connectors/csv/src/main/java/io/camunda/connector/csv/model/ReadCsvRequest.java
@@ -11,9 +11,6 @@ import io.camunda.connector.generator.java.annotation.TemplateDocumentProperty;
 import io.camunda.connector.generator.java.annotation.TemplateProperty;
 
 public record ReadCsvRequest(
-    // Legacy input from element-template versions <= 2: raw CSV text or a document reference bound
-    // directly to `data`. Kept (but hidden) so old templates and already-running instances keep
-    // working under the new runtime. Superseded by the `document` input below.
     @TemplateProperty(ignore = true) Object data,
     @TemplateDocumentProperty(
             id = "document",

--- a/connectors/csv/src/main/java/io/camunda/connector/csv/model/WriteCsvRequest.java
+++ b/connectors/csv/src/main/java/io/camunda/connector/csv/model/WriteCsvRequest.java
@@ -6,6 +6,22 @@
  */
 package io.camunda.connector.csv.model;
 
+import io.camunda.connector.api.document.DocumentReturnChoice;
+import io.camunda.connector.generator.java.annotation.DocumentReturnFormat;
+import io.camunda.connector.generator.java.annotation.TemplateProperty;
 import java.util.List;
 
-public record WriteCsvRequest(List<?> data, boolean createDocument, CsvFormat format) {}
+@DocumentReturnFormat(
+    group = "operation",
+    tooltip =
+        "How the rendered CSV should be returned. Document reference uploads it to the document"
+            + " store; as text returns the CSV inline as a String.",
+    supportedFormats = {DocumentReturnChoice.DOCUMENT, DocumentReturnChoice.TEXT},
+    defaultFormat = DocumentReturnChoice.DOCUMENT)
+public record WriteCsvRequest(
+    List<?> data,
+    // Legacy input from element-template versions <= 2, replaced by the @DocumentReturnFormat
+    // response dropdown. Kept (but hidden) so old templates still deserialize and pick the legacy
+    // output path when documentReturnFormat is absent.
+    @TemplateProperty(ignore = true) boolean createDocument,
+    CsvFormat format) {}

--- a/connectors/csv/src/main/java/io/camunda/connector/csv/model/WriteCsvRequest.java
+++ b/connectors/csv/src/main/java/io/camunda/connector/csv/model/WriteCsvRequest.java
@@ -17,11 +17,6 @@ import java.util.List;
         "How the rendered CSV should be returned. Document reference uploads it to the document"
             + " store; as text returns the CSV inline as a String.",
     supportedFormats = {DocumentReturnChoice.DOCUMENT, DocumentReturnChoice.TEXT},
-    defaultFormat = DocumentReturnChoice.DOCUMENT)
+    defaultFormat = DocumentReturnChoice.TEXT)
 public record WriteCsvRequest(
-    List<?> data,
-    // Legacy input from element-template versions <= 2, replaced by the @DocumentReturnFormat
-    // response dropdown. Kept (but hidden) so old templates still deserialize and pick the legacy
-    // output path when documentReturnFormat is absent.
-    @TemplateProperty(ignore = true) boolean createDocument,
-    CsvFormat format) {}
+    List<?> data, @TemplateProperty(ignore = true) boolean createDocument, CsvFormat format) {}

--- a/connectors/csv/src/test/java/io/camunda/connector/csv/CsvConnectorTests.java
+++ b/connectors/csv/src/test/java/io/camunda/connector/csv/CsvConnectorTests.java
@@ -9,13 +9,23 @@ package io.camunda.connector.csv;
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
+import io.camunda.connector.api.document.Document;
+import io.camunda.connector.api.document.DocumentReturn;
+import io.camunda.connector.api.document.DocumentReturnChoice;
+import io.camunda.connector.api.document.DocumentReturnFormat;
 import io.camunda.connector.api.error.ConnectorInputException;
+import io.camunda.connector.api.outbound.OutboundConnectorContext;
 import io.camunda.connector.csv.model.*;
 import io.camunda.connector.csv.model.ReadCsvRequest.RowType;
+import io.camunda.connector.runtime.test.document.TestDocument;
 import io.camunda.connector.runtime.test.outbound.OutboundConnectorContextBuilder;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.function.Function;
 import org.junit.jupiter.api.Test;
 
@@ -35,7 +45,8 @@ public class CsvConnectorTests {
 
   @Test
   public void testReadCsv() {
-    var request = new ReadCsvRequest(csv, new CsvFormat(",", true, null), RowType.Object);
+    var request =
+        new ReadCsvRequest(null, doc(csv), new CsvFormat(",", true, null), RowType.Object);
     ReadCsvResult result = connector.readCsv(request, null);
 
     var records = toList(result);
@@ -58,7 +69,8 @@ public class CsvConnectorTests {
 
   @Test
   public void testReadCsvWithMapper() {
-    var request = new ReadCsvRequest(productsCsv, new CsvFormat(",", true, null), RowType.Object);
+    var request =
+        new ReadCsvRequest(null, doc(productsCsv), new CsvFormat(",", true, null), RowType.Object);
     var mapper =
         (Function<Map<String, Object>, Object>)
             context -> {
@@ -78,7 +90,8 @@ public class CsvConnectorTests {
 
   @Test
   public void testReadCsvWithFilteringMapper() {
-    var request = new ReadCsvRequest(productsCsv, new CsvFormat(",", true, null), RowType.Object);
+    var request =
+        new ReadCsvRequest(null, doc(productsCsv), new CsvFormat(",", true, null), RowType.Object);
     var mapper =
         (Function<Map<String, Object>, Object>)
             context -> {
@@ -101,7 +114,7 @@ public class CsvConnectorTests {
 
   @Test
   public void testReadCsvWithArrayType() {
-    var request = new ReadCsvRequest(csv, new CsvFormat(",", true, null), RowType.Array);
+    var request = new ReadCsvRequest(null, doc(csv), new CsvFormat(",", true, null), RowType.Array);
     ReadCsvResult result = connector.readCsv(request, null);
 
     var records = result.records();
@@ -115,7 +128,8 @@ public class CsvConnectorTests {
 
   @Test
   public void testReadCsvWithObjectsType() {
-    var request = new ReadCsvRequest(csv, new CsvFormat(",", true, null), RowType.Object);
+    var request =
+        new ReadCsvRequest(null, doc(csv), new CsvFormat(",", true, null), RowType.Object);
     ReadCsvResult result = connector.readCsv(request, null);
 
     var records = toList(result);
@@ -129,7 +143,10 @@ public class CsvConnectorTests {
   public void testReadCsvWithObjectsTypeAndHeaders() {
     var request =
         new ReadCsvRequest(
-            csv, new CsvFormat(",", true, List.of("the_name", "the_role")), RowType.Object);
+            null,
+            doc(csv),
+            new CsvFormat(",", true, List.of("the_name", "the_role")),
+            RowType.Object);
     ReadCsvResult result = connector.readCsv(request, null);
 
     var records = toList(result);
@@ -146,7 +163,8 @@ public class CsvConnectorTests {
 
   @Test
   public void testReadCSVWithoutHeadersAndSkipHeaderRecord() {
-    var request = new ReadCsvRequest(csv, new CsvFormat(",", false, null), RowType.Object);
+    var request =
+        new ReadCsvRequest(null, doc(csv), new CsvFormat(",", false, null), RowType.Object);
     assertThatRuntimeException().isThrownBy(() -> connector.readCsv(request, null));
   }
 
@@ -218,6 +236,87 @@ public class CsvConnectorTests {
     assertThatThrownBy(() -> connector.writeCsv(emptyHeaders, context))
         .isInstanceOf(ConnectorInputException.class)
         .hasMessageContaining("Headers must be defined");
+  }
+
+  @Test
+  public void testWriteCsvAsDocumentReturn() {
+    var context = mock(OutboundConnectorContext.class);
+    when(context.readDocumentReturnFormat())
+        .thenReturn(Optional.of(new DocumentReturnFormat(DocumentReturnChoice.DOCUMENT, null)));
+    var request =
+        new WriteCsvRequest(
+            asList(asList("name", "role"), asList("Simon", "Engineering Manager")),
+            false,
+            new CsvFormat(",", true, asList("name", "role")));
+
+    var documentReturn = (DocumentReturn<?>) connector.writeCsv(request, context);
+
+    // The runtime performs the actual conversion; here we assert the raw payload and the wrap.
+    assertEquals("text/csv", documentReturn.payload().contentType());
+    var wrapped = documentReturn.wrap().apply(doc("ignored"), DocumentReturnChoice.DOCUMENT);
+    assertThat(wrapped).isInstanceOf(WriteCsvResult.Document.class);
+  }
+
+  @Test
+  public void testWriteCsvAsTextReturn() {
+    var context = mock(OutboundConnectorContext.class);
+    when(context.readDocumentReturnFormat())
+        .thenReturn(Optional.of(new DocumentReturnFormat(DocumentReturnChoice.TEXT, null)));
+    var request =
+        new WriteCsvRequest(
+            asList(asList("name", "role"), asList("Simon", "Engineering Manager")),
+            false,
+            new CsvFormat(",", true, asList("name", "role")));
+
+    var documentReturn = (DocumentReturn<?>) connector.writeCsv(request, context);
+    var wrapped =
+        (WriteCsvResult.Value)
+            documentReturn.wrap().apply("name,role\r\n", DocumentReturnChoice.TEXT);
+    assertEquals("name,role\r\n", wrapped.content());
+  }
+
+  @Test
+  public void testReadCsvLegacyRawText() {
+    // element-template <= v2 bound raw CSV text to `data`; new runtime must still accept it
+    var request = new ReadCsvRequest(csv, null, new CsvFormat(",", true, null), RowType.Object);
+    ReadCsvResult result = connector.readCsv(request, null);
+
+    var records = toList(result);
+    assertEquals(4, records.size());
+    assertThat(records).contains(Map.of("name", "Simon", "role", "Engineering Manager"));
+  }
+
+  @Test
+  public void testReadCsvLegacyDocument() {
+    // element-template <= v2 bound a document reference to `data`; still supported
+    var request =
+        new ReadCsvRequest(doc(csv), null, new CsvFormat(",", true, null), RowType.Object);
+    ReadCsvResult result = connector.readCsv(request, null);
+
+    assertEquals(4, toList(result).size());
+  }
+
+  @Test
+  public void testReadCsvDocumentTakesPrecedenceOverLegacyData() {
+    // when both are present, the new `document` input wins
+    var request =
+        new ReadCsvRequest(
+            "ignored,legacy", doc(csv), new CsvFormat(",", true, null), RowType.Object);
+    ReadCsvResult result = connector.readCsv(request, null);
+
+    assertEquals(4, toList(result).size());
+  }
+
+  @Test
+  public void testReadCsvNoDataThrows() {
+    var request = new ReadCsvRequest(null, null, new CsvFormat(",", true, null), RowType.Object);
+    assertThatThrownBy(() -> connector.readCsv(request, null))
+        .isInstanceOf(ConnectorInputException.class)
+        .hasMessageContaining("No CSV data provided");
+  }
+
+  private static Document doc(String content) {
+    return new TestDocument(content.getBytes(StandardCharsets.UTF_8), null, null, null);
   }
 
   private static List<Map<String, Object>> toList(ReadCsvResult result) {

--- a/connectors/csv/src/test/java/io/camunda/connector/csv/CsvConnectorTests.java
+++ b/connectors/csv/src/test/java/io/camunda/connector/csv/CsvConnectorTests.java
@@ -9,15 +9,11 @@ package io.camunda.connector.csv;
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 import io.camunda.connector.api.document.Document;
 import io.camunda.connector.api.document.DocumentReturn;
 import io.camunda.connector.api.document.DocumentReturnChoice;
-import io.camunda.connector.api.document.DocumentReturnFormat;
 import io.camunda.connector.api.error.ConnectorInputException;
-import io.camunda.connector.api.outbound.OutboundConnectorContext;
 import io.camunda.connector.csv.model.*;
 import io.camunda.connector.csv.model.ReadCsvRequest.RowType;
 import io.camunda.connector.runtime.test.document.TestDocument;
@@ -25,7 +21,6 @@ import io.camunda.connector.runtime.test.outbound.OutboundConnectorContextBuilde
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.function.Function;
 import org.junit.jupiter.api.Test;
 
@@ -240,9 +235,10 @@ public class CsvConnectorTests {
 
   @Test
   public void testWriteCsvAsDocumentReturn() {
-    var context = mock(OutboundConnectorContext.class);
-    when(context.readDocumentReturnFormat())
-        .thenReturn(Optional.of(new DocumentReturnFormat(DocumentReturnChoice.DOCUMENT, null)));
+    var context =
+        OutboundConnectorContextBuilder.create()
+            .variables(Map.of("documentReturnFormat", Map.of("choice", "DOCUMENT")))
+            .build();
     var request =
         new WriteCsvRequest(
             asList(asList("name", "role"), asList("Simon", "Engineering Manager")),
@@ -259,9 +255,10 @@ public class CsvConnectorTests {
 
   @Test
   public void testWriteCsvAsTextReturn() {
-    var context = mock(OutboundConnectorContext.class);
-    when(context.readDocumentReturnFormat())
-        .thenReturn(Optional.of(new DocumentReturnFormat(DocumentReturnChoice.TEXT, null)));
+    var context =
+        OutboundConnectorContextBuilder.create()
+            .variables(Map.of("documentReturnFormat", Map.of("choice", "TEXT")))
+            .build();
     var request =
         new WriteCsvRequest(
             asList(asList("name", "role"), asList("Simon", "Engineering Manager")),


### PR DESCRIPTION
## Description

Part 3/3 of https://github.com/camunda/connectors/issues/7058 — adds document handling dropdowns to the CSV connector, following PR #7553 (infra + storage connectors) and #7554 (REST). Also implements the CSV input part of https://github.com/camunda/team-connectors/issues/1251.

### Read CSV — standardized document input dropdown (backward compatible)
- Added a new `Document document` field annotated with `@TemplateDocumentProperty`. The template renders the standard source dropdown (Camunda Document / Inline Content / From URL) plus a hidden FEEL composer bound to `document`.
- The legacy `data` field is kept as a hidden `Object` (`@TemplateProperty(ignore = true)`), so old templates and already-running instances that bound raw CSV **text** *or* a document reference to `data` keep working.
- `readCsv` resolves the source via `openReader`: it prefers the new `document` input, and otherwise falls back to the legacy `data` variable (raw text → `StringReader`, document reference → `asInputStream()`).
- ✅ **Backward compatible** — no breaking change. (An earlier revision of this PR changed `data` to a required `Document`, which broke old raw-text templates; that has been reverted in favor of the split-field approach mirroring the write side.)

### Write CSV — unified response dropdown
- `WriteCsvRequest` annotated with `@DocumentReturnFormat(supportedFormats = {DOCUMENT, TEXT}, defaultFormat = TEXT)` (JSON dropped — not meaningful for CSV output).
- **Default is `TEXT`** (intentional): the legacy behavior returned CSV inline as text (`createDocument = false`), so defaulting new write tasks to `TEXT` preserves the least-surprising, non-breaking behavior. Users opt into a document reference via the dropdown.
- `writeCsv` uses the new flow (returns `DocumentReturn`, runtime converts per the user's choice) when `context.readDocumentReturnFormat()` is present; otherwise falls back to the legacy `createDocument` boolean path.
- The legacy `createDocument` field is kept but hidden, so **write stays backward compatible**.

### Versioning
- Element template version bumped 2 → 3. The read document input binds to a new `document` variable (legacy `data` kept hidden). `versionHistoryEnabled` auto-snapshotted the previous version to `versioned/csv-outbound-connector-2.json` (old String `data` + `createDocument` preserved).

## QA
- CSV module tests pass (17), including new backward-compat coverage: `testReadCsvLegacyRawText`, `testReadCsvLegacyDocument`, `testReadCsvDocumentTakesPrecedenceOverLegacyData`, `testReadCsvNoDataThrows`, plus `testWriteCsvAsDocumentReturn` / `testWriteCsvAsTextReturn`.
- spotless / license checks pass.
- Verified end-to-end on a live 8.10 runtime via a multi-branch BPMN:
  - **v3 reads** — Camunda / Inline / URL sources, Array row type, no mapper, filtering mapper (null excludes rows), semicolon delimiter, explicit headers.
  - **v3 writes** — Document, List-of-lists rows, TEXT (ascii + utf8) — encoding applied correctly (ascii mojibake vs utf8 preserved as designed).
  - **v2-template backward compat** — read raw text, read document reference, write with `createDocument` true/false — all run green on the new runtime.
  - Generated document contents fetched over the document API and byte-verified.

## Related issues

partially implements https://github.com/camunda/connectors/issues/7058
partially implements https://github.com/camunda/team-connectors/issues/1251

## Checklist

- [ ] Backport labels added if needed.
- [x] Tests for the changes have been added.
- [ ] Documentation updated if required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
