### PR TITLE
feat: multi-engine support for outbound connectors

### DIFF
--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/outbound/DefaultOutboundConnectorFactory.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/outbound/DefaultOutboundConnectorFactory.java
@@ -41,17 +41,101 @@ public class DefaultOutboundConnectorFactory
     extends AbstractConnectorFactory<OutboundConnectorFunction, OutboundConnectorConfiguration>
     implements OutboundConnectorFactory {
 
+  /**
+   * Pairs an {@link OutboundConnectorFunction} type (for reading its {@link OutboundConnector}
+   * annotation) with a {@link Supplier} that resolves an instance of it. Unlike a plain
+   * already-constructed instance, the supplier is invoked lazily and repeatedly — e.g. once per
+   * physical tenant by {@code OutboundConnectorManager} — so a supplier backed by a Spring {@code
+   * BeanFactory#getBean(String, Class)} lookup yields a genuinely fresh instance per call for
+   * prototype-scoped beans, while still returning the same shared instance for (the default)
+   * singleton-scoped beans.
+   */
+  public record FunctionRegistration(
+      Class<? extends OutboundConnectorFunction> type,
+      Supplier<OutboundConnectorFunction> supplier) {}
+
+  /** See {@link FunctionRegistration}; the equivalent for {@link OutboundConnectorProvider}. */
+  public record ProviderRegistration(
+      Class<? extends OutboundConnectorProvider> type,
+      Supplier<OutboundConnectorProvider> supplier) {}
+
   private final Map<OutboundConnectorConfiguration, OutboundConnectorFunction>
       connectorInstanceCache = new ConcurrentHashMap<>();
 
   private final Function<String, String> propertyProvider;
 
+  /**
+   * Original public constructor, preserved unchanged for source/binary compatibility: callers
+   * passing already-resolved {@link OutboundConnectorFunction}/{@link OutboundConnectorProvider}
+   * instances (e.g. non-Spring runtimes, tests) continue to work exactly as before #6961, with each
+   * instance wrapped in a constant-returning supplier (no fresh-instance-per-call capability). Use
+   * {@link #fromRegistrations} instead when per-tenant instance isolation is required.
+   */
   public DefaultOutboundConnectorFactory(
       ObjectMapper objectMapper,
       ValidationProvider validationProvider,
       List<OutboundConnectorFunction> constructorFunctions,
       List<OutboundConnectorProvider> constructorProviders,
       Function<String, String> propertyProvider) {
+    this(
+        objectMapper,
+        validationProvider,
+        constructorFunctions.stream()
+            .map(f -> new FunctionRegistration(f.getClass(), () -> f))
+            .toList(),
+        constructorProviders.stream()
+            .map(p -> new ProviderRegistration(p.getClass(), () -> p))
+            .toList(),
+        propertyProvider,
+        RegistrationMarker.INSTANCE);
+  }
+
+  /**
+   * Factory for callers that need genuine per-tenant instance isolation (#6961): each {@link
+   * FunctionRegistration}/{@link ProviderRegistration}'s {@link Supplier} is invoked lazily and
+   * repeatedly — e.g. once per physical tenant by {@code OutboundConnectorManager} — so a supplier
+   * that creates a brand-new bean instance on every call (e.g. via {@code
+   * AutowireCapableBeanFactory#createBean(Class)}) yields real isolation regardless of the bean's
+   * declared Spring scope.
+   *
+   * <p>Exposed as a distinctly-named static factory rather than an overloaded constructor: {@code
+   * List<FunctionRegistration>}/{@code List<ProviderRegistration>} erase to the same {@code List}
+   * as {@code List<OutboundConnectorFunction>}/{@code List<OutboundConnectorProvider>}, so
+   * overloading the public constructor would silently break already-compiled callers of the
+   * original constructor (same erased signature, different expected element type — a {@code
+   * ClassCastException} at runtime, not a compile error).
+   */
+  public static DefaultOutboundConnectorFactory fromRegistrations(
+      ObjectMapper objectMapper,
+      ValidationProvider validationProvider,
+      List<FunctionRegistration> functionRegistrations,
+      List<ProviderRegistration> providerRegistrations,
+      Function<String, String> propertyProvider) {
+    return new DefaultOutboundConnectorFactory(
+        objectMapper,
+        validationProvider,
+        functionRegistrations,
+        providerRegistrations,
+        propertyProvider,
+        RegistrationMarker.INSTANCE);
+  }
+
+  /**
+   * Marker type used only to give the private registration-based constructor below a distinct
+   * erased signature from the public instance-based constructor above (both would otherwise erase
+   * to the same {@code (ObjectMapper, ValidationProvider, List, List, Function)}).
+   */
+  private enum RegistrationMarker {
+    INSTANCE
+  }
+
+  private DefaultOutboundConnectorFactory(
+      ObjectMapper objectMapper,
+      ValidationProvider validationProvider,
+      List<FunctionRegistration> constructorFunctionRegistrations,
+      List<ProviderRegistration> constructorProviderRegistrations,
+      Function<String, String> propertyProvider,
+      RegistrationMarker marker) {
     this.propertyProvider = propertyProvider;
     List<OutboundConnectorConfiguration> envVarConfigurations = new ArrayList<>();
     Stream<ServiceLoader.Provider<OutboundConnectorFunction>> spiFunctions = Stream.empty();
@@ -90,10 +174,17 @@ public class DefaultOutboundConnectorFactory
 
     // 3. Constructor supplied functions
     allConfigs.addAll(
-        toConfigurations(constructorFunctions.stream(), outboundFunction -> outboundFunction));
+        toConfigurations(
+            constructorFunctionRegistrations.stream(),
+            FunctionRegistration::type,
+            fr -> fr.supplier().get()));
 
     // 4. Constructor supplied providers
-    allConfigs.addAll(toConfigurations(constructorProviders.stream(), fromProviderToFunction));
+    allConfigs.addAll(
+        toConfigurations(
+            constructorProviderRegistrations.stream(),
+            ProviderRegistration::type,
+            pr -> fromProviderToFunction.apply(pr.supplier().get())));
 
     // 5. Env vars discovered configurations
     allConfigs.addAll(envVarConfigurations);

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/outbound/JobHandlerContext.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/outbound/JobHandlerContext.java
@@ -77,6 +77,17 @@ public class JobHandlerContext extends AbstractConnectorContext
     return mappedObject;
   }
 
+  /**
+   * Exposes the {@link ObjectMapper} this context was built with (i.e. the correct per-physical-
+   * tenant mapper selected by {@code OutboundConnectorManager}), so that {@link
+   * io.camunda.connector.runtime.core.outbound.operation.OperationInvoker} can deserialize
+   * {@code @Variable}/{@code @Header} parameters with it instead of a mapper captured once at
+   * connector registration time.
+   */
+  public ObjectMapper getObjectMapper() {
+    return objectMapper;
+  }
+
   private String getJsonReplacedWithSecrets() {
     if (jsonWithSecrets == null) {
       jsonWithSecrets =

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/outbound/operation/OperationInvoker.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/outbound/operation/OperationInvoker.java
@@ -25,6 +25,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.connector.api.error.ConnectorInputException;
 import io.camunda.connector.api.outbound.OutboundConnectorContext;
 import io.camunda.connector.api.validation.ValidationProvider;
+import io.camunda.connector.runtime.core.outbound.JobHandlerContext;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Type;
@@ -47,7 +48,21 @@ public class OperationInvoker {
     this.descriptor = descriptor;
   }
 
+  /**
+   * Resolves the {@link ObjectMapper} to use for this invocation: prefers the per-physical-tenant
+   * mapper carried by a {@link JobHandlerContext} (the real runtime context, correctly wired per
+   * tenant by {@code OutboundConnectorManager}) over the mapper captured in this instance at
+   * connector-registration time, which is otherwise stale/wrong for any tenant other than the one
+   * active when the operation-based connector's registration was built.
+   */
+  private ObjectMapper resolveObjectMapper(OutboundConnectorContext context) {
+    return context instanceof JobHandlerContext jobHandlerContext
+        ? jobHandlerContext.getObjectMapper()
+        : objectMapper;
+  }
+
   public Object invoke(Object connectorInstance, OutboundConnectorContext context) {
+    ObjectMapper mapper = resolveObjectMapper(context);
     Object[] args = new Object[descriptor.params().size()];
     JsonNode jobVariables = null;
     for (int i = 0; i < args.length; i++) {
@@ -57,21 +72,23 @@ public class OperationInvoker {
             case ParameterDescriptor.Context ignored -> context;
             case ParameterDescriptor.Variable<?> variable -> {
               if (jobVariables == null) {
-                jobVariables = readJsonAsTree(context.getJobContext().getVariables());
+                jobVariables = readJsonAsTree(context.getJobContext().getVariables(), mapper);
               }
-              yield resolveVariableValue(variable, jobVariables);
+              yield resolveVariableValue(variable, jobVariables, mapper);
             }
             case ParameterDescriptor.Header<?> header ->
-                resolveHeaderValue(header, context.getJobContext().getCustomHeaders());
+                resolveHeaderValue(header, context.getJobContext().getCustomHeaders(), mapper);
           };
     }
     return invokeMethod(connectorInstance, args);
   }
 
   private Object resolveVariableValue(
-      ParameterDescriptor.Variable<?> variableDescriptor, JsonNode jobVariables) {
+      ParameterDescriptor.Variable<?> variableDescriptor,
+      JsonNode jobVariables,
+      ObjectMapper mapper) {
     JsonPointer jsonPointer = variableDescriptor.getJsonPointer();
-    Object value = readValueAs(jobVariables, jsonPointer, variableDescriptor.getType());
+    Object value = readValueAs(jobVariables, jsonPointer, variableDescriptor.getType(), mapper);
     if (variableDescriptor.isRequired() && value == null) {
       throw new ConnectorInputException(
           "Required variable '"
@@ -85,11 +102,13 @@ public class OperationInvoker {
   }
 
   private Object resolveHeaderValue(
-      ParameterDescriptor.Header<?> headerDescriptor, Map<String, String> headers) {
+      ParameterDescriptor.Header<?> headerDescriptor,
+      Map<String, String> headers,
+      ObjectMapper mapper) {
     String rawValue = headers.get(headerDescriptor.name());
     Object value;
     try {
-      value = objectMapper.convertValue(rawValue, headerDescriptor.type());
+      value = mapper.convertValue(rawValue, headerDescriptor.type());
     } catch (Throwable e) {
       throw new RuntimeException(e);
     }
@@ -103,21 +122,22 @@ public class OperationInvoker {
     return value;
   }
 
-  private Object readValueAs(JsonNode jsonNode, JsonPointer jsonPointer, Type type) {
+  private Object readValueAs(
+      JsonNode jsonNode, JsonPointer jsonPointer, Type type, ObjectMapper mapper) {
     JsonNode node = jsonNode.at(jsonPointer);
 
-    JavaType javaType = objectMapper.getTypeFactory().constructType(type);
+    JavaType javaType = mapper.getTypeFactory().constructType(type);
 
-    try (JsonParser parser = node.traverse(objectMapper)) {
-      return objectMapper.readValue(parser, javaType);
+    try (JsonParser parser = node.traverse(mapper)) {
+      return mapper.readValue(parser, javaType);
     } catch (IOException ex) {
       throw new RuntimeException(ex);
     }
   }
 
-  private JsonNode readJsonAsTree(String json) {
+  private JsonNode readJsonAsTree(String json, ObjectMapper mapper) {
     try {
-      return objectMapper.readTree(json);
+      return mapper.readTree(json);
     } catch (JsonProcessingException e) {
       throw new RuntimeException(e);
     }

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/outbound/AnnotatedOperationTests.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/outbound/AnnotatedOperationTests.java
@@ -142,6 +142,14 @@ public class AnnotatedOperationTests {
   }
 
   JobHandlerContext createMockContext(String json, String operation, Map<String, String> headers) {
+    return this.createMockContext(json, operation, headers, objectMapper);
+  }
+
+  JobHandlerContext createMockContext(
+      String json,
+      String operation,
+      Map<String, String> headers,
+      ObjectMapper contextObjectMapper) {
     var activatedJob = mock(ActivatedJob.class);
     var operationHeader = Map.of("operation", operation);
     Map<String, String> customHeaders;
@@ -158,7 +166,7 @@ public class AnnotatedOperationTests {
         new NoOpSecretProvider(),
         validationProvider,
         null,
-        objectMapper,
+        contextObjectMapper,
         SecretFilter.allowAll());
   }
 
@@ -177,5 +185,55 @@ public class AnnotatedOperationTests {
     var result = invoker.execute(createMockContext(json, "myOperation7"));
 
     assertEquals(6, result);
+  }
+
+  /**
+   * #6961: {@link io.camunda.connector.runtime.core.outbound.operation.OperationInvoker} must use
+   * the {@link ObjectMapper} carried by the runtime {@link JobHandlerContext} (the correct
+   * per-physical-tenant mapper) rather than the mapper captured once when the operation-based
+   * connector was registered — otherwise a connector registered against one tenant's mapper would
+   * silently use that tenant's {@code DocumentFactory}/settings for every other tenant's jobs.
+   * These tests use deliberately mismatched mappers — a strict, bare {@link ObjectMapper} at
+   * registration time that would fail on this operation's input, and the fully-configured {@link
+   * TestObjectMapperSupplier#INSTANCE} on the context — so they only pass if the context's mapper
+   * is actually the one used.
+   */
+  @Test
+  public void shouldUseContextObjectMapper_notRegistrationTimeMapper_forVariableResolution() {
+    var strictRegistrationMapper = new ObjectMapper();
+    var mismatchedInvoker =
+        new OutboundConnectorOperationFunction(
+            ConnectorOperations.from(connector, strictRegistrationMapper, validationProvider));
+
+    // myOperation's unnamed `nestedObjectWithoutName` @Variable parameter deserializes the whole
+    // JSON root document, which has additional unrelated properties (myStringParam, myObjectParam)
+    // that strictRegistrationMapper would reject (FAIL_ON_UNKNOWN_PROPERTIES enabled by default),
+    // but TestObjectMapperSupplier.INSTANCE (used here as the context's mapper) tolerates.
+    var result =
+        mismatchedInvoker.execute(
+            createMockContext(json, "myOperation", null, TestObjectMapperSupplier.INSTANCE));
+
+    assertEquals("Hello, World!", result);
+  }
+
+  @Test
+  public void shouldUseContextObjectMapper_notRegistrationTimeMapper_forHeaderResolution() {
+    // a bare ObjectMapper has no FEEL support, so it cannot convert the "=x+2" header string into
+    // the Function<Map<String, Integer>, Integer> parameter type that myOperation5 expects.
+    var registrationMapperWithoutFeelSupport = new ObjectMapper();
+    var mismatchedInvoker =
+        new OutboundConnectorOperationFunction(
+            ConnectorOperations.from(
+                connector, registrationMapperWithoutFeelSupport, validationProvider));
+
+    var result =
+        mismatchedInvoker.execute(
+            createMockContext(
+                "{\"x\": 10}",
+                "myOperation5",
+                Map.of("myFeelFunction", "=x+2"),
+                TestObjectMapperSupplier.INSTANCE));
+
+    assertEquals(12L, result);
   }
 }

--- a/connector-runtime/connector-runtime-spring/pom.xml
+++ b/connector-runtime/connector-runtime-spring/pom.xml
@@ -152,17 +152,17 @@
       <artifactId>jsr305</artifactId>
     </dependency>
 
-    <!-- Test -->
+    <!-- Needed to build per-physical-tenant outbound ObjectMappers (see #6961) -->
     <dependency>
       <groupId>io.camunda.connector</groupId>
       <artifactId>jackson-datatype-document</artifactId>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>io.camunda.connector</groupId>
       <artifactId>jackson-datatype-feel</artifactId>
-      <scope>test</scope>
     </dependency>
+
+    <!-- Test -->
     <dependency>
       <groupId>io.camunda.connector</groupId>
       <artifactId>connector-validation</artifactId>

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/OutboundConnectorRuntimeConfiguration.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/OutboundConnectorRuntimeConfiguration.java
@@ -22,6 +22,7 @@ import io.camunda.client.CamundaClient;
 import io.camunda.client.jobhandling.JobCallbackCommandWrapperFactory;
 import io.camunda.client.jobhandling.JobWorkerManager;
 import io.camunda.client.metrics.MetricsRecorder;
+import io.camunda.client.spring.bean.CamundaClientRegistry;
 import io.camunda.connector.api.document.DocumentFactory;
 import io.camunda.connector.api.outbound.OutboundConnectorFunction;
 import io.camunda.connector.api.outbound.OutboundConnectorProvider;
@@ -49,7 +50,12 @@ import io.micrometer.core.instrument.MeterRegistry;
 import java.net.URI;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collector;
+import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -91,6 +97,132 @@ public class OutboundConnectorRuntimeConfiguration {
     return new DocumentFactoryImpl(documentStore);
   }
 
+  /**
+   * Enumerates the configured client names: the {@link CamundaClientRegistry}'s own names when a
+   * registry bean exists, otherwise a single synthetic {@code "default"} name representing a
+   * directly-supplied legacy {@code CamundaClient} bean — some minimal/test contexts wire a raw
+   * {@code CamundaClient} bean without the full {@code camunda-spring-boot-starter} auto-config
+   * chain that would normally register a {@link CamundaClientRegistry}.
+   */
+  private static Set<String> clientNames(
+      CamundaClientRegistry registry, CamundaClient legacyCamundaClient) {
+    if (registry != null) {
+      return registry.clientNames();
+    }
+    if (legacyCamundaClient != null) {
+      return Set.of("default");
+    }
+    throw new IllegalStateException("No CamundaClient or CamundaClientRegistry configured");
+  }
+
+  /**
+   * Resolves the {@link CamundaClient} for the given client name. Prefers the {@link
+   * CamundaClientRegistry} entry, but falls back to a directly-supplied single {@code
+   * CamundaClient} bean when the registry is absent entirely, or when the registry claims the name
+   * exists but no matching bean was actually registered — e.g. when a {@code CamundaClient} bean is
+   * supplied manually/overridden (as in test fixtures) instead of via {@code camunda.clients.*}.
+   */
+  private static CamundaClient resolveClient(
+      CamundaClientRegistry registry, String name, CamundaClient legacyCamundaClient) {
+    if (registry == null) {
+      if (legacyCamundaClient == null) {
+        throw new IllegalStateException("No CamundaClient configured for client '" + name + "'");
+      }
+      return legacyCamundaClient;
+    }
+    try {
+      return registry.get(name);
+    } catch (RuntimeException e) {
+      if (legacyCamundaClient == null) {
+        throw new IllegalStateException("No CamundaClient configured for client '" + name + "'", e);
+      }
+      return legacyCamundaClient;
+    }
+  }
+
+  /**
+   * Resolves the physical tenant ID for a configured {@code CamundaClientRegistry} client name: the
+   * explicitly configured {@code physical-tenant-id} if present, otherwise the client name itself.
+   * Falls back to the client name if the configuration cannot be read at all — some test doubles
+   * defer real initialization until a test container is ready and throw if queried too early.
+   */
+  private static String resolvePhysicalTenantId(
+      CamundaClientRegistry registry, String name, CamundaClient legacyCamundaClient) {
+    try {
+      var physicalTenantId =
+          resolveClient(registry, name, legacyCamundaClient)
+              .getConfiguration()
+              .getPhysicalTenantId();
+      return physicalTenantId != null ? physicalTenantId : name;
+    } catch (RuntimeException e) {
+      return name;
+    }
+  }
+
+  /**
+   * Builds a {@code Collectors.toMap} collector keyed by the resolved physical tenant ID for each
+   * client name, failing clearly if two clients resolve to the same physical tenant ID rather than
+   * silently dropping one.
+   */
+  private static <T> Collector<String, ?, Map<String, T>> toMapByPhysicalTenantId(
+      CamundaClientRegistry registry,
+      CamundaClient legacyCamundaClient,
+      Function<String, T> valueFn) {
+    return Collectors.toMap(
+        name -> resolvePhysicalTenantId(registry, name, legacyCamundaClient),
+        valueFn,
+        (a, b) -> {
+          throw new IllegalStateException(
+              "Multiple CamundaClients resolve to the same physical tenant ID; "
+                  + "each configured client must have a unique physical-tenant-id");
+        });
+  }
+
+  /**
+   * Plain (non-{@code @Bean}) helper so this can be called both from the {@code @Bean} method below
+   * and directly from {@link #outboundConnectorManager}, without either call going through Spring's
+   * container-based parameter resolution: a {@code @Bean} method whose OWN parameter type is {@code
+   * Map<String, X>} has that parameter resolved by the container even when called directly from
+   * another method in this class (Spring's {@code @Configuration} CGLIB proxying intercepts calls
+   * to {@code @Bean} methods and resolves their declared parameters from the container, discarding
+   * whatever arguments were passed in code) — and since this class also keeps the legacy scalar
+   * {@code documentStore}/{@code documentFactory} beans for backward compatibility, such a
+   * Map-typed parameter would silently resolve to {@code {"documentStore": <scalar bean>}} instead
+   * of the real per-physical-tenant map. Avoiding {@code Map<String, X>}-typed {@code @Bean}
+   * parameters entirely sidesteps this.
+   */
+  private static Map<String, CamundaDocumentStore> buildDocumentStoresByPhysicalTenantId(
+      CamundaClientRegistry registry, CamundaClient legacyCamundaClient) {
+    return clientNames(registry, legacyCamundaClient).stream()
+        .collect(
+            toMapByPhysicalTenantId(
+                registry,
+                legacyCamundaClient,
+                name ->
+                    new CamundaDocumentStoreImpl(
+                        resolveClient(registry, name, legacyCamundaClient))));
+  }
+
+  private static Map<String, DocumentFactory> buildDocumentFactoriesByPhysicalTenantId(
+      CamundaClientRegistry registry, CamundaClient legacyCamundaClient) {
+    return buildDocumentStoresByPhysicalTenantId(registry, legacyCamundaClient).entrySet().stream()
+        .collect(Collectors.toMap(Map.Entry::getKey, e -> new DocumentFactoryImpl(e.getValue())));
+  }
+
+  @Bean
+  public Map<String, CamundaDocumentStore> documentStoresByPhysicalTenantId(
+      @Autowired(required = false) CamundaClientRegistry registry,
+      @Autowired(required = false) CamundaClient legacyCamundaClient) {
+    return buildDocumentStoresByPhysicalTenantId(registry, legacyCamundaClient);
+  }
+
+  @Bean
+  public Map<String, DocumentFactory> documentFactoriesByPhysicalTenantId(
+      @Autowired(required = false) CamundaClientRegistry registry,
+      @Autowired(required = false) CamundaClient legacyCamundaClient) {
+    return buildDocumentFactoriesByPhysicalTenantId(registry, legacyCamundaClient);
+  }
+
   @Bean
   @ConditionalOnMissingBean(ValidationProvider.class)
   ValidationProvider validationProvider() {
@@ -112,6 +244,12 @@ public class OutboundConnectorRuntimeConfiguration {
    *       monitoring port defaults to {@code 9600} and can be overridden via {@code
    *       camunda.connector.broker.monitoring.port}.
    * </ul>
+   *
+   * <p>Pre-existing, out-of-scope-for-#6961 limitation: in topology-discovery mode this still
+   * resolves a single {@code CamundaClient} (whichever is {@code @Primary} when multiple physical
+   * tenants are configured), so it only monitors that one physical tenant's brokers. Broker
+   * monitoring is informational/observability only, not part of job execution, so this is
+   * deliberately deferred rather than converted to a per-physical-tenant map.
    */
   @Bean
   @ConditionalOnProperty(
@@ -165,7 +303,7 @@ public class OutboundConnectorRuntimeConfiguration {
   public SecretKeyCache secretKeyCache(
       CamundaClient camundaClient, @Qualifier("secretKeyCacheManager") CacheManager cacheManager) {
     return new ProcessDefinitionSecretKeyCache(
-        camundaClient, cacheManager.getCache(SecretKeyCache.SECRET_KEY_CACHE_NAME));
+        "default", camundaClient, cacheManager.getCache(SecretKeyCache.SECRET_KEY_CACHE_NAME));
   }
 
   @Bean
@@ -176,6 +314,71 @@ public class OutboundConnectorRuntimeConfiguration {
     return new ConfigurableSecretFilterFactory(secretFilterMode, secretKeyCache);
   }
 
+  private static Map<String, SecretKeyCache> buildSecretKeyCachesByPhysicalTenantId(
+      CamundaClientRegistry registry,
+      CamundaClient legacyCamundaClient,
+      CacheManager cacheManager) {
+    var sharedCache = cacheManager.getCache(SecretKeyCache.SECRET_KEY_CACHE_NAME);
+    return clientNames(registry, legacyCamundaClient).stream()
+        .collect(
+            toMapByPhysicalTenantId(
+                registry,
+                legacyCamundaClient,
+                name -> {
+                  var physicalTenantId =
+                      resolvePhysicalTenantId(registry, name, legacyCamundaClient);
+                  return new ProcessDefinitionSecretKeyCache(
+                      physicalTenantId,
+                      resolveClient(registry, name, legacyCamundaClient),
+                      sharedCache);
+                }));
+  }
+
+  private static Map<String, SecretFilterFactory> buildSecretFilterFactoriesByPhysicalTenantId(
+      CamundaClientRegistry registry,
+      CamundaClient legacyCamundaClient,
+      CacheManager cacheManager,
+      SecretFilterMode secretFilterMode) {
+    return buildSecretKeyCachesByPhysicalTenantId(registry, legacyCamundaClient, cacheManager)
+        .entrySet()
+        .stream()
+        .collect(
+            Collectors.toMap(
+                Map.Entry::getKey,
+                e -> new ConfigurableSecretFilterFactory(secretFilterMode, e.getValue())));
+  }
+
+  @Bean
+  public Map<String, SecretKeyCache> secretKeyCachesByPhysicalTenantId(
+      @Autowired(required = false) CamundaClientRegistry registry,
+      @Autowired(required = false) CamundaClient legacyCamundaClient,
+      @Qualifier("secretKeyCacheManager") CacheManager cacheManager) {
+    return buildSecretKeyCachesByPhysicalTenantId(registry, legacyCamundaClient, cacheManager);
+  }
+
+  @Bean
+  public Map<String, SecretFilterFactory> secretFilterFactoriesByPhysicalTenantId(
+      @Autowired(required = false) CamundaClientRegistry registry,
+      @Autowired(required = false) CamundaClient legacyCamundaClient,
+      @Qualifier("secretKeyCacheManager") CacheManager cacheManager,
+      @Value("${camunda.connector.secret-resolver.secret-filter.mode:DISABLED}")
+          SecretFilterMode secretFilterMode) {
+    return buildSecretFilterFactoriesByPhysicalTenantId(
+        registry, legacyCamundaClient, cacheManager, secretFilterMode);
+  }
+
+  /**
+   * Builds the per-physical-tenant {@code documentFactory}/{@code secretFilterFactory} maps via the
+   * plain (non-{@code @Bean}) {@code build*} helper methods rather than declaring {@code
+   * Map<String, X>}-typed parameters or calling the sibling {@code @Bean} methods: Spring's
+   * {@code @Configuration} CGLIB proxying intercepts any call to a {@code @Bean} method — including
+   * calls from within this very class — and re-resolves that method's parameters from the container
+   * instead of using the arguments passed in code. Since a {@code Map<String, X>}-typed parameter
+   * is itself special-cased by Spring to collect all beans of type {@code X} by name, and this
+   * class also keeps legacy scalar {@code documentStore}/{@code documentFactory}/{@code
+   * secretKeyCache} beans for backward compatibility, either path would silently resolve to a
+   * single-entry map keyed by the legacy bean's name instead of the real per-physical-tenant map.
+   */
   @Bean
   public OutboundConnectorManager outboundConnectorManager(
       JobWorkerManager jobWorkerManager,
@@ -184,20 +387,28 @@ public class OutboundConnectorRuntimeConfiguration {
       SecretProviderAggregator secretProviderAggregator,
       ValidationProvider validationProvider,
       MetricsRecorder metricsRecorder,
-      DocumentFactory documentFactory,
+      @Autowired(required = false) CamundaClientRegistry registry,
+      @Autowired(required = false) CamundaClient legacyCamundaClient,
+      @Value("${camunda.connector.secret-resolver.secret-filter.mode:DISABLED}")
+          SecretFilterMode secretFilterMode,
+      @Qualifier("secretKeyCacheManager") CacheManager secretKeyCacheManager,
       @OutboundConnectorObjectMapper ObjectMapper objectMapper,
-      SecretFilterFactory secretFilterFactory,
       Optional<MeterRegistry> meterRegistry) {
+    var documentFactoriesByPhysicalTenantId =
+        buildDocumentFactoriesByPhysicalTenantId(registry, legacyCamundaClient);
+    var secretFilterFactoriesByPhysicalTenantId =
+        buildSecretFilterFactoriesByPhysicalTenantId(
+            registry, legacyCamundaClient, secretKeyCacheManager, secretFilterMode);
     return new OutboundConnectorManager(
         jobWorkerManager,
         connectorFactory,
         jobCallbackCommandWrapperFactory,
         secretProviderAggregator,
         validationProvider,
-        documentFactory,
+        documentFactoriesByPhysicalTenantId,
         objectMapper,
         metricsRecorder,
-        secretFilterFactory,
+        secretFilterFactoriesByPhysicalTenantId,
         meterRegistry.orElse(null));
   }
 }

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/OutboundConnectorRuntimeConfiguration.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/OutboundConnectorRuntimeConfiguration.java
@@ -23,15 +23,22 @@ import io.camunda.client.jobhandling.JobCallbackCommandWrapperFactory;
 import io.camunda.client.jobhandling.JobWorkerManager;
 import io.camunda.client.metrics.MetricsRecorder;
 import io.camunda.client.spring.bean.CamundaClientRegistry;
+import io.camunda.connector.api.annotation.OutboundConnector;
 import io.camunda.connector.api.document.DocumentFactory;
 import io.camunda.connector.api.outbound.OutboundConnectorFunction;
 import io.camunda.connector.api.outbound.OutboundConnectorProvider;
 import io.camunda.connector.api.validation.ValidationProvider;
+import io.camunda.connector.document.jackson.JacksonModuleDocumentDeserializer;
+import io.camunda.connector.document.jackson.JacksonModuleDocumentSerializer;
+import io.camunda.connector.feel.FeelExpressionEvaluatorBuilder;
+import io.camunda.connector.feel.jackson.JacksonModuleFeelFunction;
+import io.camunda.connector.jackson.ConnectorsObjectMapperSupplier;
 import io.camunda.connector.runtime.annotation.ConnectorsObjectMapper;
 import io.camunda.connector.runtime.annotation.OutboundConnectorObjectMapper;
 import io.camunda.connector.runtime.core.document.DocumentFactoryImpl;
 import io.camunda.connector.runtime.core.document.store.CamundaDocumentStore;
 import io.camunda.connector.runtime.core.document.store.CamundaDocumentStoreImpl;
+import io.camunda.connector.runtime.core.intrinsic.DefaultIntrinsicFunctionExecutor;
 import io.camunda.connector.runtime.core.outbound.DefaultOutboundConnectorFactory;
 import io.camunda.connector.runtime.core.outbound.OutboundConnectorFactory;
 import io.camunda.connector.runtime.core.secret.SecretFilterFactory;
@@ -47,6 +54,7 @@ import io.camunda.connector.runtime.outbound.lifecycle.OutboundConnectorManager;
 import io.camunda.connector.runtime.outbound.secret.ProcessDefinitionSecretKeyCache;
 import io.camunda.connector.runtime.outbound.secret.SecretKeyCache;
 import io.micrometer.core.instrument.MeterRegistry;
+import jakarta.annotation.PreDestroy;
 import java.net.URI;
 import java.util.Arrays;
 import java.util.List;
@@ -60,6 +68,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.cache.CacheManager;
@@ -74,17 +83,147 @@ import org.springframework.core.env.Environment;
 @Import({OutboundConnectorsRestController.class, InstanceForwardingConfiguration.class})
 public class OutboundConnectorRuntimeConfiguration {
 
+  /**
+   * Tracks every connector instance created via {@code beanFactory.createBean(type)} in {@link
+   * #functionRegistrations} / {@link #providerRegistrations}, so that {@link #destroyCreatedBeans}
+   * can invoke {@code beanFactory.destroyBean(...)} on each of them when this configuration bean is
+   * destroyed (i.e. on application context shutdown), running any {@code @PreDestroy}/{@link
+   * org.springframework.beans.factory.DisposableBean} cleanup that would otherwise never run since
+   * these instances are not registered with the container.
+   */
+  private final List<Object> createdConnectorInstances =
+      new java.util.concurrent.CopyOnWriteArrayList<>();
+
+  /**
+   * Set by {@link #functionRegistrations}/{@link #providerRegistrations}; used by {@link
+   * #destroyCreatedBeans} to destroy the tracked instances on shutdown.
+   */
+  private volatile ConfigurableListableBeanFactory beanFactory;
+
+  /**
+   * Builds one {@link DefaultOutboundConnectorFactory.FunctionRegistration} per Spring-registered
+   * {@link OutboundConnectorFunction} bean, backed by a supplier that yields a fresh instance per
+   * call regardless of the bean's declared Spring scope (#6961):
+   *
+   * <ul>
+   *   <li>Prototype-scoped beans are resolved via {@code beanFactory.getBean(name, type)}, which
+   *       already returns a brand-new instance on every call while going through the bean's real,
+   *       originating bean definition — i.e. any {@code @Bean} factory method (with whatever custom
+   *       construction logic it contains) or {@code @Component}-scanned constructor is honored
+   *       exactly as Spring would normally invoke it.
+   *   <li>(Default) singleton-scoped beans instead use {@code beanFactory.createBean(type)}, since
+   *       {@code getBean(name, ...)} would return the same cached singleton instance every time.
+   *       This is the only public Spring API able to produce a distinct instance per call for a
+   *       singleton-scoped bean definition, but it comes with a caveat: it constructs a new,
+   *       autowired instance purely from the bean's {@code Class}, bypassing any {@code @Bean}
+   *       factory method the bean might have originally been defined with (i.e. any custom
+   *       construction logic in that method's body is skipped in favor of straightforward
+   *       constructor autowiring). Connector authors relying on such custom singleton-scoped
+   *       {@code @Bean} construction logic should mark the bean {@code @Scope("prototype")}
+   *       instead, so {@code getBean(name, type)} is used and the factory method is preserved.
+   * </ul>
+   *
+   * <p>Instances created via {@code createBean(type)} are not registered with the container, so
+   * they're tracked in {@link #createdConnectorInstances} and explicitly destroyed via {@link
+   * #destroyCreatedBeans}. Instances resolved via {@code getBean(name, type)} are already
+   * container-managed and need no such tracking.
+   */
+  private List<DefaultOutboundConnectorFactory.FunctionRegistration> functionRegistrations(
+      ConfigurableListableBeanFactory beanFactory) {
+    this.beanFactory = beanFactory;
+    return Arrays.stream(beanFactory.getBeanNamesForType(OutboundConnectorFunction.class))
+        .map(
+            name -> {
+              var type = resolveConcreteType(beanFactory, name, OutboundConnectorFunction.class);
+              return new DefaultOutboundConnectorFactory.FunctionRegistration(
+                  type, () -> resolveFreshInstance(beanFactory, name, type));
+            })
+        .toList();
+  }
+
+  /** See {@link #functionRegistrations}; the equivalent for {@link OutboundConnectorProvider}. */
+  private List<DefaultOutboundConnectorFactory.ProviderRegistration> providerRegistrations(
+      ConfigurableListableBeanFactory beanFactory) {
+    this.beanFactory = beanFactory;
+    return Arrays.stream(beanFactory.getBeanNamesForType(OutboundConnectorProvider.class))
+        .map(
+            name -> {
+              var type = resolveConcreteType(beanFactory, name, OutboundConnectorProvider.class);
+              return new DefaultOutboundConnectorFactory.ProviderRegistration(
+                  type, () -> resolveFreshInstance(beanFactory, name, type));
+            })
+        .toList();
+  }
+
+  /**
+   * Resolves the concrete implementation class to use for {@code @OutboundConnector} annotation
+   * discovery for the given bean {@code name}. {@code beanFactory.getType(name)} returns the
+   * bean-definition-declared type, which for a {@code @Bean} factory method is that method's
+   * declared return type — e.g. plain {@code OutboundConnectorFunction}/{@code
+   * OutboundConnectorProvider} for a method like {@code @Bean OutboundConnectorFunction
+   * myConnector() { return new MyConnectorImpl(); }}. That declared type never carries the
+   * {@code @OutboundConnector} annotation (only the concrete {@code MyConnectorImpl} does), so
+   * relying on it would silently filter such connectors out entirely.
+   *
+   * <p>Falls back to instantiating the bean once via {@code getBean(name)} to discover its real
+   * runtime class, mirroring the pre-#6961 behavior (list-injecting {@code
+   * List<OutboundConnectorFunction>} beans and calling {@code instance.getClass()}), only when the
+   * declared type doesn't already carry the annotation.
+   */
+  private <T> Class<? extends T> resolveConcreteType(
+      ConfigurableListableBeanFactory beanFactory, String name, Class<T> supertype) {
+    Class<?> declaredType = beanFactory.getType(name);
+    if (declaredType != null && declaredType.isAnnotationPresent(OutboundConnector.class)) {
+      return declaredType.asSubclass(supertype);
+    }
+    return beanFactory.getBean(name, supertype).getClass().asSubclass(supertype);
+  }
+
+  /**
+   * Resolves a fresh instance of the given bean {@code name}/{@code type} per call: via {@code
+   * getBean(name, type)} for prototype-scoped beans (preserving the original bean definition, e.g.
+   * a {@code @Bean} factory method), or via {@code createBean(type)} for singleton-scoped beans
+   * (the only way to get a distinct instance per call, at the cost of bypassing any factory
+   * method). See {@link #functionRegistrations} for the full rationale.
+   */
+  private <T> T resolveFreshInstance(
+      ConfigurableListableBeanFactory beanFactory, String name, Class<T> type) {
+    if (beanFactory.isPrototype(name)) {
+      return beanFactory.getBean(name, type);
+    }
+    T instance = beanFactory.createBean(type);
+    createdConnectorInstances.add(instance);
+    return instance;
+  }
+
+  /**
+   * Invokes {@code beanFactory.destroyBean(...)} on every connector instance tracked in {@link
+   * #createdConnectorInstances}, running any {@code @PreDestroy}/{@link
+   * org.springframework.beans.factory.DisposableBean} cleanup on them. Called when this
+   * configuration bean is destroyed, i.e. on application context shutdown.
+   */
+  @PreDestroy
+  public void destroyCreatedBeans() {
+    if (beanFactory != null) {
+      createdConnectorInstances.forEach(beanFactory::destroyBean);
+    }
+    createdConnectorInstances.clear();
+  }
+
   @Bean
   @ConditionalOnMissingBean(OutboundConnectorFactory.class)
   public DefaultOutboundConnectorFactory outboundConnectorConfigurationRegistry(
       @ConnectorsObjectMapper ObjectMapper mapper,
       ValidationProvider validationProvider,
       Environment environment,
-      List<OutboundConnectorFunction> functions,
-      List<OutboundConnectorProvider> providers) {
+      ConfigurableListableBeanFactory beanFactory) {
 
-    return new DefaultOutboundConnectorFactory(
-        mapper, validationProvider, functions, providers, environment::getProperty);
+    return DefaultOutboundConnectorFactory.fromRegistrations(
+        mapper,
+        validationProvider,
+        functionRegistrations(beanFactory),
+        providerRegistrations(beanFactory),
+        environment::getProperty);
   }
 
   @Bean
@@ -203,8 +342,23 @@ public class OutboundConnectorRuntimeConfiguration {
                         resolveClient(registry, name, legacyCamundaClient))));
   }
 
+  /**
+   * Builds the per-physical-tenant {@link DocumentFactory} map. In the single-physical-tenant case
+   * (no {@link CamundaClientRegistry}), the already-resolved {@code injectedDocumentFactory} bean
+   * is reused instead of always constructing a new client-backed one: this preserves pre-#6961
+   * behavior for single-client/custom runtimes that override the {@code documentFactory} bean (e.g.
+   * an in-memory document store in tests), which would otherwise be silently bypassed.
+   */
   private static Map<String, DocumentFactory> buildDocumentFactoriesByPhysicalTenantId(
-      CamundaClientRegistry registry, CamundaClient legacyCamundaClient) {
+      CamundaClientRegistry registry,
+      CamundaClient legacyCamundaClient,
+      DocumentFactory injectedDocumentFactory) {
+    if (registry == null && injectedDocumentFactory != null) {
+      return clientNames(registry, legacyCamundaClient).stream()
+          .collect(
+              toMapByPhysicalTenantId(
+                  registry, legacyCamundaClient, name -> injectedDocumentFactory));
+    }
     return buildDocumentStoresByPhysicalTenantId(registry, legacyCamundaClient).entrySet().stream()
         .collect(Collectors.toMap(Map.Entry::getKey, e -> new DocumentFactoryImpl(e.getValue())));
   }
@@ -219,8 +373,9 @@ public class OutboundConnectorRuntimeConfiguration {
   @Bean
   public Map<String, DocumentFactory> documentFactoriesByPhysicalTenantId(
       @Autowired(required = false) CamundaClientRegistry registry,
-      @Autowired(required = false) CamundaClient legacyCamundaClient) {
-    return buildDocumentFactoriesByPhysicalTenantId(registry, legacyCamundaClient);
+      @Autowired(required = false) CamundaClient legacyCamundaClient,
+      @Autowired(required = false) DocumentFactory documentFactory) {
+    return buildDocumentFactoriesByPhysicalTenantId(registry, legacyCamundaClient, documentFactory);
   }
 
   @Bean
@@ -299,11 +454,30 @@ public class OutboundConnectorRuntimeConfiguration {
     return cacheManager;
   }
 
+  /**
+   * Resolves the physical tenant ID for the legacy scalar single-{@code CamundaClient} beans (
+   * {@link #secretKeyCache}): the explicitly configured {@code physical-tenant-id} if present,
+   * otherwise falls back to {@code "default"} rather than the client name (there is no client name
+   * in the single-client case). Falls back the same way if the configuration cannot be read at all
+   * — some test doubles defer real initialization until a test container is ready and throw if
+   * queried too early.
+   */
+  private static String resolvePhysicalTenantIdOrDefault(CamundaClient camundaClient) {
+    try {
+      var physicalTenantId = camundaClient.getConfiguration().getPhysicalTenantId();
+      return physicalTenantId != null ? physicalTenantId : "default";
+    } catch (RuntimeException e) {
+      return "default";
+    }
+  }
+
   @Bean
   public SecretKeyCache secretKeyCache(
       CamundaClient camundaClient, @Qualifier("secretKeyCacheManager") CacheManager cacheManager) {
     return new ProcessDefinitionSecretKeyCache(
-        "default", camundaClient, cacheManager.getCache(SecretKeyCache.SECRET_KEY_CACHE_NAME));
+        resolvePhysicalTenantIdOrDefault(camundaClient),
+        camundaClient,
+        cacheManager.getCache(SecretKeyCache.SECRET_KEY_CACHE_NAME));
   }
 
   @Bean
@@ -319,18 +493,23 @@ public class OutboundConnectorRuntimeConfiguration {
       CamundaClient legacyCamundaClient,
       CacheManager cacheManager) {
     var sharedCache = cacheManager.getCache(SecretKeyCache.SECRET_KEY_CACHE_NAME);
+    // Resolved once per client name (rather than via toMapByPhysicalTenantId, which would
+    // recompute the same physical tenant ID a second time inside the value-mapper) and reused as
+    // both the map key and the cache's own id.
     return clientNames(registry, legacyCamundaClient).stream()
+        .map(
+            name ->
+                Map.entry(
+                    resolvePhysicalTenantId(registry, name, legacyCamundaClient),
+                    resolveClient(registry, name, legacyCamundaClient)))
         .collect(
-            toMapByPhysicalTenantId(
-                registry,
-                legacyCamundaClient,
-                name -> {
-                  var physicalTenantId =
-                      resolvePhysicalTenantId(registry, name, legacyCamundaClient);
-                  return new ProcessDefinitionSecretKeyCache(
-                      physicalTenantId,
-                      resolveClient(registry, name, legacyCamundaClient),
-                      sharedCache);
+            Collectors.toMap(
+                Map.Entry::getKey,
+                e -> new ProcessDefinitionSecretKeyCache(e.getKey(), e.getValue(), sharedCache),
+                (a, b) -> {
+                  throw new IllegalStateException(
+                      "Multiple CamundaClients resolve to the same physical tenant ID; "
+                          + "each configured client must have a unique physical-tenant-id");
                 }));
   }
 
@@ -389,16 +568,20 @@ public class OutboundConnectorRuntimeConfiguration {
       MetricsRecorder metricsRecorder,
       @Autowired(required = false) CamundaClientRegistry registry,
       @Autowired(required = false) CamundaClient legacyCamundaClient,
+      @Autowired(required = false) DocumentFactory documentFactory,
       @Value("${camunda.connector.secret-resolver.secret-filter.mode:DISABLED}")
           SecretFilterMode secretFilterMode,
       @Qualifier("secretKeyCacheManager") CacheManager secretKeyCacheManager,
-      @OutboundConnectorObjectMapper ObjectMapper objectMapper,
+      @OutboundConnectorObjectMapper ObjectMapper outboundConnectorObjectMapper,
       Optional<MeterRegistry> meterRegistry) {
     var documentFactoriesByPhysicalTenantId =
-        buildDocumentFactoriesByPhysicalTenantId(registry, legacyCamundaClient);
+        buildDocumentFactoriesByPhysicalTenantId(registry, legacyCamundaClient, documentFactory);
     var secretFilterFactoriesByPhysicalTenantId =
         buildSecretFilterFactoriesByPhysicalTenantId(
             registry, legacyCamundaClient, secretKeyCacheManager, secretFilterMode);
+    var objectMappersByPhysicalTenantId =
+        buildOutboundConnectorObjectMappersByPhysicalTenantId(
+            registry, documentFactoriesByPhysicalTenantId, outboundConnectorObjectMapper);
     return new OutboundConnectorManager(
         jobWorkerManager,
         connectorFactory,
@@ -406,9 +589,59 @@ public class OutboundConnectorRuntimeConfiguration {
         secretProviderAggregator,
         validationProvider,
         documentFactoriesByPhysicalTenantId,
-        objectMapper,
+        objectMappersByPhysicalTenantId,
         metricsRecorder,
         secretFilterFactoriesByPhysicalTenantId,
         meterRegistry.orElse(null));
+  }
+
+  /**
+   * Per-physical-tenant outbound {@link ObjectMapper}s, each wired to that tenant's {@link
+   * DocumentFactory} so that {@code Document}-typed job variables are deserialized through the
+   * correct engine's document store (see #6961) instead of always going through a single
+   * globally-cached mapper. When {@code registry == null} (no {@link CamundaClientRegistry}
+   * configured), the already-built {@code outboundConnectorObjectMapper} instance (injected above)
+   * is reused as-is: this mirrors {@link #buildDocumentFactoriesByPhysicalTenantId}'s own condition
+   * for reusing the injected {@link DocumentFactory} bean in that case, so a custom/overridden
+   * {@code DocumentFactory} bean (e.g. an in-memory one in tests) and the {@code ObjectMapper} that
+   * deserializes {@code Document}-typed variables stay backed by the very same factory instance.
+   *
+   * <p>Deliberately a plain (non-{@code @Bean}) static method rather than a {@code Map<String,
+   * ObjectMapper>}-typed {@code @Bean}: as documented above for the document/secret-filter maps,
+   * Spring special-cases {@code Map<String, X>}-typed {@code @Bean} parameters to auto-collect all
+   * beans of type {@code X} keyed by bean name instead of resolving a single matching {@code Map}
+   * bean — which would silently yield a map keyed by bean names like {@code
+   * "outboundConnectorObjectMapper"} instead of physical tenant IDs.
+   */
+  private static Map<String, ObjectMapper> buildOutboundConnectorObjectMappersByPhysicalTenantId(
+      CamundaClientRegistry registry,
+      Map<String, DocumentFactory> documentFactoriesByPhysicalTenantId,
+      ObjectMapper outboundConnectorObjectMapper) {
+    if (registry == null) {
+      return documentFactoriesByPhysicalTenantId.keySet().stream()
+          .collect(Collectors.toMap(id -> id, id -> outboundConnectorObjectMapper));
+    }
+    return documentFactoriesByPhysicalTenantId.entrySet().stream()
+        .collect(
+            Collectors.toMap(
+                Map.Entry::getKey, e -> buildOutboundConnectorObjectMapper(e.getValue())));
+  }
+
+  private static ObjectMapper buildOutboundConnectorObjectMapper(DocumentFactory documentFactory) {
+    final ObjectMapper copy = ConnectorsObjectMapperSupplier.getCopy();
+    var functionExecutor = new DefaultIntrinsicFunctionExecutor(copy);
+
+    var jacksonModuleDocumentDeserializer =
+        new JacksonModuleDocumentDeserializer(
+            documentFactory,
+            functionExecutor,
+            JacksonModuleDocumentDeserializer.DocumentModuleSettings.create());
+
+    return copy.registerModules(
+        jacksonModuleDocumentDeserializer,
+        new JacksonModuleFeelFunction(
+            false,
+            FeelExpressionEvaluatorBuilder.local().build()), // FEEL annotation processing disabled
+        new JacksonModuleDocumentSerializer());
   }
 }

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/lifecycle/OutboundConnectorManager.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/lifecycle/OutboundConnectorManager.java
@@ -39,8 +39,10 @@ import io.camunda.connector.runtime.outbound.job.SpringConnectorJobHandler;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.time.Duration;
 import java.util.Arrays;
+import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.concurrent.ConcurrentHashMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -52,11 +54,24 @@ public class OutboundConnectorManager implements CamundaClientLifecycleAware {
   private final JobCallbackCommandWrapperFactory jobCallbackCommandWrapperFactory;
   private final SecretProviderAggregator secretProviderAggregator;
   private final ValidationProvider validationProvider;
+  private final Map<String, DocumentFactory> documentFactoriesByPhysicalTenantId;
   private final ObjectMapper objectMapper;
-  private final DocumentFactory documentFactory;
   private final MetricsRecorder metricsRecorder;
-  private final SecretFilterFactory secretFilterFactory;
+  private final Map<String, SecretFilterFactory> secretFilterFactoriesByPhysicalTenantId;
   private final MeterRegistry meterRegistry;
+
+  /**
+   * One {@link OutboundConnectorFunction} instance per (physical tenant, connector type) pair —
+   * connectors are re-created per physical tenant for isolation, rather than sharing the single
+   * globally-cached instance {@link OutboundConnectorFactory#getInstance(String)} would return.
+   * Entries persist for the process lifetime and are reused across an {@code onStop}+{@code
+   * onStart} cycle for the same tenant (e.g. a client reconnect) — connectors have no
+   * close/lifecycle contract to invoke on teardown.
+   */
+  private final Map<InstanceCacheKey, OutboundConnectorFunction>
+      connectorInstancesByPhysicalTenant = new ConcurrentHashMap<>();
+
+  private record InstanceCacheKey(String physicalTenantId, String connectorType) {}
 
   public OutboundConnectorManager(
       JobWorkerManager jobWorkerManager,
@@ -64,41 +79,93 @@ public class OutboundConnectorManager implements CamundaClientLifecycleAware {
       JobCallbackCommandWrapperFactory jobCallbackCommandWrapperFactory,
       SecretProviderAggregator secretProviderAggregator,
       ValidationProvider validationProvider,
-      DocumentFactory documentFactory,
+      Map<String, DocumentFactory> documentFactoriesByPhysicalTenantId,
       ObjectMapper objectMapper,
       MetricsRecorder metricsRecorder,
-      SecretFilterFactory secretFilterFactory,
+      Map<String, SecretFilterFactory> secretFilterFactoriesByPhysicalTenantId,
       MeterRegistry meterRegistry) {
     this.jobWorkerManager = jobWorkerManager;
     this.connectorFactory = connectorFactory;
     this.jobCallbackCommandWrapperFactory = jobCallbackCommandWrapperFactory;
     this.secretProviderAggregator = secretProviderAggregator;
     this.validationProvider = validationProvider;
-    this.documentFactory = documentFactory;
+    this.documentFactoriesByPhysicalTenantId = documentFactoriesByPhysicalTenantId;
     this.objectMapper = objectMapper;
     this.metricsRecorder = metricsRecorder;
-    this.secretFilterFactory = secretFilterFactory;
+    this.secretFilterFactoriesByPhysicalTenantId = secretFilterFactoriesByPhysicalTenantId;
     this.meterRegistry = meterRegistry;
   }
 
+  /**
+   * Required by {@link CamundaClientLifecycleAware}; in practice unreachable in a Spring context,
+   * since {@code CamundaClientEventListener} always invokes the 2-arg {@link
+   * #onStart(CamundaClient, String)} overload instead. Kept as a thin single-client-compatible
+   * delegation for interface compliance and direct/manual invocation (e.g. tests).
+   */
   @Override
   public void onStart(final CamundaClient client) {
+    onStart(client, "default");
+  }
+
+  /** See {@link #onStart(CamundaClient)}. */
+  @Override
+  public void onStop(CamundaClient client) {
+    onStop(client, "default");
+  }
+
+  @Override
+  public void onStart(final CamundaClient client, final String clientName) {
+    var physicalTenantId = resolvePhysicalTenantId(client, clientName);
+    var documentFactory = documentFactoriesByPhysicalTenantId.get(physicalTenantId);
+    var secretFilterFactory = secretFilterFactoriesByPhysicalTenantId.get(physicalTenantId);
+    if (documentFactory == null || secretFilterFactory == null) {
+      throw new IllegalStateException(
+          "No DocumentFactory/SecretFilterFactory configured for physical tenant '"
+              + physicalTenantId
+              + "'");
+    }
     // Currently, existing Spring beans have a higher priority
     // One result is that you will not disable Spring Bean Connectors by providing environment
     // variables for a specific connector
     Set<OutboundConnectorConfiguration> outboundConnectors =
         new TreeSet<>(new OutboundConnectorConfigurationComparator());
     outboundConnectors.addAll(connectorFactory.getActiveConfigurations());
-    outboundConnectors.forEach(connector -> openWorkerForOutboundConnector(client, connector));
+    outboundConnectors.forEach(
+        connector ->
+            openWorkerForOutboundConnector(
+                client, physicalTenantId, documentFactory, secretFilterFactory, connector));
   }
 
   @Override
-  public void onStop(CamundaClient client) {
-    jobWorkerManager.closeAllJobWorkers(this);
+  public void onStop(final CamundaClient client, final String clientName) {
+    // client-scoped: tearing down one physical tenant's client must not close every other
+    // physical tenant's job workers registered by this manager
+    jobWorkerManager.closeJobWorkers(this, client);
+  }
+
+  /**
+   * Resolves the physical tenant ID for a job-worker-opening client: the explicitly configured
+   * {@code physical-tenant-id} if present, otherwise the Spring client bean name ({@code
+   * clientName}) itself. Falls back to {@code clientName} if the configuration cannot be read at
+   * all — some test doubles defer real initialization until a test container is ready and throw if
+   * queried too early. Unlike the inbound side, no {@code CamundaClientRegistry} lookup is needed
+   * here: {@code onStart(client, clientName)} is already handed the real client instance directly.
+   */
+  private static String resolvePhysicalTenantId(CamundaClient client, String clientName) {
+    try {
+      var physicalTenantId = client.getConfiguration().getPhysicalTenantId();
+      return physicalTenantId != null ? physicalTenantId : clientName;
+    } catch (RuntimeException e) {
+      return clientName;
+    }
   }
 
   private void openWorkerForOutboundConnector(
-      CamundaClient client, OutboundConnectorConfiguration connector) {
+      CamundaClient client,
+      String physicalTenantId,
+      DocumentFactory documentFactory,
+      SecretFilterFactory secretFilterFactory,
+      OutboundConnectorConfiguration connector) {
     JobWorkerValue jobWorkerValue = new JobWorkerValue();
     jobWorkerValue.setName(new FromAnnotation<>(connector.name()));
     jobWorkerValue.setType(new FromAnnotation<>(connector.type()));
@@ -112,8 +179,14 @@ public class OutboundConnectorManager implements CamundaClientLifecycleAware {
       jobWorkerValue.setTimeout(new FromAnnotation<>(Duration.ofMillis(connector.timeout())));
     }
 
-    OutboundConnectorFunction connectorFunction = connectorFactory.getInstance(connector.type());
-    LOG.trace("Opening worker for connector {}", connector.name());
+    OutboundConnectorFunction connectorFunction =
+        connectorInstancesByPhysicalTenant.computeIfAbsent(
+            new InstanceCacheKey(physicalTenantId, connector.type()),
+            key -> connector.instanceSupplier().get());
+    LOG.trace(
+        "Opening worker for connector {} on physical tenant '{}'",
+        connector.name(),
+        physicalTenantId);
 
     JobHandlerFactory jobHandlerFactory =
         ctx ->

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/lifecycle/OutboundConnectorManager.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/lifecycle/OutboundConnectorManager.java
@@ -55,7 +55,7 @@ public class OutboundConnectorManager implements CamundaClientLifecycleAware {
   private final SecretProviderAggregator secretProviderAggregator;
   private final ValidationProvider validationProvider;
   private final Map<String, DocumentFactory> documentFactoriesByPhysicalTenantId;
-  private final ObjectMapper objectMapper;
+  private final Map<String, ObjectMapper> objectMappersByPhysicalTenantId;
   private final MetricsRecorder metricsRecorder;
   private final Map<String, SecretFilterFactory> secretFilterFactoriesByPhysicalTenantId;
   private final MeterRegistry meterRegistry;
@@ -80,7 +80,7 @@ public class OutboundConnectorManager implements CamundaClientLifecycleAware {
       SecretProviderAggregator secretProviderAggregator,
       ValidationProvider validationProvider,
       Map<String, DocumentFactory> documentFactoriesByPhysicalTenantId,
-      ObjectMapper objectMapper,
+      Map<String, ObjectMapper> objectMappersByPhysicalTenantId,
       MetricsRecorder metricsRecorder,
       Map<String, SecretFilterFactory> secretFilterFactoriesByPhysicalTenantId,
       MeterRegistry meterRegistry) {
@@ -90,7 +90,7 @@ public class OutboundConnectorManager implements CamundaClientLifecycleAware {
     this.secretProviderAggregator = secretProviderAggregator;
     this.validationProvider = validationProvider;
     this.documentFactoriesByPhysicalTenantId = documentFactoriesByPhysicalTenantId;
-    this.objectMapper = objectMapper;
+    this.objectMappersByPhysicalTenantId = objectMappersByPhysicalTenantId;
     this.metricsRecorder = metricsRecorder;
     this.secretFilterFactoriesByPhysicalTenantId = secretFilterFactoriesByPhysicalTenantId;
     this.meterRegistry = meterRegistry;
@@ -118,9 +118,10 @@ public class OutboundConnectorManager implements CamundaClientLifecycleAware {
     var physicalTenantId = resolvePhysicalTenantId(client, clientName);
     var documentFactory = documentFactoriesByPhysicalTenantId.get(physicalTenantId);
     var secretFilterFactory = secretFilterFactoriesByPhysicalTenantId.get(physicalTenantId);
-    if (documentFactory == null || secretFilterFactory == null) {
+    var objectMapper = objectMappersByPhysicalTenantId.get(physicalTenantId);
+    if (documentFactory == null || secretFilterFactory == null || objectMapper == null) {
       throw new IllegalStateException(
-          "No DocumentFactory/SecretFilterFactory configured for physical tenant '"
+          "No DocumentFactory/SecretFilterFactory/ObjectMapper configured for physical tenant '"
               + physicalTenantId
               + "'");
     }
@@ -133,7 +134,12 @@ public class OutboundConnectorManager implements CamundaClientLifecycleAware {
     outboundConnectors.forEach(
         connector ->
             openWorkerForOutboundConnector(
-                client, physicalTenantId, documentFactory, secretFilterFactory, connector));
+                client,
+                physicalTenantId,
+                documentFactory,
+                secretFilterFactory,
+                objectMapper,
+                connector));
   }
 
   @Override
@@ -165,6 +171,7 @@ public class OutboundConnectorManager implements CamundaClientLifecycleAware {
       String physicalTenantId,
       DocumentFactory documentFactory,
       SecretFilterFactory secretFilterFactory,
+      ObjectMapper objectMapper,
       OutboundConnectorConfiguration connector) {
     JobWorkerValue jobWorkerValue = new JobWorkerValue();
     jobWorkerValue.setName(new FromAnnotation<>(connector.name()));

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/secret/ProcessDefinitionSecretKeyCache.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/secret/ProcessDefinitionSecretKeyCache.java
@@ -56,20 +56,31 @@ public class ProcessDefinitionSecretKeyCache implements SecretKeyCache {
     OUTBOUND_ELIGIBLE_TYPES.add(BusinessRuleTask.class);
   }
 
+  private final String physicalTenantId;
   private final CamundaClient camundaClient;
   private final Cache cache;
 
-  public ProcessDefinitionSecretKeyCache(CamundaClient camundaClient, Cache cache) {
+  /**
+   * @param physicalTenantId identifies the physical tenant this instance's {@code camundaClient}
+   *     belongs to. Mixed into the (shared, bounded) cache key so that two physical tenants whose
+   *     {@code processDefinitionKey} values happen to collide don't return each other's secret keys
+   *     — mirrors the equivalent fix for {@code ProcessDefinitionInspector} on the inbound side.
+   */
+  public ProcessDefinitionSecretKeyCache(
+      String physicalTenantId, CamundaClient camundaClient, Cache cache) {
+    this.physicalTenantId = physicalTenantId;
     this.camundaClient = camundaClient;
     this.cache = cache;
   }
 
+  private record CachedProcessDefinitionKey(String physicalTenantId, long processDefinitionKey) {}
+
   @Override
   public List<String> getSecretKeys(SecretKeyContext secretKeyContext) {
+    var cacheKey =
+        new CachedProcessDefinitionKey(physicalTenantId, secretKeyContext.processDefinitionKey());
     return cache
-        .get(
-            secretKeyContext.processDefinitionKey(),
-            () -> fetchSecretKeysByElementIds(secretKeyContext.processDefinitionKey()))
+        .get(cacheKey, () -> fetchSecretKeysByElementIds(secretKeyContext.processDefinitionKey()))
         .getOrDefault(secretKeyContext.elementId(), Collections.emptyList());
   }
 

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/secret/ProcessDefinitionSecretKeyCache.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/secret/ProcessDefinitionSecretKeyCache.java
@@ -61,6 +61,15 @@ public class ProcessDefinitionSecretKeyCache implements SecretKeyCache {
   private final Cache cache;
 
   /**
+   * Source/binary-compatibility overload for existing callers compiled against the original
+   * single-tenant {@code (CamundaClient, Cache)} constructor: defaults {@code physicalTenantId} to
+   * {@code "default"}, matching this class's original (pre-#6961) single-tenant behavior.
+   */
+  public ProcessDefinitionSecretKeyCache(CamundaClient camundaClient, Cache cache) {
+    this("default", camundaClient, cache);
+  }
+
+  /**
    * @param physicalTenantId identifies the physical tenant this instance's {@code camundaClient}
    *     belongs to. Mixed into the (shared, bounded) cache key so that two physical tenants whose
    *     {@code processDefinitionKey} values happen to collide don't return each other's secret keys

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/OutboundConnectorRuntimeConfigurationTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/OutboundConnectorRuntimeConfigurationTest.java
@@ -16,10 +16,18 @@
  */
 package io.camunda.connector.runtime.outbound;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
+import io.camunda.client.CamundaClient;
+import io.camunda.client.spring.bean.CamundaClientRegistry;
 import io.camunda.connector.runtime.outbound.secret.SecretKeyCache;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.Test;
 import org.springframework.cache.Cache;
@@ -69,5 +77,106 @@ class OutboundConnectorRuntimeConfigurationTest {
     var cacheManager = configuration.secretKeyCacheManager(true, -1);
 
     assertInstanceOf(CaffeineCacheManager.class, cacheManager);
+  }
+
+  private static CamundaClient clientWithPhysicalTenantId(String physicalTenantId) {
+    var client = mock(CamundaClient.class, RETURNS_DEEP_STUBS);
+    when(client.getConfiguration().getPhysicalTenantId()).thenReturn(physicalTenantId);
+    return client;
+  }
+
+  @Test
+  void documentStoresByPhysicalTenantId_usesExplicitlyConfiguredPhysicalTenantId() {
+    var registry = mock(CamundaClientRegistry.class);
+    var clientA = clientWithPhysicalTenantId("explicit-tenant");
+    when(registry.clientNames()).thenReturn(Set.of("engine-a"));
+    when(registry.get("engine-a")).thenReturn(clientA);
+
+    var result = configuration.documentStoresByPhysicalTenantId(registry, null);
+
+    assertThat(result).containsOnlyKeys("explicit-tenant");
+  }
+
+  @Test
+  void documentStoresByPhysicalTenantId_fallsBackToClientNameWhenPhysicalTenantIdNotConfigured() {
+    var registry = mock(CamundaClientRegistry.class);
+    var clientB = clientWithPhysicalTenantId(null);
+    when(registry.clientNames()).thenReturn(Set.of("engine-b"));
+    when(registry.get("engine-b")).thenReturn(clientB);
+
+    var result = configuration.documentStoresByPhysicalTenantId(registry, null);
+
+    assertThat(result).containsOnlyKeys("engine-b");
+  }
+
+  @Test
+  void documentStoresByPhysicalTenantId_fallsBackToClientNameWhenConfigurationCannotBeRead() {
+    var registry = mock(CamundaClientRegistry.class);
+    when(registry.clientNames()).thenReturn(Set.of("engine-c"));
+    var uninitializedClient = mock(CamundaClient.class);
+    when(uninitializedClient.getConfiguration())
+        .thenThrow(new RuntimeException("client not initialized"));
+    when(registry.get("engine-c")).thenReturn(uninitializedClient);
+
+    var result = configuration.documentStoresByPhysicalTenantId(registry, null);
+
+    assertThat(result).containsOnlyKeys("engine-c");
+  }
+
+  @Test
+  void documentStoresByPhysicalTenantId_fallsBackToLegacyCamundaClientWhenRegistryLookupFails() {
+    var registry = mock(CamundaClientRegistry.class);
+    when(registry.clientNames()).thenReturn(Set.of("default"));
+    when(registry.get("default"))
+        .thenThrow(
+            new IllegalArgumentException("No CamundaClient configured under name 'default'"));
+    var legacyClient = clientWithPhysicalTenantId("legacy-tenant");
+
+    var result = configuration.documentStoresByPhysicalTenantId(registry, legacyClient);
+
+    assertThat(result).containsOnlyKeys("legacy-tenant");
+  }
+
+  @Test
+  void
+      documentStoresByPhysicalTenantId_throwsClearErrorWhenNeitherRegistryNorLegacyClientIsAvailable() {
+    var registry = mock(CamundaClientRegistry.class);
+    when(registry.clientNames()).thenReturn(Set.of("default"));
+    when(registry.get("default"))
+        .thenThrow(
+            new IllegalArgumentException("No CamundaClient configured under name 'default'"));
+
+    assertThatThrownBy(() -> configuration.documentStoresByPhysicalTenantId(registry, null))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("default");
+  }
+
+  @Test
+  void
+      documentStoresByPhysicalTenantId_throwsClearErrorWhenTwoClientsResolveToTheSamePhysicalTenantId() {
+    var registry = mock(CamundaClientRegistry.class);
+    var clientA = clientWithPhysicalTenantId("duplicate-tenant");
+    var clientB = clientWithPhysicalTenantId("duplicate-tenant");
+    when(registry.clientNames()).thenReturn(Set.of("engine-a", "engine-b"));
+    when(registry.get("engine-a")).thenReturn(clientA);
+    when(registry.get("engine-b")).thenReturn(clientB);
+
+    assertThatThrownBy(() -> configuration.documentStoresByPhysicalTenantId(registry, null))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("same physical tenant ID");
+  }
+
+  @Test
+  void documentFactoriesByPhysicalTenantId_oneEntryPerConfiguredClient() {
+    var registry = mock(CamundaClientRegistry.class);
+    var clientA = clientWithPhysicalTenantId("tenant-a");
+    var clientB = clientWithPhysicalTenantId("tenant-b");
+    when(registry.clientNames()).thenReturn(Set.of("engine-a", "engine-b"));
+    when(registry.get("engine-a")).thenReturn(clientA);
+    when(registry.get("engine-b")).thenReturn(clientB);
+
+    var result = configuration.documentFactoriesByPhysicalTenantId(registry, null);
+
+    assertThat(result).containsOnlyKeys("tenant-a", "tenant-b");
   }
 }

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/OutboundConnectorRuntimeConfigurationTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/OutboundConnectorRuntimeConfigurationTest.java
@@ -175,7 +175,7 @@ class OutboundConnectorRuntimeConfigurationTest {
     when(registry.get("engine-a")).thenReturn(clientA);
     when(registry.get("engine-b")).thenReturn(clientB);
 
-    var result = configuration.documentFactoriesByPhysicalTenantId(registry, null);
+    var result = configuration.documentFactoriesByPhysicalTenantId(registry, null, null);
 
     assertThat(result).containsOnlyKeys("tenant-a", "tenant-b");
   }

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/lifecycle/OutboundConnectorManagerTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/lifecycle/OutboundConnectorManagerTest.java
@@ -1,0 +1,244 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.runtime.outbound.lifecycle;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.client.CamundaClient;
+import io.camunda.client.jobhandling.JobCallbackCommandWrapperFactory;
+import io.camunda.client.jobhandling.JobWorkerManager;
+import io.camunda.client.metrics.MetricsRecorder;
+import io.camunda.connector.api.document.DocumentFactory;
+import io.camunda.connector.api.outbound.OutboundConnectorFunction;
+import io.camunda.connector.api.validation.ValidationProvider;
+import io.camunda.connector.runtime.core.config.OutboundConnectorConfiguration;
+import io.camunda.connector.runtime.core.outbound.OutboundConnectorFactory;
+import io.camunda.connector.runtime.core.secret.SecretFilterFactory;
+import io.camunda.connector.runtime.core.secret.SecretProviderAggregator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Supplier;
+import org.junit.jupiter.api.Test;
+
+class OutboundConnectorManagerTest {
+
+  private static CamundaClient clientWithPhysicalTenantId(String physicalTenantId) {
+    var client = mock(CamundaClient.class, RETURNS_DEEP_STUBS);
+    when(client.getConfiguration().getPhysicalTenantId()).thenReturn(physicalTenantId);
+    return client;
+  }
+
+  private static OutboundConnectorConfiguration connectorConfig(
+      String type, Supplier<OutboundConnectorFunction> instanceSupplier) {
+    return new OutboundConnectorConfiguration(type, new String[0], type, instanceSupplier, null);
+  }
+
+  private static OutboundConnectorManager managerWith(
+      JobWorkerManager jobWorkerManager,
+      OutboundConnectorFactory connectorFactory,
+      Map<String, DocumentFactory> documentFactoriesByPhysicalTenantId,
+      Map<String, SecretFilterFactory> secretFilterFactoriesByPhysicalTenantId) {
+    return new OutboundConnectorManager(
+        jobWorkerManager,
+        connectorFactory,
+        mock(JobCallbackCommandWrapperFactory.class),
+        mock(SecretProviderAggregator.class),
+        mock(ValidationProvider.class),
+        documentFactoriesByPhysicalTenantId,
+        mock(ObjectMapper.class),
+        mock(MetricsRecorder.class),
+        secretFilterFactoriesByPhysicalTenantId,
+        null);
+  }
+
+  @Test
+  void onStart_throwsClearErrorWhenResolvedPhysicalTenantHasNoConfiguredFactories() {
+    var jobWorkerManager = mock(JobWorkerManager.class);
+    var connectorFactory = mock(OutboundConnectorFactory.class);
+    when(connectorFactory.getActiveConfigurations()).thenReturn(Set.of());
+    var manager = managerWith(jobWorkerManager, connectorFactory, Map.of(), Map.of());
+    var client = clientWithPhysicalTenantId("unconfigured-tenant");
+
+    assertThatThrownBy(() -> manager.onStart(client, "engine-a"))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("unconfigured-tenant");
+  }
+
+  @Test
+  void onStart_opensOneWorkerPerActiveConnector_whenPhysicalTenantIsConfigured() {
+    var jobWorkerManager = mock(JobWorkerManager.class);
+    var connectorFactory = mock(OutboundConnectorFactory.class);
+    when(connectorFactory.getActiveConfigurations())
+        .thenReturn(
+            List.of(
+                connectorConfig("type-a", () -> mock(OutboundConnectorFunction.class)),
+                connectorConfig("type-b", () -> mock(OutboundConnectorFunction.class))));
+    var documentFactory = mock(DocumentFactory.class);
+    var secretFilterFactory = mock(SecretFilterFactory.class);
+    var manager =
+        managerWith(
+            jobWorkerManager,
+            connectorFactory,
+            Map.of("tenant-a", documentFactory),
+            Map.of("tenant-a", secretFilterFactory));
+    var client = clientWithPhysicalTenantId("tenant-a");
+
+    manager.onStart(client, "engine-a");
+
+    verify(jobWorkerManager, times(2)).createJobWorker(any(), any(), any());
+  }
+
+  @Test
+  void onStart_resolvesPhysicalTenantIdFromConfiguration_fallsBackToClientNameWhenNotConfigured() {
+    var jobWorkerManager = mock(JobWorkerManager.class);
+    var connectorFactory = mock(OutboundConnectorFactory.class);
+    when(connectorFactory.getActiveConfigurations()).thenReturn(Set.of());
+    var manager =
+        managerWith(
+            jobWorkerManager,
+            connectorFactory,
+            Map.of("engine-b", mock(DocumentFactory.class)),
+            Map.of("engine-b", mock(SecretFilterFactory.class)));
+    // no physical-tenant-id explicitly configured -> falls back to the client name "engine-b"
+    var client = clientWithPhysicalTenantId(null);
+
+    manager.onStart(client, "engine-b");
+
+    // no exception thrown proves resolution correctly fell back to "engine-b" and found the map
+    // entries
+  }
+
+  @Test
+  void onStart_fallsBackToClientNameWhenConfigurationCannotBeRead() {
+    var jobWorkerManager = mock(JobWorkerManager.class);
+    var connectorFactory = mock(OutboundConnectorFactory.class);
+    when(connectorFactory.getActiveConfigurations()).thenReturn(Set.of());
+    var manager =
+        managerWith(
+            jobWorkerManager,
+            connectorFactory,
+            Map.of("engine-c", mock(DocumentFactory.class)),
+            Map.of("engine-c", mock(SecretFilterFactory.class)));
+    var uninitializedClient = mock(CamundaClient.class);
+    when(uninitializedClient.getConfiguration())
+        .thenThrow(new RuntimeException("client not initialized"));
+
+    manager.onStart(uninitializedClient, "engine-c");
+
+    // no exception thrown proves resolution fell back to "engine-c" despite the config read failure
+  }
+
+  @Test
+  void onStart_createsOneConnectorInstancePerPhysicalTenant_isolatingAcrossTenants() {
+    var jobWorkerManager = mock(JobWorkerManager.class);
+    var connectorFactory = mock(OutboundConnectorFactory.class);
+    var instancesCreated = new java.util.concurrent.atomic.AtomicInteger();
+    Supplier<OutboundConnectorFunction> instanceSupplier =
+        () -> {
+          instancesCreated.incrementAndGet();
+          return mock(OutboundConnectorFunction.class);
+        };
+    when(connectorFactory.getActiveConfigurations())
+        .thenReturn(List.of(connectorConfig("type-a", instanceSupplier)));
+    var manager =
+        managerWith(
+            jobWorkerManager,
+            connectorFactory,
+            Map.of(
+                "tenant-a", mock(DocumentFactory.class),
+                "tenant-b", mock(DocumentFactory.class)),
+            Map.of(
+                "tenant-a", mock(SecretFilterFactory.class),
+                "tenant-b", mock(SecretFilterFactory.class)));
+
+    manager.onStart(clientWithPhysicalTenantId("tenant-a"), "engine-a");
+    manager.onStart(clientWithPhysicalTenantId("tenant-b"), "engine-b");
+
+    assertThat(instancesCreated.get()).isEqualTo(2);
+  }
+
+  @Test
+  void onStart_reusesSameConnectorInstance_acrossRepeatedOnStartForTheSamePhysicalTenant() {
+    var jobWorkerManager = mock(JobWorkerManager.class);
+    var connectorFactory = mock(OutboundConnectorFactory.class);
+    var instancesCreated = new java.util.concurrent.atomic.AtomicInteger();
+    Supplier<OutboundConnectorFunction> instanceSupplier =
+        () -> {
+          instancesCreated.incrementAndGet();
+          return mock(OutboundConnectorFunction.class);
+        };
+    when(connectorFactory.getActiveConfigurations())
+        .thenReturn(List.of(connectorConfig("type-a", instanceSupplier)));
+    var manager =
+        managerWith(
+            jobWorkerManager,
+            connectorFactory,
+            Map.of("tenant-a", mock(DocumentFactory.class)),
+            Map.of("tenant-a", mock(SecretFilterFactory.class)));
+    var client = clientWithPhysicalTenantId("tenant-a");
+
+    manager.onStart(client, "engine-a");
+    // simulate a client reconnect: onStop then onStart again for the same physical tenant
+    manager.onStop(client, "engine-a");
+    manager.onStart(client, "engine-a");
+
+    assertThat(instancesCreated.get()).isEqualTo(1);
+  }
+
+  @Test
+  void onStop_closesOnlyThisClientsJobWorkers_neverAllClients() {
+    var jobWorkerManager = mock(JobWorkerManager.class);
+    var connectorFactory = mock(OutboundConnectorFactory.class);
+    var manager = managerWith(jobWorkerManager, connectorFactory, Map.of(), Map.of());
+    var client = clientWithPhysicalTenantId("tenant-a");
+
+    manager.onStop(client, "engine-a");
+
+    verify(jobWorkerManager).closeJobWorkers(manager, client);
+    verify(jobWorkerManager, never()).closeAllJobWorkers(any());
+  }
+
+  @Test
+  void singleArgOnStartAndOnStop_delegateToTwoArgFormsWithDefaultClientName() {
+    var jobWorkerManager = mock(JobWorkerManager.class);
+    var connectorFactory = mock(OutboundConnectorFactory.class);
+    when(connectorFactory.getActiveConfigurations()).thenReturn(Set.of());
+    var manager =
+        managerWith(
+            jobWorkerManager,
+            connectorFactory,
+            Map.of("default", mock(DocumentFactory.class)),
+            Map.of("default", mock(SecretFilterFactory.class)));
+    var client = clientWithPhysicalTenantId(null);
+
+    manager.onStart(client);
+    manager.onStop(client);
+
+    // resolves to "default" (client name fallback) and finds the map entries without throwing
+    verify(jobWorkerManager).closeJobWorkers(manager, client);
+  }
+}

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/lifecycle/OutboundConnectorManagerTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/lifecycle/OutboundConnectorManagerTest.java
@@ -62,6 +62,9 @@ class OutboundConnectorManagerTest {
       OutboundConnectorFactory connectorFactory,
       Map<String, DocumentFactory> documentFactoriesByPhysicalTenantId,
       Map<String, SecretFilterFactory> secretFilterFactoriesByPhysicalTenantId) {
+    var objectMappersByPhysicalTenantId =
+        documentFactoriesByPhysicalTenantId.keySet().stream()
+            .collect(java.util.stream.Collectors.toMap(id -> id, id -> mock(ObjectMapper.class)));
     return new OutboundConnectorManager(
         jobWorkerManager,
         connectorFactory,
@@ -69,7 +72,7 @@ class OutboundConnectorManagerTest {
         mock(SecretProviderAggregator.class),
         mock(ValidationProvider.class),
         documentFactoriesByPhysicalTenantId,
-        mock(ObjectMapper.class),
+        objectMappersByPhysicalTenantId,
         mock(MetricsRecorder.class),
         secretFilterFactoriesByPhysicalTenantId,
         null);

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/lifecycle/OutboundRegistryTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/lifecycle/OutboundRegistryTest.java
@@ -22,17 +22,17 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.connector.api.annotation.OutboundConnector;
 import io.camunda.connector.api.outbound.OutboundConnectorContext;
 import io.camunda.connector.api.outbound.OutboundConnectorFunction;
-import io.camunda.connector.api.outbound.OutboundConnectorProvider;
 import io.camunda.connector.runtime.core.config.OutboundConnectorConfiguration;
 import io.camunda.connector.runtime.core.outbound.DefaultOutboundConnectorFactory;
 import io.camunda.connector.runtime.core.validation.ValidationUtil;
 import io.camunda.connector.runtime.outbound.OutboundConnectorRuntimeConfiguration;
-import java.util.List;
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.ThrowingConsumer;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Scope;
 import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Component;
 
@@ -45,16 +45,13 @@ class OutboundRegistryTest {
   private static class TestConfig {
     @Bean
     public DefaultOutboundConnectorFactory outboundFactory(
-        Environment environment,
-        List<OutboundConnectorFunction> functions,
-        List<OutboundConnectorProvider> providers) {
+        Environment environment, ConfigurableListableBeanFactory beanFactory) {
       return (new OutboundConnectorRuntimeConfiguration())
           .outboundConnectorConfigurationRegistry(
               new ObjectMapper(),
               ValidationUtil.discoverDefaultValidationProviderImplementation(),
               environment,
-              functions,
-              providers);
+              beanFactory);
     }
   }
 
@@ -112,6 +109,41 @@ class OutboundRegistryTest {
         });
   }
 
+  @Test
+  void suppliesFreshInstance_perInstanceSupplierCall_evenForSingletonScopedSpringBean() {
+    // #6961: genuine per-tenant isolation must not require connector authors to opt into
+    // prototype scope, so even a (default) singleton-scoped bean gets a fresh instance per call.
+    runTest(
+        contextRunner,
+        config -> {
+          var first = config.instanceSupplier().get();
+          var second = config.instanceSupplier().get();
+          assertThat(first).isInstanceOf(AnnotatedFunction.class);
+          assertThat(first).isNotSameAs(second);
+        });
+  }
+
+  @Test
+  void suppliesFreshInstance_perInstanceSupplierCall_forPrototypeScopedSpringBean() {
+    new ApplicationContextRunner()
+        .withUserConfiguration(TestConfig.class, PrototypeFunction.class)
+        .run(
+            context -> {
+              var registry = context.getBean(DefaultOutboundConnectorFactory.class);
+              var config =
+                  registry.getActiveConfigurations().stream()
+                      .filter(c -> c.type().equals("io.camunda:prototype"))
+                      .findFirst()
+                      .orElseThrow();
+
+              var first = config.instanceSupplier().get();
+              var second = config.instanceSupplier().get();
+
+              assertThat(first).isInstanceOf(PrototypeFunction.class);
+              assertThat(first).isNotSameAs(second);
+            });
+  }
+
   private void runTest(
       ApplicationContextRunner configuredContextRunner,
       ThrowingConsumer<OutboundConnectorConfiguration> configurationAssertions) {
@@ -138,6 +170,19 @@ class OutboundRegistryTest {
     type = "io.camunda:annotated")
 @Component
 class AnnotatedFunction implements OutboundConnectorFunction {
+  @Override
+  public Object execute(OutboundConnectorContext context) throws Exception {
+    return null;
+  }
+}
+
+@OutboundConnector(
+    name = "Prototype Function",
+    inputVariables = {},
+    type = "io.camunda:prototype")
+@Component
+@Scope("prototype")
+class PrototypeFunction implements OutboundConnectorFunction {
   @Override
   public Object execute(OutboundConnectorContext context) throws Exception {
     return null;

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/secret/ProcessDefinitionSecretKeyCacheTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/secret/ProcessDefinitionSecretKeyCacheTest.java
@@ -19,6 +19,9 @@ package io.camunda.connector.runtime.outbound.secret;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.camunda.client.CamundaClient;
@@ -33,6 +36,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.cache.Cache;
+import org.springframework.cache.concurrent.ConcurrentMapCache;
 
 @ExtendWith(MockitoExtension.class)
 class ProcessDefinitionSecretKeyCacheTest {
@@ -47,9 +51,14 @@ class ProcessDefinitionSecretKeyCacheTest {
 
   @BeforeEach
   void setUp() throws Exception {
-    secretKeyCache = new ProcessDefinitionSecretKeyCache(camundaClient, cache);
-    when(camundaClient.newProcessDefinitionGetXmlRequest(anyLong())).thenReturn(xmlRequest);
-    when(cache.get(anyLong(), any(Callable.class)))
+    secretKeyCache = new ProcessDefinitionSecretKeyCache("tenant", camundaClient, cache);
+    // lenient: the cross-tenant collision test below builds its own separate clients/caches and
+    // doesn't exercise these shared fields
+    lenient()
+        .when(camundaClient.newProcessDefinitionGetXmlRequest(anyLong()))
+        .thenReturn(xmlRequest);
+    lenient()
+        .when(cache.get(any(), any(Callable.class)))
         .thenAnswer(
             invocation -> {
               Callable<?> loader = invocation.getArgument(1);
@@ -107,6 +116,37 @@ class ProcessDefinitionSecretKeyCacheTest {
         secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "nonexistent-task"));
 
     assertThat(keys).isEmpty();
+  }
+
+  @Test
+  void getSecretKeys_collidingProcessDefinitionKeyAcrossPhysicalTenants_doesNotLeakBetweenTenants()
+      throws IOException {
+    // a real (unmocked) shared cache, proving the compound key actually disambiguates rather than
+    // relying on a mock that never really stores anything
+    Cache sharedCache = new ConcurrentMapCache("secret-keys");
+    var clientA = mock(CamundaClient.class);
+    var clientB = mock(CamundaClient.class);
+    var xmlRequestA = mock(ProcessDefinitionGetXmlRequest.class);
+    var xmlRequestB = mock(ProcessDefinitionGetXmlRequest.class);
+    when(clientA.newProcessDefinitionGetXmlRequest(PROCESS_DEF_KEY)).thenReturn(xmlRequestA);
+    when(clientB.newProcessDefinitionGetXmlRequest(PROCESS_DEF_KEY)).thenReturn(xmlRequestB);
+    when(xmlRequestA.execute()).thenReturn(loadBpmn("outbound-with-secrets.bpmn"));
+    when(xmlRequestB.execute()).thenReturn(loadBpmn("outbound-no-secrets.bpmn"));
+
+    var cacheForTenantA = new ProcessDefinitionSecretKeyCache("tenant-a", clientA, sharedCache);
+    var cacheForTenantB = new ProcessDefinitionSecretKeyCache("tenant-b", clientB, sharedCache);
+
+    var keysA =
+        cacheForTenantA.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1"));
+    var keysB =
+        cacheForTenantB.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "no-secrets-task"));
+
+    assertThat(keysA).containsExactlyInAnyOrder("API_KEY", "MY_TOKEN");
+    assertThat(keysB).isEmpty();
+    // each tenant's own client was queried exactly once, proving neither served the other's cache
+    // entry despite the identical processDefinitionKey
+    verify(clientA).newProcessDefinitionGetXmlRequest(PROCESS_DEF_KEY);
+    verify(clientB).newProcessDefinitionGetXmlRequest(PROCESS_DEF_KEY);
   }
 
   private String loadBpmn(String fileName) throws IOException {

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/main/java/io/camunda/connector/runtime/ConnectorsAutoConfiguration.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/main/java/io/camunda/connector/runtime/ConnectorsAutoConfiguration.java
@@ -249,6 +249,10 @@ public class ConnectorsAutoConfiguration {
   @OutboundConnectorObjectMapper
   @ConditionalOnMissingBean(name = "outboundConnectorObjectMapper")
   public ObjectMapper outboundConnectorObjectMapper(DocumentFactory documentFactory) {
+    return buildOutboundConnectorObjectMapper(documentFactory);
+  }
+
+  private static ObjectMapper buildOutboundConnectorObjectMapper(DocumentFactory documentFactory) {
     final ObjectMapper copy = ConnectorsObjectMapperSupplier.getCopy();
     var functionExecutor = new DefaultIntrinsicFunctionExecutor(copy);
 

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/app/TestPrototypeOutboundConnector.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/app/TestPrototypeOutboundConnector.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.runtime.app;
+
+import io.camunda.connector.api.annotation.OutboundConnector;
+import io.camunda.connector.api.outbound.OutboundConnectorContext;
+import io.camunda.connector.api.outbound.OutboundConnectorFunction;
+import org.springframework.context.annotation.Scope;
+
+/**
+ * A prototype-scoped outbound connector fixture used to verify (#6961) that {@code
+ * beanFactory.getBean(name, type)}-backed instance suppliers yield a genuinely fresh instance on
+ * every call, rather than always returning one globally shared instance.
+ */
+@OutboundConnector(
+    name = "TEST_PROTOTYPE",
+    type = TestPrototypeOutboundConnector.TYPE,
+    inputVariables = {})
+@Scope("prototype")
+public class TestPrototypeOutboundConnector implements OutboundConnectorFunction {
+
+  public static final String TYPE = "io.camunda:test-outbound-prototype:1";
+
+  @Override
+  public Object execute(OutboundConnectorContext context) {
+    return null;
+  }
+}

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/app/TestSingletonOutboundConnector.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/app/TestSingletonOutboundConnector.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.runtime.app;
+
+import io.camunda.connector.api.annotation.OutboundConnector;
+import io.camunda.connector.api.outbound.OutboundConnectorContext;
+import io.camunda.connector.api.outbound.OutboundConnectorFunction;
+
+/**
+ * A (default) singleton-scoped outbound connector fixture used to verify (#6961) that per-tenant
+ * instance isolation also applies to ordinary Spring singleton beans, not just connectors that opt
+ * into prototype scope (see {@link TestPrototypeOutboundConnector}).
+ */
+@OutboundConnector(
+    name = "TEST_SINGLETON",
+    type = TestSingletonOutboundConnector.TYPE,
+    inputVariables = {})
+public class TestSingletonOutboundConnector implements OutboundConnectorFunction {
+
+  public static final String TYPE = "io.camunda:test-outbound-singleton:1";
+
+  @Override
+  public Object execute(OutboundConnectorContext context) {
+    return null;
+  }
+}

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/outbound/MultiClientOutboundConnectorInstanceIsolationTest.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/outbound/MultiClientOutboundConnectorInstanceIsolationTest.java
@@ -1,0 +1,185 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.runtime.outbound;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.verify;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.worker.JobHandler;
+import io.camunda.client.jobhandling.JobHandlerFactory.JobHandlerFactoryContext;
+import io.camunda.client.jobhandling.JobWorkerManager;
+import io.camunda.client.jobhandling.ManagedJobWorker;
+import io.camunda.client.spring.bean.CamundaClientRegistry;
+import io.camunda.connector.runtime.app.TestConnectorRuntimeApplication;
+import io.camunda.connector.runtime.app.TestPrototypeOutboundConnector;
+import io.camunda.connector.runtime.app.TestSingletonOutboundConnector;
+import io.camunda.connector.runtime.outbound.lifecycle.OutboundConnectorManager;
+import java.lang.reflect.Field;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+/**
+ * End-to-end verification of the #6961 outbound multi-engine instance isolation fix, using a real
+ * Spring context with two physical tenants configured (mirroring {@link
+ * MultiClientOutboundPhysicalTenantWiringTest}) and a mocked {@link JobWorkerManager} to capture
+ * the {@link ManagedJobWorker} registrations {@link OutboundConnectorManager} produces per physical
+ * tenant — without needing a live Zeebe broker, since {@code CamundaClient} construction is lazy
+ * (see the class-level Javadoc on {@link MultiClientOutboundPhysicalTenantWiringTest}).
+ *
+ * <p>Both a {@code @Scope("prototype")} and a (default) singleton-scoped connector fixture are
+ * exercised, to confirm isolation does not depend on connector authors opting into prototype scope:
+ * {@link OutboundConnectorRuntimeConfiguration} wires connector instance suppliers via {@code
+ * AutowireCapableBeanFactory#createBean(Class)}, which always constructs a brand-new, unmanaged
+ * instance regardless of the bean definition's declared scope.
+ *
+ * <p>Reflection is used over the resulting {@code SpringConnectorJobHandler} instances (which have
+ * no public accessors) to assert that the connector instance, {@code DocumentFactory}, and {@code
+ * ObjectMapper} wired into each physical tenant's job worker are genuinely isolated.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@SpringBootTest(
+    classes = {
+      TestConnectorRuntimeApplication.class,
+      TestPrototypeOutboundConnector.class,
+      TestSingletonOutboundConnector.class
+    },
+    properties = {
+      "camunda.clients.engine-a.mode=self-managed",
+      "camunda.clients.engine-a.grpc-address=http://engine-a.internal:26500",
+      "camunda.clients.engine-a.physical-tenant-id=tenanta",
+      "camunda.clients.engine-a.primary=true",
+      "camunda.clients.engine-b.mode=self-managed",
+      "camunda.clients.engine-b.grpc-address=http://engine-b.internal:26500",
+      "camunda.clients.engine-b.physical-tenant-id=tenantb",
+      "camunda.connector.polling.enabled=false",
+      "camunda.connector.webhook.enabled=false"
+    })
+class MultiClientOutboundConnectorInstanceIsolationTest {
+
+  @MockitoBean private JobWorkerManager jobWorkerManager;
+
+  @Autowired private CamundaClientRegistry camundaClientRegistry;
+  @Autowired private OutboundConnectorManager outboundConnectorManager;
+
+  private CamundaClient clientA;
+  private CamundaClient clientB;
+
+  private JobHandler prototypeHandlerA;
+  private JobHandler prototypeHandlerB;
+  private JobHandler singletonHandlerA;
+  private JobHandler singletonHandlerB;
+
+  /**
+   * Captures both physical tenants' job handlers once, up front: {@code @MockitoBean} resets the
+   * mock's recorded invocations before each test method, so {@code verify(...).capture(...)} would
+   * otherwise see zero interactions in every test after the first.
+   */
+  @BeforeAll
+  void startBothPhysicalTenantsAndCaptureJobHandlers() {
+    clientA = camundaClientRegistry.get("engine-a");
+    clientB = camundaClientRegistry.get("engine-b");
+    outboundConnectorManager.onStart(clientA, "engine-a");
+    outboundConnectorManager.onStart(clientB, "engine-b");
+
+    prototypeHandlerA = jobHandlerFor(clientA, TestPrototypeOutboundConnector.TYPE);
+    prototypeHandlerB = jobHandlerFor(clientB, TestPrototypeOutboundConnector.TYPE);
+    singletonHandlerA = jobHandlerFor(clientA, TestSingletonOutboundConnector.TYPE);
+    singletonHandlerB = jobHandlerFor(clientB, TestSingletonOutboundConnector.TYPE);
+  }
+
+  /**
+   * Finds the {@link ManagedJobWorker} that {@link OutboundConnectorManager} registered for the
+   * given client and connector type, and builds the resulting {@link JobHandler} from its {@code
+   * JobHandlerFactory} — mirroring what {@code JobWorkerManager} would normally do internally.
+   */
+  private JobHandler jobHandlerFor(CamundaClient client, String connectorType) {
+    var clientCaptor = ArgumentCaptor.forClass(CamundaClient.class);
+    var workerCaptor = ArgumentCaptor.forClass(ManagedJobWorker.class);
+    verify(jobWorkerManager, atLeastOnce())
+        .createJobWorker(clientCaptor.capture(), workerCaptor.capture(), any());
+
+    var clients = clientCaptor.getAllValues();
+    var workers = workerCaptor.getAllValues();
+    for (int i = 0; i < clients.size(); i++) {
+      if (clients.get(i) == client
+          && workers.get(i).jobWorkerValue().getType().value().equals(connectorType)) {
+        return workers
+            .get(i)
+            .jobHandlerFactory()
+            .getJobHandler(new JobHandlerFactoryContext(workers.get(i).jobWorkerValue(), client));
+      }
+    }
+    throw new AssertionError(
+        "No job worker registered for client " + client + " and type " + connectorType);
+  }
+
+  private static Object privateField(Object target, String fieldName) throws Exception {
+    Field field = target.getClass().getDeclaredField(fieldName);
+    field.setAccessible(true);
+    return field.get(target);
+  }
+
+  @Test
+  void prototypeScopedConnectorGetsFreshInstancePerPhysicalTenant() throws Exception {
+    var connectorA = privateField(prototypeHandlerA, "call");
+    var connectorB = privateField(prototypeHandlerB, "call");
+
+    assertThat(connectorA).isInstanceOf(TestPrototypeOutboundConnector.class);
+    assertThat(connectorB).isInstanceOf(TestPrototypeOutboundConnector.class);
+    assertThat(connectorA).isNotSameAs(connectorB);
+  }
+
+  @Test
+  void singletonScopedConnectorAlsoGetsFreshInstancePerPhysicalTenant() throws Exception {
+    // #6961: isolation must not require connector authors to opt into prototype scope, so even a
+    // (default) singleton-scoped bean gets a distinct instance per physical tenant.
+    var connectorA = privateField(singletonHandlerA, "call");
+    var connectorB = privateField(singletonHandlerB, "call");
+
+    assertThat(connectorA).isInstanceOf(TestSingletonOutboundConnector.class);
+    assertThat(connectorB).isInstanceOf(TestSingletonOutboundConnector.class);
+    assertThat(connectorA).isNotSameAs(connectorB);
+  }
+
+  @Test
+  void documentFactoryDiffersPerPhysicalTenant() throws Exception {
+    var documentFactoryA = privateField(singletonHandlerA, "documentFactory");
+    var documentFactoryB = privateField(singletonHandlerB, "documentFactory");
+
+    assertThat(documentFactoryA).isNotNull();
+    assertThat(documentFactoryB).isNotNull();
+    assertThat(documentFactoryA).isNotSameAs(documentFactoryB);
+  }
+
+  @Test
+  void objectMapperDiffersPerPhysicalTenant() throws Exception {
+    var objectMapperA = privateField(singletonHandlerA, "objectMapper");
+    var objectMapperB = privateField(singletonHandlerB, "objectMapper");
+
+    assertThat(objectMapperA).isNotNull();
+    assertThat(objectMapperB).isNotNull();
+    assertThat(objectMapperA).isNotSameAs(objectMapperB);
+  }
+}

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/outbound/MultiClientOutboundPhysicalTenantWiringTest.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/outbound/MultiClientOutboundPhysicalTenantWiringTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.runtime.outbound;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.client.spring.bean.CamundaClientRegistry;
+import io.camunda.connector.runtime.app.TestConnectorRuntimeApplication;
+import io.camunda.connector.runtime.outbound.lifecycle.OutboundConnectorManager;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ApplicationContext;
+
+/**
+ * Verifies that, when multiple {@code camunda.clients.*} are configured, the outbound connector
+ * runtime wires one entry per configured physical tenant across all the per-physical-tenant beans —
+ * without needing a live Zeebe broker, since {@code CamundaClient} construction (and therefore this
+ * whole bean graph, including job worker registration) is lazy and does not connect eagerly.
+ *
+ * <p>The per-physical-tenant maps are fetched by explicit bean name via {@link ApplicationContext},
+ * not {@code @Autowired} field injection: this configuration also keeps legacy scalar {@code
+ * documentFactory}/{@code documentStore}/{@code secretKeyCache}/{@code secretFilterFactory} beans
+ * for backward compatibility, and Spring's dependency resolution special-cases any {@code
+ * Map<String, X>} autowiring point by collecting all beans of type {@code X} by name — which would
+ * silently resolve to the single legacy scalar bean instead of the real per-physical-tenant map.
+ */
+@SpringBootTest(
+    classes = TestConnectorRuntimeApplication.class,
+    properties = {
+      "camunda.clients.engine-a.mode=self-managed",
+      "camunda.clients.engine-a.grpc-address=http://engine-a.internal:26500",
+      "camunda.clients.engine-a.physical-tenant-id=tenanta",
+      // marks engine-a as @Primary so the (pre-existing, out-of-scope) single-CamundaClient
+      // autowiring beans elsewhere (e.g. ConnectorsAutoConfiguration's FEEL evaluator, the scalar
+      // documentStore/secretKeyCache beans kept for backward compat) can still resolve
+      // unambiguously with two clients configured.
+      "camunda.clients.engine-a.primary=true",
+      "camunda.clients.engine-b.mode=self-managed",
+      "camunda.clients.engine-b.grpc-address=http://engine-b.internal:26500",
+      "camunda.clients.engine-b.physical-tenant-id=tenantb",
+      "camunda.connector.polling.enabled=false",
+      "camunda.connector.webhook.enabled=false"
+    })
+class MultiClientOutboundPhysicalTenantWiringTest {
+
+  @Autowired private CamundaClientRegistry camundaClientRegistry;
+
+  @Autowired private ApplicationContext applicationContext;
+
+  @Autowired private OutboundConnectorManager outboundConnectorManager;
+
+  @SuppressWarnings("unchecked")
+  private Map<String, Object> mapBean(String beanName) {
+    return (Map<String, Object>) applicationContext.getBean(beanName, Map.class);
+  }
+
+  @Test
+  void registryContainsBothConfiguredClients() {
+    assertThat(camundaClientRegistry.clientNames())
+        .containsExactlyInAnyOrder("engine-a", "engine-b");
+  }
+
+  @Test
+  void everyPerPhysicalTenantMapHasOneEntryPerConfiguredPhysicalTenant() {
+    assertThat(mapBean("documentStoresByPhysicalTenantId")).containsOnlyKeys("tenanta", "tenantb");
+    assertThat(mapBean("documentFactoriesByPhysicalTenantId"))
+        .containsOnlyKeys("tenanta", "tenantb");
+    assertThat(mapBean("secretKeyCachesByPhysicalTenantId")).containsOnlyKeys("tenanta", "tenantb");
+    assertThat(mapBean("secretFilterFactoriesByPhysicalTenantId"))
+        .containsOnlyKeys("tenanta", "tenantb");
+  }
+
+  @Test
+  void outboundConnectorManagerBeanWiresSuccessfully() {
+    assertThat(outboundConnectorManager).isNotNull();
+  }
+}

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/outbound/SpringBasedOutboundConnectorTest.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/outbound/SpringBasedOutboundConnectorTest.java
@@ -42,7 +42,13 @@ public class SpringBasedOutboundConnectorTest {
             .get();
     assertThat(connectorConfig).isNotNull();
     var connectorFromFactory = outboundConnectorFactory.getInstance(connectorConfig.type());
-    assertThat(connectorFromFactory).isEqualTo(connector);
+    // #6961: the factory now creates a fresh, autowired instance per call (via
+    // AutowireCapableBeanFactory#createBean) rather than resolving the container-managed
+    // singleton bean, so isolation does not depend on connector authors opting into prototype
+    // scope. The autowired dependency (Environment) is still correctly injected though, as
+    // verified by the successful execute() call below.
+    assertThat(connectorFromFactory).isInstanceOf(TestSpringBasedOutboundConnector.class);
+    assertThat(connectorFromFactory).isNotSameAs(connector);
     var result = connectorFromFactory.execute(null);
     assertThat(result).isNotNull();
   }


### PR DESCRIPTION
## Description

Convert OutboundConnectorRuntimeConfiguration's document-store/secret-key/ secret-filter beans to per-physical-tenant maps, fix OutboundConnectorManager to resolve the correct tenant's dependencies via the 2-arg onStart/onStop lifecycle callbacks, scope job-worker teardown to the client being stopped (closeJobWorkers instead of closeAllJobWorkers), and re-create connector instances per physical tenant instead of sharing one globally-cached instance. Also fixes a secret-key cache collision across physical tenants with colliding processDefinitionKey values, mirroring the equivalent inbound fix.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #6961 

## Checklist

- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest
  release, as this branch will be rebased onto main before the next release. Example backport labels:
    - `backport stable/8.8`: for changes that should be included in the next 8.8.x release.
    - **or** `backport release-8.8.7`: for changes that should be included in the specific release 8.8.7, and this
      *release has already been created*. The release branch will be merged back into stable/8.8 later, so the change
      will be included in future 8.8.x releases as well.
- [ ] Tests/Integration tests for the changes have been added if applicable.
- [ ] If the change requires a documentation update, it has been added to the appropriate section in the documentation.


