### PR TITLE
feat(sagemaker): migrate to AWS SDK v2

### DIFF
--- a/connectors/aws/aws-sagemaker/pom.xml
+++ b/connectors/aws/aws-sagemaker/pom.xml
@@ -39,9 +39,20 @@
     </dependency>
 
     <dependency>
-      <groupId>com.amazonaws</groupId>
-      <artifactId>aws-java-sdk-sagemakerruntime</artifactId>
-      <version>${version.aws-java-sdk}</version>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>sagemakerruntime</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>aws-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>regions</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>sdk-core</artifactId>
     </dependency>
 
     <dependency>

--- a/connectors/aws/aws-sagemaker/src/main/java/io/camunda/connector/sagemaker/SagemakerConnectorFunction.java
+++ b/connectors/aws/aws-sagemaker/src/main/java/io/camunda/connector/sagemaker/SagemakerConnectorFunction.java
@@ -6,12 +6,10 @@
  */
 package io.camunda.connector.sagemaker;
 
-import com.amazonaws.services.sagemakerruntime.AmazonSageMakerRuntime;
-import com.amazonaws.services.sagemakerruntime.AmazonSageMakerRuntimeAsync;
 import io.camunda.connector.api.annotation.OutboundConnector;
 import io.camunda.connector.api.outbound.OutboundConnectorContext;
 import io.camunda.connector.api.outbound.OutboundConnectorFunction;
-import io.camunda.connector.aws.CredentialsProviderSupport;
+import io.camunda.connector.aws.CredentialsProviderSupportV2;
 import io.camunda.connector.aws.model.impl.AwsCredentialConfiguration;
 import io.camunda.connector.generator.java.annotation.ElementTemplate;
 import io.camunda.connector.sagemaker.caller.SageMakerAsyncCaller;
@@ -22,6 +20,8 @@ import io.camunda.connector.sagemaker.model.SageMakerRequest;
 import io.camunda.connector.sagemaker.model.SageMakerSyncResponse;
 import io.camunda.connector.sagemaker.suppliers.SageMakeClientSupplier;
 import java.util.function.BiFunction;
+import software.amazon.awssdk.services.sagemakerruntime.SageMakerRuntimeAsyncClient;
+import software.amazon.awssdk.services.sagemakerruntime.SageMakerRuntimeClient;
 
 @OutboundConnector(
     name = "AWS SageMaker",
@@ -57,9 +57,9 @@ import java.util.function.BiFunction;
 public class SagemakerConnectorFunction implements OutboundConnectorFunction {
 
   private final SageMakeClientSupplier sageMakeClientSupplier;
-  private final BiFunction<AmazonSageMakerRuntime, SageMakerRequest, SageMakerSyncResponse>
+  private final BiFunction<SageMakerRuntimeClient, SageMakerRequest, SageMakerSyncResponse>
       syncCallerFunction;
-  private final BiFunction<AmazonSageMakerRuntimeAsync, SageMakerRequest, SageMakerAsyncResponse>
+  private final BiFunction<SageMakerRuntimeAsyncClient, SageMakerRequest, SageMakerAsyncResponse>
       asyncCallerFunction;
 
   public SagemakerConnectorFunction() {
@@ -71,9 +71,9 @@ public class SagemakerConnectorFunction implements OutboundConnectorFunction {
 
   public SagemakerConnectorFunction(
       final SageMakeClientSupplier sageMakeClientSupplier,
-      final BiFunction<AmazonSageMakerRuntime, SageMakerRequest, SageMakerSyncResponse>
+      final BiFunction<SageMakerRuntimeClient, SageMakerRequest, SageMakerSyncResponse>
           syncCallerFunction,
-      final BiFunction<AmazonSageMakerRuntimeAsync, SageMakerRequest, SageMakerAsyncResponse>
+      final BiFunction<SageMakerRuntimeAsyncClient, SageMakerRequest, SageMakerAsyncResponse>
           asyncCallerFunction) {
     this.sageMakeClientSupplier = sageMakeClientSupplier;
     this.syncCallerFunction = syncCallerFunction;
@@ -86,13 +86,13 @@ public class SagemakerConnectorFunction implements OutboundConnectorFunction {
     if (request.getInput().invocationType() == SageMakerInvocationType.ASYNC) {
       return asyncCallerFunction.apply(
           sageMakeClientSupplier.getAsyncClient(
-              CredentialsProviderSupport.credentialsProvider(request),
+              CredentialsProviderSupportV2.credentialsProvider(request),
               request.getConfiguration().region()),
           request);
     } else {
       return syncCallerFunction.apply(
           sageMakeClientSupplier.getSyncClient(
-              CredentialsProviderSupport.credentialsProvider(request),
+              CredentialsProviderSupportV2.credentialsProvider(request),
               request.getConfiguration().region()),
           request);
     }

--- a/connectors/aws/aws-sagemaker/src/main/java/io/camunda/connector/sagemaker/SagemakerConnectorFunction.java
+++ b/connectors/aws/aws-sagemaker/src/main/java/io/camunda/connector/sagemaker/SagemakerConnectorFunction.java
@@ -84,17 +84,19 @@ public class SagemakerConnectorFunction implements OutboundConnectorFunction {
   public Object execute(OutboundConnectorContext context) {
     final var request = context.bindVariables(SageMakerRequest.class);
     if (request.getInput().invocationType() == SageMakerInvocationType.ASYNC) {
-      return asyncCallerFunction.apply(
+      try (var client =
           sageMakeClientSupplier.getAsyncClient(
               CredentialsProviderSupportV2.credentialsProvider(request),
-              request.getConfiguration().region()),
-          request);
+              request.getConfiguration().region())) {
+        return asyncCallerFunction.apply(client, request);
+      }
     } else {
-      return syncCallerFunction.apply(
+      try (var client =
           sageMakeClientSupplier.getSyncClient(
               CredentialsProviderSupportV2.credentialsProvider(request),
-              request.getConfiguration().region()),
-          request);
+              request.getConfiguration().region())) {
+        return syncCallerFunction.apply(client, request);
+      }
     }
   }
 }

--- a/connectors/aws/aws-sagemaker/src/main/java/io/camunda/connector/sagemaker/caller/SageMakerAsyncCaller.java
+++ b/connectors/aws/aws-sagemaker/src/main/java/io/camunda/connector/sagemaker/caller/SageMakerAsyncCaller.java
@@ -9,6 +9,7 @@ package io.camunda.connector.sagemaker.caller;
 import io.camunda.connector.api.error.ConnectorException;
 import io.camunda.connector.sagemaker.model.SageMakerAsyncResponse;
 import io.camunda.connector.sagemaker.model.SageMakerRequest;
+import java.util.concurrent.CompletionException;
 import java.util.function.BiFunction;
 import software.amazon.awssdk.services.sagemakerruntime.SageMakerRuntimeAsyncClient;
 import software.amazon.awssdk.services.sagemakerruntime.model.InvokeEndpointAsyncRequest;
@@ -41,6 +42,10 @@ public final class SageMakerAsyncCaller {
               // SageMakerAsyncResponse, matching the pre-v2 (blocking) behavior.
               var result = runtime.invokeEndpointAsync(invokeEndpointRequest).join();
               return new SageMakerAsyncResponse(result);
+            } catch (CompletionException e) {
+              // join() wraps the actual SDK failure in a CompletionException; unwrap it so the
+              // reported error matches the blocking caller's error contract (pre-v2 shape).
+              throw new ConnectorException(e.getCause() != null ? e.getCause() : e);
             } catch (Exception e) {
               throw new ConnectorException(e);
             }

--- a/connectors/aws/aws-sagemaker/src/main/java/io/camunda/connector/sagemaker/caller/SageMakerAsyncCaller.java
+++ b/connectors/aws/aws-sagemaker/src/main/java/io/camunda/connector/sagemaker/caller/SageMakerAsyncCaller.java
@@ -6,35 +6,40 @@
  */
 package io.camunda.connector.sagemaker.caller;
 
-import com.amazonaws.services.sagemakerruntime.AmazonSageMakerRuntimeAsync;
-import com.amazonaws.services.sagemakerruntime.model.InvokeEndpointAsyncRequest;
 import io.camunda.connector.api.error.ConnectorException;
 import io.camunda.connector.sagemaker.model.SageMakerAsyncResponse;
 import io.camunda.connector.sagemaker.model.SageMakerRequest;
 import java.util.function.BiFunction;
+import software.amazon.awssdk.services.sagemakerruntime.SageMakerRuntimeAsyncClient;
+import software.amazon.awssdk.services.sagemakerruntime.model.InvokeEndpointAsyncRequest;
 
 public final class SageMakerAsyncCaller {
   public static final BiFunction<
-          AmazonSageMakerRuntimeAsync, SageMakerRequest, SageMakerAsyncResponse>
+          SageMakerRuntimeAsyncClient, SageMakerRequest, SageMakerAsyncResponse>
       ASYNC_CALLER =
           (runtime, request) -> {
             try {
-              InvokeEndpointAsyncRequest invokeEndpointRequest = new InvokeEndpointAsyncRequest();
-              invokeEndpointRequest.setEndpointName(request.getInput().endpointName());
-              invokeEndpointRequest.setContentType(request.getInput().contentType());
-              invokeEndpointRequest.setAccept(request.getInput().accept());
-              invokeEndpointRequest.setCustomAttributes(request.getInput().customAttributes());
-              invokeEndpointRequest.setInferenceId(request.getInput().inferenceId());
-              invokeEndpointRequest.setInputLocation(request.getInput().inputLocation());
-              invokeEndpointRequest.setInvocationTimeoutSeconds(
-                  request.getInput().invocationTimeoutSeconds() != null
-                      ? Integer.parseInt(request.getInput().invocationTimeoutSeconds())
-                      : null);
-              invokeEndpointRequest.setRequestTTLSeconds(
-                  request.getInput().requestTTLSeconds() != null
-                      ? Integer.parseInt(request.getInput().requestTTLSeconds())
-                      : null);
-              var result = runtime.invokeEndpointAsync(invokeEndpointRequest);
+              InvokeEndpointAsyncRequest invokeEndpointRequest =
+                  InvokeEndpointAsyncRequest.builder()
+                      .endpointName(request.getInput().endpointName())
+                      .contentType(request.getInput().contentType())
+                      .accept(request.getInput().accept())
+                      .customAttributes(request.getInput().customAttributes())
+                      .inferenceId(request.getInput().inferenceId())
+                      .inputLocation(request.getInput().inputLocation())
+                      .invocationTimeoutSeconds(
+                          request.getInput().invocationTimeoutSeconds() != null
+                              ? Integer.parseInt(request.getInput().invocationTimeoutSeconds())
+                              : null)
+                      .requestTTLSeconds(
+                          request.getInput().requestTTLSeconds() != null
+                              ? Integer.parseInt(request.getInput().requestTTLSeconds())
+                              : null)
+                      .build();
+              // SageMakerRuntimeAsyncClient is the SDK v2 non-blocking (Future-based) client;
+              // .join() blocks for the result so this caller keeps returning a plain
+              // SageMakerAsyncResponse, matching the pre-v2 (blocking) behavior.
+              var result = runtime.invokeEndpointAsync(invokeEndpointRequest).join();
               return new SageMakerAsyncResponse(result);
             } catch (Exception e) {
               throw new ConnectorException(e);

--- a/connectors/aws/aws-sagemaker/src/main/java/io/camunda/connector/sagemaker/caller/SageMakerSyncCaller.java
+++ b/connectors/aws/aws-sagemaker/src/main/java/io/camunda/connector/sagemaker/caller/SageMakerSyncCaller.java
@@ -6,47 +6,46 @@
  */
 package io.camunda.connector.sagemaker.caller;
 
-import com.amazonaws.services.sagemakerruntime.AmazonSageMakerRuntime;
-import com.amazonaws.services.sagemakerruntime.model.InvokeEndpointRequest;
 import io.camunda.connector.api.error.ConnectorException;
 import io.camunda.connector.aws.ObjectMapperSupplier;
 import io.camunda.connector.sagemaker.model.SageMakerEnableExplanations;
 import io.camunda.connector.sagemaker.model.SageMakerRequest;
 import io.camunda.connector.sagemaker.model.SageMakerSyncResponse;
-import java.nio.ByteBuffer;
 import java.util.function.BiFunction;
+import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.services.sagemakerruntime.SageMakerRuntimeClient;
+import software.amazon.awssdk.services.sagemakerruntime.model.InvokeEndpointRequest;
 
 public final class SageMakerSyncCaller {
 
-  public static final BiFunction<AmazonSageMakerRuntime, SageMakerRequest, SageMakerSyncResponse>
+  public static final BiFunction<SageMakerRuntimeClient, SageMakerRequest, SageMakerSyncResponse>
       SYNC_REQUEST =
           (runtime, request) -> {
             try {
-              InvokeEndpointRequest invokeEndpointRequest = new InvokeEndpointRequest();
-              invokeEndpointRequest.setEndpointName(request.getInput().endpointName());
-              invokeEndpointRequest.setBody(
-                  ByteBuffer.wrap(
-                      ObjectMapperSupplier.getMapperInstance()
-                          .writeValueAsBytes(request.getInput().body())));
-              invokeEndpointRequest.setContentType(request.getInput().contentType());
-              invokeEndpointRequest.setAccept(request.getInput().accept());
-              invokeEndpointRequest.setCustomAttributes(request.getInput().customAttributes());
-              invokeEndpointRequest.setTargetModel(request.getInput().targetModel());
-              invokeEndpointRequest.setTargetVariant(request.getInput().targetVariant());
-
-              invokeEndpointRequest.setTargetContainerHostname(
-                  request.getInput().targetContainerHostname());
-              invokeEndpointRequest.setInferenceId(request.getInput().inferenceId());
-
-              invokeEndpointRequest.setEnableExplanations(
-                  request.getInput().enableExplanations() == SageMakerEnableExplanations.NOT_SET
-                      ? null
-                      : request.getInput().enableExplanations() == SageMakerEnableExplanations.YES
-                          ? "1"
-                          : "0");
-
-              invokeEndpointRequest.setInferenceComponentName(
-                  request.getInput().inferenceComponentName());
+              InvokeEndpointRequest invokeEndpointRequest =
+                  InvokeEndpointRequest.builder()
+                      .endpointName(request.getInput().endpointName())
+                      .body(
+                          SdkBytes.fromByteArray(
+                              ObjectMapperSupplier.getMapperInstance()
+                                  .writeValueAsBytes(request.getInput().body())))
+                      .contentType(request.getInput().contentType())
+                      .accept(request.getInput().accept())
+                      .customAttributes(request.getInput().customAttributes())
+                      .targetModel(request.getInput().targetModel())
+                      .targetVariant(request.getInput().targetVariant())
+                      .targetContainerHostname(request.getInput().targetContainerHostname())
+                      .inferenceId(request.getInput().inferenceId())
+                      .enableExplanations(
+                          request.getInput().enableExplanations()
+                                  == SageMakerEnableExplanations.NOT_SET
+                              ? null
+                              : request.getInput().enableExplanations()
+                                      == SageMakerEnableExplanations.YES
+                                  ? "1"
+                                  : "0")
+                      .inferenceComponentName(request.getInput().inferenceComponentName())
+                      .build();
 
               var result = runtime.invokeEndpoint(invokeEndpointRequest);
               return new SageMakerSyncResponse(result);

--- a/connectors/aws/aws-sagemaker/src/main/java/io/camunda/connector/sagemaker/model/SageMakerAsyncResponse.java
+++ b/connectors/aws/aws-sagemaker/src/main/java/io/camunda/connector/sagemaker/model/SageMakerAsyncResponse.java
@@ -6,12 +6,14 @@
  */
 package io.camunda.connector.sagemaker.model;
 
-import com.amazonaws.services.sagemakerruntime.model.InvokeEndpointAsyncResult;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import software.amazon.awssdk.services.sagemakerruntime.model.InvokeEndpointAsyncResponse;
 
+@JsonPropertyOrder({"outputLocation", "failureLocation", "inferenceId"})
 public record SageMakerAsyncResponse(
     String outputLocation, String failureLocation, String inferenceId) {
 
-  public SageMakerAsyncResponse(InvokeEndpointAsyncResult result) {
-    this(result.getOutputLocation(), result.getFailureLocation(), result.getInferenceId());
+  public SageMakerAsyncResponse(InvokeEndpointAsyncResponse result) {
+    this(result.outputLocation(), result.failureLocation(), result.inferenceId());
   }
 }

--- a/connectors/aws/aws-sagemaker/src/main/java/io/camunda/connector/sagemaker/model/SageMakerSyncResponse.java
+++ b/connectors/aws/aws-sagemaker/src/main/java/io/camunda/connector/sagemaker/model/SageMakerSyncResponse.java
@@ -6,36 +6,37 @@
  */
 package io.camunda.connector.sagemaker.model;
 
-import com.amazonaws.services.sagemakerruntime.model.InvokeEndpointResult;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import io.camunda.connector.aws.ObjectMapperSupplier;
 import java.io.IOException;
-import java.nio.ByteBuffer;
-import java.nio.charset.StandardCharsets;
+import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.services.sagemakerruntime.model.InvokeEndpointResponse;
 
+@JsonPropertyOrder({"body", "contentType", "customAttributes", "invokedProductionVariant"})
 public record SageMakerSyncResponse(
     Object body, String contentType, String customAttributes, String invokedProductionVariant) {
 
-  public SageMakerSyncResponse(InvokeEndpointResult result) {
+  public SageMakerSyncResponse(InvokeEndpointResponse result) {
     this(
         mapResponseBody(result),
-        result.getContentType(),
-        result.getCustomAttributes(),
-        result.getInvokedProductionVariant());
+        result.contentType(),
+        result.customAttributes(),
+        result.invokedProductionVariant());
   }
 
   /* Maps the response body to the appropriate object type
   / https://docs.aws.amazon.com/sagemaker/latest/dg/clarify-online-explainability-invoke-endpoint.html#clarify-online-explainability-response
   */
-  private static Object mapResponseBody(InvokeEndpointResult result) {
-    if (result.getContentType().equals("application/json")) {
-      return parseJsonResponseBody(result.getBody());
+  private static Object mapResponseBody(InvokeEndpointResponse result) {
+    if (result.contentType().equals("application/json")) {
+      return parseJsonResponseBody(result.body());
     }
-    return StandardCharsets.UTF_8.decode(result.getBody()).toString();
+    return result.body().asUtf8String();
   }
 
-  private static Object parseJsonResponseBody(ByteBuffer json) {
+  private static Object parseJsonResponseBody(SdkBytes json) {
     try {
-      return ObjectMapperSupplier.getMapperInstance().readValue(json.array(), Object.class);
+      return ObjectMapperSupplier.getMapperInstance().readValue(json.asByteArray(), Object.class);
     } catch (IOException e) {
       throw new RuntimeException("Error reading Sagemaker response.", e);
     }

--- a/connectors/aws/aws-sagemaker/src/main/java/io/camunda/connector/sagemaker/suppliers/SageMakeClientSupplier.java
+++ b/connectors/aws/aws-sagemaker/src/main/java/io/camunda/connector/sagemaker/suppliers/SageMakeClientSupplier.java
@@ -6,27 +6,26 @@
  */
 package io.camunda.connector.sagemaker.suppliers;
 
-import com.amazonaws.auth.AWSCredentialsProvider;
-import com.amazonaws.services.sagemakerruntime.AmazonSageMakerRuntime;
-import com.amazonaws.services.sagemakerruntime.AmazonSageMakerRuntimeAsync;
-import com.amazonaws.services.sagemakerruntime.AmazonSageMakerRuntimeAsyncClientBuilder;
-import com.amazonaws.services.sagemakerruntime.AmazonSageMakerRuntimeClientBuilder;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.sagemakerruntime.SageMakerRuntimeAsyncClient;
+import software.amazon.awssdk.services.sagemakerruntime.SageMakerRuntimeClient;
 
 public class SageMakeClientSupplier {
 
-  public AmazonSageMakerRuntime getSyncClient(
-      final AWSCredentialsProvider credentialsProvider, final String region) {
-    return AmazonSageMakerRuntimeClientBuilder.standard()
-        .withCredentials(credentialsProvider)
-        .withRegion(region)
+  public SageMakerRuntimeClient getSyncClient(
+      final AwsCredentialsProvider credentialsProvider, final String region) {
+    return SageMakerRuntimeClient.builder()
+        .credentialsProvider(credentialsProvider)
+        .region(Region.of(region))
         .build();
   }
 
-  public AmazonSageMakerRuntimeAsync getAsyncClient(
-      final AWSCredentialsProvider credentialsProvider, final String region) {
-    return AmazonSageMakerRuntimeAsyncClientBuilder.standard()
-        .withCredentials(credentialsProvider)
-        .withRegion(region)
+  public SageMakerRuntimeAsyncClient getAsyncClient(
+      final AwsCredentialsProvider credentialsProvider, final String region) {
+    return SageMakerRuntimeAsyncClient.builder()
+        .credentialsProvider(credentialsProvider)
+        .region(Region.of(region))
         .build();
   }
 }

--- a/connectors/aws/aws-sagemaker/src/test/java/io/camunda/connector/sagemaker/SagemakerConnectorFunctionTest.java
+++ b/connectors/aws/aws-sagemaker/src/test/java/io/camunda/connector/sagemaker/SagemakerConnectorFunctionTest.java
@@ -8,9 +8,6 @@ package io.camunda.connector.sagemaker;
 
 import static org.mockito.ArgumentMatchers.any;
 
-import com.amazonaws.auth.AWSCredentialsProvider;
-import com.amazonaws.services.sagemakerruntime.AmazonSageMakerRuntime;
-import com.amazonaws.services.sagemakerruntime.AmazonSageMakerRuntimeAsync;
 import io.camunda.connector.runtime.test.outbound.OutboundConnectorContextBuilder;
 import io.camunda.connector.sagemaker.suppliers.SageMakeClientSupplier;
 import io.camunda.connector.sagemaker.testutils.SageMakerTestUtils;
@@ -21,6 +18,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.services.sagemakerruntime.SageMakerRuntimeAsyncClient;
+import software.amazon.awssdk.services.sagemakerruntime.SageMakerRuntimeClient;
 
 @ExtendWith(MockitoExtension.class)
 class SagemakerConnectorFunctionTest {
@@ -34,12 +34,12 @@ class SagemakerConnectorFunctionTest {
             .variables(SageMakerTestUtils.REAL_TIME_EXECUTION_JSON)
             .build();
 
-    var syncRuntime = Mockito.mock(AmazonSageMakerRuntime.class);
+    var syncRuntime = Mockito.mock(SageMakerRuntimeClient.class);
 
     var sageMakeClientSupplier = Mockito.mock(SageMakeClientSupplier.class);
     Mockito.when(
             sageMakeClientSupplier.getSyncClient(
-                any(AWSCredentialsProvider.class), ArgumentMatchers.anyString()))
+                any(AwsCredentialsProvider.class), ArgumentMatchers.anyString()))
         .thenReturn(syncRuntime);
 
     var syncCallerFunction = Mockito.mock(BiFunction.class);
@@ -67,12 +67,12 @@ class SagemakerConnectorFunctionTest {
             .secret("SECRET_KEY", SageMakerTestUtils.ACTUAL_SECRET_KEY)
             .variables(SageMakerTestUtils.ASYNC_EXECUTION_JSON)
             .build();
-    var asyncRuntime = Mockito.mock(AmazonSageMakerRuntimeAsync.class);
+    var asyncRuntime = Mockito.mock(SageMakerRuntimeAsyncClient.class);
 
     var sageMakeClientSupplier = Mockito.mock(SageMakeClientSupplier.class);
     Mockito.when(
             sageMakeClientSupplier.getAsyncClient(
-                any(AWSCredentialsProvider.class), ArgumentMatchers.anyString()))
+                any(AwsCredentialsProvider.class), ArgumentMatchers.anyString()))
         .thenReturn(asyncRuntime);
 
     var syncCallerFunction = Mockito.mock(BiFunction.class);

--- a/connectors/aws/aws-sagemaker/src/test/java/io/camunda/connector/sagemaker/SagemakerConnectorFunctionTest.java
+++ b/connectors/aws/aws-sagemaker/src/test/java/io/camunda/connector/sagemaker/SagemakerConnectorFunctionTest.java
@@ -56,6 +56,7 @@ class SagemakerConnectorFunctionTest {
 
     Mockito.verify(syncCallerFunction).apply(any(), any());
     Mockito.verify(asyncCallerFunction, Mockito.never()).apply(any(), any());
+    Mockito.verify(syncRuntime).close();
     Assertions.assertThat(result).isSameAs(executionResult);
   }
 
@@ -89,6 +90,7 @@ class SagemakerConnectorFunctionTest {
 
     Mockito.verify(syncCallerFunction, Mockito.never()).apply(any(), any());
     Mockito.verify(asyncCallerFunction).apply(any(), any());
+    Mockito.verify(asyncRuntime).close();
     Assertions.assertThat(result).isSameAs(executionResult);
   }
 }

--- a/connectors/aws/aws-sagemaker/src/test/java/io/camunda/connector/sagemaker/caller/SageMakerAsyncCallerTest.java
+++ b/connectors/aws/aws-sagemaker/src/test/java/io/camunda/connector/sagemaker/caller/SageMakerAsyncCallerTest.java
@@ -13,11 +13,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.amazonaws.ResponseMetadata;
-import com.amazonaws.http.SdkHttpMetadata;
-import com.amazonaws.services.sagemakerruntime.AmazonSageMakerRuntimeAsync;
-import com.amazonaws.services.sagemakerruntime.model.InvokeEndpointAsyncRequest;
-import com.amazonaws.services.sagemakerruntime.model.InvokeEndpointAsyncResult;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -26,22 +21,27 @@ import io.camunda.connector.aws.ObjectMapperSupplier;
 import io.camunda.connector.jackson.ConnectorsObjectMapperSupplier;
 import io.camunda.connector.sagemaker.model.SageMakerAsyncResponse;
 import io.camunda.connector.sagemaker.model.SageMakerRequest;
-import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
+import software.amazon.awssdk.services.sagemakerruntime.SageMakerRuntimeAsyncClient;
+import software.amazon.awssdk.services.sagemakerruntime.model.InvokeEndpointAsyncRequest;
+import software.amazon.awssdk.services.sagemakerruntime.model.InvokeEndpointAsyncResponse;
 
 class SageMakerAsyncCallerTest {
 
   @Test
   void sageMakerAsyncCaller_HappyCase() throws JsonProcessingException {
-    var runtime = mock(AmazonSageMakerRuntimeAsync.class);
-    var mockedAwsCall = new InvokeEndpointAsyncResult();
-    mockedAwsCall.setOutputLocation("s3://result-bucket/result-object");
-    mockedAwsCall.setInferenceId("inference01");
-    mockedAwsCall.setFailureLocation("s3://result-bucket/failures-object");
+    var runtime = mock(SageMakerRuntimeAsyncClient.class);
+    var mockedAwsCall =
+        InvokeEndpointAsyncResponse.builder()
+            .outputLocation("s3://result-bucket/result-object")
+            .inferenceId("inference01")
+            .failureLocation("s3://result-bucket/failures-object")
+            .build();
     when(runtime.invokeEndpointAsync(any(InvokeEndpointAsyncRequest.class)))
-        .thenReturn(mockedAwsCall);
+        .thenReturn(CompletableFuture.completedFuture(mockedAwsCall));
     var captor = ArgumentCaptor.forClass(InvokeEndpointAsyncRequest.class);
     var request =
         ObjectMapperSupplier.getMapperInstance()
@@ -51,23 +51,22 @@ class SageMakerAsyncCallerTest {
     verify(runtime).invokeEndpointAsync(captor.capture());
 
     var mappedRequest = captor.getValue();
-    assertThat(mappedRequest.getEndpointName()).isEqualTo(request.getInput().endpointName());
-    assertThat(mappedRequest.getContentType()).isEqualTo(request.getInput().contentType());
-    assertThat(mappedRequest.getEndpointName()).isEqualTo(request.getInput().endpointName());
-    assertThat(mappedRequest.getAccept()).isEqualTo(request.getInput().accept());
-    assertThat(mappedRequest.getCustomAttributes())
-        .isEqualTo(request.getInput().customAttributes());
-    assertThat(mappedRequest.getInferenceId()).isEqualTo(request.getInput().inferenceId());
-    assertThat(mappedRequest.getInputLocation()).isEqualTo(request.getInput().inputLocation());
-    assertThat(mappedRequest.getInvocationTimeoutSeconds())
+    assertThat(mappedRequest.endpointName()).isEqualTo(request.getInput().endpointName());
+    assertThat(mappedRequest.contentType()).isEqualTo(request.getInput().contentType());
+    assertThat(mappedRequest.endpointName()).isEqualTo(request.getInput().endpointName());
+    assertThat(mappedRequest.accept()).isEqualTo(request.getInput().accept());
+    assertThat(mappedRequest.customAttributes()).isEqualTo(request.getInput().customAttributes());
+    assertThat(mappedRequest.inferenceId()).isEqualTo(request.getInput().inferenceId());
+    assertThat(mappedRequest.inputLocation()).isEqualTo(request.getInput().inputLocation());
+    assertThat(mappedRequest.invocationTimeoutSeconds())
         .isEqualTo(Integer.parseInt(request.getInput().invocationTimeoutSeconds()));
-    assertThat(mappedRequest.getRequestTTLSeconds())
+    assertThat(mappedRequest.requestTTLSeconds())
         .isEqualTo(Integer.parseInt(request.getInput().requestTTLSeconds()));
   }
 
   @Test
   void sageMakerAsyncCaller_ExceptionalCase() throws JsonProcessingException {
-    var runtime = mock(AmazonSageMakerRuntimeAsync.class);
+    var runtime = mock(SageMakerRuntimeAsyncClient.class);
     var request =
         ObjectMapperSupplier.getMapperInstance()
             .readValue(ASYNC_EXECUTION_JSON, SageMakerRequest.class);
@@ -81,33 +80,25 @@ class SageMakerAsyncCallerTest {
    * Golden-JSON shape test: the connector result, serialized with the real connectors {@link
    * ObjectMapper}, must reproduce the JSON shape the async invocation path documented and returned
    * before the AWS SDK v2 migration. This is the template for verifying result serialization across
-   * the v2 migration effort for aws-sagemaker: build a realistic AWS SDK v1 {@link
-   * InvokeEndpointAsyncResult} (as a live InvokeEndpointAsync call would populate it), map it
+   * the v2 migration effort for aws-sagemaker: build a realistic AWS SDK v2 {@link
+   * InvokeEndpointAsyncResponse} (as a live InvokeEndpointAsync call would populate it), map it
    * through the real caller, serialize with the production mapper, and diff the full JSON tree
    * against the frozen expectation.
    */
   @Test
   public void invokeEndpointAsyncResult_serializesToDocumentedV1JsonShape()
       throws JsonProcessingException {
-    // Given a fully populated InvokeEndpointAsyncResult, as returned by a live
+    // Given a fully populated InvokeEndpointAsyncResponse, as returned by a live
     // InvokeEndpointAsync call: output/failure S3 locations and the inference id.
-    var runtime = mock(AmazonSageMakerRuntimeAsync.class);
-    var mockedAwsCall = new InvokeEndpointAsyncResult();
-    mockedAwsCall.setOutputLocation("s3://result-bucket/result-object");
-    mockedAwsCall.setFailureLocation("s3://result-bucket/failures-object");
-    mockedAwsCall.setInferenceId("inference01");
-    // A live call also populates request/HTTP metadata inherited from AmazonWebServiceResult; set
-    // both here for realism even though the assertion below shows neither reaches the connector
-    // result.
-    mockedAwsCall.setSdkResponseMetadata(
-        new ResponseMetadata(
-            Map.of(ResponseMetadata.AWS_REQUEST_ID, "929bf054-193b-48e6-ab80-3aeeb613b415")));
-    var sdkHttpMetadata = mock(SdkHttpMetadata.class);
-    when(sdkHttpMetadata.getHttpStatusCode()).thenReturn(200);
-    when(sdkHttpMetadata.getHttpHeaders()).thenReturn(Map.of("Content-Type", "application/json"));
-    mockedAwsCall.setSdkHttpMetadata(sdkHttpMetadata);
+    var runtime = mock(SageMakerRuntimeAsyncClient.class);
+    var mockedAwsCall =
+        InvokeEndpointAsyncResponse.builder()
+            .outputLocation("s3://result-bucket/result-object")
+            .failureLocation("s3://result-bucket/failures-object")
+            .inferenceId("inference01")
+            .build();
     when(runtime.invokeEndpointAsync(any(InvokeEndpointAsyncRequest.class)))
-        .thenReturn(mockedAwsCall);
+        .thenReturn(CompletableFuture.completedFuture(mockedAwsCall));
     var request =
         ObjectMapperSupplier.getMapperInstance()
             .readValue(ASYNC_EXECUTION_JSON, SageMakerRequest.class);
@@ -122,8 +113,7 @@ class SageMakerAsyncCallerTest {
     // Then the JSON matches the pre-v2 (SDK v1) async-invocation output shape exactly.
     // sdkResponseMetadata/sdkHttpMetadata are ABSENT: SageMakerAsyncResponse only maps
     // outputLocation/failureLocation/inferenceId, so any AWS request/HTTP metadata the SDK result
-    // carries (populated above) is silently dropped today -- intentional v1 behavior being pinned
-    // for the migration.
+    // carries is silently dropped today -- intentional v1 behavior being pinned for the migration.
     String expectedJson =
         """
         {

--- a/connectors/aws/aws-sagemaker/src/test/java/io/camunda/connector/sagemaker/caller/SageMakerAsyncCallerTest.java
+++ b/connectors/aws/aws-sagemaker/src/test/java/io/camunda/connector/sagemaker/caller/SageMakerAsyncCallerTest.java
@@ -22,6 +22,7 @@ import io.camunda.connector.jackson.ConnectorsObjectMapperSupplier;
 import io.camunda.connector.sagemaker.model.SageMakerAsyncResponse;
 import io.camunda.connector.sagemaker.model.SageMakerRequest;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -74,6 +75,29 @@ class SageMakerAsyncCallerTest {
         .thenThrow(new RuntimeException("Something went terribly wrong!"));
     Assertions.assertThrows(
         ConnectorException.class, () -> SageMakerAsyncCaller.ASYNC_CALLER.apply(runtime, request));
+  }
+
+  @Test
+  void sageMakerAsyncCaller_UnwrapsCompletionExceptionFromJoin() throws JsonProcessingException {
+    var runtime = mock(SageMakerRuntimeAsyncClient.class);
+    var request =
+        ObjectMapperSupplier.getMapperInstance()
+            .readValue(ASYNC_EXECUTION_JSON, SageMakerRequest.class);
+    var sdkFailure = new RuntimeException("boom");
+    // Simulate a future that AWS completed exceptionally: .join() on it throws a
+    // CompletionException wrapping the real SDK failure, not the failure itself.
+    when(runtime.invokeEndpointAsync(any(InvokeEndpointAsyncRequest.class)))
+        .thenReturn(CompletableFuture.failedFuture(sdkFailure));
+
+    var thrown =
+        Assertions.assertThrows(
+            ConnectorException.class,
+            () -> SageMakerAsyncCaller.ASYNC_CALLER.apply(runtime, request));
+
+    // The reported cause must be the unwrapped SDK failure, not the CompletionException that
+    // join() throws internally.
+    assertThat(thrown.getCause()).isNotInstanceOf(CompletionException.class);
+    assertThat(thrown.getCause()).isSameAs(sdkFailure);
   }
 
   /**

--- a/connectors/aws/aws-sagemaker/src/test/java/io/camunda/connector/sagemaker/caller/SageMakerSyncCallerTest.java
+++ b/connectors/aws/aws-sagemaker/src/test/java/io/camunda/connector/sagemaker/caller/SageMakerSyncCallerTest.java
@@ -13,11 +13,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.amazonaws.ResponseMetadata;
-import com.amazonaws.http.SdkHttpMetadata;
-import com.amazonaws.services.sagemakerruntime.AmazonSageMakerRuntime;
-import com.amazonaws.services.sagemakerruntime.model.InvokeEndpointRequest;
-import com.amazonaws.services.sagemakerruntime.model.InvokeEndpointResult;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -26,26 +21,30 @@ import io.camunda.connector.aws.ObjectMapperSupplier;
 import io.camunda.connector.jackson.ConnectorsObjectMapperSupplier;
 import io.camunda.connector.sagemaker.model.SageMakerRequest;
 import io.camunda.connector.sagemaker.model.SageMakerSyncResponse;
-import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
-import java.util.Map;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
+import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.services.sagemakerruntime.SageMakerRuntimeClient;
+import software.amazon.awssdk.services.sagemakerruntime.model.InvokeEndpointRequest;
+import software.amazon.awssdk.services.sagemakerruntime.model.InvokeEndpointResponse;
 
 class SageMakerSyncCallerTest {
 
   @Test
   void sageMakerSyncCaller_HappyCase() throws JsonProcessingException {
-    var runtime = mock(AmazonSageMakerRuntime.class);
-    var mockedAwsCall = new InvokeEndpointResult();
-    mockedAwsCall.setBody(
-        ByteBuffer.wrap(
-            ObjectMapperSupplier.getMapperInstance()
-                .writeValueAsBytes("{\"generated_text\": \"the answer is 42\"}")));
-    mockedAwsCall.setContentType("application/json");
-    mockedAwsCall.setCustomAttributes("my-custom-attribute");
-    mockedAwsCall.setInvokedProductionVariant("variant01");
+    var runtime = mock(SageMakerRuntimeClient.class);
+    var mockedAwsCall =
+        InvokeEndpointResponse.builder()
+            .body(
+                SdkBytes.fromByteArray(
+                    ObjectMapperSupplier.getMapperInstance()
+                        .writeValueAsBytes("{\"generated_text\": \"the answer is 42\"}")))
+            .contentType("application/json")
+            .customAttributes("my-custom-attribute")
+            .invokedProductionVariant("variant01")
+            .build();
     when(runtime.invokeEndpoint(any(InvokeEndpointRequest.class))).thenReturn(mockedAwsCall);
     var captor = ArgumentCaptor.forClass(InvokeEndpointRequest.class);
     var request =
@@ -56,29 +55,28 @@ class SageMakerSyncCallerTest {
     verify(runtime).invokeEndpoint(captor.capture());
 
     var mappedRequest = captor.getValue();
-    assertThat(mappedRequest.getEndpointName()).isEqualTo(request.getInput().endpointName());
-    assertThat(mappedRequest.getBody())
+    assertThat(mappedRequest.endpointName()).isEqualTo(request.getInput().endpointName());
+    assertThat(mappedRequest.body())
         .isEqualTo(
-            ByteBuffer.wrap(
+            SdkBytes.fromByteArray(
                 ObjectMapperSupplier.getMapperInstance()
                     .writeValueAsBytes(request.getInput().body())));
-    assertThat(mappedRequest.getContentType()).isEqualTo(request.getInput().contentType());
-    assertThat(mappedRequest.getAccept()).isEqualTo(request.getInput().accept());
-    assertThat(mappedRequest.getCustomAttributes())
-        .isEqualTo(request.getInput().customAttributes());
-    assertThat(mappedRequest.getTargetModel()).isEqualTo(request.getInput().targetModel());
-    assertThat(mappedRequest.getTargetVariant()).isEqualTo(request.getInput().targetVariant());
-    assertThat(mappedRequest.getTargetContainerHostname())
+    assertThat(mappedRequest.contentType()).isEqualTo(request.getInput().contentType());
+    assertThat(mappedRequest.accept()).isEqualTo(request.getInput().accept());
+    assertThat(mappedRequest.customAttributes()).isEqualTo(request.getInput().customAttributes());
+    assertThat(mappedRequest.targetModel()).isEqualTo(request.getInput().targetModel());
+    assertThat(mappedRequest.targetVariant()).isEqualTo(request.getInput().targetVariant());
+    assertThat(mappedRequest.targetContainerHostname())
         .isEqualTo(request.getInput().targetContainerHostname());
-    assertThat(mappedRequest.getInferenceId()).isEqualTo(request.getInput().inferenceId());
-    assertThat(mappedRequest.getEnableExplanations()).isNull();
-    assertThat(mappedRequest.getInferenceComponentName())
+    assertThat(mappedRequest.inferenceId()).isEqualTo(request.getInput().inferenceId());
+    assertThat(mappedRequest.enableExplanations()).isNull();
+    assertThat(mappedRequest.inferenceComponentName())
         .isEqualTo(request.getInput().inferenceComponentName());
   }
 
   @Test
   void sageMaker_ExceptionCase() throws JsonProcessingException {
-    var runtime = mock(AmazonSageMakerRuntime.class);
+    var runtime = mock(SageMakerRuntimeClient.class);
     var request =
         ObjectMapperSupplier.getMapperInstance()
             .readValue(REAL_TIME_EXECUTION_JSON, SageMakerRequest.class);
@@ -92,35 +90,27 @@ class SageMakerSyncCallerTest {
    * Golden-JSON shape test: the connector result, serialized with the real connectors {@link
    * ObjectMapper}, must reproduce the JSON shape the sync (real-time) invocation path documented
    * and returned before the AWS SDK v2 migration. This is the template for verifying result
-   * serialization across the v2 migration effort for aws-sagemaker: build a realistic AWS SDK v1
-   * {@link InvokeEndpointResult} (as a live InvokeEndpoint call would populate it), map it through
-   * the real caller, serialize with the production mapper, and diff the full JSON tree against the
-   * frozen expectation.
+   * serialization across the v2 migration effort for aws-sagemaker: build a realistic AWS SDK v2
+   * {@link InvokeEndpointResponse} (as a live InvokeEndpoint call would populate it), map it
+   * through the real caller, serialize with the production mapper, and diff the full JSON tree
+   * against the frozen expectation.
    */
   @Test
   public void invokeEndpointResult_jsonBody_serializesToDocumentedV1JsonShape()
       throws JsonProcessingException {
-    // Given a fully populated InvokeEndpointResult with a JSON inference payload, as returned by a
-    // live InvokeEndpoint call against an "application/json" endpoint.
-    var runtime = mock(AmazonSageMakerRuntime.class);
-    var mockedAwsCall = new InvokeEndpointResult();
+    // Given a fully populated InvokeEndpointResponse with a JSON inference payload, as returned by
+    // a live InvokeEndpoint call against an "application/json" endpoint.
+    var runtime = mock(SageMakerRuntimeClient.class);
     String jsonBody =
         """
         {"predictions":[{"label":"POSITIVE","score":0.9821},{"label":"NEGATIVE","score":0.0179}],"modelId":"text-classification-v3"}""";
-    mockedAwsCall.setBody(ByteBuffer.wrap(jsonBody.getBytes(StandardCharsets.UTF_8)));
-    mockedAwsCall.setContentType("application/json");
-    mockedAwsCall.setCustomAttributes("tenant-id=42;request-source=order-service");
-    mockedAwsCall.setInvokedProductionVariant("AllTraffic");
-    // A live call also populates request/HTTP metadata inherited from AmazonWebServiceResult; set
-    // both here for realism even though the assertion below shows neither reaches the connector
-    // result.
-    mockedAwsCall.setSdkResponseMetadata(
-        new ResponseMetadata(
-            Map.of(ResponseMetadata.AWS_REQUEST_ID, "929bf054-193b-48e6-ab80-3aeeb613b415")));
-    var sdkHttpMetadata = mock(SdkHttpMetadata.class);
-    when(sdkHttpMetadata.getHttpStatusCode()).thenReturn(200);
-    when(sdkHttpMetadata.getHttpHeaders()).thenReturn(Map.of("Content-Type", "application/json"));
-    mockedAwsCall.setSdkHttpMetadata(sdkHttpMetadata);
+    var mockedAwsCall =
+        InvokeEndpointResponse.builder()
+            .body(SdkBytes.fromByteArray(jsonBody.getBytes(StandardCharsets.UTF_8)))
+            .contentType("application/json")
+            .customAttributes("tenant-id=42;request-source=order-service")
+            .invokedProductionVariant("AllTraffic")
+            .build();
     when(runtime.invokeEndpoint(any(InvokeEndpointRequest.class))).thenReturn(mockedAwsCall);
     var request =
         ObjectMapperSupplier.getMapperInstance()
@@ -138,7 +128,7 @@ class SageMakerSyncCallerTest {
     // intentional v1 behavior being pinned for the migration. Also note sdkResponseMetadata /
     // sdkHttpMetadata are ABSENT: SageMakerSyncResponse only maps
     // body/contentType/customAttributes/invokedProductionVariant, so any AWS request/HTTP
-    // metadata the SDK result carries (populated above) is silently dropped today.
+    // metadata the SDK result carries is silently dropped today.
     String expectedJson =
         """
         {
@@ -172,12 +162,14 @@ class SageMakerSyncCallerTest {
   public void invokeEndpointResult_nonJsonBody_serializesAsPlainStringNotParsed()
       throws JsonProcessingException {
     // Given a live InvokeEndpoint call against a non-JSON ("text/plain") endpoint.
-    var runtime = mock(AmazonSageMakerRuntime.class);
-    var mockedAwsCall = new InvokeEndpointResult();
+    var runtime = mock(SageMakerRuntimeClient.class);
     String textBody = "prediction: positive (0.98)";
-    mockedAwsCall.setBody(ByteBuffer.wrap(textBody.getBytes(StandardCharsets.UTF_8)));
-    mockedAwsCall.setContentType("text/plain");
-    mockedAwsCall.setInvokedProductionVariant("AllTraffic");
+    var mockedAwsCall =
+        InvokeEndpointResponse.builder()
+            .body(SdkBytes.fromByteArray(textBody.getBytes(StandardCharsets.UTF_8)))
+            .contentType("text/plain")
+            .invokedProductionVariant("AllTraffic")
+            .build();
     // customAttributes intentionally left unset -- the production mapper must serialize it as
     // an explicit null below: the mapper's default inclusion policy serializes null record
     // components rather than omitting them (no NON_NULL/NON_ABSENT inclusion is configured).
@@ -217,10 +209,12 @@ class SageMakerSyncCallerTest {
   @Test
   public void invokeEndpointResult_emptyBodyWithJsonContentType_throwsConnectorException()
       throws JsonProcessingException {
-    var runtime = mock(AmazonSageMakerRuntime.class);
-    var mockedAwsCall = new InvokeEndpointResult();
-    mockedAwsCall.setBody(ByteBuffer.wrap(new byte[0]));
-    mockedAwsCall.setContentType("application/json");
+    var runtime = mock(SageMakerRuntimeClient.class);
+    var mockedAwsCall =
+        InvokeEndpointResponse.builder()
+            .body(SdkBytes.fromByteArray(new byte[0]))
+            .contentType("application/json")
+            .build();
     when(runtime.invokeEndpoint(any(InvokeEndpointRequest.class))).thenReturn(mockedAwsCall);
     var request =
         ObjectMapperSupplier.getMapperInstance()

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -538,17 +538,17 @@ limitations under the License.</license.inlineheader>
       </dependency>
       <dependency>
         <groupId>com.amazonaws</groupId>
-        <artifactId>aws-java-sdk-sagemakerruntime</artifactId>
-        <version>${version.aws-java-sdk}</version>
-      </dependency>
-      <dependency>
-        <groupId>com.amazonaws</groupId>
         <artifactId>aws-java-sdk-sagemaker</artifactId>
         <version>${version.aws-java-sdk}</version>
       </dependency>
       <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>lambda</artifactId>
+        <version>${version.aws-sdk2}</version>
+      </dependency>
+      <dependency>
+        <groupId>software.amazon.awssdk</groupId>
+        <artifactId>sagemakerruntime</artifactId>
         <version>${version.aws-sdk2}</version>
       </dependency>
       <dependency>


### PR DESCRIPTION
Migrates the `aws-sagemaker` connector from AWS SDK v1 to v2, closing #7971 (part of the AWS SDK v1→v2 migration epic).

## What changed

- `SageMakerSyncResponse` / `SageMakerAsyncResponse` (connector-owned result records) are now built from the SDK v2 `InvokeEndpointResponse` / `InvokeEndpointAsyncResponse` types instead of the v1 `InvokeEndpointResult` / `InvokeEndpointAsyncResult`. Both records declare an explicit `@JsonPropertyOrder` matching their pre-existing (implicit) field order, mirroring the `aws-eventbridge` result-DTO pattern.
- `SageMakerSyncResponse.mapResponseBody` now reads the response body via `SdkBytes.asByteArray()` / `asUtf8String()` instead of `ByteBuffer`, preserving the three pinned behaviors: a JSON content-type body is parsed, any other content-type is returned as a UTF-8 string, and an empty `application/json` body throws a `ConnectorException` wrapping "Error reading Sagemaker response.".
- `SageMakerSyncCaller` / `SageMakerAsyncCaller` now build v2 fluent `InvokeEndpointRequest` / `InvokeEndpointAsyncRequest` builders (using `SdkBytes` instead of `ByteBuffer.wrap` for the sync body) against `SageMakerRuntimeClient` / `SageMakerRuntimeAsyncClient`. Since the v2 async client returns a `CompletableFuture`, the async caller adds a `.join()` to keep returning a plain `SageMakerAsyncResponse` synchronously, matching the pre-v2 blocking behavior.

## Output-shape parity

Golden-fixture tests pin the exact JSON shape produced before this migration (SDK v1) and assert the migrated (SDK v2) code still produces it byte-for-byte:

- `connectors/aws/aws-sagemaker/src/test/java/io/camunda/connector/sagemaker/caller/SageMakerSyncCallerTest.java`
- `connectors/aws/aws-sagemaker/src/test/java/io/camunda/connector/sagemaker/caller/SageMakerAsyncCallerTest.java`

Each of these builds a realistic SDK v2 response object (as a live call would populate it), maps it through the real caller, serializes it with the production `ObjectMapper`, and diffs both the JSON tree (key-order-insensitive) and the serialized string (order-sensitive) against a frozen expected-JSON block carried over unchanged from before the migration.

### Note on `sdkResponseMetadata` / `sdkHttpMetadata`

This migration deliberately keeps `sdkResponseMetadata` / `sdkHttpMetadata` **dropped** from the result — that matches current (pre-migration) behavior and is verified by the golden tests above, which assert those fields are absent from the serialized output. This is a deliberate contrast with `aws-comprehend`'s v2 migration, where those fields **are** reconstructed: comprehend's golden test expects them to be present, while sagemaker's golden test proves they were already absent beforehand (the sagemaker result DTOs only ever mapped their own explicit fields, never AWS request/HTTP metadata). Each module's migration follows its own pre-existing golden-test contract rather than a one-size-fits-all rule.

## Review note

GitHub Copilot's automated review flagged two real issues with the initial version of this PR, both since fixed (commit `23b36a463`):

- **Unclosed async client**: `SagemakerConnectorFunction.execute()` now wraps both the sync and async `getSyncClient(...)`/`getAsyncClient(...)` calls in try-with-resources, so the client is always closed after the (blocking) call completes.
- **`CompletionException` double-wrapping**: `SageMakerAsyncCaller` now catches `CompletionException` from `.join()` before the generic `Exception` handler and rethrows `ConnectorException(e.getCause())`, preserving the pre-v2 error shape instead of adding an extra wrapper layer.

Both fixes are covered by new tests in `SagemakerConnectorFunctionTest` (client-close verification) and `SageMakerAsyncCallerTest#sageMakerAsyncCaller_UnwrapsCompletionExceptionFromJoin`.

## Test plan

- [x] `./mvnw -pl element-template-generator/maven-plugin -am install -DskipTests -Dquickly` (one-time plugin-descriptor fixup)
- [x] `./mvnw -pl connectors/aws/aws-sagemaker -am test` — BUILD SUCCESS, 14/14 tests pass
- [x] `dependency:analyze-only` reports no dependency problems
- [x] Golden-fixture tests confirm output-shape parity with the pre-existing v1 connector (see above)

