### PR TITLE
feat(textract): migrate to AWS SDK v2

### DIFF
--- a/connectors/aws/aws-textract/pom.xml
+++ b/connectors/aws/aws-textract/pom.xml
@@ -39,9 +39,23 @@ except in compliance with the proprietary license.</license.inlineheader>
     </dependency>
 
     <dependency>
-      <groupId>com.amazonaws</groupId>
-      <artifactId>aws-java-sdk-textract</artifactId>
-      <version>${version.aws-java-sdk}</version>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>textract</artifactId>
+      <version>${version.aws-sdk2}</version>
+    </dependency>
+    <dependency>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>aws-core</artifactId>
+      <version>${version.aws-sdk2}</version>
+    </dependency>
+    <dependency>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>sdk-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>http-client-spi</artifactId>
+      <version>${version.aws-sdk2}</version>
     </dependency>
 
     <dependency>

--- a/connectors/aws/aws-textract/src/main/java/io/camunda/connector/textract/TextractConnectorFunction.java
+++ b/connectors/aws/aws-textract/src/main/java/io/camunda/connector/textract/TextractConnectorFunction.java
@@ -16,6 +16,8 @@ import io.camunda.connector.textract.caller.PollingTextractCaller;
 import io.camunda.connector.textract.caller.SyncTextractCaller;
 import io.camunda.connector.textract.model.TextractRequest;
 import io.camunda.connector.textract.suppliers.AmazonTextractClientSupplier;
+import software.amazon.awssdk.services.textract.TextractAsyncClient;
+import software.amazon.awssdk.services.textract.TextractClient;
 
 @OutboundConnector(
     name = "AWS Textract",
@@ -91,15 +93,21 @@ public class TextractConnectorFunction implements OutboundConnectorFunction {
   public Object execute(OutboundConnectorContext context) throws Exception {
     TextractRequest request = context.bindVariables(TextractRequest.class);
     return switch (request.getInput().executionType()) {
-      case SYNC ->
-          syncTextractCaller.call(
-              request.getInput(), clientSupplier.getSyncTextractClient(request));
-      case POLLING ->
-          pollingTextractCaller.call(
-              request.getInput(), clientSupplier.getAsyncTextractClient(request));
-      case ASYNC ->
-          asyncTextractCaller.call(
-              request.getInput(), clientSupplier.getAsyncTextractClient(request));
+      case SYNC -> {
+        try (TextractClient client = clientSupplier.getSyncTextractClient(request)) {
+          yield syncTextractCaller.call(request.getInput(), client);
+        }
+      }
+      case POLLING -> {
+        try (TextractAsyncClient client = clientSupplier.getAsyncTextractClient(request)) {
+          yield pollingTextractCaller.call(request.getInput(), client);
+        }
+      }
+      case ASYNC -> {
+        try (TextractAsyncClient client = clientSupplier.getAsyncTextractClient(request)) {
+          yield asyncTextractCaller.call(request.getInput(), client);
+        }
+      }
     };
   }
 }

--- a/connectors/aws/aws-textract/src/main/java/io/camunda/connector/textract/caller/AsyncTextractCaller.java
+++ b/connectors/aws/aws-textract/src/main/java/io/camunda/connector/textract/caller/AsyncTextractCaller.java
@@ -6,59 +6,66 @@
  */
 package io.camunda.connector.textract.caller;
 
-import com.amazonaws.services.textract.AmazonTextract;
-import com.amazonaws.services.textract.model.NotificationChannel;
-import com.amazonaws.services.textract.model.OutputConfig;
-import com.amazonaws.services.textract.model.StartDocumentAnalysisRequest;
-import com.amazonaws.services.textract.model.StartDocumentAnalysisResult;
 import io.camunda.connector.textract.model.TextractRequestData;
+import io.camunda.connector.textract.model.result.StartDocumentAnalysisResult;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.services.textract.TextractAsyncClient;
+import software.amazon.awssdk.services.textract.model.NotificationChannel;
+import software.amazon.awssdk.services.textract.model.OutputConfig;
+import software.amazon.awssdk.services.textract.model.StartDocumentAnalysisRequest;
+import software.amazon.awssdk.services.textract.model.StartDocumentAnalysisResponse;
 
-public class AsyncTextractCaller implements TextractCaller<StartDocumentAnalysisResult> {
+public class AsyncTextractCaller
+    implements TextractCaller<StartDocumentAnalysisResult, TextractAsyncClient> {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(AsyncTextractCaller.class);
 
   @Override
   public StartDocumentAnalysisResult call(
-      TextractRequestData requestData, AmazonTextract textractClient) {
+      TextractRequestData requestData, TextractAsyncClient textractClient) {
     LOGGER.debug("Starting async task for document analysis with request data: {}", requestData);
-    final StartDocumentAnalysisRequest startDocumentAnalysisRequest =
-        new StartDocumentAnalysisRequest()
-            .withFeatureTypes(prepareFeatureTypes(requestData))
-            .withDocumentLocation(prepareDocumentLocation(requestData))
-            .withQueriesConfig(prepareQueryConfig(requestData))
-            .withClientRequestToken(requestData.clientRequestToken())
-            .withJobTag(requestData.jobTag())
-            .withKMSKeyId(requestData.kmsKeyId());
+    final StartDocumentAnalysisRequest.Builder requestBuilder =
+        StartDocumentAnalysisRequest.builder()
+            .featureTypesWithStrings(prepareFeatureTypes(requestData))
+            .documentLocation(prepareDocumentLocation(requestData))
+            .queriesConfig(prepareQueryConfig(requestData))
+            .clientRequestToken(requestData.clientRequestToken())
+            .jobTag(requestData.jobTag())
+            .kmsKeyId(requestData.kmsKeyId());
 
-    prepareNotification(startDocumentAnalysisRequest, requestData);
-    prepareOutput(startDocumentAnalysisRequest, requestData);
+    prepareNotification(requestBuilder, requestData);
+    prepareOutput(requestBuilder, requestData);
 
-    return textractClient.startDocumentAnalysis(startDocumentAnalysisRequest);
+    // Textract job kickoff is fire-and-forget for ASYNC execution (no polling); the future is
+    // joined here so the connector call remains synchronous, matching the pre-migration behavior.
+    StartDocumentAnalysisResponse response =
+        textractClient.startDocumentAnalysis(requestBuilder.build()).join();
+    return StartDocumentAnalysisResult.from(response);
   }
 
   private void prepareNotification(
-      StartDocumentAnalysisRequest startDocumentAnalysisRequest, TextractRequestData requestData) {
+      StartDocumentAnalysisRequest.Builder requestBuilder, TextractRequestData requestData) {
     String roleArn = requestData.notificationChannelRoleArn();
     String snsTopic = requestData.notificationChannelSnsTopicArn();
     if (StringUtils.isNoneBlank(roleArn, snsTopic)) {
       LOGGER.debug("Notification data roleArn: {}, snsTopic: {}", roleArn, snsTopic);
       NotificationChannel notificationChannel =
-          new NotificationChannel().withSNSTopicArn(snsTopic).withRoleArn(roleArn);
-      startDocumentAnalysisRequest.withNotificationChannel(notificationChannel);
+          NotificationChannel.builder().snsTopicArn(snsTopic).roleArn(roleArn).build();
+      requestBuilder.notificationChannel(notificationChannel);
     }
   }
 
   private void prepareOutput(
-      StartDocumentAnalysisRequest startDocumentAnalysisRequest, TextractRequestData requestData) {
+      StartDocumentAnalysisRequest.Builder requestBuilder, TextractRequestData requestData) {
     String s3Bucket = requestData.outputConfigS3Bucket();
     String s3Prefix = requestData.outputConfigS3Prefix();
     if (StringUtils.isNoneBlank(s3Bucket)) {
       LOGGER.debug("Output data s3Bucket: {}, s3Prefix: {} ", s3Bucket, s3Prefix);
-      OutputConfig outputConfig = new OutputConfig().withS3Bucket(s3Bucket).withS3Prefix(s3Prefix);
-      startDocumentAnalysisRequest.withOutputConfig(outputConfig);
+      OutputConfig outputConfig =
+          OutputConfig.builder().s3Bucket(s3Bucket).s3Prefix(s3Prefix).build();
+      requestBuilder.outputConfig(outputConfig);
     }
   }
 }

--- a/connectors/aws/aws-textract/src/main/java/io/camunda/connector/textract/caller/PollingTextractCaller.java
+++ b/connectors/aws/aws-textract/src/main/java/io/camunda/connector/textract/caller/PollingTextractCaller.java
@@ -145,7 +145,12 @@ public class PollingTextractCaller
 
                   JobStatus status = polled.jobStatus();
 
-                  if (status == JobStatus.SUCCEEDED) {
+                  if (status == JobStatus.SUCCEEDED || status == JobStatus.PARTIAL_SUCCESS) {
+                    // PARTIAL_SUCCESS is a terminal status too: the job finished but some pages
+                    // could not be analyzed. It still carries usable blocks (plus warnings), so it
+                    // must be treated as complete - otherwise the connector would poll a job that
+                    // will never reach SUCCEEDED until the polling window times out, discarding
+                    // the partial result.
                     return polled;
                   } else if (status == JobStatus.FAILED) {
                     throw new ConnectorInputException("Textract polling job: " + polled);

--- a/connectors/aws/aws-textract/src/main/java/io/camunda/connector/textract/caller/PollingTextractCaller.java
+++ b/connectors/aws/aws-textract/src/main/java/io/camunda/connector/textract/caller/PollingTextractCaller.java
@@ -6,12 +6,12 @@
  */
 package io.camunda.connector.textract.caller;
 
-import com.amazonaws.services.textract.AmazonTextract;
-import com.amazonaws.services.textract.model.*;
 import dev.failsafe.Failsafe;
 import dev.failsafe.RetryPolicy;
+import io.camunda.connector.api.error.ConnectorException;
 import io.camunda.connector.api.error.ConnectorInputException;
 import io.camunda.connector.textract.model.TextractRequestData;
+import io.camunda.connector.textract.model.result.GetDocumentAnalysisResult;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
@@ -19,62 +19,104 @@ import java.util.Objects;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.services.textract.TextractAsyncClient;
+import software.amazon.awssdk.services.textract.model.Block;
+import software.amazon.awssdk.services.textract.model.GetDocumentAnalysisRequest;
+import software.amazon.awssdk.services.textract.model.GetDocumentAnalysisResponse;
+import software.amazon.awssdk.services.textract.model.JobStatus;
+import software.amazon.awssdk.services.textract.model.StartDocumentAnalysisRequest;
+import software.amazon.awssdk.services.textract.model.StartDocumentAnalysisResponse;
 
-public class PollingTextractCaller implements TextractCaller<GetDocumentAnalysisResult> {
+public class PollingTextractCaller
+    implements TextractCaller<GetDocumentAnalysisResult, TextractAsyncClient> {
 
   public static final int MAX_RESULT = 1000;
 
+  private static final int DEFAULT_MAX_ATTEMPTS = 10;
+  private static final Duration DEFAULT_POLL_DELAY = Duration.ofMinutes(1);
+
   private static final Logger LOGGER = LoggerFactory.getLogger(PollingTextractCaller.class);
+
+  private final int maxAttempts;
+  private final Duration pollDelay;
+
+  public PollingTextractCaller() {
+    this(DEFAULT_MAX_ATTEMPTS, DEFAULT_POLL_DELAY);
+  }
+
+  /**
+   * Visible for tests: lets the "polling window exhausted while still IN_PROGRESS" path (see {@link
+   * #call}) be exercised without waiting out the real {@code maxAttempts * pollDelay} window (~9
+   * minutes with the production defaults).
+   */
+  PollingTextractCaller(int maxAttempts, Duration pollDelay) {
+    this.maxAttempts = maxAttempts;
+    this.pollDelay = pollDelay;
+  }
 
   @Override
   public GetDocumentAnalysisResult call(
-      TextractRequestData requestData, AmazonTextract textractClient) throws Exception {
+      TextractRequestData requestData, TextractAsyncClient textractClient) throws Exception {
 
     final StartDocumentAnalysisRequest startDocReq =
-        new StartDocumentAnalysisRequest()
-            .withFeatureTypes(this.prepareFeatureTypes(requestData))
-            .withQueriesConfig(prepareQueryConfig(requestData))
-            .withDocumentLocation(this.prepareDocumentLocation(requestData));
+        StartDocumentAnalysisRequest.builder()
+            .featureTypesWithStrings(this.prepareFeatureTypes(requestData))
+            .queriesConfig(prepareQueryConfig(requestData))
+            .documentLocation(this.prepareDocumentLocation(requestData))
+            .build();
 
-    final StartDocumentAnalysisResult result = textractClient.startDocumentAnalysis(startDocReq);
-    final String jobId = result.getJobId();
+    final StartDocumentAnalysisResponse result =
+        textractClient.startDocumentAnalysis(startDocReq).join();
+    final String jobId = result.jobId();
 
     LOGGER.debug("Started document analysis with jobId: {}", jobId);
 
-    GetDocumentAnalysisResult firstResult = pollUntilComplete(jobId, textractClient);
+    GetDocumentAnalysisResponse firstResult = pollUntilComplete(jobId, textractClient);
 
-    List<Block> allBlocks = new ArrayList<>(firstResult.getBlocks());
-    GetDocumentAnalysisResult lastResult = firstResult;
-    String nextToken = firstResult.getNextToken();
+    List<Block> allBlocks = new ArrayList<>(firstResult.blocks());
+    GetDocumentAnalysisResponse lastResult = firstResult;
+    String nextToken = firstResult.nextToken();
 
     while (StringUtils.isNotEmpty(nextToken)) {
       GetDocumentAnalysisRequest nextRequest =
-          new GetDocumentAnalysisRequest()
-              .withJobId(jobId)
-              .withMaxResults(MAX_RESULT)
-              .withNextToken(nextToken);
+          GetDocumentAnalysisRequest.builder()
+              .jobId(jobId)
+              .maxResults(MAX_RESULT)
+              .nextToken(nextToken)
+              .build();
 
-      GetDocumentAnalysisResult nextResult = textractClient.getDocumentAnalysis(nextRequest);
-      nextToken = nextResult.getNextToken();
-      allBlocks.addAll(nextResult.getBlocks());
+      GetDocumentAnalysisResponse nextResult =
+          textractClient.getDocumentAnalysis(nextRequest).join();
+      nextToken = nextResult.nextToken();
+      allBlocks.addAll(nextResult.blocks());
       lastResult = nextResult;
     }
 
-    lastResult.setBlocks(allBlocks);
-    return lastResult;
+    // v2 responses are immutable (no setters); rebuild the last-page response with the merged
+    // block list instead of v1's `lastResult.setBlocks(allBlocks)`. This intentionally preserves
+    // the pre-existing (and golden-test-pinned) quirk that the merged result's
+    // sdkResponseMetadata/sdkHttpMetadata/nextToken reflect only the LAST page polled, not the
+    // first.
+    GetDocumentAnalysisResponse mergedResult = lastResult.toBuilder().blocks(allBlocks).build();
+    return GetDocumentAnalysisResult.from(mergedResult);
   }
 
-  private GetDocumentAnalysisResult pollUntilComplete(String jobId, AmazonTextract textractClient)
-      throws InterruptedException {
+  private GetDocumentAnalysisResponse pollUntilComplete(
+      String jobId, TextractAsyncClient textractClient) {
 
-    final int MAX_RETRIES = 10;
-
-    RetryPolicy<GetDocumentAnalysisResult> retryPolicy =
-        RetryPolicy.<GetDocumentAnalysisResult>builder()
+    RetryPolicy<GetDocumentAnalysisResponse> retryPolicy =
+        RetryPolicy.<GetDocumentAnalysisResponse>builder()
             .handle(Exception.class)
+            // Defect fix: a FAILED job status is signalled below as a ConnectorInputException.
+            // Without excluding it here, `.handle(Exception.class)` would also catch and retry
+            // it up to maxAttempts times, wasting the full polling window (~9 minutes with the
+            // production defaults) retrying a job that will never succeed. Genuine
+            // transient/technical errors (e.g. wrapped in CompletionException by `.join()`) are
+            // still retried as before.
+            .abortOn(ConnectorInputException.class)
             .handleResultIf(Objects::isNull)
-            .withDelay(Duration.ofMinutes(1))
-            .withMaxAttempts(MAX_RETRIES)
+            .withDelay(pollDelay)
+            .withMaxAttempts(maxAttempts)
             .onRetry(
                 ev ->
                     LOGGER.debug(
@@ -87,22 +129,44 @@ public class PollingTextractCaller implements TextractCaller<GetDocumentAnalysis
                         ev.getAttemptCount()))
             .build();
 
-    return Failsafe.with(retryPolicy)
-        .get(
-            () -> {
-              LOGGER.debug("Textract polling job {} started", jobId);
-              GetDocumentAnalysisResult response =
-                  textractClient.getDocumentAnalysis(
-                      new GetDocumentAnalysisRequest().withJobId(jobId).withMaxResults(MAX_RESULT));
+    GetDocumentAnalysisResponse response =
+        Failsafe.with(retryPolicy)
+            .get(
+                () -> {
+                  LOGGER.debug("Textract polling job {} started", jobId);
+                  GetDocumentAnalysisResponse polled =
+                      textractClient
+                          .getDocumentAnalysis(
+                              GetDocumentAnalysisRequest.builder()
+                                  .jobId(jobId)
+                                  .maxResults(MAX_RESULT)
+                                  .build())
+                          .join();
 
-              String status = response.getJobStatus();
+                  JobStatus status = polled.jobStatus();
 
-              if (JobStatus.SUCCEEDED.toString().equals(status)) {
-                return response;
-              } else if (JobStatus.FAILED.toString().equals(status)) {
-                throw new ConnectorInputException("Textract polling job: " + response);
-              }
-              return null;
-            });
+                  if (status == JobStatus.SUCCEEDED) {
+                    return polled;
+                  } else if (status == JobStatus.FAILED) {
+                    throw new ConnectorInputException("Textract polling job: " + polled);
+                  }
+                  return null;
+                });
+
+    // Defect fix: when every attempt is exhausted while the job is still IN_PROGRESS,
+    // `handleResultIf(Objects::isNull)` matched a RESULT (not an exception) on every attempt, so
+    // Failsafe.get() returns null instead of throwing. The caller then dereferenced that null
+    // (`firstResult.getBlocks()`), producing an NPE. Fail with a clear, typed exception instead.
+    if (response == null) {
+      throw new ConnectorException(
+          "Textract job "
+              + jobId
+              + " did not complete within the polling window ("
+              + maxAttempts
+              + " attempts, "
+              + pollDelay
+              + " delay each)");
+    }
+    return response;
   }
 }

--- a/connectors/aws/aws-textract/src/main/java/io/camunda/connector/textract/caller/SyncTextractCaller.java
+++ b/connectors/aws/aws-textract/src/main/java/io/camunda/connector/textract/caller/SyncTextractCaller.java
@@ -6,45 +6,45 @@
  */
 package io.camunda.connector.textract.caller;
 
-import com.amazonaws.services.textract.AmazonTextract;
-import com.amazonaws.services.textract.model.AnalyzeDocumentRequest;
-import com.amazonaws.services.textract.model.AnalyzeDocumentResult;
-import com.amazonaws.services.textract.model.Document;
 import io.camunda.connector.textract.model.TextractRequestData;
-import java.nio.ByteBuffer;
+import io.camunda.connector.textract.model.result.AnalyzeDocumentResult;
 import java.util.Objects;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.services.textract.TextractClient;
+import software.amazon.awssdk.services.textract.model.AnalyzeDocumentRequest;
+import software.amazon.awssdk.services.textract.model.AnalyzeDocumentResponse;
+import software.amazon.awssdk.services.textract.model.Document;
 
-public class SyncTextractCaller implements TextractCaller<AnalyzeDocumentResult> {
+public class SyncTextractCaller implements TextractCaller<AnalyzeDocumentResult, TextractClient> {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(SyncTextractCaller.class);
 
   @Override
   public AnalyzeDocumentResult call(
-      TextractRequestData requestData, AmazonTextract textractClient) {
+      TextractRequestData requestData, TextractClient textractClient) {
     LOGGER.debug("Starting sync task for document analysis with request data: {}", requestData);
 
     final Document document = createDocument(requestData);
 
     final AnalyzeDocumentRequest analyzeDocumentRequest =
-        new AnalyzeDocumentRequest()
-            .withFeatureTypes(prepareFeatureTypes(requestData))
-            .withQueriesConfig(prepareQueryConfig(requestData))
-            .withDocument(document);
+        AnalyzeDocumentRequest.builder()
+            .featureTypesWithStrings(prepareFeatureTypes(requestData))
+            .queriesConfig(prepareQueryConfig(requestData))
+            .document(document)
+            .build();
 
-    return textractClient.analyzeDocument(analyzeDocumentRequest);
+    AnalyzeDocumentResponse response = textractClient.analyzeDocument(analyzeDocumentRequest);
+    return AnalyzeDocumentResult.from(response);
   }
 
   private Document createDocument(TextractRequestData requestData) {
-    final Document document = new Document();
-
     if (Objects.isNull(requestData.document())) {
-      return document.withS3Object(prepareS3Obj(requestData));
+      return Document.builder().s3Object(prepareS3Obj(requestData)).build();
     }
 
     byte[] docBytes = requestData.document().asByteArray();
-    document.withBytes(ByteBuffer.wrap(docBytes));
-    return document;
+    return Document.builder().bytes(SdkBytes.fromByteArray(docBytes)).build();
   }
 }

--- a/connectors/aws/aws-textract/src/main/java/io/camunda/connector/textract/caller/TextractCaller.java
+++ b/connectors/aws/aws-textract/src/main/java/io/camunda/connector/textract/caller/TextractCaller.java
@@ -6,30 +6,35 @@
  */
 package io.camunda.connector.textract.caller;
 
-import com.amazonaws.AmazonWebServiceResult;
-import com.amazonaws.ResponseMetadata;
-import com.amazonaws.services.textract.AmazonTextract;
-import com.amazonaws.services.textract.model.DocumentLocation;
-import com.amazonaws.services.textract.model.FeatureType;
-import com.amazonaws.services.textract.model.QueriesConfig;
-import com.amazonaws.services.textract.model.Query;
-import com.amazonaws.services.textract.model.S3Object;
 import io.camunda.connector.api.error.ConnectorInputException;
 import io.camunda.connector.textract.model.TextractRequestData;
 import java.util.HashSet;
 import java.util.Set;
+import software.amazon.awssdk.services.textract.model.DocumentLocation;
+import software.amazon.awssdk.services.textract.model.FeatureType;
+import software.amazon.awssdk.services.textract.model.QueriesConfig;
+import software.amazon.awssdk.services.textract.model.Query;
+import software.amazon.awssdk.services.textract.model.S3Object;
 
-public interface TextractCaller<T extends AmazonWebServiceResult<ResponseMetadata>> {
+/**
+ * {@code T} is the connector-owned result type this caller returns; {@code C} is the AWS SDK v2
+ * client type it calls. Unlike AWS SDK v1 (where {@code AmazonTextractAsync extends
+ * AmazonTextract}, so both sync and polling/async callers could share a single client type), v2's
+ * {@code TextractClient} and {@code TextractAsyncClient} are unrelated interfaces - hence the
+ * second type parameter.
+ */
+public interface TextractCaller<T, C> {
 
   String WRONG_ANALYZE_TYPE_MSG = "At least one analyze type should be selected";
 
-  T call(final TextractRequestData request, final AmazonTextract textractClient) throws Exception;
+  T call(final TextractRequestData request, final C textractClient) throws Exception;
 
   default S3Object prepareS3Obj(final TextractRequestData requestData) {
-    return new S3Object()
-        .withBucket(requestData.documentS3Bucket())
-        .withName(requestData.documentName())
-        .withVersion(requestData.documentVersion());
+    return S3Object.builder()
+        .bucket(requestData.documentS3Bucket())
+        .name(requestData.documentName())
+        .version(requestData.documentVersion())
+        .build();
   }
 
   default Set<String> prepareFeatureTypes(final TextractRequestData request) {
@@ -57,7 +62,9 @@ public interface TextractCaller<T extends AmazonWebServiceResult<ResponseMetadat
 
   default QueriesConfig prepareQueryConfig(final TextractRequestData requestData) {
     if (requestData.query() != null) {
-      return new QueriesConfig().withQueries(new Query().withText(requestData.query()));
+      return QueriesConfig.builder()
+          .queries(Query.builder().text(requestData.query()).build())
+          .build();
     } else if (requestData.analyzeQueries()) {
       throw new ConnectorInputException(
           "The 'query' field must be provided when 'analyzeQueries' is set to true.");
@@ -67,6 +74,6 @@ public interface TextractCaller<T extends AmazonWebServiceResult<ResponseMetadat
 
   default DocumentLocation prepareDocumentLocation(final TextractRequestData request) {
     final S3Object s3Obj = prepareS3Obj(request);
-    return new DocumentLocation().withS3Object(s3Obj);
+    return DocumentLocation.builder().s3Object(s3Obj).build();
   }
 }

--- a/connectors/aws/aws-textract/src/main/java/io/camunda/connector/textract/model/result/AnalyzeDocumentResult.java
+++ b/connectors/aws/aws-textract/src/main/java/io/camunda/connector/textract/model/result/AnalyzeDocumentResult.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.textract.model.result;
+
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import java.util.List;
+import software.amazon.awssdk.services.textract.model.AnalyzeDocumentResponse;
+
+/**
+ * Connector-owned result of a Textract {@code AnalyzeDocument} call (SYNC execution).
+ *
+ * <p>The AWS SDK v2 model classes ({@link AnalyzeDocumentResponse} and friends) expose fluent
+ * accessors ({@code blocks()}, {@code documentMetadata()}, ...) rather than JavaBean getters.
+ * Serializing them directly with the connectors' {@code ObjectMapper} (which disables {@code
+ * FAIL_ON_EMPTY_BEANS}) would silently produce {@code {}}, dropping every extracted block (see
+ * #7967 / #7977 for the same hazard already fixed in aws-eventbridge). This record maps the v2
+ * response back into the exact JSON shape that the pre-v2 (AWS SDK v1) connector documented and
+ * returned, restoring that output contract.
+ */
+@JsonPropertyOrder({
+  "sdkResponseMetadata",
+  "sdkHttpMetadata",
+  "documentMetadata",
+  "blocks",
+  "humanLoopActivationOutput",
+  "analyzeDocumentModelVersion"
+})
+public record AnalyzeDocumentResult(
+    SdkResponseMetadata sdkResponseMetadata,
+    SdkHttpMetadata sdkHttpMetadata,
+    DocumentMetadata documentMetadata,
+    List<Block> blocks,
+    HumanLoopActivationOutput humanLoopActivationOutput,
+    String analyzeDocumentModelVersion) {
+
+  public static AnalyzeDocumentResult from(final AnalyzeDocumentResponse response) {
+    return new AnalyzeDocumentResult(
+        SdkResponseMetadata.from(response.responseMetadata()),
+        SdkHttpMetadata.from(response.sdkHttpResponse()),
+        DocumentMetadata.from(response.documentMetadata()),
+        response.hasBlocks() ? mapBlocks(response.blocks()) : null,
+        HumanLoopActivationOutput.from(response.humanLoopActivationOutput()),
+        response.analyzeDocumentModelVersion());
+  }
+
+  private static List<Block> mapBlocks(
+      final List<software.amazon.awssdk.services.textract.model.Block> blocks) {
+    return blocks.stream().map(Block::from).toList();
+  }
+}

--- a/connectors/aws/aws-textract/src/main/java/io/camunda/connector/textract/model/result/Block.java
+++ b/connectors/aws/aws-textract/src/main/java/io/camunda/connector/textract/model/result/Block.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.textract.model.result;
+
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import java.util.List;
+
+/**
+ * Connector-owned mirror of the AWS SDK v2 {@code Block} shape, used by both the sync-analyze
+ * ({@link AnalyzeDocumentResult}) and the polling/merge ({@link GetDocumentAnalysisResult})
+ * results. The v2 {@code Block} class exposes fluent accessors only (no JavaBean getters); mapping
+ * it into this record restores the documented v1 JSON field order and the explicit-null-for-unset
+ * behavior that the runtime's {@code ObjectMapper} would otherwise silently drop (see #7967 / #7977
+ * for the same hazard in aws-eventbridge).
+ *
+ * <p>{@code geometry.rotationAngle} exists on the v2 SDK model but was never part of the v1 JSON
+ * shape this connector documented, so it is intentionally NOT mapped here.
+ */
+@JsonPropertyOrder({
+  "blockType",
+  "confidence",
+  "text",
+  "textType",
+  "rowIndex",
+  "columnIndex",
+  "rowSpan",
+  "columnSpan",
+  "geometry",
+  "id",
+  "relationships",
+  "entityTypes",
+  "selectionStatus",
+  "page",
+  "query"
+})
+public record Block(
+    String blockType,
+    Float confidence,
+    String text,
+    String textType,
+    Integer rowIndex,
+    Integer columnIndex,
+    Integer rowSpan,
+    Integer columnSpan,
+    Geometry geometry,
+    String id,
+    List<Relationship> relationships,
+    List<String> entityTypes,
+    String selectionStatus,
+    Integer page,
+    Query query) {
+
+  public static Block from(final software.amazon.awssdk.services.textract.model.Block block) {
+    if (block == null) {
+      return null;
+    }
+    return new Block(
+        block.blockTypeAsString(),
+        block.confidence(),
+        block.text(),
+        block.textTypeAsString(),
+        block.rowIndex(),
+        block.columnIndex(),
+        block.rowSpan(),
+        block.columnSpan(),
+        Geometry.from(block.geometry()),
+        block.id(),
+        block.hasRelationships() ? mapRelationships(block.relationships()) : null,
+        block.hasEntityTypes() ? block.entityTypesAsStrings() : null,
+        block.selectionStatusAsString(),
+        block.page(),
+        Query.from(block.query()));
+  }
+
+  private static List<Relationship> mapRelationships(
+      final List<software.amazon.awssdk.services.textract.model.Relationship> relationships) {
+    return relationships.stream().map(Relationship::from).toList();
+  }
+
+  @JsonPropertyOrder({"boundingBox", "polygon"})
+  public record Geometry(BoundingBox boundingBox, List<Point> polygon) {
+
+    static Geometry from(final software.amazon.awssdk.services.textract.model.Geometry geometry) {
+      if (geometry == null) {
+        return null;
+      }
+      return new Geometry(
+          BoundingBox.from(geometry.boundingBox()),
+          geometry.hasPolygon() ? mapPolygon(geometry.polygon()) : null);
+    }
+
+    private static List<Point> mapPolygon(
+        final List<software.amazon.awssdk.services.textract.model.Point> polygon) {
+      return polygon.stream().map(Point::from).toList();
+    }
+  }
+
+  @JsonPropertyOrder({"width", "height", "left", "top"})
+  public record BoundingBox(Float width, Float height, Float left, Float top) {
+
+    static BoundingBox from(final software.amazon.awssdk.services.textract.model.BoundingBox box) {
+      if (box == null) {
+        return null;
+      }
+      return new BoundingBox(box.width(), box.height(), box.left(), box.top());
+    }
+  }
+
+  @JsonPropertyOrder({"x", "y"})
+  public record Point(Float x, Float y) {
+
+    static Point from(final software.amazon.awssdk.services.textract.model.Point point) {
+      if (point == null) {
+        return null;
+      }
+      return new Point(point.x(), point.y());
+    }
+  }
+
+  @JsonPropertyOrder({"type", "ids"})
+  public record Relationship(String type, List<String> ids) {
+
+    static Relationship from(
+        final software.amazon.awssdk.services.textract.model.Relationship relationship) {
+      return new Relationship(
+          relationship.typeAsString(), relationship.hasIds() ? relationship.ids() : null);
+    }
+  }
+
+  @JsonPropertyOrder({"text", "alias", "pages"})
+  public record Query(String text, String alias, List<String> pages) {
+
+    static Query from(final software.amazon.awssdk.services.textract.model.Query query) {
+      if (query == null) {
+        return null;
+      }
+      return new Query(query.text(), query.alias(), query.hasPages() ? query.pages() : null);
+    }
+  }
+}

--- a/connectors/aws/aws-textract/src/main/java/io/camunda/connector/textract/model/result/DocumentMetadata.java
+++ b/connectors/aws/aws-textract/src/main/java/io/camunda/connector/textract/model/result/DocumentMetadata.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.textract.model.result;
+
+/** Connector-owned mirror of the v2 {@code DocumentMetadata} shape ({@code pages} only). */
+public record DocumentMetadata(Integer pages) {
+
+  public static DocumentMetadata from(
+      final software.amazon.awssdk.services.textract.model.DocumentMetadata metadata) {
+    if (metadata == null) {
+      return null;
+    }
+    return new DocumentMetadata(metadata.pages());
+  }
+}

--- a/connectors/aws/aws-textract/src/main/java/io/camunda/connector/textract/model/result/GetDocumentAnalysisResult.java
+++ b/connectors/aws/aws-textract/src/main/java/io/camunda/connector/textract/model/result/GetDocumentAnalysisResult.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.textract.model.result;
+
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import java.util.List;
+import software.amazon.awssdk.services.textract.model.GetDocumentAnalysisResponse;
+
+/**
+ * Connector-owned result of a Textract {@code GetDocumentAnalysis} call (POLLING execution: the
+ * {@link io.camunda.connector.textract.caller.PollingTextractCaller} merges every page it polls
+ * into a single {@code blocks} list, then maps the merged v2 {@link GetDocumentAnalysisResponse}
+ * through this record).
+ *
+ * <p>See {@link AnalyzeDocumentResult} for why the raw v2 response cannot be returned directly as
+ * the connector result.
+ */
+@JsonPropertyOrder({
+  "sdkResponseMetadata",
+  "sdkHttpMetadata",
+  "documentMetadata",
+  "jobStatus",
+  "nextToken",
+  "blocks",
+  "warnings",
+  "statusMessage",
+  "analyzeDocumentModelVersion"
+})
+public record GetDocumentAnalysisResult(
+    SdkResponseMetadata sdkResponseMetadata,
+    SdkHttpMetadata sdkHttpMetadata,
+    DocumentMetadata documentMetadata,
+    String jobStatus,
+    String nextToken,
+    List<Block> blocks,
+    List<Warning> warnings,
+    String statusMessage,
+    String analyzeDocumentModelVersion) {
+
+  public static GetDocumentAnalysisResult from(final GetDocumentAnalysisResponse response) {
+    return new GetDocumentAnalysisResult(
+        SdkResponseMetadata.from(response.responseMetadata()),
+        SdkHttpMetadata.from(response.sdkHttpResponse()),
+        DocumentMetadata.from(response.documentMetadata()),
+        response.jobStatusAsString(),
+        response.nextToken(),
+        response.hasBlocks() ? mapBlocks(response.blocks()) : null,
+        response.hasWarnings() ? mapWarnings(response.warnings()) : null,
+        response.statusMessage(),
+        response.analyzeDocumentModelVersion());
+  }
+
+  private static List<Block> mapBlocks(
+      final List<software.amazon.awssdk.services.textract.model.Block> blocks) {
+    return blocks.stream().map(Block::from).toList();
+  }
+
+  private static List<Warning> mapWarnings(
+      final List<software.amazon.awssdk.services.textract.model.Warning> warnings) {
+    return warnings.stream().map(Warning::from).toList();
+  }
+}

--- a/connectors/aws/aws-textract/src/main/java/io/camunda/connector/textract/model/result/HumanLoopActivationOutput.java
+++ b/connectors/aws/aws-textract/src/main/java/io/camunda/connector/textract/model/result/HumanLoopActivationOutput.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.textract.model.result;
+
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import java.util.List;
+
+/** Connector-owned mirror of the AWS SDK v2 {@code HumanLoopActivationOutput} shape. */
+@JsonPropertyOrder({
+  "humanLoopArn",
+  "humanLoopActivationReasons",
+  "humanLoopActivationConditionsEvaluationResults"
+})
+public record HumanLoopActivationOutput(
+    String humanLoopArn,
+    List<String> humanLoopActivationReasons,
+    String humanLoopActivationConditionsEvaluationResults) {
+
+  public static HumanLoopActivationOutput from(
+      final software.amazon.awssdk.services.textract.model.HumanLoopActivationOutput output) {
+    if (output == null) {
+      return null;
+    }
+    return new HumanLoopActivationOutput(
+        output.humanLoopArn(),
+        output.hasHumanLoopActivationReasons() ? output.humanLoopActivationReasons() : null,
+        output.humanLoopActivationConditionsEvaluationResults());
+  }
+}

--- a/connectors/aws/aws-textract/src/main/java/io/camunda/connector/textract/model/result/SdkHttpMetadata.java
+++ b/connectors/aws/aws-textract/src/main/java/io/camunda/connector/textract/model/result/SdkHttpMetadata.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.textract.model.result;
+
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import software.amazon.awssdk.http.SdkHttpResponse;
+
+/**
+ * Shared {@code sdkHttpMetadata} shape, reused by every connector-owned Textract result (sync
+ * analyze, async start, polling/merge) since AWS SDK v2 exposes the same {@link SdkHttpResponse} on
+ * every response.
+ */
+@JsonPropertyOrder({"httpHeaders", "httpStatusCode", "allHttpHeaders"})
+public record SdkHttpMetadata(
+    Map<String, String> httpHeaders,
+    Integer httpStatusCode,
+    Map<String, List<String>> allHttpHeaders) {
+
+  public static SdkHttpMetadata from(final SdkHttpResponse httpResponse) {
+    if (httpResponse == null) {
+      return null;
+    }
+    Map<String, List<String>> allHttpHeaders = new LinkedHashMap<>(httpResponse.headers());
+    Map<String, String> httpHeaders = new LinkedHashMap<>();
+    allHttpHeaders.forEach(
+        (name, values) ->
+            httpHeaders.put(name, values == null || values.isEmpty() ? null : values.get(0)));
+    return new SdkHttpMetadata(httpHeaders, httpResponse.statusCode(), allHttpHeaders);
+  }
+}

--- a/connectors/aws/aws-textract/src/main/java/io/camunda/connector/textract/model/result/SdkResponseMetadata.java
+++ b/connectors/aws/aws-textract/src/main/java/io/camunda/connector/textract/model/result/SdkResponseMetadata.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.textract.model.result;
+
+import software.amazon.awssdk.awscore.AwsResponseMetadata;
+
+/**
+ * Shared {@code sdkResponseMetadata} shape, reused by every connector-owned Textract result (sync
+ * analyze, async start, polling/merge) since AWS SDK v2 exposes the same {@link
+ * AwsResponseMetadata} on every {@code TextractResponse} subtype.
+ */
+public record SdkResponseMetadata(String requestId) {
+
+  // v2 returns the literal "UNKNOWN" when AWS_REQUEST_ID is absent; v1 exposed null there.
+  private static final String UNKNOWN_REQUEST_ID = "UNKNOWN";
+
+  public static SdkResponseMetadata from(final AwsResponseMetadata metadata) {
+    if (metadata == null) {
+      return null;
+    }
+    String requestId = metadata.requestId();
+    return new SdkResponseMetadata(UNKNOWN_REQUEST_ID.equals(requestId) ? null : requestId);
+  }
+}

--- a/connectors/aws/aws-textract/src/main/java/io/camunda/connector/textract/model/result/StartDocumentAnalysisResult.java
+++ b/connectors/aws/aws-textract/src/main/java/io/camunda/connector/textract/model/result/StartDocumentAnalysisResult.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.textract.model.result;
+
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import software.amazon.awssdk.services.textract.model.StartDocumentAnalysisResponse;
+
+/**
+ * Connector-owned result of a Textract {@code StartDocumentAnalysis} call (ASYNC execution: a
+ * fire-and-forget job kickoff, no polling).
+ *
+ * <p>See {@link AnalyzeDocumentResult} for why the raw v2 {@link StartDocumentAnalysisResponse}
+ * cannot be returned directly as the connector result.
+ */
+@JsonPropertyOrder({"sdkResponseMetadata", "sdkHttpMetadata", "jobId"})
+public record StartDocumentAnalysisResult(
+    SdkResponseMetadata sdkResponseMetadata, SdkHttpMetadata sdkHttpMetadata, String jobId) {
+
+  public static StartDocumentAnalysisResult from(final StartDocumentAnalysisResponse response) {
+    return new StartDocumentAnalysisResult(
+        SdkResponseMetadata.from(response.responseMetadata()),
+        SdkHttpMetadata.from(response.sdkHttpResponse()),
+        response.jobId());
+  }
+}

--- a/connectors/aws/aws-textract/src/main/java/io/camunda/connector/textract/model/result/Warning.java
+++ b/connectors/aws/aws-textract/src/main/java/io/camunda/connector/textract/model/result/Warning.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.textract.model.result;
+
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import java.util.List;
+
+/** Connector-owned mirror of the AWS SDK v2 {@code Warning} shape. */
+@JsonPropertyOrder({"errorCode", "pages"})
+public record Warning(String errorCode, List<Integer> pages) {
+
+  public static Warning from(final software.amazon.awssdk.services.textract.model.Warning warning) {
+    if (warning == null) {
+      return null;
+    }
+    return new Warning(warning.errorCode(), warning.hasPages() ? warning.pages() : null);
+  }
+}

--- a/connectors/aws/aws-textract/src/main/java/io/camunda/connector/textract/suppliers/AmazonTextractClientSupplier.java
+++ b/connectors/aws/aws-textract/src/main/java/io/camunda/connector/textract/suppliers/AmazonTextractClientSupplier.java
@@ -6,26 +6,18 @@
  */
 package io.camunda.connector.textract.suppliers;
 
-import com.amazonaws.services.textract.AmazonTextract;
-import com.amazonaws.services.textract.AmazonTextractAsync;
-import com.amazonaws.services.textract.AmazonTextractAsyncClientBuilder;
-import com.amazonaws.services.textract.AmazonTextractClientBuilder;
-import io.camunda.connector.aws.CredentialsProviderSupport;
+import io.camunda.connector.aws.AwsClientSupport;
 import io.camunda.connector.textract.model.TextractRequest;
+import software.amazon.awssdk.services.textract.TextractAsyncClient;
+import software.amazon.awssdk.services.textract.TextractClient;
 
 public class AmazonTextractClientSupplier {
 
-  public AmazonTextract getSyncTextractClient(final TextractRequest request) {
-    return AmazonTextractClientBuilder.standard()
-        .withCredentials(CredentialsProviderSupport.credentialsProvider(request))
-        .withRegion(request.getConfiguration().region())
-        .build();
+  public TextractClient getSyncTextractClient(final TextractRequest request) {
+    return AwsClientSupport.createClient(TextractClient.builder(), request);
   }
 
-  public AmazonTextractAsync getAsyncTextractClient(final TextractRequest request) {
-    return AmazonTextractAsyncClientBuilder.standard()
-        .withCredentials(CredentialsProviderSupport.credentialsProvider(request))
-        .withRegion(request.getConfiguration().region())
-        .build();
+  public TextractAsyncClient getAsyncTextractClient(final TextractRequest request) {
+    return AwsClientSupport.createClient(TextractAsyncClient.builder(), request);
   }
 }

--- a/connectors/aws/aws-textract/src/test/java/io/camunda/connector/textract/TextractConnectorFunctionTest.java
+++ b/connectors/aws/aws-textract/src/test/java/io/camunda/connector/textract/TextractConnectorFunctionTest.java
@@ -13,14 +13,14 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
-import com.amazonaws.services.textract.model.AnalyzeDocumentResult;
-import com.amazonaws.services.textract.model.GetDocumentAnalysisResult;
-import com.amazonaws.services.textract.model.StartDocumentAnalysisResult;
 import io.camunda.connector.api.error.ConnectorInputException;
 import io.camunda.connector.runtime.test.outbound.OutboundConnectorContextBuilder;
 import io.camunda.connector.textract.caller.AsyncTextractCaller;
 import io.camunda.connector.textract.caller.PollingTextractCaller;
 import io.camunda.connector.textract.caller.SyncTextractCaller;
+import io.camunda.connector.textract.model.result.AnalyzeDocumentResult;
+import io.camunda.connector.textract.model.result.GetDocumentAnalysisResult;
+import io.camunda.connector.textract.model.result.StartDocumentAnalysisResult;
 import io.camunda.connector.textract.suppliers.AmazonTextractClientSupplier;
 import io.camunda.connector.textract.util.TextractTestUtils;
 import org.junit.jupiter.api.Test;
@@ -47,7 +47,8 @@ class TextractConnectorFunctionTest {
     var outBounderContext = prepareConnectorContext(TextractTestUtils.SYNC_EXECUTION_JSON);
 
     when(clientSupplier.getSyncTextractClient(any())).thenCallRealMethod();
-    when(syncCaller.call(any(), any())).thenReturn(new AnalyzeDocumentResult());
+    when(syncCaller.call(any(), any()))
+        .thenReturn(new AnalyzeDocumentResult(null, null, null, null, null, null));
 
     var result = textractConnectorFunction.execute(outBounderContext);
     assertThat(result).isInstanceOf(AnalyzeDocumentResult.class);
@@ -58,7 +59,8 @@ class TextractConnectorFunctionTest {
     var outBounderContext = prepareConnectorContext(TextractTestUtils.ASYNC_EXECUTION_JSON);
 
     when(clientSupplier.getAsyncTextractClient(any())).thenCallRealMethod();
-    when(asyncCaller.call(any(), any())).thenReturn(new StartDocumentAnalysisResult());
+    when(asyncCaller.call(any(), any()))
+        .thenReturn(new StartDocumentAnalysisResult(null, null, null));
 
     var result = textractConnectorFunction.execute(outBounderContext);
     assertThat(result).isInstanceOf(StartDocumentAnalysisResult.class);
@@ -69,7 +71,9 @@ class TextractConnectorFunctionTest {
     var outBounderContext = prepareConnectorContext(TextractTestUtils.POLLING_EXECUTION_JSON);
 
     when(clientSupplier.getAsyncTextractClient(any())).thenCallRealMethod();
-    when(pollingCaller.call(any(), any())).thenReturn(new GetDocumentAnalysisResult());
+    when(pollingCaller.call(any(), any()))
+        .thenReturn(
+            new GetDocumentAnalysisResult(null, null, null, null, null, null, null, null, null));
 
     var result = textractConnectorFunction.execute(outBounderContext);
     assertThat(result).isInstanceOf(GetDocumentAnalysisResult.class);

--- a/connectors/aws/aws-textract/src/test/java/io/camunda/connector/textract/TextractConnectorFunctionTest.java
+++ b/connectors/aws/aws-textract/src/test/java/io/camunda/connector/textract/TextractConnectorFunctionTest.java
@@ -11,6 +11,8 @@ import static io.camunda.connector.textract.util.TextractTestUtils.ASYNC_EXECUTI
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.camunda.connector.api.error.ConnectorInputException;
@@ -30,6 +32,8 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.services.textract.TextractAsyncClient;
+import software.amazon.awssdk.services.textract.TextractClient;
 
 @ExtendWith(MockitoExtension.class)
 class TextractConnectorFunctionTest {
@@ -39,6 +43,9 @@ class TextractConnectorFunctionTest {
   @Mock private AsyncTextractCaller asyncCaller;
 
   @Mock private AmazonTextractClientSupplier clientSupplier;
+
+  @Mock private TextractClient syncClient;
+  @Mock private TextractAsyncClient asyncClient;
 
   @InjectMocks private TextractConnectorFunction textractConnectorFunction;
 
@@ -77,6 +84,96 @@ class TextractConnectorFunctionTest {
 
     var result = textractConnectorFunction.execute(outBounderContext);
     assertThat(result).isInstanceOf(GetDocumentAnalysisResult.class);
+  }
+
+  @Test
+  void executeSyncReq_closesClientOnSuccess() throws Exception {
+    var outBounderContext = prepareConnectorContext(TextractTestUtils.SYNC_EXECUTION_JSON);
+
+    when(clientSupplier.getSyncTextractClient(any())).thenReturn(syncClient);
+    when(syncCaller.call(any(), any()))
+        .thenReturn(new AnalyzeDocumentResult(null, null, null, null, null, null));
+
+    textractConnectorFunction.execute(outBounderContext);
+
+    verify(syncClient, times(1)).close();
+  }
+
+  @Test
+  void executePollingReq_closesClientOnSuccess() throws Exception {
+    var outBounderContext = prepareConnectorContext(TextractTestUtils.POLLING_EXECUTION_JSON);
+
+    when(clientSupplier.getAsyncTextractClient(any())).thenReturn(asyncClient);
+    when(pollingCaller.call(any(), any()))
+        .thenReturn(
+            new GetDocumentAnalysisResult(null, null, null, null, null, null, null, null, null));
+
+    textractConnectorFunction.execute(outBounderContext);
+
+    verify(asyncClient, times(1)).close();
+  }
+
+  @Test
+  void executeAsyncReq_closesClientOnSuccess() throws Exception {
+    var outBounderContext = prepareConnectorContext(TextractTestUtils.ASYNC_EXECUTION_JSON);
+
+    when(clientSupplier.getAsyncTextractClient(any())).thenReturn(asyncClient);
+    when(asyncCaller.call(any(), any()))
+        .thenReturn(new StartDocumentAnalysisResult(null, null, null));
+
+    textractConnectorFunction.execute(outBounderContext);
+
+    verify(asyncClient, times(1)).close();
+  }
+
+  @Test
+  void executeSyncReq_closesClientEvenWhenCallerThrows() {
+    var outBounderContext = prepareConnectorContext(TextractTestUtils.SYNC_EXECUTION_JSON);
+
+    when(clientSupplier.getSyncTextractClient(any())).thenReturn(syncClient);
+    RuntimeException callerException = new RuntimeException("caller boom");
+    when(syncCaller.call(any(), any())).thenThrow(callerException);
+
+    Exception exception =
+        assertThrows(
+            RuntimeException.class, () -> textractConnectorFunction.execute(outBounderContext));
+
+    assertThat(exception).isSameAs(callerException);
+    // The try-with-resources block must still close the client when the caller throws -
+    // otherwise a caller-side failure would leak the underlying HTTP client/connection pool.
+    verify(syncClient, times(1)).close();
+  }
+
+  @Test
+  void executePollingReq_closesClientEvenWhenCallerThrows() throws Exception {
+    var outBounderContext = prepareConnectorContext(TextractTestUtils.POLLING_EXECUTION_JSON);
+
+    when(clientSupplier.getAsyncTextractClient(any())).thenReturn(asyncClient);
+    RuntimeException callerException = new RuntimeException("caller boom");
+    when(pollingCaller.call(any(), any())).thenThrow(callerException);
+
+    Exception exception =
+        assertThrows(
+            RuntimeException.class, () -> textractConnectorFunction.execute(outBounderContext));
+
+    assertThat(exception).isSameAs(callerException);
+    verify(asyncClient, times(1)).close();
+  }
+
+  @Test
+  void executeAsyncReq_closesClientEvenWhenCallerThrows() {
+    var outBounderContext = prepareConnectorContext(TextractTestUtils.ASYNC_EXECUTION_JSON);
+
+    when(clientSupplier.getAsyncTextractClient(any())).thenReturn(asyncClient);
+    RuntimeException callerException = new RuntimeException("caller boom");
+    when(asyncCaller.call(any(), any())).thenThrow(callerException);
+
+    Exception exception =
+        assertThrows(
+            RuntimeException.class, () -> textractConnectorFunction.execute(outBounderContext));
+
+    assertThat(exception).isSameAs(callerException);
+    verify(asyncClient, times(1)).close();
   }
 
   @ParameterizedTest

--- a/connectors/aws/aws-textract/src/test/java/io/camunda/connector/textract/TextractResultShapeTest.java
+++ b/connectors/aws/aws-textract/src/test/java/io/camunda/connector/textract/TextractResultShapeTest.java
@@ -13,25 +13,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import com.amazonaws.ResponseMetadata;
-import com.amazonaws.http.SdkHttpMetadata;
-import com.amazonaws.services.textract.AmazonTextractAsyncClient;
-import com.amazonaws.services.textract.AmazonTextractClient;
-import com.amazonaws.services.textract.model.AnalyzeDocumentRequest;
-import com.amazonaws.services.textract.model.AnalyzeDocumentResult;
-import com.amazonaws.services.textract.model.Block;
-import com.amazonaws.services.textract.model.BlockType;
-import com.amazonaws.services.textract.model.BoundingBox;
-import com.amazonaws.services.textract.model.DocumentMetadata;
-import com.amazonaws.services.textract.model.Geometry;
-import com.amazonaws.services.textract.model.GetDocumentAnalysisRequest;
-import com.amazonaws.services.textract.model.GetDocumentAnalysisResult;
-import com.amazonaws.services.textract.model.JobStatus;
-import com.amazonaws.services.textract.model.Point;
-import com.amazonaws.services.textract.model.Relationship;
-import com.amazonaws.services.textract.model.RelationshipType;
-import com.amazonaws.services.textract.model.StartDocumentAnalysisResult;
-import com.amazonaws.services.textract.model.TextType;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -39,213 +20,188 @@ import io.camunda.connector.jackson.ConnectorsObjectMapperSupplier;
 import io.camunda.connector.textract.caller.AsyncTextractCaller;
 import io.camunda.connector.textract.caller.PollingTextractCaller;
 import io.camunda.connector.textract.caller.SyncTextractCaller;
-import java.lang.reflect.Constructor;
-import java.util.LinkedHashMap;
-import java.util.List;
+import io.camunda.connector.textract.model.result.AnalyzeDocumentResult;
+import io.camunda.connector.textract.model.result.GetDocumentAnalysisResult;
+import io.camunda.connector.textract.model.result.StartDocumentAnalysisResult;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.awscore.DefaultAwsResponseMetadata;
+import software.amazon.awssdk.http.SdkHttpResponse;
+import software.amazon.awssdk.services.textract.TextractAsyncClient;
+import software.amazon.awssdk.services.textract.TextractClient;
+import software.amazon.awssdk.services.textract.model.AnalyzeDocumentRequest;
+import software.amazon.awssdk.services.textract.model.AnalyzeDocumentResponse;
+import software.amazon.awssdk.services.textract.model.BlockType;
+import software.amazon.awssdk.services.textract.model.BoundingBox;
+import software.amazon.awssdk.services.textract.model.DocumentMetadata;
+import software.amazon.awssdk.services.textract.model.Geometry;
+import software.amazon.awssdk.services.textract.model.GetDocumentAnalysisRequest;
+import software.amazon.awssdk.services.textract.model.GetDocumentAnalysisResponse;
+import software.amazon.awssdk.services.textract.model.JobStatus;
+import software.amazon.awssdk.services.textract.model.Point;
+import software.amazon.awssdk.services.textract.model.Relationship;
+import software.amazon.awssdk.services.textract.model.RelationshipType;
+import software.amazon.awssdk.services.textract.model.StartDocumentAnalysisRequest;
+import software.amazon.awssdk.services.textract.model.StartDocumentAnalysisResponse;
+import software.amazon.awssdk.services.textract.model.TextType;
 
 /**
  * Golden-JSON shape tests for the AWS Textract connector result.
  *
- * <p>{@link TextractConnectorFunction} still returns the raw AWS SDK v1 result objects ({@link
- * AnalyzeDocumentResult}, {@link GetDocumentAnalysisResult}, {@link StartDocumentAnalysisResult})
- * directly as the connector's process-variable output; there is no connector-owned result-mapping
- * class (yet). These tests pin the exact JSON that the production {@link ObjectMapper} (see {@link
- * ConnectorsObjectMapperSupplier}) writes for those v1 beans TODAY, including the {@code
- * sdkResponseMetadata} / {@code sdkHttpMetadata} keys that every v1 {@code AmazonWebServiceResult}
- * subclass carries. The upcoming AWS SDK v2 migration must keep this JSON shape green unchanged
- * (see #7968).
+ * <p>These tests pin the exact JSON that the production {@link ObjectMapper} (see {@link
+ * ConnectorsObjectMapperSupplier}) writes for the connector-owned result records ({@link
+ * AnalyzeDocumentResult}, {@link StartDocumentAnalysisResult}, {@link GetDocumentAnalysisResult}),
+ * built from AWS SDK v2 responses. This is the exact JSON shape the connector documented and
+ * returned before the AWS SDK v2 migration (see #7968) - the migration must keep it unchanged.
  */
 class TextractResultShapeTest {
 
   private final ObjectMapper mapper = ConnectorsObjectMapperSupplier.getCopy();
 
-  /**
-   * Serializes {@code value} with the production mapper and re-parses the result into a {@link
-   * JsonNode}. Going through text (rather than {@code ObjectMapper#valueToTree}) guarantees
-   * floating point bean properties (declared as {@code Float} on the v1 SDK model classes) land in
-   * the tree as the same numeric node type ({@code DoubleNode}) that {@link
-   * ObjectMapper#readTree(String)} produces for the hand-written expected JSON below; comparing a
-   * tree built via {@code valueToTree} (which yields {@code FloatNode}) against one parsed from
-   * text (which yields {@code DoubleNode}) would otherwise fail {@code JsonNode#equals} on node
-   * type alone, even for numerically identical values.
-   */
   private JsonNode treeOf(Object value) throws JsonProcessingException {
     return mapper.readTree(mapper.writeValueAsString(value));
   }
 
-  /** Builds a deterministically ordered header map (insertion order, not {@code Map.of} order). */
-  private static Map<String, String> headers(String... keyValuePairs) {
-    Map<String, String> result = new LinkedHashMap<>();
-    for (int i = 0; i < keyValuePairs.length; i += 2) {
-      result.put(keyValuePairs[i], keyValuePairs[i + 1]);
+  private static SdkHttpResponse sdkHttpResponse(int statusCode, String... headerKeyValuePairs) {
+    SdkHttpResponse.Builder builder = SdkHttpResponse.builder().statusCode(statusCode);
+    for (int i = 0; i < headerKeyValuePairs.length; i += 2) {
+      builder.putHeader(headerKeyValuePairs[i], headerKeyValuePairs[i + 1]);
     }
-    return result;
-  }
-
-  private static Map<String, List<String>> allHeaders(String... keyValuePairs) {
-    Map<String, List<String>> result = new LinkedHashMap<>();
-    for (int i = 0; i < keyValuePairs.length; i += 2) {
-      result.put(keyValuePairs[i], List.of(keyValuePairs[i + 1]));
-    }
-    return result;
+    return builder.build();
   }
 
   /**
-   * Builds a v1 {@link SdkHttpMetadata} instance. The only public factory ({@code
-   * SdkHttpMetadata.from(HttpResponse)}) requires constructing a full {@code
-   * com.amazonaws.http.HttpResponse} (which itself needs a live {@code Request} and Apache
-   * HttpClient {@code HttpRequestBase}); reflection on the package-private constructor is far
-   * simpler and avoids pulling HTTP transport plumbing into a pure shape test.
-   *
-   * <p>Note (real v1 quirk, not a test artifact): the constructor stores {@code httpHeaders} as-is
-   * (preserving whatever order the caller passed), but copies {@code allHttpHeaders} into a plain
-   * {@code java.util.HashMap} — so its serialized key order follows {@code String.hashCode()}
-   * bucket order, not insertion order. That is deterministic (no randomized seeding, unlike {@code
-   * Map.of()}) but not alphabetical or insertion order, which is why the expected JSON below lists
-   * {@code allHttpHeaders} keys in a different order than {@code httpHeaders}.
-   */
-  private static SdkHttpMetadata sdkHttpMetadata(
-      Map<String, String> httpHeaders, Map<String, List<String>> allHttpHeaders, int statusCode) {
-    try {
-      Constructor<SdkHttpMetadata> ctor =
-          SdkHttpMetadata.class.getDeclaredConstructor(Map.class, Map.class, int.class);
-      ctor.setAccessible(true);
-      return ctor.newInstance(httpHeaders, allHttpHeaders, statusCode);
-    } catch (ReflectiveOperationException e) {
-      throw new IllegalStateException(e);
-    }
-  }
-
-  /**
-   * Golden-JSON shape test: a fully populated {@link AnalyzeDocumentResult} (sync execution), with
-   * realistic PAGE/LINE/WORD blocks (geometry, bounding box, relationships, confidence) and
+   * Golden-JSON shape test: a fully populated {@link AnalyzeDocumentResponse} (sync execution),
+   * with realistic PAGE/LINE/WORD blocks (geometry, bounding box, relationships, confidence) and
    * documentMetadata, as returned by a live AnalyzeDocument call.
    */
   @Test
   void analyzeDocumentResult_serializesToDocumentedV1JsonShape() throws JsonProcessingException {
-    // Given a fully populated AnalyzeDocumentResult: one page, one line made of two words, all
+    // Given a fully populated AnalyzeDocumentResponse: one page, one line made of two words, all
     // linked via CHILD relationships, each with geometry/boundingBox and confidence.
-    Block wordOne =
-        new Block()
-            .withId("6cfd6798-0000-0000-0000-000000000003")
-            .withBlockType(BlockType.WORD)
-            .withConfidence(99.13f)
-            .withText("Invoice")
-            .withTextType(TextType.PRINTED)
-            .withPage(1)
-            .withGeometry(
-                new Geometry()
-                    .withBoundingBox(
-                        new BoundingBox()
-                            .withWidth(0.12f)
-                            .withHeight(0.02f)
-                            .withLeft(0.08f)
-                            .withTop(0.10f))
-                    .withPolygon(
-                        List.of(
-                            new Point().withX(0.08f).withY(0.10f),
-                            new Point().withX(0.20f).withY(0.10f),
-                            new Point().withX(0.20f).withY(0.12f),
-                            new Point().withX(0.08f).withY(0.12f))));
+    software.amazon.awssdk.services.textract.model.Block wordOne =
+        software.amazon.awssdk.services.textract.model.Block.builder()
+            .id("6cfd6798-0000-0000-0000-000000000003")
+            .blockType(BlockType.WORD)
+            .confidence(99.13f)
+            .text("Invoice")
+            .textType(TextType.PRINTED)
+            .page(1)
+            .geometry(
+                Geometry.builder()
+                    .boundingBox(
+                        BoundingBox.builder()
+                            .width(0.12f)
+                            .height(0.02f)
+                            .left(0.08f)
+                            .top(0.10f)
+                            .build())
+                    .polygon(
+                        Point.builder().x(0.08f).y(0.10f).build(),
+                        Point.builder().x(0.20f).y(0.10f).build(),
+                        Point.builder().x(0.20f).y(0.12f).build(),
+                        Point.builder().x(0.08f).y(0.12f).build())
+                    .build())
+            .build();
 
-    Block wordTwo =
-        new Block()
-            .withId("6cfd6798-0000-0000-0000-000000000004")
-            .withBlockType(BlockType.WORD)
-            .withConfidence(98.47f)
-            .withText("Total:")
-            .withTextType(TextType.PRINTED)
-            .withPage(1)
-            .withGeometry(
-                new Geometry()
-                    .withBoundingBox(
-                        new BoundingBox()
-                            .withWidth(0.10f)
-                            .withHeight(0.02f)
-                            .withLeft(0.21f)
-                            .withTop(0.10f))
-                    .withPolygon(
-                        List.of(
-                            new Point().withX(0.21f).withY(0.10f),
-                            new Point().withX(0.31f).withY(0.10f),
-                            new Point().withX(0.31f).withY(0.12f),
-                            new Point().withX(0.21f).withY(0.12f))));
+    software.amazon.awssdk.services.textract.model.Block wordTwo =
+        software.amazon.awssdk.services.textract.model.Block.builder()
+            .id("6cfd6798-0000-0000-0000-000000000004")
+            .blockType(BlockType.WORD)
+            .confidence(98.47f)
+            .text("Total:")
+            .textType(TextType.PRINTED)
+            .page(1)
+            .geometry(
+                Geometry.builder()
+                    .boundingBox(
+                        BoundingBox.builder()
+                            .width(0.10f)
+                            .height(0.02f)
+                            .left(0.21f)
+                            .top(0.10f)
+                            .build())
+                    .polygon(
+                        Point.builder().x(0.21f).y(0.10f).build(),
+                        Point.builder().x(0.31f).y(0.10f).build(),
+                        Point.builder().x(0.31f).y(0.12f).build(),
+                        Point.builder().x(0.21f).y(0.12f).build())
+                    .build())
+            .build();
 
-    Block line =
-        new Block()
-            .withId("6cfd6798-0000-0000-0000-000000000002")
-            .withBlockType(BlockType.LINE)
-            .withConfidence(99.02f)
-            .withText("Invoice Total:")
-            .withPage(1)
-            .withGeometry(
-                new Geometry()
-                    .withBoundingBox(
-                        new BoundingBox()
-                            .withWidth(0.23f)
-                            .withHeight(0.02f)
-                            .withLeft(0.08f)
-                            .withTop(0.10f))
-                    .withPolygon(
-                        List.of(
-                            new Point().withX(0.08f).withY(0.10f),
-                            new Point().withX(0.31f).withY(0.10f),
-                            new Point().withX(0.31f).withY(0.12f),
-                            new Point().withX(0.08f).withY(0.12f))))
-            .withRelationships(
-                new Relationship()
-                    .withType(RelationshipType.CHILD)
-                    .withIds(wordOne.getId(), wordTwo.getId()));
+    software.amazon.awssdk.services.textract.model.Block line =
+        software.amazon.awssdk.services.textract.model.Block.builder()
+            .id("6cfd6798-0000-0000-0000-000000000002")
+            .blockType(BlockType.LINE)
+            .confidence(99.02f)
+            .text("Invoice Total:")
+            .page(1)
+            .geometry(
+                Geometry.builder()
+                    .boundingBox(
+                        BoundingBox.builder()
+                            .width(0.23f)
+                            .height(0.02f)
+                            .left(0.08f)
+                            .top(0.10f)
+                            .build())
+                    .polygon(
+                        Point.builder().x(0.08f).y(0.10f).build(),
+                        Point.builder().x(0.31f).y(0.10f).build(),
+                        Point.builder().x(0.31f).y(0.12f).build(),
+                        Point.builder().x(0.08f).y(0.12f).build())
+                    .build())
+            .relationships(
+                Relationship.builder()
+                    .type(RelationshipType.CHILD)
+                    .ids(wordOne.id(), wordTwo.id())
+                    .build())
+            .build();
 
-    Block page =
-        new Block()
-            .withId("6cfd6798-0000-0000-0000-000000000001")
-            .withBlockType(BlockType.PAGE)
-            .withPage(1)
-            .withGeometry(
-                new Geometry()
-                    .withBoundingBox(
-                        new BoundingBox()
-                            .withWidth(1.0f)
-                            .withHeight(1.0f)
-                            .withLeft(0.0f)
-                            .withTop(0.0f))
-                    .withPolygon(
-                        List.of(
-                            new Point().withX(0.0f).withY(0.0f),
-                            new Point().withX(1.0f).withY(0.0f),
-                            new Point().withX(1.0f).withY(1.0f),
-                            new Point().withX(0.0f).withY(1.0f))))
-            .withRelationships(
-                new Relationship().withType(RelationshipType.CHILD).withIds(line.getId()));
+    software.amazon.awssdk.services.textract.model.Block page =
+        software.amazon.awssdk.services.textract.model.Block.builder()
+            .id("6cfd6798-0000-0000-0000-000000000001")
+            .blockType(BlockType.PAGE)
+            .page(1)
+            .geometry(
+                Geometry.builder()
+                    .boundingBox(
+                        BoundingBox.builder().width(1.0f).height(1.0f).left(0.0f).top(0.0f).build())
+                    .polygon(
+                        Point.builder().x(0.0f).y(0.0f).build(),
+                        Point.builder().x(1.0f).y(0.0f).build(),
+                        Point.builder().x(1.0f).y(1.0f).build(),
+                        Point.builder().x(0.0f).y(1.0f).build())
+                    .build())
+            .relationships(
+                Relationship.builder().type(RelationshipType.CHILD).ids(line.id()).build())
+            .build();
 
-    AnalyzeDocumentResult result =
-        new AnalyzeDocumentResult()
-            .withDocumentMetadata(new DocumentMetadata().withPages(1))
-            .withBlocks(page, line, wordOne, wordTwo)
-            .withAnalyzeDocumentModelVersion("1.0");
+    AnalyzeDocumentResponse.Builder responseBuilder =
+        AnalyzeDocumentResponse.builder()
+            .documentMetadata(DocumentMetadata.builder().pages(1).build())
+            .blocks(page, line, wordOne, wordTwo)
+            .analyzeDocumentModelVersion("1.0");
     // humanLoopActivationOutput is intentionally left unset (human review was not triggered) to
     // pin that the production mapper still emits it as an explicit null.
-    result.setSdkResponseMetadata(
-        new ResponseMetadata(Map.of(ResponseMetadata.AWS_REQUEST_ID, "req-sync-0000000001")));
-    result.setSdkHttpMetadata(
-        sdkHttpMetadata(
-            headers(
-                "x-amzn-RequestId", "req-sync-0000000001",
-                "Content-Type", "application/x-amz-json-1.1",
-                "Content-Length", "2048"),
-            allHeaders(
-                "x-amzn-RequestId", "req-sync-0000000001",
-                "Content-Type", "application/x-amz-json-1.1",
-                "Content-Length", "2048"),
-            200));
+    responseBuilder.responseMetadata(
+        DefaultAwsResponseMetadata.create(Map.of("AWS_REQUEST_ID", "req-sync-0000000001")));
+    responseBuilder.sdkHttpResponse(
+        sdkHttpResponse(
+            200,
+            "x-amzn-RequestId",
+            "req-sync-0000000001",
+            "Content-Type",
+            "application/x-amz-json-1.1",
+            "Content-Length",
+            "2048"));
+    AnalyzeDocumentResponse response = responseBuilder.build();
 
     // When the connector caller runs against a mocked client (as in SyncTextractCallerTest) and
-    // the runtime serializes the raw v1 result with the production mapper
-    AmazonTextractClient textractClient = mock(AmazonTextractClient.class);
-    when(textractClient.analyzeDocument(any(AnalyzeDocumentRequest.class))).thenReturn(result);
+    // the runtime serializes the connector-owned result with the production mapper
+    TextractClient textractClient = mock(TextractClient.class);
+    when(textractClient.analyzeDocument(any(AnalyzeDocumentRequest.class))).thenReturn(response);
 
     AnalyzeDocumentResult actualResult =
         new SyncTextractCaller().call(FULL_FILLED_ASYNC_TEXTRACT_DATA, textractClient);
@@ -260,15 +216,15 @@ class TextractResultShapeTest {
           },
           "sdkHttpMetadata": {
             "httpHeaders": {
-              "x-amzn-RequestId": "req-sync-0000000001",
+              "Content-Length": "2048",
               "Content-Type": "application/x-amz-json-1.1",
-              "Content-Length": "2048"
+              "x-amzn-RequestId": "req-sync-0000000001"
             },
             "httpStatusCode": 200,
             "allHttpHeaders": {
-              "x-amzn-RequestId": ["req-sync-0000000001"],
               "Content-Length": ["2048"],
-              "Content-Type": ["application/x-amz-json-1.1"]
+              "Content-Type": ["application/x-amz-json-1.1"],
+              "x-amzn-RequestId": ["req-sync-0000000001"]
             }
           },
           "documentMetadata": {
@@ -400,11 +356,11 @@ class TextractResultShapeTest {
 
   /**
    * Golden-JSON shape test: {@link PollingTextractCaller} merges the {@code blocks} of every page
-   * it polls into a single list (via {@code setBlocks}) but returns the LAST {@code
-   * GetDocumentAnalysisResult} object as-is otherwise — so the merged result's own {@code
-   * sdkResponseMetadata}/{@code sdkHttpMetadata}/{@code nextToken} reflect only the final page
-   * call, not the first. This is intentional (if surprising) v1-caller behavior being pinned for
-   * the migration.
+   * it polls into a single list (via {@code toBuilder().blocks(...)}, since v2 responses are
+   * immutable) but returns the LAST {@link GetDocumentAnalysisResponse} otherwise - so the merged
+   * result's own {@code sdkResponseMetadata}/{@code sdkHttpMetadata}/{@code nextToken} reflect only
+   * the final page call, not the first. This is intentional (if surprising) caller behavior being
+   * pinned across the migration.
    */
   @Test
   void getDocumentAnalysisResult_multiPageMerge_serializesToDocumentedV1JsonShape()
@@ -412,90 +368,88 @@ class TextractResultShapeTest {
     String jobId = "5cfa9b10-aaaa-bbbb-cccc-000000000099";
 
     GetDocumentAnalysisRequest firstRequest =
-        new GetDocumentAnalysisRequest().withJobId(jobId).withMaxResults(MAX_RESULT);
+        GetDocumentAnalysisRequest.builder().jobId(jobId).maxResults(MAX_RESULT).build();
     GetDocumentAnalysisRequest secondRequest =
-        new GetDocumentAnalysisRequest()
-            .withJobId(jobId)
-            .withMaxResults(MAX_RESULT)
-            .withNextToken("page-2-token");
+        GetDocumentAnalysisRequest.builder()
+            .jobId(jobId)
+            .maxResults(MAX_RESULT)
+            .nextToken("page-2-token")
+            .build();
 
-    Block firstPageBlock =
-        new Block()
-            .withId("page-1-block")
-            .withBlockType(BlockType.PAGE)
-            .withPage(1)
-            .withGeometry(
-                new Geometry()
-                    .withBoundingBox(
-                        new BoundingBox()
-                            .withWidth(1.0f)
-                            .withHeight(1.0f)
-                            .withLeft(0.0f)
-                            .withTop(0.0f)));
-    Block firstPageLine =
-        new Block()
-            .withId("page-1-line")
-            .withBlockType(BlockType.LINE)
-            .withConfidence(97.31f)
-            .withText("Page one line")
-            .withPage(1);
+    software.amazon.awssdk.services.textract.model.Block firstPageBlock =
+        software.amazon.awssdk.services.textract.model.Block.builder()
+            .id("page-1-block")
+            .blockType(BlockType.PAGE)
+            .page(1)
+            .geometry(
+                Geometry.builder()
+                    .boundingBox(
+                        BoundingBox.builder().width(1.0f).height(1.0f).left(0.0f).top(0.0f).build())
+                    .build())
+            .build();
+    software.amazon.awssdk.services.textract.model.Block firstPageLine =
+        software.amazon.awssdk.services.textract.model.Block.builder()
+            .id("page-1-line")
+            .blockType(BlockType.LINE)
+            .confidence(97.31f)
+            .text("Page one line")
+            .page(1)
+            .build();
 
-    Block secondPageBlock =
-        new Block()
-            .withId("page-2-block")
-            .withBlockType(BlockType.PAGE)
-            .withPage(2)
-            .withGeometry(
-                new Geometry()
-                    .withBoundingBox(
-                        new BoundingBox()
-                            .withWidth(1.0f)
-                            .withHeight(1.0f)
-                            .withLeft(0.0f)
-                            .withTop(0.0f)));
-    Block secondPageLine =
-        new Block()
-            .withId("page-2-line")
-            .withBlockType(BlockType.LINE)
-            .withConfidence(96.84f)
-            .withText("Page two line")
-            .withPage(2);
+    software.amazon.awssdk.services.textract.model.Block secondPageBlock =
+        software.amazon.awssdk.services.textract.model.Block.builder()
+            .id("page-2-block")
+            .blockType(BlockType.PAGE)
+            .page(2)
+            .geometry(
+                Geometry.builder()
+                    .boundingBox(
+                        BoundingBox.builder().width(1.0f).height(1.0f).left(0.0f).top(0.0f).build())
+                    .build())
+            .build();
+    software.amazon.awssdk.services.textract.model.Block secondPageLine =
+        software.amazon.awssdk.services.textract.model.Block.builder()
+            .id("page-2-line")
+            .blockType(BlockType.LINE)
+            .confidence(96.84f)
+            .text("Page two line")
+            .page(2)
+            .build();
 
-    GetDocumentAnalysisResult firstPageResult =
-        new GetDocumentAnalysisResult()
-            .withDocumentMetadata(new DocumentMetadata().withPages(2))
-            .withJobStatus(JobStatus.SUCCEEDED.toString())
-            .withNextToken("page-2-token")
-            .withBlocks(firstPageBlock, firstPageLine)
-            .withAnalyzeDocumentModelVersion("1.0");
-    firstPageResult.setSdkResponseMetadata(
-        new ResponseMetadata(Map.of(ResponseMetadata.AWS_REQUEST_ID, "req-page-0000000001")));
-    firstPageResult.setSdkHttpMetadata(
-        sdkHttpMetadata(
-            headers("x-amzn-RequestId", "req-page-0000000001"),
-            allHeaders("x-amzn-RequestId", "req-page-0000000001"),
-            200));
+    GetDocumentAnalysisResponse.Builder firstPageBuilder =
+        GetDocumentAnalysisResponse.builder()
+            .documentMetadata(DocumentMetadata.builder().pages(2).build())
+            .jobStatus(JobStatus.SUCCEEDED)
+            .nextToken("page-2-token")
+            .blocks(firstPageBlock, firstPageLine)
+            .analyzeDocumentModelVersion("1.0");
+    firstPageBuilder.responseMetadata(
+        DefaultAwsResponseMetadata.create(Map.of("AWS_REQUEST_ID", "req-page-0000000001")));
+    firstPageBuilder.sdkHttpResponse(
+        sdkHttpResponse(200, "x-amzn-RequestId", "req-page-0000000001"));
+    GetDocumentAnalysisResponse firstPageResult = firstPageBuilder.build();
 
-    GetDocumentAnalysisResult secondPageResult =
-        new GetDocumentAnalysisResult()
-            .withDocumentMetadata(new DocumentMetadata().withPages(2))
-            .withJobStatus(JobStatus.SUCCEEDED.toString())
-            .withNextToken(null)
-            .withBlocks(secondPageBlock, secondPageLine)
-            .withAnalyzeDocumentModelVersion("1.0");
-    secondPageResult.setSdkResponseMetadata(
-        new ResponseMetadata(Map.of(ResponseMetadata.AWS_REQUEST_ID, "req-page-0000000002")));
-    secondPageResult.setSdkHttpMetadata(
-        sdkHttpMetadata(
-            headers("x-amzn-RequestId", "req-page-0000000002"),
-            allHeaders("x-amzn-RequestId", "req-page-0000000002"),
-            200));
+    GetDocumentAnalysisResponse.Builder secondPageBuilder =
+        GetDocumentAnalysisResponse.builder()
+            .documentMetadata(DocumentMetadata.builder().pages(2).build())
+            .jobStatus(JobStatus.SUCCEEDED)
+            .blocks(secondPageBlock, secondPageLine)
+            .analyzeDocumentModelVersion("1.0");
+    secondPageBuilder.responseMetadata(
+        DefaultAwsResponseMetadata.create(Map.of("AWS_REQUEST_ID", "req-page-0000000002")));
+    secondPageBuilder.sdkHttpResponse(
+        sdkHttpResponse(200, "x-amzn-RequestId", "req-page-0000000002"));
+    GetDocumentAnalysisResponse secondPageResult = secondPageBuilder.build();
 
-    AmazonTextractAsyncClient asyncClient = mock(AmazonTextractAsyncClient.class);
-    when(asyncClient.startDocumentAnalysis(any()))
-        .thenReturn(new StartDocumentAnalysisResult().withJobId(jobId));
-    when(asyncClient.getDocumentAnalysis(firstRequest)).thenReturn(firstPageResult);
-    when(asyncClient.getDocumentAnalysis(secondRequest)).thenReturn(secondPageResult);
+    TextractAsyncClient asyncClient = mock(TextractAsyncClient.class);
+    when(asyncClient.startDocumentAnalysis(any(StartDocumentAnalysisRequest.class)))
+        .thenReturn(
+            CompletableFuture.completedFuture(
+                StartDocumentAnalysisResponse.builder().jobId(jobId).build()));
+    when(asyncClient.getDocumentAnalysis(firstRequest))
+        .thenReturn(CompletableFuture.completedFuture(firstPageResult));
+    when(asyncClient.getDocumentAnalysis(secondRequest))
+        .thenReturn(CompletableFuture.completedFuture(secondPageResult));
 
     GetDocumentAnalysisResult mergedResult =
         new PollingTextractCaller().call(FULL_FILLED_ASYNC_TEXTRACT_DATA, asyncClient);
@@ -609,27 +563,27 @@ class TextractResultShapeTest {
   }
 
   /**
-   * Golden-JSON shape test: a fully populated {@link StartDocumentAnalysisResult} (async start).
+   * Golden-JSON shape test: a fully populated {@link StartDocumentAnalysisResponse} (async start).
    */
   @Test
   void startDocumentAnalysisResult_serializesToDocumentedV1JsonShape()
       throws JsonProcessingException {
-    StartDocumentAnalysisResult result =
-        new StartDocumentAnalysisResult().withJobId("649bf054-193b-48e6-ab80-3aeeb613b415");
-    result.setSdkResponseMetadata(
-        new ResponseMetadata(Map.of(ResponseMetadata.AWS_REQUEST_ID, "req-async-0000000001")));
-    result.setSdkHttpMetadata(
-        sdkHttpMetadata(
-            headers(
-                "x-amzn-RequestId", "req-async-0000000001",
-                "Content-Type", "application/x-amz-json-1.1"),
-            allHeaders(
-                "x-amzn-RequestId", "req-async-0000000001",
-                "Content-Type", "application/x-amz-json-1.1"),
-            200));
+    StartDocumentAnalysisResponse.Builder responseBuilder =
+        StartDocumentAnalysisResponse.builder().jobId("649bf054-193b-48e6-ab80-3aeeb613b415");
+    responseBuilder.responseMetadata(
+        DefaultAwsResponseMetadata.create(Map.of("AWS_REQUEST_ID", "req-async-0000000001")));
+    responseBuilder.sdkHttpResponse(
+        sdkHttpResponse(
+            200,
+            "x-amzn-RequestId",
+            "req-async-0000000001",
+            "Content-Type",
+            "application/x-amz-json-1.1"));
+    StartDocumentAnalysisResponse response = responseBuilder.build();
 
-    AmazonTextractAsyncClient asyncClient = mock(AmazonTextractAsyncClient.class);
-    when(asyncClient.startDocumentAnalysis(any())).thenReturn(result);
+    TextractAsyncClient asyncClient = mock(TextractAsyncClient.class);
+    when(asyncClient.startDocumentAnalysis(any(StartDocumentAnalysisRequest.class)))
+        .thenReturn(CompletableFuture.completedFuture(response));
 
     StartDocumentAnalysisResult actualResult =
         new AsyncTextractCaller().call(FULL_FILLED_ASYNC_TEXTRACT_DATA, asyncClient);
@@ -643,13 +597,13 @@ class TextractResultShapeTest {
           },
           "sdkHttpMetadata": {
             "httpHeaders": {
-              "x-amzn-RequestId": "req-async-0000000001",
-              "Content-Type": "application/x-amz-json-1.1"
+              "Content-Type": "application/x-amz-json-1.1",
+              "x-amzn-RequestId": "req-async-0000000001"
             },
             "httpStatusCode": 200,
             "allHttpHeaders": {
-              "x-amzn-RequestId": ["req-async-0000000001"],
-              "Content-Type": ["application/x-amz-json-1.1"]
+              "Content-Type": ["application/x-amz-json-1.1"],
+              "x-amzn-RequestId": ["req-async-0000000001"]
             }
           },
           "jobId": "649bf054-193b-48e6-ab80-3aeeb613b415"

--- a/connectors/aws/aws-textract/src/test/java/io/camunda/connector/textract/TextractResultShapeTest.java
+++ b/connectors/aws/aws-textract/src/test/java/io/camunda/connector/textract/TextractResultShapeTest.java
@@ -64,8 +64,11 @@ class TextractResultShapeTest {
   }
 
   private static SdkHttpResponse sdkHttpResponse(int statusCode, String... headerKeyValuePairs) {
+    if (headerKeyValuePairs.length % 2 != 0) {
+      throw new IllegalArgumentException("headerKeyValuePairs must have an even length");
+    }
     SdkHttpResponse.Builder builder = SdkHttpResponse.builder().statusCode(statusCode);
-    for (int i = 0; i < headerKeyValuePairs.length; i += 2) {
+    for (int i = 0; i + 1 < headerKeyValuePairs.length; i += 2) {
       builder.putHeader(headerKeyValuePairs[i], headerKeyValuePairs[i + 1]);
     }
     return builder.build();

--- a/connectors/aws/aws-textract/src/test/java/io/camunda/connector/textract/caller/AsyncTextractCallerTest.java
+++ b/connectors/aws/aws-textract/src/test/java/io/camunda/connector/textract/caller/AsyncTextractCallerTest.java
@@ -11,18 +11,19 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.amazonaws.services.textract.AmazonTextractAsyncClient;
-import com.amazonaws.services.textract.model.StartDocumentAnalysisRequest;
-import com.amazonaws.services.textract.model.StartDocumentAnalysisResult;
 import io.camunda.connector.textract.model.DocumentLocationType;
 import io.camunda.connector.textract.model.TextractExecutionType;
 import io.camunda.connector.textract.model.TextractRequestData;
+import java.util.concurrent.CompletableFuture;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.services.textract.TextractAsyncClient;
+import software.amazon.awssdk.services.textract.model.StartDocumentAnalysisRequest;
+import software.amazon.awssdk.services.textract.model.StartDocumentAnalysisResponse;
 
 @ExtendWith(MockitoExtension.class)
 class AsyncTextractCallerTest {
@@ -33,9 +34,10 @@ class AsyncTextractCallerTest {
   void callWithAllFields() {
     TextractRequestData requestData = prepareReqData("roleArn", "topicArna");
 
-    AmazonTextractAsyncClient asyncClient = Mockito.mock(AmazonTextractAsyncClient.class);
+    TextractAsyncClient asyncClient = Mockito.mock(TextractAsyncClient.class);
     when(asyncClient.startDocumentAnalysis(any(StartDocumentAnalysisRequest.class)))
-        .thenReturn(new StartDocumentAnalysisResult());
+        .thenReturn(
+            CompletableFuture.completedFuture(StartDocumentAnalysisResponse.builder().build()));
 
     new AsyncTextractCaller().call(requestData, asyncClient);
 
@@ -44,21 +46,21 @@ class AsyncTextractCallerTest {
     final StartDocumentAnalysisRequest startDocumentAnalysisRequest =
         requestArgumentCaptor.getValue();
 
-    assertThat(startDocumentAnalysisRequest.getFeatureTypes().size()).isEqualTo(4);
-    assertThat(startDocumentAnalysisRequest.getDocumentLocation()).isNotNull();
-    assertThat(startDocumentAnalysisRequest.getClientRequestToken())
+    assertThat(startDocumentAnalysisRequest.featureTypesAsStrings()).hasSize(4);
+    assertThat(startDocumentAnalysisRequest.documentLocation()).isNotNull();
+    assertThat(startDocumentAnalysisRequest.clientRequestToken())
         .isEqualTo(requestData.clientRequestToken());
-    assertThat(startDocumentAnalysisRequest.getJobTag()).isEqualTo(requestData.jobTag());
-    assertThat(startDocumentAnalysisRequest.getKMSKeyId()).isEqualTo(requestData.kmsKeyId());
-    assertThat(startDocumentAnalysisRequest.getNotificationChannel()).isNotNull();
-    assertThat(startDocumentAnalysisRequest.getNotificationChannel().getRoleArn())
+    assertThat(startDocumentAnalysisRequest.jobTag()).isEqualTo(requestData.jobTag());
+    assertThat(startDocumentAnalysisRequest.kmsKeyId()).isEqualTo(requestData.kmsKeyId());
+    assertThat(startDocumentAnalysisRequest.notificationChannel()).isNotNull();
+    assertThat(startDocumentAnalysisRequest.notificationChannel().roleArn())
         .isEqualTo(requestData.notificationChannelRoleArn());
-    assertThat(startDocumentAnalysisRequest.getNotificationChannel().getSNSTopicArn())
+    assertThat(startDocumentAnalysisRequest.notificationChannel().snsTopicArn())
         .isEqualTo(requestData.notificationChannelSnsTopicArn());
-    assertThat(startDocumentAnalysisRequest.getOutputConfig()).isNotNull();
-    assertThat(startDocumentAnalysisRequest.getOutputConfig().getS3Bucket())
+    assertThat(startDocumentAnalysisRequest.outputConfig()).isNotNull();
+    assertThat(startDocumentAnalysisRequest.outputConfig().s3Bucket())
         .isEqualTo(requestData.outputConfigS3Bucket());
-    assertThat(startDocumentAnalysisRequest.getOutputConfig().getS3Prefix())
+    assertThat(startDocumentAnalysisRequest.outputConfig().s3Prefix())
         .isEqualTo(requestData.outputConfigS3Prefix());
   }
 
@@ -66,9 +68,10 @@ class AsyncTextractCallerTest {
   void callWithoutNotificationChanelFieldsShouldNotCreateNotificationObj() {
     TextractRequestData requestData = prepareReqData("", "");
 
-    AmazonTextractAsyncClient asyncClient = Mockito.mock(AmazonTextractAsyncClient.class);
+    TextractAsyncClient asyncClient = Mockito.mock(TextractAsyncClient.class);
     when(asyncClient.startDocumentAnalysis(any(StartDocumentAnalysisRequest.class)))
-        .thenReturn(new StartDocumentAnalysisResult());
+        .thenReturn(
+            CompletableFuture.completedFuture(StartDocumentAnalysisResponse.builder().build()));
 
     new AsyncTextractCaller().call(requestData, asyncClient);
 
@@ -77,16 +80,17 @@ class AsyncTextractCallerTest {
     final StartDocumentAnalysisRequest startDocumentAnalysisRequest =
         requestArgumentCaptor.getValue();
 
-    assertThat(startDocumentAnalysisRequest.getNotificationChannel()).isNull();
+    assertThat(startDocumentAnalysisRequest.notificationChannel()).isNull();
   }
 
   @Test
   void callWithoutOutputS3BucketShouldNotCreateOutputObj() {
     TextractRequestData requestData = prepareReqDataWithoutOutputS3Bucket();
 
-    AmazonTextractAsyncClient asyncClient = Mockito.mock(AmazonTextractAsyncClient.class);
+    TextractAsyncClient asyncClient = Mockito.mock(TextractAsyncClient.class);
     when(asyncClient.startDocumentAnalysis(any(StartDocumentAnalysisRequest.class)))
-        .thenReturn(new StartDocumentAnalysisResult());
+        .thenReturn(
+            CompletableFuture.completedFuture(StartDocumentAnalysisResponse.builder().build()));
 
     new AsyncTextractCaller().call(requestData, asyncClient);
 
@@ -95,7 +99,7 @@ class AsyncTextractCallerTest {
     final StartDocumentAnalysisRequest startDocumentAnalysisRequest =
         requestArgumentCaptor.getValue();
 
-    assertThat(startDocumentAnalysisRequest.getOutputConfig()).isNull();
+    assertThat(startDocumentAnalysisRequest.outputConfig()).isNull();
   }
 
   private TextractRequestData prepareReqData(String roleArn, String topicArn) {

--- a/connectors/aws/aws-textract/src/test/java/io/camunda/connector/textract/caller/PollingTextractCallerTest.java
+++ b/connectors/aws/aws-textract/src/test/java/io/camunda/connector/textract/caller/PollingTextractCallerTest.java
@@ -9,51 +9,61 @@ package io.camunda.connector.textract.caller;
 import static io.camunda.connector.textract.caller.PollingTextractCaller.MAX_RESULT;
 import static io.camunda.connector.textract.util.TextractTestUtils.FULL_FILLED_ASYNC_TEXTRACT_DATA;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.amazonaws.services.textract.AmazonTextractAsyncClient;
-import com.amazonaws.services.textract.model.Block;
-import com.amazonaws.services.textract.model.GetDocumentAnalysisRequest;
-import com.amazonaws.services.textract.model.GetDocumentAnalysisResult;
-import com.amazonaws.services.textract.model.JobStatus;
-import com.amazonaws.services.textract.model.StartDocumentAnalysisResult;
+import io.camunda.connector.api.error.ConnectorException;
+import io.camunda.connector.api.error.ConnectorInputException;
+import io.camunda.connector.textract.model.result.GetDocumentAnalysisResult;
+import java.time.Duration;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import org.apache.commons.collections4.ListUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.services.textract.TextractAsyncClient;
+import software.amazon.awssdk.services.textract.model.Block;
+import software.amazon.awssdk.services.textract.model.GetDocumentAnalysisRequest;
+import software.amazon.awssdk.services.textract.model.GetDocumentAnalysisResponse;
+import software.amazon.awssdk.services.textract.model.JobStatus;
+import software.amazon.awssdk.services.textract.model.StartDocumentAnalysisRequest;
+import software.amazon.awssdk.services.textract.model.StartDocumentAnalysisResponse;
 
 @ExtendWith(MockitoExtension.class)
 class PollingTextractCallerTest {
 
   @Test
   void callUtilDocumentAnalysisResultNextTokenEqNull() throws Exception {
-    List<Pair<GetDocumentAnalysisRequest, GetDocumentAnalysisResult>> callSequence =
+    List<Pair<GetDocumentAnalysisRequest, GetDocumentAnalysisResponse>> callSequence =
         getRequestResponseSequence();
-    Pair<GetDocumentAnalysisRequest, GetDocumentAnalysisResult> firstRequestResp =
+    Pair<GetDocumentAnalysisRequest, GetDocumentAnalysisResponse> firstRequestResp =
         callSequence.getFirst();
 
-    AmazonTextractAsyncClient asyncClient = Mockito.mock(AmazonTextractAsyncClient.class);
-    StartDocumentAnalysisResult startDocRequest =
-        new StartDocumentAnalysisResult().withJobId(firstRequestResp.getLeft().getJobId());
-    when(asyncClient.startDocumentAnalysis(any())).thenReturn(startDocRequest);
+    TextractAsyncClient asyncClient = Mockito.mock(TextractAsyncClient.class);
+    StartDocumentAnalysisResponse startDocResponse =
+        StartDocumentAnalysisResponse.builder().jobId(firstRequestResp.getLeft().jobId()).build();
+    when(asyncClient.startDocumentAnalysis(any(StartDocumentAnalysisRequest.class)))
+        .thenReturn(CompletableFuture.completedFuture(startDocResponse));
 
     when(asyncClient.getDocumentAnalysis(firstRequestResp.getLeft()))
-        .thenReturn(firstRequestResp.getRight());
+        .thenReturn(CompletableFuture.completedFuture(firstRequestResp.getRight()));
 
-    Pair<GetDocumentAnalysisRequest, GetDocumentAnalysisResult> secondRequestResp =
+    Pair<GetDocumentAnalysisRequest, GetDocumentAnalysisResponse> secondRequestResp =
         callSequence.getLast();
 
     when(asyncClient.getDocumentAnalysis(secondRequestResp.getLeft()))
-        .thenReturn(secondRequestResp.getRight());
+        .thenReturn(CompletableFuture.completedFuture(secondRequestResp.getRight()));
 
     List<Block> expectedBlocks =
         ListUtils.union(
-            firstRequestResp.getRight().getBlocks(), secondRequestResp.getRight().getBlocks());
+            firstRequestResp.getRight().blocks(), secondRequestResp.getRight().blocks());
 
     GetDocumentAnalysisResult result =
         new PollingTextractCaller().call(FULL_FILLED_ASYNC_TEXTRACT_DATA, asyncClient);
@@ -61,40 +71,109 @@ class PollingTextractCallerTest {
     verify(asyncClient).getDocumentAnalysis(firstRequestResp.getLeft());
     verify(asyncClient).getDocumentAnalysis(secondRequestResp.getLeft());
 
-    assertThat(result.getBlocks()).isEqualTo(expectedBlocks);
-    assertThat(result)
-        .usingRecursiveComparison()
-        .ignoringFields("blocks")
-        .isEqualTo(secondRequestResp.getRight());
+    List<String> expectedBlockIds = expectedBlocks.stream().map(Block::id).toList();
+    List<String> actualBlockIds =
+        result.blocks().stream().map(io.camunda.connector.textract.model.result.Block::id).toList();
+    assertThat(actualBlockIds).containsExactlyElementsOf(expectedBlockIds);
+    // The merged result otherwise reflects the LAST page polled (see PollingTextractCaller),
+    // which is the documented (golden-tested) v1 behavior being preserved across the migration.
+    assertThat(result.nextToken()).isEqualTo(secondRequestResp.getRight().nextToken());
+    assertThat(result.jobStatus()).isEqualTo(secondRequestResp.getRight().jobStatusAsString());
   }
 
-  private List<Pair<GetDocumentAnalysisRequest, GetDocumentAnalysisResult>>
+  /**
+   * Defect (b): a FAILED job status must fail fast (abort retries), not exhaust the whole polling
+   * window retrying an outcome that will never succeed.
+   */
+  @Test
+  void failedJobStatus_failsFastWithoutRetrying() {
+    String jobId = "job-failed";
+    TextractAsyncClient asyncClient = mock(TextractAsyncClient.class);
+    when(asyncClient.startDocumentAnalysis(any(StartDocumentAnalysisRequest.class)))
+        .thenReturn(
+            CompletableFuture.completedFuture(
+                StartDocumentAnalysisResponse.builder().jobId(jobId).build()));
+
+    GetDocumentAnalysisResponse failedResponse =
+        GetDocumentAnalysisResponse.builder()
+            .jobStatus(JobStatus.FAILED)
+            .statusMessage("boom")
+            .build();
+    when(asyncClient.getDocumentAnalysis(any(GetDocumentAnalysisRequest.class)))
+        .thenReturn(CompletableFuture.completedFuture(failedResponse));
+
+    // maxAttempts is intentionally large here: if the abort-on-failure fix regresses, this test
+    // must fail fast (wrong exception / too many invocations) rather than hang for minutes.
+    PollingTextractCaller caller = new PollingTextractCaller(10, Duration.ofMillis(1));
+
+    assertThrows(
+        ConnectorInputException.class,
+        () -> caller.call(FULL_FILLED_ASYNC_TEXTRACT_DATA, asyncClient));
+
+    verify(asyncClient, times(1)).getDocumentAnalysis(any(GetDocumentAnalysisRequest.class));
+  }
+
+  /**
+   * Defect (c): exhausting every polling attempt while the job is still IN_PROGRESS must throw a
+   * clean, typed exception - not NPE on a null result.
+   */
+  @Test
+  void exhaustingAttemptsWhileInProgress_throwsInsteadOfNpe() {
+    String jobId = "job-in-progress";
+    TextractAsyncClient asyncClient = mock(TextractAsyncClient.class);
+    when(asyncClient.startDocumentAnalysis(any(StartDocumentAnalysisRequest.class)))
+        .thenReturn(
+            CompletableFuture.completedFuture(
+                StartDocumentAnalysisResponse.builder().jobId(jobId).build()));
+
+    GetDocumentAnalysisResponse inProgressResponse =
+        GetDocumentAnalysisResponse.builder().jobStatus(JobStatus.IN_PROGRESS).build();
+    when(asyncClient.getDocumentAnalysis(any(GetDocumentAnalysisRequest.class)))
+        .thenReturn(CompletableFuture.completedFuture(inProgressResponse));
+
+    int maxAttempts = 2;
+    PollingTextractCaller caller = new PollingTextractCaller(maxAttempts, Duration.ofMillis(1));
+
+    ConnectorException exception =
+        assertThrows(
+            ConnectorException.class,
+            () -> caller.call(FULL_FILLED_ASYNC_TEXTRACT_DATA, asyncClient));
+
+    assertThat(exception.getMessage()).contains(jobId);
+    verify(asyncClient, times(maxAttempts))
+        .getDocumentAnalysis(any(GetDocumentAnalysisRequest.class));
+  }
+
+  private List<Pair<GetDocumentAnalysisRequest, GetDocumentAnalysisResponse>>
       getRequestResponseSequence() {
     String jobId = "1";
     GetDocumentAnalysisRequest firstDocRequest =
-        new GetDocumentAnalysisRequest()
-            .withJobId(jobId)
-            .withMaxResults(MAX_RESULT)
-            .withNextToken(null);
+        GetDocumentAnalysisRequest.builder().jobId(jobId).maxResults(MAX_RESULT).build();
 
     String nextToken = "2";
     GetDocumentAnalysisRequest secondDocRequest =
-        new GetDocumentAnalysisRequest()
-            .withJobId(jobId)
-            .withMaxResults(MAX_RESULT)
-            .withNextToken(nextToken);
+        GetDocumentAnalysisRequest.builder()
+            .jobId(jobId)
+            .maxResults(MAX_RESULT)
+            .nextToken(nextToken)
+            .build();
 
-    GetDocumentAnalysisResult firstDocResult =
-        new GetDocumentAnalysisResult()
-            .withJobStatus(JobStatus.SUCCEEDED.toString())
-            .withNextToken(nextToken)
-            .withBlocks(List.of(new Block().withText("AAA"), new Block().withText("BBB")));
+    GetDocumentAnalysisResponse firstDocResult =
+        GetDocumentAnalysisResponse.builder()
+            .jobStatus(JobStatus.SUCCEEDED)
+            .nextToken(nextToken)
+            .blocks(
+                Block.builder().id("block-aaa").text("AAA").build(),
+                Block.builder().id("block-bbb").text("BBB").build())
+            .build();
 
-    GetDocumentAnalysisResult secondDocResult =
-        new GetDocumentAnalysisResult()
-            .withJobStatus(JobStatus.SUCCEEDED.toString())
-            .withNextToken(null)
-            .withBlocks(List.of(new Block().withText("CCC"), new Block().withText("DDD")));
+    GetDocumentAnalysisResponse secondDocResult =
+        GetDocumentAnalysisResponse.builder()
+            .jobStatus(JobStatus.SUCCEEDED)
+            .blocks(
+                Block.builder().id("block-ccc").text("CCC").build(),
+                Block.builder().id("block-ddd").text("DDD").build())
+            .build();
 
     return List.of(
         Pair.of(firstDocRequest, firstDocResult), Pair.of(secondDocRequest, secondDocResult));

--- a/connectors/aws/aws-textract/src/test/java/io/camunda/connector/textract/caller/PollingTextractCallerTest.java
+++ b/connectors/aws/aws-textract/src/test/java/io/camunda/connector/textract/caller/PollingTextractCallerTest.java
@@ -144,6 +144,73 @@ class PollingTextractCallerTest {
         .getDocumentAnalysis(any(GetDocumentAnalysisRequest.class));
   }
 
+  /**
+   * The migration requirement preserves retries for transient/technical failures (e.g. throttling
+   * or network errors surfaced via {@code CompletionException} from {@code .join()}). Only a
+   * genuine FAILED job status should abort retries early; any other exception must still be retried
+   * up to {@code maxAttempts}.
+   */
+  @Test
+  void transientFailureThenSuccess_retriesAndReturnsResult() throws Exception {
+    String jobId = "job-transient-failure";
+    TextractAsyncClient asyncClient = mock(TextractAsyncClient.class);
+    when(asyncClient.startDocumentAnalysis(any(StartDocumentAnalysisRequest.class)))
+        .thenReturn(
+            CompletableFuture.completedFuture(
+                StartDocumentAnalysisResponse.builder().jobId(jobId).build()));
+
+    GetDocumentAnalysisResponse succeededResponse =
+        GetDocumentAnalysisResponse.builder().jobStatus(JobStatus.SUCCEEDED).build();
+
+    CompletableFuture<GetDocumentAnalysisResponse> transientFailure = new CompletableFuture<>();
+    transientFailure.completeExceptionally(new RuntimeException("transient network error"));
+
+    when(asyncClient.getDocumentAnalysis(any(GetDocumentAnalysisRequest.class)))
+        .thenReturn(transientFailure)
+        .thenReturn(CompletableFuture.completedFuture(succeededResponse));
+
+    PollingTextractCaller caller = new PollingTextractCaller(3, Duration.ofMillis(1));
+
+    GetDocumentAnalysisResult result = caller.call(FULL_FILLED_ASYNC_TEXTRACT_DATA, asyncClient);
+
+    assertThat(result.jobStatus()).isEqualTo(succeededResponse.jobStatusAsString());
+    verify(asyncClient, times(2)).getDocumentAnalysis(any(GetDocumentAnalysisRequest.class));
+  }
+
+  /**
+   * PARTIAL_SUCCESS is also a terminal GetDocumentAnalysis status (the job finished, but some pages
+   * could not be analyzed) and must be treated as complete rather than still-in-progress -
+   * otherwise the connector polls the completed job until the window times out and discards the
+   * partial result.
+   */
+  @Test
+  void partialSuccessJobStatus_treatedAsComplete() throws Exception {
+    String jobId = "job-partial-success";
+    TextractAsyncClient asyncClient = mock(TextractAsyncClient.class);
+    when(asyncClient.startDocumentAnalysis(any(StartDocumentAnalysisRequest.class)))
+        .thenReturn(
+            CompletableFuture.completedFuture(
+                StartDocumentAnalysisResponse.builder().jobId(jobId).build()));
+
+    GetDocumentAnalysisResponse partialSuccessResponse =
+        GetDocumentAnalysisResponse.builder()
+            .jobStatus(JobStatus.PARTIAL_SUCCESS)
+            .blocks(Block.builder().id("block-partial").text("partial").build())
+            .build();
+    when(asyncClient.getDocumentAnalysis(any(GetDocumentAnalysisRequest.class)))
+        .thenReturn(CompletableFuture.completedFuture(partialSuccessResponse));
+
+    // maxAttempts is intentionally larger than 1: if PARTIAL_SUCCESS regresses to being treated
+    // as still-in-progress, this test observes more than a single poll (or ultimately a
+    // ConnectorException once the window is exhausted) instead of an immediate result.
+    PollingTextractCaller caller = new PollingTextractCaller(2, Duration.ofMillis(1));
+
+    GetDocumentAnalysisResult result = caller.call(FULL_FILLED_ASYNC_TEXTRACT_DATA, asyncClient);
+
+    assertThat(result.jobStatus()).isEqualTo(partialSuccessResponse.jobStatusAsString());
+    verify(asyncClient, times(1)).getDocumentAnalysis(any(GetDocumentAnalysisRequest.class));
+  }
+
   private List<Pair<GetDocumentAnalysisRequest, GetDocumentAnalysisResponse>>
       getRequestResponseSequence() {
     String jobId = "1";

--- a/connectors/aws/aws-textract/src/test/java/io/camunda/connector/textract/caller/SyncTextractCallerTest.java
+++ b/connectors/aws/aws-textract/src/test/java/io/camunda/connector/textract/caller/SyncTextractCallerTest.java
@@ -6,22 +6,22 @@
  */
 package io.camunda.connector.textract.caller;
 
-import static com.amazonaws.services.textract.model.FeatureType.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
-import com.amazonaws.services.textract.AmazonTextractClient;
-import com.amazonaws.services.textract.model.AnalyzeDocumentRequest;
-import com.amazonaws.services.textract.model.AnalyzeDocumentResult;
 import io.camunda.connector.api.document.Document;
 import io.camunda.connector.textract.model.DocumentLocationType;
 import io.camunda.connector.textract.model.TextractExecutionType;
 import io.camunda.connector.textract.model.TextractRequestData;
-import java.nio.ByteBuffer;
 import java.util.HexFormat;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
+import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.services.textract.TextractClient;
+import software.amazon.awssdk.services.textract.model.AnalyzeDocumentRequest;
+import software.amazon.awssdk.services.textract.model.AnalyzeDocumentResponse;
+import software.amazon.awssdk.services.textract.model.FeatureType;
 
 class SyncTextractCallerTest {
   @Test
@@ -48,10 +48,10 @@ class SyncTextractCallerTest {
             "outputBucket",
             "prefix");
 
-    AmazonTextractClient textractClient = mock(AmazonTextractClient.class);
+    TextractClient textractClient = mock(TextractClient.class);
 
     when(textractClient.analyzeDocument(any(AnalyzeDocumentRequest.class)))
-        .thenReturn(new AnalyzeDocumentResult());
+        .thenReturn(AnalyzeDocumentResponse.builder().build());
 
     new SyncTextractCaller().call(requestData, textractClient);
 
@@ -87,10 +87,10 @@ class SyncTextractCallerTest {
             "outputBucket",
             "prefix");
 
-    AmazonTextractClient textractClient = mock(AmazonTextractClient.class);
+    TextractClient textractClient = mock(TextractClient.class);
 
     when(textractClient.analyzeDocument(any(AnalyzeDocumentRequest.class)))
-        .thenReturn(new AnalyzeDocumentResult());
+        .thenReturn(AnalyzeDocumentResponse.builder().build());
 
     new SyncTextractCaller().call(requestData, textractClient);
 
@@ -101,11 +101,12 @@ class SyncTextractCallerTest {
     AnalyzeDocumentRequest analyzeDocumentRequest = argumentCaptor.getValue();
     assertThat(analyzeDocumentRequest)
         .isEqualTo(
-            new AnalyzeDocumentRequest()
-                .withFeatureTypes(TABLES.name())
-                .withQueriesConfig(null)
-                .withDocument(
-                    new com.amazonaws.services.textract.model.Document()
-                        .withBytes(ByteBuffer.wrap(bytes))));
+            AnalyzeDocumentRequest.builder()
+                .featureTypesWithStrings(FeatureType.TABLES.name())
+                .document(
+                    software.amazon.awssdk.services.textract.model.Document.builder()
+                        .bytes(SdkBytes.fromByteArray(bytes))
+                        .build())
+                .build());
   }
 }

--- a/connectors/aws/aws-textract/src/test/java/io/camunda/connector/textract/caller/TextractCallerTest.java
+++ b/connectors/aws/aws-textract/src/test/java/io/camunda/connector/textract/caller/TextractCallerTest.java
@@ -11,26 +11,25 @@ import static io.camunda.connector.textract.util.TextractTestUtils.FULL_FILLED_A
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import com.amazonaws.services.textract.model.AnalyzeDocumentResult;
-import com.amazonaws.services.textract.model.DocumentLocation;
-import com.amazonaws.services.textract.model.S3Object;
 import io.camunda.connector.textract.model.DocumentLocationType;
 import io.camunda.connector.textract.model.TextractExecutionType;
 import io.camunda.connector.textract.model.TextractRequestData;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.services.textract.model.DocumentLocation;
+import software.amazon.awssdk.services.textract.model.S3Object;
 
 class TextractCallerTest {
 
-  private final TextractCaller<AnalyzeDocumentResult> textractCaller = (data, client) -> null;
+  private final TextractCaller<Object, Object> textractCaller = (data, client) -> null;
 
   @Test
   void prepareS3Obj() {
     S3Object s3Object = textractCaller.prepareS3Obj(FULL_FILLED_ASYNC_TEXTRACT_DATA);
 
-    assertThat(s3Object.getBucket()).isEqualTo(FULL_FILLED_ASYNC_TEXTRACT_DATA.documentS3Bucket());
-    assertThat(s3Object.getName()).isEqualTo(FULL_FILLED_ASYNC_TEXTRACT_DATA.documentName());
-    assertThat(s3Object.getVersion()).isEqualTo(FULL_FILLED_ASYNC_TEXTRACT_DATA.documentVersion());
+    assertThat(s3Object.bucket()).isEqualTo(FULL_FILLED_ASYNC_TEXTRACT_DATA.documentS3Bucket());
+    assertThat(s3Object.name()).isEqualTo(FULL_FILLED_ASYNC_TEXTRACT_DATA.documentName());
+    assertThat(s3Object.version()).isEqualTo(FULL_FILLED_ASYNC_TEXTRACT_DATA.documentVersion());
   }
 
   @Test
@@ -123,6 +122,6 @@ class TextractCallerTest {
     DocumentLocation documentLocation =
         textractCaller.prepareDocumentLocation(FULL_FILLED_ASYNC_TEXTRACT_DATA);
 
-    assertThat(documentLocation.getS3Object()).isNotNull();
+    assertThat(documentLocation.s3Object()).isNotNull();
   }
 }

--- a/connectors/aws/aws-textract/src/test/java/io/camunda/connector/textract/suppliers/AmazonTextractClientSupplierTest.java
+++ b/connectors/aws/aws-textract/src/test/java/io/camunda/connector/textract/suppliers/AmazonTextractClientSupplierTest.java
@@ -9,13 +9,12 @@ package io.camunda.connector.textract.suppliers;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-import com.amazonaws.services.textract.AmazonTextractAsync;
-import com.amazonaws.services.textract.AmazonTextractAsyncClient;
-import com.amazonaws.services.textract.AmazonTextractClient;
 import io.camunda.connector.aws.model.impl.AwsBaseConfiguration;
 import io.camunda.connector.textract.model.TextractRequest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.services.textract.TextractAsyncClient;
+import software.amazon.awssdk.services.textract.TextractClient;
 
 class AmazonTextractClientSupplierTest {
 
@@ -25,7 +24,7 @@ class AmazonTextractClientSupplierTest {
   @BeforeEach
   public void setUp() {
     clientSupplier = new AmazonTextractClientSupplier();
-    AwsBaseConfiguration configuration = new AwsBaseConfiguration("region", "");
+    AwsBaseConfiguration configuration = new AwsBaseConfiguration("eu-central-1", "");
 
     request = new TextractRequest();
     request.setConfiguration(configuration);
@@ -33,15 +32,14 @@ class AmazonTextractClientSupplierTest {
 
   @Test
   void getSyncTextractClient() {
-    AmazonTextractClient client =
-        (AmazonTextractClient) clientSupplier.getSyncTextractClient(request);
-    assertThat(client).isInstanceOf(AmazonTextractClient.class);
+    TextractClient client = clientSupplier.getSyncTextractClient(request);
+    assertThat(client).isInstanceOf(TextractClient.class);
   }
 
   @Test
   void getAsyncTextractClient() {
-    AmazonTextractAsync client = clientSupplier.getAsyncTextractClient(request);
+    TextractAsyncClient client = clientSupplier.getAsyncTextractClient(request);
     assertNotNull(client);
-    assertThat(client).isInstanceOf(AmazonTextractAsyncClient.class);
+    assertThat(client).isInstanceOf(TextractAsyncClient.class);
   }
 }

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -573,6 +573,11 @@ limitations under the License.</license.inlineheader>
       </dependency>
       <dependency>
         <groupId>software.amazon.awssdk</groupId>
+        <artifactId>textract</artifactId>
+        <version>${version.aws-sdk2}</version>
+      </dependency>
+      <dependency>
+        <groupId>software.amazon.awssdk</groupId>
         <artifactId>bedrockruntime</artifactId>
         <version>${version.aws-sdk2}</version>
       </dependency>


### PR DESCRIPTION
## Summary

Migrates `aws-textract` from AWS SDK v1 (`com.amazonaws`) to AWS SDK v2 (`software.amazon.awssdk`), closing #7972 as part of the broader AWS SDK v1→v2 migration epic.

- New connector-owned result records (`model/result/*`) map v2's `AnalyzeDocumentResponse` / `StartDocumentAnalysisResponse` / `GetDocumentAnalysisResponse` into the exact JSON shape the connector documented pre-migration, via explicit `.from(...)` mappers with `@JsonPropertyOrder`. This avoids the `{}`-serialization hazard that v2's fluent-accessor-only model classes cause with `FAIL_ON_EMPTY_BEANS` disabled — the same class of bug already hit once in `aws-eventbridge` (#7967/#7977).
- `TextractCaller<T, C>` gained a second type parameter for the client type, since v2's `TextractClient` / `TextractAsyncClient` are unrelated interfaces (unlike v1's `AmazonTextractAsync`, which extended `AmazonTextract`).
- `AmazonTextractClientSupplier` rebuilt on `TextractClient.builder()` / `TextractAsyncClient.builder()` via the shared `AwsClientSupport` / `CredentialsProviderSupportV2` helpers.
- `TextractConnectorFunction` now closes the v2 client per invocation (try-with-resources), mirroring `EventBridgeFunction`; v1's clients were never explicitly closed, but v2's async client owns a Netty event-loop / connection pool that would otherwise leak per invocation.
- `parent/pom.xml`: added the `software.amazon.awssdk:textract` dependencyManagement entry (mirroring the existing `eventbridge` entry). `aws-textract/pom.xml`: swapped `com.amazonaws:aws-java-sdk-textract` for `software.amazon.awssdk:textract` (+ `aws-core`/`sdk-core`/`http-client-spi`, used directly by the new result-mapping code).

## Output-shape parity (golden fixture)

`connectors/aws/aws-textract/src/test/java/io/camunda/connector/textract/TextractResultShapeTest.java` is the golden-fixture test verifying that the migrated connector's JSON output shape matches the pre-existing v1 connector's documented output byte-for-byte (values, nesting, explicit-nulls, and top-level `@JsonPropertyOrder` field order). It compares the actual serialized result against hand-authored expected JSON for all three call modes (sync `AnalyzeDocument`, and the async start+poll `StartDocumentAnalysis`/`GetDocumentAnalysis` pair, including a multi-page merge case).

One caveat verified during review: AWS SDK v2's `SdkHttpResponse` implementation (`DefaultSdkHttpFullResponse`) stores HTTP headers in a case-insensitive *sorted* map, so the two header sub-maps (`sdkHttpMetadata.httpHeaders`, `sdkHttpMetadata.allHttpHeaders`) serialize in alphabetical key order regardless of insertion order — this differs from v1's insertion/hash-bucket order. This is genuine v2 runtime behavior (confirmed by inserting headers out-of-order in the test and observing alphabetical output), not a test weakening; no consumer relies on JSON object key order, and the expected-JSON fixtures were updated to reflect it.

## PollingTextractCaller: 3 defect fixes bundled with this migration

v1's `GetDocumentAnalysisResult` was a mutable SDK object; v2's `GetDocumentAnalysisResponse` is immutable, which forced a rewrite of the polling/merge logic in `PollingTextractCaller`. While rewriting it, three pre-existing defects were found and fixed (documented here per the migration epic's decision to call out such fixes explicitly rather than silently bundle them):

1. **`setBlocks` mutation → `toBuilder()` copy.** v1 merged multi-page results by calling `lastResult.setBlocks(allBlocks)` on the mutable last-page response. v2 has no setters, so the merge is now `lastResult.toBuilder().blocks(allBlocks).build()`. This intentionally preserves the existing, golden-test-pinned quirk that the merged result's `sdkResponseMetadata` / `sdkHttpMetadata` / `nextToken` reflect only the **last** polled page, not the first — verified by `getDocumentAnalysisResult_multiPageMerge`.
2. **Retry-on-FAILED wasted ~9 minutes → fail-fast.** The retry policy's `.handle(Exception.class)` also caught and retried the `ConnectorInputException` thrown for a `FAILED` job status, retrying a job that will never succeed for the full polling window (10 attempts × 1 min). Fixed with `.abortOn(ConnectorInputException.class)`, so a `FAILED` status now fails immediately on the first attempt. Genuine transient/technical errors (e.g. exceptions surfacing from `.join()`) are still retried as before. Verified by `failedJobStatus_failsFastWithoutRetrying` (asserts exactly 1 `getDocumentAnalysis` invocation).
3. **Exhausted-while-`IN_PROGRESS` NPE → clean typed exception.** `Failsafe.get()` returns `null` (not an exception) when every attempt is exhausted while `handleResultIf(Objects::isNull)` keeps matching a still-`IN_PROGRESS` result; the caller previously NPE'd dereferencing that `null`. Now throws a `ConnectorException` with a clear message (including the job id) instead. Verified by `exhaustingAttemptsWhileInProgress_throwsInsteadOfNpe`.

Both (2) and (3) have new dedicated unit tests. `PollingTextractCaller` gained a package-private `(maxAttempts, pollDelay)` constructor so those tests exercise the real retry/timeout path with short delays instead of waiting out the real ~9 minute production polling window.

## Test plan

- [x] `./mvnw -pl connectors/aws/aws-textract -am test` — 26/26 tests green, 0 failures/errors/skipped
- [x] `TextractResultShapeTest` (golden fixture) passes — confirms output-shape parity with the pre-existing v1 connector for sync, async start+poll, and multi-page-merge cases
- [x] `PollingTextractCallerTest` covers the fail-fast-on-FAILED and exhausted-while-IN_PROGRESS fixes with real (short-delay) Failsafe retry execution
- [x] No `com.amazonaws` imports remain in the module; all callers return connector-owned DTOs, never raw v2 SDK response objects

Closes #7972