### PR TITLE
feat(comprehend): migrate to AWS SDK v2

### DIFF
--- a/connectors/aws/aws-comprehend/pom.xml
+++ b/connectors/aws/aws-comprehend/pom.xml
@@ -39,9 +39,27 @@
     </dependency>
 
     <dependency>
-      <groupId>com.amazonaws</groupId>
-      <artifactId>aws-java-sdk-comprehend</artifactId>
-      <version>${version.aws-java-sdk}</version>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>comprehend</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>aws-core</artifactId>
+      <version>${version.aws-sdk2}</version>
+    </dependency>
+    <dependency>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>http-client-spi</artifactId>
+      <version>${version.aws-sdk2}</version>
+    </dependency>
+
+    <!-- test-only: golden-JSON shape tests build fixture responses via the AWS SDK v2 response
+    builders' inherited SdkResponse.Builder#sdkHttpResponse(...), which is declared in sdk-core;
+    production code never references sdk-core directly (aws-core/http-client-spi suffice). -->
+    <dependency>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>sdk-core</artifactId>
+      <scope>test</scope>
     </dependency>
 
     <dependency>

--- a/connectors/aws/aws-comprehend/pom.xml
+++ b/connectors/aws/aws-comprehend/pom.xml
@@ -53,13 +53,14 @@
       <version>${version.aws-sdk2}</version>
     </dependency>
 
-    <!-- test-only: golden-JSON shape tests build fixture responses via the AWS SDK v2 response
-    builders' inherited SdkResponse.Builder#sdkHttpResponse(...), which is declared in sdk-core;
-    production code never references sdk-core directly (aws-core/http-client-spi suffice). -->
+    <!-- Required at compile scope: the v2 client/response types (e.g. ComprehendClient,
+    ClassifyDocumentResponse) implement supertypes declared in sdk-core (SdkClient, SdkResponse,
+    SdkPojo, SdkRequest, ...). javac must resolve those supertypes even though this module's code
+    never imports them by name, so sdk-core cannot be narrowed to test scope here; matching how
+    aws-eventbridge, aws-s3 and aws-lambda declare it. -->
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>sdk-core</artifactId>
-      <scope>test</scope>
     </dependency>
 
     <dependency>
@@ -80,6 +81,18 @@
 
   <build>
     <plugins>
+      <plugin>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <configuration>
+          <!-- sdk-core is required at compile scope for javac to resolve the v2 client/response
+          supertypes (SdkClient, SdkResponse, SdkPojo, SdkRequest, ...), but bytecode-level
+          dependency analysis only sees it referenced from test classes, so it is otherwise
+          flagged as a "non-test scoped test only dependency". -->
+          <ignoredNonTestScopedDependencies combine.children="append">
+            <dependency>software.amazon.awssdk:sdk-core</dependency>
+          </ignoredNonTestScopedDependencies>
+        </configuration>
+      </plugin>
       <plugin>
         <groupId>io.camunda.connector</groupId>
         <artifactId>element-template-generator-maven-plugin</artifactId>

--- a/connectors/aws/aws-comprehend/src/main/java/io/camunda/connector/comprehend/ComprehendClassificationJobResult.java
+++ b/connectors/aws/aws-comprehend/src/main/java/io/camunda/connector/comprehend/ComprehendClassificationJobResult.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ *       under one or more contributor license agreements. Licensed under a proprietary license.
+ *       See the License.txt file for more information. You may not use this file
+ *       except in compliance with the proprietary license.
+ */
+package io.camunda.connector.comprehend;
+
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import software.amazon.awssdk.services.comprehend.model.StartDocumentClassificationJobResponse;
+
+/**
+ * Connector-owned result of a Comprehend {@code StartDocumentClassificationJob} call.
+ *
+ * <p>The AWS SDK v2 model class ({@link StartDocumentClassificationJobResponse}) exposes fluent
+ * accessors ({@code jobId()}, {@code jobArn()}, ...) rather than JavaBean getters. Serializing it
+ * directly with the connectors' {@code ObjectMapper} (which disables {@code FAIL_ON_EMPTY_BEANS})
+ * would silently produce {@code {}}. This record maps the v2 response back into the exact JSON
+ * shape that the pre-v2 (AWS SDK v1) connector documented and returned.
+ */
+@JsonPropertyOrder({
+  "sdkResponseMetadata",
+  "sdkHttpMetadata",
+  "jobId",
+  "jobArn",
+  "jobStatus",
+  "documentClassifierArn"
+})
+public record ComprehendClassificationJobResult(
+    SdkResponseMetadata sdkResponseMetadata,
+    SdkHttpMetadata sdkHttpMetadata,
+    String jobId,
+    String jobArn,
+    String jobStatus,
+    String documentClassifierArn) {
+
+  /**
+   * Maps an AWS SDK v2 {@link StartDocumentClassificationJobResponse} into the v1-shaped connector
+   * result.
+   */
+  public static ComprehendClassificationJobResult from(
+      final StartDocumentClassificationJobResponse response) {
+    return new ComprehendClassificationJobResult(
+        SdkResponseMetadata.from(response.responseMetadata()),
+        SdkHttpMetadata.from(response.sdkHttpResponse()),
+        response.jobId(),
+        response.jobArn(),
+        response.jobStatusAsString(),
+        response.documentClassifierArn());
+  }
+}

--- a/connectors/aws/aws-comprehend/src/main/java/io/camunda/connector/comprehend/ComprehendClassifyResult.java
+++ b/connectors/aws/aws-comprehend/src/main/java/io/camunda/connector/comprehend/ComprehendClassifyResult.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ *       under one or more contributor license agreements. Licensed under a proprietary license.
+ *       See the License.txt file for more information. You may not use this file
+ *       except in compliance with the proprietary license.
+ */
+package io.camunda.connector.comprehend;
+
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import java.util.List;
+import software.amazon.awssdk.services.comprehend.model.ClassifyDocumentResponse;
+import software.amazon.awssdk.services.comprehend.model.DocumentClass;
+import software.amazon.awssdk.services.comprehend.model.DocumentLabel;
+import software.amazon.awssdk.services.comprehend.model.DocumentTypeListItem;
+import software.amazon.awssdk.services.comprehend.model.ErrorsListItem;
+import software.amazon.awssdk.services.comprehend.model.ExtractedCharactersListItem;
+import software.amazon.awssdk.services.comprehend.model.WarningsListItem;
+
+/**
+ * Connector-owned result of a Comprehend {@code ClassifyDocument} call.
+ *
+ * <p>The AWS SDK v2 model classes ({@link ClassifyDocumentResponse} and friends) expose fluent
+ * accessors ({@code classes()}, {@code documentMetadata()}, ...) rather than JavaBean getters.
+ * Serializing them directly with the connectors' {@code ObjectMapper} (which disables {@code
+ * FAIL_ON_EMPTY_BEANS}) would silently produce {@code {}}. This record maps the v2 response back
+ * into the exact JSON shape that the pre-v2 (AWS SDK v1) connector documented and returned,
+ * restoring that output contract -- including distinguishing an absent (never-set) list, which v1
+ * exposed as {@code null}, from an explicitly empty one (v2's {@code hasXxx()} flag).
+ */
+@JsonPropertyOrder({
+  "sdkResponseMetadata",
+  "sdkHttpMetadata",
+  "classes",
+  "labels",
+  "documentMetadata",
+  "documentType",
+  "errors",
+  "warnings"
+})
+public record ComprehendClassifyResult(
+    SdkResponseMetadata sdkResponseMetadata,
+    SdkHttpMetadata sdkHttpMetadata,
+    List<Classification> classes,
+    List<Classification> labels,
+    ClassifyDocumentMetadata documentMetadata,
+    List<DocumentTypeItem> documentType,
+    List<ErrorItem> errors,
+    List<WarningItem> warnings) {
+
+  /** Maps an AWS SDK v2 {@link ClassifyDocumentResponse} into the v1-shaped connector result. */
+  public static ComprehendClassifyResult from(final ClassifyDocumentResponse response) {
+    return new ComprehendClassifyResult(
+        SdkResponseMetadata.from(response.responseMetadata()),
+        SdkHttpMetadata.from(response.sdkHttpResponse()),
+        response.hasClasses() ? mapClasses(response.classes()) : null,
+        response.hasLabels() ? mapLabels(response.labels()) : null,
+        ClassifyDocumentMetadata.from(response.documentMetadata()),
+        response.hasDocumentType() ? mapDocumentType(response.documentType()) : null,
+        response.hasErrors() ? mapErrors(response.errors()) : null,
+        response.hasWarnings() ? mapWarnings(response.warnings()) : null);
+  }
+
+  private static List<Classification> mapClasses(final List<DocumentClass> classes) {
+    return classes.stream().map(c -> new Classification(c.name(), c.score(), c.page())).toList();
+  }
+
+  private static List<Classification> mapLabels(final List<DocumentLabel> labels) {
+    return labels.stream().map(l -> new Classification(l.name(), l.score(), l.page())).toList();
+  }
+
+  private static List<DocumentTypeItem> mapDocumentType(
+      final List<DocumentTypeListItem> documentType) {
+    return documentType.stream()
+        .map(item -> new DocumentTypeItem(item.page(), item.typeAsString()))
+        .toList();
+  }
+
+  private static List<ErrorItem> mapErrors(final List<ErrorsListItem> errors) {
+    return errors.stream()
+        .map(e -> new ErrorItem(e.page(), e.errorCodeAsString(), e.errorMessage()))
+        .toList();
+  }
+
+  private static List<WarningItem> mapWarnings(final List<WarningsListItem> warnings) {
+    return warnings.stream()
+        .map(w -> new WarningItem(w.page(), w.warnCodeAsString(), w.warnMessage()))
+        .toList();
+  }
+
+  /** Shape shared by both the {@code classes} and {@code labels} v1 JSON arrays. */
+  @JsonPropertyOrder({"name", "score", "page"})
+  public record Classification(String name, Float score, Integer page) {}
+
+  @JsonPropertyOrder({"pages", "extractedCharacters"})
+  public record ClassifyDocumentMetadata(
+      Integer pages, List<ExtractedCharacters> extractedCharacters) {
+
+    static ClassifyDocumentMetadata from(
+        final software.amazon.awssdk.services.comprehend.model.DocumentMetadata documentMetadata) {
+      if (documentMetadata == null) {
+        return null;
+      }
+      List<ExtractedCharacters> extractedCharacters =
+          documentMetadata.hasExtractedCharacters()
+              ? mapExtractedCharacters(documentMetadata.extractedCharacters())
+              : null;
+      return new ClassifyDocumentMetadata(documentMetadata.pages(), extractedCharacters);
+    }
+
+    private static List<ExtractedCharacters> mapExtractedCharacters(
+        final List<ExtractedCharactersListItem> extractedCharacters) {
+      return extractedCharacters.stream()
+          .map(item -> new ExtractedCharacters(item.page(), item.count()))
+          .toList();
+    }
+  }
+
+  @JsonPropertyOrder({"page", "count"})
+  public record ExtractedCharacters(Integer page, Integer count) {}
+
+  @JsonPropertyOrder({"page", "type"})
+  public record DocumentTypeItem(Integer page, String type) {}
+
+  @JsonPropertyOrder({"page", "errorCode", "errorMessage"})
+  public record ErrorItem(Integer page, String errorCode, String errorMessage) {}
+
+  @JsonPropertyOrder({"page", "warnCode", "warnMessage"})
+  public record WarningItem(Integer page, String warnCode, String warnMessage) {}
+}

--- a/connectors/aws/aws-comprehend/src/main/java/io/camunda/connector/comprehend/ComprehendConnectorFunction.java
+++ b/connectors/aws/aws-comprehend/src/main/java/io/camunda/connector/comprehend/ComprehendConnectorFunction.java
@@ -76,9 +76,12 @@ public class ComprehendConnectorFunction implements OutboundConnectorFunction {
     var request = context.bindVariables(ComprehendRequest.class);
     ComprehendRequestData requestData = request.getInput();
     if (requestData instanceof ComprehendSyncRequestData syncRequestData) {
-      return syncComprehendCaller.call(clientSupplier.getSyncClient(request), syncRequestData);
+      try (var client = clientSupplier.getSyncClient(request)) {
+        return syncComprehendCaller.call(client, syncRequestData);
+      }
     }
-    return asyncComprehendCaller.call(
-        clientSupplier.getAsyncClient(request), (ComprehendAsyncRequestData) requestData);
+    try (var client = clientSupplier.getAsyncClient(request)) {
+      return asyncComprehendCaller.call(client, (ComprehendAsyncRequestData) requestData);
+    }
   }
 }

--- a/connectors/aws/aws-comprehend/src/main/java/io/camunda/connector/comprehend/SdkHttpMetadata.java
+++ b/connectors/aws/aws-comprehend/src/main/java/io/camunda/connector/comprehend/SdkHttpMetadata.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ *       under one or more contributor license agreements. Licensed under a proprietary license.
+ *       See the License.txt file for more information. You may not use this file
+ *       except in compliance with the proprietary license.
+ */
+package io.camunda.connector.comprehend;
+
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import software.amazon.awssdk.http.SdkHttpResponse;
+
+/**
+ * HTTP-response metadata shared by every AWS Comprehend v2 response, reconstructed from {@code
+ * response.sdkHttpResponse()}.
+ *
+ * <p>Mirrors the {@code sdkHttpMetadata} object the pre-v2 (AWS SDK v1) connector exposed, and is
+ * shared by both {@link ComprehendClassifyResult} and {@link ComprehendClassificationJobResult}
+ * since both response types carry the same kind of HTTP metadata.
+ */
+@JsonPropertyOrder({"httpHeaders", "httpStatusCode", "allHttpHeaders"})
+public record SdkHttpMetadata(
+    Map<String, String> httpHeaders,
+    Integer httpStatusCode,
+    Map<String, List<String>> allHttpHeaders) {
+
+  public static SdkHttpMetadata from(final SdkHttpResponse httpResponse) {
+    if (httpResponse == null) {
+      return null;
+    }
+    Map<String, List<String>> allHttpHeaders = new LinkedHashMap<>(httpResponse.headers());
+    Map<String, String> httpHeaders = new LinkedHashMap<>();
+    allHttpHeaders.forEach(
+        (name, values) ->
+            httpHeaders.put(name, values == null || values.isEmpty() ? null : values.get(0)));
+    return new SdkHttpMetadata(httpHeaders, httpResponse.statusCode(), allHttpHeaders);
+  }
+}

--- a/connectors/aws/aws-comprehend/src/main/java/io/camunda/connector/comprehend/SdkResponseMetadata.java
+++ b/connectors/aws/aws-comprehend/src/main/java/io/camunda/connector/comprehend/SdkResponseMetadata.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ *       under one or more contributor license agreements. Licensed under a proprietary license.
+ *       See the License.txt file for more information. You may not use this file
+ *       except in compliance with the proprietary license.
+ */
+package io.camunda.connector.comprehend;
+
+import software.amazon.awssdk.awscore.AwsResponseMetadata;
+
+/**
+ * Request-id metadata shared by every AWS Comprehend v2 response, reconstructed from {@code
+ * response.responseMetadata()}.
+ *
+ * <p>Mirrors the {@code sdkResponseMetadata} object the pre-v2 (AWS SDK v1) connector exposed, and
+ * is shared by both {@link ComprehendClassifyResult} and {@link ComprehendClassificationJobResult}
+ * since both response types carry the same AWS-request-id metadata.
+ */
+public record SdkResponseMetadata(String requestId) {
+  // v2 returns the literal "UNKNOWN" when AWS_REQUEST_ID is absent; v1 exposed null there
+  private static final String UNKNOWN_REQUEST_ID = "UNKNOWN";
+
+  public static SdkResponseMetadata from(final AwsResponseMetadata metadata) {
+    if (metadata == null) {
+      return null;
+    }
+    String requestId = metadata.requestId();
+    return new SdkResponseMetadata(UNKNOWN_REQUEST_ID.equals(requestId) ? null : requestId);
+  }
+}

--- a/connectors/aws/aws-comprehend/src/main/java/io/camunda/connector/comprehend/caller/AsyncComprehendCaller.java
+++ b/connectors/aws/aws-comprehend/src/main/java/io/camunda/connector/comprehend/caller/AsyncComprehendCaller.java
@@ -8,9 +8,7 @@ package io.camunda.connector.comprehend.caller;
 
 import static io.camunda.connector.comprehend.model.ComprehendDocumentReadAction.TEXTRACT_ANALYZE_DOCUMENT;
 
-import com.amazonaws.services.comprehend.AmazonComprehendClient;
-import com.amazonaws.services.comprehend.model.*;
-import com.amazonaws.util.CollectionUtils;
+import io.camunda.connector.comprehend.ComprehendClassificationJobResult;
 import io.camunda.connector.comprehend.model.ComprehendAsyncRequestData;
 import io.camunda.connector.comprehend.model.ComprehendDocumentReadAction;
 import io.camunda.connector.comprehend.model.ComprehendDocumentReadMode;
@@ -22,9 +20,27 @@ import java.util.Objects;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.services.comprehend.ComprehendAsyncClient;
+import software.amazon.awssdk.services.comprehend.model.DocumentReadFeatureTypes;
+import software.amazon.awssdk.services.comprehend.model.DocumentReaderConfig;
+import software.amazon.awssdk.services.comprehend.model.InputDataConfig;
+import software.amazon.awssdk.services.comprehend.model.OutputDataConfig;
+import software.amazon.awssdk.services.comprehend.model.StartDocumentClassificationJobRequest;
+import software.amazon.awssdk.services.comprehend.model.Tag;
+import software.amazon.awssdk.services.comprehend.model.VpcConfig;
 
+/**
+ * Submits an async {@code StartDocumentClassificationJob} using the real AWS SDK v2 {@link
+ * ComprehendAsyncClient} -- unlike AWS SDK v1 (where the async client was a subtype of the sync
+ * client, so the pre-migration version of this class could get away with declaring its {@code
+ * call()} parameter as the sync client type), v2's {@code ComprehendAsyncClient} and {@code
+ * ComprehendClient} are unrelated sibling interfaces. The async client returns a {@code
+ * CompletableFuture}; this caller blocks on it (via {@code join()}) to preserve the connector's
+ * existing synchronous calling convention.
+ */
 public class AsyncComprehendCaller
-    implements ComprehendCaller<StartDocumentClassificationJobResult, ComprehendAsyncRequestData> {
+    implements ComprehendCaller<
+        ComprehendAsyncClient, ComprehendAsyncRequestData, ComprehendClassificationJobResult> {
 
   public static final String VPC_CONFIG_EXCEPTION_MSG =
       "Or both VpcConfig fields SecurityGroupIds and Subnets or none";
@@ -34,69 +50,72 @@ public class AsyncComprehendCaller
   private static final int INITIAL_FEATURES_CAPACITY = 2;
 
   @Override
-  public StartDocumentClassificationJobResult call(
-      AmazonComprehendClient client, ComprehendAsyncRequestData asyncRequest) {
+  public ComprehendClassificationJobResult call(
+      ComprehendAsyncClient client, ComprehendAsyncRequestData asyncRequest) {
     LOGGER.debug(
         "Starting async comprehend task for document classification with request data: {}",
         asyncRequest);
-    var docClassificationRequest = new StartDocumentClassificationJobRequest();
+    var requestBuilder = StartDocumentClassificationJobRequest.builder();
 
     if (StringUtils.isNotBlank(asyncRequest.clientRequestToken())) {
-      docClassificationRequest.withClientRequestToken(asyncRequest.clientRequestToken());
+      requestBuilder.clientRequestToken(asyncRequest.clientRequestToken());
     }
 
-    docClassificationRequest.withDataAccessRoleArn(asyncRequest.dataAccessRoleArn());
+    requestBuilder.dataAccessRoleArn(asyncRequest.dataAccessRoleArn());
 
     if (StringUtils.isNotBlank(asyncRequest.documentClassifierArn())) {
-      docClassificationRequest.withDocumentClassifierArn(asyncRequest.documentClassifierArn());
+      requestBuilder.documentClassifierArn(asyncRequest.documentClassifierArn());
     }
 
     if (StringUtils.isNotBlank(asyncRequest.flywheelArn())) {
-      docClassificationRequest.withFlywheelArn(asyncRequest.flywheelArn());
+      requestBuilder.flywheelArn(asyncRequest.flywheelArn());
     }
 
-    docClassificationRequest.withInputDataConfig(prepareInputConfig(asyncRequest));
+    requestBuilder.inputDataConfig(prepareInputConfig(asyncRequest));
 
     if (StringUtils.isNotBlank(asyncRequest.jobName())) {
-      docClassificationRequest.withJobName(asyncRequest.jobName());
+      requestBuilder.jobName(asyncRequest.jobName());
     }
 
-    docClassificationRequest.withOutputDataConfig(prepareOutputDataConf(asyncRequest));
+    requestBuilder.outputDataConfig(prepareOutputDataConf(asyncRequest));
 
     if (asyncRequest.tags() != null && !asyncRequest.tags().isEmpty()) {
-      docClassificationRequest.withTags(prepareTags(asyncRequest));
+      requestBuilder.tags(prepareTags(asyncRequest));
     }
 
     if (StringUtils.isNotBlank(asyncRequest.volumeKmsKeyId())) {
-      docClassificationRequest.withVolumeKmsKeyId(asyncRequest.volumeKmsKeyId());
+      requestBuilder.volumeKmsKeyId(asyncRequest.volumeKmsKeyId());
     }
 
-    docClassificationRequest.withVpcConfig(prepareVpcConfig(asyncRequest));
+    requestBuilder.vpcConfig(prepareVpcConfig(asyncRequest));
 
-    return client.startDocumentClassificationJob(docClassificationRequest);
+    StartDocumentClassificationJobRequest docClassificationRequest = requestBuilder.build();
+
+    return ComprehendClassificationJobResult.from(
+        client.startDocumentClassificationJob(docClassificationRequest).join());
   }
 
   private InputDataConfig prepareInputConfig(ComprehendAsyncRequestData request) {
-    var inputConfig =
-        new InputDataConfig()
-            .withS3Uri(request.inputS3Uri())
-            .withDocumentReaderConfig(prepareDocumentReaderConfig(request));
+    var inputConfigBuilder =
+        InputDataConfig.builder()
+            .s3Uri(request.inputS3Uri())
+            .documentReaderConfig(prepareDocumentReaderConfig(request));
 
     if (request.comprehendInputFormat() != ComprehendInputFormat.NO_DATA) {
-      inputConfig.withInputFormat(request.comprehendInputFormat().name());
+      inputConfigBuilder.inputFormat(request.comprehendInputFormat().name());
     }
 
-    return inputConfig;
+    return inputConfigBuilder.build();
   }
 
   private OutputDataConfig prepareOutputDataConf(ComprehendAsyncRequestData request) {
-    var outputConf = new OutputDataConfig().withS3Uri(request.outputS3Uri());
+    var outputConfBuilder = OutputDataConfig.builder().s3Uri(request.outputS3Uri());
 
     if (StringUtils.isNotBlank(request.outputKmsKeyId())) {
-      outputConf.withKmsKeyId(request.outputKmsKeyId());
+      outputConfBuilder.kmsKeyId(request.outputKmsKeyId());
     }
 
-    return outputConf;
+    return outputConfBuilder.build();
   }
 
   private List<Tag> prepareTags(ComprehendAsyncRequestData request) {
@@ -104,23 +123,27 @@ public class AsyncComprehendCaller
   }
 
   private Tag creatTag(Map.Entry<String, String> entry) {
-    return new Tag().withKey(entry.getKey()).withValue(entry.getValue());
+    return Tag.builder().key(entry.getKey()).value(entry.getValue()).build();
   }
 
   private VpcConfig prepareVpcConfig(ComprehendAsyncRequestData request) {
     List<String> groupIds = request.securityGroupIds();
     List<String> subnets = request.subnets();
 
-    if (CollectionUtils.isNullOrEmpty(groupIds) && CollectionUtils.isNullOrEmpty(subnets)) {
+    if (isNullOrEmpty(groupIds) && isNullOrEmpty(subnets)) {
       return null;
     }
 
-    if (!CollectionUtils.isNullOrEmpty(groupIds) && !CollectionUtils.isNullOrEmpty(subnets)) {
-      return new VpcConfig().withSecurityGroupIds(groupIds).withSubnets(subnets);
+    if (!isNullOrEmpty(groupIds) && !isNullOrEmpty(subnets)) {
+      return VpcConfig.builder().securityGroupIds(groupIds).subnets(subnets).build();
     } else {
       LOGGER.warn(VPC_CONFIG_EXCEPTION_MSG);
       throw new IllegalArgumentException(VPC_CONFIG_EXCEPTION_MSG);
     }
+  }
+
+  private static boolean isNullOrEmpty(List<String> list) {
+    return list == null || list.isEmpty();
   }
 
   private DocumentReaderConfig prepareDocumentReaderConfig(ComprehendAsyncRequestData requestData) {
@@ -128,11 +151,11 @@ public class AsyncComprehendCaller
       return null;
     }
 
-    var documentReaderConfig =
-        new DocumentReaderConfig().withDocumentReadAction(requestData.documentReadAction().name());
+    var documentReaderConfigBuilder =
+        DocumentReaderConfig.builder().documentReadAction(requestData.documentReadAction().name());
 
     if (requestData.documentReadMode() != (ComprehendDocumentReadMode.NO_DATA)) {
-      documentReaderConfig.withDocumentReadMode(requestData.documentReadMode().name());
+      documentReaderConfigBuilder.documentReadMode(requestData.documentReadMode().name());
     }
 
     if (requestData.documentReadAction() == TEXTRACT_ANALYZE_DOCUMENT) {
@@ -141,10 +164,10 @@ public class AsyncComprehendCaller
         LOGGER.warn("DocumentReadAction: TEXTRACT_ANALYZE_DOCUMENT, but features not selected.");
         throw new IllegalArgumentException(READ_ACTION_WITHOUT_FEATURES_EX);
       }
-      documentReaderConfig.withFeatureTypes(features);
+      documentReaderConfigBuilder.featureTypesWithStrings(features);
     }
 
-    return documentReaderConfig;
+    return documentReaderConfigBuilder.build();
   }
 
   private List<String> prepareFeatures(ComprehendAsyncRequestData requestData) {

--- a/connectors/aws/aws-comprehend/src/main/java/io/camunda/connector/comprehend/caller/AsyncComprehendCaller.java
+++ b/connectors/aws/aws-comprehend/src/main/java/io/camunda/connector/comprehend/caller/AsyncComprehendCaller.java
@@ -17,6 +17,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -92,7 +94,24 @@ public class AsyncComprehendCaller
     StartDocumentClassificationJobRequest docClassificationRequest = requestBuilder.build();
 
     return ComprehendClassificationJobResult.from(
-        client.startDocumentClassificationJob(docClassificationRequest).join());
+        joinUnwrapped(client.startDocumentClassificationJob(docClassificationRequest)));
+  }
+
+  /**
+   * Blocks on the async SDK call's future and unwraps {@link CompletionException} so a failing call
+   * surfaces the original AWS SDK exception (e.g. {@code ComprehendException}) to callers, matching
+   * the exception type that the pre-migration (AWS SDK v1) synchronous-call-based async caller
+   * propagated, rather than the future's wrapper exception.
+   */
+  private static <T> T joinUnwrapped(CompletableFuture<T> future) {
+    try {
+      return future.join();
+    } catch (CompletionException e) {
+      if (e.getCause() instanceof RuntimeException runtimeException) {
+        throw runtimeException;
+      }
+      throw e;
+    }
   }
 
   private InputDataConfig prepareInputConfig(ComprehendAsyncRequestData request) {

--- a/connectors/aws/aws-comprehend/src/main/java/io/camunda/connector/comprehend/caller/ComprehendCaller.java
+++ b/connectors/aws/aws-comprehend/src/main/java/io/camunda/connector/comprehend/caller/ComprehendCaller.java
@@ -6,17 +6,21 @@
  */
 package io.camunda.connector.comprehend.caller;
 
-import com.amazonaws.AmazonWebServiceResult;
-import com.amazonaws.ResponseMetadata;
-import com.amazonaws.services.comprehend.AmazonComprehendClient;
 import io.camunda.connector.comprehend.model.ComprehendRequestData;
 
-public interface ComprehendCaller<
-    T extends AmazonWebServiceResult<ResponseMetadata>, R extends ComprehendRequestData> {
+/**
+ * @param <C> the AWS SDK v2 client type this caller invokes -- {@code SyncComprehendCaller} and
+ *     {@code AsyncComprehendCaller} use unrelated client interfaces (unlike AWS SDK v1, where the
+ *     async client was a subtype of the sync one), so the client type is parameterized here rather
+ *     than fixed to a single supertype.
+ * @param <R> the connector request data this caller consumes
+ * @param <T> the connector-owned result this caller returns
+ */
+public interface ComprehendCaller<C, R extends ComprehendRequestData, T> {
 
   String READ_ACTION_WITHOUT_FEATURES_EX =
       "If you chose TEXTRACT_ANALYZE_DOCUMENT as the read action, "
           + "you must specify one feature types";
 
-  T call(AmazonComprehendClient client, R requestData);
+  T call(C client, R requestData);
 }

--- a/connectors/aws/aws-comprehend/src/main/java/io/camunda/connector/comprehend/caller/SyncComprehendCaller.java
+++ b/connectors/aws/aws-comprehend/src/main/java/io/camunda/connector/comprehend/caller/SyncComprehendCaller.java
@@ -6,29 +6,31 @@
  */
 package io.camunda.connector.comprehend.caller;
 
-import com.amazonaws.services.comprehend.AmazonComprehendClient;
-import com.amazonaws.services.comprehend.model.ClassifyDocumentRequest;
-import com.amazonaws.services.comprehend.model.ClassifyDocumentResult;
+import io.camunda.connector.comprehend.ComprehendClassifyResult;
 import io.camunda.connector.comprehend.model.ComprehendSyncRequestData;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.services.comprehend.ComprehendClient;
+import software.amazon.awssdk.services.comprehend.model.ClassifyDocumentRequest;
 
 public class SyncComprehendCaller
-    implements ComprehendCaller<ClassifyDocumentResult, ComprehendSyncRequestData> {
+    implements ComprehendCaller<
+        ComprehendClient, ComprehendSyncRequestData, ComprehendClassifyResult> {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(SyncComprehendCaller.class);
 
   @Override
-  public ClassifyDocumentResult call(
-      AmazonComprehendClient client, ComprehendSyncRequestData requestData) {
+  public ComprehendClassifyResult call(
+      ComprehendClient client, ComprehendSyncRequestData requestData) {
     LOGGER.debug(
         "Starting sync comprehend task for document classification with request data: {}",
         requestData);
     ClassifyDocumentRequest classifyDocumentRequest =
-        new ClassifyDocumentRequest()
-            .withText(requestData.text())
-            .withEndpointArn(requestData.endpointArn());
+        ClassifyDocumentRequest.builder()
+            .text(requestData.text())
+            .endpointArn(requestData.endpointArn())
+            .build();
 
-    return client.classifyDocument(classifyDocumentRequest);
+    return ComprehendClassifyResult.from(client.classifyDocument(classifyDocumentRequest));
   }
 }

--- a/connectors/aws/aws-comprehend/src/main/java/io/camunda/connector/comprehend/supplier/ComprehendClientSupplier.java
+++ b/connectors/aws/aws-comprehend/src/main/java/io/camunda/connector/comprehend/supplier/ComprehendClientSupplier.java
@@ -6,26 +6,19 @@
  */
 package io.camunda.connector.comprehend.supplier;
 
-import com.amazonaws.services.comprehend.AmazonComprehendAsyncClient;
-import com.amazonaws.services.comprehend.AmazonComprehendClient;
-import io.camunda.connector.aws.CredentialsProviderSupport;
+import static io.camunda.connector.aws.AwsClientSupport.createClient;
+
 import io.camunda.connector.comprehend.model.ComprehendRequest;
+import software.amazon.awssdk.services.comprehend.ComprehendAsyncClient;
+import software.amazon.awssdk.services.comprehend.ComprehendClient;
 
 public class ComprehendClientSupplier {
 
-  public AmazonComprehendClient getSyncClient(ComprehendRequest comprehendRequest) {
-    return (AmazonComprehendClient)
-        AmazonComprehendClient.builder()
-            .withCredentials(CredentialsProviderSupport.credentialsProvider(comprehendRequest))
-            .withRegion(comprehendRequest.getConfiguration().region())
-            .build();
+  public ComprehendClient getSyncClient(ComprehendRequest comprehendRequest) {
+    return createClient(ComprehendClient.builder(), comprehendRequest);
   }
 
-  public AmazonComprehendAsyncClient getAsyncClient(ComprehendRequest comprehendRequest) {
-    return (AmazonComprehendAsyncClient)
-        AmazonComprehendAsyncClient.asyncBuilder()
-            .withCredentials(CredentialsProviderSupport.credentialsProvider(comprehendRequest))
-            .withRegion(comprehendRequest.getConfiguration().region())
-            .build();
+  public ComprehendAsyncClient getAsyncClient(ComprehendRequest comprehendRequest) {
+    return createClient(ComprehendAsyncClient.builder(), comprehendRequest);
   }
 }

--- a/connectors/aws/aws-comprehend/src/test/java/io/camunda/connector/comprehend/ComprehendConnectorFunctionTest.java
+++ b/connectors/aws/aws-comprehend/src/test/java/io/camunda/connector/comprehend/ComprehendConnectorFunctionTest.java
@@ -7,6 +7,7 @@
 package io.camunda.connector.comprehend;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
@@ -54,6 +55,22 @@ class ComprehendConnectorFunctionTest {
 
     var result = comprehendConnectorFunction.execute(outBounderContext);
     assertThat(result).isInstanceOf(ComprehendClassifyResult.class);
+    Mockito.verify(syncClient).close();
+  }
+
+  @Test
+  void executeSyncRequestClosesClientWhenCallerThrows() {
+    var outBounderContext = prepareConnectorContext(ComprehendTestUtils.SYNC_EXECUTION_JSON);
+
+    ComprehendClient syncClient = Mockito.mock(ComprehendClient.class);
+    when(syncClient.classifyDocument(any(ClassifyDocumentRequest.class)))
+        .thenThrow(new RuntimeException("boom"));
+
+    when(clientSupplier.getSyncClient(any(ComprehendRequest.class))).thenReturn(syncClient);
+
+    assertThrows(
+        RuntimeException.class, () -> comprehendConnectorFunction.execute(outBounderContext));
+    Mockito.verify(syncClient).close();
   }
 
   @Test
@@ -71,6 +88,23 @@ class ComprehendConnectorFunctionTest {
 
     var result = comprehendConnectorFunction.execute(outBounderContext);
     assertThat(result).isInstanceOf(ComprehendClassificationJobResult.class);
+    Mockito.verify(asyncClient).close();
+  }
+
+  @Test
+  void executeAsyncRequestClosesClientWhenCallerThrows() {
+    var outBounderContext = prepareConnectorContext(ComprehendTestUtils.ASYNC_EXECUTION_JSON);
+
+    ComprehendAsyncClient asyncClient = Mockito.mock(ComprehendAsyncClient.class);
+    when(asyncClient.startDocumentClassificationJob(
+            any(StartDocumentClassificationJobRequest.class)))
+        .thenThrow(new RuntimeException("boom"));
+
+    when(clientSupplier.getAsyncClient(any(ComprehendRequest.class))).thenReturn(asyncClient);
+
+    assertThrows(
+        RuntimeException.class, () -> comprehendConnectorFunction.execute(outBounderContext));
+    Mockito.verify(asyncClient).close();
   }
 
   private OutboundConnectorContextBuilder.TestConnectorContext prepareConnectorContext(

--- a/connectors/aws/aws-comprehend/src/test/java/io/camunda/connector/comprehend/ComprehendConnectorFunctionTest.java
+++ b/connectors/aws/aws-comprehend/src/test/java/io/camunda/connector/comprehend/ComprehendConnectorFunctionTest.java
@@ -10,23 +10,24 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
-import com.amazonaws.services.comprehend.AmazonComprehendAsyncClient;
-import com.amazonaws.services.comprehend.AmazonComprehendClient;
-import com.amazonaws.services.comprehend.model.ClassifyDocumentRequest;
-import com.amazonaws.services.comprehend.model.ClassifyDocumentResult;
-import com.amazonaws.services.comprehend.model.StartDocumentClassificationJobRequest;
-import com.amazonaws.services.comprehend.model.StartDocumentClassificationJobResult;
 import io.camunda.connector.comprehend.caller.AsyncComprehendCaller;
 import io.camunda.connector.comprehend.caller.SyncComprehendCaller;
 import io.camunda.connector.comprehend.model.ComprehendRequest;
 import io.camunda.connector.comprehend.supplier.ComprehendClientSupplier;
 import io.camunda.connector.runtime.test.outbound.OutboundConnectorContextBuilder;
+import java.util.concurrent.CompletableFuture;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.services.comprehend.ComprehendAsyncClient;
+import software.amazon.awssdk.services.comprehend.ComprehendClient;
+import software.amazon.awssdk.services.comprehend.model.ClassifyDocumentRequest;
+import software.amazon.awssdk.services.comprehend.model.ClassifyDocumentResponse;
+import software.amazon.awssdk.services.comprehend.model.StartDocumentClassificationJobRequest;
+import software.amazon.awssdk.services.comprehend.model.StartDocumentClassificationJobResponse;
 
 @ExtendWith(MockitoExtension.class)
 class ComprehendConnectorFunctionTest {
@@ -45,29 +46,31 @@ class ComprehendConnectorFunctionTest {
   void executeSyncRequest() {
     var outBounderContext = prepareConnectorContext(ComprehendTestUtils.SYNC_EXECUTION_JSON);
 
-    AmazonComprehendClient syncClient = Mockito.mock(AmazonComprehendClient.class);
+    ComprehendClient syncClient = Mockito.mock(ComprehendClient.class);
     when(syncClient.classifyDocument(any(ClassifyDocumentRequest.class)))
-        .thenReturn(new ClassifyDocumentResult());
+        .thenReturn(ClassifyDocumentResponse.builder().build());
 
     when(clientSupplier.getSyncClient(any(ComprehendRequest.class))).thenReturn(syncClient);
 
     var result = comprehendConnectorFunction.execute(outBounderContext);
-    assertThat(result).isInstanceOf(ClassifyDocumentResult.class);
+    assertThat(result).isInstanceOf(ComprehendClassifyResult.class);
   }
 
   @Test
   void executeAsyncRequest() {
     var outBounderContext = prepareConnectorContext(ComprehendTestUtils.ASYNC_EXECUTION_JSON);
 
-    AmazonComprehendAsyncClient asyncClient = Mockito.mock(AmazonComprehendAsyncClient.class);
+    ComprehendAsyncClient asyncClient = Mockito.mock(ComprehendAsyncClient.class);
     when(asyncClient.startDocumentClassificationJob(
             any(StartDocumentClassificationJobRequest.class)))
-        .thenReturn(new StartDocumentClassificationJobResult());
+        .thenReturn(
+            CompletableFuture.completedFuture(
+                StartDocumentClassificationJobResponse.builder().build()));
 
     when(clientSupplier.getAsyncClient(any(ComprehendRequest.class))).thenReturn(asyncClient);
 
     var result = comprehendConnectorFunction.execute(outBounderContext);
-    assertThat(result).isInstanceOf(StartDocumentClassificationJobResult.class);
+    assertThat(result).isInstanceOf(ComprehendClassificationJobResult.class);
   }
 
   private OutboundConnectorContextBuilder.TestConnectorContext prepareConnectorContext(

--- a/connectors/aws/aws-comprehend/src/test/java/io/camunda/connector/comprehend/ComprehendResultJsonShapeTest.java
+++ b/connectors/aws/aws-comprehend/src/test/java/io/camunda/connector/comprehend/ComprehendResultJsonShapeTest.java
@@ -11,19 +11,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import com.amazonaws.ResponseMetadata;
-import com.amazonaws.http.SdkHttpMetadata;
-import com.amazonaws.services.comprehend.AmazonComprehendAsyncClient;
-import com.amazonaws.services.comprehend.AmazonComprehendClient;
-import com.amazonaws.services.comprehend.model.ClassifyDocumentRequest;
-import com.amazonaws.services.comprehend.model.ClassifyDocumentResult;
-import com.amazonaws.services.comprehend.model.DocumentClass;
-import com.amazonaws.services.comprehend.model.DocumentMetadata;
-import com.amazonaws.services.comprehend.model.DocumentTypeListItem;
-import com.amazonaws.services.comprehend.model.ExtractedCharactersListItem;
-import com.amazonaws.services.comprehend.model.StartDocumentClassificationJobRequest;
-import com.amazonaws.services.comprehend.model.StartDocumentClassificationJobResult;
-import com.amazonaws.services.comprehend.model.WarningsListItem;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -35,23 +22,38 @@ import io.camunda.connector.comprehend.model.ComprehendDocumentReadMode;
 import io.camunda.connector.comprehend.model.ComprehendInputFormat;
 import io.camunda.connector.comprehend.model.ComprehendSyncRequestData;
 import io.camunda.connector.jackson.ConnectorsObjectMapperSupplier;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.awscore.DefaultAwsResponseMetadata;
+import software.amazon.awssdk.http.SdkHttpResponse;
+import software.amazon.awssdk.services.comprehend.ComprehendAsyncClient;
+import software.amazon.awssdk.services.comprehend.ComprehendClient;
+import software.amazon.awssdk.services.comprehend.model.ClassifyDocumentRequest;
+import software.amazon.awssdk.services.comprehend.model.ClassifyDocumentResponse;
+import software.amazon.awssdk.services.comprehend.model.DocumentClass;
+import software.amazon.awssdk.services.comprehend.model.DocumentMetadata;
+import software.amazon.awssdk.services.comprehend.model.DocumentTypeListItem;
+import software.amazon.awssdk.services.comprehend.model.ErrorsListItem;
+import software.amazon.awssdk.services.comprehend.model.ExtractedCharactersListItem;
+import software.amazon.awssdk.services.comprehend.model.StartDocumentClassificationJobRequest;
+import software.amazon.awssdk.services.comprehend.model.StartDocumentClassificationJobResponse;
+import software.amazon.awssdk.services.comprehend.model.WarningsListItem;
 
 /**
  * Golden-JSON shape tests for the AWS Comprehend connector's outbound result.
  *
- * <p>{@link ComprehendConnectorFunction} returns the raw AWS SDK v1 result objects ({@link
- * ClassifyDocumentResult}, {@link StartDocumentClassificationJobResult}) directly as the process
- * variable payload -- there is no connector-owned result-mapping class. Both are {@code
- * AmazonWebServiceResult} subclasses that expose plain JavaBean getters (unlike the AWS SDK v2
- * model classes, which use fluent accessors), so they serialize fine today under the production
- * {@code ObjectMapper} (which disables {@code FAIL_ON_EMPTY_BEANS}). These tests pin that exact v1
- * JSON shape -- including the {@code sdkResponseMetadata}/{@code sdkHttpMetadata} keys inherited
- * from {@code AmazonWebServiceResult} and all explicit nulls -- as the contract the upcoming AWS
- * SDK v2 migration must reproduce unchanged.
+ * <p>{@link ComprehendConnectorFunction} used to return the raw AWS SDK v1 result objects ({@code
+ * ClassifyDocumentResult}, {@code StartDocumentClassificationJobResult}) directly as the process
+ * variable payload. AWS SDK v2's model classes ({@link ClassifyDocumentResponse}, {@link
+ * StartDocumentClassificationJobResponse}) expose fluent accessors instead of JavaBean getters, so
+ * serializing them directly with the connectors' {@code ObjectMapper} (which disables {@code
+ * FAIL_ON_EMPTY_BEANS}) would silently produce {@code {}}. {@link ComprehendClassifyResult} and
+ * {@link ComprehendClassificationJobResult} map the v2 responses back into connector-owned DTOs.
+ * These tests pin the exact v1 JSON shape -- including the {@code sdkResponseMetadata}/{@code
+ * sdkHttpMetadata} keys and all explicit nulls -- as the contract the AWS SDK v2 migration must
+ * reproduce unchanged.
  */
 class ComprehendResultJsonShapeTest {
 
@@ -60,7 +62,7 @@ class ComprehendResultJsonShapeTest {
   private final AsyncComprehendCaller asyncCaller = new AsyncComprehendCaller();
 
   /**
-   * Sync classify: a fully populated {@link ClassifyDocumentResult} as returned by a live,
+   * Sync classify: a fully populated {@link ClassifyDocumentResponse} as returned by a live,
    * multi-page {@code ClassifyDocument} call against a TEXTRACT-backed custom classifier -- classes
    * (name/score/page), document metadata, document type, warnings, an explicitly empty errors list,
    * and populated SDK response/HTTP metadata.
@@ -68,51 +70,51 @@ class ComprehendResultJsonShapeTest {
   @Test
   void classifyDocumentResult_populated_serializesToDocumentedV1JsonShape()
       throws JsonProcessingException {
-    // Given a fully populated ClassifyDocumentResult, as returned by a live ClassifyDocument call
-    var result =
-        new ClassifyDocumentResult()
-            .withClasses(
-                new DocumentClass().withName("POSITIVE").withScore(0.987654f).withPage(1),
-                new DocumentClass().withName("NEGATIVE").withScore(0.012346f).withPage(1))
-            .withDocumentMetadata(
-                new DocumentMetadata()
-                    .withPages(2)
-                    .withExtractedCharacters(
-                        new ExtractedCharactersListItem().withPage(1).withCount(1200),
-                        new ExtractedCharactersListItem().withPage(2).withCount(980)))
-            .withDocumentType(new DocumentTypeListItem().withPage(1).withType("NATIVE_PDF"))
-            .withErrors()
-            .withWarnings(
-                new WarningsListItem()
-                    .withPage(2)
-                    .withWarnCode("INFERENCING_PLAINTEXT_WITH_NATIVE_TRAINED_MODEL")
-                    .withWarnMessage(
+    // Given a fully populated ClassifyDocumentResponse, as returned by a live ClassifyDocument call
+    var responseBuilder =
+        ClassifyDocumentResponse.builder()
+            .classes(
+                DocumentClass.builder().name("POSITIVE").score(0.987654f).page(1).build(),
+                DocumentClass.builder().name("NEGATIVE").score(0.012346f).page(1).build())
+            .documentMetadata(
+                DocumentMetadata.builder()
+                    .pages(2)
+                    .extractedCharacters(
+                        ExtractedCharactersListItem.builder().page(1).count(1200).build(),
+                        ExtractedCharactersListItem.builder().page(2).count(980).build())
+                    .build())
+            .documentType(DocumentTypeListItem.builder().page(1).type("NATIVE_PDF").build())
+            .errors(List.<ErrorsListItem>of())
+            .warnings(
+                WarningsListItem.builder()
+                    .page(2)
+                    .warnCode("INFERENCING_PLAINTEXT_WITH_NATIVE_TRAINED_MODEL")
+                    .warnMessage(
                         "The document was submitted as plain text but the model was trained on"
-                            + " native documents."));
-    result.setSdkResponseMetadata(
-        new ResponseMetadata(Map.of(ResponseMetadata.AWS_REQUEST_ID, REQUEST_ID)));
-    result.setSdkHttpMetadata(populatedHttpMetadata());
+                            + " native documents.")
+                    .build());
+    responseBuilder.responseMetadata(
+        DefaultAwsResponseMetadata.create(Map.of("AWS_REQUEST_ID", REQUEST_ID)));
+    responseBuilder.sdkHttpResponse(
+        SdkHttpResponse.builder()
+            .statusCode(200)
+            .putHeader("Content-Length", "85")
+            .putHeader("Content-Type", "application/x-amz-json-1.1")
+            .putHeader("x-amzn-RequestId", REQUEST_ID)
+            .build());
+    ClassifyDocumentResponse response = responseBuilder.build();
 
-    AmazonComprehendClient client = mock(AmazonComprehendClient.class);
-    when(client.classifyDocument(any(ClassifyDocumentRequest.class))).thenReturn(result);
+    ComprehendClient client = mock(ComprehendClient.class);
+    when(client.classifyDocument(any(ClassifyDocumentRequest.class))).thenReturn(response);
 
-    // When the caller returns the client's response, unmodified, as the connector does today
-    ClassifyDocumentResult actualResult =
+    // When the caller maps the client's response through the connector-owned result DTO
+    ComprehendClassifyResult actualResult =
         syncCaller.call(client, new ComprehendSyncRequestData("plain text", "endpoint-arn"));
 
     // Then the JSON produced by the production mapper matches the documented v1 shape exactly,
     // including explicit nulls (labels is null: a multi-class classifier response never populates
     // the multi-label "labels" field).
-    // Parsed from the mapper's own serialized string (not valueToTree) so that numeric node types
-    // match the expected side exactly -- valueToTree would keep the Float DocumentClass#score as
-    // a FloatNode, which JsonNode#equals treats as unequal to the DoubleNode produced by parsing
-    // the JSON text below, even when the numeric value is identical.
     JsonNode actual = productionMapper.readTree(productionMapper.writeValueAsString(actualResult));
-    // Property order below is NOT alphabetical or declaration order: it is whatever the
-    // production mapper's default bean introspection produces for this class today (the
-    // AmazonWebServiceResult-inherited sdkResponseMetadata/sdkHttpMetadata surface first, ahead of
-    // this class's own fields, since there is no @JsonPropertyOrder on the AWS SDK v1 model
-    // classes). This is intentional v1 behavior being pinned for the migration.
     String expectedJson =
         """
         {
@@ -158,34 +160,32 @@ class ComprehendResultJsonShapeTest {
     JsonNode expected = productionMapper.readTree(expectedJson);
     assertThat(actual).isEqualTo(expected);
     // Tree equality above is key-order-insensitive; also pin the serialized field order to the
-    // one the production mapper produces today (default bean-introspection order; there is no
-    // @JsonPropertyOrder on the AWS SDK v1 model classes).
+    // documented v1 layout (enforced here via @JsonPropertyOrder on the connector-owned DTOs).
     assertThat(productionMapper.writeValueAsString(actualResult))
         .isEqualTo(productionMapper.writeValueAsString(expected));
   }
 
   /**
-   * Sync classify: the empty/minimal {@link ClassifyDocumentResult} a mocked (or genuinely
-   * near-empty) response yields -- every field, including the inherited SDK metadata, is null. This
-   * is also exactly what {@code new ClassifyDocumentResult()} produces, as already exercised by
-   * {@code SyncComprehendCallerTest} and {@code ComprehendConnectorFunctionTest}.
+   * Sync classify: the empty/minimal {@link ClassifyDocumentResponse} a mocked (or genuinely
+   * near-empty) response yields -- every field, including the inherited SDK metadata, is null.
    */
   @Test
   void classifyDocumentResult_empty_serializesToDocumentedV1JsonShape()
       throws JsonProcessingException {
-    // Given a minimal/empty ClassifyDocumentResult (no field populated)
-    var result = new ClassifyDocumentResult();
+    // Given a minimal/empty ClassifyDocumentResponse (no field populated)
+    var result = ClassifyDocumentResponse.builder().build();
 
-    AmazonComprehendClient client = mock(AmazonComprehendClient.class);
+    ComprehendClient client = mock(ComprehendClient.class);
     when(client.classifyDocument(any(ClassifyDocumentRequest.class))).thenReturn(result);
 
-    // When the caller returns the client's response, unmodified, as the connector does today
-    ClassifyDocumentResult actualResult =
+    // When the caller maps the client's response through the connector-owned result DTO
+    ComprehendClassifyResult actualResult =
         syncCaller.call(client, new ComprehendSyncRequestData("plain text", "endpoint-arn"));
 
-    // Then every field -- including the two AmazonWebServiceResult-inherited SDK metadata keys --
-    // is serialized as an explicit null (the production mapper disables FAIL_ON_EMPTY_BEANS, so
-    // this does not collapse to "{}").
+    // Then every field -- including the two SDK metadata keys -- is serialized as an explicit
+    // null (the production mapper disables FAIL_ON_EMPTY_BEANS, so this does not collapse to
+    // "{}"), and unset v2 list fields (which never surface as Java null, only as hasXxx()==false)
+    // are normalized back to null to match the pre-v2 shape.
     JsonNode actual = productionMapper.readTree(productionMapper.writeValueAsString(actualResult));
     String expectedJson =
         """
@@ -207,31 +207,32 @@ class ComprehendResultJsonShapeTest {
   }
 
   /**
-   * Async job-start: a populated {@link StartDocumentClassificationJobResult} as returned by a live
-   * {@code StartDocumentClassificationJob} call (job accepted and submitted).
+   * Async job-start: a populated {@link StartDocumentClassificationJobResponse} as returned by a
+   * live {@code StartDocumentClassificationJob} call (job accepted and submitted).
    */
   @Test
   void startDocumentClassificationJobResult_serializesToDocumentedV1JsonShape()
       throws JsonProcessingException {
-    // Given a populated StartDocumentClassificationJobResult, as returned by a live
+    // Given a populated StartDocumentClassificationJobResponse, as returned by a live
     // StartDocumentClassificationJob call
-    var result =
-        new StartDocumentClassificationJobResult()
-            .withJobId("12345678-1234-1234-1234-123456789012")
-            .withJobArn(
+    var responseBuilder =
+        StartDocumentClassificationJobResponse.builder()
+            .jobId("12345678-1234-1234-1234-123456789012")
+            .jobArn(
                 "arn:aws:comprehend:eu-central-1:123456789012:document-classification-job/12345678-1234-1234-1234-123456789012")
-            .withJobStatus("SUBMITTED")
-            .withDocumentClassifierArn(
+            .jobStatus("SUBMITTED")
+            .documentClassifierArn(
                 "arn:aws:comprehend:eu-central-1:123456789012:document-classifier/my-classifier");
-    result.setSdkResponseMetadata(
-        new ResponseMetadata(Map.of(ResponseMetadata.AWS_REQUEST_ID, REQUEST_ID)));
+    responseBuilder.responseMetadata(
+        DefaultAwsResponseMetadata.create(Map.of("AWS_REQUEST_ID", REQUEST_ID)));
+    StartDocumentClassificationJobResponse response = responseBuilder.build();
 
-    AmazonComprehendAsyncClient client = mock(AmazonComprehendAsyncClient.class);
+    ComprehendAsyncClient client = mock(ComprehendAsyncClient.class);
     when(client.startDocumentClassificationJob(any(StartDocumentClassificationJobRequest.class)))
-        .thenReturn(result);
+        .thenReturn(CompletableFuture.completedFuture(response));
 
-    // When the caller returns the client's response, unmodified, as the connector does today
-    StartDocumentClassificationJobResult actualResult =
+    // When the caller maps the client's response through the connector-owned result DTO
+    ComprehendClassificationJobResult actualResult =
         asyncCaller.call(client, minimalAsyncRequest());
 
     // Then the JSON produced by the production mapper matches the documented v1 shape exactly.
@@ -258,32 +259,6 @@ class ComprehendResultJsonShapeTest {
   }
 
   private static final String REQUEST_ID = "929bf054-193b-48e6-ab80-3aeeb613b415";
-
-  /**
-   * Builds the {@link SdkHttpMetadata} a real ClassifyDocument call's HTTP response carries.
-   *
-   * <p>{@code SdkHttpMetadata} only exposes a private constructor plus the static {@code
-   * from(HttpResponse)} factory, and building a real {@code HttpResponse} would drag in {@code
-   * org.apache.httpcomponents:httpclient} as a new direct test dependency just to construct a data
-   * holder. A stubbed mock is equivalent from the production mapper's point of view: it only ever
-   * calls the three getters below via bean introspection.
-   */
-  private static SdkHttpMetadata populatedHttpMetadata() {
-    Map<String, String> httpHeaders = new LinkedHashMap<>();
-    httpHeaders.put("Content-Length", "85");
-    httpHeaders.put("Content-Type", "application/x-amz-json-1.1");
-    httpHeaders.put("x-amzn-RequestId", REQUEST_ID);
-    Map<String, List<String>> allHttpHeaders = new LinkedHashMap<>();
-    allHttpHeaders.put("Content-Length", List.of("85"));
-    allHttpHeaders.put("Content-Type", List.of("application/x-amz-json-1.1"));
-    allHttpHeaders.put("x-amzn-RequestId", List.of(REQUEST_ID));
-
-    SdkHttpMetadata httpMetadata = mock(SdkHttpMetadata.class);
-    when(httpMetadata.getHttpHeaders()).thenReturn(httpHeaders);
-    when(httpMetadata.getAllHttpHeaders()).thenReturn(allHttpHeaders);
-    when(httpMetadata.getHttpStatusCode()).thenReturn(200);
-    return httpMetadata;
-  }
 
   private static ComprehendAsyncRequestData minimalAsyncRequest() {
     return new ComprehendAsyncRequestData(

--- a/connectors/aws/aws-comprehend/src/test/java/io/camunda/connector/comprehend/caller/AsyncComprehendCallerTest.java
+++ b/connectors/aws/aws-comprehend/src/test/java/io/camunda/connector/comprehend/caller/AsyncComprehendCallerTest.java
@@ -9,19 +9,27 @@ package io.camunda.connector.comprehend.caller;
 import static io.camunda.connector.comprehend.caller.ComprehendCaller.READ_ACTION_WITHOUT_FEATURES_EX;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.amazonaws.services.comprehend.AmazonComprehendClient;
-import com.amazonaws.services.comprehend.model.*;
 import io.camunda.connector.comprehend.model.ComprehendAsyncRequestData;
 import io.camunda.connector.comprehend.model.ComprehendDocumentReadAction;
 import io.camunda.connector.comprehend.model.ComprehendDocumentReadMode;
 import io.camunda.connector.comprehend.model.ComprehendInputFormat;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
+import software.amazon.awssdk.services.comprehend.ComprehendAsyncClient;
+import software.amazon.awssdk.services.comprehend.model.DocumentReadFeatureTypes;
+import software.amazon.awssdk.services.comprehend.model.DocumentReaderConfig;
+import software.amazon.awssdk.services.comprehend.model.InputDataConfig;
+import software.amazon.awssdk.services.comprehend.model.OutputDataConfig;
+import software.amazon.awssdk.services.comprehend.model.StartDocumentClassificationJobRequest;
+import software.amazon.awssdk.services.comprehend.model.StartDocumentClassificationJobResponse;
+import software.amazon.awssdk.services.comprehend.model.Tag;
+import software.amazon.awssdk.services.comprehend.model.VpcConfig;
 
 class AsyncComprehendCallerTest {
 
@@ -37,41 +45,49 @@ class AsyncComprehendCallerTest {
             true);
 
     var docClassificationRequest =
-        new StartDocumentClassificationJobRequest()
-            .withClientRequestToken(asyncRequest.clientRequestToken())
-            .withDataAccessRoleArn(asyncRequest.dataAccessRoleArn())
-            .withDocumentClassifierArn(asyncRequest.documentClassifierArn())
-            .withFlywheelArn(asyncRequest.flywheelArn())
-            .withInputDataConfig(
-                new InputDataConfig()
-                    .withS3Uri(asyncRequest.inputS3Uri())
-                    .withDocumentReaderConfig(
-                        new DocumentReaderConfig()
-                            .withDocumentReadAction(asyncRequest.documentReadAction().name())
-                            .withDocumentReadMode(asyncRequest.documentReadMode().name())
-                            .withFeatureTypes(
+        StartDocumentClassificationJobRequest.builder()
+            .clientRequestToken(asyncRequest.clientRequestToken())
+            .dataAccessRoleArn(asyncRequest.dataAccessRoleArn())
+            .documentClassifierArn(asyncRequest.documentClassifierArn())
+            .flywheelArn(asyncRequest.flywheelArn())
+            .inputDataConfig(
+                InputDataConfig.builder()
+                    .s3Uri(asyncRequest.inputS3Uri())
+                    .documentReaderConfig(
+                        DocumentReaderConfig.builder()
+                            .documentReadAction(asyncRequest.documentReadAction().name())
+                            .documentReadMode(asyncRequest.documentReadMode().name())
+                            .featureTypesWithStrings(
                                 List.of(
                                     DocumentReadFeatureTypes.FORMS.name(),
-                                    DocumentReadFeatureTypes.TABLES.name())))
-                    .withInputFormat(asyncRequest.comprehendInputFormat().name()))
-            .withJobName(asyncRequest.jobName())
-            .withOutputDataConfig(
-                new OutputDataConfig()
-                    .withS3Uri(asyncRequest.outputS3Uri())
-                    .withKmsKeyId(asyncRequest.outputKmsKeyId()))
-            .withTags(
-                List.of(
-                    new Tag()
-                        .withKey(asyncRequest.tags().keySet().stream().findFirst().get())
-                        .withValue(asyncRequest.tags().values().stream().findFirst().get())))
-            .withVolumeKmsKeyId(asyncRequest.volumeKmsKeyId())
-            .withVpcConfig(
-                new VpcConfig()
-                    .withSecurityGroupIds(asyncRequest.securityGroupIds())
-                    .withSubnets(asyncRequest.subnets()));
-    var client = Mockito.mock(AmazonComprehendClient.class);
+                                    DocumentReadFeatureTypes.TABLES.name()))
+                            .build())
+                    .inputFormat(asyncRequest.comprehendInputFormat().name())
+                    .build())
+            .jobName(asyncRequest.jobName())
+            .outputDataConfig(
+                OutputDataConfig.builder()
+                    .s3Uri(asyncRequest.outputS3Uri())
+                    .kmsKeyId(asyncRequest.outputKmsKeyId())
+                    .build())
+            .tags(
+                Tag.builder()
+                    .key(asyncRequest.tags().keySet().stream().findFirst().get())
+                    .value(asyncRequest.tags().values().stream().findFirst().get())
+                    .build())
+            .volumeKmsKeyId(asyncRequest.volumeKmsKeyId())
+            .vpcConfig(
+                VpcConfig.builder()
+                    .securityGroupIds(asyncRequest.securityGroupIds())
+                    .subnets(asyncRequest.subnets())
+                    .build())
+            .build();
+    var client = mock(ComprehendAsyncClient.class);
 
-    when(client.startDocumentClassificationJob(docClassificationRequest)).thenReturn(null);
+    when(client.startDocumentClassificationJob(docClassificationRequest))
+        .thenReturn(
+            CompletableFuture.completedFuture(
+                StartDocumentClassificationJobResponse.builder().build()));
     asyncCaller.call(client, asyncRequest);
 
     verify(client).startDocumentClassificationJob(docClassificationRequest);
@@ -84,33 +100,40 @@ class AsyncComprehendCallerTest {
             ComprehendDocumentReadMode.NO_DATA, ComprehendDocumentReadAction.NO_DATA, false, false);
 
     var docClassificationRequest =
-        new StartDocumentClassificationJobRequest()
-            .withClientRequestToken(asyncRequest.clientRequestToken())
-            .withDataAccessRoleArn(asyncRequest.dataAccessRoleArn())
-            .withDocumentClassifierArn(asyncRequest.documentClassifierArn())
-            .withFlywheelArn(asyncRequest.flywheelArn())
-            .withInputDataConfig(
-                new InputDataConfig()
-                    .withS3Uri(asyncRequest.inputS3Uri())
-                    .withInputFormat(asyncRequest.comprehendInputFormat().name()))
-            .withJobName(asyncRequest.jobName())
-            .withOutputDataConfig(
-                new OutputDataConfig()
-                    .withS3Uri(asyncRequest.outputS3Uri())
-                    .withKmsKeyId(asyncRequest.outputKmsKeyId()))
-            .withTags(
-                List.of(
-                    new Tag()
-                        .withKey(asyncRequest.tags().keySet().stream().findFirst().get())
-                        .withValue(asyncRequest.tags().values().stream().findFirst().get())))
-            .withVolumeKmsKeyId(asyncRequest.volumeKmsKeyId())
-            .withVpcConfig(
-                new VpcConfig()
-                    .withSecurityGroupIds(asyncRequest.securityGroupIds())
-                    .withSubnets(asyncRequest.subnets()));
-    var client = Mockito.mock(AmazonComprehendClient.class);
+        StartDocumentClassificationJobRequest.builder()
+            .clientRequestToken(asyncRequest.clientRequestToken())
+            .dataAccessRoleArn(asyncRequest.dataAccessRoleArn())
+            .documentClassifierArn(asyncRequest.documentClassifierArn())
+            .flywheelArn(asyncRequest.flywheelArn())
+            .inputDataConfig(
+                InputDataConfig.builder()
+                    .s3Uri(asyncRequest.inputS3Uri())
+                    .inputFormat(asyncRequest.comprehendInputFormat().name())
+                    .build())
+            .jobName(asyncRequest.jobName())
+            .outputDataConfig(
+                OutputDataConfig.builder()
+                    .s3Uri(asyncRequest.outputS3Uri())
+                    .kmsKeyId(asyncRequest.outputKmsKeyId())
+                    .build())
+            .tags(
+                Tag.builder()
+                    .key(asyncRequest.tags().keySet().stream().findFirst().get())
+                    .value(asyncRequest.tags().values().stream().findFirst().get())
+                    .build())
+            .volumeKmsKeyId(asyncRequest.volumeKmsKeyId())
+            .vpcConfig(
+                VpcConfig.builder()
+                    .securityGroupIds(asyncRequest.securityGroupIds())
+                    .subnets(asyncRequest.subnets())
+                    .build())
+            .build();
+    var client = mock(ComprehendAsyncClient.class);
 
-    when(client.startDocumentClassificationJob(docClassificationRequest)).thenReturn(null);
+    when(client.startDocumentClassificationJob(docClassificationRequest))
+        .thenReturn(
+            CompletableFuture.completedFuture(
+                StartDocumentClassificationJobResponse.builder().build()));
     asyncCaller.call(client, asyncRequest);
 
     verify(client).startDocumentClassificationJob(docClassificationRequest);
@@ -139,14 +162,18 @@ class AsyncComprehendCallerTest {
             List.of());
 
     var docClassificationRequest =
-        new StartDocumentClassificationJobRequest()
-            .withDataAccessRoleArn(asyncRequest.dataAccessRoleArn())
-            .withDocumentClassifierArn(asyncRequest.documentClassifierArn())
-            .withInputDataConfig(new InputDataConfig().withS3Uri(asyncRequest.inputS3Uri()))
-            .withOutputDataConfig(new OutputDataConfig().withS3Uri(asyncRequest.outputS3Uri()));
+        StartDocumentClassificationJobRequest.builder()
+            .dataAccessRoleArn(asyncRequest.dataAccessRoleArn())
+            .documentClassifierArn(asyncRequest.documentClassifierArn())
+            .inputDataConfig(InputDataConfig.builder().s3Uri(asyncRequest.inputS3Uri()).build())
+            .outputDataConfig(OutputDataConfig.builder().s3Uri(asyncRequest.outputS3Uri()).build())
+            .build();
 
-    var client = Mockito.mock(AmazonComprehendClient.class);
-    when(client.startDocumentClassificationJob(docClassificationRequest)).thenReturn(null);
+    var client = mock(ComprehendAsyncClient.class);
+    when(client.startDocumentClassificationJob(docClassificationRequest))
+        .thenReturn(
+            CompletableFuture.completedFuture(
+                StartDocumentClassificationJobResponse.builder().build()));
     asyncCaller.call(client, asyncRequest);
 
     verify(client).startDocumentClassificationJob(docClassificationRequest);
@@ -160,7 +187,7 @@ class AsyncComprehendCallerTest {
             ComprehendDocumentReadAction.TEXTRACT_ANALYZE_DOCUMENT,
             false,
             false);
-    var client = Mockito.mock(AmazonComprehendClient.class);
+    var client = mock(ComprehendAsyncClient.class);
 
     Exception ex =
         assertThrows(IllegalArgumentException.class, () -> asyncCaller.call(client, asyncRequest));
@@ -189,7 +216,7 @@ class AsyncComprehendCallerTest {
             List.of("seg-1"),
             List.of());
 
-    AmazonComprehendClient asyncClient = Mockito.mock(AmazonComprehendClient.class);
+    ComprehendAsyncClient asyncClient = mock(ComprehendAsyncClient.class);
 
     Exception ex =
         assertThrows(

--- a/connectors/aws/aws-comprehend/src/test/java/io/camunda/connector/comprehend/caller/AsyncComprehendCallerTest.java
+++ b/connectors/aws/aws-comprehend/src/test/java/io/camunda/connector/comprehend/caller/AsyncComprehendCallerTest.java
@@ -9,6 +9,7 @@ package io.camunda.connector.comprehend.caller;
 import static io.camunda.connector.comprehend.caller.ComprehendCaller.READ_ACTION_WITHOUT_FEATURES_EX;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -22,6 +23,7 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.services.comprehend.ComprehendAsyncClient;
+import software.amazon.awssdk.services.comprehend.model.ComprehendException;
 import software.amazon.awssdk.services.comprehend.model.DocumentReadFeatureTypes;
 import software.amazon.awssdk.services.comprehend.model.DocumentReaderConfig;
 import software.amazon.awssdk.services.comprehend.model.InputDataConfig;
@@ -192,6 +194,27 @@ class AsyncComprehendCallerTest {
     Exception ex =
         assertThrows(IllegalArgumentException.class, () -> asyncCaller.call(client, asyncRequest));
     assertThat(ex.getMessage()).isEqualTo(READ_ACTION_WITHOUT_FEATURES_EX);
+  }
+
+  @Test
+  void callUnwrapsCompletionExceptionToPropagateOriginalAwsException() {
+    var asyncRequest =
+        prepareAsyncRequest(
+            ComprehendDocumentReadMode.SERVICE_DEFAULT,
+            ComprehendDocumentReadAction.TEXTRACT_ANALYZE_DOCUMENT,
+            true,
+            true);
+    var client = mock(ComprehendAsyncClient.class);
+    var awsException = ComprehendException.builder().message("boom").build();
+    var failedFuture = new CompletableFuture<StartDocumentClassificationJobResponse>();
+    failedFuture.completeExceptionally(awsException);
+
+    when(client.startDocumentClassificationJob(any(StartDocumentClassificationJobRequest.class)))
+        .thenReturn(failedFuture);
+
+    Exception ex =
+        assertThrows(ComprehendException.class, () -> asyncCaller.call(client, asyncRequest));
+    assertThat(ex).isSameAs(awsException);
   }
 
   @Test

--- a/connectors/aws/aws-comprehend/src/test/java/io/camunda/connector/comprehend/caller/SyncComprehendCallerTest.java
+++ b/connectors/aws/aws-comprehend/src/test/java/io/camunda/connector/comprehend/caller/SyncComprehendCallerTest.java
@@ -9,12 +9,12 @@ package io.camunda.connector.comprehend.caller;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.amazonaws.services.comprehend.AmazonComprehendClient;
-import com.amazonaws.services.comprehend.model.ClassifyDocumentRequest;
-import com.amazonaws.services.comprehend.model.ClassifyDocumentResult;
 import io.camunda.connector.comprehend.model.ComprehendSyncRequestData;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
+import software.amazon.awssdk.services.comprehend.ComprehendClient;
+import software.amazon.awssdk.services.comprehend.model.ClassifyDocumentRequest;
+import software.amazon.awssdk.services.comprehend.model.ClassifyDocumentResponse;
 
 class SyncComprehendCallerTest {
 
@@ -25,13 +25,14 @@ class SyncComprehendCallerTest {
     var syncRequest = new ComprehendSyncRequestData("text", "arn::");
 
     var expectedClassifyDocumentRequest =
-        new ClassifyDocumentRequest()
-            .withText(syncRequest.text())
-            .withEndpointArn(syncRequest.endpointArn());
+        ClassifyDocumentRequest.builder()
+            .text(syncRequest.text())
+            .endpointArn(syncRequest.endpointArn())
+            .build();
 
-    AmazonComprehendClient syncClient = Mockito.mock(AmazonComprehendClient.class);
+    ComprehendClient syncClient = Mockito.mock(ComprehendClient.class);
     when(syncClient.classifyDocument(expectedClassifyDocumentRequest))
-        .thenReturn(new ClassifyDocumentResult());
+        .thenReturn(ClassifyDocumentResponse.builder().build());
 
     syncCaller.call(syncClient, syncRequest);
 

--- a/connectors/aws/aws-comprehend/src/test/java/io/camunda/connector/comprehend/supplier/ComprehendClientSupplierTest.java
+++ b/connectors/aws/aws-comprehend/src/test/java/io/camunda/connector/comprehend/supplier/ComprehendClientSupplierTest.java
@@ -8,12 +8,12 @@ package io.camunda.connector.comprehend.supplier;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.amazonaws.services.comprehend.AmazonComprehendAsyncClient;
-import com.amazonaws.services.comprehend.AmazonComprehendClient;
 import io.camunda.connector.aws.model.impl.AwsBaseConfiguration;
 import io.camunda.connector.comprehend.model.ComprehendRequest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.services.comprehend.ComprehendAsyncClient;
+import software.amazon.awssdk.services.comprehend.ComprehendClient;
 
 class ComprehendClientSupplierTest {
 
@@ -31,17 +31,17 @@ class ComprehendClientSupplierTest {
 
   @Test
   void getSyncClient() {
-    var amazonComprehendClient = clientSupplier.getSyncClient(request);
+    var comprehendClient = clientSupplier.getSyncClient(request);
 
-    assertThat(amazonComprehendClient).isNotNull();
-    assertThat(amazonComprehendClient).isInstanceOf(AmazonComprehendClient.class);
+    assertThat(comprehendClient).isNotNull();
+    assertThat(comprehendClient).isInstanceOf(ComprehendClient.class);
   }
 
   @Test
   void getAsyncClient() {
-    var amazonComprehendAsyncClient = clientSupplier.getAsyncClient(request);
+    var comprehendAsyncClient = clientSupplier.getAsyncClient(request);
 
-    assertThat(amazonComprehendAsyncClient).isNotNull();
-    assertThat(amazonComprehendAsyncClient).isInstanceOf(AmazonComprehendAsyncClient.class);
+    assertThat(comprehendAsyncClient).isNotNull();
+    assertThat(comprehendAsyncClient).isInstanceOf(ComprehendAsyncClient.class);
   }
 }

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -568,6 +568,11 @@ limitations under the License.</license.inlineheader>
       </dependency>
       <dependency>
         <groupId>software.amazon.awssdk</groupId>
+        <artifactId>comprehend</artifactId>
+        <version>${version.aws-sdk2}</version>
+      </dependency>
+      <dependency>
+        <groupId>software.amazon.awssdk</groupId>
         <artifactId>bedrockruntime</artifactId>
         <version>${version.aws-sdk2}</version>
       </dependency>


### PR DESCRIPTION
## Summary

Migrates the `aws-comprehend` outbound connector from AWS SDK v1 to AWS SDK v2, closing out #7970 (part of the "AWS SDK v1 to v2 migration" epic).

- `ComprehendClientSupplier` now builds the v2 `ComprehendClient` / `ComprehendAsyncClient` instead of the v1 `AmazonComprehend` / `AmazonComprehendAsync` clients.
- `SyncComprehendCaller` / `AsyncComprehendCaller` build v2 request objects via builders and call the v2 clients. `AsyncComprehendCaller` now declares the real v2 `ComprehendAsyncClient` type (v1's async client was a subtype of the sync client, so the pre-migration async caller could get away with declaring its parameter as the sync client type; v2's `ComprehendAsyncClient` and `ComprehendClient` are unrelated sibling interfaces).
- v2 response objects (`ClassifyDocumentResponse`, `StartDocumentClassificationJobResponse`) expose fluent accessors rather of JavaBean getters, so serializing them directly would silently produce `{}` with the connectors' `ObjectMapper` (which disables `FAIL_ON_EMPTY_BEANS`). `ComprehendClassifyResult` / `ComprehendClassificationJobResult` map the v2 response back into the exact v1 JSON shape, including preserving the null-vs-empty-list distinction (v1 exposed unset lists as `null`; v2's response objects use `hasXxx()` flags to distinguish "never set" from "explicitly empty").
- **`sdkResponseMetadata` / `sdkHttpMetadata` are reconstructed, not dropped**, from the v2 response (`response.responseMetadata()` / `response.sdkHttpResponse()`), following the `EventBridgeResult` precedent (see `fix(eventbridge): restore result payload lost in SDK v2 migration`, #7977) — these are real, pinned fields in the golden-fixture JSON, not incidental metadata, so silently dropping them would be a regression versus v1's documented output shape. The v2 `"UNKNOWN"` request-id sentinel is normalized to `null` to match v1's behavior.

### Output-shape parity

`connectors/aws/aws-comprehend/src/test/java/io/camunda/connector/comprehend/ComprehendResultJsonShapeTest.java` pins the v1 JSON output shape as a golden fixture (extracted from the pre-migration connector) and asserts the migrated v2-backed code produces byte-for-byte identical JSON for: a populated `ClassifyDocument` response, an empty `ClassifyDocument` response, and an async job-start response. This is the test that verifies parity with the pre-existing v1 connector's output contract.

### Additional fixes applied in this PR (beyond the initial migration commit)

- **Client lifecycle**: `ComprehendConnectorFunction#execute` now closes the sync/async v2 client via try-with-resources on every invocation, matching the `EventBridgeFunction` reference pattern this migration follows. Previously each job activation built a new `ComprehendClient` (Apache HTTP connection pool) or `ComprehendAsyncClient` (Netty event-loop threads + connection pool) and never closed it — a resource leak under sustained load, worse than v1 due to the async client's Netty footprint.
- **`AsyncComprehendCaller` client-type cleanup**: as noted above, the async caller declares the real v2 `ComprehendAsyncClient` type instead of relying on v1's sync/async subtyping — a minor incidental fix required by v2's client hierarchy.
- **Exception semantics**: `AsyncComprehendCaller` blocks on the async call via `CompletableFuture#join()`, which wraps a failing call's exception in `CompletionException`. This is now unwrapped so callers see the original AWS SDK exception (e.g. `ComprehendException`), matching what the pre-migration v1 async caller (which invoked the inherited synchronous method) propagated. Covered by a new test that exercises a failing future.
- **Build fix**: `connector-aws-comprehend/pom.xml` incorrectly scoped `software.amazon.awssdk:sdk-core` to `test` only. Main code needs it at compile scope for javac to resolve the v2 client/response supertypes (`SdkClient`, `SdkResponse`, `SdkPojo`, `SdkRequest`) even though those types are never imported by name in this module's source — **the module did not compile from a clean build** (`mvn clean test-compile`) with the test-scope restriction in place. Corrected to compile scope (matching how `aws-eventbridge`, `aws-s3` and `aws-lambda` declare it) and added `ignoredNonTestScopedDependencies` to the module's `maven-dependency-plugin` config, since `analyze-only`'s bytecode-level analysis only sees `sdk-core` referenced from test classes and would otherwise flag it as a false positive.

## Test plan

- [x] `./mvnw -pl connectors/aws/aws-comprehend -am clean test` → BUILD SUCCESS, 17/17 tests passing, 0 failures/errors/skipped
- [x] `ComprehendResultJsonShapeTest` (golden-fixture output-shape parity test): 3/3 green
- [x] `ComprehendConnectorFunctionTest`: asserts `execute()` closes the client and returns the connector-owned DTO (not the raw v2 SDK response) for both sync and async paths
- [x] `AsyncComprehendCallerTest`: new test added covering a failing future, asserting the original AWS exception (not `CompletionException`) propagates
- [x] Verified the module compiles from a clean build (`mvn clean test-compile`), not just an incremental one

🤖 Generated with [Claude Code](https://claude.com/claude-code)