### PR TITLE
ci(release): parallelize docker builds and add e2e skip option

### DIFF
--- a/.github/workflows/RELEASE.yaml
+++ b/.github/workflows/RELEASE.yaml
@@ -18,6 +18,11 @@ on:
         required: false
         type: boolean
         default: false
+      skip-e2e-tests:
+        description: 'Skip E2E tests'
+        required: false
+        type: boolean
+        default: false
       latest:
         description: 'Mark this release as latest (push latest docker tags & mark GitHub release latest)'
         required: false
@@ -195,6 +200,7 @@ jobs:
   e2e-tests:
     needs: setup
     name: Run E2E tests
+    if: ${{ !inputs.skip-e2e-tests }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -286,6 +292,7 @@ jobs:
   version-bump-docs-links:
     needs: [setup, e2e-tests]
     name: Version bump documentation links, if this is the first minor release
+    if: needs.setup.result == 'success' && (needs.e2e-tests.result == 'success' || needs.e2e-tests.result == 'skipped')
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -461,8 +468,26 @@ jobs:
   docker-release:
     needs: [setup, e2e-tests]
     runs-on: ubuntu-latest
-    name: Perform the docker release
+    name: Docker release - ${{ matrix.name }}
     if: ${{ !inputs.skip-docker-release }}
+    strategy:
+      matrix:
+        include:
+          - name: connector-runtime
+            context: connector-runtime/connector-runtime-application/
+            image: camunda/connectors
+            readme: ''
+            short_description: ''
+          - name: bundle-default
+            context: bundle/default-bundle/
+            image: camunda/connectors-bundle
+            readme: bundle/README.md
+            short_description: 'Camunda out-of-the-box Connectors Bundle'
+          - name: bundle-saas
+            context: bundle/camunda-saas-bundle/
+            image: camunda/connectors-bundle-saas
+            readme: bundle/README.md
+            short_description: 'Camunda out-of-the-box Connectors Bundle for SaaS'
     permissions:
       contents: read
     steps:
@@ -494,7 +519,7 @@ jobs:
         with:
           platforms: 'arm64,arm'
 
-      - name: Set up Docker Build
+      - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
       - name: Login to Docker Hub
@@ -510,106 +535,51 @@ jobs:
           username: minimus
           password: ${{ steps.secrets.outputs.REGISTRY_MINIMUS_PSW }}
 
-      # Build & push bundle docker images (with version tag)
-
-      - name: Build and Push Docker Image tag ${{ inputs.version }} - connector-runtime
+      - name: Build and Push Docker Image tag ${{ inputs.version }} - ${{ matrix.name }}
         uses: docker/build-push-action@v7
         with:
-          context: connector-runtime/connector-runtime-application/
+          context: ${{ matrix.context }}
           push: true
-          tags: camunda/connectors:${{ inputs.version }}
+          tags: ${{ matrix.image }}:${{ inputs.version }}
           platforms: linux/amd64,linux/arm64
           provenance: false
-
-      - name: Build and Push Docker Image tag ${{ inputs.version }} - bundle-default
-        uses: docker/build-push-action@v7
-        with:
-          context: bundle/default-bundle/
-          push: true
-          tags: camunda/connectors-bundle:${{ inputs.version }}
-          platforms: linux/amd64,linux/arm64
-          provenance: false
-
-      - name: Build and Push Docker Image tag ${{ inputs.version }} - bundle-saas
-        uses: docker/build-push-action@v7
-        with:
-          context: bundle/camunda-saas-bundle/
-          push: true
-          tags: camunda/connectors-bundle-saas:${{ inputs.version }}
-          platforms: linux/amd64,linux/arm64
-          provenance: false
-
-      # Build & push bundle docker images (with 'latest' tag)
 
       - name: Log latest tag push decision
         run: |
           echo "Tag type: ${{ needs.setup.outputs.tagType }}"
           echo "Latest input: ${{ inputs.latest }}"
           if [[ "${{ inputs.latest }}" == "true" && "${{ needs.setup.outputs.tagType }}" == "NORMAL" ]]; then
-            echo "Will push 'latest' tags for all images"
+            echo "Will push 'latest' tag for ${{ matrix.name }}"
           else
-            echo "Will NOT push 'latest' tags (either latest not requested or not a NORMAL release)"
+            echo "Will NOT push 'latest' tag (either latest not requested or not a NORMAL release)"
           fi
 
-      - name: Build and Push Docker Image tag latest - connector-runtime
+      - name: Build and Push Docker Image tag latest - ${{ matrix.name }}
         if: ${{ inputs.latest && needs.setup.outputs.tagType == 'NORMAL' }}
         uses: docker/build-push-action@v7
         with:
-          context: connector-runtime/connector-runtime-application/
+          context: ${{ matrix.context }}
           push: true
-          tags: camunda/connectors:latest
+          tags: ${{ matrix.image }}:latest
           platforms: linux/amd64,linux/arm64
           provenance: false
 
-      - name: Build and Push Docker Image tag latest - bundle-default
-        if: ${{ inputs.latest && needs.setup.outputs.tagType == 'NORMAL' }}
-        uses: docker/build-push-action@v7
-        with:
-          context: bundle/default-bundle/
-          push: true
-          tags: camunda/connectors-bundle:latest
-          platforms: linux/amd64,linux/arm64
-          provenance: false
-
-      - name: Build and Push Docker Image tag latest - bundle-saas
-        if: ${{ inputs.latest && needs.setup.outputs.tagType == 'NORMAL' }}
-        uses: docker/build-push-action@v7
-        with:
-          context: bundle/camunda-saas-bundle/
-          push: true
-          tags: camunda/connectors-bundle-saas:latest
-          platforms: linux/amd64,linux/arm64
-          provenance: false
-
-      # Update README in Dockerhub
-
-      - name: Push README to Dockerhub - bundle-default
-        if: ${{ inputs.latest && needs.setup.outputs.tagType == 'NORMAL' }}
+      - name: Push README to Dockerhub - ${{ matrix.name }}
+        if: ${{ inputs.latest && needs.setup.outputs.tagType == 'NORMAL' && matrix.readme != '' }}
         uses: christian-korneck/update-container-description-action@v1
         env:
           DOCKER_USER: ${{ steps.secrets.outputs.DOCKERHUB_USER }}
           DOCKER_PASS: ${{ steps.secrets.outputs.DOCKERHUB_PASSWORD }}
         with:
-          destination_container_repo: camunda/connectors-bundle
+          destination_container_repo: ${{ matrix.image }}
           provider: dockerhub
-          readme_file: bundle/README.md
-          short_description: 'Camunda out-of-the-box Connectors Bundle'
-
-      - name: Push README to Dockerhub - bundle-saas
-        if: ${{ inputs.latest && needs.setup.outputs.tagType == 'NORMAL' }}
-        uses: christian-korneck/update-container-description-action@v1
-        env:
-          DOCKER_USER: ${{ steps.secrets.outputs.DOCKERHUB_USER }}
-          DOCKER_PASS: ${{ steps.secrets.outputs.DOCKERHUB_PASSWORD }}
-        with:
-          destination_container_repo: camunda/connectors-bundle-saas
-          provider: dockerhub
-          readme_file: bundle/README.md
-          short_description: 'Camunda out-of-the-box Connectors Bundle for SaaS'
+          readme_file: ${{ matrix.readme }}
+          short_description: ${{ matrix.short_description }}
 
   bundle-and-build-changelog:
     needs: [setup, e2e-tests]
     name: Bundle and generate changelogs
+    if: needs.setup.result == 'success' && (needs.e2e-tests.result == 'success' || needs.e2e-tests.result == 'skipped')
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -678,7 +648,7 @@ jobs:
 
     if: |
       needs.setup.result == 'success' &&
-      needs.e2e-tests.result == 'success' &&
+      (needs.e2e-tests.result == 'success' || needs.e2e-tests.result == 'skipped') &&
       (needs.maven-release.result == 'success' || needs.maven-release.result == 'skipped') &&
       (needs.docker-release.result == 'success' || needs.docker-release.result == 'skipped') &&
       needs.bundle-and-build-changelog.result == 'success' &&
@@ -740,7 +710,7 @@ jobs:
     if: |
       !contains(inputs.version, 'rc') &&
       needs.setup.result == 'success' &&
-      needs.e2e-tests.result == 'success' &&
+      (needs.e2e-tests.result == 'success' || needs.e2e-tests.result == 'skipped') &&
       needs.maven-release.result == 'success' &&
       needs.docker-release.result == 'success' &&
       needs.bundle-and-build-changelog.result == 'success'

--- a/.github/workflows/RELEASE.yaml
+++ b/.github/workflows/RELEASE.yaml
@@ -292,7 +292,10 @@ jobs:
   version-bump-docs-links:
     needs: [setup, e2e-tests]
     name: Version bump documentation links, if this is the first minor release
-    if: needs.setup.result == 'success' && (needs.e2e-tests.result == 'success' || needs.e2e-tests.result == 'skipped')
+    if: |
+      always() &&
+      needs.setup.result == 'success' &&
+      (needs.e2e-tests.result == 'success' || needs.e2e-tests.result == 'skipped')
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -355,7 +358,11 @@ jobs:
     needs: [setup, e2e-tests]
     name: Create a maven release
     runs-on: ubuntu-latest
-    if: ${{ !inputs.skip-maven-release }}
+    if: |
+      always() &&
+      !inputs.skip-maven-release &&
+      needs.setup.result == 'success' &&
+      (needs.e2e-tests.result == 'success' || needs.e2e-tests.result == 'skipped')
     permissions:
       contents: read
     steps:
@@ -469,7 +476,11 @@ jobs:
     needs: [setup, e2e-tests]
     runs-on: ubuntu-latest
     name: Docker release - ${{ matrix.name }}
-    if: ${{ !inputs.skip-docker-release }}
+    if: |
+      always() &&
+      !inputs.skip-docker-release &&
+      needs.setup.result == 'success' &&
+      (needs.e2e-tests.result == 'success' || needs.e2e-tests.result == 'skipped')
     strategy:
       matrix:
         include:
@@ -579,7 +590,10 @@ jobs:
   bundle-and-build-changelog:
     needs: [setup, e2e-tests]
     name: Bundle and generate changelogs
-    if: needs.setup.result == 'success' && (needs.e2e-tests.result == 'success' || needs.e2e-tests.result == 'skipped')
+    if: |
+      always() &&
+      needs.setup.result == 'success' &&
+      (needs.e2e-tests.result == 'success' || needs.e2e-tests.result == 'skipped')
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -621,7 +635,12 @@ jobs:
 
   helm-deploy:
     needs: [ setup, e2e-tests, docker-release ]
-    if: ${{ !inputs.skip-docker-release }}
+    if: |
+      always() &&
+      !inputs.skip-docker-release &&
+      needs.setup.result == 'success' &&
+      (needs.e2e-tests.result == 'success' || needs.e2e-tests.result == 'skipped') &&
+      needs.docker-release.result == 'success'
     name: Run Helm Integration Tests
     uses: ./.github/workflows/INTEGRATION_TEST.yml
     secrets: inherit
@@ -647,6 +666,7 @@ jobs:
       contents: read
 
     if: |
+      always() &&
       needs.setup.result == 'success' &&
       (needs.e2e-tests.result == 'success' || needs.e2e-tests.result == 'skipped') &&
       (needs.maven-release.result == 'success' || needs.maven-release.result == 'skipped') &&
@@ -708,6 +728,7 @@ jobs:
 
     # Automatically notify PRs for non-RC releases (case-insensitive check)
     if: |
+      always() &&
       !contains(inputs.version, 'rc') &&
       needs.setup.result == 'success' &&
       (needs.e2e-tests.result == 'success' || needs.e2e-tests.result == 'skipped') &&


### PR DESCRIPTION
## Summary
- Runs the three release Docker images (`connector-runtime`, `bundle-default`, `bundle-saas`) as a parallel matrix in `docker-release` instead of sequentially in one job, cutting that job's wall-clock roughly 3x.
- Adds a `skip-e2e-tests` workflow input so a release run can skip E2E (e.g. on a re-run where only maven/docker need to be redone). Downstream jobs (`version-bump-docs-links`, `bundle-and-build-changelog`, `fossa_release`, `notify-prs-released`) are updated to treat a skipped `e2e-tests` job the same as a successful one, matching the pattern already used for `skip-maven-release`/`skip-docker-release`.

## Test plan
- [ ] Validate YAML syntax (`actionlint` / GitHub's workflow linter on the PR)
- [ ] Dry-run via `workflow_dispatch` with `skip-e2e-tests: true` on a test/RC version and confirm `e2e-tests` shows as skipped while `maven-release`/`docker-release`/`bundle-and-build-changelog` still run
- [ ] Dry-run a normal release (all defaults) and confirm the three docker images build/push correctly under the new matrix, and `latest` tag + README push logic still behaves as before for `bundle-default`/`bundle-saas` and is skipped for `connector-runtime`

🤖 Generated with [Claude Code](https://claude.com/claude-code)