### PR TITLE
ci(release): parallelize docker builds (backport of #8033, docker-only)

### DIFF
--- a/.github/workflows/RELEASE.yaml
+++ b/.github/workflows/RELEASE.yaml
@@ -361,8 +361,26 @@ jobs:
   docker-release:
     needs: setup
     runs-on: ubuntu-latest
-    name: Perform the docker release
+    name: Docker release - ${{ matrix.name }}
     if: ${{ !inputs.skip-docker-release }}
+    strategy:
+      matrix:
+        include:
+          - name: connector-runtime
+            context: connector-runtime/connector-runtime-application/
+            image: camunda/connectors
+            readme: ''
+            short_description: ''
+          - name: bundle-default
+            context: bundle/default-bundle/
+            image: camunda/connectors-bundle
+            readme: bundle/README.md
+            short_description: 'Camunda out-of-the-box Connectors Bundle'
+          - name: bundle-saas
+            context: bundle/camunda-saas-bundle/
+            image: camunda/connectors-bundle-saas
+            readme: bundle/README.md
+            short_description: 'Camunda out-of-the-box Connectors Bundle for SaaS'
     permissions:
       contents: read
     steps:
@@ -394,7 +412,7 @@ jobs:
         with:
           platforms: 'arm64,arm'
 
-      - name: Set up Docker Build
+      - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
       - name: Login to Docker Hub
@@ -410,102 +428,46 @@ jobs:
           username: minimus
           password: ${{ steps.secrets.outputs.REGISTRY_MINIMUS_PSW }}
 
-      # Build & push bundle docker images (with version tag)
-
-      - name: Build and Push Docker Image tag ${{ inputs.version }} - connector-runtime
+      - name: Build and Push Docker Image tag ${{ inputs.version }} - ${{ matrix.name }}
         uses: docker/build-push-action@v6
         with:
-          context: connector-runtime/connector-runtime-application/
+          context: ${{ matrix.context }}
           push: true
-          tags: camunda/connectors:${{ inputs.version }}
+          tags: ${{ matrix.image }}:${{ inputs.version }}
           platforms: linux/amd64,linux/arm64
           provenance: false
-
-      - name: Build and Push Docker Image tag ${{ inputs.version }} - bundle-default
-        uses: docker/build-push-action@v6
-        with:
-          context: bundle/default-bundle/
-          push: true
-          tags: camunda/connectors-bundle:${{ inputs.version }}
-          platforms: linux/amd64,linux/arm64
-          provenance: false
-
-      - name: Build and Push Docker Image tag ${{ inputs.version }} - bundle-saas
-        uses: docker/build-push-action@v6
-        with:
-          context: bundle/camunda-saas-bundle/
-          push: true
-          tags: camunda/connectors-bundle-saas:${{ inputs.version }}
-          platforms: linux/amd64,linux/arm64
-          provenance: false
-
-      # Build & push bundle docker images (with 'latest' tag)
 
       - name: Log latest tag push decision
         run: |
           echo "Tag type: ${{ needs.setup.outputs.tagType }}"
           echo "Latest input: ${{ inputs.latest }}"
           if [[ "${{ inputs.latest }}" == "true" && "${{ needs.setup.outputs.tagType }}" == "NORMAL" ]]; then
-            echo "Will push 'latest' tags for all images"
+            echo "Will push 'latest' tag for ${{ matrix.name }}"
           else
-            echo "Will NOT push 'latest' tags (either latest not requested or not a NORMAL release)"
+            echo "Will NOT push 'latest' tag (either latest not requested or not a NORMAL release)"
           fi
 
-      - name: Build and Push Docker Image tag latest - connector-runtime
+      - name: Build and Push Docker Image tag latest - ${{ matrix.name }}
         if: ${{ inputs.latest && needs.setup.outputs.tagType == 'NORMAL' }}
         uses: docker/build-push-action@v6
         with:
-          context: connector-runtime/connector-runtime-application/
+          context: ${{ matrix.context }}
           push: true
-          tags: camunda/connectors:latest
+          tags: ${{ matrix.image }}:latest
           platforms: linux/amd64,linux/arm64
           provenance: false
 
-      - name: Build and Push Docker Image tag latest - bundle-default
-        if: ${{ inputs.latest && needs.setup.outputs.tagType == 'NORMAL' }}
-        uses: docker/build-push-action@v6
-        with:
-          context: bundle/default-bundle/
-          push: true
-          tags: camunda/connectors-bundle:latest
-          platforms: linux/amd64,linux/arm64
-          provenance: false
-
-      - name: Build and Push Docker Image tag latest - bundle-saas
-        if: ${{ inputs.latest && needs.setup.outputs.tagType == 'NORMAL' }}
-        uses: docker/build-push-action@v6
-        with:
-          context: bundle/camunda-saas-bundle/
-          push: true
-          tags: camunda/connectors-bundle-saas:latest
-          platforms: linux/amd64,linux/arm64
-          provenance: false
-
-      # Update README in Dockerhub
-
-      - name: Push README to Dockerhub - bundle-default
-        if: ${{ inputs.latest && needs.setup.outputs.tagType == 'NORMAL' }}
+      - name: Push README to Dockerhub - ${{ matrix.name }}
+        if: ${{ inputs.latest && needs.setup.outputs.tagType == 'NORMAL' && matrix.readme != '' }}
         uses: christian-korneck/update-container-description-action@v1
         env:
           DOCKER_USER: ${{ steps.secrets.outputs.DOCKERHUB_USER }}
           DOCKER_PASS: ${{ steps.secrets.outputs.DOCKERHUB_PASSWORD }}
         with:
-          destination_container_repo: camunda/connectors-bundle
+          destination_container_repo: ${{ matrix.image }}
           provider: dockerhub
-          readme_file: bundle/README.md
-          short_description: 'Camunda out-of-the-box Connectors Bundle'
-
-      - name: Push README to Dockerhub - bundle-saas
-        if: ${{ inputs.latest && needs.setup.outputs.tagType == 'NORMAL' }}
-        uses: christian-korneck/update-container-description-action@v1
-        env:
-          DOCKER_USER: ${{ steps.secrets.outputs.DOCKERHUB_USER }}
-          DOCKER_PASS: ${{ steps.secrets.outputs.DOCKERHUB_PASSWORD }}
-        with:
-          destination_container_repo: camunda/connectors-bundle-saas
-          provider: dockerhub
-          readme_file: bundle/README.md
-          short_description: 'Camunda out-of-the-box Connectors Bundle for SaaS'
+          readme_file: ${{ matrix.readme }}
+          short_description: ${{ matrix.short_description }}
 
   bundle-and-build-changelog:
     needs: setup


### PR DESCRIPTION
## Summary
Manual, partial backport of #8033 to `stable/8.8`, since the automated backport-action bot failed to cherry-pick (comment on #8033).

- Applies **only** the docker-release matrix parallelization from #8033: the three release Docker images (`connector-runtime`, `bundle-default`, `bundle-saas`) now build on separate parallel runners instead of sequentially in one job, cutting that job's wall-clock roughly 3x.
- Does **not** include the `skip-e2e-tests` input or its `always()` job-condition fixes from #8033: `stable/8.8`'s `RELEASE.yaml` predates the `e2e-tests` job entirely, so that part of #8033 doesn't apply here.
- This branch's existing GitHub Action version pins are left untouched (no incidental dependency bumps).

## Test plan
- [ ] Validate YAML syntax on this PR
- [ ] Dry-run via `workflow_dispatch` on `stable/8.8` with a test/RC version and confirm all three docker images (`connector-runtime`, `bundle-default`, `bundle-saas`) build/push correctly under the new matrix, and `latest` tag + README push logic still behaves as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)