### PR TITLE
feat(agentic-ai): add v2 AI Agent Task/Sub-process connectors and Custom provider configuration

### DIFF
--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/AgentTestFixtures.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/AgentTestFixtures.java
@@ -20,15 +20,22 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
 
 import java.util.Map;
+import java.util.stream.Collectors;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.assertj.core.api.ThrowingConsumer;
 
 public interface AgentTestFixtures {
-  String AI_AGENT_CONNECTOR_ELEMENT_TEMPLATE_PATH =
+  String AI_AGENT_TASK_V1_ELEMENT_TEMPLATE_PATH =
       "../../connectors/agentic-ai/connector-agentic-ai/element-templates/agenticai-aiagent-outbound-connector.json";
 
-  String AI_AGENT_JOB_WORKER_ELEMENT_TEMPLATE_PATH =
+  String AI_AGENT_TASK_V2_ELEMENT_TEMPLATE_PATH =
+      "../../connectors/agentic-ai/connector-agentic-ai/element-templates/agenticai-ai-agent-task.v2.json";
+
+  String AI_AGENT_SUB_PROCESS_V1_ELEMENT_TEMPLATE_PATH =
       "../../connectors/agentic-ai/connector-agentic-ai/element-templates/agenticai-aiagent-job-worker.json";
+
+  String AI_AGENT_SUB_PROCESS_V2_ELEMENT_TEMPLATE_PATH =
+      "../../connectors/agentic-ai/connector-agentic-ai/element-templates/agenticai-ai-agent-subprocess.v2.json";
 
   String AD_HOC_TOOLS_SCHEMA_ELEMENT_TEMPLATE_PATH =
       "../../connectors/agentic-ai/connector-agentic-ai/element-templates/agenticai-adhoctoolsschema-outbound-connector.json";
@@ -36,7 +43,7 @@ public interface AgentTestFixtures {
   String AGENT_RESPONSE_VARIABLE = "agent";
   String AI_AGENT_TASK_ID = "AI_Agent";
 
-  Map<String, String> AI_AGENT_CONNECTOR_ELEMENT_TEMPLATE_PROPERTIES =
+  Map<String, String> AI_AGENT_TASK_V1_ELEMENT_TEMPLATE_PROPERTIES =
       Map.ofEntries(
           Map.entry("provider.type", "openai"),
           Map.entry("provider.openai.authentication.apiKey", "DUMMY_API_KEY"),
@@ -58,7 +65,12 @@ public interface AgentTestFixtures {
           Map.entry("retryCount", "3"),
           Map.entry("retryBackoff", "PT2S"));
 
-  Map<String, String> AI_AGENT_JOB_WORKER_ELEMENT_TEMPLATE_PROPERTIES =
+  Map<String, String> AI_AGENT_TASK_V2_ELEMENT_TEMPLATE_PROPERTIES =
+      AI_AGENT_TASK_V1_ELEMENT_TEMPLATE_PROPERTIES.entrySet().stream()
+          .filter(e -> !e.getKey().startsWith("provider."))
+          .collect(Collectors.toUnmodifiableMap(Map.Entry::getKey, Map.Entry::getValue));
+
+  Map<String, String> AI_AGENT_SUB_PROCESS_V1_ELEMENT_TEMPLATE_PROPERTIES =
       Map.ofEntries(
           Map.entry("agentContext", "=agent.context"),
           Map.entry("provider.type", "openai"),
@@ -77,6 +89,11 @@ public interface AgentTestFixtures {
           Map.entry("data.memory.contextWindowSize", "=50"),
           Map.entry("data.response.includeAssistantMessage", "=true"),
           Map.entry("data.response.includeAgentContext", "=true"));
+
+  Map<String, String> AI_AGENT_SUB_PROCESS_V2_ELEMENT_TEMPLATE_PROPERTIES =
+      AI_AGENT_SUB_PROCESS_V1_ELEMENT_TEMPLATE_PROPERTIES.entrySet().stream()
+          .filter(e -> !e.getKey().startsWith("provider."))
+          .collect(Collectors.toUnmodifiableMap(Map.Entry::getKey, Map.Entry::getValue));
 
   String HAIKU_TEXT = "Endless waves whisper | moonlight dances on the tide | secrets drift below.";
   String HAIKU_JSON =

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/TestChatModelFactoryConfiguration.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/TestChatModelFactoryConfiguration.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.e2e.agenticai.aiagent;
+
+import io.camunda.connector.agenticai.aiagent.chatmodel.ChatModel;
+import io.camunda.connector.agenticai.aiagent.chatmodel.ChatModelConfiguration;
+import io.camunda.connector.agenticai.aiagent.chatmodel.ChatModelFactory;
+import io.camunda.connector.agenticai.aiagent.chatmodel.ChatRequest;
+import io.camunda.connector.agenticai.aiagent.chatmodel.ChatResult;
+import io.camunda.connector.agenticai.aiagent.model.AgentMetrics;
+import io.camunda.connector.agenticai.aiagent.model.message.AssistantMessage;
+import io.camunda.connector.agenticai.aiagent.model.message.content.TextContent;
+import io.camunda.connector.agenticai.aiagent.model.tool.ToolCall;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+
+@TestConfiguration
+public class TestChatModelFactoryConfiguration {
+
+  @Bean
+  public TestChatModelFactory testChatModelFactory() {
+    return new TestChatModelFactory();
+  }
+
+  /**
+   * Test double for {@link ChatModelFactory} standing in for a user-supplied custom chat model
+   * provider (see {@code CustomProviderConfiguration}). Serves scripted {@link ChatResult}s in
+   * order and records every {@link ChatRequest} it receives plus the {@link ChatModelConfiguration}
+   * it was resolved with, so e2e tests can drive the full tool-calling loop through the "custom"
+   * provider discriminator without any real (or WireMock-stubbed) LLM endpoint.
+   */
+  public static class TestChatModelFactory implements ChatModelFactory {
+
+    public static final String PROVIDER_TYPE = "e2e-custom";
+    public static final String MODEL_ID = "e2e-custom-model";
+
+    private final List<ChatResult> scriptedResults = new ArrayList<>();
+    private final List<ChatRequest> recordedRequests =
+        Collections.synchronizedList(new ArrayList<>());
+    private final List<ChatModelConfiguration> configurations =
+        Collections.synchronizedList(new ArrayList<>());
+
+    @Override
+    public boolean supports(ChatModelConfiguration configuration) {
+      return PROVIDER_TYPE.equals(configuration.provider());
+    }
+
+    @Override
+    public ChatModel create(ChatModelConfiguration configuration) {
+      configurations.add(configuration);
+      return new ChatModel() {
+        @Override
+        public ChatResult execute(ChatRequest request) {
+          recordedRequests.add(request);
+          if (scriptedResults.isEmpty()) {
+            throw new IllegalStateException(
+                "No scripted chat result configured for call #" + recordedRequests.size());
+          }
+          return scriptedResults.remove(0);
+        }
+
+        @Override
+        public void close() {}
+      };
+    }
+
+    public void enqueue(ChatResult... results) {
+      Collections.addAll(scriptedResults, results);
+    }
+
+    public void reset() {
+      scriptedResults.clear();
+      recordedRequests.clear();
+      configurations.clear();
+    }
+
+    public List<ChatRequest> recordedRequests() {
+      return List.copyOf(recordedRequests);
+    }
+
+    public List<ChatModelConfiguration> configurations() {
+      return List.copyOf(configurations);
+    }
+
+    /** The {@link ChatModelConfiguration} this factory was last resolved/created with. */
+    public ChatModelConfiguration lastConfiguration() {
+      return configurations.get(configurations.size() - 1);
+    }
+
+    public static ChatResult text(String text, int inputTokens, int outputTokens) {
+      return new ChatResult.Completed(
+          AssistantMessage.builder().content(List.of(TextContent.textContent(text))).build(),
+          new AgentMetrics(1, new AgentMetrics.TokenUsage(inputTokens, outputTokens), 0));
+    }
+
+    public static ChatResult toolCalls(
+        String text, int inputTokens, int outputTokens, ToolCall... toolCalls) {
+      return new ChatResult.Completed(
+          AssistantMessage.builder()
+              .content(List.of(TextContent.textContent(text)))
+              .toolCalls(List.of(toolCalls))
+              .build(),
+          new AgentMetrics(
+              1, new AgentMetrics.TokenUsage(inputTokens, outputTokens), toolCalls.length));
+    }
+  }
+}

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/TestChatModelFactoryConfiguration.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/TestChatModelFactoryConfiguration.java
@@ -27,7 +27,10 @@ import io.camunda.connector.agenticai.aiagent.model.message.content.TextContent;
 import io.camunda.connector.agenticai.aiagent.model.tool.ToolCall;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Deque;
 import java.util.List;
+import java.util.concurrent.ConcurrentLinkedDeque;
+import org.jspecify.annotations.NullMarked;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 
@@ -46,15 +49,17 @@ public class TestChatModelFactoryConfiguration {
    * it was resolved with, so e2e tests can drive the full tool-calling loop through the "custom"
    * provider discriminator without any real (or WireMock-stubbed) LLM endpoint.
    */
+  @NullMarked
   public static class TestChatModelFactory implements ChatModelFactory {
 
     public static final String PROVIDER_TYPE = "e2e-custom";
     public static final String MODEL_ID = "e2e-custom-model";
 
-    private final List<ChatResult> scriptedResults = new ArrayList<>();
-    private final List<ChatRequest> recordedRequests =
+    private final Deque<ChatResult> enqueuedResults = new ConcurrentLinkedDeque<>();
+
+    private final List<ChatModelConfiguration> recordedConfigurations =
         Collections.synchronizedList(new ArrayList<>());
-    private final List<ChatModelConfiguration> configurations =
+    private final List<ChatRequest> recordedRequests =
         Collections.synchronizedList(new ArrayList<>());
 
     @Override
@@ -64,16 +69,18 @@ public class TestChatModelFactoryConfiguration {
 
     @Override
     public ChatModel create(ChatModelConfiguration configuration) {
-      configurations.add(configuration);
+      recordedConfigurations.add(configuration);
       return new ChatModel() {
         @Override
         public ChatResult execute(ChatRequest request) {
           recordedRequests.add(request);
-          if (scriptedResults.isEmpty()) {
+          var result = enqueuedResults.pollFirst();
+          if (result == null) {
             throw new IllegalStateException(
-                "No scripted chat result configured for call #" + recordedRequests.size());
+                "No enqueued chat result configured for call #" + recordedRequests.size());
           }
-          return scriptedResults.remove(0);
+
+          return result;
         }
 
         @Override
@@ -82,26 +89,21 @@ public class TestChatModelFactoryConfiguration {
     }
 
     public void enqueue(ChatResult... results) {
-      Collections.addAll(scriptedResults, results);
+      Collections.addAll(enqueuedResults, results);
     }
 
     public void reset() {
-      scriptedResults.clear();
+      enqueuedResults.clear();
+      recordedConfigurations.clear();
       recordedRequests.clear();
-      configurations.clear();
     }
 
     public List<ChatRequest> recordedRequests() {
       return List.copyOf(recordedRequests);
     }
 
-    public List<ChatModelConfiguration> configurations() {
-      return List.copyOf(configurations);
-    }
-
-    /** The {@link ChatModelConfiguration} this factory was last resolved/created with. */
-    public ChatModelConfiguration lastConfiguration() {
-      return configurations.get(configurations.size() - 1);
+    public List<ChatModelConfiguration> recordedConfigurations() {
+      return List.copyOf(recordedConfigurations);
     }
 
     public static ChatResult text(String text, int inputTokens, int outputTokens) {

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/subprocess/AgentSubProcessVariableScopeTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/subprocess/AgentSubProcessVariableScopeTests.java
@@ -16,7 +16,7 @@
  */
 package io.camunda.connector.e2e.agenticai.aiagent.subprocess;
 
-import static io.camunda.connector.e2e.agenticai.aiagent.AgentTestFixtures.AI_AGENT_JOB_WORKER_ELEMENT_TEMPLATE_PATH;
+import static io.camunda.connector.e2e.agenticai.aiagent.AgentTestFixtures.AI_AGENT_SUB_PROCESS_V1_ELEMENT_TEMPLATE_PATH;
 import static io.camunda.connector.e2e.agenticai.aiagent.AgentTestFixtures.FEEDBACK_LOOP_RESPONSE_TEXT;
 import static io.camunda.connector.e2e.agenticai.aiagent.AgentTestFixtures.HAIKU_TEXT;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -46,7 +46,7 @@ public class AgentSubProcessVariableScopeTests extends BaseAgentSubProcessTest {
 
   @ParameterizedTest
   @ValueSource(
-      strings = {AI_AGENT_JOB_WORKER_ELEMENT_TEMPLATE_PATH, LAST_8_8_ELEMENT_TEMPLATE_PATH})
+      strings = {AI_AGENT_SUB_PROCESS_V1_ELEMENT_TEMPLATE_PATH, LAST_8_8_ELEMENT_TEMPLATE_PATH})
   void agentVariableDoesNotLeakToGlobalScope(String elementTemplatePath) throws Exception {
     OpenAiCompletionsChatModelStubs.stubConversation(Turn.text(HAIKU_TEXT, 10, 20));
     enqueueUserFeedback(userSatisfiedFeedback());
@@ -61,7 +61,7 @@ public class AgentSubProcessVariableScopeTests extends BaseAgentSubProcessTest {
 
   @ParameterizedTest
   @ValueSource(
-      strings = {AI_AGENT_JOB_WORKER_ELEMENT_TEMPLATE_PATH, LAST_8_8_ELEMENT_TEMPLATE_PATH})
+      strings = {AI_AGENT_SUB_PROCESS_V1_ELEMENT_TEMPLATE_PATH, LAST_8_8_ELEMENT_TEMPLATE_PATH})
   void agentVariableDoesNotLeakAfterToolCallingAndFeedbackLoop(String elementTemplatePath)
       throws Exception {
     OpenAiCompletionsChatModelStubs.stubConversation(

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/subprocess/BaseAgentSubProcessTest.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/subprocess/BaseAgentSubProcessTest.java
@@ -17,8 +17,8 @@
 package io.camunda.connector.e2e.agenticai.aiagent.subprocess;
 
 import static io.camunda.connector.e2e.agenticai.aiagent.AgentTestFixtures.AGENT_RESPONSE_VARIABLE;
-import static io.camunda.connector.e2e.agenticai.aiagent.AgentTestFixtures.AI_AGENT_JOB_WORKER_ELEMENT_TEMPLATE_PATH;
-import static io.camunda.connector.e2e.agenticai.aiagent.AgentTestFixtures.AI_AGENT_JOB_WORKER_ELEMENT_TEMPLATE_PROPERTIES;
+import static io.camunda.connector.e2e.agenticai.aiagent.AgentTestFixtures.AI_AGENT_SUB_PROCESS_V1_ELEMENT_TEMPLATE_PATH;
+import static io.camunda.connector.e2e.agenticai.aiagent.AgentTestFixtures.AI_AGENT_SUB_PROCESS_V1_ELEMENT_TEMPLATE_PROPERTIES;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
@@ -75,12 +75,12 @@ public abstract class BaseAgentSubProcessTest extends BaseAgentTest {
 
   @Override
   protected String elementTemplatePath() {
-    return AI_AGENT_JOB_WORKER_ELEMENT_TEMPLATE_PATH;
+    return AI_AGENT_SUB_PROCESS_V1_ELEMENT_TEMPLATE_PATH;
   }
 
   @Override
   protected Map<String, String> elementTemplateProperties() {
-    return AI_AGENT_JOB_WORKER_ELEMENT_TEMPLATE_PROPERTIES;
+    return AI_AGENT_SUB_PROCESS_V1_ELEMENT_TEMPLATE_PROPERTIES;
   }
 
   // ---------------------------------------------------------------------------
@@ -95,6 +95,10 @@ public abstract class BaseAgentSubProcessTest extends BaseAgentTest {
         .property("provider.openaiCompatible.model.model", "test-model");
   }
 
+  protected Function<ElementTemplate, ElementTemplate> providerConfigurer() {
+    return this::withOpenAiCompatibleProvider;
+  }
+
   @Override
   protected ZeebeTest createProcessInstance(
       Resource process,
@@ -102,8 +106,7 @@ public abstract class BaseAgentSubProcessTest extends BaseAgentTest {
       Map<String, Object> variables)
       throws IOException {
     final Function<ElementTemplate, ElementTemplate> composed =
-        ((Function<ElementTemplate, ElementTemplate>) this::withOpenAiCompatibleProvider)
-            .andThen(elementTemplateModifier);
+        providerConfigurer().andThen(elementTemplateModifier);
     return super.createProcessInstance(process, composed, variables);
   }
 

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/subprocess/v2/AgentSubProcessCustomProviderToolCallingTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/subprocess/v2/AgentSubProcessCustomProviderToolCallingTests.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.e2e.agenticai.aiagent.subprocess.v2;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.connector.agenticai.aiagent.model.AgentMetrics;
+import io.camunda.connector.agenticai.aiagent.model.message.AssistantMessage;
+import io.camunda.connector.agenticai.aiagent.model.message.SystemMessage;
+import io.camunda.connector.agenticai.aiagent.model.message.ToolCallResultMessage;
+import io.camunda.connector.agenticai.aiagent.model.message.UserMessage;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.CustomProviderConfiguration;
+import io.camunda.connector.agenticai.aiagent.model.tool.ToolCall;
+import io.camunda.connector.e2e.ElementTemplate;
+import io.camunda.connector.e2e.agenticai.aiagent.TestChatModelFactoryConfiguration;
+import io.camunda.connector.e2e.agenticai.aiagent.TestChatModelFactoryConfiguration.TestChatModelFactory;
+import io.camunda.connector.e2e.agenticai.assertj.AgentSubProcessResponseAssert;
+import io.camunda.connector.test.utils.annotation.SlowTest;
+import java.util.Map;
+import java.util.function.Function;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
+
+@SlowTest
+@Import(TestChatModelFactoryConfiguration.class)
+class AgentSubProcessCustomProviderToolCallingTests extends BaseAgentSubProcessV2Test {
+
+  @Autowired private TestChatModelFactory chatModelFactory;
+
+  @BeforeEach
+  void resetChatModelFactory() {
+    chatModelFactory.reset();
+  }
+
+  @Override
+  protected Function<ElementTemplate, ElementTemplate> providerConfigurer() {
+    return this::configureCustomProvider;
+  }
+
+  private ElementTemplate configureCustomProvider(ElementTemplate template) {
+    return template
+        .property("provider.type", "custom")
+        .property("provider.providerType", TestChatModelFactory.PROVIDER_TYPE)
+        .property("provider.model", TestChatModelFactory.MODEL_ID)
+        .property("provider.parameters", "={\"answer\": \"fortytwo\"}");
+  }
+
+  @Test
+  void executesToolCallingLoopAgainstCustomProvider() throws Exception {
+    final var initialUserPrompt = "Explore some of your tools!";
+    final var toolCallMessage = "I will call the superflux calculation tool.";
+    final var finalResponseText = "The superflux calculation of 5 and 3 is 24.";
+
+    chatModelFactory.enqueue(
+        TestChatModelFactory.toolCalls(
+            toolCallMessage,
+            10,
+            20,
+            new ToolCall("aaa111", "SuperfluxProduct", Map.of("a", 5, "b", 3))),
+        TestChatModelFactory.text(finalResponseText, 11, 22));
+
+    enqueueUserFeedback(userSatisfiedFeedback());
+
+    final var zeebeTest =
+        awaitProcessCompletion(createProcessInstance(Map.of("userPrompt", initialUserPrompt)));
+
+    assertThat(chatModelFactory.lastConfiguration())
+        .isInstanceOfSatisfying(
+            CustomProviderConfiguration.class,
+            customProviderConfiguration ->
+                assertThat(customProviderConfiguration.parameters())
+                    .containsEntry("answer", "fortytwo"));
+
+    final var recordedRequests = chatModelFactory.recordedRequests();
+    assertThat(recordedRequests).hasSize(2);
+
+    final var lastMessages = recordedRequests.get(1).snapshot().messages();
+    assertThat(lastMessages).hasSize(4);
+    assertThat(lastMessages.get(0)).isInstanceOf(SystemMessage.class);
+    assertThat(lastMessages.get(1)).isInstanceOf(UserMessage.class);
+    assertThat(lastMessages.get(2))
+        .isInstanceOfSatisfying(
+            AssistantMessage.class,
+            assistantMessage -> {
+              assertThat(assistantMessage.hasToolCalls()).isTrue();
+              assertThat(assistantMessage.toolCalls())
+                  .extracting(ToolCall::name)
+                  .containsExactly("SuperfluxProduct");
+            });
+    assertThat(lastMessages.get(3))
+        .isInstanceOfSatisfying(
+            ToolCallResultMessage.class,
+            toolCallResultMessage ->
+                assertThat(toolCallResultMessage.results())
+                    .extracting("id")
+                    .containsExactly("aaa111"));
+
+    assertAgentResponse(
+        zeebeTest,
+        agentResponse ->
+            AgentSubProcessResponseAssert.assertThat(agentResponse)
+                .isReady()
+                .hasMetrics(new AgentMetrics(2, new AgentMetrics.TokenUsage(21, 42), 1))
+                .hasResponseMessageText(finalResponseText)
+                .hasResponseText(finalResponseText));
+
+    assertThat(userFeedbackJobWorkerCounter.get()).isEqualTo(1);
+  }
+}

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/subprocess/v2/AgentSubProcessCustomProviderToolCallingTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/subprocess/v2/AgentSubProcessCustomProviderToolCallingTests.java
@@ -58,7 +58,7 @@ class AgentSubProcessCustomProviderToolCallingTests extends BaseAgentSubProcessV
         .property("provider.type", "custom")
         .property("provider.providerType", TestChatModelFactory.PROVIDER_TYPE)
         .property("provider.model", TestChatModelFactory.MODEL_ID)
-        .property("provider.parameters", "={\"answer\": \"fortytwo\"}");
+        .property("provider.parameters", "={\"type\": \"sub-process\"}");
   }
 
   @Test
@@ -80,12 +80,14 @@ class AgentSubProcessCustomProviderToolCallingTests extends BaseAgentSubProcessV
     final var zeebeTest =
         awaitProcessCompletion(createProcessInstance(Map.of("userPrompt", initialUserPrompt)));
 
-    assertThat(chatModelFactory.lastConfiguration())
+    assertThat(chatModelFactory.recordedConfigurations())
+        .hasSize(2)
+        .last()
         .isInstanceOfSatisfying(
             CustomProviderConfiguration.class,
             customProviderConfiguration ->
                 assertThat(customProviderConfiguration.parameters())
-                    .containsEntry("answer", "fortytwo"));
+                    .containsExactly(Map.entry("type", "sub-process")));
 
     final var recordedRequests = chatModelFactory.recordedRequests();
     assertThat(recordedRequests).hasSize(2);

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/subprocess/v2/BaseAgentSubProcessV2Test.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/subprocess/v2/BaseAgentSubProcessV2Test.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.e2e.agenticai.aiagent.subprocess.v2;
+
+import static io.camunda.connector.e2e.agenticai.aiagent.AgentTestFixtures.AI_AGENT_SUB_PROCESS_V2_ELEMENT_TEMPLATE_PATH;
+import static io.camunda.connector.e2e.agenticai.aiagent.AgentTestFixtures.AI_AGENT_SUB_PROCESS_V2_ELEMENT_TEMPLATE_PROPERTIES;
+
+import io.camunda.connector.e2e.agenticai.aiagent.subprocess.BaseAgentSubProcessTest;
+import java.util.Map;
+
+abstract class BaseAgentSubProcessV2Test extends BaseAgentSubProcessTest {
+
+  @Override
+  protected String elementTemplatePath() {
+    return AI_AGENT_SUB_PROCESS_V2_ELEMENT_TEMPLATE_PATH;
+  }
+
+  @Override
+  protected Map<String, String> elementTemplateProperties() {
+    return AI_AGENT_SUB_PROCESS_V2_ELEMENT_TEMPLATE_PROPERTIES;
+  }
+}

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/task/BaseAgentTaskTest.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/task/BaseAgentTaskTest.java
@@ -17,8 +17,8 @@
 package io.camunda.connector.e2e.agenticai.aiagent.task;
 
 import static io.camunda.connector.e2e.agenticai.aiagent.AgentTestFixtures.AGENT_RESPONSE_VARIABLE;
-import static io.camunda.connector.e2e.agenticai.aiagent.AgentTestFixtures.AI_AGENT_CONNECTOR_ELEMENT_TEMPLATE_PATH;
-import static io.camunda.connector.e2e.agenticai.aiagent.AgentTestFixtures.AI_AGENT_CONNECTOR_ELEMENT_TEMPLATE_PROPERTIES;
+import static io.camunda.connector.e2e.agenticai.aiagent.AgentTestFixtures.AI_AGENT_TASK_V1_ELEMENT_TEMPLATE_PATH;
+import static io.camunda.connector.e2e.agenticai.aiagent.AgentTestFixtures.AI_AGENT_TASK_V1_ELEMENT_TEMPLATE_PROPERTIES;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.connector.agenticai.adhoctoolsschema.schema.AdHocToolsSchemaResolver;
@@ -70,12 +70,12 @@ public abstract class BaseAgentTaskTest extends BaseAgentTest {
 
   @Override
   protected String elementTemplatePath() {
-    return AI_AGENT_CONNECTOR_ELEMENT_TEMPLATE_PATH;
+    return AI_AGENT_TASK_V1_ELEMENT_TEMPLATE_PATH;
   }
 
   @Override
   protected Map<String, String> elementTemplateProperties() {
-    return AI_AGENT_CONNECTOR_ELEMENT_TEMPLATE_PROPERTIES;
+    return AI_AGENT_TASK_V1_ELEMENT_TEMPLATE_PROPERTIES;
   }
 
   // ---------------------------------------------------------------------------
@@ -91,6 +91,10 @@ public abstract class BaseAgentTaskTest extends BaseAgentTest {
         .property("provider.openaiCompatible.model.model", "test-model");
   }
 
+  protected Function<ElementTemplate, ElementTemplate> providerConfigurer() {
+    return this::withOpenAiCompatibleProvider;
+  }
+
   @Override
   protected ZeebeTest createProcessInstance(
       Resource process,
@@ -98,8 +102,7 @@ public abstract class BaseAgentTaskTest extends BaseAgentTest {
       Map<String, Object> variables)
       throws IOException {
     final Function<ElementTemplate, ElementTemplate> composed =
-        ((Function<ElementTemplate, ElementTemplate>) this::withOpenAiCompatibleProvider)
-            .andThen(elementTemplateModifier);
+        providerConfigurer().andThen(elementTemplateModifier);
     return super.createProcessInstance(process, composed, variables);
   }
 

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/task/v2/AgentTaskCustomProviderToolCallingTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/task/v2/AgentTaskCustomProviderToolCallingTests.java
@@ -65,7 +65,7 @@ class AgentTaskCustomProviderToolCallingTests extends BaseAgentTaskV2Test {
         .property("provider.type", "custom")
         .property("provider.providerType", TestChatModelFactory.PROVIDER_TYPE)
         .property("provider.model", TestChatModelFactory.MODEL_ID)
-        .property("provider.parameters", "={\"answer\": \"fortytwo\"}");
+        .property("provider.parameters", "={\"type\": \"task\"}");
   }
 
   @Test
@@ -87,12 +87,14 @@ class AgentTaskCustomProviderToolCallingTests extends BaseAgentTaskV2Test {
     final var zeebeTest =
         awaitProcessCompletion(createProcessInstance(Map.of("userPrompt", initialUserPrompt)));
 
-    assertThat(chatModelFactory.lastConfiguration())
+    assertThat(chatModelFactory.recordedConfigurations())
+        .hasSize(2)
+        .last()
         .isInstanceOfSatisfying(
             CustomProviderConfiguration.class,
             customProviderConfiguration ->
                 assertThat(customProviderConfiguration.parameters())
-                    .containsEntry("answer", "fortytwo"));
+                    .containsExactly(Map.entry("type", "task")));
 
     final var recordedRequests = chatModelFactory.recordedRequests();
     assertThat(recordedRequests).hasSize(2);

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/task/v2/AgentTaskCustomProviderToolCallingTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/task/v2/AgentTaskCustomProviderToolCallingTests.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.e2e.agenticai.aiagent.task.v2;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.connector.agenticai.aiagent.model.AgentMetrics;
+import io.camunda.connector.agenticai.aiagent.model.message.AssistantMessage;
+import io.camunda.connector.agenticai.aiagent.model.message.SystemMessage;
+import io.camunda.connector.agenticai.aiagent.model.message.ToolCallResultMessage;
+import io.camunda.connector.agenticai.aiagent.model.message.UserMessage;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.CustomProviderConfiguration;
+import io.camunda.connector.agenticai.aiagent.model.tool.ToolCall;
+import io.camunda.connector.e2e.ElementTemplate;
+import io.camunda.connector.e2e.agenticai.aiagent.TestChatModelFactoryConfiguration;
+import io.camunda.connector.e2e.agenticai.aiagent.TestChatModelFactoryConfiguration.TestChatModelFactory;
+import io.camunda.connector.e2e.agenticai.assertj.AgentResponseAssert;
+import io.camunda.connector.test.utils.annotation.SlowTest;
+import java.util.Map;
+import java.util.function.Function;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
+
+/**
+ * Exercises the AI Agent Task against the v2 element template with the {@code custom} provider
+ * configuration, backed by {@link TestChatModelFactory} instead of a real (or WireMock-stubbed) LLM
+ * endpoint. Proves that a user-supplied {@code ChatModelFactory} is resolved and driven through a
+ * full multi-round tool-calling loop, and that {@code CustomProviderConfiguration#parameters()} is
+ * threaded through to it unchanged.
+ */
+@SlowTest
+@Import(TestChatModelFactoryConfiguration.class)
+class AgentTaskCustomProviderToolCallingTests extends BaseAgentTaskV2Test {
+
+  @Autowired private TestChatModelFactory chatModelFactory;
+
+  @BeforeEach
+  void resetChatModelFactory() {
+    chatModelFactory.reset();
+  }
+
+  @Override
+  protected Function<ElementTemplate, ElementTemplate> providerConfigurer() {
+    return this::configureCustomProvider;
+  }
+
+  private ElementTemplate configureCustomProvider(ElementTemplate template) {
+    return template
+        .property("provider.type", "custom")
+        .property("provider.providerType", TestChatModelFactory.PROVIDER_TYPE)
+        .property("provider.model", TestChatModelFactory.MODEL_ID)
+        .property("provider.parameters", "={\"answer\": \"fortytwo\"}");
+  }
+
+  @Test
+  void executesToolCallingLoopAgainstCustomProvider() throws Exception {
+    final var initialUserPrompt = "Explore some of your tools!";
+    final var toolCallMessage = "I will call the superflux calculation tool.";
+    final var finalResponseText = "The superflux calculation of 5 and 3 is 24.";
+
+    chatModelFactory.enqueue(
+        TestChatModelFactory.toolCalls(
+            toolCallMessage,
+            10,
+            20,
+            new ToolCall("aaa111", "SuperfluxProduct", Map.of("a", 5, "b", 3))),
+        TestChatModelFactory.text(finalResponseText, 11, 22));
+
+    enqueueUserFeedback(userSatisfiedFeedback());
+
+    final var zeebeTest =
+        awaitProcessCompletion(createProcessInstance(Map.of("userPrompt", initialUserPrompt)));
+
+    assertThat(chatModelFactory.lastConfiguration())
+        .isInstanceOfSatisfying(
+            CustomProviderConfiguration.class,
+            customProviderConfiguration ->
+                assertThat(customProviderConfiguration.parameters())
+                    .containsEntry("answer", "fortytwo"));
+
+    final var recordedRequests = chatModelFactory.recordedRequests();
+    assertThat(recordedRequests).hasSize(2);
+
+    final var lastMessages = recordedRequests.get(1).snapshot().messages();
+    assertThat(lastMessages).hasSize(4);
+    assertThat(lastMessages.get(0)).isInstanceOf(SystemMessage.class);
+    assertThat(lastMessages.get(1)).isInstanceOf(UserMessage.class);
+    assertThat(lastMessages.get(2))
+        .isInstanceOfSatisfying(
+            AssistantMessage.class,
+            assistantMessage -> {
+              assertThat(assistantMessage.hasToolCalls()).isTrue();
+              assertThat(assistantMessage.toolCalls())
+                  .extracting(ToolCall::name)
+                  .containsExactly("SuperfluxProduct");
+            });
+    assertThat(lastMessages.get(3))
+        .isInstanceOfSatisfying(
+            ToolCallResultMessage.class,
+            toolCallResultMessage ->
+                assertThat(toolCallResultMessage.results())
+                    .extracting("id")
+                    .containsExactly("aaa111"));
+
+    assertAgentResponse(
+        zeebeTest,
+        agentResponse ->
+            AgentResponseAssert.assertThat(agentResponse)
+                .isReady()
+                .hasNoToolCalls()
+                .hasMetrics(new AgentMetrics(2, new AgentMetrics.TokenUsage(21, 42), 1))
+                .hasResponseMessageText(finalResponseText)
+                .hasResponseText(finalResponseText));
+
+    assertThat(userFeedbackJobWorkerCounter.get()).isEqualTo(1);
+  }
+}

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/task/v2/BaseAgentTaskV2Test.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/task/v2/BaseAgentTaskV2Test.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.e2e.agenticai.aiagent.task.v2;
+
+import static io.camunda.connector.e2e.agenticai.aiagent.AgentTestFixtures.AI_AGENT_TASK_V2_ELEMENT_TEMPLATE_PATH;
+import static io.camunda.connector.e2e.agenticai.aiagent.AgentTestFixtures.AI_AGENT_TASK_V2_ELEMENT_TEMPLATE_PROPERTIES;
+
+import io.camunda.connector.e2e.agenticai.aiagent.task.BaseAgentTaskTest;
+import java.util.Map;
+
+abstract class BaseAgentTaskV2Test extends BaseAgentTaskTest {
+
+  @Override
+  protected String elementTemplatePath() {
+    return AI_AGENT_TASK_V2_ELEMENT_TEMPLATE_PATH;
+  }
+
+  @Override
+  protected Map<String, String> elementTemplateProperties() {
+    return AI_AGENT_TASK_V2_ELEMENT_TEMPLATE_PROPERTIES;
+  }
+}

--- a/connectors/agentic-ai/connector-agentic-ai/element-templates/README.md
+++ b/connectors/agentic-ai/connector-agentic-ai/element-templates/README.md
@@ -24,19 +24,27 @@ The AI Agent ships in two flavors that share the same versioning scheme.
 
 ### AI Agent Task
 
-| Connector     | Minimum Camunda version | Template version | File |
+The v2 template is a new, independently versioned connector type (`io.camunda.agenticai:aiagent:task:2`)
+running on the new chat-model provider SPI; it does not supersede the v1 template below.
+
+| Connector         | Minimum Camunda version | Template version | File |
 | --- | --- | --- | --- |
-| AI Agent Task | 8.10 | 11 | [`agenticai-aiagent-outbound-connector.json`](./agenticai-aiagent-outbound-connector.json) |
-| AI Agent Task | 8.9  | 7  | [`versioned/agenticai-aiagent-outbound-connector-7.json`](./versioned/agenticai-aiagent-outbound-connector-7.json) |
-| AI Agent Task | 8.8  | 5  | [`versioned/agenticai-aiagent-outbound-connector-5.json`](./versioned/agenticai-aiagent-outbound-connector-5.json) |
+| AI Agent Task v2  | 8.10 | 1  | [`agenticai-ai-agent-task.v2.json`](./agenticai-ai-agent-task.v2.json) |
+| AI Agent Task     | 8.10 | 11 | [`agenticai-aiagent-outbound-connector.json`](./agenticai-aiagent-outbound-connector.json) |
+| AI Agent Task     | 8.9  | 7  | [`versioned/agenticai-aiagent-outbound-connector-7.json`](./versioned/agenticai-aiagent-outbound-connector-7.json) |
+| AI Agent Task     | 8.8  | 5  | [`versioned/agenticai-aiagent-outbound-connector-5.json`](./versioned/agenticai-aiagent-outbound-connector-5.json) |
 
 ### AI Agent Sub-process
 
-| Connector            | Minimum Camunda version | Template version | File |
+The v2 template is a new, independently versioned connector type (`io.camunda.agenticai:aiagent:subprocess:2`)
+running on the new chat-model provider SPI; it does not supersede the v1 template below.
+
+| Connector                | Minimum Camunda version | Template version | File |
 | --- | --- | --- | --- |
-| AI Agent Sub-process | 8.10 | 11 | [`agenticai-aiagent-job-worker.json`](./agenticai-aiagent-job-worker.json) |
-| AI Agent Sub-process | 8.9  | 7  | [`versioned/agenticai-aiagent-job-worker-7.json`](./versioned/agenticai-aiagent-job-worker-7.json) |
-| AI Agent Sub-process | 8.8  | 5  | [`versioned/agenticai-aiagent-job-worker-5.json`](./versioned/agenticai-aiagent-job-worker-5.json) |
+| AI Agent Sub-process v2  | 8.10 | 1  | [`agenticai-ai-agent-subprocess.v2.json`](./agenticai-ai-agent-subprocess.v2.json) |
+| AI Agent Sub-process     | 8.10 | 11 | [`agenticai-aiagent-job-worker.json`](./agenticai-aiagent-job-worker.json) |
+| AI Agent Sub-process     | 8.9  | 7  | [`versioned/agenticai-aiagent-job-worker-7.json`](./versioned/agenticai-aiagent-job-worker-7.json) |
+| AI Agent Sub-process     | 8.8  | 5  | [`versioned/agenticai-aiagent-job-worker-5.json`](./versioned/agenticai-aiagent-job-worker-5.json) |
 
 ## MCP Client connectors
 

--- a/connectors/agentic-ai/connector-agentic-ai/element-templates/agenticai-ai-agent-subprocess.v2.json
+++ b/connectors/agentic-ai/connector-agentic-ai/element-templates/agenticai-ai-agent-subprocess.v2.json
@@ -1,0 +1,702 @@
+{
+  "$schema" : "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+  "name" : "AI Agent Sub-process",
+  "id" : "io.camunda.connectors.agenticai.ai-agent-subprocess.v2",
+  "description" : "Run a multi-step AI reasoning loop with dynamic tool selection",
+  "keywords" : [ "AI", "AI Agent", "agentic orchestration" ],
+  "documentationRef" : "https://docs.camunda.io/docs/8.10/components/connectors/out-of-the-box-connectors/agentic-ai-aiagent-subprocess/",
+  "version" : 1,
+  "category" : {
+    "id" : "aiTools",
+    "name" : "AI Tools"
+  },
+  "appliesTo" : [ "bpmn:SubProcess" ],
+  "elementType" : {
+    "value" : "bpmn:AdHocSubProcess"
+  },
+  "engines" : {
+    "camunda" : "^8.10"
+  },
+  "groups" : [ {
+    "id" : "provider",
+    "label" : "Model provider",
+    "openByDefault" : false
+  }, {
+    "id" : "model",
+    "label" : "Model",
+    "openByDefault" : false
+  }, {
+    "id" : "systemPrompt",
+    "label" : "System prompt",
+    "tooltip" : "A system prompt is a set of foundational instructions given to a model before any user interaction begins. It defines the AI agent’s role, behavior, tone, and communication style, ensuring that responses remain consistent and aligned with the AI agent’s intended purpose. These instructions help shape how the model interprets and responds to user input throughout the conversation.",
+    "openByDefault" : false
+  }, {
+    "id" : "userPrompt",
+    "label" : "User prompt",
+    "tooltip" : "A user prompt is the message or question you give to the AI to start or continue a conversation. It tells the AI what you need, whether it's information, help with a task, or just a chat. The AI uses your prompt to understand how to respond.",
+    "openByDefault" : false
+  }, {
+    "id" : "tools",
+    "label" : "Tools",
+    "tooltip" : "Tools are optional features the AI Agent can use to perform specific tasks. Configure this if the agent should participate in a tools feedback loop.",
+    "openByDefault" : false
+  }, {
+    "id" : "memory",
+    "label" : "Memory",
+    "tooltip" : "Configuration of the Agent's short-term/conversational memory.",
+    "openByDefault" : false
+  }, {
+    "id" : "limits",
+    "label" : "Limits",
+    "openByDefault" : false
+  }, {
+    "id" : "events",
+    "label" : "Event handling",
+    "tooltip" : "Configure how event sub-process results are handled. Results are added as user messages to the running agent.",
+    "openByDefault" : false
+  }, {
+    "id" : "response",
+    "label" : "Response",
+    "tooltip" : "Configuration of the model response format and how to map the model response to the connector result.<br><br>Depending on the selection, the model response will be available as <code>response.responseText</code> or <code>response.responseJson</code>.<br><br>See <a href=\"https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/agentic-ai-aiagent-subprocess/#response\">documentation</a> for details.",
+    "openByDefault" : false
+  }, {
+    "id" : "connector",
+    "label" : "Connector"
+  }, {
+    "id" : "output",
+    "label" : "Output mapping"
+  }, {
+    "id" : "error",
+    "label" : "Error handling"
+  }, {
+    "id" : "retries",
+    "label" : "Retries"
+  } ],
+  "properties" : [ {
+    "value" : "io.camunda.agenticai:aiagent:subprocess:2",
+    "binding" : {
+      "property" : "type",
+      "type" : "zeebe:taskDefinition"
+    },
+    "type" : "Hidden"
+  }, {
+    "id" : "outputCollection",
+    "binding" : {
+      "property" : "outputCollection",
+      "type" : "zeebe:adHoc"
+    },
+    "value" : "toolCallResults",
+    "type" : "Hidden"
+  }, {
+    "id" : "outputElement",
+    "binding" : {
+      "property" : "outputElement",
+      "type" : "zeebe:adHoc"
+    },
+    "value" : "={\n  id: toolCall._meta.id,\n  name: toolCall._meta.name,\n  content: toolCallResult,\n  completedAt: now()\n}",
+    "type" : "Hidden"
+  }, {
+    "value" : "true",
+    "binding" : {
+      "name" : "io.camunda.agenticai.toolContainer",
+      "type" : "zeebe:property"
+    },
+    "type" : "Hidden"
+  }, {
+    "id" : "provider.type",
+    "label" : "Provider",
+    "description" : "Specify the LLM provider to use.",
+    "value" : "custom",
+    "group" : "provider",
+    "binding" : {
+      "name" : "provider.type",
+      "type" : "zeebe:input"
+    },
+    "type" : "Dropdown",
+    "choices" : [ {
+      "name" : "Custom Implementation (Self-Managed/Hybrid only)",
+      "value" : "custom"
+    } ]
+  }, {
+    "id" : "provider.providerType",
+    "label" : "Provider type",
+    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "provider",
+    "binding" : {
+      "name" : "provider.providerType",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "provider.type",
+      "equals" : "custom",
+      "type" : "simple"
+    },
+    "type" : "String"
+  }, {
+    "id" : "provider.parameters",
+    "label" : "Provider parameters",
+    "description" : "Parameters for the custom chat model factory implementation.",
+    "optional" : true,
+    "feel" : "required",
+    "group" : "provider",
+    "binding" : {
+      "name" : "provider.parameters",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "provider.type",
+      "equals" : "custom",
+      "type" : "simple"
+    },
+    "type" : "String"
+  }, {
+    "id" : "provider.model",
+    "label" : "Model",
+    "description" : "Identifier of the model to use.",
+    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "model",
+    "binding" : {
+      "name" : "provider.model",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "provider.type",
+      "equals" : "custom",
+      "type" : "simple"
+    },
+    "type" : "String"
+  }, {
+    "id" : "data.systemPrompt.prompt",
+    "label" : "System prompt",
+    "optional" : false,
+    "value" : "=\"You are **TaskAgent**, a helpful, generic chat agent that can handle a wide variety of customer requests using your own domain knowledge **and** any tools explicitly provided to you at runtime.\n\nIf tools are provided, you should prefer them instead of guessing an answer. You can call the same tool multiple times by providing different input values. Don't guess any tools which were not explicitly configured. If no tool matches the request, try to generate an answer. If you're not able to find a good answer, return with a message stating why you're not able to.\n\nWrap minimal, inspectable reasoning in *exactly* this XML template:\n\n<thinking>\n<context>…briefly state the customer’s need and current state…</context>\n<reflection>…list candidate tools, justify which you will call next and why…</reflection>\n</thinking>\n\nReveal **no** additional private reasoning outside these tags.\"",
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "required",
+    "group" : "systemPrompt",
+    "binding" : {
+      "name" : "data.systemPrompt.prompt",
+      "type" : "zeebe:input"
+    },
+    "type" : "Text"
+  }, {
+    "id" : "data.userPrompt.prompt",
+    "label" : "User prompt",
+    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "required",
+    "group" : "userPrompt",
+    "binding" : {
+      "name" : "data.userPrompt.prompt",
+      "type" : "zeebe:input"
+    },
+    "type" : "Text"
+  }, {
+    "id" : "data.userPrompt.documents",
+    "label" : "Documents",
+    "description" : "Documents to be included in the user prompt.",
+    "optional" : true,
+    "feel" : "required",
+    "group" : "userPrompt",
+    "binding" : {
+      "name" : "data.userPrompt.documents",
+      "type" : "zeebe:input"
+    },
+    "tooltip" : "Referenced documents will be automatically added to the user prompt. <a href=\"https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/agentic-ai-aiagent-subprocess/\" target=\"_blank\">See documentation</a> for details and supported file types.",
+    "type" : "String"
+  }, {
+    "id" : "agentContext",
+    "label" : "Agent context",
+    "description" : "Initial agent context from previous interactions. Avoid reusing context variables across agents to prevent issues with stale data or tool access.",
+    "optional" : false,
+    "feel" : "required",
+    "group" : "memory",
+    "binding" : {
+      "name" : "agentContext",
+      "type" : "zeebe:input"
+    },
+    "tooltip" : "The agent context variable containing all relevant data for the agent to support the feedback loop between user requests, tool calls and LLM responses. Make sure this variable points to the <code>context</code> variable which is returned from the agent response. <a href=\"https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/agentic-ai-aiagent-subprocess/\" target=\"_blank\">See documentation</a> for details.",
+    "type" : "Text"
+  }, {
+    "id" : "data.memory.storage.type",
+    "label" : "Memory storage type",
+    "description" : "Specify how to store the conversation memory.",
+    "value" : "in-process",
+    "group" : "memory",
+    "binding" : {
+      "name" : "data.memory.storage.type",
+      "type" : "zeebe:input"
+    },
+    "type" : "Dropdown",
+    "choices" : [ {
+      "name" : "In Process (part of agent context)",
+      "value" : "in-process"
+    }, {
+      "name" : "Camunda Document Storage",
+      "value" : "camunda-document"
+    }, {
+      "name" : "AWS AgentCore Memory",
+      "value" : "aws-agentcore"
+    }, {
+      "name" : "Custom Implementation (Hybrid/Self-Managed only)",
+      "value" : "custom"
+    } ]
+  }, {
+    "id" : "data.memory.storage.timeToLive",
+    "label" : "Document TTL",
+    "description" : "How long to retain the conversation document as ISO-8601 duration (example: <code>P14D</code>).",
+    "optional" : true,
+    "feel" : "optional",
+    "group" : "memory",
+    "binding" : {
+      "name" : "data.memory.storage.timeToLive",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "data.memory.storage.type",
+      "equals" : "camunda-document",
+      "type" : "simple"
+    },
+    "tooltip" : "Will use the cluster default TTL (time-to-live) if not specified. Make sure to set this value to a reasonable duration matching your process lifecycle.",
+    "type" : "String"
+  }, {
+    "id" : "data.memory.storage.customProperties",
+    "label" : "Custom document properties",
+    "description" : "An optional map of custom properties to be stored with the conversation document.",
+    "optional" : true,
+    "feel" : "required",
+    "group" : "memory",
+    "binding" : {
+      "name" : "data.memory.storage.customProperties",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "data.memory.storage.type",
+      "equals" : "camunda-document",
+      "type" : "simple"
+    },
+    "type" : "String"
+  }, {
+    "id" : "data.memory.storage.region",
+    "label" : "Region",
+    "description" : "Specify the AWS region (example: <code>us-east-1</code>)",
+    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "memory",
+    "binding" : {
+      "name" : "data.memory.storage.region",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "data.memory.storage.type",
+      "equals" : "aws-agentcore",
+      "type" : "simple"
+    },
+    "type" : "String"
+  }, {
+    "id" : "data.memory.storage.endpoint",
+    "label" : "Endpoint",
+    "description" : "Custom API endpoint for VPC/PrivateLink configurations, AWS GovCloud, or other non-standard deployments.",
+    "optional" : true,
+    "feel" : "optional",
+    "group" : "memory",
+    "binding" : {
+      "name" : "data.memory.storage.endpoint",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "data.memory.storage.type",
+      "equals" : "aws-agentcore",
+      "type" : "simple"
+    },
+    "type" : "String"
+  }, {
+    "id" : "data.memory.storage.authentication.type",
+    "label" : "Authentication",
+    "description" : "Specify the AWS authentication strategy for AgentCore Memory access.",
+    "value" : "credentials",
+    "group" : "memory",
+    "binding" : {
+      "name" : "data.memory.storage.authentication.type",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "data.memory.storage.type",
+      "equals" : "aws-agentcore",
+      "type" : "simple"
+    },
+    "type" : "Dropdown",
+    "choices" : [ {
+      "name" : "Credentials",
+      "value" : "credentials"
+    }, {
+      "name" : "Default Credentials Chain (Hybrid/Self-Managed only)",
+      "value" : "defaultCredentialsChain"
+    } ]
+  }, {
+    "id" : "data.memory.storage.authentication.accessKey",
+    "label" : "Access key",
+    "description" : "Provide an IAM access key with permissions for <code>bedrock-agentcore:CreateEvent</code> and <code>bedrock-agentcore:ListEvents</code>",
+    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "memory",
+    "binding" : {
+      "name" : "data.memory.storage.authentication.accessKey",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "allMatch" : [ {
+        "property" : "data.memory.storage.authentication.type",
+        "equals" : "credentials",
+        "type" : "simple"
+      }, {
+        "property" : "data.memory.storage.type",
+        "equals" : "aws-agentcore",
+        "type" : "simple"
+      } ]
+    },
+    "type" : "String"
+  }, {
+    "id" : "data.memory.storage.authentication.secretKey",
+    "label" : "Secret key",
+    "description" : "Provide the secret key for the IAM access key",
+    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "memory",
+    "binding" : {
+      "name" : "data.memory.storage.authentication.secretKey",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "allMatch" : [ {
+        "property" : "data.memory.storage.authentication.type",
+        "equals" : "credentials",
+        "type" : "simple"
+      }, {
+        "property" : "data.memory.storage.type",
+        "equals" : "aws-agentcore",
+        "type" : "simple"
+      } ]
+    },
+    "type" : "String"
+  }, {
+    "id" : "data.memory.storage.memoryId",
+    "label" : "Memory ID",
+    "description" : "The ID of the pre-provisioned AgentCore Memory resource.",
+    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "memory",
+    "binding" : {
+      "name" : "data.memory.storage.memoryId",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "data.memory.storage.type",
+      "equals" : "aws-agentcore",
+      "type" : "simple"
+    },
+    "type" : "String"
+  }, {
+    "id" : "data.memory.storage.actorId",
+    "label" : "Actor ID",
+    "description" : "Identifier of the actor associated with events (e.g., end-user or agent/user combination).",
+    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "memory",
+    "binding" : {
+      "name" : "data.memory.storage.actorId",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "data.memory.storage.type",
+      "equals" : "aws-agentcore",
+      "type" : "simple"
+    },
+    "type" : "String"
+  }, {
+    "id" : "data.memory.storage.storeType",
+    "label" : "Implementation type",
+    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "memory",
+    "binding" : {
+      "name" : "data.memory.storage.storeType",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "data.memory.storage.type",
+      "equals" : "custom",
+      "type" : "simple"
+    },
+    "type" : "String"
+  }, {
+    "id" : "data.memory.storage.parameters",
+    "label" : "Parameters",
+    "description" : "Parameters for the custom memory storage implementation.",
+    "optional" : true,
+    "feel" : "required",
+    "group" : "memory",
+    "binding" : {
+      "name" : "data.memory.storage.parameters",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "data.memory.storage.type",
+      "equals" : "custom",
+      "type" : "simple"
+    },
+    "type" : "String"
+  }, {
+    "id" : "data.memory.contextWindowSize",
+    "label" : "Context window size",
+    "description" : "Maximum number of recent conversation messages which are passed to the model.",
+    "optional" : false,
+    "value" : 20,
+    "feel" : "static",
+    "group" : "memory",
+    "binding" : {
+      "name" : "data.memory.contextWindowSize",
+      "type" : "zeebe:input"
+    },
+    "tooltip" : "Use this to limit the number of messages which are sent to the model. The agent will only send the most recent messages up to the configured limit to the LLM. Older messages will be kept in the conversation store, but not sent to the model. <a href=\"https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/agentic-ai-aiagent-subprocess/\" target=\"_blank\">See documentation</a> for details.",
+    "type" : "Number"
+  }, {
+    "id" : "data.limits.maxModelCalls",
+    "label" : "Maximum model calls",
+    "description" : "Maximum number of calls to the model as a safety limit to prevent infinite loops.",
+    "optional" : false,
+    "value" : 10,
+    "feel" : "static",
+    "group" : "limits",
+    "binding" : {
+      "name" : "data.limits.maxModelCalls",
+      "type" : "zeebe:input"
+    },
+    "type" : "Number"
+  }, {
+    "id" : "data.events.behavior",
+    "label" : "Event handling behavior",
+    "description" : "Behavior on completing an event sub-process.",
+    "optional" : false,
+    "value" : "WAIT_FOR_TOOL_CALL_RESULTS",
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "group" : "events",
+    "binding" : {
+      "name" : "data.events.behavior",
+      "type" : "zeebe:input"
+    },
+    "type" : "Dropdown",
+    "choices" : [ {
+      "name" : "Wait for tool call results",
+      "value" : "WAIT_FOR_TOOL_CALL_RESULTS"
+    }, {
+      "name" : "Cancel tool calls",
+      "value" : "INTERRUPT_TOOL_CALLS"
+    } ]
+  }, {
+    "id" : "data.response.format.type",
+    "label" : "Response format",
+    "description" : "Specify the response format. Support for JSON mode varies by provider.",
+    "value" : "text",
+    "group" : "response",
+    "binding" : {
+      "name" : "data.response.format.type",
+      "type" : "zeebe:input"
+    },
+    "type" : "Dropdown",
+    "choices" : [ {
+      "name" : "Text",
+      "value" : "text"
+    }, {
+      "name" : "JSON",
+      "value" : "json"
+    } ]
+  }, {
+    "id" : "data.response.format.parseJson",
+    "label" : "Parse text as JSON",
+    "description" : "Tries to parse the LLM response text as JSON object.",
+    "optional" : true,
+    "feel" : "static",
+    "group" : "response",
+    "binding" : {
+      "name" : "data.response.format.parseJson",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "data.response.format.type",
+      "equals" : "text",
+      "type" : "simple"
+    },
+    "tooltip" : "Use this option in combination with models which don't support native JSON mode/structured tool calling (e.g. Anthropic). Make sure to instruct the model to return valid JSON in the system prompt. The parsed JSON will be available as <code>response.responseJson</code>.<br><br>If parsing fails, <code>null</code> will be returned as JSON response, but the text content will still be available as <code>response.responseText</code>.",
+    "type" : "Boolean"
+  }, {
+    "id" : "data.response.format.schema",
+    "label" : "Response JSON schema",
+    "description" : "An optional response <a href=\"https://json-schema.org/\" target=\"_blank\">JSON Schema</a> to instruct the model how to structure the JSON output.",
+    "optional" : true,
+    "feel" : "required",
+    "group" : "response",
+    "binding" : {
+      "name" : "data.response.format.schema",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "data.response.format.type",
+      "equals" : "json",
+      "type" : "simple"
+    },
+    "tooltip" : "If supported by the model, the response will be structured according to the provided schema. A parsed version of the response will be available as <code>response.responseJson</code>.",
+    "type" : "String"
+  }, {
+    "id" : "data.response.format.schemaName",
+    "label" : "Response JSON schema name",
+    "description" : "An optional name for the response JSON Schema to make the model aware of the expected output.",
+    "optional" : true,
+    "value" : "Response",
+    "feel" : "optional",
+    "group" : "response",
+    "binding" : {
+      "name" : "data.response.format.schemaName",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "data.response.format.type",
+      "equals" : "json",
+      "type" : "simple"
+    },
+    "type" : "String"
+  }, {
+    "id" : "data.response.includeAssistantMessage",
+    "label" : "Include assistant message",
+    "description" : "Include the full assistant message as part of the result object.",
+    "optional" : true,
+    "feel" : "static",
+    "group" : "response",
+    "binding" : {
+      "name" : "data.response.includeAssistantMessage",
+      "type" : "zeebe:input"
+    },
+    "tooltip" : "In addition to the text content, the assistant message may include multiple additional content blocks and metadata (such as token usage). The message will be available as <code>response.responseMessage</code>.",
+    "type" : "Boolean"
+  }, {
+    "id" : "data.response.includeAgentContext",
+    "label" : "Include agent context",
+    "description" : "Include the agent context as part of the result object.",
+    "optional" : true,
+    "feel" : "static",
+    "group" : "response",
+    "binding" : {
+      "name" : "data.response.includeAgentContext",
+      "type" : "zeebe:input"
+    },
+    "tooltip" : "Use this option if you need to re-inject the previous agent context into a future agent execution, for example when modeling a user feedback loop between an agent and a user task.",
+    "type" : "Boolean"
+  }, {
+    "id" : "version",
+    "label" : "Version",
+    "description" : "Version of the element template",
+    "value" : "1",
+    "group" : "connector",
+    "binding" : {
+      "key" : "elementTemplateVersion",
+      "type" : "zeebe:taskHeader"
+    },
+    "type" : "Hidden"
+  }, {
+    "id" : "id",
+    "label" : "ID",
+    "description" : "ID of the element template",
+    "value" : "io.camunda.connectors.agenticai.ai-agent-subprocess.v2",
+    "group" : "connector",
+    "binding" : {
+      "key" : "elementTemplateId",
+      "type" : "zeebe:taskHeader"
+    },
+    "type" : "Hidden"
+  }, {
+    "id" : "resultVariable",
+    "label" : "Result variable",
+    "description" : "Name of variable to store the response in. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-variable\" target=\"_blank\">documentation</a>.",
+    "value" : "agent",
+    "group" : "output",
+    "binding" : {
+      "source" : "=agent",
+      "type" : "zeebe:output"
+    },
+    "type" : "String"
+  }, {
+    "id" : "errorExpression",
+    "label" : "Error expression",
+    "description" : "Expression to handle errors. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/\" target=\"_blank\">documentation</a>.",
+    "feel" : "required",
+    "group" : "error",
+    "binding" : {
+      "key" : "errorExpression",
+      "type" : "zeebe:taskHeader"
+    },
+    "type" : "Text"
+  }, {
+    "id" : "retryCount",
+    "label" : "Retries",
+    "description" : "Number of retries",
+    "value" : "3",
+    "feel" : "optional",
+    "group" : "retries",
+    "binding" : {
+      "property" : "retries",
+      "type" : "zeebe:taskDefinition"
+    },
+    "type" : "String"
+  }, {
+    "id" : "retryBackoff",
+    "label" : "Retry backoff",
+    "description" : "ISO-8601 duration to wait between retries",
+    "value" : "PT30S",
+    "group" : "retries",
+    "binding" : {
+      "key" : "retryBackoff",
+      "type" : "zeebe:taskHeader"
+    },
+    "type" : "String"
+  }, {
+    "binding" : {
+      "name" : "agent",
+      "type" : "zeebe:input"
+    },
+    "type" : "Hidden"
+  } ],
+  "icon" : {
+    "contents" : "data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMzIiIGhlaWdodD0iMzIiIHZpZXdCb3g9IjAgMCAzMiAzMiIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPGNpcmNsZSBjeD0iMTYiIGN5PSIxNiIgcj0iMTYiIGZpbGw9IiNBNTZFRkYiLz4KPG1hc2sgaWQ9InBhdGgtMi1vdXRzaWRlLTFfMTg1XzYiIG1hc2tVbml0cz0idXNlclNwYWNlT25Vc2UiIHg9IjQiIHk9IjQiIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgZmlsbD0iYmxhY2siPgo8cmVjdCBmaWxsPSJ3aGl0ZSIgeD0iNCIgeT0iNCIgd2lkdGg9IjI0IiBoZWlnaHQ9IjI0Ii8+CjxwYXRoIGZpbGwtcnVsZT0iZXZlbm9kZCIgY2xpcC1ydWxlPSJldmVub2RkIiBkPSJNMjAuMDEwNSAxMi4wOTg3QzE4LjQ5IDEwLjU4OTQgMTcuMTU5NCA4LjEwODE0IDE2LjE3OTkgNi4wMTEwM0MxNi4xNTIgNi4wMDQ1MSAxNi4xMTc2IDYgMTYuMDc5NCA2QzE2LjA0MTEgNiAxNi4wMDY2IDYuMDA0NTEgMTUuOTc4OCA2LjAxMTA0QzE0Ljk5OTQgOC4xMDgxNCAxMy42Njk3IDEwLjU4ODkgMTIuMTQ4MSAxMi4wOTgxQzEwLjYyNjkgMTMuNjA3MSA4LjEyNTY4IDE0LjkyNjQgNi4wMTE1NyAxNS44OTgxQzYuMDA0NzQgMTUuOTI2MSA2IDE1Ljk2MTEgNiAxNkM2IDE2LjAzODcgNi4wMDQ2OCAxNi4wNzM2IDYuMDExNDQgMTYuMTAxNEM4LjEyNTE5IDE3LjA3MjkgMTAuNjI2MiAxOC4zOTE5IDEyLjE0NzcgMTkuOTAxNkMxMy42Njk3IDIxLjQxMDcgMTQuOTk5NiAyMy44OTIgMTUuOTc5MSAyNS45ODlDMTYuMDA2OCAyNS45OTU2IDE2LjA0MTEgMjYgMTYuMDc5MyAyNkMxNi4xMTc1IDI2IDE2LjE1MTkgMjUuOTk1NCAxNi4xNzk2IDI1Ljk4OUMxNy4xNTkxIDIzLjg5MiAxOC40ODg4IDIxLjQxMSAyMC4wMDk5IDE5LjkwMjFNMjAuMDA5OSAxOS45MDIxQzIxLjUyNTMgMTguMzk4NyAyMy45NDY1IDE3LjA2NjkgMjUuOTkxNSAxNi4wODI0QzI1Ljk5NjUgMTYuMDU5MyAyNiAxNi4wMzEgMjYgMTUuOTk5N0MyNiAxNS45Njg0IDI1Ljk5NjUgMTUuOTQwMyAyNS45OTE1IDE1LjkxNzFDMjMuOTQ3NCAxNC45MzI3IDIxLjUyNTkgMTMuNjAxIDIwLjAxMDUgMTIuMDk4NyIvPgo8L21hc2s+CjxwYXRoIGZpbGwtcnVsZT0iZXZlbm9kZCIgY2xpcC1ydWxlPSJldmVub2RkIiBkPSJNMjAuMDEwNSAxMi4wOTg3QzE4LjQ5IDEwLjU4OTQgMTcuMTU5NCA4LjEwODE0IDE2LjE3OTkgNi4wMTEwM0MxNi4xNTIgNi4wMDQ1MSAxNi4xMTc2IDYgMTYuMDc5NCA2QzE2LjA0MTEgNiAxNi4wMDY2IDYuMDA0NTEgMTUuOTc4OCA2LjAxMTA0QzE0Ljk5OTQgOC4xMDgxNCAxMy42Njk3IDEwLjU4ODkgMTIuMTQ4MSAxMi4wOTgxQzEwLjYyNjkgMTMuNjA3MSA4LjEyNTY4IDE0LjkyNjQgNi4wMTE1NyAxNS44OTgxQzYuMDA0NzQgMTUuOTI2MSA2IDE1Ljk2MTEgNiAxNkM2IDE2LjAzODcgNi4wMDQ2OCAxNi4wNzM2IDYuMDExNDQgMTYuMTAxNEM4LjEyNTE5IDE3LjA3MjkgMTAuNjI2MiAxOC4zOTE5IDEyLjE0NzcgMTkuOTAxNkMxMy42Njk3IDIxLjQxMDcgMTQuOTk5NiAyMy44OTIgMTUuOTc5MSAyNS45ODlDMTYuMDA2OCAyNS45OTU2IDE2LjA0MTEgMjYgMTYuMDc5MyAyNkMxNi4xMTc1IDI2IDE2LjE1MTkgMjUuOTk1NCAxNi4xNzk2IDI1Ljk4OUMxNy4xNTkxIDIzLjg5MiAxOC40ODg4IDIxLjQxMSAyMC4wMDk5IDE5LjkwMjFNMjAuMDA5OSAxOS45MDIxQzIxLjUyNTMgMTguMzk4NyAyMy45NDY1IDE3LjA2NjkgMjUuOTkxNSAxNi4wODI0QzI1Ljk5NjUgMTYuMDU5MyAyNiAxNi4wMzEgMjYgMTUuOTk5N0MyNiAxNS45Njg0IDI1Ljk5NjUgMTUuOTQwMyAyNS45OTE1IDE1LjkxNzFDMjMuOTQ3NCAxNC45MzI3IDIxLjUyNTkgMTMuNjAxIDIwLjAxMDUgMTIuMDk4NyIgZmlsbD0id2hpdGUiLz4KPHBhdGggZmlsbC1ydWxlPSJldmVub2RkIiBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGQ9Ik0yMC4wMTA1IDEyLjA5ODdDMTguNDkgMTAuNTg5NCAxNy4xNTk0IDguMTA4MTQgMTYuMTc5OSA2LjAxMTAzQzE2LjE1MiA2LjAwNDUxIDE2LjExNzYgNiAxNi4wNzk0IDZDMTYuMDQxMSA2IDE2LjAwNjYgNi4wMDQ1MSAxNS45Nzg4IDYuMDExMDRDMTQuOTk5NCA4LjEwODE0IDEzLjY2OTcgMTAuNTg4OSAxMi4xNDgxIDEyLjA5ODFDMTAuNjI2OSAxMy42MDcxIDguMTI1NjggMTQuOTI2NCA2LjAxMTU3IDE1Ljg5ODFDNi4wMDQ3NCAxNS45MjYxIDYgMTUuOTYxMSA2IDE2QzYgMTYuMDM4NyA2LjAwNDY4IDE2LjA3MzYgNi4wMTE0NCAxNi4xMDE0QzguMTI1MTkgMTcuMDcyOSAxMC42MjYyIDE4LjM5MTkgMTIuMTQ3NyAxOS45MDE2QzEzLjY2OTcgMjEuNDEwNyAxNC45OTk2IDIzLjg5MiAxNS45NzkxIDI1Ljk4OUMxNi4wMDY4IDI1Ljk5NTYgMTYuMDQxMSAyNiAxNi4wNzkzIDI2QzE2LjExNzUgMjYgMTYuMTUxOSAyNS45OTU0IDE2LjE3OTYgMjUuOTg5QzE3LjE1OTEgMjMuODkyIDE4LjQ4ODggMjEuNDExIDIwLjAwOTkgMTkuOTAyMU0yMC4wMDk5IDE5LjkwMjFDMjEuNTI1MyAxOC4zOTg3IDIzLjk0NjUgMTcuMDY2OSAyNS45OTE1IDE2LjA4MjRDMjUuOTk2NSAxNi4wNTkzIDI2IDE2LjAzMSAyNiAxNS45OTk3QzI2IDE1Ljk2ODQgMjUuOTk2NSAxNS45NDAzIDI1Ljk5MTUgMTUuOTE3MUMyMy45NDc0IDE0LjkzMjcgMjEuNTI1OSAxMy42MDEgMjAuMDEwNSAxMi4wOTg3IiBzdHJva2U9IiM0OTFEOEIiIHN0cm9rZS13aWR0aD0iNCIgc3Ryb2tlLWxpbmVqb2luPSJyb3VuZCIgbWFzaz0idXJsKCNwYXRoLTItb3V0c2lkZS0xXzE4NV82KSIvPgo8L3N2Zz4K"
+  }
+}

--- a/connectors/agentic-ai/connector-agentic-ai/element-templates/agenticai-ai-agent-subprocess.v2.json
+++ b/connectors/agentic-ai/connector-agentic-ai/element-templates/agenticai-ai-agent-subprocess.v2.json
@@ -120,6 +120,7 @@
   }, {
     "id" : "provider.providerType",
     "label" : "Provider type",
+    "description" : "Identifier for the custom chat model provider.",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -135,11 +136,12 @@
       "equals" : "custom",
       "type" : "simple"
     },
+    "tooltip" : "Must match the identifier configured for the custom implementation.",
     "type" : "String"
   }, {
     "id" : "provider.parameters",
     "label" : "Provider parameters",
-    "description" : "Parameters for the custom chat model factory implementation.",
+    "description" : "Parameters for the custom chat model provider implementation.",
     "optional" : true,
     "feel" : "required",
     "group" : "provider",
@@ -442,6 +444,7 @@
   }, {
     "id" : "data.memory.storage.storeType",
     "label" : "Implementation type",
+    "description" : "Identifier for the custom memory storage implementation.",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -457,6 +460,7 @@
       "equals" : "custom",
       "type" : "simple"
     },
+    "tooltip" : "Must match the identifier configured for the custom implementation.",
     "type" : "String"
   }, {
     "id" : "data.memory.storage.parameters",

--- a/connectors/agentic-ai/connector-agentic-ai/element-templates/agenticai-ai-agent-task.v2.json
+++ b/connectors/agentic-ai/connector-agentic-ai/element-templates/agenticai-ai-agent-task.v2.json
@@ -1,0 +1,674 @@
+{
+  "$schema" : "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+  "name" : "AI Agent Task",
+  "id" : "io.camunda.connectors.agenticai.ai-agent-task.v2",
+  "description" : "Execute a single AI-powered action with tool calling capabilities",
+  "keywords" : [ "AI", "AI Agent", "agentic orchestration" ],
+  "documentationRef" : "https://docs.camunda.io/docs/8.10/components/connectors/out-of-the-box-connectors/agentic-ai-aiagent-task/",
+  "version" : 1,
+  "category" : {
+    "id" : "aiTools",
+    "name" : "AI Tools"
+  },
+  "appliesTo" : [ "bpmn:Task" ],
+  "elementType" : {
+    "value" : "bpmn:ServiceTask"
+  },
+  "engines" : {
+    "camunda" : "^8.10"
+  },
+  "groups" : [ {
+    "id" : "provider",
+    "label" : "Model provider",
+    "openByDefault" : false
+  }, {
+    "id" : "model",
+    "label" : "Model",
+    "openByDefault" : false
+  }, {
+    "id" : "systemPrompt",
+    "label" : "System prompt",
+    "tooltip" : "A system prompt is a set of foundational instructions given to a model before any user interaction begins. It defines the AI agent’s role, behavior, tone, and communication style, ensuring that responses remain consistent and aligned with the AI agent’s intended purpose. These instructions help shape how the model interprets and responds to user input throughout the conversation.",
+    "openByDefault" : false
+  }, {
+    "id" : "userPrompt",
+    "label" : "User prompt",
+    "tooltip" : "A user prompt is the message or question you give to the AI to start or continue a conversation. It tells the AI what you need, whether it's information, help with a task, or just a chat. The AI uses your prompt to understand how to respond.",
+    "openByDefault" : false
+  }, {
+    "id" : "tools",
+    "label" : "Tools",
+    "tooltip" : "Tools are optional features the AI Agent can use to perform specific tasks. Configure this if the agent should participate in a tools feedback loop.",
+    "openByDefault" : false
+  }, {
+    "id" : "memory",
+    "label" : "Memory",
+    "tooltip" : "Configuration of the Agent's short-term/conversational memory.",
+    "openByDefault" : false
+  }, {
+    "id" : "limits",
+    "label" : "Limits",
+    "openByDefault" : false
+  }, {
+    "id" : "response",
+    "label" : "Response",
+    "tooltip" : "Configuration of the model response format and how to map the model response to the connector result.<br><br>Depending on the selection, the model response will be available as <code>response.responseText</code> or <code>response.responseJson</code>.<br><br>See <a href=\"https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/agentic-ai-aiagent-task/#response\">documentation</a> for details.",
+    "openByDefault" : false
+  }, {
+    "id" : "connector",
+    "label" : "Connector"
+  }, {
+    "id" : "output",
+    "label" : "Output mapping"
+  }, {
+    "id" : "error",
+    "label" : "Error handling"
+  }, {
+    "id" : "retries",
+    "label" : "Retries"
+  } ],
+  "properties" : [ {
+    "value" : "io.camunda.agenticai:aiagent:task:2",
+    "binding" : {
+      "property" : "type",
+      "type" : "zeebe:taskDefinition"
+    },
+    "type" : "Hidden"
+  }, {
+    "id" : "provider.type",
+    "label" : "Provider",
+    "description" : "Specify the LLM provider to use.",
+    "value" : "custom",
+    "group" : "provider",
+    "binding" : {
+      "name" : "provider.type",
+      "type" : "zeebe:input"
+    },
+    "type" : "Dropdown",
+    "choices" : [ {
+      "name" : "Custom Implementation (Self-Managed/Hybrid only)",
+      "value" : "custom"
+    } ]
+  }, {
+    "id" : "provider.providerType",
+    "label" : "Provider type",
+    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "provider",
+    "binding" : {
+      "name" : "provider.providerType",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "provider.type",
+      "equals" : "custom",
+      "type" : "simple"
+    },
+    "type" : "String"
+  }, {
+    "id" : "provider.parameters",
+    "label" : "Provider parameters",
+    "description" : "Parameters for the custom chat model factory implementation.",
+    "optional" : true,
+    "feel" : "required",
+    "group" : "provider",
+    "binding" : {
+      "name" : "provider.parameters",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "provider.type",
+      "equals" : "custom",
+      "type" : "simple"
+    },
+    "type" : "String"
+  }, {
+    "id" : "provider.model",
+    "label" : "Model",
+    "description" : "Identifier of the model to use.",
+    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "model",
+    "binding" : {
+      "name" : "provider.model",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "provider.type",
+      "equals" : "custom",
+      "type" : "simple"
+    },
+    "type" : "String"
+  }, {
+    "id" : "data.systemPrompt.prompt",
+    "label" : "System prompt",
+    "optional" : false,
+    "value" : "=\"You are **TaskAgent**, a helpful, generic chat agent that can handle a wide variety of customer requests using your own domain knowledge **and** any tools explicitly provided to you at runtime.\n\nIf tools are provided, you should prefer them instead of guessing an answer. You can call the same tool multiple times by providing different input values. Don't guess any tools which were not explicitly configured. If no tool matches the request, try to generate an answer. If you're not able to find a good answer, return with a message stating why you're not able to.\n\nWrap minimal, inspectable reasoning in *exactly* this XML template:\n\n<thinking>\n<context>…briefly state the customer’s need and current state…</context>\n<reflection>…list candidate tools, justify which you will call next and why…</reflection>\n</thinking>\n\nReveal **no** additional private reasoning outside these tags.\"",
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "required",
+    "group" : "systemPrompt",
+    "binding" : {
+      "name" : "data.systemPrompt.prompt",
+      "type" : "zeebe:input"
+    },
+    "type" : "Text"
+  }, {
+    "id" : "data.userPrompt.prompt",
+    "label" : "User prompt",
+    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "required",
+    "group" : "userPrompt",
+    "binding" : {
+      "name" : "data.userPrompt.prompt",
+      "type" : "zeebe:input"
+    },
+    "type" : "Text"
+  }, {
+    "id" : "data.userPrompt.documents",
+    "label" : "Documents",
+    "description" : "Documents to be included in the user prompt.",
+    "optional" : true,
+    "feel" : "required",
+    "group" : "userPrompt",
+    "binding" : {
+      "name" : "data.userPrompt.documents",
+      "type" : "zeebe:input"
+    },
+    "tooltip" : "Referenced documents will be automatically added to the user prompt. <a href=\"https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/agentic-ai-aiagent-task/\" target=\"_blank\">See documentation</a> for details and supported file types.",
+    "type" : "String"
+  }, {
+    "id" : "data.tools.containerElementId",
+    "label" : "Ad-hoc sub-process ID",
+    "description" : "ID of the sub-process that contains the tools the AI agent can use.",
+    "optional" : true,
+    "feel" : "optional",
+    "group" : "tools",
+    "binding" : {
+      "name" : "data.tools.containerElementId",
+      "type" : "zeebe:input"
+    },
+    "tooltip" : "Add an ad-hoc sub-process ID to attach the AI agent to the tools. Ensure your process includes a tools feedback loop routing into the ad-hoc sub-process and back to the AI agent connector. <a href=\"https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/agentic-ai-aiagent-task/\" target=\"_blank\">See documentation</a> for details.",
+    "type" : "String"
+  }, {
+    "id" : "data.tools.toolCallResults",
+    "label" : "Tool call results",
+    "description" : "Tool call results as returned by the sub-process.",
+    "optional" : true,
+    "feel" : "required",
+    "group" : "tools",
+    "binding" : {
+      "name" : "data.tools.toolCallResults",
+      "type" : "zeebe:input"
+    },
+    "tooltip" : "This defines where to handle tool call results returned by the ad-hoc sub-process. Model this as part of your process and route it into the tools feedback loop. <a href=\"https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/agentic-ai-aiagent-task/\" target=\"_blank\">See documentation</a> for details.",
+    "type" : "Text"
+  }, {
+    "id" : "data.agentContext",
+    "label" : "Agent context",
+    "description" : "Avoid reusing context variables across agents to prevent issues with stale data or tool access.",
+    "optional" : false,
+    "value" : "=agent.context",
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "required",
+    "group" : "memory",
+    "binding" : {
+      "name" : "data.context",
+      "type" : "zeebe:input"
+    },
+    "tooltip" : "The agent context variable containing all relevant data for the agent to support the feedback loop between user requests, tool calls and LLM responses. Make sure this variable points to the <code>context</code> variable which is returned from the agent response. <a href=\"https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/agentic-ai-aiagent-task/\" target=\"_blank\">See documentation</a> for details.",
+    "type" : "Text"
+  }, {
+    "id" : "data.memory.storage.type",
+    "label" : "Memory storage type",
+    "description" : "Specify how to store the conversation memory.",
+    "value" : "in-process",
+    "group" : "memory",
+    "binding" : {
+      "name" : "data.memory.storage.type",
+      "type" : "zeebe:input"
+    },
+    "type" : "Dropdown",
+    "choices" : [ {
+      "name" : "In Process (part of agent context)",
+      "value" : "in-process"
+    }, {
+      "name" : "Camunda Document Storage",
+      "value" : "camunda-document"
+    }, {
+      "name" : "AWS AgentCore Memory",
+      "value" : "aws-agentcore"
+    }, {
+      "name" : "Custom Implementation (Hybrid/Self-Managed only)",
+      "value" : "custom"
+    } ]
+  }, {
+    "id" : "data.memory.storage.timeToLive",
+    "label" : "Document TTL",
+    "description" : "How long to retain the conversation document as ISO-8601 duration (example: <code>P14D</code>).",
+    "optional" : true,
+    "feel" : "optional",
+    "group" : "memory",
+    "binding" : {
+      "name" : "data.memory.storage.timeToLive",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "data.memory.storage.type",
+      "equals" : "camunda-document",
+      "type" : "simple"
+    },
+    "tooltip" : "Will use the cluster default TTL (time-to-live) if not specified. Make sure to set this value to a reasonable duration matching your process lifecycle.",
+    "type" : "String"
+  }, {
+    "id" : "data.memory.storage.customProperties",
+    "label" : "Custom document properties",
+    "description" : "An optional map of custom properties to be stored with the conversation document.",
+    "optional" : true,
+    "feel" : "required",
+    "group" : "memory",
+    "binding" : {
+      "name" : "data.memory.storage.customProperties",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "data.memory.storage.type",
+      "equals" : "camunda-document",
+      "type" : "simple"
+    },
+    "type" : "String"
+  }, {
+    "id" : "data.memory.storage.region",
+    "label" : "Region",
+    "description" : "Specify the AWS region (example: <code>us-east-1</code>)",
+    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "memory",
+    "binding" : {
+      "name" : "data.memory.storage.region",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "data.memory.storage.type",
+      "equals" : "aws-agentcore",
+      "type" : "simple"
+    },
+    "type" : "String"
+  }, {
+    "id" : "data.memory.storage.endpoint",
+    "label" : "Endpoint",
+    "description" : "Custom API endpoint for VPC/PrivateLink configurations, AWS GovCloud, or other non-standard deployments.",
+    "optional" : true,
+    "feel" : "optional",
+    "group" : "memory",
+    "binding" : {
+      "name" : "data.memory.storage.endpoint",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "data.memory.storage.type",
+      "equals" : "aws-agentcore",
+      "type" : "simple"
+    },
+    "type" : "String"
+  }, {
+    "id" : "data.memory.storage.authentication.type",
+    "label" : "Authentication",
+    "description" : "Specify the AWS authentication strategy for AgentCore Memory access.",
+    "value" : "credentials",
+    "group" : "memory",
+    "binding" : {
+      "name" : "data.memory.storage.authentication.type",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "data.memory.storage.type",
+      "equals" : "aws-agentcore",
+      "type" : "simple"
+    },
+    "type" : "Dropdown",
+    "choices" : [ {
+      "name" : "Credentials",
+      "value" : "credentials"
+    }, {
+      "name" : "Default Credentials Chain (Hybrid/Self-Managed only)",
+      "value" : "defaultCredentialsChain"
+    } ]
+  }, {
+    "id" : "data.memory.storage.authentication.accessKey",
+    "label" : "Access key",
+    "description" : "Provide an IAM access key with permissions for <code>bedrock-agentcore:CreateEvent</code> and <code>bedrock-agentcore:ListEvents</code>",
+    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "memory",
+    "binding" : {
+      "name" : "data.memory.storage.authentication.accessKey",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "allMatch" : [ {
+        "property" : "data.memory.storage.authentication.type",
+        "equals" : "credentials",
+        "type" : "simple"
+      }, {
+        "property" : "data.memory.storage.type",
+        "equals" : "aws-agentcore",
+        "type" : "simple"
+      } ]
+    },
+    "type" : "String"
+  }, {
+    "id" : "data.memory.storage.authentication.secretKey",
+    "label" : "Secret key",
+    "description" : "Provide the secret key for the IAM access key",
+    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "memory",
+    "binding" : {
+      "name" : "data.memory.storage.authentication.secretKey",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "allMatch" : [ {
+        "property" : "data.memory.storage.authentication.type",
+        "equals" : "credentials",
+        "type" : "simple"
+      }, {
+        "property" : "data.memory.storage.type",
+        "equals" : "aws-agentcore",
+        "type" : "simple"
+      } ]
+    },
+    "type" : "String"
+  }, {
+    "id" : "data.memory.storage.memoryId",
+    "label" : "Memory ID",
+    "description" : "The ID of the pre-provisioned AgentCore Memory resource.",
+    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "memory",
+    "binding" : {
+      "name" : "data.memory.storage.memoryId",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "data.memory.storage.type",
+      "equals" : "aws-agentcore",
+      "type" : "simple"
+    },
+    "type" : "String"
+  }, {
+    "id" : "data.memory.storage.actorId",
+    "label" : "Actor ID",
+    "description" : "Identifier of the actor associated with events (e.g., end-user or agent/user combination).",
+    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "memory",
+    "binding" : {
+      "name" : "data.memory.storage.actorId",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "data.memory.storage.type",
+      "equals" : "aws-agentcore",
+      "type" : "simple"
+    },
+    "type" : "String"
+  }, {
+    "id" : "data.memory.storage.storeType",
+    "label" : "Implementation type",
+    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "memory",
+    "binding" : {
+      "name" : "data.memory.storage.storeType",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "data.memory.storage.type",
+      "equals" : "custom",
+      "type" : "simple"
+    },
+    "type" : "String"
+  }, {
+    "id" : "data.memory.storage.parameters",
+    "label" : "Parameters",
+    "description" : "Parameters for the custom memory storage implementation.",
+    "optional" : true,
+    "feel" : "required",
+    "group" : "memory",
+    "binding" : {
+      "name" : "data.memory.storage.parameters",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "data.memory.storage.type",
+      "equals" : "custom",
+      "type" : "simple"
+    },
+    "type" : "String"
+  }, {
+    "id" : "data.memory.contextWindowSize",
+    "label" : "Context window size",
+    "description" : "Maximum number of recent conversation messages which are passed to the model.",
+    "optional" : false,
+    "value" : 20,
+    "feel" : "static",
+    "group" : "memory",
+    "binding" : {
+      "name" : "data.memory.contextWindowSize",
+      "type" : "zeebe:input"
+    },
+    "tooltip" : "Use this to limit the number of messages which are sent to the model. The agent will only send the most recent messages up to the configured limit to the LLM. Older messages will be kept in the conversation store, but not sent to the model. <a href=\"https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/agentic-ai-aiagent-task/\" target=\"_blank\">See documentation</a> for details.",
+    "type" : "Number"
+  }, {
+    "id" : "data.limits.maxModelCalls",
+    "label" : "Maximum model calls",
+    "description" : "Maximum number of calls to the model as a safety limit to prevent infinite loops.",
+    "optional" : false,
+    "value" : 10,
+    "feel" : "static",
+    "group" : "limits",
+    "binding" : {
+      "name" : "data.limits.maxModelCalls",
+      "type" : "zeebe:input"
+    },
+    "type" : "Number"
+  }, {
+    "id" : "data.response.format.type",
+    "label" : "Response format",
+    "description" : "Specify the response format. Support for JSON mode varies by provider.",
+    "value" : "text",
+    "group" : "response",
+    "binding" : {
+      "name" : "data.response.format.type",
+      "type" : "zeebe:input"
+    },
+    "type" : "Dropdown",
+    "choices" : [ {
+      "name" : "Text",
+      "value" : "text"
+    }, {
+      "name" : "JSON",
+      "value" : "json"
+    } ]
+  }, {
+    "id" : "data.response.format.parseJson",
+    "label" : "Parse text as JSON",
+    "description" : "Tries to parse the LLM response text as JSON object.",
+    "optional" : true,
+    "feel" : "static",
+    "group" : "response",
+    "binding" : {
+      "name" : "data.response.format.parseJson",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "data.response.format.type",
+      "equals" : "text",
+      "type" : "simple"
+    },
+    "tooltip" : "Use this option in combination with models which don't support native JSON mode/structured tool calling (e.g. Anthropic). Make sure to instruct the model to return valid JSON in the system prompt. The parsed JSON will be available as <code>response.responseJson</code>.<br><br>If parsing fails, <code>null</code> will be returned as JSON response, but the text content will still be available as <code>response.responseText</code>.",
+    "type" : "Boolean"
+  }, {
+    "id" : "data.response.format.schema",
+    "label" : "Response JSON schema",
+    "description" : "An optional response <a href=\"https://json-schema.org/\" target=\"_blank\">JSON Schema</a> to instruct the model how to structure the JSON output.",
+    "optional" : true,
+    "feel" : "required",
+    "group" : "response",
+    "binding" : {
+      "name" : "data.response.format.schema",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "data.response.format.type",
+      "equals" : "json",
+      "type" : "simple"
+    },
+    "tooltip" : "If supported by the model, the response will be structured according to the provided schema. A parsed version of the response will be available as <code>response.responseJson</code>.",
+    "type" : "String"
+  }, {
+    "id" : "data.response.format.schemaName",
+    "label" : "Response JSON schema name",
+    "description" : "An optional name for the response JSON Schema to make the model aware of the expected output.",
+    "optional" : true,
+    "value" : "Response",
+    "feel" : "optional",
+    "group" : "response",
+    "binding" : {
+      "name" : "data.response.format.schemaName",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "data.response.format.type",
+      "equals" : "json",
+      "type" : "simple"
+    },
+    "type" : "String"
+  }, {
+    "id" : "data.response.includeAssistantMessage",
+    "label" : "Include assistant message",
+    "description" : "Include the full assistant message as part of the result object.",
+    "optional" : true,
+    "feel" : "static",
+    "group" : "response",
+    "binding" : {
+      "name" : "data.response.includeAssistantMessage",
+      "type" : "zeebe:input"
+    },
+    "tooltip" : "In addition to the text content, the assistant message may include multiple additional content blocks and metadata (such as token usage). The message will be available as <code>response.responseMessage</code>.",
+    "type" : "Boolean"
+  }, {
+    "id" : "version",
+    "label" : "Version",
+    "description" : "Version of the element template",
+    "value" : "1",
+    "group" : "connector",
+    "binding" : {
+      "key" : "elementTemplateVersion",
+      "type" : "zeebe:taskHeader"
+    },
+    "type" : "Hidden"
+  }, {
+    "id" : "id",
+    "label" : "ID",
+    "description" : "ID of the element template",
+    "value" : "io.camunda.connectors.agenticai.ai-agent-task.v2",
+    "group" : "connector",
+    "binding" : {
+      "key" : "elementTemplateId",
+      "type" : "zeebe:taskHeader"
+    },
+    "type" : "Hidden"
+  }, {
+    "id" : "resultVariable",
+    "label" : "Result variable",
+    "description" : "Name of variable to store the response in. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-variable\" target=\"_blank\">documentation</a>.",
+    "value" : "agent",
+    "group" : "output",
+    "binding" : {
+      "key" : "resultVariable",
+      "type" : "zeebe:taskHeader"
+    },
+    "type" : "String"
+  }, {
+    "id" : "resultExpression",
+    "label" : "Result expression",
+    "description" : "Expression to map the response into process variables. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-expression\" target=\"_blank\">documentation</a>.",
+    "feel" : "required",
+    "group" : "output",
+    "binding" : {
+      "key" : "resultExpression",
+      "type" : "zeebe:taskHeader"
+    },
+    "type" : "Text"
+  }, {
+    "id" : "errorExpression",
+    "label" : "Error expression",
+    "description" : "Expression to handle errors. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/\" target=\"_blank\">documentation</a>.",
+    "feel" : "required",
+    "group" : "error",
+    "binding" : {
+      "key" : "errorExpression",
+      "type" : "zeebe:taskHeader"
+    },
+    "type" : "Text"
+  }, {
+    "id" : "retryCount",
+    "label" : "Retries",
+    "description" : "Number of retries",
+    "value" : "3",
+    "feel" : "optional",
+    "group" : "retries",
+    "binding" : {
+      "property" : "retries",
+      "type" : "zeebe:taskDefinition"
+    },
+    "type" : "String"
+  }, {
+    "id" : "retryBackoff",
+    "label" : "Retry backoff",
+    "description" : "ISO-8601 duration to wait between retries",
+    "value" : "PT30S",
+    "group" : "retries",
+    "binding" : {
+      "key" : "retryBackoff",
+      "type" : "zeebe:taskHeader"
+    },
+    "type" : "String"
+  } ],
+  "icon" : {
+    "contents" : "data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMzIiIGhlaWdodD0iMzIiIHZpZXdCb3g9IjAgMCAzMiAzMiIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPGNpcmNsZSBjeD0iMTYiIGN5PSIxNiIgcj0iMTYiIGZpbGw9IiNBNTZFRkYiLz4KPG1hc2sgaWQ9InBhdGgtMi1vdXRzaWRlLTFfMTg1XzYiIG1hc2tVbml0cz0idXNlclNwYWNlT25Vc2UiIHg9IjQiIHk9IjQiIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgZmlsbD0iYmxhY2siPgo8cmVjdCBmaWxsPSJ3aGl0ZSIgeD0iNCIgeT0iNCIgd2lkdGg9IjI0IiBoZWlnaHQ9IjI0Ii8+CjxwYXRoIGZpbGwtcnVsZT0iZXZlbm9kZCIgY2xpcC1ydWxlPSJldmVub2RkIiBkPSJNMjAuMDEwNSAxMi4wOTg3QzE4LjQ5IDEwLjU4OTQgMTcuMTU5NCA4LjEwODE0IDE2LjE3OTkgNi4wMTEwM0MxNi4xNTIgNi4wMDQ1MSAxNi4xMTc2IDYgMTYuMDc5NCA2QzE2LjA0MTEgNiAxNi4wMDY2IDYuMDA0NTEgMTUuOTc4OCA2LjAxMTA0QzE0Ljk5OTQgOC4xMDgxNCAxMy42Njk3IDEwLjU4ODkgMTIuMTQ4MSAxMi4wOTgxQzEwLjYyNjkgMTMuNjA3MSA4LjEyNTY4IDE0LjkyNjQgNi4wMTE1NyAxNS44OTgxQzYuMDA0NzQgMTUuOTI2MSA2IDE1Ljk2MTEgNiAxNkM2IDE2LjAzODcgNi4wMDQ2OCAxNi4wNzM2IDYuMDExNDQgMTYuMTAxNEM4LjEyNTE5IDE3LjA3MjkgMTAuNjI2MiAxOC4zOTE5IDEyLjE0NzcgMTkuOTAxNkMxMy42Njk3IDIxLjQxMDcgMTQuOTk5NiAyMy44OTIgMTUuOTc5MSAyNS45ODlDMTYuMDA2OCAyNS45OTU2IDE2LjA0MTEgMjYgMTYuMDc5MyAyNkMxNi4xMTc1IDI2IDE2LjE1MTkgMjUuOTk1NCAxNi4xNzk2IDI1Ljk4OUMxNy4xNTkxIDIzLjg5MiAxOC40ODg4IDIxLjQxMSAyMC4wMDk5IDE5LjkwMjFNMjAuMDA5OSAxOS45MDIxQzIxLjUyNTMgMTguMzk4NyAyMy45NDY1IDE3LjA2NjkgMjUuOTkxNSAxNi4wODI0QzI1Ljk5NjUgMTYuMDU5MyAyNiAxNi4wMzEgMjYgMTUuOTk5N0MyNiAxNS45Njg0IDI1Ljk5NjUgMTUuOTQwMyAyNS45OTE1IDE1LjkxNzFDMjMuOTQ3NCAxNC45MzI3IDIxLjUyNTkgMTMuNjAxIDIwLjAxMDUgMTIuMDk4NyIvPgo8L21hc2s+CjxwYXRoIGZpbGwtcnVsZT0iZXZlbm9kZCIgY2xpcC1ydWxlPSJldmVub2RkIiBkPSJNMjAuMDEwNSAxMi4wOTg3QzE4LjQ5IDEwLjU4OTQgMTcuMTU5NCA4LjEwODE0IDE2LjE3OTkgNi4wMTEwM0MxNi4xNTIgNi4wMDQ1MSAxNi4xMTc2IDYgMTYuMDc5NCA2QzE2LjA0MTEgNiAxNi4wMDY2IDYuMDA0NTEgMTUuOTc4OCA2LjAxMTA0QzE0Ljk5OTQgOC4xMDgxNCAxMy42Njk3IDEwLjU4ODkgMTIuMTQ4MSAxMi4wOTgxQzEwLjYyNjkgMTMuNjA3MSA4LjEyNTY4IDE0LjkyNjQgNi4wMTE1NyAxNS44OTgxQzYuMDA0NzQgMTUuOTI2MSA2IDE1Ljk2MTEgNiAxNkM2IDE2LjAzODcgNi4wMDQ2OCAxNi4wNzM2IDYuMDExNDQgMTYuMTAxNEM4LjEyNTE5IDE3LjA3MjkgMTAuNjI2MiAxOC4zOTE5IDEyLjE0NzcgMTkuOTAxNkMxMy42Njk3IDIxLjQxMDcgMTQuOTk5NiAyMy44OTIgMTUuOTc5MSAyNS45ODlDMTYuMDA2OCAyNS45OTU2IDE2LjA0MTEgMjYgMTYuMDc5MyAyNkMxNi4xMTc1IDI2IDE2LjE1MTkgMjUuOTk1NCAxNi4xNzk2IDI1Ljk4OUMxNy4xNTkxIDIzLjg5MiAxOC40ODg4IDIxLjQxMSAyMC4wMDk5IDE5LjkwMjFNMjAuMDA5OSAxOS45MDIxQzIxLjUyNTMgMTguMzk4NyAyMy45NDY1IDE3LjA2NjkgMjUuOTkxNSAxNi4wODI0QzI1Ljk5NjUgMTYuMDU5MyAyNiAxNi4wMzEgMjYgMTUuOTk5N0MyNiAxNS45Njg0IDI1Ljk5NjUgMTUuOTQwMyAyNS45OTE1IDE1LjkxNzFDMjMuOTQ3NCAxNC45MzI3IDIxLjUyNTkgMTMuNjAxIDIwLjAxMDUgMTIuMDk4NyIgZmlsbD0id2hpdGUiLz4KPHBhdGggZmlsbC1ydWxlPSJldmVub2RkIiBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGQ9Ik0yMC4wMTA1IDEyLjA5ODdDMTguNDkgMTAuNTg5NCAxNy4xNTk0IDguMTA4MTQgMTYuMTc5OSA2LjAxMTAzQzE2LjE1MiA2LjAwNDUxIDE2LjExNzYgNiAxNi4wNzk0IDZDMTYuMDQxMSA2IDE2LjAwNjYgNi4wMDQ1MSAxNS45Nzg4IDYuMDExMDRDMTQuOTk5NCA4LjEwODE0IDEzLjY2OTcgMTAuNTg4OSAxMi4xNDgxIDEyLjA5ODFDMTAuNjI2OSAxMy42MDcxIDguMTI1NjggMTQuOTI2NCA2LjAxMTU3IDE1Ljg5ODFDNi4wMDQ3NCAxNS45MjYxIDYgMTUuOTYxMSA2IDE2QzYgMTYuMDM4NyA2LjAwNDY4IDE2LjA3MzYgNi4wMTE0NCAxNi4xMDE0QzguMTI1MTkgMTcuMDcyOSAxMC42MjYyIDE4LjM5MTkgMTIuMTQ3NyAxOS45MDE2QzEzLjY2OTcgMjEuNDEwNyAxNC45OTk2IDIzLjg5MiAxNS45NzkxIDI1Ljk4OUMxNi4wMDY4IDI1Ljk5NTYgMTYuMDQxMSAyNiAxNi4wNzkzIDI2QzE2LjExNzUgMjYgMTYuMTUxOSAyNS45OTU0IDE2LjE3OTYgMjUuOTg5QzE3LjE1OTEgMjMuODkyIDE4LjQ4ODggMjEuNDExIDIwLjAwOTkgMTkuOTAyMU0yMC4wMDk5IDE5LjkwMjFDMjEuNTI1MyAxOC4zOTg3IDIzLjk0NjUgMTcuMDY2OSAyNS45OTE1IDE2LjA4MjRDMjUuOTk2NSAxNi4wNTkzIDI2IDE2LjAzMSAyNiAxNS45OTk3QzI2IDE1Ljk2ODQgMjUuOTk2NSAxNS45NDAzIDI1Ljk5MTUgMTUuOTE3MUMyMy45NDc0IDE0LjkzMjcgMjEuNTI1OSAxMy42MDEgMjAuMDEwNSAxMi4wOTg3IiBzdHJva2U9IiM0OTFEOEIiIHN0cm9rZS13aWR0aD0iNCIgc3Ryb2tlLWxpbmVqb2luPSJyb3VuZCIgbWFzaz0idXJsKCNwYXRoLTItb3V0c2lkZS0xXzE4NV82KSIvPgo8L3N2Zz4K"
+  }
+}

--- a/connectors/agentic-ai/connector-agentic-ai/element-templates/agenticai-ai-agent-task.v2.json
+++ b/connectors/agentic-ai/connector-agentic-ai/element-templates/agenticai-ai-agent-task.v2.json
@@ -92,6 +92,7 @@
   }, {
     "id" : "provider.providerType",
     "label" : "Provider type",
+    "description" : "Identifier for the custom chat model provider.",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -107,11 +108,12 @@
       "equals" : "custom",
       "type" : "simple"
     },
+    "tooltip" : "Must match the identifier configured for the custom implementation.",
     "type" : "String"
   }, {
     "id" : "provider.parameters",
     "label" : "Provider parameters",
-    "description" : "Parameters for the custom chat model factory implementation.",
+    "description" : "Parameters for the custom chat model provider implementation.",
     "optional" : true,
     "feel" : "required",
     "group" : "provider",
@@ -444,6 +446,7 @@
   }, {
     "id" : "data.memory.storage.storeType",
     "label" : "Implementation type",
+    "description" : "Identifier for the custom memory storage implementation.",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -459,6 +462,7 @@
       "equals" : "custom",
       "type" : "simple"
     },
+    "tooltip" : "Must match the identifier configured for the custom implementation.",
     "type" : "String"
   }, {
     "id" : "data.memory.storage.parameters",

--- a/connectors/agentic-ai/connector-agentic-ai/element-templates/agenticai-aiagent-job-worker.json
+++ b/connectors/agentic-ai/connector-agentic-ai/element-templates/agenticai-aiagent-job-worker.json
@@ -1526,6 +1526,7 @@
   }, {
     "id" : "data.memory.storage.storeType",
     "label" : "Implementation type",
+    "description" : "Identifier for the custom memory storage implementation.",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -1541,6 +1542,7 @@
       "equals" : "custom",
       "type" : "simple"
     },
+    "tooltip" : "Must match the identifier configured for the custom implementation.",
     "type" : "String"
   }, {
     "id" : "data.memory.storage.parameters",

--- a/connectors/agentic-ai/connector-agentic-ai/element-templates/agenticai-aiagent-outbound-connector.json
+++ b/connectors/agentic-ai/connector-agentic-ai/element-templates/agenticai-aiagent-outbound-connector.json
@@ -1528,6 +1528,7 @@
   }, {
     "id" : "data.memory.storage.storeType",
     "label" : "Implementation type",
+    "description" : "Identifier for the custom memory storage implementation.",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -1543,6 +1544,7 @@
       "equals" : "custom",
       "type" : "simple"
     },
+    "tooltip" : "Must match the identifier configured for the custom implementation.",
     "type" : "String"
   }, {
     "id" : "data.memory.storage.parameters",

--- a/connectors/agentic-ai/connector-agentic-ai/element-templates/hybrid/agenticai-ai-agent-subprocess.v2-hybrid.json
+++ b/connectors/agentic-ai/connector-agentic-ai/element-templates/hybrid/agenticai-ai-agent-subprocess.v2-hybrid.json
@@ -1,0 +1,707 @@
+{
+  "$schema" : "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+  "name" : "Hybrid AI Agent Sub-process",
+  "id" : "io.camunda.connectors.agenticai.ai-agent-subprocess.v2-hybrid",
+  "description" : "Run a multi-step AI reasoning loop with dynamic tool selection",
+  "keywords" : [ "AI", "AI Agent", "agentic orchestration" ],
+  "documentationRef" : "https://docs.camunda.io/docs/8.10/components/connectors/out-of-the-box-connectors/agentic-ai-aiagent-subprocess/",
+  "version" : 1,
+  "category" : {
+    "id" : "aiTools",
+    "name" : "AI Tools"
+  },
+  "appliesTo" : [ "bpmn:SubProcess" ],
+  "elementType" : {
+    "value" : "bpmn:AdHocSubProcess"
+  },
+  "engines" : {
+    "camunda" : "^8.10"
+  },
+  "groups" : [ {
+    "id" : "taskDefinitionType",
+    "label" : "Task definition type"
+  }, {
+    "id" : "provider",
+    "label" : "Model provider",
+    "openByDefault" : false
+  }, {
+    "id" : "model",
+    "label" : "Model",
+    "openByDefault" : false
+  }, {
+    "id" : "systemPrompt",
+    "label" : "System prompt",
+    "tooltip" : "A system prompt is a set of foundational instructions given to a model before any user interaction begins. It defines the AI agent’s role, behavior, tone, and communication style, ensuring that responses remain consistent and aligned with the AI agent’s intended purpose. These instructions help shape how the model interprets and responds to user input throughout the conversation.",
+    "openByDefault" : false
+  }, {
+    "id" : "userPrompt",
+    "label" : "User prompt",
+    "tooltip" : "A user prompt is the message or question you give to the AI to start or continue a conversation. It tells the AI what you need, whether it's information, help with a task, or just a chat. The AI uses your prompt to understand how to respond.",
+    "openByDefault" : false
+  }, {
+    "id" : "tools",
+    "label" : "Tools",
+    "tooltip" : "Tools are optional features the AI Agent can use to perform specific tasks. Configure this if the agent should participate in a tools feedback loop.",
+    "openByDefault" : false
+  }, {
+    "id" : "memory",
+    "label" : "Memory",
+    "tooltip" : "Configuration of the Agent's short-term/conversational memory.",
+    "openByDefault" : false
+  }, {
+    "id" : "limits",
+    "label" : "Limits",
+    "openByDefault" : false
+  }, {
+    "id" : "events",
+    "label" : "Event handling",
+    "tooltip" : "Configure how event sub-process results are handled. Results are added as user messages to the running agent.",
+    "openByDefault" : false
+  }, {
+    "id" : "response",
+    "label" : "Response",
+    "tooltip" : "Configuration of the model response format and how to map the model response to the connector result.<br><br>Depending on the selection, the model response will be available as <code>response.responseText</code> or <code>response.responseJson</code>.<br><br>See <a href=\"https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/agentic-ai-aiagent-subprocess/#response\">documentation</a> for details.",
+    "openByDefault" : false
+  }, {
+    "id" : "connector",
+    "label" : "Connector"
+  }, {
+    "id" : "output",
+    "label" : "Output mapping"
+  }, {
+    "id" : "error",
+    "label" : "Error handling"
+  }, {
+    "id" : "retries",
+    "label" : "Retries"
+  } ],
+  "properties" : [ {
+    "id" : "taskDefinitionType",
+    "value" : "io.camunda.agenticai:aiagent:subprocess:2",
+    "group" : "taskDefinitionType",
+    "binding" : {
+      "property" : "type",
+      "type" : "zeebe:taskDefinition"
+    },
+    "type" : "String"
+  }, {
+    "id" : "outputCollection",
+    "binding" : {
+      "property" : "outputCollection",
+      "type" : "zeebe:adHoc"
+    },
+    "value" : "toolCallResults",
+    "type" : "Hidden"
+  }, {
+    "id" : "outputElement",
+    "binding" : {
+      "property" : "outputElement",
+      "type" : "zeebe:adHoc"
+    },
+    "value" : "={\n  id: toolCall._meta.id,\n  name: toolCall._meta.name,\n  content: toolCallResult,\n  completedAt: now()\n}",
+    "type" : "Hidden"
+  }, {
+    "value" : "true",
+    "binding" : {
+      "name" : "io.camunda.agenticai.toolContainer",
+      "type" : "zeebe:property"
+    },
+    "type" : "Hidden"
+  }, {
+    "id" : "provider.type",
+    "label" : "Provider",
+    "description" : "Specify the LLM provider to use.",
+    "value" : "custom",
+    "group" : "provider",
+    "binding" : {
+      "name" : "provider.type",
+      "type" : "zeebe:input"
+    },
+    "type" : "Dropdown",
+    "choices" : [ {
+      "name" : "Custom Implementation (Self-Managed/Hybrid only)",
+      "value" : "custom"
+    } ]
+  }, {
+    "id" : "provider.providerType",
+    "label" : "Provider type",
+    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "provider",
+    "binding" : {
+      "name" : "provider.providerType",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "provider.type",
+      "equals" : "custom",
+      "type" : "simple"
+    },
+    "type" : "String"
+  }, {
+    "id" : "provider.parameters",
+    "label" : "Provider parameters",
+    "description" : "Parameters for the custom chat model factory implementation.",
+    "optional" : true,
+    "feel" : "required",
+    "group" : "provider",
+    "binding" : {
+      "name" : "provider.parameters",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "provider.type",
+      "equals" : "custom",
+      "type" : "simple"
+    },
+    "type" : "String"
+  }, {
+    "id" : "provider.model",
+    "label" : "Model",
+    "description" : "Identifier of the model to use.",
+    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "model",
+    "binding" : {
+      "name" : "provider.model",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "provider.type",
+      "equals" : "custom",
+      "type" : "simple"
+    },
+    "type" : "String"
+  }, {
+    "id" : "data.systemPrompt.prompt",
+    "label" : "System prompt",
+    "optional" : false,
+    "value" : "=\"You are **TaskAgent**, a helpful, generic chat agent that can handle a wide variety of customer requests using your own domain knowledge **and** any tools explicitly provided to you at runtime.\n\nIf tools are provided, you should prefer them instead of guessing an answer. You can call the same tool multiple times by providing different input values. Don't guess any tools which were not explicitly configured. If no tool matches the request, try to generate an answer. If you're not able to find a good answer, return with a message stating why you're not able to.\n\nWrap minimal, inspectable reasoning in *exactly* this XML template:\n\n<thinking>\n<context>…briefly state the customer’s need and current state…</context>\n<reflection>…list candidate tools, justify which you will call next and why…</reflection>\n</thinking>\n\nReveal **no** additional private reasoning outside these tags.\"",
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "required",
+    "group" : "systemPrompt",
+    "binding" : {
+      "name" : "data.systemPrompt.prompt",
+      "type" : "zeebe:input"
+    },
+    "type" : "Text"
+  }, {
+    "id" : "data.userPrompt.prompt",
+    "label" : "User prompt",
+    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "required",
+    "group" : "userPrompt",
+    "binding" : {
+      "name" : "data.userPrompt.prompt",
+      "type" : "zeebe:input"
+    },
+    "type" : "Text"
+  }, {
+    "id" : "data.userPrompt.documents",
+    "label" : "Documents",
+    "description" : "Documents to be included in the user prompt.",
+    "optional" : true,
+    "feel" : "required",
+    "group" : "userPrompt",
+    "binding" : {
+      "name" : "data.userPrompt.documents",
+      "type" : "zeebe:input"
+    },
+    "tooltip" : "Referenced documents will be automatically added to the user prompt. <a href=\"https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/agentic-ai-aiagent-subprocess/\" target=\"_blank\">See documentation</a> for details and supported file types.",
+    "type" : "String"
+  }, {
+    "id" : "agentContext",
+    "label" : "Agent context",
+    "description" : "Initial agent context from previous interactions. Avoid reusing context variables across agents to prevent issues with stale data or tool access.",
+    "optional" : false,
+    "feel" : "required",
+    "group" : "memory",
+    "binding" : {
+      "name" : "agentContext",
+      "type" : "zeebe:input"
+    },
+    "tooltip" : "The agent context variable containing all relevant data for the agent to support the feedback loop between user requests, tool calls and LLM responses. Make sure this variable points to the <code>context</code> variable which is returned from the agent response. <a href=\"https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/agentic-ai-aiagent-subprocess/\" target=\"_blank\">See documentation</a> for details.",
+    "type" : "Text"
+  }, {
+    "id" : "data.memory.storage.type",
+    "label" : "Memory storage type",
+    "description" : "Specify how to store the conversation memory.",
+    "value" : "in-process",
+    "group" : "memory",
+    "binding" : {
+      "name" : "data.memory.storage.type",
+      "type" : "zeebe:input"
+    },
+    "type" : "Dropdown",
+    "choices" : [ {
+      "name" : "In Process (part of agent context)",
+      "value" : "in-process"
+    }, {
+      "name" : "Camunda Document Storage",
+      "value" : "camunda-document"
+    }, {
+      "name" : "AWS AgentCore Memory",
+      "value" : "aws-agentcore"
+    }, {
+      "name" : "Custom Implementation (Hybrid/Self-Managed only)",
+      "value" : "custom"
+    } ]
+  }, {
+    "id" : "data.memory.storage.timeToLive",
+    "label" : "Document TTL",
+    "description" : "How long to retain the conversation document as ISO-8601 duration (example: <code>P14D</code>).",
+    "optional" : true,
+    "feel" : "optional",
+    "group" : "memory",
+    "binding" : {
+      "name" : "data.memory.storage.timeToLive",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "data.memory.storage.type",
+      "equals" : "camunda-document",
+      "type" : "simple"
+    },
+    "tooltip" : "Will use the cluster default TTL (time-to-live) if not specified. Make sure to set this value to a reasonable duration matching your process lifecycle.",
+    "type" : "String"
+  }, {
+    "id" : "data.memory.storage.customProperties",
+    "label" : "Custom document properties",
+    "description" : "An optional map of custom properties to be stored with the conversation document.",
+    "optional" : true,
+    "feel" : "required",
+    "group" : "memory",
+    "binding" : {
+      "name" : "data.memory.storage.customProperties",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "data.memory.storage.type",
+      "equals" : "camunda-document",
+      "type" : "simple"
+    },
+    "type" : "String"
+  }, {
+    "id" : "data.memory.storage.region",
+    "label" : "Region",
+    "description" : "Specify the AWS region (example: <code>us-east-1</code>)",
+    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "memory",
+    "binding" : {
+      "name" : "data.memory.storage.region",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "data.memory.storage.type",
+      "equals" : "aws-agentcore",
+      "type" : "simple"
+    },
+    "type" : "String"
+  }, {
+    "id" : "data.memory.storage.endpoint",
+    "label" : "Endpoint",
+    "description" : "Custom API endpoint for VPC/PrivateLink configurations, AWS GovCloud, or other non-standard deployments.",
+    "optional" : true,
+    "feel" : "optional",
+    "group" : "memory",
+    "binding" : {
+      "name" : "data.memory.storage.endpoint",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "data.memory.storage.type",
+      "equals" : "aws-agentcore",
+      "type" : "simple"
+    },
+    "type" : "String"
+  }, {
+    "id" : "data.memory.storage.authentication.type",
+    "label" : "Authentication",
+    "description" : "Specify the AWS authentication strategy for AgentCore Memory access.",
+    "value" : "credentials",
+    "group" : "memory",
+    "binding" : {
+      "name" : "data.memory.storage.authentication.type",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "data.memory.storage.type",
+      "equals" : "aws-agentcore",
+      "type" : "simple"
+    },
+    "type" : "Dropdown",
+    "choices" : [ {
+      "name" : "Credentials",
+      "value" : "credentials"
+    }, {
+      "name" : "Default Credentials Chain (Hybrid/Self-Managed only)",
+      "value" : "defaultCredentialsChain"
+    } ]
+  }, {
+    "id" : "data.memory.storage.authentication.accessKey",
+    "label" : "Access key",
+    "description" : "Provide an IAM access key with permissions for <code>bedrock-agentcore:CreateEvent</code> and <code>bedrock-agentcore:ListEvents</code>",
+    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "memory",
+    "binding" : {
+      "name" : "data.memory.storage.authentication.accessKey",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "allMatch" : [ {
+        "property" : "data.memory.storage.authentication.type",
+        "equals" : "credentials",
+        "type" : "simple"
+      }, {
+        "property" : "data.memory.storage.type",
+        "equals" : "aws-agentcore",
+        "type" : "simple"
+      } ]
+    },
+    "type" : "String"
+  }, {
+    "id" : "data.memory.storage.authentication.secretKey",
+    "label" : "Secret key",
+    "description" : "Provide the secret key for the IAM access key",
+    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "memory",
+    "binding" : {
+      "name" : "data.memory.storage.authentication.secretKey",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "allMatch" : [ {
+        "property" : "data.memory.storage.authentication.type",
+        "equals" : "credentials",
+        "type" : "simple"
+      }, {
+        "property" : "data.memory.storage.type",
+        "equals" : "aws-agentcore",
+        "type" : "simple"
+      } ]
+    },
+    "type" : "String"
+  }, {
+    "id" : "data.memory.storage.memoryId",
+    "label" : "Memory ID",
+    "description" : "The ID of the pre-provisioned AgentCore Memory resource.",
+    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "memory",
+    "binding" : {
+      "name" : "data.memory.storage.memoryId",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "data.memory.storage.type",
+      "equals" : "aws-agentcore",
+      "type" : "simple"
+    },
+    "type" : "String"
+  }, {
+    "id" : "data.memory.storage.actorId",
+    "label" : "Actor ID",
+    "description" : "Identifier of the actor associated with events (e.g., end-user or agent/user combination).",
+    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "memory",
+    "binding" : {
+      "name" : "data.memory.storage.actorId",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "data.memory.storage.type",
+      "equals" : "aws-agentcore",
+      "type" : "simple"
+    },
+    "type" : "String"
+  }, {
+    "id" : "data.memory.storage.storeType",
+    "label" : "Implementation type",
+    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "memory",
+    "binding" : {
+      "name" : "data.memory.storage.storeType",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "data.memory.storage.type",
+      "equals" : "custom",
+      "type" : "simple"
+    },
+    "type" : "String"
+  }, {
+    "id" : "data.memory.storage.parameters",
+    "label" : "Parameters",
+    "description" : "Parameters for the custom memory storage implementation.",
+    "optional" : true,
+    "feel" : "required",
+    "group" : "memory",
+    "binding" : {
+      "name" : "data.memory.storage.parameters",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "data.memory.storage.type",
+      "equals" : "custom",
+      "type" : "simple"
+    },
+    "type" : "String"
+  }, {
+    "id" : "data.memory.contextWindowSize",
+    "label" : "Context window size",
+    "description" : "Maximum number of recent conversation messages which are passed to the model.",
+    "optional" : false,
+    "value" : 20,
+    "feel" : "static",
+    "group" : "memory",
+    "binding" : {
+      "name" : "data.memory.contextWindowSize",
+      "type" : "zeebe:input"
+    },
+    "tooltip" : "Use this to limit the number of messages which are sent to the model. The agent will only send the most recent messages up to the configured limit to the LLM. Older messages will be kept in the conversation store, but not sent to the model. <a href=\"https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/agentic-ai-aiagent-subprocess/\" target=\"_blank\">See documentation</a> for details.",
+    "type" : "Number"
+  }, {
+    "id" : "data.limits.maxModelCalls",
+    "label" : "Maximum model calls",
+    "description" : "Maximum number of calls to the model as a safety limit to prevent infinite loops.",
+    "optional" : false,
+    "value" : 10,
+    "feel" : "static",
+    "group" : "limits",
+    "binding" : {
+      "name" : "data.limits.maxModelCalls",
+      "type" : "zeebe:input"
+    },
+    "type" : "Number"
+  }, {
+    "id" : "data.events.behavior",
+    "label" : "Event handling behavior",
+    "description" : "Behavior on completing an event sub-process.",
+    "optional" : false,
+    "value" : "WAIT_FOR_TOOL_CALL_RESULTS",
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "group" : "events",
+    "binding" : {
+      "name" : "data.events.behavior",
+      "type" : "zeebe:input"
+    },
+    "type" : "Dropdown",
+    "choices" : [ {
+      "name" : "Wait for tool call results",
+      "value" : "WAIT_FOR_TOOL_CALL_RESULTS"
+    }, {
+      "name" : "Cancel tool calls",
+      "value" : "INTERRUPT_TOOL_CALLS"
+    } ]
+  }, {
+    "id" : "data.response.format.type",
+    "label" : "Response format",
+    "description" : "Specify the response format. Support for JSON mode varies by provider.",
+    "value" : "text",
+    "group" : "response",
+    "binding" : {
+      "name" : "data.response.format.type",
+      "type" : "zeebe:input"
+    },
+    "type" : "Dropdown",
+    "choices" : [ {
+      "name" : "Text",
+      "value" : "text"
+    }, {
+      "name" : "JSON",
+      "value" : "json"
+    } ]
+  }, {
+    "id" : "data.response.format.parseJson",
+    "label" : "Parse text as JSON",
+    "description" : "Tries to parse the LLM response text as JSON object.",
+    "optional" : true,
+    "feel" : "static",
+    "group" : "response",
+    "binding" : {
+      "name" : "data.response.format.parseJson",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "data.response.format.type",
+      "equals" : "text",
+      "type" : "simple"
+    },
+    "tooltip" : "Use this option in combination with models which don't support native JSON mode/structured tool calling (e.g. Anthropic). Make sure to instruct the model to return valid JSON in the system prompt. The parsed JSON will be available as <code>response.responseJson</code>.<br><br>If parsing fails, <code>null</code> will be returned as JSON response, but the text content will still be available as <code>response.responseText</code>.",
+    "type" : "Boolean"
+  }, {
+    "id" : "data.response.format.schema",
+    "label" : "Response JSON schema",
+    "description" : "An optional response <a href=\"https://json-schema.org/\" target=\"_blank\">JSON Schema</a> to instruct the model how to structure the JSON output.",
+    "optional" : true,
+    "feel" : "required",
+    "group" : "response",
+    "binding" : {
+      "name" : "data.response.format.schema",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "data.response.format.type",
+      "equals" : "json",
+      "type" : "simple"
+    },
+    "tooltip" : "If supported by the model, the response will be structured according to the provided schema. A parsed version of the response will be available as <code>response.responseJson</code>.",
+    "type" : "String"
+  }, {
+    "id" : "data.response.format.schemaName",
+    "label" : "Response JSON schema name",
+    "description" : "An optional name for the response JSON Schema to make the model aware of the expected output.",
+    "optional" : true,
+    "value" : "Response",
+    "feel" : "optional",
+    "group" : "response",
+    "binding" : {
+      "name" : "data.response.format.schemaName",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "data.response.format.type",
+      "equals" : "json",
+      "type" : "simple"
+    },
+    "type" : "String"
+  }, {
+    "id" : "data.response.includeAssistantMessage",
+    "label" : "Include assistant message",
+    "description" : "Include the full assistant message as part of the result object.",
+    "optional" : true,
+    "feel" : "static",
+    "group" : "response",
+    "binding" : {
+      "name" : "data.response.includeAssistantMessage",
+      "type" : "zeebe:input"
+    },
+    "tooltip" : "In addition to the text content, the assistant message may include multiple additional content blocks and metadata (such as token usage). The message will be available as <code>response.responseMessage</code>.",
+    "type" : "Boolean"
+  }, {
+    "id" : "data.response.includeAgentContext",
+    "label" : "Include agent context",
+    "description" : "Include the agent context as part of the result object.",
+    "optional" : true,
+    "feel" : "static",
+    "group" : "response",
+    "binding" : {
+      "name" : "data.response.includeAgentContext",
+      "type" : "zeebe:input"
+    },
+    "tooltip" : "Use this option if you need to re-inject the previous agent context into a future agent execution, for example when modeling a user feedback loop between an agent and a user task.",
+    "type" : "Boolean"
+  }, {
+    "id" : "version",
+    "label" : "Version",
+    "description" : "Version of the element template",
+    "value" : "1",
+    "group" : "connector",
+    "binding" : {
+      "key" : "elementTemplateVersion",
+      "type" : "zeebe:taskHeader"
+    },
+    "type" : "Hidden"
+  }, {
+    "id" : "id",
+    "label" : "ID",
+    "description" : "ID of the element template",
+    "value" : "io.camunda.connectors.agenticai.ai-agent-subprocess.v2",
+    "group" : "connector",
+    "binding" : {
+      "key" : "elementTemplateId",
+      "type" : "zeebe:taskHeader"
+    },
+    "type" : "Hidden"
+  }, {
+    "id" : "resultVariable",
+    "label" : "Result variable",
+    "description" : "Name of variable to store the response in. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-variable\" target=\"_blank\">documentation</a>.",
+    "value" : "agent",
+    "group" : "output",
+    "binding" : {
+      "source" : "=agent",
+      "type" : "zeebe:output"
+    },
+    "type" : "String"
+  }, {
+    "id" : "errorExpression",
+    "label" : "Error expression",
+    "description" : "Expression to handle errors. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/\" target=\"_blank\">documentation</a>.",
+    "feel" : "required",
+    "group" : "error",
+    "binding" : {
+      "key" : "errorExpression",
+      "type" : "zeebe:taskHeader"
+    },
+    "type" : "Text"
+  }, {
+    "id" : "retryCount",
+    "label" : "Retries",
+    "description" : "Number of retries",
+    "value" : "3",
+    "feel" : "optional",
+    "group" : "retries",
+    "binding" : {
+      "property" : "retries",
+      "type" : "zeebe:taskDefinition"
+    },
+    "type" : "String"
+  }, {
+    "id" : "retryBackoff",
+    "label" : "Retry backoff",
+    "description" : "ISO-8601 duration to wait between retries",
+    "value" : "PT30S",
+    "group" : "retries",
+    "binding" : {
+      "key" : "retryBackoff",
+      "type" : "zeebe:taskHeader"
+    },
+    "type" : "String"
+  }, {
+    "binding" : {
+      "name" : "agent",
+      "type" : "zeebe:input"
+    },
+    "type" : "Hidden"
+  } ],
+  "icon" : {
+    "contents" : "data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMzIiIGhlaWdodD0iMzIiIHZpZXdCb3g9IjAgMCAzMiAzMiIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPGNpcmNsZSBjeD0iMTYiIGN5PSIxNiIgcj0iMTYiIGZpbGw9IiNBNTZFRkYiLz4KPG1hc2sgaWQ9InBhdGgtMi1vdXRzaWRlLTFfMTg1XzYiIG1hc2tVbml0cz0idXNlclNwYWNlT25Vc2UiIHg9IjQiIHk9IjQiIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgZmlsbD0iYmxhY2siPgo8cmVjdCBmaWxsPSJ3aGl0ZSIgeD0iNCIgeT0iNCIgd2lkdGg9IjI0IiBoZWlnaHQ9IjI0Ii8+CjxwYXRoIGZpbGwtcnVsZT0iZXZlbm9kZCIgY2xpcC1ydWxlPSJldmVub2RkIiBkPSJNMjAuMDEwNSAxMi4wOTg3QzE4LjQ5IDEwLjU4OTQgMTcuMTU5NCA4LjEwODE0IDE2LjE3OTkgNi4wMTEwM0MxNi4xNTIgNi4wMDQ1MSAxNi4xMTc2IDYgMTYuMDc5NCA2QzE2LjA0MTEgNiAxNi4wMDY2IDYuMDA0NTEgMTUuOTc4OCA2LjAxMTA0QzE0Ljk5OTQgOC4xMDgxNCAxMy42Njk3IDEwLjU4ODkgMTIuMTQ4MSAxMi4wOTgxQzEwLjYyNjkgMTMuNjA3MSA4LjEyNTY4IDE0LjkyNjQgNi4wMTE1NyAxNS44OTgxQzYuMDA0NzQgMTUuOTI2MSA2IDE1Ljk2MTEgNiAxNkM2IDE2LjAzODcgNi4wMDQ2OCAxNi4wNzM2IDYuMDExNDQgMTYuMTAxNEM4LjEyNTE5IDE3LjA3MjkgMTAuNjI2MiAxOC4zOTE5IDEyLjE0NzcgMTkuOTAxNkMxMy42Njk3IDIxLjQxMDcgMTQuOTk5NiAyMy44OTIgMTUuOTc5MSAyNS45ODlDMTYuMDA2OCAyNS45OTU2IDE2LjA0MTEgMjYgMTYuMDc5MyAyNkMxNi4xMTc1IDI2IDE2LjE1MTkgMjUuOTk1NCAxNi4xNzk2IDI1Ljk4OUMxNy4xNTkxIDIzLjg5MiAxOC40ODg4IDIxLjQxMSAyMC4wMDk5IDE5LjkwMjFNMjAuMDA5OSAxOS45MDIxQzIxLjUyNTMgMTguMzk4NyAyMy45NDY1IDE3LjA2NjkgMjUuOTkxNSAxNi4wODI0QzI1Ljk5NjUgMTYuMDU5MyAyNiAxNi4wMzEgMjYgMTUuOTk5N0MyNiAxNS45Njg0IDI1Ljk5NjUgMTUuOTQwMyAyNS45OTE1IDE1LjkxNzFDMjMuOTQ3NCAxNC45MzI3IDIxLjUyNTkgMTMuNjAxIDIwLjAxMDUgMTIuMDk4NyIvPgo8L21hc2s+CjxwYXRoIGZpbGwtcnVsZT0iZXZlbm9kZCIgY2xpcC1ydWxlPSJldmVub2RkIiBkPSJNMjAuMDEwNSAxMi4wOTg3QzE4LjQ5IDEwLjU4OTQgMTcuMTU5NCA4LjEwODE0IDE2LjE3OTkgNi4wMTEwM0MxNi4xNTIgNi4wMDQ1MSAxNi4xMTc2IDYgMTYuMDc5NCA2QzE2LjA0MTEgNiAxNi4wMDY2IDYuMDA0NTEgMTUuOTc4OCA2LjAxMTA0QzE0Ljk5OTQgOC4xMDgxNCAxMy42Njk3IDEwLjU4ODkgMTIuMTQ4MSAxMi4wOTgxQzEwLjYyNjkgMTMuNjA3MSA4LjEyNTY4IDE0LjkyNjQgNi4wMTE1NyAxNS44OTgxQzYuMDA0NzQgMTUuOTI2MSA2IDE1Ljk2MTEgNiAxNkM2IDE2LjAzODcgNi4wMDQ2OCAxNi4wNzM2IDYuMDExNDQgMTYuMTAxNEM4LjEyNTE5IDE3LjA3MjkgMTAuNjI2MiAxOC4zOTE5IDEyLjE0NzcgMTkuOTAxNkMxMy42Njk3IDIxLjQxMDcgMTQuOTk5NiAyMy44OTIgMTUuOTc5MSAyNS45ODlDMTYuMDA2OCAyNS45OTU2IDE2LjA0MTEgMjYgMTYuMDc5MyAyNkMxNi4xMTc1IDI2IDE2LjE1MTkgMjUuOTk1NCAxNi4xNzk2IDI1Ljk4OUMxNy4xNTkxIDIzLjg5MiAxOC40ODg4IDIxLjQxMSAyMC4wMDk5IDE5LjkwMjFNMjAuMDA5OSAxOS45MDIxQzIxLjUyNTMgMTguMzk4NyAyMy45NDY1IDE3LjA2NjkgMjUuOTkxNSAxNi4wODI0QzI1Ljk5NjUgMTYuMDU5MyAyNiAxNi4wMzEgMjYgMTUuOTk5N0MyNiAxNS45Njg0IDI1Ljk5NjUgMTUuOTQwMyAyNS45OTE1IDE1LjkxNzFDMjMuOTQ3NCAxNC45MzI3IDIxLjUyNTkgMTMuNjAxIDIwLjAxMDUgMTIuMDk4NyIgZmlsbD0id2hpdGUiLz4KPHBhdGggZmlsbC1ydWxlPSJldmVub2RkIiBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGQ9Ik0yMC4wMTA1IDEyLjA5ODdDMTguNDkgMTAuNTg5NCAxNy4xNTk0IDguMTA4MTQgMTYuMTc5OSA2LjAxMTAzQzE2LjE1MiA2LjAwNDUxIDE2LjExNzYgNiAxNi4wNzk0IDZDMTYuMDQxMSA2IDE2LjAwNjYgNi4wMDQ1MSAxNS45Nzg4IDYuMDExMDRDMTQuOTk5NCA4LjEwODE0IDEzLjY2OTcgMTAuNTg4OSAxMi4xNDgxIDEyLjA5ODFDMTAuNjI2OSAxMy42MDcxIDguMTI1NjggMTQuOTI2NCA2LjAxMTU3IDE1Ljg5ODFDNi4wMDQ3NCAxNS45MjYxIDYgMTUuOTYxMSA2IDE2QzYgMTYuMDM4NyA2LjAwNDY4IDE2LjA3MzYgNi4wMTE0NCAxNi4xMDE0QzguMTI1MTkgMTcuMDcyOSAxMC42MjYyIDE4LjM5MTkgMTIuMTQ3NyAxOS45MDE2QzEzLjY2OTcgMjEuNDEwNyAxNC45OTk2IDIzLjg5MiAxNS45NzkxIDI1Ljk4OUMxNi4wMDY4IDI1Ljk5NTYgMTYuMDQxMSAyNiAxNi4wNzkzIDI2QzE2LjExNzUgMjYgMTYuMTUxOSAyNS45OTU0IDE2LjE3OTYgMjUuOTg5QzE3LjE1OTEgMjMuODkyIDE4LjQ4ODggMjEuNDExIDIwLjAwOTkgMTkuOTAyMU0yMC4wMDk5IDE5LjkwMjFDMjEuNTI1MyAxOC4zOTg3IDIzLjk0NjUgMTcuMDY2OSAyNS45OTE1IDE2LjA4MjRDMjUuOTk2NSAxNi4wNTkzIDI2IDE2LjAzMSAyNiAxNS45OTk3QzI2IDE1Ljk2ODQgMjUuOTk2NSAxNS45NDAzIDI1Ljk5MTUgMTUuOTE3MUMyMy45NDc0IDE0LjkzMjcgMjEuNTI1OSAxMy42MDEgMjAuMDEwNSAxMi4wOTg3IiBzdHJva2U9IiM0OTFEOEIiIHN0cm9rZS13aWR0aD0iNCIgc3Ryb2tlLWxpbmVqb2luPSJyb3VuZCIgbWFzaz0idXJsKCNwYXRoLTItb3V0c2lkZS0xXzE4NV82KSIvPgo8L3N2Zz4K"
+  }
+}

--- a/connectors/agentic-ai/connector-agentic-ai/element-templates/hybrid/agenticai-ai-agent-subprocess.v2-hybrid.json
+++ b/connectors/agentic-ai/connector-agentic-ai/element-templates/hybrid/agenticai-ai-agent-subprocess.v2-hybrid.json
@@ -125,6 +125,7 @@
   }, {
     "id" : "provider.providerType",
     "label" : "Provider type",
+    "description" : "Identifier for the custom chat model provider.",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -140,11 +141,12 @@
       "equals" : "custom",
       "type" : "simple"
     },
+    "tooltip" : "Must match the identifier configured for the custom implementation.",
     "type" : "String"
   }, {
     "id" : "provider.parameters",
     "label" : "Provider parameters",
-    "description" : "Parameters for the custom chat model factory implementation.",
+    "description" : "Parameters for the custom chat model provider implementation.",
     "optional" : true,
     "feel" : "required",
     "group" : "provider",
@@ -447,6 +449,7 @@
   }, {
     "id" : "data.memory.storage.storeType",
     "label" : "Implementation type",
+    "description" : "Identifier for the custom memory storage implementation.",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -462,6 +465,7 @@
       "equals" : "custom",
       "type" : "simple"
     },
+    "tooltip" : "Must match the identifier configured for the custom implementation.",
     "type" : "String"
   }, {
     "id" : "data.memory.storage.parameters",

--- a/connectors/agentic-ai/connector-agentic-ai/element-templates/hybrid/agenticai-ai-agent-task.v2-hybrid.json
+++ b/connectors/agentic-ai/connector-agentic-ai/element-templates/hybrid/agenticai-ai-agent-task.v2-hybrid.json
@@ -1,0 +1,679 @@
+{
+  "$schema" : "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+  "name" : "Hybrid AI Agent Task",
+  "id" : "io.camunda.connectors.agenticai.ai-agent-task.v2-hybrid",
+  "description" : "Execute a single AI-powered action with tool calling capabilities",
+  "keywords" : [ "AI", "AI Agent", "agentic orchestration" ],
+  "documentationRef" : "https://docs.camunda.io/docs/8.10/components/connectors/out-of-the-box-connectors/agentic-ai-aiagent-task/",
+  "version" : 1,
+  "category" : {
+    "id" : "aiTools",
+    "name" : "AI Tools"
+  },
+  "appliesTo" : [ "bpmn:Task" ],
+  "elementType" : {
+    "value" : "bpmn:ServiceTask"
+  },
+  "engines" : {
+    "camunda" : "^8.10"
+  },
+  "groups" : [ {
+    "id" : "taskDefinitionType",
+    "label" : "Task definition type"
+  }, {
+    "id" : "provider",
+    "label" : "Model provider",
+    "openByDefault" : false
+  }, {
+    "id" : "model",
+    "label" : "Model",
+    "openByDefault" : false
+  }, {
+    "id" : "systemPrompt",
+    "label" : "System prompt",
+    "tooltip" : "A system prompt is a set of foundational instructions given to a model before any user interaction begins. It defines the AI agent’s role, behavior, tone, and communication style, ensuring that responses remain consistent and aligned with the AI agent’s intended purpose. These instructions help shape how the model interprets and responds to user input throughout the conversation.",
+    "openByDefault" : false
+  }, {
+    "id" : "userPrompt",
+    "label" : "User prompt",
+    "tooltip" : "A user prompt is the message or question you give to the AI to start or continue a conversation. It tells the AI what you need, whether it's information, help with a task, or just a chat. The AI uses your prompt to understand how to respond.",
+    "openByDefault" : false
+  }, {
+    "id" : "tools",
+    "label" : "Tools",
+    "tooltip" : "Tools are optional features the AI Agent can use to perform specific tasks. Configure this if the agent should participate in a tools feedback loop.",
+    "openByDefault" : false
+  }, {
+    "id" : "memory",
+    "label" : "Memory",
+    "tooltip" : "Configuration of the Agent's short-term/conversational memory.",
+    "openByDefault" : false
+  }, {
+    "id" : "limits",
+    "label" : "Limits",
+    "openByDefault" : false
+  }, {
+    "id" : "response",
+    "label" : "Response",
+    "tooltip" : "Configuration of the model response format and how to map the model response to the connector result.<br><br>Depending on the selection, the model response will be available as <code>response.responseText</code> or <code>response.responseJson</code>.<br><br>See <a href=\"https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/agentic-ai-aiagent-task/#response\">documentation</a> for details.",
+    "openByDefault" : false
+  }, {
+    "id" : "connector",
+    "label" : "Connector"
+  }, {
+    "id" : "output",
+    "label" : "Output mapping"
+  }, {
+    "id" : "error",
+    "label" : "Error handling"
+  }, {
+    "id" : "retries",
+    "label" : "Retries"
+  } ],
+  "properties" : [ {
+    "id" : "taskDefinitionType",
+    "value" : "io.camunda.agenticai:aiagent:task:2",
+    "group" : "taskDefinitionType",
+    "binding" : {
+      "property" : "type",
+      "type" : "zeebe:taskDefinition"
+    },
+    "type" : "String"
+  }, {
+    "id" : "provider.type",
+    "label" : "Provider",
+    "description" : "Specify the LLM provider to use.",
+    "value" : "custom",
+    "group" : "provider",
+    "binding" : {
+      "name" : "provider.type",
+      "type" : "zeebe:input"
+    },
+    "type" : "Dropdown",
+    "choices" : [ {
+      "name" : "Custom Implementation (Self-Managed/Hybrid only)",
+      "value" : "custom"
+    } ]
+  }, {
+    "id" : "provider.providerType",
+    "label" : "Provider type",
+    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "provider",
+    "binding" : {
+      "name" : "provider.providerType",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "provider.type",
+      "equals" : "custom",
+      "type" : "simple"
+    },
+    "type" : "String"
+  }, {
+    "id" : "provider.parameters",
+    "label" : "Provider parameters",
+    "description" : "Parameters for the custom chat model factory implementation.",
+    "optional" : true,
+    "feel" : "required",
+    "group" : "provider",
+    "binding" : {
+      "name" : "provider.parameters",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "provider.type",
+      "equals" : "custom",
+      "type" : "simple"
+    },
+    "type" : "String"
+  }, {
+    "id" : "provider.model",
+    "label" : "Model",
+    "description" : "Identifier of the model to use.",
+    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "model",
+    "binding" : {
+      "name" : "provider.model",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "provider.type",
+      "equals" : "custom",
+      "type" : "simple"
+    },
+    "type" : "String"
+  }, {
+    "id" : "data.systemPrompt.prompt",
+    "label" : "System prompt",
+    "optional" : false,
+    "value" : "=\"You are **TaskAgent**, a helpful, generic chat agent that can handle a wide variety of customer requests using your own domain knowledge **and** any tools explicitly provided to you at runtime.\n\nIf tools are provided, you should prefer them instead of guessing an answer. You can call the same tool multiple times by providing different input values. Don't guess any tools which were not explicitly configured. If no tool matches the request, try to generate an answer. If you're not able to find a good answer, return with a message stating why you're not able to.\n\nWrap minimal, inspectable reasoning in *exactly* this XML template:\n\n<thinking>\n<context>…briefly state the customer’s need and current state…</context>\n<reflection>…list candidate tools, justify which you will call next and why…</reflection>\n</thinking>\n\nReveal **no** additional private reasoning outside these tags.\"",
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "required",
+    "group" : "systemPrompt",
+    "binding" : {
+      "name" : "data.systemPrompt.prompt",
+      "type" : "zeebe:input"
+    },
+    "type" : "Text"
+  }, {
+    "id" : "data.userPrompt.prompt",
+    "label" : "User prompt",
+    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "required",
+    "group" : "userPrompt",
+    "binding" : {
+      "name" : "data.userPrompt.prompt",
+      "type" : "zeebe:input"
+    },
+    "type" : "Text"
+  }, {
+    "id" : "data.userPrompt.documents",
+    "label" : "Documents",
+    "description" : "Documents to be included in the user prompt.",
+    "optional" : true,
+    "feel" : "required",
+    "group" : "userPrompt",
+    "binding" : {
+      "name" : "data.userPrompt.documents",
+      "type" : "zeebe:input"
+    },
+    "tooltip" : "Referenced documents will be automatically added to the user prompt. <a href=\"https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/agentic-ai-aiagent-task/\" target=\"_blank\">See documentation</a> for details and supported file types.",
+    "type" : "String"
+  }, {
+    "id" : "data.tools.containerElementId",
+    "label" : "Ad-hoc sub-process ID",
+    "description" : "ID of the sub-process that contains the tools the AI agent can use.",
+    "optional" : true,
+    "feel" : "optional",
+    "group" : "tools",
+    "binding" : {
+      "name" : "data.tools.containerElementId",
+      "type" : "zeebe:input"
+    },
+    "tooltip" : "Add an ad-hoc sub-process ID to attach the AI agent to the tools. Ensure your process includes a tools feedback loop routing into the ad-hoc sub-process and back to the AI agent connector. <a href=\"https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/agentic-ai-aiagent-task/\" target=\"_blank\">See documentation</a> for details.",
+    "type" : "String"
+  }, {
+    "id" : "data.tools.toolCallResults",
+    "label" : "Tool call results",
+    "description" : "Tool call results as returned by the sub-process.",
+    "optional" : true,
+    "feel" : "required",
+    "group" : "tools",
+    "binding" : {
+      "name" : "data.tools.toolCallResults",
+      "type" : "zeebe:input"
+    },
+    "tooltip" : "This defines where to handle tool call results returned by the ad-hoc sub-process. Model this as part of your process and route it into the tools feedback loop. <a href=\"https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/agentic-ai-aiagent-task/\" target=\"_blank\">See documentation</a> for details.",
+    "type" : "Text"
+  }, {
+    "id" : "data.agentContext",
+    "label" : "Agent context",
+    "description" : "Avoid reusing context variables across agents to prevent issues with stale data or tool access.",
+    "optional" : false,
+    "value" : "=agent.context",
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "required",
+    "group" : "memory",
+    "binding" : {
+      "name" : "data.context",
+      "type" : "zeebe:input"
+    },
+    "tooltip" : "The agent context variable containing all relevant data for the agent to support the feedback loop between user requests, tool calls and LLM responses. Make sure this variable points to the <code>context</code> variable which is returned from the agent response. <a href=\"https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/agentic-ai-aiagent-task/\" target=\"_blank\">See documentation</a> for details.",
+    "type" : "Text"
+  }, {
+    "id" : "data.memory.storage.type",
+    "label" : "Memory storage type",
+    "description" : "Specify how to store the conversation memory.",
+    "value" : "in-process",
+    "group" : "memory",
+    "binding" : {
+      "name" : "data.memory.storage.type",
+      "type" : "zeebe:input"
+    },
+    "type" : "Dropdown",
+    "choices" : [ {
+      "name" : "In Process (part of agent context)",
+      "value" : "in-process"
+    }, {
+      "name" : "Camunda Document Storage",
+      "value" : "camunda-document"
+    }, {
+      "name" : "AWS AgentCore Memory",
+      "value" : "aws-agentcore"
+    }, {
+      "name" : "Custom Implementation (Hybrid/Self-Managed only)",
+      "value" : "custom"
+    } ]
+  }, {
+    "id" : "data.memory.storage.timeToLive",
+    "label" : "Document TTL",
+    "description" : "How long to retain the conversation document as ISO-8601 duration (example: <code>P14D</code>).",
+    "optional" : true,
+    "feel" : "optional",
+    "group" : "memory",
+    "binding" : {
+      "name" : "data.memory.storage.timeToLive",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "data.memory.storage.type",
+      "equals" : "camunda-document",
+      "type" : "simple"
+    },
+    "tooltip" : "Will use the cluster default TTL (time-to-live) if not specified. Make sure to set this value to a reasonable duration matching your process lifecycle.",
+    "type" : "String"
+  }, {
+    "id" : "data.memory.storage.customProperties",
+    "label" : "Custom document properties",
+    "description" : "An optional map of custom properties to be stored with the conversation document.",
+    "optional" : true,
+    "feel" : "required",
+    "group" : "memory",
+    "binding" : {
+      "name" : "data.memory.storage.customProperties",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "data.memory.storage.type",
+      "equals" : "camunda-document",
+      "type" : "simple"
+    },
+    "type" : "String"
+  }, {
+    "id" : "data.memory.storage.region",
+    "label" : "Region",
+    "description" : "Specify the AWS region (example: <code>us-east-1</code>)",
+    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "memory",
+    "binding" : {
+      "name" : "data.memory.storage.region",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "data.memory.storage.type",
+      "equals" : "aws-agentcore",
+      "type" : "simple"
+    },
+    "type" : "String"
+  }, {
+    "id" : "data.memory.storage.endpoint",
+    "label" : "Endpoint",
+    "description" : "Custom API endpoint for VPC/PrivateLink configurations, AWS GovCloud, or other non-standard deployments.",
+    "optional" : true,
+    "feel" : "optional",
+    "group" : "memory",
+    "binding" : {
+      "name" : "data.memory.storage.endpoint",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "data.memory.storage.type",
+      "equals" : "aws-agentcore",
+      "type" : "simple"
+    },
+    "type" : "String"
+  }, {
+    "id" : "data.memory.storage.authentication.type",
+    "label" : "Authentication",
+    "description" : "Specify the AWS authentication strategy for AgentCore Memory access.",
+    "value" : "credentials",
+    "group" : "memory",
+    "binding" : {
+      "name" : "data.memory.storage.authentication.type",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "data.memory.storage.type",
+      "equals" : "aws-agentcore",
+      "type" : "simple"
+    },
+    "type" : "Dropdown",
+    "choices" : [ {
+      "name" : "Credentials",
+      "value" : "credentials"
+    }, {
+      "name" : "Default Credentials Chain (Hybrid/Self-Managed only)",
+      "value" : "defaultCredentialsChain"
+    } ]
+  }, {
+    "id" : "data.memory.storage.authentication.accessKey",
+    "label" : "Access key",
+    "description" : "Provide an IAM access key with permissions for <code>bedrock-agentcore:CreateEvent</code> and <code>bedrock-agentcore:ListEvents</code>",
+    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "memory",
+    "binding" : {
+      "name" : "data.memory.storage.authentication.accessKey",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "allMatch" : [ {
+        "property" : "data.memory.storage.authentication.type",
+        "equals" : "credentials",
+        "type" : "simple"
+      }, {
+        "property" : "data.memory.storage.type",
+        "equals" : "aws-agentcore",
+        "type" : "simple"
+      } ]
+    },
+    "type" : "String"
+  }, {
+    "id" : "data.memory.storage.authentication.secretKey",
+    "label" : "Secret key",
+    "description" : "Provide the secret key for the IAM access key",
+    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "memory",
+    "binding" : {
+      "name" : "data.memory.storage.authentication.secretKey",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "allMatch" : [ {
+        "property" : "data.memory.storage.authentication.type",
+        "equals" : "credentials",
+        "type" : "simple"
+      }, {
+        "property" : "data.memory.storage.type",
+        "equals" : "aws-agentcore",
+        "type" : "simple"
+      } ]
+    },
+    "type" : "String"
+  }, {
+    "id" : "data.memory.storage.memoryId",
+    "label" : "Memory ID",
+    "description" : "The ID of the pre-provisioned AgentCore Memory resource.",
+    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "memory",
+    "binding" : {
+      "name" : "data.memory.storage.memoryId",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "data.memory.storage.type",
+      "equals" : "aws-agentcore",
+      "type" : "simple"
+    },
+    "type" : "String"
+  }, {
+    "id" : "data.memory.storage.actorId",
+    "label" : "Actor ID",
+    "description" : "Identifier of the actor associated with events (e.g., end-user or agent/user combination).",
+    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "memory",
+    "binding" : {
+      "name" : "data.memory.storage.actorId",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "data.memory.storage.type",
+      "equals" : "aws-agentcore",
+      "type" : "simple"
+    },
+    "type" : "String"
+  }, {
+    "id" : "data.memory.storage.storeType",
+    "label" : "Implementation type",
+    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "memory",
+    "binding" : {
+      "name" : "data.memory.storage.storeType",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "data.memory.storage.type",
+      "equals" : "custom",
+      "type" : "simple"
+    },
+    "type" : "String"
+  }, {
+    "id" : "data.memory.storage.parameters",
+    "label" : "Parameters",
+    "description" : "Parameters for the custom memory storage implementation.",
+    "optional" : true,
+    "feel" : "required",
+    "group" : "memory",
+    "binding" : {
+      "name" : "data.memory.storage.parameters",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "data.memory.storage.type",
+      "equals" : "custom",
+      "type" : "simple"
+    },
+    "type" : "String"
+  }, {
+    "id" : "data.memory.contextWindowSize",
+    "label" : "Context window size",
+    "description" : "Maximum number of recent conversation messages which are passed to the model.",
+    "optional" : false,
+    "value" : 20,
+    "feel" : "static",
+    "group" : "memory",
+    "binding" : {
+      "name" : "data.memory.contextWindowSize",
+      "type" : "zeebe:input"
+    },
+    "tooltip" : "Use this to limit the number of messages which are sent to the model. The agent will only send the most recent messages up to the configured limit to the LLM. Older messages will be kept in the conversation store, but not sent to the model. <a href=\"https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/agentic-ai-aiagent-task/\" target=\"_blank\">See documentation</a> for details.",
+    "type" : "Number"
+  }, {
+    "id" : "data.limits.maxModelCalls",
+    "label" : "Maximum model calls",
+    "description" : "Maximum number of calls to the model as a safety limit to prevent infinite loops.",
+    "optional" : false,
+    "value" : 10,
+    "feel" : "static",
+    "group" : "limits",
+    "binding" : {
+      "name" : "data.limits.maxModelCalls",
+      "type" : "zeebe:input"
+    },
+    "type" : "Number"
+  }, {
+    "id" : "data.response.format.type",
+    "label" : "Response format",
+    "description" : "Specify the response format. Support for JSON mode varies by provider.",
+    "value" : "text",
+    "group" : "response",
+    "binding" : {
+      "name" : "data.response.format.type",
+      "type" : "zeebe:input"
+    },
+    "type" : "Dropdown",
+    "choices" : [ {
+      "name" : "Text",
+      "value" : "text"
+    }, {
+      "name" : "JSON",
+      "value" : "json"
+    } ]
+  }, {
+    "id" : "data.response.format.parseJson",
+    "label" : "Parse text as JSON",
+    "description" : "Tries to parse the LLM response text as JSON object.",
+    "optional" : true,
+    "feel" : "static",
+    "group" : "response",
+    "binding" : {
+      "name" : "data.response.format.parseJson",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "data.response.format.type",
+      "equals" : "text",
+      "type" : "simple"
+    },
+    "tooltip" : "Use this option in combination with models which don't support native JSON mode/structured tool calling (e.g. Anthropic). Make sure to instruct the model to return valid JSON in the system prompt. The parsed JSON will be available as <code>response.responseJson</code>.<br><br>If parsing fails, <code>null</code> will be returned as JSON response, but the text content will still be available as <code>response.responseText</code>.",
+    "type" : "Boolean"
+  }, {
+    "id" : "data.response.format.schema",
+    "label" : "Response JSON schema",
+    "description" : "An optional response <a href=\"https://json-schema.org/\" target=\"_blank\">JSON Schema</a> to instruct the model how to structure the JSON output.",
+    "optional" : true,
+    "feel" : "required",
+    "group" : "response",
+    "binding" : {
+      "name" : "data.response.format.schema",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "data.response.format.type",
+      "equals" : "json",
+      "type" : "simple"
+    },
+    "tooltip" : "If supported by the model, the response will be structured according to the provided schema. A parsed version of the response will be available as <code>response.responseJson</code>.",
+    "type" : "String"
+  }, {
+    "id" : "data.response.format.schemaName",
+    "label" : "Response JSON schema name",
+    "description" : "An optional name for the response JSON Schema to make the model aware of the expected output.",
+    "optional" : true,
+    "value" : "Response",
+    "feel" : "optional",
+    "group" : "response",
+    "binding" : {
+      "name" : "data.response.format.schemaName",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "data.response.format.type",
+      "equals" : "json",
+      "type" : "simple"
+    },
+    "type" : "String"
+  }, {
+    "id" : "data.response.includeAssistantMessage",
+    "label" : "Include assistant message",
+    "description" : "Include the full assistant message as part of the result object.",
+    "optional" : true,
+    "feel" : "static",
+    "group" : "response",
+    "binding" : {
+      "name" : "data.response.includeAssistantMessage",
+      "type" : "zeebe:input"
+    },
+    "tooltip" : "In addition to the text content, the assistant message may include multiple additional content blocks and metadata (such as token usage). The message will be available as <code>response.responseMessage</code>.",
+    "type" : "Boolean"
+  }, {
+    "id" : "version",
+    "label" : "Version",
+    "description" : "Version of the element template",
+    "value" : "1",
+    "group" : "connector",
+    "binding" : {
+      "key" : "elementTemplateVersion",
+      "type" : "zeebe:taskHeader"
+    },
+    "type" : "Hidden"
+  }, {
+    "id" : "id",
+    "label" : "ID",
+    "description" : "ID of the element template",
+    "value" : "io.camunda.connectors.agenticai.ai-agent-task.v2",
+    "group" : "connector",
+    "binding" : {
+      "key" : "elementTemplateId",
+      "type" : "zeebe:taskHeader"
+    },
+    "type" : "Hidden"
+  }, {
+    "id" : "resultVariable",
+    "label" : "Result variable",
+    "description" : "Name of variable to store the response in. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-variable\" target=\"_blank\">documentation</a>.",
+    "value" : "agent",
+    "group" : "output",
+    "binding" : {
+      "key" : "resultVariable",
+      "type" : "zeebe:taskHeader"
+    },
+    "type" : "String"
+  }, {
+    "id" : "resultExpression",
+    "label" : "Result expression",
+    "description" : "Expression to map the response into process variables. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-expression\" target=\"_blank\">documentation</a>.",
+    "feel" : "required",
+    "group" : "output",
+    "binding" : {
+      "key" : "resultExpression",
+      "type" : "zeebe:taskHeader"
+    },
+    "type" : "Text"
+  }, {
+    "id" : "errorExpression",
+    "label" : "Error expression",
+    "description" : "Expression to handle errors. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/\" target=\"_blank\">documentation</a>.",
+    "feel" : "required",
+    "group" : "error",
+    "binding" : {
+      "key" : "errorExpression",
+      "type" : "zeebe:taskHeader"
+    },
+    "type" : "Text"
+  }, {
+    "id" : "retryCount",
+    "label" : "Retries",
+    "description" : "Number of retries",
+    "value" : "3",
+    "feel" : "optional",
+    "group" : "retries",
+    "binding" : {
+      "property" : "retries",
+      "type" : "zeebe:taskDefinition"
+    },
+    "type" : "String"
+  }, {
+    "id" : "retryBackoff",
+    "label" : "Retry backoff",
+    "description" : "ISO-8601 duration to wait between retries",
+    "value" : "PT30S",
+    "group" : "retries",
+    "binding" : {
+      "key" : "retryBackoff",
+      "type" : "zeebe:taskHeader"
+    },
+    "type" : "String"
+  } ],
+  "icon" : {
+    "contents" : "data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMzIiIGhlaWdodD0iMzIiIHZpZXdCb3g9IjAgMCAzMiAzMiIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPGNpcmNsZSBjeD0iMTYiIGN5PSIxNiIgcj0iMTYiIGZpbGw9IiNBNTZFRkYiLz4KPG1hc2sgaWQ9InBhdGgtMi1vdXRzaWRlLTFfMTg1XzYiIG1hc2tVbml0cz0idXNlclNwYWNlT25Vc2UiIHg9IjQiIHk9IjQiIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgZmlsbD0iYmxhY2siPgo8cmVjdCBmaWxsPSJ3aGl0ZSIgeD0iNCIgeT0iNCIgd2lkdGg9IjI0IiBoZWlnaHQ9IjI0Ii8+CjxwYXRoIGZpbGwtcnVsZT0iZXZlbm9kZCIgY2xpcC1ydWxlPSJldmVub2RkIiBkPSJNMjAuMDEwNSAxMi4wOTg3QzE4LjQ5IDEwLjU4OTQgMTcuMTU5NCA4LjEwODE0IDE2LjE3OTkgNi4wMTEwM0MxNi4xNTIgNi4wMDQ1MSAxNi4xMTc2IDYgMTYuMDc5NCA2QzE2LjA0MTEgNiAxNi4wMDY2IDYuMDA0NTEgMTUuOTc4OCA2LjAxMTA0QzE0Ljk5OTQgOC4xMDgxNCAxMy42Njk3IDEwLjU4ODkgMTIuMTQ4MSAxMi4wOTgxQzEwLjYyNjkgMTMuNjA3MSA4LjEyNTY4IDE0LjkyNjQgNi4wMTE1NyAxNS44OTgxQzYuMDA0NzQgMTUuOTI2MSA2IDE1Ljk2MTEgNiAxNkM2IDE2LjAzODcgNi4wMDQ2OCAxNi4wNzM2IDYuMDExNDQgMTYuMTAxNEM4LjEyNTE5IDE3LjA3MjkgMTAuNjI2MiAxOC4zOTE5IDEyLjE0NzcgMTkuOTAxNkMxMy42Njk3IDIxLjQxMDcgMTQuOTk5NiAyMy44OTIgMTUuOTc5MSAyNS45ODlDMTYuMDA2OCAyNS45OTU2IDE2LjA0MTEgMjYgMTYuMDc5MyAyNkMxNi4xMTc1IDI2IDE2LjE1MTkgMjUuOTk1NCAxNi4xNzk2IDI1Ljk4OUMxNy4xNTkxIDIzLjg5MiAxOC40ODg4IDIxLjQxMSAyMC4wMDk5IDE5LjkwMjFNMjAuMDA5OSAxOS45MDIxQzIxLjUyNTMgMTguMzk4NyAyMy45NDY1IDE3LjA2NjkgMjUuOTkxNSAxNi4wODI0QzI1Ljk5NjUgMTYuMDU5MyAyNiAxNi4wMzEgMjYgMTUuOTk5N0MyNiAxNS45Njg0IDI1Ljk5NjUgMTUuOTQwMyAyNS45OTE1IDE1LjkxNzFDMjMuOTQ3NCAxNC45MzI3IDIxLjUyNTkgMTMuNjAxIDIwLjAxMDUgMTIuMDk4NyIvPgo8L21hc2s+CjxwYXRoIGZpbGwtcnVsZT0iZXZlbm9kZCIgY2xpcC1ydWxlPSJldmVub2RkIiBkPSJNMjAuMDEwNSAxMi4wOTg3QzE4LjQ5IDEwLjU4OTQgMTcuMTU5NCA4LjEwODE0IDE2LjE3OTkgNi4wMTEwM0MxNi4xNTIgNi4wMDQ1MSAxNi4xMTc2IDYgMTYuMDc5NCA2QzE2LjA0MTEgNiAxNi4wMDY2IDYuMDA0NTEgMTUuOTc4OCA2LjAxMTA0QzE0Ljk5OTQgOC4xMDgxNCAxMy42Njk3IDEwLjU4ODkgMTIuMTQ4MSAxMi4wOTgxQzEwLjYyNjkgMTMuNjA3MSA4LjEyNTY4IDE0LjkyNjQgNi4wMTE1NyAxNS44OTgxQzYuMDA0NzQgMTUuOTI2MSA2IDE1Ljk2MTEgNiAxNkM2IDE2LjAzODcgNi4wMDQ2OCAxNi4wNzM2IDYuMDExNDQgMTYuMTAxNEM4LjEyNTE5IDE3LjA3MjkgMTAuNjI2MiAxOC4zOTE5IDEyLjE0NzcgMTkuOTAxNkMxMy42Njk3IDIxLjQxMDcgMTQuOTk5NiAyMy44OTIgMTUuOTc5MSAyNS45ODlDMTYuMDA2OCAyNS45OTU2IDE2LjA0MTEgMjYgMTYuMDc5MyAyNkMxNi4xMTc1IDI2IDE2LjE1MTkgMjUuOTk1NCAxNi4xNzk2IDI1Ljk4OUMxNy4xNTkxIDIzLjg5MiAxOC40ODg4IDIxLjQxMSAyMC4wMDk5IDE5LjkwMjFNMjAuMDA5OSAxOS45MDIxQzIxLjUyNTMgMTguMzk4NyAyMy45NDY1IDE3LjA2NjkgMjUuOTkxNSAxNi4wODI0QzI1Ljk5NjUgMTYuMDU5MyAyNiAxNi4wMzEgMjYgMTUuOTk5N0MyNiAxNS45Njg0IDI1Ljk5NjUgMTUuOTQwMyAyNS45OTE1IDE1LjkxNzFDMjMuOTQ3NCAxNC45MzI3IDIxLjUyNTkgMTMuNjAxIDIwLjAxMDUgMTIuMDk4NyIgZmlsbD0id2hpdGUiLz4KPHBhdGggZmlsbC1ydWxlPSJldmVub2RkIiBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGQ9Ik0yMC4wMTA1IDEyLjA5ODdDMTguNDkgMTAuNTg5NCAxNy4xNTk0IDguMTA4MTQgMTYuMTc5OSA2LjAxMTAzQzE2LjE1MiA2LjAwNDUxIDE2LjExNzYgNiAxNi4wNzk0IDZDMTYuMDQxMSA2IDE2LjAwNjYgNi4wMDQ1MSAxNS45Nzg4IDYuMDExMDRDMTQuOTk5NCA4LjEwODE0IDEzLjY2OTcgMTAuNTg4OSAxMi4xNDgxIDEyLjA5ODFDMTAuNjI2OSAxMy42MDcxIDguMTI1NjggMTQuOTI2NCA2LjAxMTU3IDE1Ljg5ODFDNi4wMDQ3NCAxNS45MjYxIDYgMTUuOTYxMSA2IDE2QzYgMTYuMDM4NyA2LjAwNDY4IDE2LjA3MzYgNi4wMTE0NCAxNi4xMDE0QzguMTI1MTkgMTcuMDcyOSAxMC42MjYyIDE4LjM5MTkgMTIuMTQ3NyAxOS45MDE2QzEzLjY2OTcgMjEuNDEwNyAxNC45OTk2IDIzLjg5MiAxNS45NzkxIDI1Ljk4OUMxNi4wMDY4IDI1Ljk5NTYgMTYuMDQxMSAyNiAxNi4wNzkzIDI2QzE2LjExNzUgMjYgMTYuMTUxOSAyNS45OTU0IDE2LjE3OTYgMjUuOTg5QzE3LjE1OTEgMjMuODkyIDE4LjQ4ODggMjEuNDExIDIwLjAwOTkgMTkuOTAyMU0yMC4wMDk5IDE5LjkwMjFDMjEuNTI1MyAxOC4zOTg3IDIzLjk0NjUgMTcuMDY2OSAyNS45OTE1IDE2LjA4MjRDMjUuOTk2NSAxNi4wNTkzIDI2IDE2LjAzMSAyNiAxNS45OTk3QzI2IDE1Ljk2ODQgMjUuOTk2NSAxNS45NDAzIDI1Ljk5MTUgMTUuOTE3MUMyMy45NDc0IDE0LjkzMjcgMjEuNTI1OSAxMy42MDEgMjAuMDEwNSAxMi4wOTg3IiBzdHJva2U9IiM0OTFEOEIiIHN0cm9rZS13aWR0aD0iNCIgc3Ryb2tlLWxpbmVqb2luPSJyb3VuZCIgbWFzaz0idXJsKCNwYXRoLTItb3V0c2lkZS0xXzE4NV82KSIvPgo8L3N2Zz4K"
+  }
+}

--- a/connectors/agentic-ai/connector-agentic-ai/element-templates/hybrid/agenticai-ai-agent-task.v2-hybrid.json
+++ b/connectors/agentic-ai/connector-agentic-ai/element-templates/hybrid/agenticai-ai-agent-task.v2-hybrid.json
@@ -97,6 +97,7 @@
   }, {
     "id" : "provider.providerType",
     "label" : "Provider type",
+    "description" : "Identifier for the custom chat model provider.",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -112,11 +113,12 @@
       "equals" : "custom",
       "type" : "simple"
     },
+    "tooltip" : "Must match the identifier configured for the custom implementation.",
     "type" : "String"
   }, {
     "id" : "provider.parameters",
     "label" : "Provider parameters",
-    "description" : "Parameters for the custom chat model factory implementation.",
+    "description" : "Parameters for the custom chat model provider implementation.",
     "optional" : true,
     "feel" : "required",
     "group" : "provider",
@@ -449,6 +451,7 @@
   }, {
     "id" : "data.memory.storage.storeType",
     "label" : "Implementation type",
+    "description" : "Identifier for the custom memory storage implementation.",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -464,6 +467,7 @@
       "equals" : "custom",
       "type" : "simple"
     },
+    "tooltip" : "Must match the identifier configured for the custom implementation.",
     "type" : "String"
   }, {
     "id" : "data.memory.storage.parameters",

--- a/connectors/agentic-ai/connector-agentic-ai/element-templates/hybrid/agenticai-aiagent-job-worker-hybrid.json
+++ b/connectors/agentic-ai/connector-agentic-ai/element-templates/hybrid/agenticai-aiagent-job-worker-hybrid.json
@@ -1531,6 +1531,7 @@
   }, {
     "id" : "data.memory.storage.storeType",
     "label" : "Implementation type",
+    "description" : "Identifier for the custom memory storage implementation.",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -1546,6 +1547,7 @@
       "equals" : "custom",
       "type" : "simple"
     },
+    "tooltip" : "Must match the identifier configured for the custom implementation.",
     "type" : "String"
   }, {
     "id" : "data.memory.storage.parameters",

--- a/connectors/agentic-ai/connector-agentic-ai/element-templates/hybrid/agenticai-aiagent-outbound-connector-hybrid.json
+++ b/connectors/agentic-ai/connector-agentic-ai/element-templates/hybrid/agenticai-aiagent-outbound-connector-hybrid.json
@@ -1533,6 +1533,7 @@
   }, {
     "id" : "data.memory.storage.storeType",
     "label" : "Implementation type",
+    "description" : "Identifier for the custom memory storage implementation.",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -1548,6 +1549,7 @@
       "equals" : "custom",
       "type" : "simple"
     },
+    "tooltip" : "Must match the identifier configured for the custom implementation.",
     "type" : "String"
   }, {
     "id" : "data.memory.storage.parameters",

--- a/connectors/agentic-ai/connector-agentic-ai/pom.xml
+++ b/connectors/agentic-ai/connector-agentic-ai/pom.xml
@@ -457,6 +457,17 @@
               <writeMetaInfFileGeneration>false</writeMetaInfFileGeneration>
             </connector>
             <connector>
+              <connectorClass>io.camunda.connector.agenticai.aiagent.AgentTaskV2Function</connectorClass>
+              <files>
+                <file>
+                  <templateId>io.camunda.connectors.agenticai.ai-agent-task.v2</templateId>
+                  <templateFileName>agenticai-ai-agent-task.v2.json</templateFileName>
+                </file>
+              </files>
+              <generateHybridTemplates>true</generateHybridTemplates>
+              <writeMetaInfFileGeneration>false</writeMetaInfFileGeneration>
+            </connector>
+            <connector>
               <connectorClass>io.camunda.connector.agenticai.mcp.client.McpClientFunction</connectorClass>
               <files>
                 <file>
@@ -599,6 +610,70 @@
                 <property>
                   <name>connectorType</name>
                   <value>io.camunda.agenticai:aiagent-job-worker:1</value>
+                </property>
+              </properties>
+            </configuration>
+          </execution>
+          <execution>
+            <id>generate-subprocess-v2-template</id>
+            <phase>process-classes</phase>
+            <goals>
+              <goal>execute</goal>
+            </goals>
+            <configuration>
+              <scripts>
+                <script>file:///${project.basedir}/bin/transform-ai-agent-sub-process-template.groovy</script>
+              </scripts>
+              <properties>
+                <property>
+                  <name>sourceFile</name>
+                  <value>${project.basedir}/element-templates/agenticai-ai-agent-task.v2.json</value>
+                </property>
+                <property>
+                  <name>outputFile</name>
+                  <value>${project.basedir}/element-templates/agenticai-ai-agent-subprocess.v2.json</value>
+                </property>
+                <property>
+                  <name>templateId</name>
+                  <value>io.camunda.connectors.agenticai.ai-agent-subprocess.v2</value>
+                </property>
+                <property>
+                  <name>connectorType</name>
+                  <value>io.camunda.agenticai:aiagent:subprocess:2</value>
+                </property>
+              </properties>
+            </configuration>
+          </execution>
+          <execution>
+            <id>generate-subprocess-v2-template-hybrid</id>
+            <phase>process-classes</phase>
+            <goals>
+              <goal>execute</goal>
+            </goals>
+            <configuration>
+              <scripts>
+                <script>file:///${project.basedir}/bin/transform-ai-agent-sub-process-template.groovy</script>
+              </scripts>
+              <properties>
+                <property>
+                  <name>sourceFile</name>
+                  <value>
+                    ${project.basedir}/element-templates/hybrid/agenticai-ai-agent-task.v2-hybrid.json
+                  </value>
+                </property>
+                <property>
+                  <name>outputFile</name>
+                  <value>
+                    ${project.basedir}/element-templates/hybrid/agenticai-ai-agent-subprocess.v2-hybrid.json
+                  </value>
+                </property>
+                <property>
+                  <name>templateId</name>
+                  <value>io.camunda.connectors.agenticai.ai-agent-subprocess.v2</value>
+                </property>
+                <property>
+                  <name>connectorType</name>
+                  <value>io.camunda.agenticai:aiagent:subprocess:2</value>
                 </property>
               </properties>
             </configuration>

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/AgentSubProcessV2Function.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/AgentSubProcessV2Function.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.agenticai.aiagent;
+
+import io.camunda.connector.agenticai.aiagent.agent.AgentSubProcessRequestHandler;
+import io.camunda.connector.agenticai.aiagent.model.AgentSubProcessExecutionContext;
+import io.camunda.connector.agenticai.aiagent.model.request.AgentSubProcessV2Request;
+import io.camunda.connector.api.annotation.OutboundConnector;
+import io.camunda.connector.api.outbound.OutboundConnectorContext;
+
+/** AI Agent Sub-process v2 connector (LLM-provider layer). Job worker on an ad-hoc sub-process. */
+@OutboundConnector(
+    name = AgentSubProcessV2Function.JOB_WORKER_NAME,
+    type = AgentSubProcessV2Function.JOB_WORKER_TYPE,
+    inputVariables = {
+      AgentSubProcessV2Function.AD_HOC_SUB_PROCESS_ELEMENT_VARIABLE,
+      AgentSubProcessV2Function.AGENT_CONTEXT_VARIABLE,
+      AgentSubProcessV2Function.TOOL_CALL_RESULTS_VARIABLE,
+      AgentSubProcessV2Function.PROVIDER_VARIABLE,
+      AgentSubProcessV2Function.DATA_VARIABLE
+    })
+public class AgentSubProcessV2Function implements AgentConnectorFunction {
+
+  public static final String JOB_WORKER_NAME = "AI Agent Sub-process";
+  public static final String JOB_WORKER_TYPE = "io.camunda.agenticai:aiagent:subprocess:2";
+
+  public static final String AD_HOC_SUB_PROCESS_ELEMENT_VARIABLE = "adHocSubProcessElements";
+  public static final String AGENT_CONTEXT_VARIABLE = "agentContext";
+  public static final String TOOL_CALL_RESULTS_VARIABLE = "toolCallResults";
+  public static final String PROVIDER_VARIABLE = "provider";
+  public static final String DATA_VARIABLE = "data";
+
+  private final AgentSubProcessRequestHandler agentRequestHandler;
+
+  public AgentSubProcessV2Function(AgentSubProcessRequestHandler agentRequestHandler) {
+    this.agentRequestHandler = agentRequestHandler;
+  }
+
+  @Override
+  public AgentSubProcessConnectorResponse execute(OutboundConnectorContext context)
+      throws Exception {
+    var request = context.bindVariables(AgentSubProcessV2Request.class);
+    var executionContext =
+        new AgentSubProcessExecutionContext(
+            context.getJobContext(),
+            request.data(),
+            request.agentContext(),
+            request.toolCallResults(),
+            request.toolElements(),
+            request.provider());
+    return agentRequestHandler.handleRequest(executionContext);
+  }
+}

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/AgentTaskV2Function.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/AgentTaskV2Function.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.agenticai.aiagent;
+
+import io.camunda.connector.agenticai.adhoctoolsschema.processdefinition.ProcessDefinitionAdHocToolElementsResolver;
+import io.camunda.connector.agenticai.aiagent.agent.AgentTaskRequestHandler;
+import io.camunda.connector.agenticai.aiagent.model.AgentResponse;
+import io.camunda.connector.agenticai.aiagent.model.AgentTaskExecutionContext;
+import io.camunda.connector.agenticai.aiagent.model.request.AgentTaskV2Request;
+import io.camunda.connector.api.annotation.OutboundConnector;
+import io.camunda.connector.api.outbound.OutboundConnectorContext;
+import io.camunda.connector.generator.java.annotation.ElementTemplate;
+import io.camunda.connector.generator.java.annotation.ElementTemplate.PropertyGroup;
+
+/**
+ * AI Agent Task v2 connector (LLM-provider layer). Service-task flavor; reuses the shared handler.
+ */
+@OutboundConnector(
+    name = "AI Agent Task",
+    inputVariables = {"provider", "data"},
+    type = "io.camunda.agenticai:aiagent:task:2")
+@ElementTemplate(
+    id = "io.camunda.connectors.agenticai.ai-agent-task.v2",
+    name = "AI Agent Task",
+    description = "Execute a single AI-powered action with tool calling capabilities",
+    keywords = {"AI", "AI Agent", "agentic orchestration"},
+    documentationRef =
+        "https://docs.camunda.io/docs/8.10/components/connectors/out-of-the-box-connectors/agentic-ai-aiagent-task/",
+    engineVersion = "^8.10",
+    version = 1,
+    category = @ElementTemplate.Category(id = "aiTools", name = "AI Tools"),
+    inputDataClass = AgentTaskV2Request.class,
+    outputDataClass = AgentResponse.class,
+    defaultResultVariable = "agent",
+    propertyGroups = {
+      @PropertyGroup(id = "provider", label = "Model provider", openByDefault = false),
+      @PropertyGroup(id = "model", label = "Model", openByDefault = false),
+      @PropertyGroup(
+          id = "systemPrompt",
+          label = "System prompt",
+          tooltip =
+              "A system prompt is a set of foundational instructions given to a model before any user interaction begins. "
+                  + "It defines the AI agent’s role, behavior, tone, and communication style, ensuring that responses remain consistent "
+                  + "and aligned with the AI agent’s intended purpose. These instructions help shape how the model interprets and responds "
+                  + "to user input throughout the conversation.",
+          openByDefault = false),
+      @PropertyGroup(
+          id = "userPrompt",
+          label = "User prompt",
+          tooltip =
+              "A user prompt is the message or question you give to the AI to start or continue a conversation. It tells "
+                  + "the AI what you need, whether it's information, help with a task, or just a chat. The AI uses your prompt "
+                  + "to understand how to respond.",
+          openByDefault = false),
+      @PropertyGroup(
+          id = "tools",
+          label = "Tools",
+          tooltip =
+              "Tools are optional features the AI Agent can use to perform specific tasks. Configure this if the agent should participate in a tools feedback loop.",
+          openByDefault = false),
+      @PropertyGroup(
+          id = "memory",
+          label = "Memory",
+          tooltip = "Configuration of the Agent's short-term/conversational memory.",
+          openByDefault = false),
+      @PropertyGroup(id = "limits", label = "Limits", openByDefault = false),
+      @PropertyGroup(
+          id = "response",
+          label = "Response",
+          tooltip =
+              "Configuration of the model response format and how to map the model response to the connector result.<br><br>Depending on the selection, the model response will be available as <code>response.responseText</code> or <code>response.responseJson</code>.<br><br>See <a href=\"https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/agentic-ai-aiagent-task/#response\">documentation</a> for details.",
+          openByDefault = false)
+    },
+    icon = "aiagent.svg")
+public class AgentTaskV2Function implements AgentConnectorFunction {
+  private final ProcessDefinitionAdHocToolElementsResolver toolElementsResolver;
+  private final AgentTaskRequestHandler agentRequestHandler;
+
+  public AgentTaskV2Function(
+      ProcessDefinitionAdHocToolElementsResolver toolElementsResolver,
+      AgentTaskRequestHandler agentRequestHandler) {
+    this.toolElementsResolver = toolElementsResolver;
+    this.agentRequestHandler = agentRequestHandler;
+  }
+
+  @Override
+  public AgentTaskConnectorResponse execute(OutboundConnectorContext context) {
+    var request = context.bindVariables(AgentTaskV2Request.class);
+    var executionContext =
+        new AgentTaskExecutionContext(
+            context.getJobContext(), request.data(), request.provider(), toolElementsResolver);
+    return agentRequestHandler.handleRequest(executionContext);
+  }
+}

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/ChatModelConfiguration.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/ChatModelConfiguration.java
@@ -8,10 +8,7 @@ package io.camunda.connector.agenticai.aiagent.chatmodel;
 
 /**
  * Neutral, connector-agnostic descriptor a {@link ChatModelFactory} inspects to decide whether it
- * can serve a request and to build a {@link ChatModel}. Today the built-in AI Agent request
- * supplies configurations via the sealed {@code ProviderConfiguration} union; the SPI is the seam
- * for custom/native providers to contribute their own {@link ChatModelConfiguration}
- * implementation, whose request-side wiring lands with the v2 request types.
+ * can serve a request and to build a {@link ChatModel}.
  */
 public interface ChatModelConfiguration {
 

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/AgentSubProcessV1Request.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/AgentSubProcessV1Request.java
@@ -14,31 +14,13 @@ import io.camunda.connector.agenticai.aiagent.model.request.v1.ProviderConfigura
 import io.camunda.connector.agenticai.aiagent.model.tool.ToolCallResult;
 import io.camunda.connector.agenticai.aiagent.model.versioning.VersionedAgentContextDeserializer;
 import io.camunda.connector.api.annotation.FEEL;
-import io.camunda.connector.generator.java.annotation.FeelMode;
-import io.camunda.connector.generator.java.annotation.TemplateProperty;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import java.util.List;
 
 public record AgentSubProcessV1Request(
     @JsonProperty("adHocSubProcessElements") List<AdHocToolElement> toolElements,
-    @FEEL
-        @TemplateProperty(
-            label = "Agent context",
-            group = "memory",
-            id = "agentContext",
-            description =
-                "Initial agent context from previous interactions. Avoid reusing context variables across agents to prevent issues with stale data or tool access.",
-            tooltip =
-                "The agent context variable containing all relevant data for the agent to support the feedback loop between "
-                    + "user requests, tool calls and LLM responses. Make sure this variable points to the <code>context</code> "
-                    + "variable which is returned from the agent response. "
-                    + "<a href=\"https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/agentic-ai-aiagent-subprocess/\" target=\"_blank\">See documentation</a> "
-                    + "for details.",
-            type = TemplateProperty.PropertyType.Text,
-            feel = FeelMode.required)
-        @Valid
-        @JsonDeserialize(using = VersionedAgentContextDeserializer.class)
+    @FEEL @Valid @JsonDeserialize(using = VersionedAgentContextDeserializer.class)
         AgentContext agentContext,
     List<ToolCallResult> toolCallResults,
     @Valid @NotNull ProviderConfiguration provider,

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/AgentSubProcessV1Request.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/AgentSubProcessV1Request.java
@@ -13,14 +13,13 @@ import io.camunda.connector.agenticai.aiagent.model.AgentContext;
 import io.camunda.connector.agenticai.aiagent.model.request.v1.ProviderConfiguration;
 import io.camunda.connector.agenticai.aiagent.model.tool.ToolCallResult;
 import io.camunda.connector.agenticai.aiagent.model.versioning.VersionedAgentContextDeserializer;
-import io.camunda.connector.api.annotation.FEEL;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import java.util.List;
 
 public record AgentSubProcessV1Request(
     @JsonProperty("adHocSubProcessElements") List<AdHocToolElement> toolElements,
-    @FEEL @Valid @JsonDeserialize(using = VersionedAgentContextDeserializer.class)
+    @Valid @JsonDeserialize(using = VersionedAgentContextDeserializer.class)
         AgentContext agentContext,
     List<ToolCallResult> toolCallResults,
     @Valid @NotNull ProviderConfiguration provider,

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/AgentSubProcessV2Request.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/AgentSubProcessV2Request.java
@@ -13,14 +13,13 @@ import io.camunda.connector.agenticai.aiagent.model.AgentContext;
 import io.camunda.connector.agenticai.aiagent.model.request.v2.ProviderConfiguration;
 import io.camunda.connector.agenticai.aiagent.model.tool.ToolCallResult;
 import io.camunda.connector.agenticai.aiagent.model.versioning.VersionedAgentContextDeserializer;
-import io.camunda.connector.api.annotation.FEEL;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import java.util.List;
 
 public record AgentSubProcessV2Request(
     @JsonProperty("adHocSubProcessElements") List<AdHocToolElement> toolElements,
-    @FEEL @Valid @JsonDeserialize(using = VersionedAgentContextDeserializer.class)
+    @Valid @JsonDeserialize(using = VersionedAgentContextDeserializer.class)
         AgentContext agentContext,
     List<ToolCallResult> toolCallResults,
     @Valid @NotNull ProviderConfiguration provider,

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/AgentSubProcessV2Request.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/AgentSubProcessV2Request.java
@@ -14,31 +14,13 @@ import io.camunda.connector.agenticai.aiagent.model.request.v2.ProviderConfigura
 import io.camunda.connector.agenticai.aiagent.model.tool.ToolCallResult;
 import io.camunda.connector.agenticai.aiagent.model.versioning.VersionedAgentContextDeserializer;
 import io.camunda.connector.api.annotation.FEEL;
-import io.camunda.connector.generator.java.annotation.FeelMode;
-import io.camunda.connector.generator.java.annotation.TemplateProperty;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import java.util.List;
 
 public record AgentSubProcessV2Request(
     @JsonProperty("adHocSubProcessElements") List<AdHocToolElement> toolElements,
-    @FEEL
-        @TemplateProperty(
-            label = "Agent context",
-            group = "memory",
-            id = "agentContext",
-            description =
-                "Initial agent context from previous interactions. Avoid reusing context variables across agents to prevent issues with stale data or tool access.",
-            tooltip =
-                "The agent context variable containing all relevant data for the agent to support the feedback loop between "
-                    + "user requests, tool calls and LLM responses. Make sure this variable points to the <code>context</code> "
-                    + "variable which is returned from the agent response. "
-                    + "<a href=\"https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/agentic-ai-aiagent-subprocess/\" target=\"_blank\">See documentation</a> "
-                    + "for details.",
-            type = TemplateProperty.PropertyType.Text,
-            feel = FeelMode.required)
-        @Valid
-        @JsonDeserialize(using = VersionedAgentContextDeserializer.class)
+    @FEEL @Valid @JsonDeserialize(using = VersionedAgentContextDeserializer.class)
         AgentContext agentContext,
     List<ToolCallResult> toolCallResults,
     @Valid @NotNull ProviderConfiguration provider,

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/AgentSubProcessV2Request.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/AgentSubProcessV2Request.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.agenticai.aiagent.model.request;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import io.camunda.connector.agenticai.adhoctoolsschema.model.AdHocToolElement;
+import io.camunda.connector.agenticai.aiagent.model.AgentContext;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.ProviderConfiguration;
+import io.camunda.connector.agenticai.aiagent.model.tool.ToolCallResult;
+import io.camunda.connector.agenticai.aiagent.model.versioning.VersionedAgentContextDeserializer;
+import io.camunda.connector.api.annotation.FEEL;
+import io.camunda.connector.generator.java.annotation.FeelMode;
+import io.camunda.connector.generator.java.annotation.TemplateProperty;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import java.util.List;
+
+public record AgentSubProcessV2Request(
+    @JsonProperty("adHocSubProcessElements") List<AdHocToolElement> toolElements,
+    @FEEL
+        @TemplateProperty(
+            label = "Agent context",
+            group = "memory",
+            id = "agentContext",
+            description =
+                "Initial agent context from previous interactions. Avoid reusing context variables across agents to prevent issues with stale data or tool access.",
+            tooltip =
+                "The agent context variable containing all relevant data for the agent to support the feedback loop between "
+                    + "user requests, tool calls and LLM responses. Make sure this variable points to the <code>context</code> "
+                    + "variable which is returned from the agent response. "
+                    + "<a href=\"https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/agentic-ai-aiagent-subprocess/\" target=\"_blank\">See documentation</a> "
+                    + "for details.",
+            type = TemplateProperty.PropertyType.Text,
+            feel = FeelMode.required)
+        @Valid
+        @JsonDeserialize(using = VersionedAgentContextDeserializer.class)
+        AgentContext agentContext,
+    List<ToolCallResult> toolCallResults,
+    @Valid @NotNull ProviderConfiguration provider,
+    @Valid @NotNull AgentSubProcessRequestData data) {}

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/AgentTaskV2Request.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/AgentTaskV2Request.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.agenticai.aiagent.model.request;
+
+import io.camunda.connector.agenticai.aiagent.model.request.v2.ProviderConfiguration;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+
+public record AgentTaskV2Request(
+    @Valid @NotNull ProviderConfiguration provider, @Valid @NotNull AgentTaskRequestData data) {}

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/MemoryStorageConfiguration.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/MemoryStorageConfiguration.java
@@ -196,6 +196,8 @@ public sealed interface MemoryStorageConfiguration
       @FEEL
           @TemplateProperty(
               label = "Implementation type",
+              description = "Identifier for the custom memory storage implementation.",
+              tooltip = "Must match the identifier configured for the custom implementation.",
               type = TemplateProperty.PropertyType.String,
               feel = FeelMode.optional,
               constraints = @TemplateProperty.PropertyConstraints(notEmpty = true))

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/MemoryStorageConfiguration.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/MemoryStorageConfiguration.java
@@ -24,6 +24,8 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import java.time.Duration;
 import java.util.Map;
+import java.util.Objects;
+import org.jspecify.annotations.Nullable;
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
 @JsonSubTypes({
@@ -206,5 +208,11 @@ public sealed interface MemoryStorageConfiguration
               feel = FeelMode.required,
               optional = true)
           Map<String, Object> parameters)
-      implements MemoryStorageConfiguration {}
+      implements MemoryStorageConfiguration {
+    public CustomMemoryStorageConfiguration(
+        String storeType, @Nullable Map<String, Object> parameters) {
+      this.storeType = storeType;
+      this.parameters = Objects.requireNonNullElse(parameters, Map.of());
+    }
+  }
 }

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/v1/ProviderConfiguration.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/v1/ProviderConfiguration.java
@@ -43,7 +43,6 @@ public sealed interface ProviderConfiguration extends ChatModelConfiguration
         OpenAiProviderConfiguration,
         OpenAiCompatibleProviderConfiguration {
 
-  /** Type of the provider implementation used to resolve the backing chat model. */
   @Override
   String provider();
 

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/v2/CustomProviderConfiguration.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/v2/CustomProviderConfiguration.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.agenticai.aiagent.model.request.v2;
+
+import static io.camunda.connector.agenticai.aiagent.model.request.v2.CustomProviderConfiguration.CUSTOM_ID;
+
+import io.camunda.connector.api.annotation.FEEL;
+import io.camunda.connector.generator.java.annotation.FeelMode;
+import io.camunda.connector.generator.java.annotation.TemplateProperty;
+import io.camunda.connector.generator.java.annotation.TemplateSubType;
+import jakarta.validation.constraints.NotBlank;
+import java.util.Map;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * User-supplied chat model provider. The {@link #providerType()} discriminator is dispatched to a
+ * {@code ChatModelFactory} bean the user implements and registers themselves (see {@code
+ * ChatModelRegistry}); {@link #parameters()} is opaque configuration only that factory understands.
+ */
+@TemplateSubType(id = CUSTOM_ID, label = "Custom Implementation (Self-Managed/Hybrid only)")
+public record CustomProviderConfiguration(
+    @FEEL
+        @TemplateProperty(
+            group = "provider",
+            label = "Provider type",
+            type = TemplateProperty.PropertyType.String,
+            feel = FeelMode.optional,
+            constraints = @TemplateProperty.PropertyConstraints(notEmpty = true))
+        @NotBlank
+        String providerType,
+    @FEEL
+        @TemplateProperty(
+            group = "model",
+            label = "Model",
+            description = "Identifier of the model to use.",
+            type = TemplateProperty.PropertyType.String,
+            feel = FeelMode.optional,
+            constraints = @TemplateProperty.PropertyConstraints(notEmpty = true))
+        @NotBlank
+        String model,
+    @FEEL
+        @TemplateProperty(
+            group = "provider",
+            label = "Provider parameters",
+            description = "Parameters for the custom chat model factory implementation.",
+            feel = FeelMode.required,
+            optional = true)
+        Map<String, Object> parameters)
+    implements ProviderConfiguration {
+
+  @TemplateProperty(ignore = true)
+  public static final String CUSTOM_ID = "custom";
+
+  @Override
+  public String provider() {
+    return providerType;
+  }
+
+  @Override
+  public @Nullable String backend() {
+    return null;
+  }
+}

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/v2/CustomProviderConfiguration.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/v2/CustomProviderConfiguration.java
@@ -14,7 +14,6 @@ import io.camunda.connector.generator.java.annotation.TemplateProperty;
 import io.camunda.connector.generator.java.annotation.TemplateSubType;
 import jakarta.validation.constraints.NotBlank;
 import java.util.Map;
-import org.jspecify.annotations.Nullable;
 
 /**
  * User-supplied chat model provider. The {@link #providerType()} discriminator is dispatched to a
@@ -58,10 +57,5 @@ public record CustomProviderConfiguration(
   @Override
   public String provider() {
     return providerType;
-  }
-
-  @Override
-  public @Nullable String backend() {
-    return null;
   }
 }

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/v2/CustomProviderConfiguration.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/v2/CustomProviderConfiguration.java
@@ -28,6 +28,8 @@ public record CustomProviderConfiguration(
         @TemplateProperty(
             group = "provider",
             label = "Provider type",
+            description = "Identifier for the custom chat model provider.",
+            tooltip = "Must match the identifier configured for the custom implementation.",
             type = TemplateProperty.PropertyType.String,
             feel = FeelMode.optional,
             constraints = @TemplateProperty.PropertyConstraints(notEmpty = true))
@@ -47,7 +49,7 @@ public record CustomProviderConfiguration(
         @TemplateProperty(
             group = "provider",
             label = "Provider parameters",
-            description = "Parameters for the custom chat model factory implementation.",
+            description = "Parameters for the custom chat model provider implementation.",
             feel = FeelMode.required,
             optional = true)
         Map<String, Object> parameters)

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/v2/CustomProviderConfiguration.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/v2/CustomProviderConfiguration.java
@@ -14,6 +14,8 @@ import io.camunda.connector.generator.java.annotation.TemplateProperty;
 import io.camunda.connector.generator.java.annotation.TemplateSubType;
 import jakarta.validation.constraints.NotBlank;
 import java.util.Map;
+import java.util.Objects;
+import org.jspecify.annotations.Nullable;
 
 /**
  * User-supplied chat model provider. The {@link #providerType()} discriminator is dispatched to a
@@ -53,6 +55,13 @@ public record CustomProviderConfiguration(
 
   @TemplateProperty(ignore = true)
   public static final String CUSTOM_ID = "custom";
+
+  public CustomProviderConfiguration(
+      String providerType, String model, @Nullable Map<String, Object> parameters) {
+    this.providerType = providerType;
+    this.model = model;
+    this.parameters = Objects.requireNonNullElse(parameters, Map.of());
+  }
 
   @Override
   public String provider() {

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/v2/CustomProviderConfiguration.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/v2/CustomProviderConfiguration.java
@@ -8,7 +8,6 @@ package io.camunda.connector.agenticai.aiagent.model.request.v2;
 
 import static io.camunda.connector.agenticai.aiagent.model.request.v2.CustomProviderConfiguration.CUSTOM_ID;
 
-import io.camunda.connector.api.annotation.FEEL;
 import io.camunda.connector.generator.java.annotation.FeelMode;
 import io.camunda.connector.generator.java.annotation.TemplateProperty;
 import io.camunda.connector.generator.java.annotation.TemplateSubType;
@@ -24,8 +23,7 @@ import org.jspecify.annotations.Nullable;
  */
 @TemplateSubType(id = CUSTOM_ID, label = "Custom Implementation (Self-Managed/Hybrid only)")
 public record CustomProviderConfiguration(
-    @FEEL
-        @TemplateProperty(
+    @TemplateProperty(
             group = "provider",
             label = "Provider type",
             description = "Identifier for the custom chat model provider.",
@@ -35,8 +33,7 @@ public record CustomProviderConfiguration(
             constraints = @TemplateProperty.PropertyConstraints(notEmpty = true))
         @NotBlank
         String providerType,
-    @FEEL
-        @TemplateProperty(
+    @TemplateProperty(
             group = "model",
             label = "Model",
             description = "Identifier of the model to use.",
@@ -45,8 +42,7 @@ public record CustomProviderConfiguration(
             constraints = @TemplateProperty.PropertyConstraints(notEmpty = true))
         @NotBlank
         String model,
-    @FEEL
-        @TemplateProperty(
+    @TemplateProperty(
             group = "provider",
             label = "Provider parameters",
             description = "Parameters for the custom chat model provider implementation.",

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/v2/ProviderConfiguration.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/v2/ProviderConfiguration.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.agenticai.aiagent.model.request.v2;
+
+import static io.camunda.connector.agenticai.aiagent.model.request.v2.CustomProviderConfiguration.CUSTOM_ID;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import io.camunda.connector.agenticai.aiagent.chatmodel.ChatModelConfiguration;
+import io.camunda.connector.generator.java.annotation.TemplateDiscriminatorProperty;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Wire-format-first chat-model configuration surfaced by the v2 connectors. Each provider member
+ * nests its fields under a single provider-named component (mirroring the v1 {@code
+ * ProviderConfiguration}), so generated element-template property ids are namespaced ({@code
+ * provider.anthropic.*} / {@code provider.openai.*}) and the interface accessors below compute from
+ * the nested data without colliding with a record component. Polymorphism is by the {@code type}
+ * discriminator; the concrete member owns its backend-conditional authentication.
+ */
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+@JsonSubTypes({@JsonSubTypes.Type(value = CustomProviderConfiguration.class, name = CUSTOM_ID)})
+@TemplateDiscriminatorProperty(
+    label = "Provider",
+    group = "provider",
+    name = "type",
+    description = "Specify the LLM provider to use.",
+    defaultValue = CUSTOM_ID)
+public sealed interface ProviderConfiguration extends ChatModelConfiguration
+    permits CustomProviderConfiguration {
+
+  /** Discriminator string identifying the provider (e.g. {@code anthropic}, {@code openai}). */
+  @Override
+  String provider();
+
+  /** The model id / deployment the request targets. */
+  @Override
+  String model();
+
+  /** The backend discriminator (e.g. {@code direct}, {@code bedrock}, {@code compatible}). */
+  @Nullable String backend();
+}

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/v2/ProviderConfiguration.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/v2/ProviderConfiguration.java
@@ -42,5 +42,7 @@ public sealed interface ProviderConfiguration extends ChatModelConfiguration
   String model();
 
   /** The backend discriminator (e.g. {@code direct}, {@code bedrock}, {@code compatible}). */
-  @Nullable String backend();
+  default @Nullable String backend() {
+    return null;
+  }
 }

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/v2/ProviderConfiguration.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/v2/ProviderConfiguration.java
@@ -14,14 +14,6 @@ import io.camunda.connector.agenticai.aiagent.chatmodel.ChatModelConfiguration;
 import io.camunda.connector.generator.java.annotation.TemplateDiscriminatorProperty;
 import org.jspecify.annotations.Nullable;
 
-/**
- * Wire-format-first chat-model configuration surfaced by the v2 connectors. Each provider member
- * nests its fields under a single provider-named component (mirroring the v1 {@code
- * ProviderConfiguration}), so generated element-template property ids are namespaced ({@code
- * provider.anthropic.*} / {@code provider.openai.*}) and the interface accessors below compute from
- * the nested data without colliding with a record component. Polymorphism is by the {@code type}
- * discriminator; the concrete member owns its backend-conditional authentication.
- */
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
 @JsonSubTypes({@JsonSubTypes.Type(value = CustomProviderConfiguration.class, name = CUSTOM_ID)})
 @TemplateDiscriminatorProperty(
@@ -33,11 +25,9 @@ import org.jspecify.annotations.Nullable;
 public sealed interface ProviderConfiguration extends ChatModelConfiguration
     permits CustomProviderConfiguration {
 
-  /** Discriminator string identifying the provider (e.g. {@code anthropic}, {@code openai}). */
   @Override
   String provider();
 
-  /** The model id / deployment the request targets. */
   @Override
   String model();
 

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/v2/ProviderConfiguration.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/v2/ProviderConfiguration.java
@@ -12,7 +12,6 @@ import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import io.camunda.connector.agenticai.aiagent.chatmodel.ChatModelConfiguration;
 import io.camunda.connector.generator.java.annotation.TemplateDiscriminatorProperty;
-import org.jspecify.annotations.Nullable;
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
 @JsonSubTypes({@JsonSubTypes.Type(value = CustomProviderConfiguration.class, name = CUSTOM_ID)})
@@ -30,9 +29,4 @@ public sealed interface ProviderConfiguration extends ChatModelConfiguration
 
   @Override
   String model();
-
-  /** The backend discriminator (e.g. {@code direct}, {@code bedrock}, {@code compatible}). */
-  default @Nullable String backend() {
-    return null;
-  }
 }

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/v2/package-info.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/v2/package-info.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+@NullMarked
+package io.camunda.connector.agenticai.aiagent.model.request.v2;
+
+import org.jspecify.annotations.NullMarked;

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/autoconfigure/AgenticAiConnectorsAutoConfiguration.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/autoconfigure/AgenticAiConnectorsAutoConfiguration.java
@@ -25,7 +25,9 @@ import io.camunda.connector.agenticai.adhoctoolsschema.schema.AdHocToolsSchemaRe
 import io.camunda.connector.agenticai.adhoctoolsschema.schema.AdHocToolsSchemaResolverImpl;
 import io.camunda.connector.agenticai.adhoctoolsschema.schema.GatewayToolDefinitionResolver;
 import io.camunda.connector.agenticai.aiagent.AgentSubProcessV1Function;
+import io.camunda.connector.agenticai.aiagent.AgentSubProcessV2Function;
 import io.camunda.connector.agenticai.aiagent.AgentTaskV1Function;
+import io.camunda.connector.agenticai.aiagent.AgentTaskV2Function;
 import io.camunda.connector.agenticai.aiagent.agent.AgentConversationTurnInputComposer;
 import io.camunda.connector.agenticai.aiagent.agent.AgentConversationTurnInputComposerImpl;
 import io.camunda.connector.agenticai.aiagent.agent.AgentInitializer;
@@ -73,6 +75,7 @@ import io.camunda.connector.runtime.annotation.ConnectorsObjectMapper;
 import io.camunda.connector.runtime.core.document.store.CamundaDocumentStore;
 import io.camunda.zeebe.feel.tagged.impl.TaggedParameterExtractor;
 import java.util.List;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBooleanProperty;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -359,5 +362,28 @@ public class AgenticAiConnectorsAutoConfiguration {
   public AgentSubProcessV1Function aiAgentSubProcessV1Function(
       AgentSubProcessRequestHandler agentRequestHandler) {
     return new AgentSubProcessV1Function(agentRequestHandler);
+  }
+
+  @Bean
+  @ConditionalOnMissingBean
+  @ConditionalOnBean(AgentTaskRequestHandler.class)
+  @ConditionalOnBooleanProperty(
+      value = "camunda.connector.agenticai.aiagent.outbound-connector.enabled",
+      matchIfMissing = true)
+  public AgentTaskV2Function aiAgentTaskV2Function(
+      ProcessDefinitionAdHocToolElementsResolver toolElementsResolver,
+      AgentTaskRequestHandler agentRequestHandler) {
+    return new AgentTaskV2Function(toolElementsResolver, agentRequestHandler);
+  }
+
+  @Bean
+  @ConditionalOnMissingBean
+  @ConditionalOnBean(AgentSubProcessRequestHandler.class)
+  @ConditionalOnBooleanProperty(
+      value = "camunda.connector.agenticai.aiagent.job-worker.enabled",
+      matchIfMissing = true)
+  public AgentSubProcessV2Function aiAgentSubProcessV2Function(
+      AgentSubProcessRequestHandler agentRequestHandler) {
+    return new AgentSubProcessV2Function(agentRequestHandler);
   }
 }

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/model/request/AgentSubProcessV2RequestTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/model/request/AgentSubProcessV2RequestTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.agenticai.aiagent.model.request;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.connector.agenticai.aiagent.memory.conversation.inprocess.InProcessConversationContext;
+import io.camunda.connector.agenticai.aiagent.model.AgentContext;
+import io.camunda.connector.agenticai.aiagent.model.message.ToolCallResultMessage;
+import io.camunda.connector.agenticai.aiagent.model.message.content.TextContent;
+import io.camunda.connector.document.jackson.JacksonModuleDocumentDeserializer;
+import io.camunda.connector.document.jackson.JacksonModuleDocumentDeserializer.DocumentModuleSettings;
+import io.camunda.connector.document.jackson.JacksonModuleDocumentSerializer;
+import io.camunda.connector.jackson.ConnectorsObjectMapperSupplier;
+import io.camunda.connector.runtime.core.document.DocumentFactoryImpl;
+import io.camunda.connector.runtime.core.document.store.InMemoryDocumentStore;
+import io.camunda.connector.runtime.core.intrinsic.DefaultIntrinsicFunctionExecutor;
+import org.junit.jupiter.api.Test;
+
+class AgentSubProcessV2RequestTest {
+
+  /**
+   * Mirrors the production {@code outboundConnectorObjectMapper} bean (see {@code
+   * ConnectorsAutoConfiguration#outboundConnectorObjectMapper}), which is the actual ObjectMapper
+   * used by {@code JobHandlerContext#bindVariables} for job worker requests: {@code @FEEL}
+   * annotation processing is disabled there (FEEL for jobs is evaluated by Zeebe before the
+   * variables reach the connector), so field-level {@code @JsonDeserialize} annotations such as
+   * {@code VersionedAgentContextDeserializer} take effect instead of being overridden by a
+   * FEEL-aware deserializer. This mapper reproduces that by simply never registering the FEEL
+   * Jackson module, which has the same effect without pulling in the {@code connector-feel}
+   * dependency (undeclared in this module's pom) just to construct a disabled instance of it.
+   * {@link io.camunda.connector.agenticai.testutil.TestObjectMapperSupplier} deliberately does NOT
+   * mirror this (it enables FEEL annotation processing for other test needs), so it must not be
+   * used here.
+   */
+  private static ObjectMapper outboundObjectMapper() {
+    var copy = ConnectorsObjectMapperSupplier.getCopy();
+    var documentFactory = new DocumentFactoryImpl(InMemoryDocumentStore.INSTANCE);
+    var functionExecutor = new DefaultIntrinsicFunctionExecutor(copy);
+    var jacksonModuleDocumentDeserializer =
+        new JacksonModuleDocumentDeserializer(
+            documentFactory, functionExecutor, DocumentModuleSettings.create());
+    return copy.registerModules(
+        jacksonModuleDocumentDeserializer, new JacksonModuleDocumentSerializer());
+  }
+
+  private final ObjectMapper objectMapper = outboundObjectMapper();
+
+  @Test
+  void deserializesLegacyShapedAgentContext() throws Exception {
+    // legacy (pre-8.10, pre-CURRENT_SCHEMA_VERSION) persisted agentContext shape: no
+    // schemaVersion field and flat string tool-call-result content instead of structured
+    // List<Content>. Regression coverage for the missing @JsonDeserialize on
+    // AgentSubProcessV2Request.agentContext (mirrors AgentSubProcessV1Request's handling of the
+    // same field).
+    String json =
+        """
+        {
+          "adHocSubProcessElements": [],
+          "agentContext": {
+            "state": "READY",
+            "metrics": {"modelCalls": 1, "tokenUsage": {"inputTokenCount": 1, "outputTokenCount": 1}},
+            "toolDefinitions": [],
+            "conversation": {
+              "type": "in-process",
+              "conversationId": "test",
+              "messages": [
+                {
+                  "role": "tool_call_result",
+                  "results": [
+                    {"id": "call-1", "name": "search", "content": "Found 3 items"}
+                  ]
+                }
+              ]
+            },
+            "properties": {}
+          },
+          "toolCallResults": []
+        }
+        """;
+
+    AgentSubProcessV2Request request = objectMapper.readValue(json, AgentSubProcessV2Request.class);
+
+    AgentContext agentContext = request.agentContext();
+    assertThat(agentContext).isNotNull();
+    // migrated on read despite the missing schemaVersion field
+    assertThat(agentContext.schemaVersion()).isEqualTo(AgentContext.CURRENT_SCHEMA_VERSION);
+
+    InProcessConversationContext conversation =
+        (InProcessConversationContext) agentContext.conversation();
+    assertThat(conversation).isNotNull();
+    ToolCallResultMessage message = (ToolCallResultMessage) conversation.messages().get(0);
+
+    // flat "content": "Found 3 items" was lifted into a structured List<Content>, not left as a
+    // raw string (which would otherwise fail to bind against ToolCallResultContent#content)
+    assertThat(message.results().get(0).content())
+        .containsExactly(TextContent.textContent("Found 3 items"));
+  }
+}

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/model/request/MemoryStorageConfigurationTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/model/request/MemoryStorageConfigurationTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.agenticai.aiagent.model.request;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.connector.agenticai.aiagent.model.request.MemoryStorageConfiguration.CustomMemoryStorageConfiguration;
+import org.junit.jupiter.api.Test;
+
+class MemoryStorageConfigurationTest {
+
+  private final ObjectMapper mapper = new ObjectMapper();
+
+  @Test
+  void deserialisesCustomStorageWithoutParametersToAnEmptyMap() throws Exception {
+    final String json =
+        """
+        {
+          "type": "custom",
+          "storeType": "acme-store"
+        }
+        """;
+
+    final MemoryStorageConfiguration parsed =
+        mapper.readValue(json, MemoryStorageConfiguration.class);
+
+    assertThat(parsed).isInstanceOf(CustomMemoryStorageConfiguration.class);
+    final CustomMemoryStorageConfiguration custom = (CustomMemoryStorageConfiguration) parsed;
+    assertThat(custom.storeType()).isEqualTo("acme-store");
+    assertThat(custom.parameters()).isNotNull().isEmpty();
+  }
+
+  @Test
+  void deserialisesCustomStorageWithParameters() throws Exception {
+    final String json =
+        """
+        {
+          "type": "custom",
+          "storeType": "acme-store",
+          "parameters": { "endpoint": "https://acme.example.com" }
+        }
+        """;
+
+    final MemoryStorageConfiguration parsed =
+        mapper.readValue(json, MemoryStorageConfiguration.class);
+
+    final CustomMemoryStorageConfiguration custom = (CustomMemoryStorageConfiguration) parsed;
+    assertThat(custom.parameters()).containsEntry("endpoint", "https://acme.example.com");
+  }
+}

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/model/request/v2/CustomProviderConfigurationTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/model/request/v2/CustomProviderConfigurationTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.agenticai.aiagent.model.request.v2;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.connector.agenticai.aiagent.chatmodel.ChatModel;
+import io.camunda.connector.agenticai.aiagent.chatmodel.ChatModelConfiguration;
+import io.camunda.connector.agenticai.aiagent.chatmodel.ChatModelFactory;
+import io.camunda.connector.agenticai.aiagent.chatmodel.ChatModelRegistryImpl;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+class CustomProviderConfigurationTest {
+
+  private final ObjectMapper mapper = new ObjectMapper();
+
+  @Test
+  void deserialisesViaTypeDiscriminatorAndRoundTrips() throws Exception {
+    final String json =
+        """
+        {
+          "type": "custom",
+          "providerType": "acme-llm",
+          "model": "acme-model-v1",
+          "parameters": { "endpoint": "https://acme.example.com", "timeout": 30 }
+        }
+        """;
+
+    final ProviderConfiguration parsed = mapper.readValue(json, ProviderConfiguration.class);
+
+    assertThat(parsed).isInstanceOf(CustomProviderConfiguration.class);
+    assertThat(parsed.provider()).isEqualTo("acme-llm");
+    assertThat(parsed.model()).isEqualTo("acme-model-v1");
+    assertThat(parsed.backend()).isNull();
+
+    final CustomProviderConfiguration custom = (CustomProviderConfiguration) parsed;
+    assertThat(custom.providerType()).isEqualTo("acme-llm");
+    assertThat(custom.parameters())
+        .containsEntry("endpoint", "https://acme.example.com")
+        .containsEntry("timeout", 30);
+
+    final String reserialised = mapper.writeValueAsString(parsed);
+    assertThat(mapper.readValue(reserialised, ProviderConfiguration.class)).isEqualTo(parsed);
+  }
+
+  @Test
+  void providerModelAndBackendAreDerivedFromDedicatedFields() {
+    final var config =
+        new CustomProviderConfiguration("acme-llm", "acme-model-v1", Map.of("key", "value"));
+
+    assertThat(config.provider()).isEqualTo("acme-llm");
+    assertThat(config.model()).isEqualTo("acme-model-v1");
+    assertThat(config.backend()).isNull();
+  }
+
+  @Test
+  void userSuppliedFactoryResolvesCustomProviderConfiguration() {
+    final var config = new CustomProviderConfiguration("acme-llm", "acme-model-v1", Map.of());
+    final var expectedChatModel = Mockito.mock(ChatModel.class);
+
+    final ChatModelFactory userFactory =
+        new ChatModelFactory() {
+          @Override
+          public boolean supports(ChatModelConfiguration configuration) {
+            return configuration instanceof CustomProviderConfiguration custom
+                && "acme-llm".equals(custom.providerType());
+          }
+
+          @Override
+          public ChatModel create(ChatModelConfiguration configuration) {
+            return expectedChatModel;
+          }
+        };
+
+    final var registry = new ChatModelRegistryImpl(List.of(userFactory));
+
+    assertThat(registry.resolve(config)).isSameAs(expectedChatModel);
+  }
+
+  @Test
+  void resolvingWithoutARegisteredFactoryYieldsTheNoFactoryRegisteredError() {
+    final var config = new CustomProviderConfiguration("acme-llm", "acme-model-v1", Map.of());
+
+    final var registry = new ChatModelRegistryImpl(List.of());
+
+    assertThatThrownBy(() -> registry.resolve(config))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("No chat model registered for configuration")
+        .hasMessageContaining("acme-llm")
+        .hasMessageContaining("acme-model-v1");
+  }
+}

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/model/request/v2/CustomProviderConfigurationTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/model/request/v2/CustomProviderConfigurationTest.java
@@ -40,7 +40,6 @@ class CustomProviderConfigurationTest {
     assertThat(parsed).isInstanceOf(CustomProviderConfiguration.class);
     assertThat(parsed.provider()).isEqualTo("acme-llm");
     assertThat(parsed.model()).isEqualTo("acme-model-v1");
-    assertThat(parsed.backend()).isNull();
 
     final CustomProviderConfiguration custom = (CustomProviderConfiguration) parsed;
     assertThat(custom.providerType()).isEqualTo("acme-llm");
@@ -53,13 +52,29 @@ class CustomProviderConfigurationTest {
   }
 
   @Test
-  void providerModelAndBackendAreDerivedFromDedicatedFields() {
+  void deserialisesWithoutParametersToAnEmptyMap() throws Exception {
+    final String json =
+        """
+        {
+          "type": "custom",
+          "providerType": "acme-llm",
+          "model": "acme-model-v1"
+        }
+        """;
+
+    final ProviderConfiguration parsed = mapper.readValue(json, ProviderConfiguration.class);
+
+    final CustomProviderConfiguration custom = (CustomProviderConfiguration) parsed;
+    assertThat(custom.parameters()).isNotNull().isEmpty();
+  }
+
+  @Test
+  void providerAndModelAreDerivedFromDedicatedFields() {
     final var config =
         new CustomProviderConfiguration("acme-llm", "acme-model-v1", Map.of("key", "value"));
 
     assertThat(config.provider()).isEqualTo("acme-llm");
     assertThat(config.model()).isEqualTo("acme-model-v1");
-    assertThat(config.backend()).isNull();
   }
 
   @Test

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/autoconfigure/AgenticAiConnectorsAutoConfigurationTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/autoconfigure/AgenticAiConnectorsAutoConfigurationTest.java
@@ -19,7 +19,9 @@ import io.camunda.connector.agenticai.adhoctoolsschema.processdefinition.feel.Ad
 import io.camunda.connector.agenticai.adhoctoolsschema.schema.AdHocToolSchemaGenerator;
 import io.camunda.connector.agenticai.adhoctoolsschema.schema.AdHocToolsSchemaResolver;
 import io.camunda.connector.agenticai.aiagent.AgentSubProcessV1Function;
+import io.camunda.connector.agenticai.aiagent.AgentSubProcessV2Function;
 import io.camunda.connector.agenticai.aiagent.AgentTaskV1Function;
+import io.camunda.connector.agenticai.aiagent.AgentTaskV2Function;
 import io.camunda.connector.agenticai.aiagent.agent.AgentConversationTurnInputComposer;
 import io.camunda.connector.agenticai.aiagent.agent.AgentInitializer;
 import io.camunda.connector.agenticai.aiagent.agent.AgentResponseHandler;
@@ -98,8 +100,10 @@ class AgenticAiConnectorsAutoConfigurationTest {
           AgentResponseHandler.class,
           AgentTaskRequestHandler.class,
           AgentTaskV1Function.class,
+          AgentTaskV2Function.class,
           AgentSubProcessRequestHandler.class,
           AgentSubProcessV1Function.class,
+          AgentSubProcessV2Function.class,
           AgentInstanceClient.class,
           ChatModelRegistry.class);
 
@@ -151,11 +155,16 @@ class AgenticAiConnectorsAutoConfigurationTest {
               assertHasAllBeansOf(
                   context,
                   ALL_BEANS.stream()
-                      .filter(notAnyOf(AgentTaskRequestHandler.class, AgentTaskV1Function.class))
+                      .filter(
+                          notAnyOf(
+                              AgentTaskRequestHandler.class,
+                              AgentTaskV1Function.class,
+                              AgentTaskV2Function.class))
                       .toList());
               assertThat(context)
                   .doesNotHaveBean(AgentTaskRequestHandler.class)
-                  .doesNotHaveBean(AgentTaskV1Function.class);
+                  .doesNotHaveBean(AgentTaskV1Function.class)
+                  .doesNotHaveBean(AgentTaskV2Function.class);
             });
   }
 
@@ -170,11 +179,14 @@ class AgenticAiConnectorsAutoConfigurationTest {
                   ALL_BEANS.stream()
                       .filter(
                           notAnyOf(
-                              AgentSubProcessRequestHandler.class, AgentSubProcessV1Function.class))
+                              AgentSubProcessRequestHandler.class,
+                              AgentSubProcessV1Function.class,
+                              AgentSubProcessV2Function.class))
                       .toList());
               assertThat(context)
                   .doesNotHaveBean(AgentSubProcessRequestHandler.class)
-                  .doesNotHaveBean(AgentSubProcessV1Function.class);
+                  .doesNotHaveBean(AgentSubProcessV1Function.class)
+                  .doesNotHaveBean(AgentSubProcessV2Function.class);
             });
   }
 

--- a/connectors/agentic-ai/docs/reference/ai-agent.md
+++ b/connectors/agentic-ai/docs/reference/ai-agent.md
@@ -1009,7 +1009,7 @@ LangChain4JChatModel
 **Key converters:**
 
 - **`ChatMessageConverter`**: Top-level converter. `map(Message)` dispatches on sealed type (System/User/Assistant/ToolCallResult). `toAssistantMessage(ChatResponse)` converts back, attaching metadata (timestamp, finishReason, tokenUsage).
-- **`ContentConverter`**: Converts `TextContent` → text, `DocumentContent` → delegates to `DocumentToContentConverter`, `ObjectContent` → JSON string. Uses a copy of `ObjectMapper` with `DocumentToContentModule` for nested document serialization.
+- **`ContentConverter`**: Converts `TextContent` → text, `DocumentContent` → delegates to `DocumentToContentConverter`, `ObjectContent` → JSON string. Uses the injected `@ConnectorsObjectMapper`, which `ConnectorsAutoConfiguration` registers with `JacksonModuleDocumentSerializer` for nested document serialization.
 - **`DocumentToContentConverter`**: Dispatches on MIME type: `text/*` → `TextContent`; `application/pdf` → `PdfFileContent`; images → `ImageContent`; throws `DocumentConversionException` for unsupported types.
 - **`ToolSpecificationConverter`**: Uses `JsonSchemaConverter` to convert between `Map<String,Object>` (domain) and `JsonObjectSchema` (LangChain4j). Throws `ParseSchemaException` if schema is not an object.
 - **`JsonSchemaElementModule`**: Custom Jackson module needed because LangChain4j doesn't expose standard polymorphic annotations on `JsonSchemaElement`. Serializer/deserializer handle all concrete types (`JsonObjectSchema`, `JsonEnumSchema`, `JsonStringSchema`, `JsonArraySchema`, `JsonAnyOfSchema`, `JsonReferenceSchema`, etc.).

--- a/connectors/agentic-ai/docs/reference/ai-agent.md
+++ b/connectors/agentic-ai/docs/reference/ai-agent.md
@@ -1830,8 +1830,8 @@ The v2 request's `CustomProviderConfiguration` (`model/request/v2`, discriminato
 Hybrid only) is the connector-facing entry point for this SPI: it carries a user-chosen `providerType`
 (dispatch discriminator), a dedicated `model` field (so agent-instance history/reporting works without
 digging it out of opaque config), and an opaque `parameters` map understood only by the user's factory.
-To use it, implement `ChatModelFactory` directly, with `providerType()`/`supports(...)` matching your
-chosen discriminator string, and register it as a Spring bean. `LangChain4JChatModelFactory` itself is
+To use it, implement `ChatModelFactory` directly, matching your chosen discriminator string inside
+`supports(...)`, and register it as a Spring bean. `LangChain4JChatModelFactory` itself is
 bound to `ProviderConfiguration` and cannot be extended for `CustomProviderConfiguration`, but its
 building block, `LangChain4JChatModel`, is a public, framework-agnostic `ChatModel` wrapper: a custom
 factory that wants to reuse LangChain4J can build its own `dev.langchain4j.model.chat.ChatModel`, wrap it

--- a/connectors/agentic-ai/docs/reference/ai-agent.md
+++ b/connectors/agentic-ai/docs/reference/ai-agent.md
@@ -932,7 +932,9 @@ own configuration through the SPI rather than being confined to the module's bui
 The sealed `ProviderConfiguration` (`AnthropicProviderConfiguration`, `BedrockProviderConfiguration`,
 etc.) is the concrete implementation contributed by this module. Today the v1 request supplies
 configurations through this sealed union only; request-side binding for a custom/native
-`ChatModelConfiguration` is delivered incrementally by the v2 request types.
+`ChatModelConfiguration` is delivered incrementally by the v2 request types
+(`ProviderConfiguration`), which so far offers `CustomProviderConfiguration`, a genuinely runnable
+path for user-supplied factories (see [§25.1](#251-add-an-llm-provider)).
 `ChatModelRegistryImpl` asks every registered `ChatModelFactory` whether it `supports` the
 configuration and routes to the single match; a configuration matched by zero factories throws
 `IllegalArgumentException`, and one matched by more than one throws `IllegalStateException` — fail
@@ -974,8 +976,9 @@ factories:
   `AgenticAiLangChain4JChatModelConfiguration` wires one `ChatModelFactory` bean per provider. Provider
   selection is by `ChatModelFactory.supports(...)` via the SPI registry, so the configuration loads
   unconditionally rather than behind a global framework toggle.
-- `LangChain4JChatModelFactory<T extends ProviderConfiguration>` is the abstract base: `supports`
-  matches a `ProviderConfiguration` whose `provider()` equals the factory's `providerType()`, and
+- `LangChain4JChatModelFactory<T extends ProviderConfiguration>` (the v1 `ProviderConfiguration`) is the
+  abstract base: `supports` matches a `ProviderConfiguration` whose `provider()` equals the factory's
+  `providerType()`, and
   `create` builds the underlying LangChain4j model once via the abstract `createChatModel` and wraps it
   in a `LangChain4JChatModel`. Concrete subclasses: `AnthropicChatModelFactory`,
   `BedrockChatModelFactory`, `OpenAiChatModelFactory`, `OpenAiCompatibleChatModelFactory`,
@@ -1006,7 +1009,7 @@ LangChain4JChatModel
 **Key converters:**
 
 - **`ChatMessageConverter`**: Top-level converter. `map(Message)` dispatches on sealed type (System/User/Assistant/ToolCallResult). `toAssistantMessage(ChatResponse)` converts back, attaching metadata (timestamp, finishReason, tokenUsage).
-- **`ContentConverter`**: Converts `TextContent` → text, `DocumentContent` → delegates to `DocumentToContentConverter`, `ObjectContent` → JSON string via the injected `ObjectMapper`.
+- **`ContentConverter`**: Converts `TextContent` → text, `DocumentContent` → delegates to `DocumentToContentConverter`, `ObjectContent` → JSON string. Uses a copy of `ObjectMapper` with `DocumentToContentModule` for nested document serialization.
 - **`DocumentToContentConverter`**: Dispatches on MIME type: `text/*` → `TextContent`; `application/pdf` → `PdfFileContent`; images → `ImageContent`; throws `DocumentConversionException` for unsupported types.
 - **`ToolSpecificationConverter`**: Uses `JsonSchemaConverter` to convert between `Map<String,Object>` (domain) and `JsonObjectSchema` (LangChain4j). Throws `ParseSchemaException` if schema is not an object.
 - **`JsonSchemaElementModule`**: Custom Jackson module needed because LangChain4j doesn't expose standard polymorphic annotations on `JsonSchemaElement`. Serializer/deserializer handle all concrete types (`JsonObjectSchema`, `JsonEnumSchema`, `JsonStringSchema`, `JsonArraySchema`, `JsonAnyOfSchema`, `JsonReferenceSchema`, etc.).
@@ -1151,8 +1154,8 @@ Also registers `ChatModelRegistry` (`ChatModelRegistryImpl`, taking every `ChatM
 | Property                                                          | Default      | Controls                           |
 |-------------------------------------------------------------------|--------------|------------------------------------|
 | `camunda.connector.agenticai.enabled`                             | `true`       | Master switch                      |
-| `camunda.connector.agenticai.aiagent.outbound-connector.enabled`  | `true`       | AI Agent Task connector            |
-| `camunda.connector.agenticai.aiagent.job-worker.enabled`          | `true`       | AI Agent Sub-process job worker    |
+| `camunda.connector.agenticai.aiagent.outbound-connector.enabled`  | `true`       | AI Agent Task connector (v1 and v2)     |
+| `camunda.connector.agenticai.aiagent.job-worker.enabled`          | `true`       | AI Agent Sub-process job worker (v1 and v2) |
 | `camunda.connector.agenticai.ad-hoc-tools-schema-resolver.enabled` | `true`     | Ad-Hoc Tools Schema connector     |
 
 ### Key Configuration Defaults
@@ -1814,13 +1817,29 @@ Implement `ChatModelFactory` (`supports(ChatModelConfiguration)` / `create(ChatM
 and register it as a Spring bean; `ChatModelRegistryImpl` auto-collects every `ChatModelFactory` bean
 and routes a request to the single one whose `supports` returns true ([§12](#12-framework-abstraction)).
 A provider going through LangChain4j extends the abstract `LangChain4JChatModelFactory<T extends
-ProviderConfiguration>` instead — it only needs to supply `providerType()` and `createChatModel(T)`,
-plus the matching `ProviderConfiguration` subtype (`supports`/`create` are already implemented by the
+ProviderConfiguration>` (the v1 `ProviderConfiguration`) instead — it only needs to supply
+`providerType()` and `createChatModel(T)`, plus the matching `ProviderConfiguration` subtype
+(`supports`/`create` are already implemented by the
 base class). Reference implementation: `AnthropicChatModelFactory` with
 `AnthropicProviderConfiguration`. The LangChain4j provider package
 (`aiagent/chatmodel/provider/langchain4j/**`) is the only place that may touch `dev.langchain4j`
 (invariant I1); a fully native provider implements `ChatModel`/`ChatModelFactory` directly with its own
 `ChatModelConfiguration` and stays out of that package.
+
+The v2 request's `CustomProviderConfiguration` (`model/request/v2`, discriminator `custom`, Self-Managed/
+Hybrid only) is the connector-facing entry point for this SPI: it carries a user-chosen `providerType`
+(dispatch discriminator), a dedicated `model` field (so agent-instance history/reporting works without
+digging it out of opaque config), and an opaque `parameters` map understood only by the user's factory.
+To use it, implement `ChatModelFactory` directly, with `providerType()`/`supports(...)` matching your
+chosen discriminator string, and register it as a Spring bean. `LangChain4JChatModelFactory` itself is
+bound to `ProviderConfiguration` and cannot be extended for `CustomProviderConfiguration`, but its
+building block, `LangChain4JChatModel`, is a public, framework-agnostic `ChatModel` wrapper: a custom
+factory that wants to reuse LangChain4J can build its own `dev.langchain4j.model.chat.ChatModel`, wrap it
+in a `CloseableChatModel`, and construct a `LangChain4JChatModel` directly. `ChatModelRegistryImpl` then
+dispatches `CustomProviderConfiguration` requests to the registered factory the
+same way it dispatches any other provider. No built-in factory ever matches `CustomProviderConfiguration`
+— it exists purely so the registry fails with the ordinary "no factory registered" error until the user
+registers one.
 
 <a id="252-add-a-systempromptcontributor"></a>
 

--- a/ignore-templates.json
+++ b/ignore-templates.json
@@ -2,5 +2,7 @@
   "io.camunda.connector.IdpClassificationOutBoundTemplate.v1",
   "io.camunda.connector.IdpExtractionOutBoundTemplate.v1",
   "io.camunda.connector.IdpStructuredExtractionOutBoundTemplate.v1",
-  "io.camunda.connector.IdpUnstructuredExtractionOutBoundTemplate.v1"
+  "io.camunda.connector.IdpUnstructuredExtractionOutBoundTemplate.v1",
+  "io.camunda.connectors.agenticai.ai-agent-task.v2",
+  "io.camunda.connectors.agenticai.ai-agent-subprocess.v2"
 ]


### PR DESCRIPTION
## Summary

Introduces the v2 AI Agent connector types and element templates on top of the new chat-model provider SPI from #8023 and the renaming/prep work in #8048:

- **`io.camunda.agenticai:aiagent:task:2`** / **`io.camunda.agenticai:aiagent:subprocess:2`** — new job types with matching `AgentTaskV2Function` / `AgentSubProcessV2Function` connectors and element templates (`agenticai-ai-agent-task.v2.json`, `agenticai-ai-agent-subprocess.v2.json`, plus hybrid variants). These sit alongside the existing v1 connectors (`AgentTaskV1Function` / `AgentSubProcessV1Function`), which keep their current behavior unchanged.
- **`ProviderConfiguration`** (in the new `v2` request package) — a new, wire-format-first, polymorphic (`type` discriminator) provider configuration model, replacing the legacy provider structure for these v2 connectors.
- **`CustomProviderConfiguration`** — the first, and for this PR the only, member of the v2 `ProviderConfiguration`: a user-chosen `providerType`, a `model` field, and free-form `parameters`, dispatched at runtime through a user-supplied `ChatModelFactory` bean. This is the implementation of #5547.

Native providers (Anthropic, OpenAI) are intentionally out of scope here and will be added as their own v2 `ProviderConfiguration` members in follow-up PRs, along with regenerated templates at that point.

Closes #7225
Closes #7224
Closes #5547

## Test plan

- [x] `mvn -pl connectors/agentic-ai/connector-agentic-ai test` green
- [x] Element templates regenerated (`mvn -pl connectors/agentic-ai/connector-agentic-ai process-classes`) and committed
