### PR TITLE
fix(http-client): preserve response headers on 204 No Content responses

### DIFF
--- a/connector-commons/http-client/src/main/java/io/camunda/connector/http/client/client/apache/CustomResponseHandler.java
+++ b/connector-commons/http-client/src/main/java/io/camunda/connector/http/client/client/apache/CustomResponseHandler.java
@@ -73,7 +73,15 @@ public class CustomResponseHandler<T> implements HttpClientResponseHandler<HttpR
       StreamingHttpResponse rawResponse = new StreamingHttpResponse(code, reason, headers, null);
       throw ConnectorExceptionMapper.from(rawResponse);
     }
-    return new HttpResponse<>(code, reason, headers, null);
+    try {
+      StreamingHttpResponse rawResponse =
+          new StreamingHttpResponse(code, reason, headers, InputStream.nullInputStream());
+      T mappedResponse = responseMapper.apply(rawResponse);
+      return new HttpResponse<>(code, reason, headers, mappedResponse);
+    } catch (final Exception e) {
+      LOGGER.error("Failed to process response: {}", response, e);
+      throw ConnectorExceptionMapper.from(e);
+    }
   }
 
   private static Map<String, List<String>> formatHeaders(Header[] headersArray) {

--- a/connector-commons/http-client/src/main/java/io/camunda/connector/http/client/mapper/ResponseMappers.java
+++ b/connector-commons/http-client/src/main/java/io/camunda/connector/http/client/mapper/ResponseMappers.java
@@ -102,6 +102,9 @@ public final class ResponseMappers {
 
   private static JsonNode asJson(StreamingHttpResponse response, ObjectMapper objectMapper) {
     var stringBody = asString(response);
+    if (stringBody == null) {
+      return null;
+    }
     if (!JsonHelper.isJsonStringValid(stringBody)) {
       throw new ConnectorException(
           "Response body is not valid JSON: "

--- a/connector-commons/http-client/src/test/java/io/camunda/connector/http/client/client/apache/CustomResponseHandlerTest.java
+++ b/connector-commons/http-client/src/test/java/io/camunda/connector/http/client/client/apache/CustomResponseHandlerTest.java
@@ -81,6 +81,28 @@ public class CustomResponseHandlerTest {
   }
 
   @Test
+  public void shouldHandleNoContentResponse_withHeadersPreserved() {
+    // given
+    CustomResponseHandler<JsonNode> handler =
+        new CustomResponseHandler<>(
+            ResponseMappers.asJsonNode(HttpClientObjectMapperSupplier::getCopy), false);
+
+    ClassicHttpResponse response = new BasicClassicHttpResponse(204);
+    Header[] headers = new Header[] {new BasicHeader("X-Custom-Header", "custom-value")};
+    response.setHeaders(headers);
+    // no entity set: response.getEntity() is null, as it would be for a real 204 response
+
+    // when
+    HttpResponse<JsonNode> result = handler.handleResponse(response);
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.status()).isEqualTo(204);
+    assertThat(result.entity()).isNull();
+    assertThat(result.headers()).containsEntry("X-Custom-Header", List.of("custom-value"));
+  }
+
+  @Test
   public void shouldHandleErrorResponse() {
     // given
     CustomResponseHandler<Void> handler = new CustomResponseHandler<>((response) -> null, false);

--- a/connectors/http/http-base/src/test/java/io/camunda/connector/http/base/HttpServiceTest.java
+++ b/connectors/http/http-base/src/test/java/io/camunda/connector/http/base/HttpServiceTest.java
@@ -382,6 +382,48 @@ public class HttpServiceTest {
   }
 
   @Test
+  public void shouldReturnHeaders_whenNoContentResponse(WireMockRuntimeInfo wmRuntimeInfo) {
+    WireMock.stubFor(
+        WireMock.post("/path")
+            .willReturn(WireMock.noContent().withHeader("X-Custom-Header", "custom-value")));
+
+    // given
+    HttpCommonRequest request = new HttpCommonRequest();
+    request.setMethod(HttpMethod.POST);
+    request.setBody(Map.of("name", "John"));
+    request.setUrl(getHostAndPort(wmRuntimeInfo) + "/path");
+
+    // when
+    HttpCommonResult result = httpService.executeConnectorRequest(request);
+
+    // then
+    Assertions.assertThat(result).isNotNull();
+    Assertions.assertThat(result.status()).isEqualTo(204);
+    Assertions.assertThat(result.headers()).containsEntry("X-Custom-Header", "custom-value");
+    Assertions.assertThat(result.body()).isNull();
+  }
+
+  @Test
+  public void shouldNotFail_whenNoContentResponseWithStoreResponseEnabled(
+      WireMockRuntimeInfo wmRuntimeInfo) {
+    WireMock.stubFor(WireMock.post("/path").willReturn(WireMock.noContent()));
+
+    // given
+    HttpCommonRequest request = new HttpCommonRequest();
+    request.setMethod(HttpMethod.POST);
+    request.setStoreResponse(true);
+    request.setUrl(getHostAndPort(wmRuntimeInfo) + "/path");
+
+    // when
+    HttpCommonResult result =
+        (HttpCommonResult) httpService.executeConnectorRequest(request, documentFactory);
+
+    // then
+    Assertions.assertThat(result).isNotNull();
+    Assertions.assertThat(result.status()).isEqualTo(204);
+  }
+
+  @Test
   public void shouldReturn200WithBody_whenPostRequestWithNullContentType(
       WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
 


### PR DESCRIPTION
## Summary

- `CustomResponseHandler.handleResponse()` skipped the `responseMapper` entirely whenever the HTTP response had no entity — which Apache HttpClient5 guarantees for `204 No Content` (and other bodyless responses). It hardcoded the mapped result to `null` instead of running it through the mapper, so the REST connector's whole result (`response`), including headers, came back as `null` in the FEEL result expression instead of just an empty body.
- `ResponseMappers.asJsonNode()` threw `"Response body is not valid JSON: <empty>"` for an empty body. This was previously masked because the mapper was never invoked for 204s; now that it runs, it returns `null` for an empty body, consistent with `asString()`'s existing behavior.

Fixes #8024

## Test plan

- [x] Added `HttpServiceTest.shouldReturnHeaders_whenNoContentResponse` reproducing the reported bug (verified it failed with `result == null` before the fix)
- [x] Added `CustomResponseHandlerTest.shouldHandleNoContentResponse_withHeadersPreserved` locking in that headers survive a 204 through `asJsonNode`
- [x] Added `HttpServiceTest.shouldNotFail_whenNoContentResponseWithStoreResponseEnabled` to confirm the `storeResponse=true` + 204 combination doesn't crash
- [x] Full test suites pass for `http-client`, `http-base`, `rest`, `graphql`, `polling`, `app-integrations`, `agentic-ai`, and `connector-runtime-core` — no regressions

## Note

The same "no entity → null" pattern also exists for **non-followed redirects with no body** (mechanically identical root cause), but the linked issue only reports 204, so that branch was intentionally left untouched to keep this fix scoped and low-risk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)