### PR TITLE
fix(saas-bundle): close gaps in internal-secret-manager credentials path

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -563,6 +563,12 @@ Key workflow files in `.github/workflows/`:
 - **Docker images**: Use `DockerImages.get()` utility for Testcontainers, add images to `docker-images.properties`
 - **Integration tests**: Mark with `@SlowTest` to exclude from regular unit test runs
 - **FEEL expressions**: Use `@FEEL` annotation for properties that need runtime evaluation
+- **Investigating `camunda-client-java` / `camunda-spring-boot-starter` behavior**: don't decompile
+  the jars (`javap`, unzip + bytecode reading, etc.). If the `camunda/camunda` monorepo is checked
+  out locally (often as a sibling of this repo, e.g. `../camunda`), read the actual source instead
+  — e.g. `clients/java/src/main/java/io/camunda/client/...` or
+  `clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/...`. Only fall back
+  to decompiling if that checkout isn't available.
 
 ## Reference Implementations
 

--- a/bundle/camunda-saas-bundle/src/main/java/io/camunda/connector/runtime/saas/CamundaClientSaaSConfiguration.java
+++ b/bundle/camunda-saas-bundle/src/main/java/io/camunda/connector/runtime/saas/CamundaClientSaaSConfiguration.java
@@ -17,10 +17,13 @@
 package io.camunda.connector.runtime.saas;
 
 import io.camunda.client.CredentialsProvider;
-import io.camunda.client.impl.oauth.OAuthCredentialsProviderBuilder;
 import io.camunda.client.spring.configuration.CredentialsProviderConfiguration;
+import io.camunda.client.spring.properties.CamundaClientAuthProperties;
+import io.camunda.client.spring.properties.CamundaClientAuthProperties.AuthMethod;
 import io.camunda.client.spring.properties.CamundaClientProperties;
 import io.camunda.connector.api.secret.SecretProvider;
+import java.net.URI;
+import org.springframework.beans.BeanUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
@@ -39,14 +42,11 @@ public class CamundaClientSaaSConfiguration {
 
   private final SecretProvider internalSecretProvider;
 
-  @Value("${camunda.client.auth.token-url}")
+  @Value("${camunda.client.auth.token-url:#{null}}")
   private String camundaClientTokenUrl;
 
-  @Value("${camunda.client.auth.audience}")
+  @Value("${camunda.client.auth.audience:#{null}}")
   private String camundaClientAudience;
-
-  @Value("${camunda.client.auth.credentials-cache-path:/tmp/connectors}")
-  private String credentialsCachePath;
 
   public CamundaClientSaaSConfiguration(@Autowired SaaSSecretConfiguration saaSConfiguration) {
     this.internalSecretProvider = saaSConfiguration.getInternalSecretProvider();
@@ -55,9 +55,11 @@ public class CamundaClientSaaSConfiguration {
   /**
    * Provides a custom {@link CredentialsProviderConfiguration} that is always registered. When
    * client-id/secret are absent from a resolved client's properties, it fetches M2M credentials
-   * from the internal secret manager (GCP or AWS). When credentials are present in the per-client
-   * properties, it delegates to the parent implementation so that each client uses its own
-   * configured credentials.
+   * from the internal secret manager (GCP or AWS) and delegates to the parent implementation on a
+   * copy of the properties, so scope/resource/issuer/TLS/timeout/retry settings resolved for that
+   * client are honored the same way they are for clients with explicit credentials. When
+   * credentials are present in the per-client properties, it delegates to the parent implementation
+   * directly so that each client uses its own configured credentials.
    *
    * <p>This bean replaces the default {@link CredentialsProviderConfiguration} from the Camunda
    * Spring Boot starter (which would register via {@code @ConditionalOnMissingBean}).
@@ -68,27 +70,47 @@ public class CamundaClientSaaSConfiguration {
       @Override
       public CredentialsProvider camundaClientCredentialsProvider(
           final CamundaClientProperties properties) {
-        if (properties.getAuth().getClientId() == null
-            && properties.getAuth().getClientSecret() == null) {
-          var auth = properties.getAuth();
-          var tokenUrl =
-              auth.getTokenUrl() != null ? auth.getTokenUrl().toString() : camundaClientTokenUrl;
-          var audience = auth.getAudience() != null ? auth.getAudience() : camundaClientAudience;
-          var cachePath =
-              auth.getCredentialsCachePath() != null
-                  ? auth.getCredentialsCachePath()
-                  : credentialsCachePath;
-          return new OAuthCredentialsProviderBuilder()
-              .applyEnvironmentOverrides(false)
-              .clientId(internalSecretProvider.getSecret(SECRET_NAME_CLIENT_ID, null))
-              .clientSecret(internalSecretProvider.getSecret(SECRET_NAME_SECRET, null))
-              .authorizationServerUrl(tokenUrl)
-              .audience(audience)
-              .credentialsCachePath(cachePath)
-              .build();
+        var auth = properties.getAuth();
+        if (auth.getClientId() == null && auth.getClientSecret() == null) {
+          return super.camundaClientCredentialsProvider(
+              withInternalSecretManagerCredentials(properties));
         }
         return super.camundaClientCredentialsProvider(properties);
       }
     };
+  }
+
+  /**
+   * Copies the resolved client properties and fills in the M2M credentials from the internal secret
+   * manager, without mutating the original Spring-bound properties (which would otherwise leak the
+   * fetched secret into the shared configuration bean). The copy is created reflectively via {@link
+   * BeanUtils} so any auth setting the starter adds in the future is carried through to the
+   * delegated {@code super} call automatically.
+   *
+   * <p>The credentials cache path is intentionally NOT defaulted to a shared global value here:
+   * every client falling back to the internal secret manager resolves the same client id, and
+   * {@link io.camunda.client.impl.oauth.OAuthCredentialsCache} keys cached tokens by client id
+   * only. Leaving it unset (unless the client explicitly configured its own path) makes the builder
+   * use a private in-memory cache instead of a file shared across clients, preventing a client with
+   * one audience/token-url from reusing another client's cached token.
+   */
+  private CamundaClientProperties withInternalSecretManagerCredentials(
+      CamundaClientProperties properties) {
+    var resolvedProperties = new CamundaClientProperties();
+    BeanUtils.copyProperties(properties, resolvedProperties);
+    var auth = new CamundaClientAuthProperties();
+    BeanUtils.copyProperties(properties.getAuth(), auth);
+    resolvedProperties.setAuth(auth);
+
+    auth.setMethod(AuthMethod.oidc);
+    auth.setClientId(internalSecretProvider.getSecret(SECRET_NAME_CLIENT_ID, null));
+    auth.setClientSecret(internalSecretProvider.getSecret(SECRET_NAME_SECRET, null));
+    if (auth.getTokenUrl() == null && camundaClientTokenUrl != null) {
+      auth.setTokenUrl(URI.create(camundaClientTokenUrl));
+    }
+    if (auth.getAudience() == null) {
+      auth.setAudience(camundaClientAudience);
+    }
+    return resolvedProperties;
   }
 }

--- a/bundle/camunda-saas-bundle/src/main/java/io/camunda/connector/runtime/saas/CamundaClientSaaSConfiguration.java
+++ b/bundle/camunda-saas-bundle/src/main/java/io/camunda/connector/runtime/saas/CamundaClientSaaSConfiguration.java
@@ -87,12 +87,17 @@ public class CamundaClientSaaSConfiguration {
    * BeanUtils} so any auth setting the starter adds in the future is carried through to the
    * delegated {@code super} call automatically.
    *
-   * <p>The credentials cache path is intentionally NOT defaulted to a shared global value here:
-   * every client falling back to the internal secret manager resolves the same client id, and
-   * {@link io.camunda.client.impl.oauth.OAuthCredentialsCache} keys cached tokens by client id
-   * only. Leaving it unset (unless the client explicitly configured its own path) makes the builder
-   * use a private in-memory cache instead of a file shared across clients, preventing a client with
-   * one audience/token-url from reusing another client's cached token.
+   * <p>The credentials cache path is always cleared, even if one is present on the resolved
+   * properties. {@code MultiCamundaClientPropertiesResolver} binds the global {@code
+   * camunda.client.*} properties onto every named client's {@link CamundaClientProperties} before
+   * overlaying {@code camunda.clients.<name>.*} on top of that same instance, so a globally
+   * configured {@code credentials-cache-path} is indistinguishable, by the time it reaches this
+   * method, from one a client set for itself. Every client falling back to the internal secret
+   * manager resolves the same client id, and {@link
+   * io.camunda.client.impl.oauth.OAuthCredentialsCache} keys cached tokens by client id only, so
+   * honoring either would let two clients with different audiences/token-urls share one cache file
+   * and reuse each other's cached token. Clearing it unconditionally makes the builder use a
+   * private in-memory cache instead.
    */
   private CamundaClientProperties withInternalSecretManagerCredentials(
       CamundaClientProperties properties) {
@@ -111,6 +116,7 @@ public class CamundaClientSaaSConfiguration {
     if (auth.getAudience() == null) {
       auth.setAudience(camundaClientAudience);
     }
+    auth.setCredentialsCachePath(null);
     return resolvedProperties;
   }
 }

--- a/bundle/camunda-saas-bundle/src/test/java/io/camunda/connector/runtime/saas/auth/CamundaClientSaaSConfigurationTest.java
+++ b/bundle/camunda-saas-bundle/src/test/java/io/camunda/connector/runtime/saas/auth/CamundaClientSaaSConfigurationTest.java
@@ -165,4 +165,35 @@ class CamundaClientSaaSConfigurationTest {
     var cache = ReflectionTestUtils.getField(result, "credentialsCache");
     assertThat(ReflectionTestUtils.getField(cache, "cacheFile")).isNull();
   }
+
+  @Test
+  void whenCredentialsMissingAndCachePathInheritedFromGlobalOverlay_stillUsesInMemoryCache() {
+    when(mockSecretProvider.getSecret(CamundaClientSaaSConfiguration.SECRET_NAME_CLIENT_ID, null))
+        .thenReturn("gcp-client-id");
+    when(mockSecretProvider.getSecret(CamundaClientSaaSConfiguration.SECRET_NAME_SECRET, null))
+        .thenReturn("gcp-client-secret");
+
+    var config = createConfig();
+    var properties = new CamundaClientProperties();
+    // MultiCamundaClientPropertiesResolver binds camunda.client.* onto every named client's
+    // properties before overlaying camunda.clients.<name>.*, so a globally configured
+    // credentials-cache-path is indistinguishable, from here, from a genuinely per-client one.
+    // Both clients below simulate that inherited value; they must NOT end up sharing a cache file.
+    properties.getAuth().setCredentialsCachePath("/tmp/connectors");
+    var otherClientProperties = new CamundaClientProperties();
+    otherClientProperties.getAuth().setCredentialsCachePath("/tmp/connectors");
+    otherClientProperties.getAuth().setAudience("other-audience");
+
+    var result =
+        config.credentialsProviderConfiguration().camundaClientCredentialsProvider(properties);
+    var otherResult =
+        config
+            .credentialsProviderConfiguration()
+            .camundaClientCredentialsProvider(otherClientProperties);
+
+    var cache = ReflectionTestUtils.getField(result, "credentialsCache");
+    var otherCache = ReflectionTestUtils.getField(otherResult, "credentialsCache");
+    assertThat(ReflectionTestUtils.getField(cache, "cacheFile")).isNull();
+    assertThat(ReflectionTestUtils.getField(otherCache, "cacheFile")).isNull();
+  }
 }

--- a/bundle/camunda-saas-bundle/src/test/java/io/camunda/connector/runtime/saas/auth/CamundaClientSaaSConfigurationTest.java
+++ b/bundle/camunda-saas-bundle/src/test/java/io/camunda/connector/runtime/saas/auth/CamundaClientSaaSConfigurationTest.java
@@ -53,7 +53,6 @@ class CamundaClientSaaSConfigurationTest {
     ReflectionTestUtils.setField(
         config, "camundaClientTokenUrl", "https://token.example.com/oauth/token");
     ReflectionTestUtils.setField(config, "camundaClientAudience", "test-audience");
-    ReflectionTestUtils.setField(config, "credentialsCachePath", "/tmp/test-credentials");
     return config;
   }
 
@@ -104,7 +103,6 @@ class CamundaClientSaaSConfigurationTest {
     ReflectionTestUtils.setField(
         config, "camundaClientTokenUrl", "https://global.token.example.com/oauth/token");
     ReflectionTestUtils.setField(config, "camundaClientAudience", "global-audience");
-    ReflectionTestUtils.setField(config, "credentialsCachePath", "/tmp/test-credentials");
 
     var properties = new CamundaClientProperties();
     properties
@@ -122,5 +120,49 @@ class CamundaClientSaaSConfigurationTest {
     verify(mockSecretProvider)
         .getSecret(CamundaClientSaaSConfiguration.SECRET_NAME_CLIENT_ID, null);
     verify(mockSecretProvider).getSecret(CamundaClientSaaSConfiguration.SECRET_NAME_SECRET, null);
+  }
+
+  @Test
+  void whenCredentialsMissing_perClientScopeResourceStillReachTheBuiltProvider() {
+    when(mockSecretProvider.getSecret(CamundaClientSaaSConfiguration.SECRET_NAME_CLIENT_ID, null))
+        .thenReturn("gcp-client-id");
+    when(mockSecretProvider.getSecret(CamundaClientSaaSConfiguration.SECRET_NAME_SECRET, null))
+        .thenReturn("gcp-client-secret");
+
+    var config = createConfig();
+    var properties = new CamundaClientProperties();
+    properties.getAuth().setScope("cluster-scope");
+    properties.getAuth().setResource("cluster-resource");
+    // clientId and clientSecret remain null -> uses internal secret provider
+
+    var result =
+        config.credentialsProviderConfiguration().camundaClientCredentialsProvider(properties);
+
+    assertThat(ReflectionTestUtils.getField(result, "scope")).isEqualTo("cluster-scope");
+    assertThat(ReflectionTestUtils.getField(result, "resource")).isEqualTo("cluster-resource");
+  }
+
+  @Test
+  void whenCredentialsMissingAndNoCachePathConfigured_usesInMemoryCacheNotSharedFile() {
+    when(mockSecretProvider.getSecret(CamundaClientSaaSConfiguration.SECRET_NAME_CLIENT_ID, null))
+        .thenReturn("gcp-client-id");
+    when(mockSecretProvider.getSecret(CamundaClientSaaSConfiguration.SECRET_NAME_SECRET, null))
+        .thenReturn("gcp-client-secret");
+
+    var config = new CamundaClientSaaSConfiguration(mockSaaSConfig);
+    ReflectionTestUtils.setField(
+        config, "camundaClientTokenUrl", "https://token.example.com/oauth/token");
+    ReflectionTestUtils.setField(config, "camundaClientAudience", "test-audience");
+    // no per-client credentials-cache-path configured, and there is no global fallback for it:
+    // every internal-secret client resolves the same client id, so a shared cache file would let
+    // one client's cached token leak into another client with a different audience/token-url.
+
+    var properties = new CamundaClientProperties();
+
+    var result =
+        config.credentialsProviderConfiguration().camundaClientCredentialsProvider(properties);
+
+    var cache = ReflectionTestUtils.getField(result, "credentialsCache");
+    assertThat(ReflectionTestUtils.getField(cache, "cacheFile")).isNull();
   }
 }

--- a/bundle/camunda-saas-bundle/src/test/java/io/camunda/connector/runtime/saas/auth/PerClientOnlyAuthConfigBootTest.java
+++ b/bundle/camunda-saas-bundle/src/test/java/io/camunda/connector/runtime/saas/auth/PerClientOnlyAuthConfigBootTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.runtime.saas.auth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.connector.runtime.saas.SaaSConnectorRuntimeApplication;
+import io.camunda.connector.runtime.saas.SaaSSecretConfiguration;
+import io.camunda.connector.test.utils.oidc.MockOidcServer;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
+import org.mockito.Answers;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ApplicationContext;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+/**
+ * Reproduces issue 1 from https://github.com/camunda/connectors/issues/8001: a deployment that only
+ * configures a named client's auth properties (`camunda.clients.<name>.auth.*`) and never sets the
+ * global `camunda.client.auth.*` equivalents must not crash on startup, even though {@link
+ * io.camunda.connector.runtime.saas.CamundaClientSaaSConfiguration} injects those global values as
+ * a fallback for the internal-secret-manager path.
+ */
+@SpringBootTest(
+    classes = {SaaSConnectorRuntimeApplication.class},
+    properties = {
+      "camunda.saas.secrets.projectId=42",
+      "camunda.connector.auth.audience=connectors.dev.ultrawombat.com",
+      "camunda.connector.secretprovider.discovery.enabled=false",
+      "camunda.clients.default.auth.audience=connectors.dev.ultrawombat.com",
+      // NOTE: neither camunda.client.auth.token-url/audience (global) nor client-id/client-secret
+      // are provided - only the per-client auth properties below are set.
+      "spring.cloud.gcp.parametermanager.enabled=false"
+    })
+@ActiveProfiles("test")
+public class PerClientOnlyAuthConfigBootTest {
+
+  private static final MockOidcServer OIDC_SERVER = MockOidcServer.start();
+
+  @DynamicPropertySource
+  static void registerOidcProperties(DynamicPropertyRegistry registry) {
+    registry.add("camunda.connector.auth.issuer", OIDC_SERVER::issuer);
+    registry.add("camunda.clients.default.auth.token-url", OIDC_SERVER::tokenUrl);
+  }
+
+  @AfterAll
+  static void stopOidcServer() {
+    OIDC_SERVER.close();
+  }
+
+  @MockitoBean(answers = Answers.RETURNS_MOCKS)
+  public SaaSSecretConfiguration saaSSecretConfiguration;
+
+  @Autowired private ApplicationContext applicationContext;
+
+  @Test
+  public void contextStartsWithOnlyPerClientAuthPropertiesConfigured() {
+    assertThat(applicationContext).isNotNull();
+  }
+}


### PR DESCRIPTION
## Summary

Fixes the three gaps flagged in #8001 in `CamundaClientSaaSConfiguration` (the internal-secret-manager credentials path for the SaaS bundle's multi-client architecture):

- **Startup crash on per-client-only config**: `camunda.client.auth.token-url`/`.audience` were injected via `@Value` with no default, so a deployment that only sets `camunda.clients.<name>.auth.*` would fail to start. Both now default to `null`.
- **Dropped auth settings**: the hand-rolled `OAuthCredentialsProviderBuilder` only mapped `clientId`/`clientSecret`/`tokenUrl`/`audience`/`cachePath`, silently defaulting scope, resource, issuer/well-known URLs, TLS keystore/truststore, timeouts and retry policy. The code now fills in the secret-manager-sourced `clientId`/`clientSecret` (and `method=oidc`) on a copy of the resolved properties and delegates to the starter's own `camundaClientCredentialsProvider`, so every other auth setting is carried through automatically (and stays future-proof against new fields the starter adds later).
- **Shared token cache collision**: `OAuthCredentialsCache` keys cached tokens by client id only, and every client falling back to the internal secret manager resolves the *same* client id. Defaulting all of them to the same cache file meant two clients with different audiences/token-urls could read back each other's cached token. The cache path is never carried over from the resolved properties (whether per-client or inherited from the global `camunda.client.*` overlay done by `MultiCamundaClientPropertiesResolver`) — it's always cleared, so the builder uses a private in-memory cache scoped to that client's `OAuthCredentialsProvider` instance.

Also includes a small, intentionally-coupled doc change: `.github/copilot-instructions.md` (`AGENTS.md` symlinks to it) now tells agents/devs investigating `camunda-client-java`/`camunda-spring-boot-starter` behavior to read the local `camunda/camunda` checkout instead of decompiling jars — added directly at the maintainer's request while this PR was in review, since it's exactly the lesson learned while building this fix.

## Test plan

- [x] `CamundaClientSaaSConfigurationTest`: new tests for scope/resource pass-through, in-memory cache behavior, and the global-property-overlay cache collision (all watched RED against the original code, then GREEN after the fix)
- [x] `PerClientOnlyAuthConfigBootTest` (new): boots the full Spring context with only per-client auth properties set, no global fallback — proves startup no longer crashes on the placeholder
- [x] Existing `CamundaClientSaaSConfigurationTest` and `CustomCredentialsProviderUsedTest` cases still pass unmodified in behavior
- [x] Full module build (`mvn test -pl bundle/camunda-saas-bundle`): spotless, license, enforcer, and all 50 tests pass