### PR TITLE
ci: skip stale bot Slack notification when nothing was closed

### DIFF
--- a/.github/workflows/STALE.yml
+++ b/.github/workflows/STALE.yml
@@ -58,7 +58,7 @@ jobs:
             activity. Please reopen if this is still relevant.
 
       - name: Send Slack notification
-        if: steps.stale.outputs.closed-issues-prs != ''
+        if: steps.stale.outputs.closed-issues-prs != '[]'
         uses: slackapi/slack-github-action@v4.0.0
         with:
           token: ${{ secrets.CONNECTORS_SLACK_BOT_TOKEN }}


### PR DESCRIPTION
## Description

The `stale` action's `closed-issues-prs` output is always a JSON array string (e.g. `[]` when nothing was closed), never an empty string. The Slack notification condition (`!= ''`) was therefore always true, so the weekly Stale bot report was posted even when 0 issues/PRs were closed, producing an odd message like:

> Closed [] stale issues/PRs this week.

This PR fixes the condition to `!= '[]'` so the notification is only sent when something was actually closed.

## Related issues

closes #

## Checklist

- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest
  release, as this branch will be rebased onto main before the next release. Example backport labels:
    - `backport stable/8.8`: for changes that should be included in the next 8.8.x release.
    - **or** `backport release-8.8.7`: for changes that should be included in the specific release 8.8.7, and this
      *release has already been created*. The release branch will be merged back into stable/8.8 later, so the change
      will be included in future 8.8.x releases as well.
- [x] Tests/Integration tests for the changes have been added if applicable. (N/A - CI workflow config change)
- [ ] If the change requires a documentation update, it has been added to the appropriate section in the documentation. (N/A)