### PR TITLE
feat: document store updates for multi-engine support

### DIFF
--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/ConnectorResultHandler.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/ConnectorResultHandler.java
@@ -22,6 +22,7 @@ import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.connector.api.document.DocumentFactory;
 import io.camunda.connector.api.error.ConnectorInputException;
 import io.camunda.connector.api.inbound.InboundConnectorExecutable;
 import io.camunda.connector.api.outbound.OutboundConnectorFunction;
@@ -32,6 +33,7 @@ import io.camunda.connector.feel.LocalFeelExpressionEvaluator;
 import io.camunda.connector.runtime.core.error.BpmnError;
 import io.camunda.connector.runtime.core.error.ConnectorError;
 import io.camunda.connector.runtime.core.outbound.ErrorExpressionJobContext;
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -59,7 +61,8 @@ public class ConnectorResultHandler {
   public Map<String, Object> createOutputVariables(
       final Object responseContent,
       final @Nullable String resultVariableName,
-      final @Nullable String resultExpression) {
+      final @Nullable String resultExpression,
+      final @Nullable String physicalTenantId) {
     final Map<String, Object> outputVariables = new HashMap<>();
 
     if (isNotBlank(resultVariableName)) {
@@ -74,7 +77,11 @@ public class ConnectorResultHandler {
         verifyNoForbiddenLiterals(mappedResponseJson);
         var mappedResponse =
             parseJsonVarsAsTypeOrThrow(
-                mappedResponseJson, Map.class, resultExpression, "Result expression");
+                mappedResponseJson,
+                Map.class,
+                resultExpression,
+                "Result expression",
+                physicalTenantId);
         if (mappedResponse != null) {
           outputVariables.putAll(mappedResponse);
         }
@@ -86,7 +93,8 @@ public class ConnectorResultHandler {
   public Optional<ConnectorError> examineErrorExpression(
       final Object responseContent,
       final Map<String, String> jobHeaders,
-      ErrorExpressionJobContext jobContext) {
+      ErrorExpressionJobContext jobContext,
+      final @Nullable String physicalTenantId) {
     final var errorExpression = jobHeaders.get(Keywords.ERROR_EXPRESSION_KEYWORD);
     if (errorExpression == null || errorExpression.isBlank()) {
       return Optional.empty();
@@ -97,12 +105,17 @@ public class ConnectorResultHandler {
                 errorExpression, responseContent, wrapResponse(responseContent), jobContext))
         .filter(
             json ->
-                !parseJsonVarsAsTypeOrThrow(json, Map.class, errorExpression, "Error expression")
+                !parseJsonVarsAsTypeOrThrow(
+                        json, Map.class, errorExpression, "Error expression", physicalTenantId)
                     .isEmpty())
         .map(
             json ->
                 parseJsonVarsAsTypeOrThrow(
-                    json, ConnectorError.class, errorExpression, "Error expression"))
+                    json,
+                    ConnectorError.class,
+                    errorExpression,
+                    "Error expression",
+                    physicalTenantId))
         .filter(
             error -> {
               if (error instanceof BpmnError bpmnError) {
@@ -116,7 +129,8 @@ public class ConnectorResultHandler {
       final String jsonVars,
       Class<T> type,
       final String expression,
-      final String expressionNameForError) {
+      final String expressionNameForError,
+      final @Nullable String physicalTenantId) {
     try {
       // When expecting a Map (from a FEEL evaluation), check if it's actually a JSON object
       if (type.equals(Map.class)) {
@@ -131,12 +145,25 @@ public class ConnectorResultHandler {
                   jsonVars));
         }
       }
-      return objectMapper.readValue(jsonVars, type);
+      return objectMapper
+          .reader()
+          .withAttribute(DocumentFactory.PHYSICAL_TENANT_ID_ATTRIBUTE, physicalTenantId)
+          .readValue(jsonVars, type);
     } catch (ConnectorInputException e) {
       // Re-throw our custom exception
       throw e;
     } catch (JsonProcessingException e) {
       // For other types (like ConnectorError), keep the original message
+      throw new ConnectorInputException(
+          new FeelEngineWrapperException(
+              String.format(ERROR_CANNOT_PARSE_VARIABLES, jsonVars, type.getName()),
+              expression,
+              jsonVars,
+              e));
+    } catch (IOException e) {
+      // ObjectReader#readValue declares the broader IOException (unlike ObjectMapper#readValue's
+      // JsonProcessingException), though in practice this path only ever throws for JSON-parsing
+      // reasons already covered above; kept for exhaustiveness.
       throw new ConnectorInputException(
           new FeelEngineWrapperException(
               String.format(ERROR_CANNOT_PARSE_VARIABLES, jsonVars, type.getName()),

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/document/store/CamundaDocumentStoreImpl.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/document/store/CamundaDocumentStoreImpl.java
@@ -22,17 +22,34 @@ import io.camunda.connector.api.document.DocumentLinkParameters;
 import io.camunda.connector.api.document.DocumentReference.CamundaDocumentReference;
 import io.camunda.connector.runtime.core.document.CamundaDocumentReferenceImpl;
 import java.io.InputStream;
+import org.jspecify.annotations.Nullable;
 
 public class CamundaDocumentStoreImpl implements CamundaDocumentStore {
 
   private final CamundaClient camundaClient;
+  private final @Nullable String physicalTenantId;
 
   public CamundaDocumentStoreImpl(CamundaClient camundaClient) {
+    this(camundaClient, null);
+  }
+
+  public CamundaDocumentStoreImpl(CamundaClient camundaClient, @Nullable String physicalTenantId) {
     this.camundaClient = camundaClient;
+    this.physicalTenantId = physicalTenantId;
   }
 
   @Override
   public CamundaDocumentReference createDocument(DocumentCreationRequest request) {
+    if (physicalTenantId != null
+        && request.physicalTenantId() != null
+        && !physicalTenantId.equals(request.physicalTenantId())) {
+      throw new IllegalStateException(
+          "Attempted to create a document for physical tenant '"
+              + request.physicalTenantId()
+              + "' using a document store configured for physical tenant '"
+              + physicalTenantId
+              + "' — this likely indicates a DocumentFactory reused across physical tenants.");
+    }
     final var command = camundaClient.newCreateDocumentCommand().content(request.content());
 
     if (request.contentType() != null) {

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/DefaultProcessInstanceContext.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/DefaultProcessInstanceContext.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.search.response.ElementInstance;
+import io.camunda.connector.api.document.DocumentFactory;
 import io.camunda.connector.api.inbound.CorrelationRequest;
 import io.camunda.connector.api.inbound.ProcessInstanceContext;
 import io.camunda.connector.api.validation.ValidationProvider;
@@ -82,6 +83,9 @@ public final class DefaultProcessInstanceContext implements ProcessInstanceConte
       T mappedObject =
           FeelContextAwareObjectReader.of(objectMapper)
               .withEvaluator(evaluator)
+              .withAttribute(
+                  DocumentFactory.PHYSICAL_TENANT_ID_ATTRIBUTE,
+                  context.getDefinition().physicalTenantId())
               .readValue(processDefinitionProperties, cls);
       validationProvider.validate(mappedObject);
       return mappedObject;

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextImpl.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextImpl.java
@@ -348,7 +348,7 @@ public class InboundConnectorContextImpl extends AbstractConnectorContext
               new SecretContext(
                   connectorDetails.tenantId(),
                   connectorDetails.processDefinitionId(),
-                  getPhysicalTenantId()));
+                  physicalTenantId()));
       var propertiesJson = objectMapper.valueToTree(withSecrets);
       var result =
           FeelContextAwareObjectReader.of(objectMapper)
@@ -509,7 +509,7 @@ public class InboundConnectorContextImpl extends AbstractConnectorContext
 
   @Override
   public Document create(DocumentCreationRequest request) {
-    return documentFactory.create(request);
+    return documentFactory.create(request.withPhysicalTenantIdIfAbsent(physicalTenantId()));
   }
 
   @Override

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextImpl.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextImpl.java
@@ -321,6 +321,7 @@ public class InboundConnectorContextImpl extends AbstractConnectorContext
       var result =
           FeelContextAwareObjectReader.of(objectMapper)
               .withEvaluator(evaluator)
+              .withAttribute(DocumentFactory.PHYSICAL_TENANT_ID_ATTRIBUTE, physicalTenantId())
               .readValue(propertiesJson, cls);
       getValidationProvider().validate(result);
       return result;
@@ -352,6 +353,7 @@ public class InboundConnectorContextImpl extends AbstractConnectorContext
       var result =
           FeelContextAwareObjectReader.of(objectMapper)
               .withEvaluator(evaluator)
+              .withAttribute(DocumentFactory.PHYSICAL_TENANT_ID_ATTRIBUTE, physicalTenantId())
               .readValue(propertiesJson, cls);
       getValidationProvider().validate(result);
       return result;
@@ -366,6 +368,18 @@ public class InboundConnectorContextImpl extends AbstractConnectorContext
     }
   }
 
+  /**
+   * The physical tenant (Zeebe cluster/"engine") this connector's element is deployed against, or
+   * {@code null} if this context has no elements (shouldn't normally happen, but mirrors {@link
+   * #getDefinition()}'s own guard) — set as a Jackson reader attribute in {@link #bindProperties}/
+   * {@link #bindElementProperties} so {@code DocumentDeserializer} can resolve {@code Document}-
+   * typed fields against the correct physical tenant's document store.
+   */
+  private @Nullable String physicalTenantId() {
+    var elements = connectorDetails.connectorElements();
+    return elements.isEmpty() ? null : elements.getFirst().physicalTenantId();
+  }
+
   @Override
   public InboundConnectorDefinition getDefinition() {
     var elements = connectorDetails.connectorElements();
@@ -374,12 +388,7 @@ public class InboundConnectorContextImpl extends AbstractConnectorContext
         connectorDetails.tenantId(),
         connectorDetails.deduplicationId(),
         elements.stream().map(InboundConnectorElement::element).collect(Collectors.toList()),
-        getPhysicalTenantId());
-  }
-
-  private @Nullable String getPhysicalTenantId() {
-    var elements = connectorDetails.connectorElements();
-    return elements.isEmpty() ? null : elements.getFirst().physicalTenantId();
+        physicalTenantId());
   }
 
   @Override
@@ -466,7 +475,7 @@ public class InboundConnectorContextImpl extends AbstractConnectorContext
               new SecretContext(
                   connectorDetails.tenantId(),
                   connectorDetails.processDefinitionId(),
-                  getPhysicalTenantId()));
+                  physicalTenantId()));
     }
     return propertiesWithSecrets;
   }

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/correlation/InboundCorrelationHandler.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/correlation/InboundCorrelationHandler.java
@@ -375,7 +375,10 @@ public class InboundCorrelationHandler {
 
   protected Object extractVariables(Object rawVariables, InboundConnectorElement definition) {
     return connectorResultHandler.createOutputVariables(
-        rawVariables, definition.resultVariable(), definition.resultExpression());
+        rawVariables,
+        definition.resultVariable(),
+        definition.resultExpression(),
+        definition.physicalTenantId());
   }
 
   private void checkVariablesSize(Object variables) {

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/outbound/JobHandlerContext.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/outbound/JobHandlerContext.java
@@ -185,6 +185,6 @@ public class JobHandlerContext extends AbstractConnectorContext
 
   @Override
   public Document create(DocumentCreationRequest request) {
-    return documentFactory.create(request);
+    return documentFactory.create(request.withPhysicalTenantIdIfAbsent(job.getPhysicalTenantId()));
   }
 }

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/ConnectorResultHandlerTest.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/ConnectorResultHandlerTest.java
@@ -20,13 +20,18 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.connector.api.document.Document;
+import io.camunda.connector.api.document.DocumentFactory;
 import io.camunda.connector.api.error.ConnectorInputException;
+import io.camunda.connector.document.jackson.IntrinsicFunctionExecutor;
+import io.camunda.connector.document.jackson.JacksonModuleDocumentDeserializer;
 import io.camunda.connector.runtime.core.outbound.ErrorExpressionJobContext;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 class ConnectorResultHandlerTest {
 
@@ -57,7 +62,8 @@ class ConnectorResultHandlerTest {
                 	res5: data[date(item.date) = date("2024-02-01")][1].attr,
                 	res6: today()
                 }
-                """);
+                """,
+            null);
 
     assertThat(actual)
         .contains(
@@ -82,7 +88,9 @@ class ConnectorResultHandlerTest {
     final var exception =
         assertThrows(
             ConnectorInputException.class,
-            () -> connectorResultHandler.createOutputVariables(context, null, resultExpression));
+            () ->
+                connectorResultHandler.createOutputVariables(
+                    context, null, resultExpression, null));
 
     assertThat(exception)
         .hasMessageContaining(
@@ -97,7 +105,7 @@ class ConnectorResultHandlerTest {
 
     // when - should not throw exception even though responseContent is null
     final var actual =
-        connectorResultHandler.createOutputVariables(responseContent, null, resultExpression);
+        connectorResultHandler.createOutputVariables(responseContent, null, resultExpression, null);
 
     // then - should evaluate successfully with null values
     assertThat(actual).containsEntry("status", null);
@@ -115,7 +123,7 @@ class ConnectorResultHandlerTest {
             ConnectorInputException.class,
             () ->
                 connectorResultHandler.createOutputVariables(
-                    responseContent, null, resultExpression));
+                    responseContent, null, resultExpression, null));
 
     // then - should indicate that an array was returned and JSON object is expected
     assertThat(exception.getMessage())
@@ -136,7 +144,7 @@ class ConnectorResultHandlerTest {
             ConnectorInputException.class,
             () ->
                 connectorResultHandler.createOutputVariables(
-                    responseContent, null, resultExpression));
+                    responseContent, null, resultExpression, null));
 
     // then - should indicate that a string was returned and JSON object is expected
     assertThat(exception.getMessage())
@@ -157,7 +165,7 @@ class ConnectorResultHandlerTest {
             ConnectorInputException.class,
             () ->
                 connectorResultHandler.createOutputVariables(
-                    responseContent, null, resultExpression));
+                    responseContent, null, resultExpression, null));
 
     // then - should indicate that a number was returned and JSON object is expected
     assertThat(exception.getMessage())
@@ -178,7 +186,7 @@ class ConnectorResultHandlerTest {
             ConnectorInputException.class,
             () ->
                 connectorResultHandler.createOutputVariables(
-                    responseContent, null, resultExpression));
+                    responseContent, null, resultExpression, null));
 
     // then - should indicate that a boolean was returned and JSON object is expected
     assertThat(exception.getMessage())
@@ -203,12 +211,48 @@ class ConnectorResultHandlerTest {
             ConnectorInputException.class,
             () ->
                 connectorResultHandler.examineErrorExpression(
-                    responseContent, jobHeaders, jobContext));
+                    responseContent, jobHeaders, jobContext, null));
 
     // then - should indicate that an array was returned and "Error expression" is mentioned
     assertThat(exception.getMessage())
         .contains("Error expression must return a JSON object")
         .contains("array")
         .contains("[1,2,3]");
+  }
+
+  @Test
+  void createOutputVariables_resolvesADocumentInTheResultThroughItsOwnPhysicalTenant() {
+    // reproduces a real webhook bug: a Document created via the webhook is echoed back through a
+    // result expression BEFORE the process instance is created, using the same map-based
+    // (multi-tenant) ObjectMapper the runtime uses for property binding elsewhere. Without the
+    // PHYSICAL_TENANT_ID_ATTRIBUTE, DocumentDeserializer.resolveDocumentFactory throws "no
+    // physical tenant ID attribute was set", which surfaces as an HTTP 422 and no process
+    // instance ever gets created.
+    var factoryA = Mockito.mock(DocumentFactory.class);
+    var factoryB = Mockito.mock(DocumentFactory.class);
+    var expectedDocument = Mockito.mock(Document.class);
+    Mockito.when(factoryB.resolve(Mockito.any())).thenReturn(expectedDocument);
+    var multiTenantMapper =
+        new ObjectMapper()
+            .registerModule(
+                new JacksonModuleDocumentDeserializer(
+                    Map.of("tenant-a", factoryA, "tenant-b", factoryB),
+                    Mockito.mock(IntrinsicFunctionExecutor.class),
+                    JacksonModuleDocumentDeserializer.DocumentModuleSettings.create()));
+    var handler = new ConnectorResultHandler(multiTenantMapper);
+
+    var documentReference =
+        Map.of(
+            "camunda.document.type", "camunda",
+            "storeId", "store-1",
+            "documentId", "doc-1",
+            "contentHash", "hash-1");
+    var responseContent = Map.of("document", documentReference);
+
+    var result =
+        handler.createOutputVariables(responseContent, null, "={document: document}", "tenant-b");
+
+    assertThat(result.get("document")).isEqualTo(expectedDocument);
+    Mockito.verifyNoInteractions(factoryA);
   }
 }

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/document/DocumentDeserializationPhysicalTenantIdTest.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/document/DocumentDeserializationPhysicalTenantIdTest.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.runtime.core.document;
+
+import static io.camunda.connector.runtime.core.document.DocumentDeserializationTest.createDocumentMock;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import io.camunda.connector.api.document.Document;
+import io.camunda.connector.api.document.DocumentFactory;
+import io.camunda.connector.document.jackson.IntrinsicFunctionExecutor;
+import io.camunda.connector.document.jackson.JacksonModuleDocumentDeserializer;
+import io.camunda.connector.runtime.core.document.store.CamundaDocumentStore;
+import java.io.IOException;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * Exercises the {@code Map<String, DocumentFactory>}-based {@link
+ * JacksonModuleDocumentDeserializer} constructor, which resolves the {@link DocumentFactory} to use
+ * per deserialization call from the {@link DocumentFactory#PHYSICAL_TENANT_ID_ATTRIBUTE} reader
+ * attribute rather than a single constructor-supplied instance (see {@link
+ * DocumentDeserializationTest} for the single-factory variant, which this mirrors).
+ */
+@ExtendWith(MockitoExtension.class)
+class DocumentDeserializationPhysicalTenantIdTest {
+
+  private final CamundaDocumentStore storeA = mock(CamundaDocumentStore.class);
+  private final CamundaDocumentStore storeB = mock(CamundaDocumentStore.class);
+  private final DocumentFactory factoryA = new DocumentFactoryImpl(storeA);
+  private final DocumentFactory factoryB = new DocumentFactoryImpl(storeB);
+  private final IntrinsicFunctionExecutor operationExecutor = mock(IntrinsicFunctionExecutor.class);
+
+  private ObjectMapper mapperFor(Map<String, DocumentFactory> factoriesByPhysicalTenantId) {
+    return new ObjectMapper()
+        .registerModule(
+            new JacksonModuleDocumentDeserializer(
+                factoriesByPhysicalTenantId,
+                operationExecutor,
+                JacksonModuleDocumentDeserializer.DocumentModuleSettings.create()))
+        .registerModule(new Jdk8Module());
+  }
+
+  @Test
+  void resolvesTheFactoryMatchingTheReaderAttribute() throws IOException {
+    var objectMapper = mapperFor(Map.of("tenant-a", factoryA, "tenant-b", factoryB));
+    var ref = createDocumentMock("Hello from tenant B", null, storeB);
+    var payload = Map.of("document", ref);
+
+    var result =
+        objectMapper
+            .reader()
+            .withAttribute(DocumentFactory.PHYSICAL_TENANT_ID_ATTRIBUTE, "tenant-b")
+            .readValue(objectMapper.valueToTree(payload).toString(), TargetTypeDocument.class);
+
+    assertThat(result.document().reference()).isEqualTo(ref);
+  }
+
+  @Test
+  void fallsBackToTheSoleFactoryWhenNoAttributeIsSetAndOnlyOneTenantIsConfigured() {
+    var objectMapper = mapperFor(Map.of("tenant-a", factoryA));
+    var ref = createDocumentMock("Hello from the only tenant", null, storeA);
+    var payload = Map.of("document", ref);
+
+    var result = objectMapper.convertValue(payload, TargetTypeDocument.class); // no attribute set
+
+    assertThat(result.document().reference()).isEqualTo(ref);
+  }
+
+  @Test
+  void throwsWhenNoAttributeIsSetAndMultipleTenantsAreConfigured() {
+    var objectMapper = mapperFor(Map.of("tenant-a", factoryA, "tenant-b", factoryB));
+    var ref = createDocumentMock("Hello from nowhere in particular", null, storeA);
+    var payload = Map.of("document", ref);
+
+    assertThatThrownBy(() -> objectMapper.convertValue(payload, TargetTypeDocument.class))
+        .rootCause()
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("no physical tenant ID attribute was set");
+  }
+
+  @Test
+  void throwsWhenTheAttributeDoesNotMatchAnyConfiguredTenant() {
+    var objectMapper = mapperFor(Map.of("tenant-a", factoryA));
+    var ref = createDocumentMock("Hello from an unknown tenant", null, storeA);
+    var payload = Map.of("document", ref);
+
+    assertThatThrownBy(
+            () ->
+                objectMapper
+                    .reader()
+                    .withAttribute(DocumentFactory.PHYSICAL_TENANT_ID_ATTRIBUTE, "tenant-unknown")
+                    .readValue(
+                        objectMapper.valueToTree(payload).toString(), TargetTypeDocument.class))
+        .hasCauseInstanceOf(IllegalStateException.class)
+        .cause()
+        .hasMessageContaining("No DocumentFactory configured for physical tenant 'tenant-unknown'");
+  }
+
+  public record TargetTypeDocument(Document document) {}
+}

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/document/store/CamundaDocumentStoreImplTest.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/document/store/CamundaDocumentStoreImplTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.runtime.core.document.store;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.connector.api.document.DocumentCreationRequest;
+import java.io.ByteArrayInputStream;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Exercises {@link CamundaDocumentStoreImpl#createDocument}'s physical-tenant sanity check: when
+ * both the store and the request carry a physical tenant ID, they must match — catching a stale/
+ * cross-wired {@code DocumentFactory} rather than silently creating the document against the wrong
+ * cluster.
+ */
+class CamundaDocumentStoreImplTest {
+
+  private static DocumentCreationRequest requestWithPhysicalTenantId(String physicalTenantId) {
+    return DocumentCreationRequest.from(new ByteArrayInputStream("hello".getBytes()))
+        .physicalTenantId(physicalTenantId)
+        .build();
+  }
+
+  @Test
+  void throwsWhenRequestsPhysicalTenantIdDoesNotMatchTheStores() {
+    var camundaClient = mock(CamundaClient.class);
+    var store = new CamundaDocumentStoreImpl(camundaClient, "tenant-a");
+
+    assertThatThrownBy(() -> store.createDocument(requestWithPhysicalTenantId("tenant-b")))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("tenant-b")
+        .hasMessageContaining("tenant-a");
+
+    // the mismatch is caught before ever touching the (wrong) client
+    verifyNoInteractions(camundaClient);
+  }
+
+  @Test
+  void succeedsWhenRequestsPhysicalTenantIdMatchesTheStores() {
+    var camundaClient = mock(CamundaClient.class, RETURNS_DEEP_STUBS);
+    var store = new CamundaDocumentStoreImpl(camundaClient, "tenant-a");
+
+    var reference = store.createDocument(requestWithPhysicalTenantId("tenant-a"));
+
+    assertThat(reference).isNotNull();
+  }
+
+  @Test
+  void succeedsWhenNeitherSideHasAPhysicalTenantId() {
+    var camundaClient = mock(CamundaClient.class, RETURNS_DEEP_STUBS);
+    var store = new CamundaDocumentStoreImpl(camundaClient);
+
+    var reference = store.createDocument(requestWithPhysicalTenantId(null));
+
+    assertThat(reference).isNotNull();
+  }
+
+  @Test
+  void succeedsWhenTheStoreHasNoConfiguredPhysicalTenantId() {
+    // e.g. a legacy single-client deployment where physical-tenant-id was never configured
+    var camundaClient = mock(CamundaClient.class, RETURNS_DEEP_STUBS);
+    var store = new CamundaDocumentStoreImpl(camundaClient);
+
+    var reference = store.createDocument(requestWithPhysicalTenantId("tenant-a"));
+
+    assertThat(reference).isNotNull();
+  }
+}

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/inbound/DefaultProcessInstanceContextTest.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/inbound/DefaultProcessInstanceContextTest.java
@@ -26,16 +26,24 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.command.EvaluateExpressionCommandStep1.EvaluateExpressionCommandStep2;
 import io.camunda.client.api.response.EvaluateExpressionResponse;
 import io.camunda.client.api.search.response.ElementInstance;
 import io.camunda.connector.api.annotation.FEEL;
+import io.camunda.connector.api.document.Document;
 import io.camunda.connector.api.inbound.InboundConnectorDefinition;
 import io.camunda.connector.api.validation.ValidationProvider;
+import io.camunda.connector.document.jackson.IntrinsicFunctionExecutor;
+import io.camunda.connector.document.jackson.JacksonModuleDocumentDeserializer;
 import io.camunda.connector.runtime.core.TestObjectMapperSupplier;
+import io.camunda.connector.runtime.core.document.DocumentDeserializationTest;
+import io.camunda.connector.runtime.core.document.DocumentFactoryImpl;
+import io.camunda.connector.runtime.core.document.store.CamundaDocumentStore;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 class DefaultProcessInstanceContextTest {
 
@@ -107,6 +115,66 @@ class DefaultProcessInstanceContextTest {
         .hasMessageContaining("tenantId=tenant-A")
         .hasMessageContaining("scopeKey=987654321")
         .hasRootCauseMessage("remote FEEL failed");
+  }
+
+  @Test
+  void bind_resolvesDocumentFieldsThroughTheContextsOwnPhysicalTenant() {
+    // given: two physical tenants, each with its own DocumentFactory/store
+    var storeA = Mockito.mock(CamundaDocumentStore.class);
+    var storeB = Mockito.mock(CamundaDocumentStore.class);
+    var factoryA = new DocumentFactoryImpl(storeA);
+    var factoryB = new DocumentFactoryImpl(storeB);
+    var multiTenantMapper =
+        new ObjectMapper()
+            .registerModule(
+                new JacksonModuleDocumentDeserializer(
+                    Map.of("tenant-a", factoryA, "tenant-b", factoryB),
+                    Mockito.mock(IntrinsicFunctionExecutor.class),
+                    JacksonModuleDocumentDeserializer.DocumentModuleSettings.create()))
+            .registerModule(new Jdk8Module());
+
+    var ref = DocumentDeserializationTest.createDocumentMock("hello from tenant b", null, storeB);
+
+    var intermediateContext = mock(InboundIntermediateConnectorContextImpl.class);
+    when(intermediateContext.getProperties()).thenReturn(Map.of("document", ref));
+    when(intermediateContext.getDefinition())
+        .thenReturn(
+            new InboundConnectorDefinition(
+                "type", "tenant-A", "dedup", java.util.List.of(), "tenant-b"));
+
+    var elementInstance = mock(ElementInstance.class);
+    when(elementInstance.getElementInstanceKey()).thenReturn(1L);
+
+    var camundaClient = mock(CamundaClient.class, RETURNS_DEEP_STUBS);
+    ValidationProvider validationProvider = obj -> {};
+
+    var context =
+        new DefaultProcessInstanceContext(
+            intermediateContext,
+            elementInstance,
+            validationProvider,
+            null,
+            multiTenantMapper,
+            camundaClient);
+
+    // when
+    var result = context.bind(DocumentProps.class);
+
+    // then: resolved through tenant-b's factory, matching the reader attribute set from
+    // context.getDefinition().physicalTenantId()
+    assertThat(result.getDocument().reference()).isEqualTo(ref);
+  }
+
+  public static class DocumentProps {
+    private Document document;
+
+    public Document getDocument() {
+      return document;
+    }
+
+    public void setDocument(Document document) {
+      this.document = document;
+    }
   }
 
   public static class SimpleProps {

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextImplTest.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextImplTest.java
@@ -27,6 +27,8 @@ import io.camunda.client.CamundaClient;
 import io.camunda.client.api.command.EvaluateExpressionCommandStep1.EvaluateExpressionCommandStep2;
 import io.camunda.client.api.response.EvaluateExpressionResponse;
 import io.camunda.connector.api.annotation.FEEL;
+import io.camunda.connector.api.document.DocumentCreationRequest;
+import io.camunda.connector.api.document.DocumentFactory;
 import io.camunda.connector.api.inbound.ActivityLogTag;
 import io.camunda.connector.api.inbound.CorrelationRequest;
 import io.camunda.connector.api.inbound.CorrelationResult;
@@ -45,6 +47,7 @@ import io.camunda.connector.runtime.core.inbound.correlation.InboundCorrelationH
 import io.camunda.connector.runtime.core.inbound.correlation.MessageCorrelationPoint.StandaloneMessageCorrelationPoint;
 import io.camunda.connector.runtime.core.inbound.details.InboundConnectorDetails;
 import io.camunda.connector.runtime.core.inbound.details.InboundConnectorDetails.ValidInboundConnectorDetails;
+import java.io.ByteArrayInputStream;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -195,6 +198,50 @@ class InboundConnectorContextImplTest {
     assertThat(result).isInstanceOf(CorrelationResult.Success.class);
     var bound = ((CorrelationResult.Success) result).bindProperties(TestPropertiesClass.class);
     assertThat(bound.getStringMap()).containsEntry("from", "activated-element");
+  }
+
+  @Test
+  void create_stampsTheElementsPhysicalTenantIdWhenRequestHasNone() {
+    var element =
+        new InboundConnectorElement(
+            Map.of("inbound.type", "io.camunda:connector:1"),
+            new StandaloneMessageCorrelationPoint("", "", null, null),
+            new ProcessElementWithRuntimeData(
+                "bool",
+                null,
+                null,
+                0,
+                0,
+                "id",
+                null,
+                null,
+                "<default>",
+                "tenant-a",
+                new ElementTemplateDetails("t", "1", "icon"),
+                Map.of()));
+    var definition =
+        (ValidInboundConnectorDetails)
+            InboundConnectorDetails.of(element.deduplicationId(List.of()), List.of(element));
+    var documentFactory = mock(DocumentFactory.class);
+    var context =
+        new InboundConnectorContextImpl(
+            secretProvider,
+            (e) -> {},
+            documentFactory,
+            definition,
+            null,
+            (e) -> {},
+            mapper,
+            activityLogRegistry,
+            camundaClient);
+    var request =
+        DocumentCreationRequest.from(new ByteArrayInputStream("hello".getBytes())).build();
+
+    context.create(request);
+
+    var captor = ArgumentCaptor.forClass(DocumentCreationRequest.class);
+    verify(documentFactory).create(captor.capture());
+    assertThat(captor.getValue().physicalTenantId()).isEqualTo("tenant-a");
   }
 
   @Test

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/outbound/JobHandlerContextTest.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/outbound/JobHandlerContextTest.java
@@ -24,6 +24,8 @@ import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.client.api.response.ActivatedJob;
+import io.camunda.connector.api.document.DocumentCreationRequest;
+import io.camunda.connector.api.document.DocumentFactory;
 import io.camunda.connector.api.document.DocumentReturnChoice;
 import io.camunda.connector.api.document.DocumentReturnFormat;
 import io.camunda.connector.api.error.ConnectorInputException;
@@ -33,6 +35,7 @@ import io.camunda.connector.api.validation.ValidationProvider;
 import io.camunda.connector.runtime.core.secret.SecretFilter;
 import io.camunda.connector.runtime.core.testutil.classexample.TestClass;
 import io.camunda.connector.runtime.core.testutil.classexample.TestClassString;
+import java.io.ByteArrayInputStream;
 import java.util.Map;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
@@ -48,6 +51,7 @@ class JobHandlerContextTest {
   @Mock private ActivatedJob activatedJob;
   @Mock private SecretProvider secretProvider;
   @Mock private ValidationProvider validationProvider;
+  @Mock private DocumentFactory documentFactory;
 
   private final ObjectMapper objectMapper = new ObjectMapper();
   private JobHandlerContext jobHandlerContext;
@@ -158,6 +162,49 @@ class JobHandlerContextTest {
     var secretContext = ArgumentCaptor.forClass(SecretContext.class);
     verify(secretProvider).getSecret(eq("FOO"), secretContext.capture());
     assertThat(secretContext.getValue().physicalTenantId()).isNull();
+  }
+
+  @Test
+  void create_stampsTheJobsPhysicalTenantIdWhenRequestHasNone() {
+    when(activatedJob.getPhysicalTenantId()).thenReturn("tenant-a");
+    var contextWithDocumentFactory =
+        new JobHandlerContext(
+            activatedJob,
+            secretProvider,
+            validationProvider,
+            documentFactory,
+            objectMapper,
+            SecretFilter.allowAll());
+    var request =
+        DocumentCreationRequest.from(new ByteArrayInputStream("hello".getBytes())).build();
+
+    contextWithDocumentFactory.create(request);
+
+    var captor = ArgumentCaptor.forClass(DocumentCreationRequest.class);
+    verify(documentFactory).create(captor.capture());
+    assertThat(captor.getValue().physicalTenantId()).isEqualTo("tenant-a");
+  }
+
+  @Test
+  void create_neverOverridesAnExplicitlySetPhysicalTenantId() {
+    var contextWithDocumentFactory =
+        new JobHandlerContext(
+            activatedJob,
+            secretProvider,
+            validationProvider,
+            documentFactory,
+            objectMapper,
+            SecretFilter.allowAll());
+    var request =
+        DocumentCreationRequest.from(new ByteArrayInputStream("hello".getBytes()))
+            .physicalTenantId("explicit-tenant")
+            .build();
+
+    contextWithDocumentFactory.create(request);
+
+    var captor = ArgumentCaptor.forClass(DocumentCreationRequest.class);
+    verify(documentFactory).create(captor.capture());
+    assertThat(captor.getValue().physicalTenantId()).isEqualTo("explicit-tenant");
   }
 
   @Test

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/InboundConnectorRuntimeConfiguration.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/InboundConnectorRuntimeConfiguration.java
@@ -94,12 +94,15 @@ public class InboundConnectorRuntimeConfiguration {
       SecretProviderAggregator secretProviderAggregator,
       @Autowired(required = false) ValidationProvider validationProvider,
       Map<String, ProcessInstanceClient> processInstanceClientsByPhysicalTenantId,
-      DocumentFactory documentFactory,
+      @Autowired(required = false) DocumentFactory legacyDocumentFactory,
       CamundaClientRegistry registry,
       @Autowired(required = false) CamundaClient legacyCamundaClient) {
     Map<String, InboundCorrelationHandler> correlationHandlersByPhysicalTenantId =
         InboundCorrelationConfiguration.buildCorrelationHandlersByPhysicalTenantId(
             registry, legacyCamundaClient, mapper, messageTtl, connectorsInboundMetrics);
+    Map<String, DocumentFactory> documentFactoriesByPhysicalTenantId =
+        PhysicalTenantIds.buildDocumentFactoriesByPhysicalTenantId(
+            registry, legacyCamundaClient, legacyDocumentFactory);
     Map<String, InboundConnectorContextFactory> delegatesByPhysicalTenantId =
         registry.clientNames().stream()
             .collect(
@@ -116,7 +119,7 @@ public class InboundConnectorRuntimeConfiguration {
                           secretProviderAggregator,
                           validationProvider,
                           processInstanceClientsByPhysicalTenantId.get(physicalTenantId),
-                          documentFactory,
+                          documentFactoriesByPhysicalTenantId.get(physicalTenantId),
                           PhysicalTenantIds.resolveClient(registry, name, legacyCamundaClient));
                     }));
     return new PhysicalTenantIdRoutingInboundConnectorContextFactory(delegatesByPhysicalTenantId);

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/PhysicalTenantIds.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/PhysicalTenantIds.java
@@ -182,6 +182,7 @@ public final class PhysicalTenantIds {
                         ? legacyDocumentFactory
                         : new DocumentFactoryImpl(
                             new CamundaDocumentStoreImpl(
-                                resolveClient(registry, name, legacyCamundaClient)))));
+                                resolveClient(registry, name, legacyCamundaClient),
+                                resolvePhysicalTenantId(registry, name, legacyCamundaClient)))));
   }
 }

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/PhysicalTenantIds.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/PhysicalTenantIds.java
@@ -18,6 +18,9 @@ package io.camunda.connector.runtime.inbound;
 
 import io.camunda.client.CamundaClient;
 import io.camunda.client.spring.bean.CamundaClientRegistry;
+import io.camunda.connector.api.document.DocumentFactory;
+import io.camunda.connector.runtime.core.document.DocumentFactoryImpl;
+import io.camunda.connector.runtime.core.document.store.CamundaDocumentStoreImpl;
 import io.camunda.connector.runtime.inbound.search.SearchQueryClient;
 import io.camunda.connector.runtime.inbound.search.SearchQueryClientImpl;
 import java.util.Map;
@@ -153,5 +156,32 @@ public final class PhysicalTenantIds {
                         ? legacySearchQueryClient
                         : new SearchQueryClientImpl(
                             resolveClient(registry, name, legacyCamundaClient), limit)));
+  }
+
+  /**
+   * Builds one {@link DocumentFactory} per configured physical tenant, each backed by its own
+   * {@link CamundaDocumentStoreImpl}/{@link CamundaClient} — mirrors {@link
+   * #buildSearchQueryClientsByPhysicalTenantId} exactly, including the single-client-only {@code
+   * legacyDocumentFactory} override escape hatch (e.g. a test's {@code @Primary DocumentFactory}
+   * bean, or an in-memory store for tests), so overriding this bean continues to work for existing
+   * single-physical-tenant deployments/tests without silently applying the same override to every
+   * physical tenant in a genuine multi-client setup.
+   */
+  public static Map<String, DocumentFactory> buildDocumentFactoriesByPhysicalTenantId(
+      CamundaClientRegistry registry,
+      CamundaClient legacyCamundaClient,
+      DocumentFactory legacyDocumentFactory) {
+    boolean useOverride = legacyDocumentFactory != null && registry.clientNames().size() <= 1;
+    return registry.clientNames().stream()
+        .collect(
+            toMapByPhysicalTenantId(
+                registry,
+                legacyCamundaClient,
+                name ->
+                    useOverride
+                        ? legacyDocumentFactory
+                        : new DocumentFactoryImpl(
+                            new CamundaDocumentStoreImpl(
+                                resolveClient(registry, name, legacyCamundaClient)))));
   }
 }

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/OutboundConnectorRuntimeConfiguration.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/OutboundConnectorRuntimeConfiguration.java
@@ -228,7 +228,23 @@ public class OutboundConnectorRuntimeConfiguration {
 
   @Bean
   public CamundaDocumentStore documentStore(CamundaClient camundaClient) {
-    return new CamundaDocumentStoreImpl(camundaClient);
+    return new CamundaDocumentStoreImpl(
+        camundaClient, readPhysicalTenantIdIfAvailable(camundaClient));
+  }
+
+  /**
+   * Reads the client's configured physical tenant ID, tolerating the case where its configuration
+   * cannot be read at all — some test doubles (e.g. the {@code camunda-process-test-spring} client
+   * proxy) defer real initialization until the test container is ready and throw if queried during
+   * Spring context startup. Returning {@code null} here simply means the resulting {@link
+   * CamundaDocumentStoreImpl} skips its physical-tenant sanity check, rather than failing startup.
+   */
+  private static String readPhysicalTenantIdIfAvailable(CamundaClient camundaClient) {
+    try {
+      return camundaClient.getConfiguration().getPhysicalTenantId();
+    } catch (RuntimeException e) {
+      return null;
+    }
   }
 
   @Bean
@@ -339,7 +355,8 @@ public class OutboundConnectorRuntimeConfiguration {
                 legacyCamundaClient,
                 name ->
                     new CamundaDocumentStoreImpl(
-                        resolveClient(registry, name, legacyCamundaClient))));
+                        resolveClient(registry, name, legacyCamundaClient),
+                        resolvePhysicalTenantId(registry, name, legacyCamundaClient))));
   }
 
   /**

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/SpringConnectorJobHandler.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/SpringConnectorJobHandler.java
@@ -217,7 +217,8 @@ public class SpringConnectorJobHandler implements JobHandler {
           connectorResultHandler.createOutputVariables(
               connectorResponse.responseValue(),
               job.getCustomHeaders().get(Keywords.RESULT_VARIABLE_KEYWORD),
-              job.getCustomHeaders().get(Keywords.RESULT_EXPRESSION_KEYWORD));
+              job.getCustomHeaders().get(Keywords.RESULT_EXPRESSION_KEYWORD),
+              job.getPhysicalTenantId());
       if (!responseVariables.isEmpty()) {
         InlineSizeGuard.check(objectMapper.writeValueAsBytes(responseVariables).length);
       }
@@ -269,7 +270,8 @@ public class SpringConnectorJobHandler implements JobHandler {
               finalResult.responseValue(),
               job.getCustomHeaders(),
               new ErrorExpressionJobContext(
-                  new ErrorExpressionJobContext.ErrorExpressionJob(job.getRetries())));
+                  new ErrorExpressionJobContext.ErrorExpressionJob(job.getRetries())),
+              job.getPhysicalTenantId());
       optionalConnectorError.ifPresentOrElse(
           error ->
               handleConnectorError(client, job, context, finalResult, error, counterMetricsContext),

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/inbound/PhysicalTenantIdResolutionTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/inbound/PhysicalTenantIdResolutionTest.java
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.when;
 
 import io.camunda.client.CamundaClient;
 import io.camunda.client.spring.bean.CamundaClientRegistry;
+import io.camunda.connector.api.document.DocumentFactory;
 import io.camunda.connector.runtime.inbound.search.SearchQueryClient;
 import java.util.Map;
 import java.util.Set;
@@ -147,5 +148,36 @@ class PhysicalTenantIdResolutionTest {
             () -> configuration.searchQueryClientsByPhysicalTenantId(registry, null, null, 200))
         .isInstanceOf(IllegalStateException.class)
         .hasMessageContaining("same physical tenant ID");
+  }
+
+  @Test
+  void buildDocumentFactoriesByPhysicalTenantId_usesManuallySuppliedOverrideForASingleClient() {
+    // simulates the @Primary DocumentFactory test-spy pattern used by WebhookActivatedDocumentTests
+    var registry = mock(CamundaClientRegistry.class);
+    var client = clientWithPhysicalTenantId("tenant");
+    when(registry.clientNames()).thenReturn(Set.of("default"));
+    when(registry.get("default")).thenReturn(client);
+    var overrideDocumentFactory = mock(DocumentFactory.class);
+
+    var result =
+        PhysicalTenantIds.buildDocumentFactoriesByPhysicalTenantId(
+            registry, null, overrideDocumentFactory);
+
+    assertThat(result).containsOnly(Map.entry("tenant", overrideDocumentFactory));
+  }
+
+  @Test
+  void buildDocumentFactoriesByPhysicalTenantId_buildsOneRealFactoryPerPhysicalTenant() {
+    var registry = mock(CamundaClientRegistry.class);
+    var clientA = clientWithPhysicalTenantId("tenant-a");
+    var clientB = clientWithPhysicalTenantId("tenant-b");
+    when(registry.clientNames()).thenReturn(Set.of("engine-a", "engine-b"));
+    when(registry.get("engine-a")).thenReturn(clientA);
+    when(registry.get("engine-b")).thenReturn(clientB);
+
+    var result = PhysicalTenantIds.buildDocumentFactoriesByPhysicalTenantId(registry, null, null);
+
+    assertThat(result).containsOnlyKeys("tenant-a", "tenant-b");
+    assertThat(result.get("tenant-a")).isNotSameAs(result.get("tenant-b"));
   }
 }

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/inbound/PhysicalTenantIdResolutionTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/inbound/PhysicalTenantIdResolutionTest.java
@@ -24,8 +24,10 @@ import static org.mockito.Mockito.when;
 
 import io.camunda.client.CamundaClient;
 import io.camunda.client.spring.bean.CamundaClientRegistry;
+import io.camunda.connector.api.document.DocumentCreationRequest;
 import io.camunda.connector.api.document.DocumentFactory;
 import io.camunda.connector.runtime.inbound.search.SearchQueryClient;
+import java.io.ByteArrayInputStream;
 import java.util.Map;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
@@ -179,5 +181,27 @@ class PhysicalTenantIdResolutionTest {
 
     assertThat(result).containsOnlyKeys("tenant-a", "tenant-b");
     assertThat(result.get("tenant-a")).isNotSameAs(result.get("tenant-b"));
+  }
+
+  @Test
+  void buildDocumentFactoriesByPhysicalTenantId_wiresEachFactoryToItsOwnResolvedPhysicalTenantId() {
+    // each factory's underlying CamundaDocumentStoreImpl must know ITS OWN physical tenant ID
+    // (not just be backed by the right client), so it can reject a request explicitly addressed
+    // to a different physical tenant (see CamundaDocumentStoreImplTest)
+    var registry = mock(CamundaClientRegistry.class);
+    var clientA = clientWithPhysicalTenantId("tenant-a");
+    when(registry.clientNames()).thenReturn(Set.of("engine-a"));
+    when(registry.get("engine-a")).thenReturn(clientA);
+
+    var result = PhysicalTenantIds.buildDocumentFactoriesByPhysicalTenantId(registry, null, null);
+
+    var request =
+        DocumentCreationRequest.from(new ByteArrayInputStream("hello".getBytes()))
+            .physicalTenantId("tenant-b")
+            .build();
+    assertThatThrownBy(() -> result.get("tenant-a").create(request))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("tenant-a")
+        .hasMessageContaining("tenant-b");
   }
 }

--- a/connector-runtime/jackson-datatype-document/src/main/java/io/camunda/connector/document/jackson/JacksonModuleDocumentDeserializer.java
+++ b/connector-runtime/jackson-datatype-document/src/main/java/io/camunda/connector/document/jackson/JacksonModuleDocumentDeserializer.java
@@ -26,10 +26,12 @@ import io.camunda.connector.document.jackson.deserializer.InputStreamDeserialize
 import io.camunda.connector.document.jackson.deserializer.ObjectDeserializer;
 import io.camunda.connector.document.jackson.deserializer.StringDeserializer;
 import java.io.InputStream;
+import java.util.Map;
 
 public class JacksonModuleDocumentDeserializer extends SimpleModule {
 
   private final DocumentFactory documentFactory;
+  private final Map<String, DocumentFactory> documentFactoriesByPhysicalTenantId;
   private final IntrinsicFunctionExecutor intrinsicFunctionExecutor;
   private final DocumentModuleSettings settings;
 
@@ -38,6 +40,7 @@ public class JacksonModuleDocumentDeserializer extends SimpleModule {
       IntrinsicFunctionExecutor intrinsicFunctionExecutor,
       DocumentModuleSettings settings) {
     this.documentFactory = documentFactory;
+    this.documentFactoriesByPhysicalTenantId = null;
     this.intrinsicFunctionExecutor = intrinsicFunctionExecutor;
     this.settings = settings;
   }
@@ -45,6 +48,17 @@ public class JacksonModuleDocumentDeserializer extends SimpleModule {
   public JacksonModuleDocumentDeserializer(
       DocumentFactory documentFactory, IntrinsicFunctionExecutor intrinsicFunctionExecutor) {
     this(documentFactory, intrinsicFunctionExecutor, DocumentModuleSettings.create());
+  }
+
+  /** Physical-tenant-aware variant — see {@link DocumentDeserializer}'s equivalent constructor. */
+  public JacksonModuleDocumentDeserializer(
+      Map<String, DocumentFactory> documentFactoriesByPhysicalTenantId,
+      IntrinsicFunctionExecutor intrinsicFunctionExecutor,
+      DocumentModuleSettings settings) {
+    this.documentFactory = null;
+    this.documentFactoriesByPhysicalTenantId = documentFactoriesByPhysicalTenantId;
+    this.intrinsicFunctionExecutor = intrinsicFunctionExecutor;
+    this.settings = settings;
   }
 
   @Override
@@ -60,24 +74,51 @@ public class JacksonModuleDocumentDeserializer extends SimpleModule {
 
   @Override
   public void setupModule(SetupContext context) {
-    addDeserializer(
-        Document.class,
-        new DocumentDeserializer(documentFactory, intrinsicFunctionExecutor, settings));
-    addDeserializer(
-        byte[].class,
-        new ByteArrayDeserializer(documentFactory, intrinsicFunctionExecutor, settings));
-    addDeserializer(
-        InputStream.class,
-        new InputStreamDeserializer(documentFactory, intrinsicFunctionExecutor, settings));
-    if (settings.isObjectEnabled()) {
+    if (documentFactory != null) {
       addDeserializer(
-          Object.class,
-          new ObjectDeserializer(documentFactory, intrinsicFunctionExecutor, settings));
-    }
-    if (settings.isStringEnabled()) {
+          Document.class,
+          new DocumentDeserializer(documentFactory, intrinsicFunctionExecutor, settings));
       addDeserializer(
-          String.class,
-          new StringDeserializer(documentFactory, intrinsicFunctionExecutor, settings));
+          byte[].class,
+          new ByteArrayDeserializer(documentFactory, intrinsicFunctionExecutor, settings));
+      addDeserializer(
+          InputStream.class,
+          new InputStreamDeserializer(documentFactory, intrinsicFunctionExecutor, settings));
+      if (settings.isObjectEnabled()) {
+        addDeserializer(
+            Object.class,
+            new ObjectDeserializer(documentFactory, intrinsicFunctionExecutor, settings));
+      }
+      if (settings.isStringEnabled()) {
+        addDeserializer(
+            String.class,
+            new StringDeserializer(documentFactory, intrinsicFunctionExecutor, settings));
+      }
+    } else {
+      addDeserializer(
+          Document.class,
+          new DocumentDeserializer(
+              documentFactoriesByPhysicalTenantId, intrinsicFunctionExecutor, settings));
+      addDeserializer(
+          byte[].class,
+          new ByteArrayDeserializer(
+              documentFactoriesByPhysicalTenantId, intrinsicFunctionExecutor, settings));
+      addDeserializer(
+          InputStream.class,
+          new InputStreamDeserializer(
+              documentFactoriesByPhysicalTenantId, intrinsicFunctionExecutor, settings));
+      if (settings.isObjectEnabled()) {
+        addDeserializer(
+            Object.class,
+            new ObjectDeserializer(
+                documentFactoriesByPhysicalTenantId, intrinsicFunctionExecutor, settings));
+      }
+      if (settings.isStringEnabled()) {
+        addDeserializer(
+            String.class,
+            new StringDeserializer(
+                documentFactoriesByPhysicalTenantId, intrinsicFunctionExecutor, settings));
+      }
     }
     super.setupModule(context);
   }

--- a/connector-runtime/jackson-datatype-document/src/main/java/io/camunda/connector/document/jackson/deserializer/ByteArrayDeserializer.java
+++ b/connector-runtime/jackson-datatype-document/src/main/java/io/camunda/connector/document/jackson/deserializer/ByteArrayDeserializer.java
@@ -27,6 +27,7 @@ import io.camunda.connector.api.document.DocumentFactory;
 import io.camunda.connector.document.jackson.IntrinsicFunctionExecutor;
 import io.camunda.connector.document.jackson.JacksonModuleDocumentDeserializer.DocumentModuleSettings;
 import java.io.IOException;
+import java.util.Map;
 
 public class ByteArrayDeserializer extends AbstractDeserializer<byte[]> {
 
@@ -43,6 +44,19 @@ public class ByteArrayDeserializer extends AbstractDeserializer<byte[]> {
     super(settings);
     this.documentDeserializer =
         new DocumentDeserializer(documentFactory, intrinsicFunctionExecutor, settings);
+    this.intrinsicFunctionDeserializer =
+        new IntrinsicFunctionObjectResultDeserializer(intrinsicFunctionExecutor, settings);
+  }
+
+  /** Physical-tenant-aware variant — see {@link DocumentDeserializer}'s equivalent constructor. */
+  public ByteArrayDeserializer(
+      Map<String, DocumentFactory> documentFactoriesByPhysicalTenantId,
+      IntrinsicFunctionExecutor intrinsicFunctionExecutor,
+      DocumentModuleSettings settings) {
+    super(settings);
+    this.documentDeserializer =
+        new DocumentDeserializer(
+            documentFactoriesByPhysicalTenantId, intrinsicFunctionExecutor, settings);
     this.intrinsicFunctionDeserializer =
         new IntrinsicFunctionObjectResultDeserializer(intrinsicFunctionExecutor, settings);
   }

--- a/connector-runtime/jackson-datatype-document/src/main/java/io/camunda/connector/document/jackson/deserializer/DocumentDeserializer.java
+++ b/connector-runtime/jackson-datatype-document/src/main/java/io/camunda/connector/document/jackson/deserializer/DocumentDeserializer.java
@@ -29,6 +29,7 @@ import io.camunda.connector.document.jackson.JacksonModuleDocumentDeserializer.D
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Deserializer for {@link Document} targets. It supports both the case where the source is a
@@ -38,6 +39,7 @@ public class DocumentDeserializer extends AbstractDeserializer<Document> {
 
   private final IntrinsicFunctionObjectResultDeserializer intrinsicFunctionDeserializer;
   private final DocumentFactory documentFactory;
+  private final Map<String, DocumentFactory> documentFactoriesByPhysicalTenantId;
 
   public DocumentDeserializer(
       DocumentFactory documentFactory,
@@ -45,8 +47,52 @@ public class DocumentDeserializer extends AbstractDeserializer<Document> {
       DocumentModuleSettings settings) {
     super(settings);
     this.documentFactory = documentFactory;
+    this.documentFactoriesByPhysicalTenantId = null;
     this.intrinsicFunctionDeserializer =
         new IntrinsicFunctionObjectResultDeserializer(intrinsicFunctionExecutor, settings);
+  }
+
+  /**
+   * Physical-tenant-aware variant: resolves the {@link DocumentFactory} to use for each
+   * deserialization call from the {@link DocumentFactory#PHYSICAL_TENANT_ID_ATTRIBUTE} reader
+   * attribute, set by the writer (e.g. {@code JobHandlerContext}/{@code
+   * InboundConnectorContextImpl}) before deserializing — necessary because this deserializer is
+   * registered into a long-lived, shared {@code ObjectMapper}/module, not rebuilt per physical
+   * tenant.
+   */
+  public DocumentDeserializer(
+      Map<String, DocumentFactory> documentFactoriesByPhysicalTenantId,
+      IntrinsicFunctionExecutor intrinsicFunctionExecutor,
+      DocumentModuleSettings settings) {
+    super(settings);
+    this.documentFactory = null;
+    this.documentFactoriesByPhysicalTenantId = documentFactoriesByPhysicalTenantId;
+    this.intrinsicFunctionDeserializer =
+        new IntrinsicFunctionObjectResultDeserializer(intrinsicFunctionExecutor, settings);
+  }
+
+  private DocumentFactory resolveDocumentFactory(DeserializationContext context) {
+    if (documentFactory != null) {
+      return documentFactory;
+    }
+    var physicalTenantId =
+        (String) context.getAttribute(DocumentFactory.PHYSICAL_TENANT_ID_ATTRIBUTE);
+    if (physicalTenantId != null) {
+      var resolved = documentFactoriesByPhysicalTenantId.get(physicalTenantId);
+      if (resolved == null) {
+        throw new IllegalStateException(
+            "No DocumentFactory configured for physical tenant '" + physicalTenantId + "'");
+      }
+      return resolved;
+    }
+    if (documentFactoriesByPhysicalTenantId.size() == 1) {
+      return documentFactoriesByPhysicalTenantId.values().iterator().next();
+    }
+    throw new IllegalStateException(
+        "Cannot resolve a DocumentFactory to deserialize a Document: no physical tenant ID "
+            + "attribute was set on the reader and "
+            + documentFactoriesByPhysicalTenantId.size()
+            + " physical tenants are configured");
   }
 
   @Override
@@ -54,7 +100,7 @@ public class DocumentDeserializer extends AbstractDeserializer<Document> {
       throws IOException {
     if (isDocumentReference(node)) {
       final var reference = context.readTreeAsValue(node, DocumentReferenceModel.class);
-      return documentFactory.resolve(reference);
+      return resolveDocumentFactory(context).resolve(reference);
     }
     if (node.isArray()) {
       List<JsonNode> elements = new ArrayList<>();
@@ -62,7 +108,7 @@ public class DocumentDeserializer extends AbstractDeserializer<Document> {
       if (elements.size() == 1 && isDocumentReference(elements.get(0))) {
         final var reference =
             context.readTreeAsValue(elements.get(0), DocumentReferenceModel.class);
-        return documentFactory.resolve(reference);
+        return resolveDocumentFactory(context).resolve(reference);
       } else {
         throw new IllegalArgumentException(
             "Cant bind a multi element document array to a single document.");

--- a/connector-runtime/jackson-datatype-document/src/main/java/io/camunda/connector/document/jackson/deserializer/InputStreamDeserializer.java
+++ b/connector-runtime/jackson-datatype-document/src/main/java/io/camunda/connector/document/jackson/deserializer/InputStreamDeserializer.java
@@ -26,10 +26,12 @@ import io.camunda.connector.document.jackson.IntrinsicFunctionExecutor;
 import io.camunda.connector.document.jackson.JacksonModuleDocumentDeserializer.DocumentModuleSettings;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Map;
 
 public class InputStreamDeserializer extends AbstractDeserializer<InputStream> {
 
   private final DocumentFactory documentFactory;
+  private final Map<String, DocumentFactory> documentFactoriesByPhysicalTenantId;
   private final IntrinsicFunctionExecutor operationExecutor;
 
   public InputStreamDeserializer(
@@ -38,16 +40,33 @@ public class InputStreamDeserializer extends AbstractDeserializer<InputStream> {
       DocumentModuleSettings settings) {
     super(settings);
     this.documentFactory = documentFactory;
+    this.documentFactoriesByPhysicalTenantId = null;
     this.operationExecutor = intrinsicFunctionExecutor;
+  }
+
+  /** Physical-tenant-aware variant — see {@link DocumentDeserializer}'s equivalent constructor. */
+  public InputStreamDeserializer(
+      Map<String, DocumentFactory> documentFactoriesByPhysicalTenantId,
+      IntrinsicFunctionExecutor intrinsicFunctionExecutor,
+      DocumentModuleSettings settings) {
+    super(settings);
+    this.documentFactory = null;
+    this.documentFactoriesByPhysicalTenantId = documentFactoriesByPhysicalTenantId;
+    this.operationExecutor = intrinsicFunctionExecutor;
+  }
+
+  private DocumentDeserializer buildDocumentDeserializer() {
+    return documentFactory != null
+        ? new DocumentDeserializer(documentFactory, operationExecutor, settings)
+        : new DocumentDeserializer(
+            documentFactoriesByPhysicalTenantId, operationExecutor, settings);
   }
 
   @Override
   protected InputStream handleJsonNode(JsonNode node, DeserializationContext context)
       throws IOException {
     if (isDocumentReference(node)) {
-      final var document =
-          new DocumentDeserializer(documentFactory, operationExecutor, settings)
-              .handleJsonNode(node, context);
+      final var document = buildDocumentDeserializer().handleJsonNode(node, context);
       return document.asInputStream();
     }
     if (DeserializationUtil.isIntrinsicFunction(node)) {

--- a/connector-runtime/jackson-datatype-document/src/main/java/io/camunda/connector/document/jackson/deserializer/ObjectDeserializer.java
+++ b/connector-runtime/jackson-datatype-document/src/main/java/io/camunda/connector/document/jackson/deserializer/ObjectDeserializer.java
@@ -28,6 +28,7 @@ import io.camunda.connector.document.jackson.JacksonModuleDocumentDeserializer.D
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
+import java.util.Map;
 
 public class ObjectDeserializer extends AbstractDeserializer<Object> {
 
@@ -41,6 +42,19 @@ public class ObjectDeserializer extends AbstractDeserializer<Object> {
     super(settings);
     this.documentDeserializer =
         new DocumentDeserializer(documentFactory, intrinsicFunctionExecutor, settings);
+    this.functionDeserializer =
+        new IntrinsicFunctionObjectResultDeserializer(intrinsicFunctionExecutor, settings);
+  }
+
+  /** Physical-tenant-aware variant — see {@link DocumentDeserializer}'s equivalent constructor. */
+  public ObjectDeserializer(
+      Map<String, DocumentFactory> documentFactoriesByPhysicalTenantId,
+      IntrinsicFunctionExecutor intrinsicFunctionExecutor,
+      DocumentModuleSettings settings) {
+    super(settings);
+    this.documentDeserializer =
+        new DocumentDeserializer(
+            documentFactoriesByPhysicalTenantId, intrinsicFunctionExecutor, settings);
     this.functionDeserializer =
         new IntrinsicFunctionObjectResultDeserializer(intrinsicFunctionExecutor, settings);
   }

--- a/connector-runtime/jackson-datatype-document/src/main/java/io/camunda/connector/document/jackson/deserializer/StringDeserializer.java
+++ b/connector-runtime/jackson-datatype-document/src/main/java/io/camunda/connector/document/jackson/deserializer/StringDeserializer.java
@@ -25,6 +25,7 @@ import io.camunda.connector.api.document.DocumentFactory;
 import io.camunda.connector.document.jackson.IntrinsicFunctionExecutor;
 import io.camunda.connector.document.jackson.JacksonModuleDocumentDeserializer.DocumentModuleSettings;
 import java.io.IOException;
+import java.util.Map;
 
 public class StringDeserializer extends AbstractDeserializer<String> {
 
@@ -41,6 +42,19 @@ public class StringDeserializer extends AbstractDeserializer<String> {
     super(settings);
     this.documentDeserializer =
         new DocumentDeserializer(documentFactory, intrinsicFunctionExecutor, settings);
+    this.intrinsicFunctionDeserializer =
+        new IntrinsicFunctionObjectResultDeserializer(intrinsicFunctionExecutor, settings);
+  }
+
+  /** Physical-tenant-aware variant — see {@link DocumentDeserializer}'s equivalent constructor. */
+  public StringDeserializer(
+      Map<String, DocumentFactory> documentFactoriesByPhysicalTenantId,
+      IntrinsicFunctionExecutor intrinsicFunctionExecutor,
+      DocumentModuleSettings settings) {
+    super(settings);
+    this.documentDeserializer =
+        new DocumentDeserializer(
+            documentFactoriesByPhysicalTenantId, intrinsicFunctionExecutor, settings);
     this.intrinsicFunctionDeserializer =
         new IntrinsicFunctionObjectResultDeserializer(intrinsicFunctionExecutor, settings);
   }

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/main/java/io/camunda/connector/runtime/ConnectorsAutoConfiguration.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/main/java/io/camunda/connector/runtime/ConnectorsAutoConfiguration.java
@@ -19,6 +19,7 @@ package io.camunda.connector.runtime;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.client.CamundaClient;
 import io.camunda.client.impl.CamundaObjectMapper;
+import io.camunda.client.spring.bean.CamundaClientRegistry;
 import io.camunda.client.spring.configuration.CamundaAutoConfiguration;
 import io.camunda.client.spring.properties.CamundaClientProperties;
 import io.camunda.connector.api.document.DocumentFactory;
@@ -40,6 +41,7 @@ import io.camunda.connector.runtime.annotation.OutboundConnectorObjectMapper;
 import io.camunda.connector.runtime.core.intrinsic.DefaultIntrinsicFunctionExecutor;
 import io.camunda.connector.runtime.core.secret.SecretProviderAggregator;
 import io.camunda.connector.runtime.core.secret.SecretProviderDiscovery;
+import io.camunda.connector.runtime.inbound.PhysicalTenantIds;
 import io.camunda.connector.runtime.secret.ConsoleSecretProvider;
 import io.camunda.connector.runtime.secret.EnvironmentSecretProvider;
 import io.camunda.connector.runtime.secret.console.ConsoleSecretApiClient;
@@ -56,6 +58,7 @@ import org.hibernate.validator.messageinterpolation.ParameterMessageInterpolator
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.beans.factory.config.AutowireCapableBeanFactory;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
@@ -220,16 +223,22 @@ public class ConnectorsAutoConfiguration {
   @ConnectorsObjectMapper
   @ConditionalOnMissingBean(name = "connectorObjectMapper")
   public ObjectMapper connectorObjectMapper(
-      DocumentFactory documentFactory, FeelExpressionEvaluator feelExpressionEvaluator) {
+      CamundaClientRegistry registry,
+      @Autowired(required = false) CamundaClient legacyCamundaClient,
+      DocumentFactory legacyDocumentFactory,
+      FeelExpressionEvaluator feelExpressionEvaluator) {
     final ObjectMapper copy = ConnectorsObjectMapperSupplier.getCopy();
     // default intrinsic function contains a pointer of the copy
     var functionExecutor = new DefaultIntrinsicFunctionExecutor(copy);
 
     // The deserializer module contains the function executor, which contains the pointer of the
     // object mapper
+    var documentFactoriesByPhysicalTenantId =
+        PhysicalTenantIds.buildDocumentFactoriesByPhysicalTenantId(
+            registry, legacyCamundaClient, legacyDocumentFactory);
     var jacksonModuleDocumentDeserializer =
         new JacksonModuleDocumentDeserializer(
-            documentFactory,
+            documentFactoriesByPhysicalTenantId,
             functionExecutor,
             JacksonModuleDocumentDeserializer.DocumentModuleSettings.create());
 

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/inbound/DocumentPhysicalTenantIsolationWiringTest.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/inbound/DocumentPhysicalTenantIsolationWiringTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.runtime.inbound;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.client.spring.bean.CamundaClientRegistry;
+import io.camunda.connector.api.document.DocumentCreationRequest;
+import io.camunda.connector.runtime.app.TestConnectorRuntimeApplication;
+import java.io.ByteArrayInputStream;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+/**
+ * End-to-end proof that, when multiple {@code camunda.clients.*} are configured, each physical
+ * tenant's {@link io.camunda.connector.api.document.DocumentFactory} genuinely routes document I/O
+ * through its OWN configured {@code CamundaClient} — never silently through another physical
+ * tenant's — using the real Spring-bound {@link CamundaClientRegistry} (built from actual {@code
+ * camunda.clients.*} properties, not a hand-built test double, unlike {@link
+ * PhysicalTenantIdResolutionTest}).
+ *
+ * <p>No live broker is needed to prove isolation: each client is configured with a distinct,
+ * unreachable {@code grpc-address}, so attempting a document operation through the wrong tenant's
+ * factory would either fail against the wrong host or (if genuinely cross-wired) succeed/fail
+ * identically for both tenants. Asserting the failure for each tenant surfaces ITS OWN configured
+ * host proves the two factories are backed by two distinct {@code CamundaClient} instances, not one
+ * shared/mixed-up client.
+ */
+@SpringBootTest(
+    classes = TestConnectorRuntimeApplication.class,
+    properties = {
+      "camunda.clients.engine-a.mode=self-managed",
+      "camunda.clients.engine-a.grpc-address=http://engine-a.internal:26500",
+      "camunda.clients.engine-a.rest-address=http://engine-a.internal:8080",
+      "camunda.clients.engine-a.physical-tenant-id=tenanta",
+      "camunda.clients.engine-a.primary=true",
+      "camunda.clients.engine-b.mode=self-managed",
+      "camunda.clients.engine-b.grpc-address=http://engine-b.internal:26500",
+      "camunda.clients.engine-b.rest-address=http://engine-b.internal:8080",
+      "camunda.clients.engine-b.physical-tenant-id=tenantb",
+      "camunda.connector.polling.enabled=false",
+      "camunda.connector.webhook.enabled=false"
+    })
+class DocumentPhysicalTenantIsolationWiringTest {
+
+  @Autowired private CamundaClientRegistry camundaClientRegistry;
+
+  private static DocumentCreationRequest documentCreationRequest() {
+    return DocumentCreationRequest.from(new ByteArrayInputStream("hello".getBytes())).build();
+  }
+
+  @Test
+  void eachPhysicalTenantsDocumentFactoryTargetsItsOwnConfiguredClient() {
+    var documentFactoriesByPhysicalTenantId =
+        PhysicalTenantIds.buildDocumentFactoriesByPhysicalTenantId(
+            camundaClientRegistry, null, null);
+
+    assertThat(documentFactoriesByPhysicalTenantId).containsOnlyKeys("tenanta", "tenantb");
+    assertThat(documentFactoriesByPhysicalTenantId.get("tenanta"))
+        .isNotSameAs(documentFactoriesByPhysicalTenantId.get("tenantb"));
+
+    assertThatThrownBy(
+            () ->
+                documentFactoriesByPhysicalTenantId
+                    .get("tenanta")
+                    .create(documentCreationRequest()))
+        .rootCause()
+        .hasMessageContaining("engine-a.internal");
+
+    assertThatThrownBy(
+            () ->
+                documentFactoriesByPhysicalTenantId
+                    .get("tenantb")
+                    .create(documentCreationRequest()))
+        .rootCause()
+        .hasMessageContaining("engine-b.internal");
+  }
+}

--- a/connector-sdk/core/src/main/java/io/camunda/connector/api/document/DocumentCreationRequest.java
+++ b/connector-sdk/core/src/main/java/io/camunda/connector/api/document/DocumentCreationRequest.java
@@ -34,6 +34,60 @@ public record DocumentCreationRequest(
     Map<String, Object> customProperties,
     String physicalTenantId) {
 
+  /**
+   * Restores the pre-{@code physicalTenantId} 9-argument canonical constructor for binary
+   * compatibility: code compiled against the previous record shape (without {@code
+   * physicalTenantId}) would otherwise fail with {@code NoSuchMethodError} against this jar.
+   * Defaults the physical tenant to {@code null}, matching every deployment that predates
+   * multi-engine document routing.
+   */
+  public DocumentCreationRequest(
+      InputStream content,
+      String documentId,
+      String storeId,
+      String contentType,
+      String fileName,
+      Duration timeToLive,
+      String processDefinitionId,
+      Long processInstanceKey,
+      Map<String, Object> customProperties) {
+    this(
+        content,
+        documentId,
+        storeId,
+        contentType,
+        fileName,
+        timeToLive,
+        processDefinitionId,
+        processInstanceKey,
+        customProperties,
+        null);
+  }
+
+  /**
+   * Returns a copy of this request with {@code physicalTenantId} set to the given value, unless
+   * this request already has one — an explicit, connector-supplied value is never overridden. Used
+   * by the runtime (not connector code) to stamp the request with its own physical tenant before
+   * forwarding it to a {@link DocumentFactory}, so {@code CamundaDocumentStoreImpl} can validate it
+   * against the store's own physical tenant.
+   */
+  public DocumentCreationRequest withPhysicalTenantIdIfAbsent(String physicalTenantId) {
+    if (this.physicalTenantId != null) {
+      return this;
+    }
+    return new DocumentCreationRequest(
+        content,
+        documentId,
+        storeId,
+        contentType,
+        fileName,
+        timeToLive,
+        processDefinitionId,
+        processInstanceKey,
+        customProperties,
+        physicalTenantId);
+  }
+
   public static BuilderFinalStep from(InputStream content) {
     return new BuilderFinalStep(content);
   }

--- a/connector-sdk/core/src/main/java/io/camunda/connector/api/document/DocumentCreationRequest.java
+++ b/connector-sdk/core/src/main/java/io/camunda/connector/api/document/DocumentCreationRequest.java
@@ -31,7 +31,8 @@ public record DocumentCreationRequest(
     Duration timeToLive,
     String processDefinitionId,
     Long processInstanceKey,
-    Map<String, Object> customProperties) {
+    Map<String, Object> customProperties,
+    String physicalTenantId) {
 
   public static BuilderFinalStep from(InputStream content) {
     return new BuilderFinalStep(content);
@@ -52,6 +53,7 @@ public record DocumentCreationRequest(
     private String processDefinitionId;
     private Long processInstanceKey;
     private Map<String, Object> customProperties;
+    private String physicalTenantId;
 
     public BuilderFinalStep(InputStream content) {
       this.content = content;
@@ -97,6 +99,18 @@ public record DocumentCreationRequest(
       return this;
     }
 
+    /**
+     * The physical tenant (Zeebe cluster/"engine") this document is being created for. Optional —
+     * when set, {@code CamundaDocumentStoreImpl} uses it as a sanity check against the store's own
+     * physical tenant, catching wiring bugs (e.g. a stale {@code DocumentFactory} reference reused
+     * across physical tenants) rather than silently creating the document against the wrong
+     * cluster.
+     */
+    public BuilderFinalStep physicalTenantId(String physicalTenantId) {
+      this.physicalTenantId = physicalTenantId;
+      return this;
+    }
+
     public DocumentCreationRequest build() {
       return new DocumentCreationRequest(
           content,
@@ -107,7 +121,8 @@ public record DocumentCreationRequest(
           timeToLive,
           processDefinitionId,
           processInstanceKey,
-          customProperties);
+          customProperties,
+          physicalTenantId);
     }
   }
 }

--- a/connector-sdk/core/src/main/java/io/camunda/connector/api/document/DocumentFactory.java
+++ b/connector-sdk/core/src/main/java/io/camunda/connector/api/document/DocumentFactory.java
@@ -18,6 +18,16 @@ package io.camunda.connector.api.document;
 
 public interface DocumentFactory {
 
+  /**
+   * Jackson {@code ObjectReader}/{@code DeserializationContext} attribute key used to carry the
+   * physical tenant (Zeebe cluster/"engine") a {@code Document}-typed field should be resolved
+   * against. Set via {@code objectMapper.reader().withAttribute(PHYSICAL_TENANT_ID_ATTRIBUTE, ...)}
+   * before deserializing, read back via {@code context.getAttribute(PHYSICAL_TENANT_ID_ATTRIBUTE)}
+   * inside the deserializer — necessary because the {@code ObjectMapper}/module holding the
+   * document deserializer is a long-lived singleton, not rebuilt per physical tenant.
+   */
+  String PHYSICAL_TENANT_ID_ATTRIBUTE = "physicalTenantId";
+
   /** Given a document reference, create the Document object */
   Document resolve(DocumentReference reference);
 

--- a/connector-sdk/core/src/test/java/io/camunda/connector/api/document/DocumentCreationRequestTest.java
+++ b/connector-sdk/core/src/test/java/io/camunda/connector/api/document/DocumentCreationRequestTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.api.document;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.ByteArrayInputStream;
+import org.junit.jupiter.api.Test;
+
+class DocumentCreationRequestTest {
+
+  @Test
+  void legacyNineArgConstructorDefaultsPhysicalTenantIdToNull() {
+    // proves binary/source compatibility for callers compiled against the pre-physicalTenantId
+    // record shape: this constructor must keep existing, unchanged, non-deprecated
+    var request =
+        new DocumentCreationRequest(
+            new ByteArrayInputStream("hello".getBytes()),
+            "documentId",
+            "storeId",
+            "text/plain",
+            "file.txt",
+            null,
+            "processDefinitionId",
+            1L,
+            null);
+
+    assertThat(request.physicalTenantId()).isNull();
+  }
+
+  @Test
+  void withPhysicalTenantIdIfAbsent_setsItWhenNotAlreadyPresent() {
+    var request =
+        DocumentCreationRequest.from(new ByteArrayInputStream("hello".getBytes())).build();
+
+    var result = request.withPhysicalTenantIdIfAbsent("tenant-a");
+
+    assertThat(result.physicalTenantId()).isEqualTo("tenant-a");
+  }
+
+  @Test
+  void withPhysicalTenantIdIfAbsent_neverOverridesAnExplicitValue() {
+    var request =
+        DocumentCreationRequest.from(new ByteArrayInputStream("hello".getBytes()))
+            .physicalTenantId("explicit-tenant")
+            .build();
+
+    var result = request.withPhysicalTenantIdIfAbsent("tenant-a");
+
+    assertThat(result.physicalTenantId()).isEqualTo("explicit-tenant");
+    assertThat(result).isSameAs(request);
+  }
+}

--- a/connectors/aws/aws-bedrock/src/test/java/io/camunda/connector/aws/bedrock/mapper/BedrockContentMapperTest.java
+++ b/connectors/aws/aws-bedrock/src/test/java/io/camunda/connector/aws/bedrock/mapper/BedrockContentMapperTest.java
@@ -101,7 +101,6 @@ class BedrockContentMapperTest {
                 Duration.ofHours(1),
                 null,
                 null,
-                null,
                 null));
 
     var docContent = new BedrockContent(document);

--- a/connectors/aws/aws-bedrock/src/test/java/io/camunda/connector/aws/bedrock/mapper/BedrockContentMapperTest.java
+++ b/connectors/aws/aws-bedrock/src/test/java/io/camunda/connector/aws/bedrock/mapper/BedrockContentMapperTest.java
@@ -101,6 +101,7 @@ class BedrockContentMapperTest {
                 Duration.ofHours(1),
                 null,
                 null,
+                null,
                 null));
 
     var docContent = new BedrockContent(document);


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

Propagates the physical tenant through document creation and resolution, so multi-client deployments no longer share a single global document store across every configured client.

- Adds an optional `physicalTenantId` field to `DocumentCreationRequest` and a shared `DocumentFactory.PHYSICAL_TENANT_ID_ATTRIBUTE` Jackson reader-attribute key, with a legacy constructor overload preserved for binary/source compatibility.
- Builds one `DocumentFactory`/`CamundaDocumentStoreImpl` per configured physical tenant for inbound connectors (mirroring the existing per-tenant `SearchQueryClient`/`ProcessInstanceClient` pattern); outbound already had this via the sibling multi-engine work on this branch.
- Adds a `Map<String, DocumentFactory>`-based constructor overload to the Jackson document deserializers, resolving the correct tenant's factory from the reader attribute at deserialize time — needed because the shared, singleton `ObjectMapper` backing inbound property binding can't be rebuilt per tenant the way outbound's per-worker mapper can.
- Wires the attribute through every inbound binding path: `InboundConnectorContextImpl.bindProperties`/`bindElementProperties` and `DefaultProcessInstanceContext.bind` (intermediate/polling connectors).
- `JobHandlerContext.create`/`InboundConnectorContextImpl.create` now stamp outgoing `DocumentCreationRequest`s with their own physical tenant ID (never overriding an explicit connector-supplied value), and `CamundaDocumentStoreImpl` validates it against its own configured tenant, catching a stale/cross-wired `DocumentFactory` instead of silently writing to the wrong cluster.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #6960 

## Checklist

- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest
  release, as this branch will be rebased onto main before the next release. Example backport labels:
    - `backport stable/8.8`: for changes that should be included in the next 8.8.x release.
    - **or** `backport release-8.8.7`: for changes that should be included in the specific release 8.8.7, and this
      *release has already been created*. The release branch will be merged back into stable/8.8 later, so the change
      will be included in future 8.8.x releases as well.
- [ ] Tests/Integration tests for the changes have been added if applicable.
- [ ] If the change requires a documentation update, it has been added to the appropriate section in the documentation.


