### PR TITLE
feat: propagate physicalTenantId for secret resolution

### DIFF
--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextImpl.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextImpl.java
@@ -345,7 +345,9 @@ public class InboundConnectorContextImpl extends AbstractConnectorContext
               objectMapper,
               wrapped,
               new SecretContext(
-                  connectorDetails.tenantId(), connectorDetails.processDefinitionId()));
+                  connectorDetails.tenantId(),
+                  connectorDetails.processDefinitionId(),
+                  getPhysicalTenantId()));
       var propertiesJson = objectMapper.valueToTree(withSecrets);
       var result =
           FeelContextAwareObjectReader.of(objectMapper)
@@ -372,7 +374,12 @@ public class InboundConnectorContextImpl extends AbstractConnectorContext
         connectorDetails.tenantId(),
         connectorDetails.deduplicationId(),
         elements.stream().map(InboundConnectorElement::element).collect(Collectors.toList()),
-        elements.isEmpty() ? null : elements.getFirst().physicalTenantId());
+        getPhysicalTenantId());
+  }
+
+  private @Nullable String getPhysicalTenantId() {
+    var elements = connectorDetails.connectorElements();
+    return elements.isEmpty() ? null : elements.getFirst().physicalTenantId();
   }
 
   @Override
@@ -457,7 +464,9 @@ public class InboundConnectorContextImpl extends AbstractConnectorContext
               objectMapper,
               properties,
               new SecretContext(
-                  connectorDetails.tenantId(), connectorDetails.processDefinitionId()));
+                  connectorDetails.tenantId(),
+                  connectorDetails.processDefinitionId(),
+                  getPhysicalTenantId()));
     }
     return propertiesWithSecrets;
   }

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/outbound/JobHandlerContext.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/outbound/JobHandlerContext.java
@@ -93,7 +93,9 @@ public class JobHandlerContext extends AbstractConnectorContext
       jsonWithSecrets =
           getSecretHandler()
               .replaceSecrets(
-                  job.getVariables(), new SecretContext(job.getTenantId(), job.getBpmnProcessId()));
+                  job.getVariables(),
+                  new SecretContext(
+                      job.getTenantId(), job.getBpmnProcessId(), job.getPhysicalTenantId()));
     }
     return jsonWithSecrets;
   }

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextImplTest.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextImplTest.java
@@ -33,6 +33,7 @@ import io.camunda.connector.api.inbound.CorrelationResult;
 import io.camunda.connector.api.inbound.ElementTemplateDetails;
 import io.camunda.connector.api.inbound.Health;
 import io.camunda.connector.api.inbound.Severity;
+import io.camunda.connector.api.secret.SecretContext;
 import io.camunda.connector.api.secret.SecretProvider;
 import io.camunda.connector.feel.FeelEngineWrapperException;
 import io.camunda.connector.feel.LocalFeelExpressionEvaluator;
@@ -77,6 +78,32 @@ class InboundConnectorContextImplTest {
             properties,
             new StandaloneMessageCorrelationPoint("", "", null, null),
             new ProcessElementWithRuntimeData("bool", 0, 0, "id", tenantId));
+    var details = InboundConnectorDetails.of(element.deduplicationId(List.of()), List.of(element));
+    assertThat(details).isInstanceOf(ValidInboundConnectorDetails.class);
+    return (ValidInboundConnectorDetails) details;
+  }
+
+  private static ValidInboundConnectorDetails getInboundConnectorDefinitionWithPhysicalTenant(
+      Map<String, String> properties, String physicalTenantId) {
+    properties = new HashMap<>(properties);
+    properties.put("inbound.type", "io.camunda:connector:1");
+    InboundConnectorElement element =
+        new InboundConnectorElement(
+            properties,
+            new StandaloneMessageCorrelationPoint("", "", null, null),
+            new ProcessElementWithRuntimeData(
+                "bool",
+                null,
+                null,
+                0,
+                0,
+                "id",
+                null,
+                null,
+                "<default>",
+                physicalTenantId,
+                new ElementTemplateDetails("Test", "1", "icon"),
+                properties));
     var details = InboundConnectorDetails.of(element.deduplicationId(List.of()), List.of(element));
     assertThat(details).isInstanceOf(ValidInboundConnectorDetails.class);
     return (ValidInboundConnectorDetails) details;
@@ -193,6 +220,54 @@ class InboundConnectorContextImplTest {
     assertThat(exception).hasMessageContaining("Failed to bind process instance properties");
     assertThat(exception).hasStackTraceContaining(FeelEngineWrapperException.class.getName());
     assertThat(exception).hasStackTraceContaining("Failed to evaluate expression");
+  }
+
+  @Test
+  void bindProperties_secretContextCarriesTheElementsPhysicalTenantId() {
+    // given a connector deployed on a specific engine, secrets must be resolved against that
+    // engine's physical tenant so multi-engine runtimes can scope secret lookups per cluster
+    var definition =
+        getInboundConnectorDefinitionWithPhysicalTenant(
+            Map.of("stringMap", "={}", "token", "secrets.FOO"), "engine-1");
+    var secretProvider = mock(SecretProvider.class);
+    when(secretProvider.getSecret(eq("FOO"), any())).thenReturn("bar");
+    var context =
+        new InboundConnectorContextImpl(
+            secretProvider,
+            (e) -> {},
+            definition,
+            null,
+            (e) -> {},
+            mapper,
+            activityLogRegistry,
+            camundaClient);
+
+    // when
+    context.bindProperties(TestPropertiesClass.class);
+
+    // then
+    var secretContext = ArgumentCaptor.forClass(SecretContext.class);
+    verify(secretProvider).getSecret(eq("FOO"), secretContext.capture());
+    assertThat(secretContext.getValue().physicalTenantId()).isEqualTo("engine-1");
+    assertThat(secretContext.getValue().tenantId()).isEqualTo("<default>");
+  }
+
+  @Test
+  void getDefinition_reportsTheElementsPhysicalTenantId() {
+    var definition =
+        getInboundConnectorDefinitionWithPhysicalTenant(Map.of("stringMap", "={}"), "engine-1");
+    var context =
+        new InboundConnectorContextImpl(
+            secretProvider,
+            (e) -> {},
+            definition,
+            null,
+            (e) -> {},
+            mapper,
+            activityLogRegistry,
+            camundaClient);
+
+    assertThat(context.getDefinition().physicalTenantId()).isEqualTo("engine-1");
   }
 
   @Test

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/outbound/JobHandlerContextTest.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/outbound/JobHandlerContextTest.java
@@ -27,6 +27,7 @@ import io.camunda.client.api.response.ActivatedJob;
 import io.camunda.connector.api.document.DocumentReturnChoice;
 import io.camunda.connector.api.document.DocumentReturnFormat;
 import io.camunda.connector.api.error.ConnectorInputException;
+import io.camunda.connector.api.secret.SecretContext;
 import io.camunda.connector.api.secret.SecretProvider;
 import io.camunda.connector.api.validation.ValidationProvider;
 import io.camunda.connector.runtime.core.secret.SecretFilter;
@@ -37,6 +38,7 @@ import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -126,6 +128,36 @@ class JobHandlerContextTest {
     when(activatedJob.getVariables()).thenReturn(json);
     when(secretProvider.getSecret(eq("FOO"), any())).thenReturn("1");
     assertThat(jobHandlerContext.bindVariables(TestClass.class).integer).isEqualTo(1);
+  }
+
+  @Test
+  void bindVariables_secretContextCarriesTheJobsPhysicalTenantId() {
+    when(activatedJob.getVariables()).thenReturn("{ \"integer\": {{secrets.FOO}} }");
+    when(activatedJob.getTenantId()).thenReturn("my-tenant");
+    when(activatedJob.getBpmnProcessId()).thenReturn("my-process");
+    when(activatedJob.getPhysicalTenantId()).thenReturn("engine-1");
+    when(secretProvider.getSecret(eq("FOO"), any())).thenReturn("1");
+
+    jobHandlerContext.bindVariables(TestClass.class);
+
+    var secretContext = ArgumentCaptor.forClass(SecretContext.class);
+    verify(secretProvider).getSecret(eq("FOO"), secretContext.capture());
+    assertThat(secretContext.getValue())
+        .isEqualTo(new SecretContext("my-tenant", "my-process", "engine-1"));
+  }
+
+  @Test
+  void bindVariables_secretContextHasNoPhysicalTenantIdWhenTheJobReportsNone() {
+    // clusters that predate multi-engine support report an empty physical tenant
+    when(activatedJob.getVariables()).thenReturn("{ \"integer\": {{secrets.FOO}} }");
+    when(activatedJob.getPhysicalTenantId()).thenReturn("");
+    when(secretProvider.getSecret(eq("FOO"), any())).thenReturn("1");
+
+    jobHandlerContext.bindVariables(TestClass.class);
+
+    var secretContext = ArgumentCaptor.forClass(SecretContext.class);
+    verify(secretProvider).getSecret(eq("FOO"), secretContext.capture());
+    assertThat(secretContext.getValue().physicalTenantId()).isNull();
   }
 
   @Test

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/OutboundConnectorExceptionHandler.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/OutboundConnectorExceptionHandler.java
@@ -77,7 +77,9 @@ public class OutboundConnectorExceptionHandler {
               .toList();
       secrets =
           this.secretProvider.fetchAll(
-              allowedKeys, new SecretContext(job.getTenantId(), job.getBpmnProcessId()));
+              allowedKeys,
+              new SecretContext(
+                  job.getTenantId(), job.getBpmnProcessId(), job.getPhysicalTenantId()));
     } catch (Exception ex) {
       LOGGER.error(
           "Initial error for job: {} for tenant: {} can't be displayed because fetching secrets failed: {}",
@@ -178,7 +180,9 @@ public class OutboundConnectorExceptionHandler {
             .toList();
     List<String> secrets =
         this.secretProvider.fetchAll(
-            allowedKeys, new SecretContext(job.getTenantId(), job.getBpmnProcessId()));
+            allowedKeys,
+            new SecretContext(
+                job.getTenantId(), job.getBpmnProcessId(), job.getPhysicalTenantId()));
     Exception newException = new Exception(hideSecretsFromMessage(ex.getMessage(), secrets), ex);
     LOGGER.error(
         "Exception while processing job: {} for tenant: {}, message: {}",

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/OutboundConnectorExceptionHandler.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/OutboundConnectorExceptionHandler.java
@@ -37,13 +37,18 @@ public class OutboundConnectorExceptionHandler {
 
   private static final Logger LOGGER =
       LoggerFactory.getLogger(OutboundConnectorExceptionHandler.class);
+
+  /** Stands in for a container that (transitively) contains itself, so masking cannot loop. */
+  private static final String CIRCULAR_REFERENCE = "[circular reference]";
+
   private final SecretProvider secretProvider;
 
   public OutboundConnectorExceptionHandler(SecretProvider secretProvider) {
     this.secretProvider = secretProvider;
   }
 
-  private static Map<String, Object> exceptionToMap(Exception wrappedException) {
+  private static Map<String, Object> exceptionToMap(
+      Exception wrappedException, List<String> secrets) {
     Map<String, Object> result = new HashMap<>();
     Throwable originalCause = wrappedException.getCause();
     result.put("type", originalCause.getClass().getName());
@@ -57,14 +62,70 @@ public class OutboundConnectorExceptionHandler {
       var variables = connectorException.getErrorVariables();
 
       if (code != null) {
+        // deliberately not masked: BPMN error boundary events match on this value, so altering it
+        // would stop the error from being caught
         result.put("code", code);
       }
 
       if (variables != null) {
-        result.put("variables", variables);
+        result.put("variables", maskSecrets(variables, secrets));
       }
     }
     return Map.copyOf(result);
+  }
+
+  /**
+   * Masks every secret occurrence in {@code value}, recursing through maps and collections.
+   *
+   * <p>The error message is masked by the callers, but the error variables are copied straight off
+   * the original exception, and for HTTP connectors they carry the full response body and headers
+   * (see {@code ConnectorExceptionMapper}). An API that echoes a rejected credential back would
+   * otherwise put the resolved secret into process variables, which are visible to anyone who can
+   * see the process instance.
+   *
+   * <p>Only strings are rewritten; numbers, booleans and other scalars keep their type, since
+   * processes may branch on them. Values of types other than {@link Map}/{@link Collection}/{@link
+   * String} are passed through untouched — a secret held in a field of a custom object is not
+   * reached.
+   */
+  private static Object maskSecrets(Object value, List<String> secrets) {
+    return maskSecrets(value, secrets, Collections.newSetFromMap(new IdentityHashMap<>()));
+  }
+
+  private static Object maskSecrets(Object value, List<String> secrets, Set<Object> enclosing) {
+    return switch (value) {
+      case null -> null;
+      case String string -> hideSecretsFromMessage(string, secrets);
+      case Map<?, ?> map -> {
+        // error variables are user-supplied, so a container may contain itself
+        if (!enclosing.add(map)) {
+          yield CIRCULAR_REFERENCE;
+        }
+        try {
+          // keys are masked too, and collapsed keys simply overwrite rather than fail
+          var masked = new LinkedHashMap<String, Object>();
+          map.forEach(
+              (key, entry) ->
+                  masked.put(
+                      hideSecretsFromMessage(String.valueOf(key), secrets),
+                      maskSecrets(entry, secrets, enclosing)));
+          yield masked;
+        } finally {
+          enclosing.remove(map);
+        }
+      }
+      case Collection<?> collection -> {
+        if (!enclosing.add(collection)) {
+          yield CIRCULAR_REFERENCE;
+        }
+        try {
+          yield collection.stream().map(item -> maskSecrets(item, secrets, enclosing)).toList();
+        } finally {
+          enclosing.remove(collection);
+        }
+      }
+      default -> value;
+    };
   }
 
   public ConnectorResult.ErrorResult manageConnectorJobHandlerException(
@@ -92,7 +153,8 @@ public class OutboundConnectorExceptionHandler {
                   + ex.getMessage(),
               ex);
       return new ConnectorResult.ErrorResult(
-          Map.of("error", exceptionToMap(wrappedException)),
+          // secrets could not be fetched, so there is nothing to mask with
+          Map.of("error", exceptionToMap(wrappedException, List.of())),
           wrappedException,
           job.getRetries() - 1);
     }
@@ -107,7 +169,7 @@ public class OutboundConnectorExceptionHandler {
     };
   }
 
-  private String hideSecretsFromMessage(String message, List<String> secrets) {
+  private static String hideSecretsFromMessage(String message, List<String> secrets) {
     if (!Objects.isNull(message))
       return secrets.stream()
           .reduce(message, (newMessage, nextSecret) -> newMessage.replace(nextSecret, "***"));
@@ -117,7 +179,7 @@ public class OutboundConnectorExceptionHandler {
   private ConnectorResult.ErrorResult handleBackOffException(Exception e, List<String> secrets) {
     Exception newException = new Exception(hideSecretsFromMessage(e.getMessage(), secrets), e);
     return new ConnectorResult.ErrorResult(
-        Map.of("error", exceptionToMap(newException)), newException, 0);
+        Map.of("error", exceptionToMap(newException, secrets)), newException, 0);
   }
 
   private ConnectorResult.ErrorResult handleConnectorRetryException(
@@ -134,11 +196,17 @@ public class OutboundConnectorExceptionHandler {
         newException,
         Optional.ofNullable(ex.getRetries()).orElse(job.getRetries() - 1),
         errorCode,
-        Optional.ofNullable(ex.getBackoffDuration()).orElse(retryBackoff));
+        Optional.ofNullable(ex.getBackoffDuration()).orElse(retryBackoff),
+        secrets);
   }
 
   private ConnectorResult.ErrorResult handleSDKException(
-      ActivatedJob job, Exception ex, Integer retries, String errorCode, Duration backoffDuration) {
+      ActivatedJob job,
+      Exception ex,
+      Integer retries,
+      String errorCode,
+      Duration backoffDuration,
+      List<String> secrets) {
     LOGGER.debug(
         "Failing job with retry config => job: {} for tenant: {} with error code: {}, retries: {} and remaining backoffDuration: {}",
         job.getKey(),
@@ -148,7 +216,7 @@ public class OutboundConnectorExceptionHandler {
         backoffDuration);
 
     return new ConnectorResult.ErrorResult(
-        Map.of("error", exceptionToMap(ex)), ex, retries, backoffDuration);
+        Map.of("error", exceptionToMap(ex, secrets)), ex, retries, backoffDuration);
   }
 
   private ConnectorResult.ErrorResult handleGenericException(
@@ -169,7 +237,7 @@ public class OutboundConnectorExceptionHandler {
     if (ex instanceof ConnectorInputException || ex.getCause() instanceof ConnectorInputException) {
       retries = 0;
     }
-    return handleSDKException(job, newException, retries, errorCode, retryBackoff);
+    return handleSDKException(job, newException, retries, errorCode, retryBackoff, secrets);
   }
 
   public ConnectorResult.ErrorResult handleFinalResultException(
@@ -190,6 +258,6 @@ public class OutboundConnectorExceptionHandler {
         job.getTenantId(),
         ex.getMessage());
     return new ConnectorResult.ErrorResult(
-        Map.of("error", exceptionToMap(newException)), newException, 0);
+        Map.of("error", exceptionToMap(newException, secrets)), newException, 0);
   }
 }

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/secret/EnvironmentSecretProvider.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/secret/EnvironmentSecretProvider.java
@@ -19,6 +19,7 @@ package io.camunda.connector.runtime.secret;
 import io.camunda.connector.api.secret.SecretContext;
 import io.camunda.connector.api.secret.SecretProvider;
 import jakarta.annotation.PostConstruct;
+import java.util.ArrayList;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.core.env.Environment;
@@ -26,17 +27,42 @@ import org.springframework.util.StringUtils;
 
 public class EnvironmentSecretProvider implements SecretProvider {
   private static final Logger LOG = LoggerFactory.getLogger(EnvironmentSecretProvider.class);
+
+  /**
+   * Segment used when the physical tenant is unknown, i.e. against a cluster that predates
+   * multi-engine support. Matches the {@code "default"} convention already used for the physical
+   * tenant elsewhere in the runtime, so a single-cluster deployment that enables {@code
+   * physicalTenantAware} resolves a stable, predictable name instead of silently falling back to an
+   * unscoped one.
+   */
+  private static final String DEFAULT_PHYSICAL_TENANT_ID = "default";
+
   private final Environment environment;
   private final String prefix;
+  private final boolean physicalTenantAware;
   private final boolean tenantAware;
   private final boolean processDefinitionAware;
 
   public EnvironmentSecretProvider(
-      Environment environment, String prefix, boolean tenantAware, boolean processDefinitionAware) {
+      Environment environment,
+      String prefix,
+      boolean physicalTenantAware,
+      boolean tenantAware,
+      boolean processDefinitionAware) {
     this.environment = environment;
     this.prefix = prefix;
+    this.physicalTenantAware = physicalTenantAware;
     this.tenantAware = tenantAware;
     this.processDefinitionAware = processDefinitionAware;
+  }
+
+  /**
+   * Retains the pre-multi-engine constructor signature, leaving the physical tenant out of the
+   * composed secret name.
+   */
+  public EnvironmentSecretProvider(
+      Environment environment, String prefix, boolean tenantAware, boolean processDefinitionAware) {
+    this(environment, prefix, false, tenantAware, processDefinitionAware);
   }
 
   @PostConstruct
@@ -92,67 +118,40 @@ public class EnvironmentSecretProvider implements SecretProvider {
     return composeSecretNameWithPrefix(name, context, prefix);
   }
 
-  /** Composes the full secret name using the given prefix (may be empty for unprefixed lookup). */
+  /**
+   * Composes the full secret name as {@code ${prefix}${scope segments...}_${name}}, where the scope
+   * segments are those enabled by configuration, in the order physical tenant, tenant, process
+   * definition. With no scope enabled this is just {@code ${prefix}${name}}.
+   *
+   * <p>{@code context} is only dereferenced for the scopes that are actually enabled, so an
+   * unscoped provider still resolves with a {@code null} context.
+   *
+   * @param effectivePrefix the prefix to prepend (may be empty for unprefixed lookup)
+   */
   private String composeSecretNameWithPrefix(
       String name, SecretContext context, String effectivePrefix) {
     String resolvedPrefix = StringUtils.hasText(effectivePrefix) ? effectivePrefix : "";
-    return tenantAware
-        ? (processDefinitionAware
-            ? composeSecretNameTenantAwareProcessDefinitionAware(name, context, resolvedPrefix)
-            : composeSecretNameTenantAware(name, context, resolvedPrefix))
-        : (processDefinitionAware
-            ? composeSecretNameProcessDefinitionAware(name, context, resolvedPrefix)
-            : composeSecretNameSimple(name, resolvedPrefix));
+    var segments = new ArrayList<String>();
+    if (physicalTenantAware) {
+      segments.add(resolvePhysicalTenantId(context));
+    }
+    if (tenantAware) {
+      segments.add(context.tenantId());
+    }
+    if (processDefinitionAware) {
+      segments.add(context.processDefinitionId());
+    }
+    segments.add(name);
+    return resolvedPrefix + String.join("_", segments);
   }
 
   /**
-   * Returns the secret name in format {@code ${prefix}${name}}.
-   *
-   * @param name the secret name to find the value for
-   * @param resolvedPrefix the prefix to prepend (may be empty)
-   * @return the final secret name
+   * Returns the context's physical tenant, or {@link #DEFAULT_PHYSICAL_TENANT_ID} when it is unset
+   * — resolving to an unscoped name instead would let a misconfigured multi-engine deployment
+   * silently share one secret across engines.
    */
-  private String composeSecretNameSimple(String name, String resolvedPrefix) {
-    return String.format("%s%s", resolvedPrefix, name);
-  }
-
-  /**
-   * Returns the secret name in format {@code ${prefix}${tenantId}_${name}}.
-   *
-   * @param name the secret name to find the value for
-   * @param context the context of where the secret is originated
-   * @param resolvedPrefix the prefix to prepend (may be empty)
-   * @return the final secret name
-   */
-  private String composeSecretNameTenantAware(
-      String name, SecretContext context, String resolvedPrefix) {
-    return String.format("%s%s_%s", resolvedPrefix, context.tenantId(), name);
-  }
-
-  /**
-   * Returns the secret name in format {@code ${prefix}${processDefinitionId}_${name}}.
-   *
-   * @param name the secret name to find the value for
-   * @param context the context of where the secret is originated
-   * @param resolvedPrefix the prefix to prepend (may be empty)
-   * @return the final secret name
-   */
-  private String composeSecretNameProcessDefinitionAware(
-      String name, SecretContext context, String resolvedPrefix) {
-    return String.format("%s%s_%s", resolvedPrefix, context.processDefinitionId(), name);
-  }
-
-  /**
-   * Returns the secret name in format {@code ${prefix}${tenantId}_${processDefinitionId}_${name}}.
-   *
-   * @param name the secret name to find the value for
-   * @param context the context of where the secret is originated
-   * @param resolvedPrefix the prefix to prepend (may be empty)
-   * @return the final secret name
-   */
-  private String composeSecretNameTenantAwareProcessDefinitionAware(
-      String name, SecretContext context, String resolvedPrefix) {
-    return String.format(
-        "%s%s_%s_%s", resolvedPrefix, context.tenantId(), context.processDefinitionId(), name);
+  private String resolvePhysicalTenantId(SecretContext context) {
+    var physicalTenantId = context.physicalTenantId();
+    return physicalTenantId != null ? physicalTenantId : DEFAULT_PHYSICAL_TENANT_ID;
   }
 }

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/job/OutboundConnectorExceptionHandlerTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/job/OutboundConnectorExceptionHandlerTest.java
@@ -23,11 +23,15 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.camunda.client.api.response.ActivatedJob;
+import io.camunda.connector.api.error.ConnectorException;
 import io.camunda.connector.api.secret.SecretContext;
 import io.camunda.connector.api.secret.SecretProvider;
+import io.camunda.connector.runtime.core.outbound.ConnectorResult;
 import io.camunda.connector.runtime.core.secret.SecretFilter;
 import java.time.Duration;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
@@ -106,5 +110,100 @@ class OutboundConnectorExceptionHandlerTest {
                 SecretFilter.allowAll());
 
     assertThat(result.responseValue().toString()).doesNotContain("super-secret");
+  }
+
+  /**
+   * The error message was already masked, but the error variables are copied straight off the
+   * original exception. For HTTP connectors those carry the whole response body and headers, so an
+   * API that echoes a rejected credential back used to publish the resolved secret as a process
+   * variable.
+   */
+  @Test
+  void errorVariables_maskSecretsNestedInAnHttpResponseBody() {
+    var errorVariables =
+        Map.<String, Object>of(
+            "response",
+            Map.of(
+                "headers",
+                Map.of("www-authenticate", "Bearer error=\"invalid_token super-secret\""),
+                "body",
+                Map.of("errors", List.of(Map.of("detail", "token super-secret is not valid")))));
+
+    var masked = maskedErrorVariables(errorVariables);
+
+    assertThat(masked.toString()).doesNotContain("super-secret").contains("***");
+  }
+
+  @Test
+  void errorVariables_maskSecretsUsedAsMapKeys() {
+    var masked = maskedErrorVariables(Map.of("super-secret", "harmless"));
+
+    assertThat(masked).containsOnlyKeys("***");
+  }
+
+  /** Processes branch on these, so rewriting them into strings would change behaviour. */
+  @Test
+  void errorVariables_leaveNonStringLeavesUntouched() {
+    var errorVariables = new HashMap<String, Object>();
+    errorVariables.put("status", 401);
+    errorVariables.put("retryable", false);
+    errorVariables.put("body", null);
+
+    var masked = maskedErrorVariables(errorVariables);
+
+    assertThat(masked).containsEntry("status", 401).containsEntry("retryable", false);
+    assertThat(masked).containsKey("body");
+    assertThat(masked.get("body")).isNull();
+  }
+
+  /** Error variables are supplied by connector authors, so a container may contain itself. */
+  @Test
+  void errorVariables_terminateOnSelfReferencingContainers() {
+    var errorVariables = new HashMap<String, Object>();
+    errorVariables.put("detail", "token super-secret rejected");
+    errorVariables.put("self", errorVariables);
+
+    var masked = maskedErrorVariables(errorVariables);
+
+    assertThat(masked).containsEntry("detail", "token *** rejected");
+    assertThat(masked).containsEntry("self", "[circular reference]");
+  }
+
+  /**
+   * BPMN error boundary events match on the error code, so masking it would silently stop the error
+   * from being caught. Codes come from HTTP statuses and connector-authored constants, not from
+   * remote payloads.
+   */
+  @Test
+  void errorCode_isNotMasked() {
+    var job = jobOnEngine("engine-1");
+    when(job.getRetries()).thenReturn(1);
+    when(secretProvider.fetchAll(any(), any())).thenReturn(List.of("401"));
+
+    var result =
+        handler.handleFinalResultException(
+            new ConnectorException("401", "Unauthorized"), job, SecretFilter.allowAll());
+
+    assertThat(error(result)).containsEntry("code", "401");
+  }
+
+  @SuppressWarnings("unchecked")
+  private Map<String, Object> maskedErrorVariables(Map<String, Object> errorVariables) {
+    var job = jobOnEngine("engine-1");
+    when(job.getRetries()).thenReturn(1);
+    when(secretProvider.fetchAll(any(), any())).thenReturn(List.of("super-secret"));
+
+    var result =
+        handler.handleFinalResultException(
+            new ConnectorException("401", "Unauthorized", null, errorVariables),
+            job,
+            SecretFilter.allowAll());
+
+    return (Map<String, Object>) error(result).get("variables");
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Map<String, Object> error(ConnectorResult.ErrorResult result) {
+    return (Map<String, Object>) ((Map<String, Object>) result.responseValue()).get("error");
   }
 }

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/job/OutboundConnectorExceptionHandlerTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/job/OutboundConnectorExceptionHandlerTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.runtime.outbound.job;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.client.api.response.ActivatedJob;
+import io.camunda.connector.api.secret.SecretContext;
+import io.camunda.connector.api.secret.SecretProvider;
+import io.camunda.connector.runtime.core.secret.SecretFilter;
+import java.time.Duration;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+/**
+ * Secrets are masked out of error output by re-resolving them, so this handler has to resolve
+ * against the same scope {@code JobHandlerContext} used when it substituted them. If the two
+ * disagree, a secret resolved for one engine would not be recognized here and would leak into the
+ * error payload verbatim.
+ */
+class OutboundConnectorExceptionHandlerTest {
+
+  private final SecretProvider secretProvider = mock(SecretProvider.class);
+  private final OutboundConnectorExceptionHandler handler =
+      new OutboundConnectorExceptionHandler(secretProvider);
+
+  private static ActivatedJob jobOnEngine(String physicalTenantId) {
+    var job = mock(ActivatedJob.class);
+    when(job.getVariables()).thenReturn("{\"token\": \"{{secrets.FOO}}\"}");
+    when(job.getTenantId()).thenReturn("my-tenant");
+    when(job.getBpmnProcessId()).thenReturn("my-process");
+    when(job.getPhysicalTenantId()).thenReturn(physicalTenantId);
+    return job;
+  }
+
+  private SecretContext captureSecretContext() {
+    var captor = ArgumentCaptor.forClass(SecretContext.class);
+    verify(secretProvider).fetchAll(any(), captor.capture());
+    return captor.getValue();
+  }
+
+  @Test
+  void manageConnectorJobHandlerException_resolvesSecretsAgainstTheJobsPhysicalTenant() {
+    var job = jobOnEngine("engine-1");
+    when(secretProvider.fetchAll(any(), any())).thenReturn(List.of("secret-value"));
+
+    handler.manageConnectorJobHandlerException(
+        new RuntimeException("boom"), job, Duration.ofSeconds(1), SecretFilter.allowAll());
+
+    assertThat(captureSecretContext())
+        .isEqualTo(new SecretContext("my-tenant", "my-process", "engine-1"));
+  }
+
+  @Test
+  void handleFinalResultException_resolvesSecretsAgainstTheJobsPhysicalTenant() {
+    var job = jobOnEngine("engine-1");
+    when(job.getRetries()).thenReturn(1);
+    when(secretProvider.fetchAll(any(), any())).thenReturn(List.of("secret-value"));
+
+    handler.handleFinalResultException(new RuntimeException("boom"), job, SecretFilter.allowAll());
+
+    assertThat(captureSecretContext())
+        .isEqualTo(new SecretContext("my-tenant", "my-process", "engine-1"));
+  }
+
+  @Test
+  void handleFinalResultException_masksASecretScopedToTheJobsEngine() {
+    // the payoff of scoping correctly: this provider only knows the secret under engine-1, so
+    // resolving with the wrong physical tenant leaves the value unmasked in the error payload
+    var job = jobOnEngine("engine-1");
+    when(job.getRetries()).thenReturn(1);
+    SecretProvider engineScopedProvider =
+        new SecretProvider() {
+          @Override
+          public String getSecret(String name, SecretContext context) {
+            return "FOO".equals(name) && "engine-1".equals(context.physicalTenantId())
+                ? "super-secret"
+                : null;
+          }
+        };
+
+    var result =
+        new OutboundConnectorExceptionHandler(engineScopedProvider)
+            .handleFinalResultException(
+                new RuntimeException("failed talking to https://api?key=super-secret"),
+                job,
+                SecretFilter.allowAll());
+
+    assertThat(result.responseValue().toString()).doesNotContain("super-secret");
+  }
+}

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/secret/EnvironmentSecretProviderNameCompositionTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/secret/EnvironmentSecretProviderNameCompositionTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.runtime.secret;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.connector.api.secret.SecretContext;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.env.MockEnvironment;
+
+/**
+ * Covers how the scope flags compose the environment variable name that a secret is looked up
+ * under. The pre-existing tenant/process-definition combinations are asserted too, since they were
+ * previously built by dedicated methods and are now assembled from a segment list.
+ */
+class EnvironmentSecretProviderNameCompositionTest {
+
+  private static final SecretContext CONTEXT =
+      new SecretContext("my-tenant", "my-process", "engine-1");
+
+  private final MockEnvironment environment = new MockEnvironment();
+
+  private String resolve(
+      String variableName,
+      boolean physicalTenantAware,
+      boolean tenantAware,
+      boolean processDefinitionAware,
+      SecretContext context) {
+    environment.setProperty(variableName, "the-value");
+    var provider =
+        new EnvironmentSecretProvider(
+            environment, "SECRET_", physicalTenantAware, tenantAware, processDefinitionAware);
+    return provider.getSecret("FOO", context);
+  }
+
+  @Test
+  void unscoped_looksUpThePlainPrefixedName() {
+    assertThat(resolve("SECRET_FOO", false, false, false, CONTEXT)).isEqualTo("the-value");
+  }
+
+  @Test
+  void unscoped_resolvesWithoutADependencyOnTheContext() {
+    // SecretProviderAggregator is called with a null context in places; an unscoped provider must
+    // not dereference it
+    assertThat(resolve("SECRET_FOO", false, false, false, null)).isEqualTo("the-value");
+  }
+
+  @Test
+  void tenantAware_prependsTheTenant() {
+    assertThat(resolve("SECRET_my-tenant_FOO", false, true, false, CONTEXT)).isEqualTo("the-value");
+  }
+
+  @Test
+  void processDefinitionAware_prependsTheProcessDefinition() {
+    assertThat(resolve("SECRET_my-process_FOO", false, false, true, CONTEXT))
+        .isEqualTo("the-value");
+  }
+
+  @Test
+  void tenantAndProcessDefinitionAware_prependsBothInOrder() {
+    assertThat(resolve("SECRET_my-tenant_my-process_FOO", false, true, true, CONTEXT))
+        .isEqualTo("the-value");
+  }
+
+  @Test
+  void physicalTenantAware_prependsThePhysicalTenant() {
+    assertThat(resolve("SECRET_engine-1_FOO", true, false, false, CONTEXT)).isEqualTo("the-value");
+  }
+
+  @Test
+  void physicalTenantAware_orderedOutermostWhenCombinedWithTheOtherScopes() {
+    assertThat(resolve("SECRET_engine-1_my-tenant_my-process_FOO", true, true, true, CONTEXT))
+        .isEqualTo("the-value");
+  }
+
+  @Test
+  void physicalTenantAware_fallsBackToDefaultWhenThePhysicalTenantIsUnknown() {
+    // against a cluster that predates multi-engine support. Resolving the unscoped SECRET_FOO
+    // instead would let a misconfigured multi-engine deployment share one secret across engines.
+    var noPhysicalTenant = new SecretContext("my-tenant", "my-process", null);
+
+    assertThat(resolve("SECRET_default_FOO", true, false, false, noPhysicalTenant))
+        .isEqualTo("the-value");
+  }
+
+  @Test
+  void physicalTenantAware_doesNotFallBackToTheUnscopedName() {
+    assertThat(resolve("SECRET_FOO", true, false, false, CONTEXT)).isNull();
+  }
+
+  @Test
+  void physicalTenantAware_doesNotResolveASecretScopedToAnotherEngine() {
+    assertThat(resolve("SECRET_engine-2_FOO", true, false, false, CONTEXT)).isNull();
+  }
+}

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/main/java/io/camunda/connector/runtime/ConnectorsAutoConfiguration.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/main/java/io/camunda/connector/runtime/ConnectorsAutoConfiguration.java
@@ -87,6 +87,9 @@ public class ConnectorsAutoConfiguration {
   @Value("${camunda.connector.secretprovider.environment.prefix:SECRET_}")
   String environmentSecretProviderPrefix;
 
+  @Value("${camunda.connector.secretprovider.environment.physicaltenantaware:false}")
+  boolean environmentSecretProviderPhysicalTenantAware;
+
   @Value("${camunda.connector.secretprovider.environment.tenantaware:false}")
   boolean environmentSecretProviderTenantAware;
 
@@ -160,6 +163,7 @@ public class ConnectorsAutoConfiguration {
     return new EnvironmentSecretProvider(
         environment,
         environmentSecretProviderPrefix,
+        environmentSecretProviderPhysicalTenantAware,
         environmentSecretProviderTenantAware,
         environmentSecretProviderProcessDefinitionAware);
   }

--- a/connector-sdk/core/src/main/java/io/camunda/connector/api/secret/SecretContext.java
+++ b/connector-sdk/core/src/main/java/io/camunda/connector/api/secret/SecretContext.java
@@ -16,4 +16,33 @@
  */
 package io.camunda.connector.api.secret;
 
-public record SecretContext(String tenantId, String processDefinitionId) {}
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Scope in which a secret is resolved.
+ *
+ * @param tenantId the logical (multi-tenancy) tenant the process belongs to
+ * @param processDefinitionId the BPMN process definition ID the secret is resolved for
+ * @param physicalTenantId identifies the orchestration cluster (engine) the process runs on, so
+ *     that secrets can be resolved per engine in multi-engine deployments. {@code null} when the
+ *     runtime could not determine it, e.g. against a cluster that predates multi-engine support.
+ */
+public record SecretContext(
+    String tenantId, String processDefinitionId, @Nullable String physicalTenantId) {
+
+  public SecretContext {
+    // clients report an unset physical tenant as an empty string (protobuf/REST default);
+    // normalize it so providers only have to check for null
+    if (physicalTenantId != null && physicalTenantId.isBlank()) {
+      physicalTenantId = null;
+    }
+  }
+
+  /**
+   * Retains the pre-multi-engine constructor signature so code compiled against the previous record
+   * shape keeps working. Leaves {@link #physicalTenantId()} unset.
+   */
+  public SecretContext(String tenantId, String processDefinitionId) {
+    this(tenantId, processDefinitionId, null);
+  }
+}

--- a/connector-sdk/core/src/test/java/io/camunda/connector/api/secret/SecretContextTest.java
+++ b/connector-sdk/core/src/test/java/io/camunda/connector/api/secret/SecretContextTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.api.secret;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class SecretContextTest {
+
+  @Test
+  void keepsTheProvidedPhysicalTenantId() {
+    var context = new SecretContext("tenant", "process", "engine-1");
+
+    assertThat(context.physicalTenantId()).isEqualTo("engine-1");
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"", " "})
+  void normalizesABlankPhysicalTenantIdToNull(String blank) {
+    // clients surface an unset physical tenant as an empty string, providers should only ever
+    // have to null-check
+    var context = new SecretContext("tenant", "process", blank);
+
+    assertThat(context.physicalTenantId()).isNull();
+  }
+
+  @Test
+  void legacyConstructorLeavesThePhysicalTenantIdUnset() {
+    var context = new SecretContext("tenant", "process");
+
+    assertThat(context.tenantId()).isEqualTo("tenant");
+    assertThat(context.processDefinitionId()).isEqualTo("process");
+    assertThat(context.physicalTenantId()).isNull();
+  }
+}


### PR DESCRIPTION
## Description

Multi-engine deployments need secrets resolved per orchestration cluster, but `SecretProvider` implementations currently have no way to tell which engine a process is running on — `SecretContext` only carries the logical tenant and the process definition ID.

This adds a `physicalTenantId` component to `SecretContext` and populates it at every place secrets are resolved:

- **Outbound** — sourced from `ActivatedJob.getPhysicalTenantId()`, both when substituting secrets into job variables (`JobHandlerContext`) and when masking them out of error output (`OutboundConnectorExceptionHandler`). These two have to agree: masking works by re-resolving the secret, so if the substituting path scoped to engine A and the masking path didn't, the value would be re-resolved as "not found" and leak into the error payload verbatim.
- **Inbound** — sourced from the connector element, via a `getPhysicalTenantId()` helper extracted from the lookup that already existed inline in `getDefinition()`.

Two compatibility details worth calling out for review:

- The record keeps its previous 2-arg constructor, so third-party `SecretProvider` implementations and existing call sites compile unchanged. `physicalTenantId` is `@Nullable`.
- Clients report an unset physical tenant as an **empty string** (`ActivatedJobImpl` uses `getOrEmpty`), so the compact constructor normalizes blank to `null`. Without this, every provider would have to null-check *and* blank-check.

No behavior changes for single-cluster deployments — the new component is purely additive and providers that ignore it resolve exactly as before.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #6959

## Checklist

- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest
  release, as this branch will be rebased onto main before the next release. Example backport labels:
    - `backport stable/8.8`: for changes that should be included in the next 8.8.x release.
    - **or** `backport release-8.8.7`: for changes that should be included in the specific release 8.8.7, and this
      *release has already been created*. The release branch will be merged back into stable/8.8 later, so the change
      will be included in future 8.8.x releases as well.
- [ ] Tests/Integration tests for the changes have been added if applicable.
- [ ] If the change requires a documentation update, it has been added to the appropriate section in the documentation.


