### PR TITLE
[Backport release-8.7.23] fix: override lz4-java to 1.11.1 (transitive)

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -123,6 +123,9 @@ limitations under the License.</license.inlineheader>
     <version.commons-codec>1.16.1</version.commons-codec>
 
     <version.kafka-clients>3.9.2</version.kafka-clients>
+    <!-- CVE-2026-59949: lz4-java transitive override — remove once kafka-clients ships lz4-java >= 1.11.1
+         Ref: https://nvd.nist.gov/vuln/detail/CVE-2026-59949 -->
+    <version.lz4-java>1.11.1</version.lz4-java>
 
     <version.microsoft-graph>6.67.0</version.microsoft-graph>
     <version.azure-identity>1.18.4</version.azure-identity>
@@ -501,6 +504,14 @@ limitations under the License.</license.inlineheader>
         <version>${version.kafka-clients}</version>
       </dependency>
 
+      <!-- CVE-2026-59949 (https://nvd.nist.gov/vuln/detail/CVE-2026-59949): override lz4-java transitive
+           version brought in by kafka-clients. Remove once kafka-clients ships lz4-java >= 1.11.1. -->
+      <dependency>
+        <groupId>at.yawk.lz4</groupId>
+        <artifactId>lz4-java</artifactId>
+        <version>${version.lz4-java}</version>
+      </dependency>
+
       <dependency>
         <groupId>com.microsoft.graph</groupId>
         <artifactId>microsoft-graph</artifactId>
@@ -839,6 +850,18 @@ limitations under the License.</license.inlineheader>
               <requirePluginVersions>
                 <banSnapshots>false</banSnapshots>
               </requirePluginVersions>
+              <!-- CVE-2026-59949 guard: fails if kafka-clients is bumped, as a reminder to
+                   check whether the lz4-java override can be removed (see version.lz4-java). -->
+              <requireProperty>
+                <property>version.kafka-clients</property>
+                <regex>^3\.9\.2$</regex>
+                <regexMessage>
+version.kafka-clients was changed! Check if the lz4-java CVE-2026-59949 override can be removed.
+If the new kafka-clients version ships lz4-java &gt;= 1.11.1, remove the version.lz4-java property,
+the lz4-java dependencyManagement entry, and this enforcer rule from parent/pom.xml.
+See: https://nvd.nist.gov/vuln/detail/CVE-2026-59949
+                </regexMessage>
+              </requireProperty>
             </rules>
           </configuration>
           <executions>


### PR DESCRIPTION
## Summary

Manual backport of #8114 to `release-8.7.23` — the automated backport-action failed to cherry-pick cleanly because this branch is on `kafka-clients 3.9.2` (vs. 4.3.1 on main), so the enforcer guard regex differs.

Adds a `dependencyManagement` override pinning the transitive `at.yawk.lz4:lz4-java` dependency (pulled in via `kafka-clients`) to `1.11.1`, plus a Maven Enforcer rule that will fail the build once `kafka-clients` is upgraded on this branch — a reminder to check if the override can be removed at that point.

Security fix. Details in the internal tracking issue: camunda/team-connectors#1249