### PR TITLE
fix: update release workflow to import secrets and create Maven settings

### DIFF
--- a/.github/workflows/RELEASE.yaml
+++ b/.github/workflows/RELEASE.yaml
@@ -113,6 +113,44 @@ jobs:
       - name: Install element templates CLI
         run: npm install --global element-templates-cli@$(jq -r '.devDependencies["element-templates-cli"]' .github/workflows/package.json)
 
+      # Credentials and ~/.m2/settings.xml must be in place before the first Maven
+      # invocation below, otherwise Maven resolves the POM anonymously and 401s on
+      # any artifact that is not publicly available on Maven Central.
+      - name: Import Secrets
+        id: vault-secrets
+        uses: hashicorp/vault-action@892a26828f195e65540a40b4768ae4571f51ebfc # v4.0.0
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          exportEnv: false
+          secrets: |
+            secret/data/products/connectors/ci/common GITHUB_APP_ID;
+            secret/data/products/connectors/ci/common GITHUB_APP_PRIVATE_KEY;
+            secret/data/products/connectors/ci/nexus USER | CI_NEXUS_USR;
+            secret/data/products/connectors/ci/nexus PASSWORD | CI_NEXUS_PSW;
+
+      - name: 'Create settings.xml'
+        uses: s4u/maven-settings-action@v4.0.0
+        with:
+          githubServer: false
+          # Mirror uses id=nexus-mirror (distinct from deploy id=camunda-nexus) so each gets the right credentials:
+          # - nexus-mirror: CI Nexus creds for the pull-through cache at repository.nexus.camunda.cloud
+          # - camunda-nexus: Nexus creds for resolving artifacts
+          servers: |
+            [{
+              "id": "nexus-mirror",
+              "username": "${{ steps.vault-secrets.outputs.CI_NEXUS_USR }}",
+              "password": "${{ steps.vault-secrets.outputs.CI_NEXUS_PSW }}"
+             },
+             {
+               "id": "camunda-nexus",
+               "username": "${{ steps.vault-secrets.outputs.CI_NEXUS_USR }}",
+               "password": "${{ steps.vault-secrets.outputs.CI_NEXUS_PSW }}"
+             }]
+          mirrors: '[{"url": "https://repository.nexus.camunda.cloud/content/groups/internal/", "id": "nexus-mirror", "mirrorOf": "*,!confluent,!shibboleth", "name": "camunda Nexus"}]'
+
         # Maven build & version bump
       - name: Set Connectors release version
         run: ./mvnw -B versions:set -DnewVersion=${RELEASE_VERSION} -DgenerateBackupPoms=false -f parent
@@ -136,18 +174,6 @@ jobs:
       - name: Generate sbom reports
         run: |
           ./mvnw cyclonedx:makeAggregateBom -pl bundle/default-bundle
-
-      - name: Import Secrets
-        id: vault-secrets
-        uses: hashicorp/vault-action@4c06c5ccf5c0761b6029f56cfb1dcf5565918a3b # v3.4.0
-        with:
-          url: ${{ secrets.VAULT_ADDR }}
-          method: approle
-          roleId: ${{ secrets.VAULT_ROLE_ID }}
-          secretId: ${{ secrets.VAULT_SECRET_ID }}
-          secrets: |
-            secret/data/products/connectors/ci/common GITHUB_APP_ID;
-            secret/data/products/connectors/ci/common GITHUB_APP_PRIVATE_KEY;
 
       - name: Generate a GitHub App token
         id: app-token


### PR DESCRIPTION
This pull request updates the secrets management and Maven configuration in the release workflow to improve security and reliability. The main changes involve moving the Vault secrets import and Maven `settings.xml` creation steps earlier in the workflow, updating the Vault action version, and ensuring Maven credentials are in place before any Maven command is run.

**Secrets management and Maven configuration:**

* Moved the Vault secrets import step and the creation of the Maven `settings.xml` file to run before the first Maven invocation, ensuring Maven always has the necessary credentials to resolve private artifacts.
* Updated the `hashicorp/vault-action` from version `v3.4.0` to a specific commit from `v4.0.0` for improved security and compatibility. [[1]](diffhunk://#diff-7c90c3dea924e481fe4ec37ecf28a6dcd64d17a06a2f633c095994572e48a3ceR116-R153) [[2]](diffhunk://#diff-7c90c3dea924e481fe4ec37ecf28a6dcd64d17a06a2f633c095994572e48a3ceL140-L151)
* Removed a redundant Vault secrets import step later in the workflow, as secrets are now imported earlier.
* Configured the `s4u/maven-settings-action` to generate a `settings.xml` with credentials for both `nexus-mirror` and `camunda-nexus`, using secrets fetched from Vault, and set up a Nexus mirror for Maven artifact resolution.