### PR TITLE
fix(ci): pin CODEOWNERS Slack-mentions action to @main in E2E notify job

### DIFF
--- a/.github/workflows/E2E_BRANCH_RUN.yml
+++ b/.github/workflows/E2E_BRANCH_RUN.yml
@@ -267,10 +267,13 @@ jobs:
 
       # Resolve owning teams to Slack groups; medic is always included as the fallback.
       # Map is built from secrets (full-mention format); an unset secret falls back to medic.
+      # Pinned to @main (not a local ./ path): the checkout above is at inputs.branch (e.g. a
+      # stable/* branch) for CODEOWNERS, but this workflow file itself only lives on main, so the
+      # action must too - a local ref would 404 on branches that never had this action backported.
       - name: Derive Slack mentions from CODEOWNERS
         id: mentions
         continue-on-error: true
-        uses: ./.github/actions/codeowners-slack-mentions
+        uses: camunda/connectors/.github/actions/codeowners-slack-mentions@main
         with:
           paths: ${{ steps.modules.outputs.module_paths }}
           team-slack-map: |


### PR DESCRIPTION
## Description

The `notify` job in `E2E_BRANCH_RUN.yml` checks out `inputs.branch` (e.g. a `stable/*` branch) so it can read that branch's `CODEOWNERS`, then resolved Slack mentions via a local `./.github/actions/codeowners-slack-mentions` reference. A local `./` ref resolves from the *currently checked-out* commit, not from wherever the workflow file itself lives — but `E2E_BRANCH_RUN.yml` is only ever invoked from `main` (via a local-ref `workflow_call` in `NIGHTLY_E2E.yml`, which only runs on schedule/dispatch off the default branch). Older `stable/*` branches never had this action backported, so the step failed to find it and silently fell back to the medic-only Slack mention (see [thread](https://camunda.slack.com/archives/C05Q7C4HJ5Q/p1785300994580719) — E2E failure notify on `stable/8.9` hit exactly this).

Fix: pin the action reference to `camunda/connectors/.github/actions/codeowners-slack-mentions@main` instead of the local path. `CODEOWNERS` itself still resolves from the checked-out branch (`inputs.branch`), which is correct — ownership is genuinely branch-specific. This fixes mention resolution on every branch without ever needing to backport the action itself, since the workflow file that calls it only exists on `main` anyway.

## Related issues

n/a

## Checklist

- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest
  release, as this branch will be rebased onto main before the next release. Example backport labels:
    - `backport stable/8.8`: for changes that should be included in the next 8.8.x release.
    - **or** `backport release-8.8.7`: for changes that should be included in the specific release 8.8.7, and this
      *release has already been created*. The release branch will be merged back into stable/8.8 later, so the change
      will be included in future 8.8.x releases as well.
- [x] Tests/Integration tests for the changes have been added if applicable. (workflow-only change; see below for how to exercise it)
- [ ] If the change requires a documentation update, it has been added to the appropriate section in the documentation.