### PR TITLE
fix(release): update Artifactory credentials and adjust mirror configurations in settings.xml

### DIFF
--- a/.github/workflows/RELEASE.yaml
+++ b/.github/workflows/RELEASE.yaml
@@ -135,14 +135,22 @@ jobs:
             secret/data/products/connectors/ci/common GITHUB_APP_PRIVATE_KEY;
             secret/data/products/connectors/ci/nexus USER | CI_NEXUS_USR;
             secret/data/products/connectors/ci/nexus PASSWORD | CI_NEXUS_PSW;
+            secret/data/products/connectors/ci/artifactory USER | ARTIFACTORY_USR;
+            secret/data/products/connectors/ci/artifactory TOKEN | ARTIFACTORY_PSW;
 
       - name: 'Create settings.xml'
         uses: s4u/maven-settings-action@v4.0.0
         with:
           githubServer: false
-          # Mirror uses id=nexus-mirror (distinct from deploy id=camunda-nexus) so each gets the right credentials:
+          # Two mirrors, because the HeroDevs NES repo is not served by the CI Nexus cache:
+          # - camunda-nexus: mirrors herodevs-nes to the internal Artifactory virtual repo.
+          #   Required on stable/8.7 and stable/8.8, whose parent/pom.xml pins an NES-only
+          #   Spring Boot patch. Inert on main (no herodevs-nes repository declared).
+          #   Mirror credentials are keyed on the *mirror* id, so camunda-nexus carries the
+          #   Artifactory creds. See the HeroDevs NES PSA in #prj-spring-boot-35-end-of-oss-support.
           # - nexus-mirror: CI Nexus creds for the pull-through cache at repository.nexus.camunda.cloud
-          # - camunda-nexus: Nexus creds for resolving artifacts
+          #   for everything else. herodevs-nes is excluded so the wildcard cannot swallow it —
+          #   Maven picks the first matching mirror by declaration order, not by specificity.
           servers: |
             [{
               "id": "nexus-mirror",
@@ -151,10 +159,10 @@ jobs:
              },
              {
                "id": "camunda-nexus",
-               "username": "${{ steps.vault-secrets.outputs.CI_NEXUS_USR }}",
-               "password": "${{ steps.vault-secrets.outputs.CI_NEXUS_PSW }}"
+               "username": "${{ steps.vault-secrets.outputs.ARTIFACTORY_USR }}",
+               "password": "${{ steps.vault-secrets.outputs.ARTIFACTORY_PSW }}"
              }]
-          mirrors: '[{"url": "https://repository.nexus.camunda.cloud/content/groups/internal/", "id": "nexus-mirror", "mirrorOf": "*,!confluent,!shibboleth", "name": "camunda Nexus"}]'
+          mirrors: '[{"url": "https://artifacts.camunda.com/artifactory/internal", "id": "camunda-nexus", "mirrorOf": "herodevs-nes", "name": "camunda Nexus"}, {"url": "https://repository.nexus.camunda.cloud/content/groups/internal/", "id": "nexus-mirror", "mirrorOf": "*,!confluent,!shibboleth,!herodevs-nes", "name": "camunda Nexus"}]'
 
         # Maven build & version bump
       - name: Set Connectors release version


### PR DESCRIPTION
This pull request updates the CI/CD release workflow to improve how Maven resolves dependencies, specifically for handling the HeroDevs NES repository. The main changes involve configuring Artifactory credentials and adjusting Maven mirror settings to ensure the correct repository is used for specific dependencies.

Dependency resolution and credentials:

* Added Artifactory credentials (`ARTIFACTORY_USR`, `ARTIFACTORY_PSW`) to the Vault secrets for use in the workflow, enabling access to the internal Artifactory repository.
* Updated the `camunda-nexus` server configuration to use Artifactory credentials instead of Nexus credentials.

Maven mirror configuration:

* Configured two Maven mirrors:
  * `camunda-nexus` now points to Artifactory and is used exclusively for the `herodevs-nes` repository.
  * `nexus-mirror` continues to point to the internal Nexus repository for all other dependencies, explicitly excluding `herodevs-nes` to prevent conflicts.
* Updated documentation in the workflow to clarify the purpose and behavior of each mirror, especially regarding the handling of the HeroDevs NES repository and credential assignment.