### PR TITLE
test(agentic-ai): deploy element-template regression fixtures as recorded

### DIFF
--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/subprocess/AgentSubProcessElementTemplateRegressionTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/subprocess/AgentSubProcessElementTemplateRegressionTests.java
@@ -19,6 +19,7 @@ package io.camunda.connector.e2e.agenticai.aiagent.subprocess;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.connector.agenticai.aiagent.model.AgentMetrics;
+import io.camunda.connector.e2e.BpmnFile;
 import io.camunda.connector.e2e.agenticai.aiagent.wiremock.openai.OpenAiCompletionsChatModelStubs;
 import io.camunda.connector.e2e.agenticai.aiagent.wiremock.openai.OpenAiCompletionsChatModelStubs.ToolCall;
 import io.camunda.connector.e2e.agenticai.aiagent.wiremock.openai.OpenAiCompletionsChatModelStubs.Turn;
@@ -29,6 +30,25 @@ import java.util.Map;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
+/**
+ * Verifies that AI Agent sub-processes modeled against <em>older</em> element template versions
+ * keep working against the current connector code.
+ *
+ * <p>The BPMN fixtures under {@code src/test/resources/regression/} are recordings of real,
+ * previously deployed processes. They must be deployed <strong>exactly as recorded</strong> — do
+ * not regenerate them, do not reapply the current element template to them, and do not hand-edit
+ * their input mappings to match today's defaults. The moment a fixture is brought in line with the
+ * current template it stops representing a legacy deployment and this class no longer tests
+ * anything.
+ *
+ * <p>For that reason these tests deploy the fixture model directly instead of going through {@link
+ * io.camunda.connector.e2e.agenticai.aiagent.BaseAgentTest#createProcessInstance(
+ * org.springframework.core.io.Resource, java.util.Map)}, which would first reapply the current
+ * element template — including the {@code elementTemplateProperties()} overrides that exist for the
+ * behavioral tests. Those overrides describe how we configure an agent <em>today</em>; forcing them
+ * onto a legacy recording overwrites the very values under test. Everything the process needs at
+ * runtime therefore has to come from the fixture itself plus the process variables passed in below.
+ */
 @SlowTest
 public class AgentSubProcessElementTemplateRegressionTests extends BaseAgentSubProcessTest {
 
@@ -63,7 +83,7 @@ public class AgentSubProcessElementTemplateRegressionTests extends BaseAgentSubP
     final var zeebeTest =
         awaitProcessCompletion(
             createProcessInstance(
-                processResource,
+                new BpmnFile(processResource.getFile()).getBpmnModelInstance(),
                 Map.of(
                     "userPrompt",
                     initialUserPrompt,

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/task/AgentTaskElementTemplateRegressionTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/task/AgentTaskElementTemplateRegressionTests.java
@@ -19,6 +19,7 @@ package io.camunda.connector.e2e.agenticai.aiagent.task;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.connector.agenticai.aiagent.model.AgentMetrics;
+import io.camunda.connector.e2e.BpmnFile;
 import io.camunda.connector.e2e.agenticai.aiagent.wiremock.openai.OpenAiCompletionsChatModelStubs;
 import io.camunda.connector.e2e.agenticai.aiagent.wiremock.openai.OpenAiCompletionsChatModelStubs.ToolCall;
 import io.camunda.connector.e2e.agenticai.aiagent.wiremock.openai.OpenAiCompletionsChatModelStubs.Turn;
@@ -29,6 +30,25 @@ import java.util.Map;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
+/**
+ * Verifies that AI Agent processes modeled against <em>older</em> element template versions keep
+ * working against the current connector code.
+ *
+ * <p>The BPMN fixtures under {@code src/test/resources/regression/} are recordings of real,
+ * previously deployed processes. They must be deployed <strong>exactly as recorded</strong> — do
+ * not regenerate them, do not reapply the current element template to them, and do not hand-edit
+ * their input mappings to match today's defaults. The moment a fixture is brought in line with the
+ * current template it stops representing a legacy deployment and this class no longer tests
+ * anything.
+ *
+ * <p>For that reason these tests deploy the fixture model directly instead of going through {@link
+ * io.camunda.connector.e2e.agenticai.aiagent.BaseAgentTest#createProcessInstance(
+ * org.springframework.core.io.Resource, java.util.Map)}, which would first reapply the current
+ * element template — including the {@code elementTemplateProperties()} overrides that exist for the
+ * behavioral tests. Those overrides describe how we configure an agent <em>today</em>; forcing them
+ * onto a legacy recording overwrites the very values under test. Everything the process needs at
+ * runtime therefore has to come from the fixture itself plus the process variables passed in below.
+ */
 @SlowTest
 public class AgentTaskElementTemplateRegressionTests extends BaseAgentTaskTest {
 
@@ -63,7 +83,7 @@ public class AgentTaskElementTemplateRegressionTests extends BaseAgentTaskTest {
     final var zeebeTest =
         awaitProcessCompletion(
             createProcessInstance(
-                processResource,
+                new BpmnFile(processResource.getFile()).getBpmnModelInstance(),
                 Map.of(
                     "userPrompt",
                     initialUserPrompt,


### PR DESCRIPTION
## Description

The BPMN files under `connectors-e2e-test-agentic-ai/src/test/resources/regression/` are recordings of real,
previously deployed processes. They exist to prove that diagrams modeled against *older* element template
versions still run against current connector code — which only works as long as they stay stale.

Both regression test classes deployed them through `BaseAgentTest.createProcessInstance(Resource, Map)`.
That overload reapplies the current element template via `element-templates-cli` before deploying, and layers
the `elementTemplateProperties()` overrides on top. Those overrides describe how we configure an agent
*today* — among them `data.response.includeAssistantMessage = "=true"` — so they overwrote exactly the
recorded values under test. `AgentTaskElementTemplateRegressionTests` then asserted `hasNoResponseMessage()`,
which contradicts that override outright.

The conflict was invisible until now because `element-templates-cli` 0.5.0 kept the element's existing value
for Boolean properties, so the forced `"=true"` never reached the deployed model. 0.6.0 added a
`type === "Boolean"` short circuit to `shouldKeepValue()`, started honoring the template value, and surfaced
it — which is what turned CI red.

This PR deploys the fixture model directly instead, restoring the behavior these tests had before #7463
introduced the identity-modifier overload. Everything a fixture needs at runtime now comes from the recording
plus the process variables the test passes in (`providerEndpoint`, which the recordings already reference as
`=providerEndpoint`). The rule is documented as javadoc on both test classes so the fixtures don't get
"fixed" into matching today's template later.

**Not in scope:** our element templates also use the deprecated value-less `optional: true` Boolean +
`zeebe:input` construct, which 0.6.0 drops from the `ioMapping` entirely on reapply. That's a real problem,
but independent of this test regression — it gets its own PR.

## Related issues

CI failure this fixes: https://github.com/camunda/connectors/actions/runs/30421265485

<!-- no tracking issue -->

## Checklist

- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest
  release, as this branch will be rebased onto main before the next release. Example backport labels:
    - `backport stable/8.8`: for changes that should be included in the next 8.8.x release.
    - **or** `backport release-8.8.7`: for changes that should be included in the specific release 8.8.7, and this
      *release has already been created*. The release branch will be merged back into stable/8.8 later, so the change
      will be included in future 8.8.x releases as well.

  No backport needed — `stable/8.9` and `stable/8.8` still deploy these fixtures raw (the identity-modifier
  overload from #7463 is not on those branches), so they are structurally immune to this.
- [x] Tests/Integration tests for the changes have been added if applicable. — this PR *is* the test change.
- [x] If the change requires a documentation update, it has been added to the appropriate section in the documentation.
  — no user-facing change.
