### PR TITLE
fix(inbound): retry publishing a lost process state change

### DIFF
--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/InboundConnectorRuntimeConfiguration.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/InboundConnectorRuntimeConfiguration.java
@@ -224,7 +224,9 @@ public class InboundConnectorRuntimeConfiguration {
   public ProcessStateManager processStateManager(
       InboundExecutableRegistry registry,
       ProcessDefinitionInspector inspector,
-      ProcessStateContainer processStateContainer) {
-    return new ProcessStateManagerImpl(processStateContainer, inspector, registry);
+      ProcessStateContainer processStateContainer,
+      ConnectorsInboundMetrics connectorsInboundMetrics) {
+    return new ProcessStateManagerImpl(
+        processStateContainer, inspector, registry, connectorsInboundMetrics);
   }
 }

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/README.md
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/README.md
@@ -81,6 +81,15 @@ ImportSchedulers:
 These results are merged into the process state store. If the relevant versions for a process
 change, the runtime publishes a `ProcessStateChanged` event.
 
+A given state transition is only ever reported once: the state store commits it before the event is
+published, so a subsequent import of unchanged data yields no diff. Publishing can fail — it fetches
+the BPMN model from the Orchestration Cluster, which may be briefly unreachable during a rolling
+update — so `ProcessStateManagerImpl` queues any process whose event it could not publish and retries
+it on the next poll, re-reading the active versions from the state store rather than reusing the ones
+it failed with. Without that retry the process would be recorded as active while its connectors were
+never activated, and nothing would ever notice. Failures are counted by
+`camunda.connector.inbound.process-state-change.publish-failures`.
+
 Then the executable store is updated from those events:
 
 ```text
@@ -115,6 +124,7 @@ flowchart TD
     T --> importSchedulers
     S1 & S2 --> OC --> PS
     PS -->|versions changed| EV --> registry
+    EV -->|publish failed, retry next poll| PS
 ```
 
 ### When the listener receives an event, e.g. a new email in the inbox

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/state/ProcessStateContainer.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/state/ProcessStateContainer.java
@@ -17,7 +17,9 @@
 package io.camunda.connector.runtime.inbound.state;
 
 import io.camunda.connector.runtime.inbound.state.model.ImportResult;
+import io.camunda.connector.runtime.inbound.state.model.ProcessDefinitionRef;
 import io.camunda.connector.runtime.inbound.state.model.StateUpdateResult;
+import java.util.Set;
 
 /**
  * Container for the current process state. It is responsible for comparing the current state with
@@ -37,4 +39,18 @@ public interface ProcessStateContainer {
    *     deactivated
    */
   StateUpdateResult compareAndUpdate(ImportResult importResult);
+
+  /**
+   * Returns the process definition keys (versions) currently active for the given process, without
+   * modifying any state.
+   *
+   * <p>{@link #compareAndUpdate} only reports a given state transition once, so a caller that
+   * failed to act on one cannot obtain it again from a later import. This lets such a caller
+   * re-read the current state instead, so its retry acts on what is active now rather than on a
+   * remembered — and possibly superseded — set of versions.
+   *
+   * @param processRef the process definition to look up
+   * @return the active process definition keys, or an empty set if the process is not tracked
+   */
+  Set<Long> getActiveVersions(ProcessDefinitionRef processRef);
 }

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/state/ProcessStateContainerImpl.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/state/ProcessStateContainerImpl.java
@@ -105,7 +105,8 @@ public class ProcessStateContainerImpl implements ProcessStateContainer {
   }
 
   /** Returns the set of currently active process definition keys for a given process definition. */
-  private Set<Long> getActiveVersions(ProcessDefinitionRef processRef) {
+  @Override
+  public synchronized Set<Long> getActiveVersions(ProcessDefinitionRef processRef) {
     var versionsInState = processStates.get(processRef);
     if (versionsInState == null) {
       return Set.of();

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/state/ProcessStateManagerImpl.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/state/ProcessStateManagerImpl.java
@@ -24,13 +24,33 @@ import io.camunda.connector.runtime.inbound.executable.InboundExecutableRegistry
 import io.camunda.connector.runtime.inbound.state.model.ImportResult;
 import io.camunda.connector.runtime.inbound.state.model.ProcessDefinitionRef;
 import io.camunda.connector.runtime.inbound.state.model.StateUpdateResult;
+import io.camunda.connector.runtime.metrics.ConnectorsInboundMetrics;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Turns imported process data into {@code ProcessStateChanged} events.
+ *
+ * <p><b>Assumes the two {@code @Scheduled} importers in {@code ImportSchedulers} do not
+ * overlap.</b> {@code compareAndUpdate} releases the container's lock before we publish, so the
+ * versions we publish are a snapshot taken earlier. Two polls running concurrently for the same
+ * physical tenant could therefore queue snapshots out of order, and because the executable registry
+ * applies events in queue order, an older snapshot arriving last would win with no diff left to
+ * correct it. This holds for the retry path in this class and equally for the plain diff path,
+ * which has always published outside the lock.
+ *
+ * <p>Spring Boot's default single-threaded task scheduler serializes those importers, which is what
+ * makes the assumption hold today; nothing here enforces it. Note that {@code @EnableScheduling}
+ * ships in the public connectors starter, so an embedding application that raises {@code
+ * spring.task.scheduling.pool.size} would break it. Fan-out across physical tenants within a single
+ * poll is safe — {@code pendingRetries} is tenant-scoped, so those threads never contend for the
+ * same process.
+ */
 public class ProcessStateManagerImpl implements ProcessStateManager {
 
   private static final Logger LOG = LoggerFactory.getLogger(ProcessStateManagerImpl.class);
@@ -38,79 +58,125 @@ public class ProcessStateManagerImpl implements ProcessStateManager {
   private final ProcessStateContainer processStateContainer;
   private final ProcessDefinitionInspector processDefinitionInspector;
   private final InboundExecutableRegistry executableRegistry;
+  private final ConnectorsInboundMetrics metrics;
+
+  /**
+   * Processes whose state change could not be published, to be retried on the next poll for their
+   * physical tenant. Only the reference is kept, never the versions it failed with — those are
+   * re-read from the container at retry time, see {@link #pendingRetries}.
+   */
+  private final Set<ProcessDefinitionRef> failedToPublish = ConcurrentHashMap.newKeySet();
 
   public ProcessStateManagerImpl(
       ProcessStateContainer processStateContainer,
       ProcessDefinitionInspector processDefinitionInspector,
-      InboundExecutableRegistry executableRegistry) {
+      InboundExecutableRegistry executableRegistry,
+      ConnectorsInboundMetrics metrics) {
     this.processStateContainer = processStateContainer;
     this.processDefinitionInspector = processDefinitionInspector;
     this.executableRegistry = executableRegistry;
+    this.metrics = metrics;
   }
 
   @Override
   public void update(ImportResult processDefinitions) {
     StateUpdateResult result = processStateContainer.compareAndUpdate(processDefinitions);
 
-    if (result.isEmpty()) {
+    var toPublish = pendingRetries(processDefinitions.physicalTenantId());
+    // A change reported by this import supersedes a pending retry for the same process: it reflects
+    // the state as of now, whereas the retry was only queued for one that we never delivered.
+    toPublish.putAll(result.affectedProcesses());
+
+    if (toPublish.isEmpty()) {
       LOG.debug("No process state changes detected");
       return;
     }
 
     // For each affected process, fetch connector elements for all active versions and publish event
-    for (var entry : result.affectedProcesses().entrySet()) {
+    for (var entry : toPublish.entrySet()) {
       var processRef = entry.getKey();
       var activeVersionKeys = entry.getValue();
-      publishProcessStateChangedEvent(processRef, activeVersionKeys);
+      try {
+        publishProcessStateChangedEvent(processRef, activeVersionKeys);
+      } catch (Exception e) {
+        // compareAndUpdate has already committed the transition and only ever reports it once, so
+        // this change would never be seen again. Queue the process for retry — otherwise a
+        // transient failure here (typically the Orchestration Cluster being briefly unreachable
+        // while the BPMN model is fetched) would strand its connectors until the runtime is
+        // restarted. Other processes in this batch are unaffected.
+        failedToPublish.add(processRef);
+        metrics.increaseProcessStateChangePublishFailure();
+        LOG.error(
+            "Failed to publish state change event for process '{}' (tenant '{}', physical tenant"
+                + " '{}'); will retry on the next poll",
+            processRef.bpmnProcessId(),
+            processRef.tenantId(),
+            processRef.physicalTenantId(),
+            e);
+      }
     }
+  }
+
+  /**
+   * Removes the processes queued for retry that belong to the given physical tenant, resolved
+   * against the state as it is now. Scoped to one physical tenant because each import batch only
+   * reports on its own, and re-read rather than remembered so that a retry cannot publish a set of
+   * versions that has since been superseded.
+   *
+   * <p>The removal is atomic so that concurrent polls cannot both drain the same entry and publish
+   * it twice. That is all the concurrency this method guarantees on its own — see the class javadoc
+   * for the ordering assumption it inherits.
+   */
+  private Map<ProcessDefinitionRef, Set<Long>> pendingRetries(String physicalTenantId) {
+    Map<ProcessDefinitionRef, Set<Long>> retries = new HashMap<>();
+    for (var processRef : List.copyOf(failedToPublish)) {
+      if (processRef.physicalTenantId().equals(physicalTenantId)
+          && failedToPublish.remove(processRef)) {
+        retries.put(processRef, processStateContainer.getActiveVersions(processRef));
+      }
+    }
+    if (!retries.isEmpty()) {
+      LOG.debug("Retrying {} previously unpublished process state change(s)", retries.keySet());
+    }
+    return retries;
   }
 
   private void publishProcessStateChangedEvent(
       ProcessDefinitionRef processRef, Set<Long> activeVersionKeys) {
-    try {
-      Map<Long, List<InboundConnectorElement>> elementsByVersion = new HashMap<>();
+    Map<Long, List<InboundConnectorElement>> elementsByVersion = new HashMap<>();
 
-      // Determine the latest version key (highest value)
-      Long latestVersionKey = activeVersionKeys.stream().max(Long::compareTo).orElse(null);
+    // Determine the latest version key (highest value)
+    Long latestVersionKey = activeVersionKeys.stream().max(Long::compareTo).orElse(null);
 
-      for (Long versionKey : activeVersionKeys) {
-        var elements = getConnectors(processRef, versionKey);
+    for (Long versionKey : activeVersionKeys) {
+      var elements = getConnectors(processRef, versionKey);
 
-        // For non-latest versions, filter out start events.
-        // Start events should always use the latest version - there's no reason to keep
-        // older versions' start events active since new instances always start on the latest.
-        if (!versionKey.equals(latestVersionKey)) {
-          elements = filterStartEvents(elements, versionKey);
-        }
-
-        // Include version even if it has no connectors - registry needs to know about it
-        elementsByVersion.put(versionKey, elements);
+      // For non-latest versions, filter out start events.
+      // Start events should always use the latest version - there's no reason to keep
+      // older versions' start events active since new instances always start on the latest.
+      if (!versionKey.equals(latestVersionKey)) {
+        elements = filterStartEvents(elements, versionKey);
       }
 
-      var event =
-          new InboundExecutableEvent.ProcessStateChanged(
-              processRef.physicalTenantId(),
-              processRef.bpmnProcessId(),
-              processRef.tenantId(),
-              elementsByVersion);
-
-      LOG.debug(
-          "Publishing ProcessStateChanged for process '{}' (tenant '{}', physical tenant '{}'): {} active version(s)",
-          processRef.bpmnProcessId(),
-          processRef.tenantId(),
-          processRef.physicalTenantId(),
-          activeVersionKeys.size());
-
-      executableRegistry.publishEvent(event);
-
-    } catch (Exception e) {
-      LOG.error(
-          "Failed to publish state change event for process '{}' (tenant '{}', physical tenant '{}')",
-          processRef.bpmnProcessId(),
-          processRef.tenantId(),
-          processRef.physicalTenantId(),
-          e);
+      // Include version even if it has no connectors - registry needs to know about it
+      elementsByVersion.put(versionKey, elements);
     }
+
+    var event =
+        new InboundExecutableEvent.ProcessStateChanged(
+            processRef.physicalTenantId(),
+            processRef.bpmnProcessId(),
+            processRef.tenantId(),
+            elementsByVersion);
+
+    LOG.debug(
+        "Publishing ProcessStateChanged for process '{}' (tenant '{}', physical tenant '{}'): {} active version(s)",
+        processRef.bpmnProcessId(),
+        processRef.tenantId(),
+        processRef.physicalTenantId(),
+        activeVersionKeys.size());
+
+    executableRegistry.publishEvent(event);
   }
 
   /**

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/metrics/ConnectorMetrics.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/metrics/ConnectorMetrics.java
@@ -102,6 +102,15 @@ public class ConnectorMetrics {
     public static final String RESULT_CACHE_MISS = "miss";
 
     /**
+     * Number of process state changes that could not be published to the executable registry,
+     * typically because the Orchestration Cluster was unreachable while the BPMN model was fetched.
+     * Each one is retried on a subsequent poll, so a non-zero rate that does not settle indicates
+     * connectors are failing to activate.
+     */
+    public static final String METRIC_NAME_PROCESS_STATE_CHANGE_PUBLISH_FAILURES =
+        "camunda.connector.inbound.process-state-change.publish-failures";
+
+    /**
      * Epoch-millisecond timestamp of the last successful activation, per connector type. Value is
      * {@code 0} if no activation has occurred yet.
      */

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/metrics/ConnectorsInboundMetrics.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/metrics/ConnectorsInboundMetrics.java
@@ -33,6 +33,7 @@ public class ConnectorsInboundMetrics {
   private final Map<String, AtomicLong> lastTriggeredGauges = new ConcurrentHashMap<>();
   private final Counter processDefinitionCacheHitCounter;
   private final Counter processDefinitionCacheMissCounter;
+  private final Counter processStateChangePublishFailureCounter;
 
   public ConnectorsInboundMetrics(MeterRegistry meterRegistry) {
     this.meterRegistry = meterRegistry;
@@ -43,6 +44,9 @@ public class ConnectorsInboundMetrics {
     this.processDefinitionCacheMissCounter =
         Counter.builder(ConnectorMetrics.Inbound.METRIC_NAME_PROCESS_DEFINITION_CACHE_ACCESSES)
             .tag(ConnectorMetrics.Tag.RESULT, ConnectorMetrics.Inbound.RESULT_CACHE_MISS)
+            .register(meterRegistry);
+    this.processStateChangePublishFailureCounter =
+        Counter.builder(ConnectorMetrics.Inbound.METRIC_NAME_PROCESS_STATE_CHANGE_PUBLISH_FAILURES)
             .register(meterRegistry);
   }
 
@@ -167,6 +171,11 @@ public class ConnectorsInboundMetrics {
   /** Records a miss on the process-definition inspection cache. */
   public void increaseProcessDefinitionCacheMiss() {
     processDefinitionCacheMissCounter.increment();
+  }
+
+  /** Records a process state change that could not be published and will be retried. */
+  public void increaseProcessStateChangePublishFailure() {
+    processStateChangePublishFailureCounter.increment();
   }
 
   private void recordLastActivated(String type) {

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/inbound/state/ProcessStateManagerImplTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/inbound/state/ProcessStateManagerImplTest.java
@@ -1,0 +1,286 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.runtime.inbound.state;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.connector.runtime.inbound.executable.InboundExecutableEvent;
+import io.camunda.connector.runtime.inbound.executable.InboundExecutableRegistry;
+import io.camunda.connector.runtime.inbound.state.model.ImportResult;
+import io.camunda.connector.runtime.inbound.state.model.ImportResult.ImportType;
+import io.camunda.connector.runtime.inbound.state.model.ProcessDefinitionRef;
+import io.camunda.connector.runtime.metrics.ConnectorMetrics;
+import io.camunda.connector.runtime.metrics.ConnectorsInboundMetrics;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+class ProcessStateManagerImplTest {
+
+  private static final String PHYSICAL_TENANT = ProcessDefinitionRef.DEFAULT_PHYSICAL_TENANT_ID;
+
+  private ProcessStateContainerImpl container;
+  private ProcessDefinitionInspector inspector;
+  private InboundExecutableRegistry registry;
+  private SimpleMeterRegistry meterRegistry;
+  private ProcessStateManagerImpl manager;
+
+  @BeforeEach
+  void setUp() {
+    container = new ProcessStateContainerImpl();
+    inspector = mock(ProcessDefinitionInspector.class);
+    registry = mock(InboundExecutableRegistry.class);
+    meterRegistry = new SimpleMeterRegistry();
+    manager =
+        new ProcessStateManagerImpl(
+            container, inspector, registry, new ConnectorsInboundMetrics(meterRegistry));
+  }
+
+  private ProcessDefinitionRef processRef(String bpmnProcessId) {
+    return new ProcessDefinitionRef(PHYSICAL_TENANT, bpmnProcessId, "tenant1");
+  }
+
+  private ImportResult latestVersions(Map<ProcessDefinitionRef, Set<Long>> versions) {
+    return new ImportResult(versions, ImportType.LATEST_VERSIONS, PHYSICAL_TENANT);
+  }
+
+  private double publishFailureCount() {
+    var counter =
+        meterRegistry
+            .find(ConnectorMetrics.Inbound.METRIC_NAME_PROCESS_STATE_CHANGE_PUBLISH_FAILURES)
+            .counter();
+    return counter == null ? 0d : counter.count();
+  }
+
+  @Test
+  void shouldPublishStateChangeOnFirstImport() {
+    // given
+    var processRef = processRef("process1");
+    when(inspector.findInboundConnectors(eq(processRef), anyLong())).thenReturn(List.of());
+
+    // when
+    manager.update(latestVersions(Map.of(processRef, Set.of(1L))));
+
+    // then
+    verify(registry, times(1)).publishEvent(any(InboundExecutableEvent.ProcessStateChanged.class));
+  }
+
+  @Test
+  void shouldNotRepublishWhenNothingChanged() {
+    // given
+    var processRef = processRef("process1");
+    when(inspector.findInboundConnectors(eq(processRef), anyLong())).thenReturn(List.of());
+    var importResult = latestVersions(Map.of(processRef, Set.of(1L)));
+    manager.update(importResult);
+
+    // when - the same unchanged data is imported again
+    manager.update(importResult);
+
+    // then - the change is only ever reported once
+    verify(registry, times(1)).publishEvent(any(InboundExecutableEvent.ProcessStateChanged.class));
+  }
+
+  /**
+   * Regression test for a lost state change: the state transition is committed by {@code
+   * compareAndUpdate} before the event is published, and an unchanged import produces no further
+   * diff. If a transient failure while fetching the BPMN model is swallowed, the process is
+   * recorded as active but its connectors are never activated, and no later poll ever retries —
+   * stranding them until the runtime is restarted. See camunda/connectors#8148.
+   */
+  @Test
+  void shouldRetryPublishingOnNextUpdateWhenFetchingConnectorsFailed() {
+    // given - fetching the BPMN model fails once (Orchestration Cluster briefly unreachable),
+    // then succeeds
+    var processRef = processRef("process1");
+    when(inspector.findInboundConnectors(eq(processRef), anyLong()))
+        .thenThrow(new RuntimeException("Connection refused"))
+        .thenReturn(List.of());
+
+    var importResult = latestVersions(Map.of(processRef, Set.of(1L)));
+
+    // when - the first poll fails to publish
+    manager.update(importResult);
+
+    // then - nothing was published, and the failure is observable
+    verify(registry, never()).publishEvent(any());
+    assertThat(publishFailureCount()).isEqualTo(1d);
+
+    // when - the next poll imports the very same, unchanged data
+    manager.update(importResult);
+
+    // then - the change is reported again and the connectors are activated
+    verify(registry, times(1)).publishEvent(any(InboundExecutableEvent.ProcessStateChanged.class));
+  }
+
+  @Test
+  void shouldKeepRetryingWhilePublishingKeepsFailing() {
+    // given - fetching the BPMN model fails on the first two polls
+    var processRef = processRef("process1");
+    when(inspector.findInboundConnectors(eq(processRef), anyLong()))
+        .thenThrow(new RuntimeException("Connection refused"))
+        .thenThrow(new RuntimeException("Connection refused"))
+        .thenReturn(List.of());
+
+    var importResult = latestVersions(Map.of(processRef, Set.of(1L)));
+
+    // when
+    manager.update(importResult);
+    manager.update(importResult);
+
+    // then - still nothing published, but the retry flag was not consumed for good
+    verify(registry, never()).publishEvent(any());
+    assertThat(publishFailureCount()).isEqualTo(2d);
+
+    // when - the cluster becomes reachable again
+    manager.update(importResult);
+
+    // then
+    verify(registry, times(1)).publishEvent(any(InboundExecutableEvent.ProcessStateChanged.class));
+  }
+
+  /**
+   * A retry must act on the versions that are active when it runs, not on the ones it originally
+   * failed with — those may have been superseded by a deployment in the meantime, and republishing
+   * them would activate a stale version.
+   */
+  @Test
+  void shouldRetryWithTheVersionsActiveNowNotTheOnesItFailedWith() {
+    // given - publishing version 1 fails
+    var processRef = processRef("process1");
+    when(inspector.findInboundConnectors(eq(processRef), anyLong()))
+        .thenThrow(new RuntimeException("Connection refused"))
+        .thenReturn(List.of());
+    manager.update(latestVersions(Map.of(processRef, Set.of(1L))));
+    verify(registry, never()).publishEvent(any());
+
+    // when - version 2 is deployed before the retry gets a chance to run
+    manager.update(latestVersions(Map.of(processRef, Set.of(2L))));
+
+    // then - published once, for version 2 only
+    var event = ArgumentCaptor.forClass(InboundExecutableEvent.ProcessStateChanged.class);
+    verify(registry, times(1)).publishEvent(event.capture());
+    assertThat(event.getValue().elementsByProcessDefinitionKey()).containsOnlyKeys(2L);
+  }
+
+  /**
+   * A process can be undeployed while its retry is still queued. The retry must then publish a
+   * deactivation (an empty version map) rather than resurrecting the version it failed with.
+   */
+  @Test
+  void shouldPublishDeactivationWhenProcessWasUndeployedWhileRetryPending() {
+    // given - publishing version 1 fails
+    var processRef = processRef("process1");
+    when(inspector.findInboundConnectors(eq(processRef), anyLong()))
+        .thenThrow(new RuntimeException("Connection refused"))
+        .thenReturn(List.of());
+    manager.update(latestVersions(Map.of(processRef, Set.of(1L))));
+    verify(registry, never()).publishEvent(any());
+
+    // when - the process is undeployed, so the next import no longer reports it
+    manager.update(new ImportResult(Map.of(), ImportType.LATEST_VERSIONS, PHYSICAL_TENANT));
+
+    // then - a deactivation is published, not version 1 again
+    var event = ArgumentCaptor.forClass(InboundExecutableEvent.ProcessStateChanged.class);
+    verify(registry, times(1)).publishEvent(event.capture());
+    assertThat(event.getValue().bpmnProcessId()).isEqualTo("process1");
+    assertThat(event.getValue().elementsByProcessDefinitionKey()).isEmpty();
+  }
+
+  @Test
+  void shouldNotStrandOtherProcessesWhenOneFailsToPublish() {
+    // given - only process1 fails to be inspected
+    var failing = processRef("process1");
+    var healthy = processRef("process2");
+    when(inspector.findInboundConnectors(eq(failing), anyLong()))
+        .thenThrow(new RuntimeException("Connection refused"))
+        .thenReturn(List.of());
+    when(inspector.findInboundConnectors(eq(healthy), anyLong())).thenReturn(List.of());
+
+    var importResult = latestVersions(Map.of(failing, Set.of(1L), healthy, Set.of(2L)));
+
+    // when
+    manager.update(importResult);
+
+    // then - process2 was published despite process1 failing
+    verify(registry, times(1)).publishEvent(any(InboundExecutableEvent.ProcessStateChanged.class));
+
+    // when - the next poll retries only the failed one
+    manager.update(importResult);
+
+    // then
+    verify(registry, times(2)).publishEvent(any(InboundExecutableEvent.ProcessStateChanged.class));
+  }
+
+  @Test
+  void shouldRetryPublishingWhenRegistryRejectedTheEvent() {
+    // given - inspection succeeds but the registry itself fails once
+    var processRef = processRef("process1");
+    when(inspector.findInboundConnectors(eq(processRef), anyLong())).thenReturn(List.of());
+    doThrow(new RuntimeException("registry unavailable"))
+        .doNothing()
+        .when(registry)
+        .publishEvent(any());
+
+    var importResult = latestVersions(Map.of(processRef, Set.of(1L)));
+
+    // when
+    manager.update(importResult);
+    manager.update(importResult);
+
+    // then - published twice: the rejected attempt and the successful retry
+    verify(registry, times(2)).publishEvent(any(InboundExecutableEvent.ProcessStateChanged.class));
+    assertThat(publishFailureCount()).isEqualTo(1d);
+  }
+
+  @Test
+  void shouldNotRetryProcessesFromAnotherPhysicalTenant() {
+    // given - a failing process on physical tenant 'other'
+    var otherTenantRef = new ProcessDefinitionRef("other", "process1", "tenant1");
+    when(inspector.findInboundConnectors(eq(otherTenantRef), anyLong()))
+        .thenThrow(new RuntimeException("Connection refused"))
+        .thenReturn(List.of());
+    manager.update(
+        new ImportResult(Map.of(otherTenantRef, Set.of(1L)), ImportType.LATEST_VERSIONS, "other"));
+    verify(registry, never()).publishEvent(any());
+
+    // when - the default physical tenant polls, reporting its own (empty) batch
+    manager.update(new ImportResult(Map.of(), ImportType.LATEST_VERSIONS, PHYSICAL_TENANT));
+
+    // then - the other tenant's pending retry was not consumed by this poll
+    verify(registry, never()).publishEvent(any());
+
+    // when - 'other' polls again
+    manager.update(
+        new ImportResult(Map.of(otherTenantRef, Set.of(1L)), ImportType.LATEST_VERSIONS, "other"));
+
+    // then
+    verify(registry, times(1)).publishEvent(any(InboundExecutableEvent.ProcessStateChanged.class));
+  }
+}


### PR DESCRIPTION
## Description

A transient Orchestration Cluster outage could permanently disable inbound connectors until the connectors pod was restarted. Reported via [SUPPORT-33961](https://jira.camunda.com/browse/SUPPORT-33961) / INC-6835 (L2 — Critical): during Zeebe pod rotation, some — not all — RabbitMQ inbound connectors stopped consuming and process instances got stuck.

RabbitMQ reconnection is not involved. The affected connectors were never started in the first place, so there was nothing to reconnect.

### The defect

A state transition is only ever reported once. `compareAndUpdate` commits it *before* the `ProcessStateChanged` event is published, and a later import of unchanged data produces no diff:

1. `compareAndUpdate` installs a new version and returns `stateChanged = true` — already committed.
2. Publishing fetches the BPMN model over HTTP, which fails during pod rotation (`Connection refused` to `camunda-zeebe-gateway:8080`).
3. That exception was caught and **only logged**.
4. Next poll: the version is now `presentInBoth`, so no diff → `result.isEmpty()` → early return, forever.

The state store believed the connector was active; the registry never heard about it. The registry is purely event-driven with no reconciliation pass, so the divergence was permanent. Only the processes whose fetch landed inside the outage window were affected — hence "some queues".

It was also invisible: the exception was caught below `pollOnePhysicalTenant`, so `ready` stayed `true` and the readiness probe never went unhealthy. A single ERROR log line was the only evidence, which is why "restart the pod" isn't really a workaround — operators can't tell they need to.

### Changes

The retry state lives in `ProcessStateManagerImpl` — the component that actually failed to publish — so the state container's `compareAndUpdate` diffing logic is untouched.

- **`ProcessStateManagerImpl`** — keeps a set of processes whose event could not be published and retries them on the next poll for their physical tenant, draining on read and re-adding on repeated failure so a persistent outage keeps retrying instead of being dropped once. `publishProcessStateChangedEvent` propagates instead of swallowing, and the handling moved up into the per-process loop so the failure has somewhere to be recorded. Per-process isolation is unchanged, not new — the old `catch` sat inside the publish method, so the loop already continued past a failure.
- **`ProcessStateContainer#getActiveVersions`** (new) — a read-only query, promoted from an existing private method (`private` → `@Override public synchronized`, a 2-line diff). The retry re-reads current versions through it rather than reusing the ones it failed with, so it cannot republish a set that a deployment has since superseded. A change reported by the current import also supersedes a pending retry for the same process.
- **New metric `camunda.connector.inbound.process-state-change.publish-failures`** — a rate that doesn't settle back to zero means connectors are failing to activate.
- **Inbound `README.md`** — documented the retry, which the event-flow description previously omitted.

Caffeine does not negative-cache a failed load, so the `processDefinitions` cache was never poisoned — a retry simply succeeds. The only thing missing was something to trigger it.

### Regression scope

Affects `main` and `stable/8.9` only. Introduced in 8.9 by #6056 (`4bc4463b40`): 8.8's `ProcessStateStoreImpl` resolved connectors *inside* the `processStates.compute(...)` remapping function, so a throw propagated without installing the entry and the process self-healed on the next tick. The refactor split "commit state" from "publish event" and lost that atomicity.

`stable/8.8` and `stable/8.7` do not have this bug and need no backport.

### Reviewer notes

- **Why not just wrap the publish in a Failsafe retry?** A bounded inline retry narrows the window but doesn't close it: a rolling update can outlast any backoff budget, and on exhaustion you're back to the same permanent latch. The queue is what makes it actually converge.
- **Why the container gains a getter at all.** An earlier version of this fix put the retry queue *inside* the container and folded it into `compareAndUpdate`. Same interface-method count, but it added mutable state to the diffing class and edited its hot path — the wrong risk profile for a fix that backports to a maintenance branch. Keeping the queue in the manager and re-reading versions through a getter leaves `compareAndUpdate` byte-for-byte unchanged, and avoids the staleness that remembering versions would introduce.
- **`getActiveVersions` is reentrant-safe.** It is `synchronized` and also called from within the already-`synchronized` `compareAndUpdate`; Java monitors are reentrant.
- **Concurrent polls and event ordering.** `compareAndUpdate` releases the container lock before publishing, so published versions are an earlier snapshot. Two polls overlapping on the same physical tenant could queue snapshots out of order and the stale one would win. That is a pre-existing property of the plain diff path, not something the retry introduces — it publishes outside the lock on `main` today too. It is unreachable under Spring Boot's default single-threaded task scheduler, which serializes the two `@Scheduled` importers, and this repo sets no custom `TaskScheduler` or `spring.task.scheduling.pool.size`.

  I initially added a per-physical-tenant lock here and then removed it: it would have closed the retry path while leaving the diff path three lines away open, which implies an enforced invariant that isn't. The assumption is now stated explicitly in the `ProcessStateManagerImpl` class javadoc, including that `@EnableScheduling` ships in the public starter so an embedding app raising the pool size would break it. Making the runtime genuinely safe under a multi-threaded scheduler is a broader change and belongs with the reconciliation pass below. Fan-out across physical tenants *within* one poll is safe — the retry queue is tenant-scoped, so those threads never contend for the same process.
- **Metric rather than readiness.** Flipping readiness to `false` would surface the degraded state more loudly, but risks restart loops during exactly the cluster outage that triggers this. Happy to change if the team prefers.
- **Reconciliation pass deliberately not included.** This PR fixes the reported bug. Periodically re-deriving target executable state from `ProcessStateContainer` would close the whole class of lost-event bugs and is worth its own PR — the registry currently has no self-healing path at all.

## Related issues

closes #8148

## Checklist

- [x] Backport labels are added if these code changes should be backported. No backport label is added to the latest
  release, as this branch will be rebased onto main before the next release. Example backport labels:
    - `backport stable/8.8`: for changes that should be included in the next 8.8.x release.
    - **or** `backport release-8.8.7`: for changes that should be included in the specific release 8.8.7, and this
      *release has already been created*. The release branch will be merged back into stable/8.9 later, so the change
      will be included in future 8.9.x releases as well.

  `backport stable/8.9` added. Add `backport release-8.9.7` as well if this should go into that already-created release
  rather than waiting for the next 8.9.x — that is a release-management call. No 8.8/8.7 labels: those branches are not
  affected.
- [x] Tests/Integration tests for the changes have been added if applicable.

  9 new tests in `ProcessStateManagerImplTest`, using the real `ProcessStateContainerImpl` with a mocked inspector so
  they exercise the actual latch rather than a stand-in. `shouldRetryPublishingOnNextUpdateWhenFetchingConnectorsFailed`
  fails on `main` today. Also covered: repeated failures, one process failing without stranding its batch-mates, the
  registry itself rejecting the event, and cross-physical-tenant scoping, a retry publishing the versions active *now* rather than the superseded ones it failed
  with, and a process undeployed while its retry is still queued (publishes a deactivation, not the old version). Full
  `connector-runtime-spring` suite: 375 tests, 0 failures.
- [ ] If the change requires a documentation update, it has been added to the appropriate section in the documentation.

  The inbound runtime `README.md` is updated. The new metric is operator-facing, so it may warrant an entry in
  `camunda/camunda-docs` alongside the other inbound connector metrics — flagging rather than assuming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
