### PR TITLE
fix(uniquet): skip symlinked element-templates directories

### DIFF
--- a/element-template-generator/uniquet/src/main/java/io/camunda/connector/uniquet/core/ConnectorsFinder.java
+++ b/element-template-generator/uniquet/src/main/java/io/camunda/connector/uniquet/core/ConnectorsFinder.java
@@ -53,8 +53,8 @@ public class ConnectorsFinder {
 
       this.connectors =
           files
+              .filter(path -> Files.isDirectory(path) && !Files.isSymbolicLink(path))
               .map(path -> new File(path.toUri()))
-              .filter(File::isDirectory)
               .filter(this::containsElementTemplates)
               .map(this::getElementTemplateDirectory)
               .flatMap(this::findVersionedConnectors)
@@ -70,6 +70,7 @@ public class ConnectorsFinder {
 
   private File getElementTemplateDirectory(File file) {
     return Arrays.stream(Objects.requireNonNull(file.listFiles()))
+        .filter(file1 -> !isSymlink(file1))
         .filter(file1 -> file1.getName().endsWith(ELEMENT_TEMPLATES))
         .findFirst()
         .orElseThrow();
@@ -114,7 +115,12 @@ public class ConnectorsFinder {
       return false;
     }
     return Arrays.stream(Objects.requireNonNull(directory.listFiles()))
+        .filter(file -> !isSymlink(file))
         .anyMatch(file -> file.getName().endsWith(ELEMENT_TEMPLATES));
+  }
+
+  private static boolean isSymlink(File file) {
+    return Files.isSymbolicLink(file.toPath());
   }
 
   public List<Connector> getAllConnectors() {

--- a/element-template-generator/uniquet/src/test/java/io/camunda/connector/uniquet/core/ConnectorsFinderTest.java
+++ b/element-template-generator/uniquet/src/test/java/io/camunda/connector/uniquet/core/ConnectorsFinderTest.java
@@ -30,7 +30,7 @@ class ConnectorsFinderTest {
   void create() {
     ConnectorsFinder connectorsFinder =
         ConnectorsFinder.create(Path.of("src/test/resources"), null);
-    assertEquals(1, connectorsFinder.getAllConnectors().size());
+    assertEquals(2, connectorsFinder.getAllConnectors().size());
   }
 
   @Test
@@ -39,7 +39,7 @@ class ConnectorsFinderTest {
         ConnectorsFinder.create(
             Path.of("src/test/resources"),
             Path.of("src/test/resources/ignore-templates.json").toString());
-    assertEquals(0, connectorsFinder.getAllConnectors().size());
+    assertEquals(1, connectorsFinder.getAllConnectors().size());
   }
 
   @Test
@@ -49,7 +49,7 @@ class ConnectorsFinderTest {
     ConnectorsFinder connectorsFinder =
         ConnectorsFinder.create(Path.of("src/test/resources"), null);
     List<Connector> connectors = connectorsFinder.getAllConnectors();
-    assertEquals(1, connectors.size());
+    assertEquals(2, connectors.size());
     connectors.forEach(
         c -> {
           assertTrue(c.currentElementTemplate().getName().endsWith(".json"));
@@ -61,12 +61,25 @@ class ConnectorsFinderTest {
   void next() {
     ConnectorsFinder connectorsFinder =
         ConnectorsFinder.create(Path.of("src/test/resources"), null);
-    List<Connector> connectors = connectorsFinder.getAllConnectors();
+    Connector soap = findConnector(connectorsFinder, "soap-outbound-connector.json");
+    assertEquals(1, soap.versionedElementTemplate().size());
     assertEquals(
-        "soap-outbound-connector.json", connectors.getFirst().currentElementTemplate().getName());
-    assertEquals(1, connectors.getFirst().versionedElementTemplate().size());
-    assertEquals(
-        "soap-outbound-connector-2.json",
-        connectors.getFirst().versionedElementTemplate().getFirst().getName());
+        "soap-outbound-connector-2.json", soap.versionedElementTemplate().getFirst().getName());
+  }
+
+  @Test
+  void symlinkedElementTemplatesDirectoryIsSkipped() {
+    ConnectorsFinder connectorsFinder =
+        ConnectorsFinder.create(Path.of("src/test/resources"), null);
+    Connector foo = findConnector(connectorsFinder, "foo-connector.json");
+    assertTrue(
+        foo.currentElementTemplate().getPath().contains("with-symlink/real/element-templates"));
+  }
+
+  private static Connector findConnector(ConnectorsFinder connectorsFinder, String fileName) {
+    return connectorsFinder.getAllConnectors().stream()
+        .filter(c -> c.currentElementTemplate().getName().equals(fileName))
+        .findFirst()
+        .orElseThrow();
   }
 }

--- a/element-template-generator/uniquet/src/test/java/io/camunda/connector/uniquet/core/ConnectorsFinderTest.java
+++ b/element-template-generator/uniquet/src/test/java/io/camunda/connector/uniquet/core/ConnectorsFinderTest.java
@@ -73,7 +73,10 @@ class ConnectorsFinderTest {
         ConnectorsFinder.create(Path.of("src/test/resources"), null);
     Connector foo = findConnector(connectorsFinder, "foo-connector.json");
     assertTrue(
-        foo.currentElementTemplate().getPath().contains("with-symlink/real/element-templates"));
+        foo.currentElementTemplate()
+            .toPath()
+            .getParent()
+            .endsWith(Path.of("with-symlink", "real", "element-templates")));
   }
 
   private static Connector findConnector(ConnectorsFinder connectorsFinder, String fileName) {

--- a/element-template-generator/uniquet/src/test/resources/connectors/with-symlink/element-templates
+++ b/element-template-generator/uniquet/src/test/resources/connectors/with-symlink/element-templates
@@ -1,0 +1,1 @@
+real/element-templates

--- a/element-template-generator/uniquet/src/test/resources/connectors/with-symlink/real/element-templates/foo-connector.json
+++ b/element-template-generator/uniquet/src/test/resources/connectors/with-symlink/real/element-templates/foo-connector.json
@@ -1,0 +1,4 @@
+{
+  "name": "Foo Connector",
+  "id": "io.camunda:foo"
+}


### PR DESCRIPTION
## Description

`uniquet` deduplicates element templates by ID by walking the `connectors` directory. When an `element-templates` directory is reached via a symlink (e.g. as a compatibility shortcut after moving templates to a subdirectory), it got picked up as its own entry with the symlinked path instead of the real one, producing wrong `ref` paths in the generated index.

`ConnectorsFinder` now explicitly excludes symlinked directories, so only the real path is used.

## Related issues

closes #

## Checklist

- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest
  release, as this branch will be rebased onto main before the next release. Example backport labels:
    - `backport stable/8.8`: for changes that should be included in the next 8.8.x release.
    - **or** `backport release-8.8.7`: for changes that should be included in the specific release 8.8.7, and this
      *release has already been created*. The release branch will be merged back into stable/8.8 later, so the change
      will be included in future 8.8.x releases as well.
- [x] Tests/Integration tests for the changes have been added if applicable.
- [ ] If the change requires a documentation update, it has been added to the appropriate section in the documentation.