### PR TITLE
fix(credentials): correct engine floor on frozen pre-8.10 credential snapshots

### DIFF
--- a/connectors/aws/aws-comprehend/element-templates/versioned/aws-comprehend-outbound-connector-4.json
+++ b/connectors/aws/aws-comprehend/element-templates/versioned/aws-comprehend-outbound-connector-4.json
@@ -15,7 +15,7 @@
     "value" : "bpmn:ServiceTask"
   },
   "engines" : {
-    "camunda" : "^8.7"
+    "camunda" : "^8.10"
   },
   "groups" : [ {
     "id" : "operation",

--- a/connectors/aws/aws-dynamodb/element-templates/versioned/aws-dynamodb-outbound-connector-10.json
+++ b/connectors/aws/aws-dynamodb/element-templates/versioned/aws-dynamodb-outbound-connector-10.json
@@ -15,7 +15,7 @@
     "value" : "bpmn:ServiceTask"
   },
   "engines" : {
-    "camunda" : "^8.6"
+    "camunda" : "^8.10"
   },
   "groups" : [ {
     "id" : "operation",

--- a/connectors/aws/aws-eventbridge/element-templates/versioned/aws-eventbridge-outbound-connector-7.json
+++ b/connectors/aws/aws-eventbridge/element-templates/versioned/aws-eventbridge-outbound-connector-7.json
@@ -15,7 +15,7 @@
     "value" : "bpmn:ServiceTask"
   },
   "engines" : {
-    "camunda" : "^8.3"
+    "camunda" : "^8.10"
   },
   "groups" : [ {
     "id" : "authentication",

--- a/connectors/aws/aws-lambda/element-templates/versioned/aws-lambda-outbound-connector-7.json
+++ b/connectors/aws/aws-lambda/element-templates/versioned/aws-lambda-outbound-connector-7.json
@@ -15,7 +15,7 @@
     "value" : "bpmn:ServiceTask"
   },
   "engines" : {
-    "camunda" : "^8.3"
+    "camunda" : "^8.10"
   },
   "groups" : [ {
     "id" : "authentication",

--- a/connectors/aws/aws-sagemaker/element-templates/versioned/aws-sagemaker-outbound-connector-3.json
+++ b/connectors/aws/aws-sagemaker/element-templates/versioned/aws-sagemaker-outbound-connector-3.json
@@ -15,7 +15,7 @@
     "value" : "bpmn:ServiceTask"
   },
   "engines" : {
-    "camunda" : "^8.6"
+    "camunda" : "^8.10"
   },
   "groups" : [ {
     "id" : "authentication",

--- a/connectors/aws/aws-sns/element-templates/versioned/aws-sns-outbound-connector-9.json
+++ b/connectors/aws/aws-sns/element-templates/versioned/aws-sns-outbound-connector-9.json
@@ -15,7 +15,7 @@
     "value" : "bpmn:ServiceTask"
   },
   "engines" : {
-    "camunda" : "^8.3"
+    "camunda" : "^8.10"
   },
   "groups" : [ {
     "id" : "authentication",

--- a/connectors/aws/aws-sqs/element-templates/versioned/aws-sqs-boundary-connector-11.json
+++ b/connectors/aws/aws-sqs/element-templates/versioned/aws-sqs-boundary-connector-11.json
@@ -16,7 +16,7 @@
     "eventDefinition" : "bpmn:MessageEventDefinition"
   },
   "engines" : {
-    "camunda" : "^8.3"
+    "camunda" : "^8.10"
   },
   "groups" : [ {
     "id" : "authentication",

--- a/connectors/aws/aws-sqs/element-templates/versioned/aws-sqs-inbound-intermediate-connector-11.json
+++ b/connectors/aws/aws-sqs/element-templates/versioned/aws-sqs-inbound-intermediate-connector-11.json
@@ -16,7 +16,7 @@
     "eventDefinition" : "bpmn:MessageEventDefinition"
   },
   "engines" : {
-    "camunda" : "^8.3"
+    "camunda" : "^8.10"
   },
   "groups" : [ {
     "id" : "authentication",

--- a/connectors/aws/aws-sqs/element-templates/versioned/aws-sqs-outbound-connector-12.json
+++ b/connectors/aws/aws-sqs/element-templates/versioned/aws-sqs-outbound-connector-12.json
@@ -15,7 +15,7 @@
     "value" : "bpmn:ServiceTask"
   },
   "engines" : {
-    "camunda" : "^8.3"
+    "camunda" : "^8.10"
   },
   "groups" : [ {
     "id" : "authentication",

--- a/connectors/aws/aws-sqs/element-templates/versioned/aws-sqs-receive-connector-11.json
+++ b/connectors/aws/aws-sqs/element-templates/versioned/aws-sqs-receive-connector-11.json
@@ -15,7 +15,7 @@
     "value" : "bpmn:ReceiveTask"
   },
   "engines" : {
-    "camunda" : "^8.3"
+    "camunda" : "^8.10"
   },
   "groups" : [ {
     "id" : "authentication",

--- a/connectors/aws/aws-sqs/element-templates/versioned/aws-sqs-start-message-11.json
+++ b/connectors/aws/aws-sqs/element-templates/versioned/aws-sqs-start-message-11.json
@@ -16,7 +16,7 @@
     "eventDefinition" : "bpmn:MessageEventDefinition"
   },
   "engines" : {
-    "camunda" : "^8.3"
+    "camunda" : "^8.10"
   },
   "groups" : [ {
     "id" : "authentication",

--- a/connectors/aws/aws-textract/element-templates/versioned/aws-textract-outbound-connector-5.json
+++ b/connectors/aws/aws-textract/element-templates/versioned/aws-textract-outbound-connector-5.json
@@ -15,7 +15,7 @@
     "value" : "bpmn:ServiceTask"
   },
   "engines" : {
-    "camunda" : "^8.6"
+    "camunda" : "^8.10"
   },
   "groups" : [ {
     "id" : "authentication",

--- a/connectors/http/polling/element-templates/versioned/http-polling-boundary-catch-event-connector-7.json
+++ b/connectors/http/polling/element-templates/versioned/http-polling-boundary-catch-event-connector-7.json
@@ -16,7 +16,7 @@
     "eventDefinition" : "bpmn:MessageEventDefinition"
   },
   "engines" : {
-    "camunda" : "^8.9"
+    "camunda" : "^8.10"
   },
   "groups" : [ {
     "id" : "authentication",

--- a/connectors/http/polling/element-templates/versioned/http-polling-connector-7.json
+++ b/connectors/http/polling/element-templates/versioned/http-polling-connector-7.json
@@ -16,7 +16,7 @@
     "eventDefinition" : "bpmn:MessageEventDefinition"
   },
   "engines" : {
-    "camunda" : "^8.9"
+    "camunda" : "^8.10"
   },
   "groups" : [ {
     "id" : "authentication",

--- a/connectors/idp-extraction/element-templates/versioned/idp-extraction-outbound-connector-3.json
+++ b/connectors/idp-extraction/element-templates/versioned/idp-extraction-outbound-connector-3.json
@@ -14,7 +14,7 @@
     "value" : "bpmn:ServiceTask"
   },
   "engines" : {
-    "camunda" : "^8.7"
+    "camunda" : "^8.10"
   },
   "groups" : [ {
     "id" : "input",

--- a/connectors/jdbc/element-templates/versioned/jdbc-outbound-connector-4.json
+++ b/connectors/jdbc/element-templates/versioned/jdbc-outbound-connector-4.json
@@ -15,7 +15,7 @@
     "value" : "bpmn:ServiceTask"
   },
   "engines" : {
-    "camunda" : "^8.6"
+    "camunda" : "^8.10"
   },
   "groups" : [ {
     "id" : "database",


### PR DESCRIPTION
## Summary

Follow-up to #8164. That PR bumped `engineVersion` to `^8.10` on the *current* template for every already-migrated credentials connector, but the frozen `versioned/*-N.json` snapshot it created for each one still preserves the **immediately-prior** version's old engine value — because that prior version is exactly the one that first shipped `@ElementTemplate.configurations()` without a matching engine bump (the original bug #8164 fixed going forward).

Left as-is, that historical entry stays permanently queryable via `connector-templates.json` (generated by `uniquet` from `versioned/`): a consumer resolving "latest template compatible with my engine" for e.g. Camunda 8.9 would correctly skip the new bumped version (needs 8.10) and land on the frozen old one — which still renders the credential chooser their engine can't support.

## Fix

Metadata-only: correct `engines.camunda` to `^8.10` on exactly the one poisoned `versioned/` snapshot per connector — version number and all other content untouched, since the template's actual behavior always required 8.10; it was just mis-declared.

| File | engine before | after |
|---|---|---|
| jdbc-outbound-connector-4.json | `^8.6` | `^8.10` |
| http-polling-connector-7.json | `^8.9` | `^8.10` |
| http-polling-boundary-catch-event-connector-7.json | `^8.9` | `^8.10` |
| aws-comprehend-outbound-connector-4.json | `^8.7` | `^8.10` |
| aws-dynamodb-outbound-connector-10.json | `^8.6` | `^8.10` |
| aws-eventbridge-outbound-connector-7.json | `^8.3` | `^8.10` |
| aws-lambda-outbound-connector-7.json | `^8.3` | `^8.10` |
| aws-sagemaker-outbound-connector-3.json | `^8.6` | `^8.10` |
| aws-sns-outbound-connector-9.json | `^8.3` | `^8.10` |
| aws-sqs-{boundary-11, inbound-intermediate-11, outbound-12, receive-11, start-message-11} | `^8.3` | `^8.10` |
| aws-textract-outbound-connector-5.json | `^8.6` | `^8.10` |
| idp-extraction-outbound-connector-3.json | `^8.7` | `^8.10` |

## Test plan

- [x] Full-repo sweep confirms these 16 files were the only ones with `configurationTemplates` present and `engines.camunda != ^8.10` (checked every `element-templates/*.json` including `versioned/`)
- [x] Confirmed the connectors already at `^8.10` before #8164 (S3, REST, GraphQL, Bedrock family) have no equivalent poisoned history
- [x] `element-template-validator` run against the full repo: 672 templates, 0 findings
- [x] Diff is exactly 16 files, 1 line changed each (verified via `git diff --numstat`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)