### PR TITLE
fix(inbound): retry publishing a lost process state change (backport #8150)

### DIFF
--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/InboundConnectorRuntimeConfiguration.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/InboundConnectorRuntimeConfiguration.java
@@ -193,7 +193,9 @@ public class InboundConnectorRuntimeConfiguration {
   public ProcessStateManager processStateManager(
       InboundExecutableRegistry registry,
       ProcessDefinitionInspector inspector,
-      ProcessStateContainer processStateContainer) {
-    return new ProcessStateManagerImpl(processStateContainer, inspector, registry);
+      ProcessStateContainer processStateContainer,
+      ConnectorsInboundMetrics connectorsInboundMetrics) {
+    return new ProcessStateManagerImpl(
+        processStateContainer, inspector, registry, connectorsInboundMetrics);
   }
 }

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/state/ProcessStateContainer.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/state/ProcessStateContainer.java
@@ -17,7 +17,9 @@
 package io.camunda.connector.runtime.inbound.state;
 
 import io.camunda.connector.runtime.inbound.state.model.ImportResult;
+import io.camunda.connector.runtime.inbound.state.model.ProcessDefinitionRef;
 import io.camunda.connector.runtime.inbound.state.model.StateUpdateResult;
+import java.util.Set;
 
 /**
  * Container for the current process state. It is responsible for comparing the current state with
@@ -37,4 +39,18 @@ public interface ProcessStateContainer {
    *     deactivated
    */
   StateUpdateResult compareAndUpdate(ImportResult importResult);
+
+  /**
+   * Returns the process definition keys (versions) currently active for the given process, without
+   * modifying any state.
+   *
+   * <p>{@link #compareAndUpdate} only reports a given state transition once, so a caller that
+   * failed to act on one cannot obtain it again from a later import. This lets such a caller
+   * re-read the current state instead, so its retry acts on what is active now rather than on a
+   * remembered — and possibly superseded — set of versions.
+   *
+   * @param processRef the process definition to look up
+   * @return the active process definition keys, or an empty set if the process is not tracked
+   */
+  Set<Long> getActiveVersions(ProcessDefinitionRef processRef);
 }

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/state/ProcessStateContainerImpl.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/state/ProcessStateContainerImpl.java
@@ -97,7 +97,8 @@ public class ProcessStateContainerImpl implements ProcessStateContainer {
   }
 
   /** Returns the set of currently active process definition keys for a given process definition. */
-  private Set<Long> getActiveVersions(ProcessDefinitionRef processRef) {
+  @Override
+  public synchronized Set<Long> getActiveVersions(ProcessDefinitionRef processRef) {
     var versionsInState = processStates.get(processRef);
     if (versionsInState == null) {
       return Set.of();

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/state/ProcessStateManagerImpl.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/state/ProcessStateManagerImpl.java
@@ -24,13 +24,31 @@ import io.camunda.connector.runtime.inbound.executable.InboundExecutableRegistry
 import io.camunda.connector.runtime.inbound.state.model.ImportResult;
 import io.camunda.connector.runtime.inbound.state.model.ProcessDefinitionRef;
 import io.camunda.connector.runtime.inbound.state.model.StateUpdateResult;
+import io.camunda.connector.runtime.metrics.ConnectorsInboundMetrics;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Turns imported process data into {@code ProcessStateChanged} events.
+ *
+ * <p><b>Assumes the two {@code @Scheduled} importers in {@code ImportSchedulers} do not
+ * overlap.</b> {@code compareAndUpdate} releases the container's lock before we publish, so the
+ * versions we publish are a snapshot taken earlier. Two polls running concurrently could therefore
+ * queue snapshots for the same process out of order, and because the executable registry applies
+ * events in queue order, an older snapshot arriving last would win with no diff left to correct it.
+ * This holds for the retry path in this class and equally for the plain diff path, which has always
+ * published outside the lock.
+ *
+ * <p>Spring Boot's default single-threaded task scheduler serializes those importers, which is what
+ * makes the assumption hold today; nothing here enforces it. Note that {@code @EnableScheduling}
+ * ships in the public connectors starter, so an embedding application that raises {@code
+ * spring.task.scheduling.pool.size} would break it.
+ */
 public class ProcessStateManagerImpl implements ProcessStateManager {
 
   private static final Logger LOG = LoggerFactory.getLogger(ProcessStateManagerImpl.class);
@@ -38,74 +56,118 @@ public class ProcessStateManagerImpl implements ProcessStateManager {
   private final ProcessStateContainer processStateContainer;
   private final ProcessDefinitionInspector processDefinitionInspector;
   private final InboundExecutableRegistry executableRegistry;
+  private final ConnectorsInboundMetrics metrics;
+
+  /**
+   * Processes whose state change could not be published, to be retried on the next poll. Only the
+   * reference is kept, never the versions it failed with — those are re-read from the container at
+   * retry time, see {@link #pendingRetries}.
+   */
+  private final Set<ProcessDefinitionRef> failedToPublish = ConcurrentHashMap.newKeySet();
 
   public ProcessStateManagerImpl(
       ProcessStateContainer processStateContainer,
       ProcessDefinitionInspector processDefinitionInspector,
-      InboundExecutableRegistry executableRegistry) {
+      InboundExecutableRegistry executableRegistry,
+      ConnectorsInboundMetrics metrics) {
     this.processStateContainer = processStateContainer;
     this.processDefinitionInspector = processDefinitionInspector;
     this.executableRegistry = executableRegistry;
+    this.metrics = metrics;
   }
 
   @Override
   public void update(ImportResult processDefinitions) {
     StateUpdateResult result = processStateContainer.compareAndUpdate(processDefinitions);
 
-    if (result.isEmpty()) {
+    var toPublish = pendingRetries();
+    // A change reported by this import supersedes a pending retry for the same process: it reflects
+    // the state as of now, whereas the retry was only queued for one that we never delivered.
+    toPublish.putAll(result.affectedProcesses());
+
+    if (toPublish.isEmpty()) {
       LOG.debug("No process state changes detected");
       return;
     }
 
     // For each affected process, fetch connector elements for all active versions and publish event
-    for (var entry : result.affectedProcesses().entrySet()) {
+    for (var entry : toPublish.entrySet()) {
       var processRef = entry.getKey();
       var activeVersionKeys = entry.getValue();
-      publishProcessStateChangedEvent(processRef, activeVersionKeys);
+      try {
+        publishProcessStateChangedEvent(processRef, activeVersionKeys);
+      } catch (Exception e) {
+        // compareAndUpdate has already committed the transition and only ever reports it once, so
+        // this change would never be seen again. Queue the process for retry — otherwise a
+        // transient failure here (typically the Orchestration Cluster being briefly unreachable
+        // while the BPMN model is fetched) would strand its connectors until the runtime is
+        // restarted. Other processes in this batch are unaffected.
+        failedToPublish.add(processRef);
+        metrics.increaseProcessStateChangePublishFailure();
+        LOG.error(
+            "Failed to publish state change event for process '{}' (tenant '{}'); will retry on the"
+                + " next poll",
+            processRef.bpmnProcessId(),
+            processRef.tenantId(),
+            e);
+      }
     }
+  }
+
+  /**
+   * Removes the processes queued for retry, resolved against the state as it is now. The versions
+   * are re-read rather than remembered so that a retry cannot publish a set that has since been
+   * superseded.
+   *
+   * <p>The removal is atomic so that concurrent polls cannot both drain the same entry and publish
+   * it twice. That is all the concurrency this method guarantees on its own — see the class javadoc
+   * for the ordering assumption it inherits.
+   */
+  private Map<ProcessDefinitionRef, Set<Long>> pendingRetries() {
+    Map<ProcessDefinitionRef, Set<Long>> retries = new HashMap<>();
+    for (var processRef : List.copyOf(failedToPublish)) {
+      if (failedToPublish.remove(processRef)) {
+        retries.put(processRef, processStateContainer.getActiveVersions(processRef));
+      }
+    }
+    if (!retries.isEmpty()) {
+      LOG.debug("Retrying {} previously unpublished process state change(s)", retries.keySet());
+    }
+    return retries;
   }
 
   private void publishProcessStateChangedEvent(
       ProcessDefinitionRef processRef, Set<Long> activeVersionKeys) {
-    try {
-      Map<Long, List<InboundConnectorElement>> elementsByVersion = new HashMap<>();
+    Map<Long, List<InboundConnectorElement>> elementsByVersion = new HashMap<>();
 
-      // Determine the latest version key (highest value)
-      Long latestVersionKey = activeVersionKeys.stream().max(Long::compareTo).orElse(null);
+    // Determine the latest version key (highest value)
+    Long latestVersionKey = activeVersionKeys.stream().max(Long::compareTo).orElse(null);
 
-      for (Long versionKey : activeVersionKeys) {
-        var elements = getConnectors(processRef, versionKey);
+    for (Long versionKey : activeVersionKeys) {
+      var elements = getConnectors(processRef, versionKey);
 
-        // For non-latest versions, filter out start events.
-        // Start events should always use the latest version - there's no reason to keep
-        // older versions' start events active since new instances always start on the latest.
-        if (!versionKey.equals(latestVersionKey)) {
-          elements = filterStartEvents(elements, versionKey);
-        }
-
-        // Include version even if it has no connectors - registry needs to know about it
-        elementsByVersion.put(versionKey, elements);
+      // For non-latest versions, filter out start events.
+      // Start events should always use the latest version - there's no reason to keep
+      // older versions' start events active since new instances always start on the latest.
+      if (!versionKey.equals(latestVersionKey)) {
+        elements = filterStartEvents(elements, versionKey);
       }
 
-      var event =
-          new InboundExecutableEvent.ProcessStateChanged(
-              processRef.bpmnProcessId(), processRef.tenantId(), elementsByVersion);
-
-      LOG.debug(
-          "Publishing ProcessStateChanged for process '{}' (tenant '{}'): {} active version(s)",
-          processRef.bpmnProcessId(),
-          processRef.tenantId(),
-          activeVersionKeys.size());
-
-      executableRegistry.publishEvent(event);
-
-    } catch (Exception e) {
-      LOG.error(
-          "Failed to publish state change event for process '{}' (tenant '{}')",
-          processRef.bpmnProcessId(),
-          processRef.tenantId(),
-          e);
+      // Include version even if it has no connectors - registry needs to know about it
+      elementsByVersion.put(versionKey, elements);
     }
+
+    var event =
+        new InboundExecutableEvent.ProcessStateChanged(
+            processRef.bpmnProcessId(), processRef.tenantId(), elementsByVersion);
+
+    LOG.debug(
+        "Publishing ProcessStateChanged for process '{}' (tenant '{}'): {} active version(s)",
+        processRef.bpmnProcessId(),
+        processRef.tenantId(),
+        activeVersionKeys.size());
+
+    executableRegistry.publishEvent(event);
   }
 
   /**

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/metrics/ConnectorMetrics.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/metrics/ConnectorMetrics.java
@@ -43,6 +43,15 @@ public class ConnectorMetrics {
     public static final String METRIC_NAME_INBOUND_PROCESS_DEFINITIONS_CHECKED =
         "camunda.connector.inbound.process-definitions-checked";
 
+    /**
+     * Number of process state changes that could not be published to the executable registry,
+     * typically because the Orchestration Cluster was unreachable while the BPMN model was fetched.
+     * Each one is retried on a subsequent poll, so a non-zero rate that does not settle indicates
+     * connectors are failing to activate.
+     */
+    public static final String METRIC_NAME_PROCESS_STATE_CHANGE_PUBLISH_FAILURES =
+        "camunda.connector.inbound.process-state-change.publish-failures";
+
     public static final String ACTION_ACTIVATED = "activated";
     public static final String ACTION_DEACTIVATED = "deactivated";
     public static final String ACTION_ACTIVATION_FAILED = "activation-failed";

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/metrics/ConnectorsInboundMetrics.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/metrics/ConnectorsInboundMetrics.java
@@ -26,9 +26,13 @@ public class ConnectorsInboundMetrics {
 
   private final MeterRegistry meterRegistry;
   private final Map<String, Counter> activationCounter = new ConcurrentHashMap<>();
+  private final Counter processStateChangePublishFailureCounter;
 
   public ConnectorsInboundMetrics(MeterRegistry meterRegistry) {
     this.meterRegistry = meterRegistry;
+    this.processStateChangePublishFailureCounter =
+        Counter.builder(ConnectorMetrics.Inbound.METRIC_NAME_PROCESS_STATE_CHANGE_PUBLISH_FAILURES)
+            .register(meterRegistry);
   }
 
   public void increaseActivation(InboundConnectorElement connectorElement) {
@@ -140,5 +144,10 @@ public class ConnectorsInboundMetrics {
                     .tag(ConnectorMetrics.Tag.ELEMENT_TEMPLATE_VERSION, result.version())
                     .register(meterRegistry))
         .increment();
+  }
+
+  /** Records a process state change that could not be published and will be retried. */
+  public void increaseProcessStateChangePublishFailure() {
+    processStateChangePublishFailureCounter.increment();
   }
 }

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/inbound/state/ProcessStateManagerImplTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/inbound/state/ProcessStateManagerImplTest.java
@@ -1,0 +1,259 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.runtime.inbound.state;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.connector.runtime.inbound.executable.InboundExecutableEvent;
+import io.camunda.connector.runtime.inbound.executable.InboundExecutableRegistry;
+import io.camunda.connector.runtime.inbound.state.model.ImportResult;
+import io.camunda.connector.runtime.inbound.state.model.ImportResult.ImportType;
+import io.camunda.connector.runtime.inbound.state.model.ProcessDefinitionRef;
+import io.camunda.connector.runtime.metrics.ConnectorMetrics;
+import io.camunda.connector.runtime.metrics.ConnectorsInboundMetrics;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+class ProcessStateManagerImplTest {
+
+  private ProcessStateContainerImpl container;
+  private ProcessDefinitionInspector inspector;
+  private InboundExecutableRegistry registry;
+  private SimpleMeterRegistry meterRegistry;
+  private ProcessStateManagerImpl manager;
+
+  @BeforeEach
+  void setUp() {
+    container = new ProcessStateContainerImpl();
+    inspector = mock(ProcessDefinitionInspector.class);
+    registry = mock(InboundExecutableRegistry.class);
+    meterRegistry = new SimpleMeterRegistry();
+    manager =
+        new ProcessStateManagerImpl(
+            container, inspector, registry, new ConnectorsInboundMetrics(meterRegistry));
+  }
+
+  private ProcessDefinitionRef processRef(String bpmnProcessId) {
+    return new ProcessDefinitionRef(bpmnProcessId, "tenant1");
+  }
+
+  private ImportResult latestVersions(Map<ProcessDefinitionRef, Set<Long>> versions) {
+    return new ImportResult(versions, ImportType.LATEST_VERSIONS);
+  }
+
+  private double publishFailureCount() {
+    var counter =
+        meterRegistry
+            .find(ConnectorMetrics.Inbound.METRIC_NAME_PROCESS_STATE_CHANGE_PUBLISH_FAILURES)
+            .counter();
+    return counter == null ? 0d : counter.count();
+  }
+
+  @Test
+  void shouldPublishStateChangeOnFirstImport() {
+    // given
+    var processRef = processRef("process1");
+    when(inspector.findInboundConnectors(eq(processRef), anyLong())).thenReturn(List.of());
+
+    // when
+    manager.update(latestVersions(Map.of(processRef, Set.of(1L))));
+
+    // then
+    verify(registry, times(1)).publishEvent(any(InboundExecutableEvent.ProcessStateChanged.class));
+  }
+
+  @Test
+  void shouldNotRepublishWhenNothingChanged() {
+    // given
+    var processRef = processRef("process1");
+    when(inspector.findInboundConnectors(eq(processRef), anyLong())).thenReturn(List.of());
+    var importResult = latestVersions(Map.of(processRef, Set.of(1L)));
+    manager.update(importResult);
+
+    // when - the same unchanged data is imported again
+    manager.update(importResult);
+
+    // then - the change is only ever reported once
+    verify(registry, times(1)).publishEvent(any(InboundExecutableEvent.ProcessStateChanged.class));
+  }
+
+  /**
+   * Regression test for a lost state change: the state transition is committed by {@code
+   * compareAndUpdate} before the event is published, and an unchanged import produces no further
+   * diff. If a transient failure while fetching the BPMN model is swallowed, the process is
+   * recorded as active but its connectors are never activated, and no later poll ever retries —
+   * stranding them until the runtime is restarted. See camunda/connectors#8148.
+   */
+  @Test
+  void shouldRetryPublishingOnNextUpdateWhenFetchingConnectorsFailed() {
+    // given - fetching the BPMN model fails once (Orchestration Cluster briefly unreachable),
+    // then succeeds
+    var processRef = processRef("process1");
+    when(inspector.findInboundConnectors(eq(processRef), anyLong()))
+        .thenThrow(new RuntimeException("Connection refused"))
+        .thenReturn(List.of());
+
+    var importResult = latestVersions(Map.of(processRef, Set.of(1L)));
+
+    // when - the first poll fails to publish
+    manager.update(importResult);
+
+    // then - nothing was published, and the failure is observable
+    verify(registry, never()).publishEvent(any());
+    assertThat(publishFailureCount()).isEqualTo(1d);
+
+    // when - the next poll imports the very same, unchanged data
+    manager.update(importResult);
+
+    // then - the change is reported again and the connectors are activated
+    verify(registry, times(1)).publishEvent(any(InboundExecutableEvent.ProcessStateChanged.class));
+  }
+
+  @Test
+  void shouldKeepRetryingWhilePublishingKeepsFailing() {
+    // given - fetching the BPMN model fails on the first two polls
+    var processRef = processRef("process1");
+    when(inspector.findInboundConnectors(eq(processRef), anyLong()))
+        .thenThrow(new RuntimeException("Connection refused"))
+        .thenThrow(new RuntimeException("Connection refused"))
+        .thenReturn(List.of());
+
+    var importResult = latestVersions(Map.of(processRef, Set.of(1L)));
+
+    // when
+    manager.update(importResult);
+    manager.update(importResult);
+
+    // then - still nothing published, but the retry flag was not consumed for good
+    verify(registry, never()).publishEvent(any());
+    assertThat(publishFailureCount()).isEqualTo(2d);
+
+    // when - the cluster becomes reachable again
+    manager.update(importResult);
+
+    // then
+    verify(registry, times(1)).publishEvent(any(InboundExecutableEvent.ProcessStateChanged.class));
+  }
+
+  /**
+   * A retry must act on the versions that are active when it runs, not on the ones it originally
+   * failed with — those may have been superseded by a deployment in the meantime, and republishing
+   * them would activate a stale version.
+   */
+  @Test
+  void shouldRetryWithTheVersionsActiveNowNotTheOnesItFailedWith() {
+    // given - publishing version 1 fails
+    var processRef = processRef("process1");
+    when(inspector.findInboundConnectors(eq(processRef), anyLong()))
+        .thenThrow(new RuntimeException("Connection refused"))
+        .thenReturn(List.of());
+    manager.update(latestVersions(Map.of(processRef, Set.of(1L))));
+    verify(registry, never()).publishEvent(any());
+
+    // when - version 2 is deployed before the retry gets a chance to run
+    manager.update(latestVersions(Map.of(processRef, Set.of(2L))));
+
+    // then - published once, for version 2 only
+    var event = ArgumentCaptor.forClass(InboundExecutableEvent.ProcessStateChanged.class);
+    verify(registry, times(1)).publishEvent(event.capture());
+    assertThat(event.getValue().elementsByProcessDefinitionKey()).containsOnlyKeys(2L);
+  }
+
+  /**
+   * A process can be undeployed while its retry is still queued. The retry must then publish a
+   * deactivation (an empty version map) rather than resurrecting the version it failed with.
+   */
+  @Test
+  void shouldPublishDeactivationWhenProcessWasUndeployedWhileRetryPending() {
+    // given - publishing version 1 fails
+    var processRef = processRef("process1");
+    when(inspector.findInboundConnectors(eq(processRef), anyLong()))
+        .thenThrow(new RuntimeException("Connection refused"))
+        .thenReturn(List.of());
+    manager.update(latestVersions(Map.of(processRef, Set.of(1L))));
+    verify(registry, never()).publishEvent(any());
+
+    // when - the process is undeployed, so the next import no longer reports it
+    manager.update(new ImportResult(Map.of(), ImportType.LATEST_VERSIONS));
+
+    // then - a deactivation is published, not version 1 again
+    var event = ArgumentCaptor.forClass(InboundExecutableEvent.ProcessStateChanged.class);
+    verify(registry, times(1)).publishEvent(event.capture());
+    assertThat(event.getValue().bpmnProcessId()).isEqualTo("process1");
+    assertThat(event.getValue().elementsByProcessDefinitionKey()).isEmpty();
+  }
+
+  @Test
+  void shouldNotStrandOtherProcessesWhenOneFailsToPublish() {
+    // given - only process1 fails to be inspected
+    var failing = processRef("process1");
+    var healthy = processRef("process2");
+    when(inspector.findInboundConnectors(eq(failing), anyLong()))
+        .thenThrow(new RuntimeException("Connection refused"))
+        .thenReturn(List.of());
+    when(inspector.findInboundConnectors(eq(healthy), anyLong())).thenReturn(List.of());
+
+    var importResult = latestVersions(Map.of(failing, Set.of(1L), healthy, Set.of(2L)));
+
+    // when
+    manager.update(importResult);
+
+    // then - process2 was published despite process1 failing
+    verify(registry, times(1)).publishEvent(any(InboundExecutableEvent.ProcessStateChanged.class));
+
+    // when - the next poll retries only the failed one
+    manager.update(importResult);
+
+    // then
+    verify(registry, times(2)).publishEvent(any(InboundExecutableEvent.ProcessStateChanged.class));
+  }
+
+  @Test
+  void shouldRetryPublishingWhenRegistryRejectedTheEvent() {
+    // given - inspection succeeds but the registry itself fails once
+    var processRef = processRef("process1");
+    when(inspector.findInboundConnectors(eq(processRef), anyLong())).thenReturn(List.of());
+    doThrow(new RuntimeException("registry unavailable"))
+        .doNothing()
+        .when(registry)
+        .publishEvent(any());
+
+    var importResult = latestVersions(Map.of(processRef, Set.of(1L)));
+
+    // when
+    manager.update(importResult);
+    manager.update(importResult);
+
+    // then - published twice: the rejected attempt and the successful retry
+    verify(registry, times(2)).publishEvent(any(InboundExecutableEvent.ProcessStateChanged.class));
+    assertThat(publishFailureCount()).isEqualTo(1d);
+  }
+}


### PR DESCRIPTION
## Description

Backport of #8150 to `release-8.9.7`.

A process state transition was only ever reported once: `compareAndUpdate` commits it before the
`ProcessStateChanged` event is published, and a subsequent import of unchanged data yields no diff.
Publication failures were caught and only logged, so a transient failure while fetching the BPMN
model — typically the Orchestration Cluster being briefly unreachable during a rolling update — left
the process recorded as active while its connectors were never activated. Nothing retried, so the
affected inbound connectors stayed dead until the runtime was restarted.

`ProcessStateManagerImpl` now queues a process whose event it could not publish and retries it on the
next poll. The retry re-reads the active versions from the state container instead of reusing the ones
it failed with, so it cannot republish a set that a deployment has since superseded. Queue entries are
drained on read and re-added on repeated failure, so a persistent outage keeps retrying rather than
being dropped once. Failures are counted by the new metric
`camunda.connector.inbound.process-state-change.publish-failures`.

### Backport adaptations

The cherry-pick did not apply cleanly. This branch has no physical-tenant partitioning, so:

- the retry queue is drained on every poll rather than scoped to the polled physical tenant, and the
  physical tenant is absent from the published event and the log messages;
- the `shouldNotRetryProcessesFromAnotherPhysicalTenant` test was dropped, as it asserts behaviour
  that does not exist here.

The metrics constants for the process-definition cache and the last-activated/last-triggered gauges,
and the inbound `README.md`, are main-only and were left out; only the publish-failure counter was
taken.

The class javadoc's assumption — that the two `@Scheduled` importers in `ImportSchedulers` do not
overlap, which holds by virtue of Spring Boot's default single-threaded task scheduler — applies
unchanged on this branch.

## Related issues

related to #8148
backport of #8150

## Checklist

- [x] Backport labels are added if these code changes should be backported. — N/A, this *is* the backport.
- [x] Tests/Integration tests for the changes have been added if applicable. — 8 tests in
  `ProcessStateManagerImplTest`, including a regression test for the lost state change.
