### PR TITLE
feat: inbound connector management endpoints for multi-engine support

### DIFF
--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/controller/ActiveInboundConnectorResponse.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/controller/ActiveInboundConnectorResponse.java
@@ -32,4 +32,5 @@ public record ActiveInboundConnectorResponse(
     Map<String, String> data,
     Health health,
     Long activationTimestamp,
-    Collection<Activity> logs) {}
+    Collection<Activity> logs,
+    String physicalTenantId) {}

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/controller/InboundConnectorRestController.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/controller/InboundConnectorRestController.java
@@ -73,8 +73,9 @@ public class InboundConnectorRestController {
   public List<ActiveInboundConnectorResponse> getActiveInboundConnectors(
       @RequestParam(required = false, value = "bpmnProcessId") String bpmnProcessId,
       @RequestParam(required = false, value = "elementId") String elementId,
-      @RequestParam(required = false, value = "type") String type) {
-    return getActiveInboundConnectors(bpmnProcessId, elementId, type, null);
+      @RequestParam(required = false, value = "type") String type,
+      @RequestParam(required = false, value = "physicalTenantIds") List<String> physicalTenantIds) {
+    return getActiveInboundConnectors(bpmnProcessId, elementId, type, null, physicalTenantIds);
   }
 
   @GetMapping("/tenants/{tenantId}/inbound")
@@ -82,8 +83,9 @@ public class InboundConnectorRestController {
       @PathVariable(value = "tenantId") String tenantId,
       @RequestParam(required = false, value = "bpmnProcessId") String bpmnProcessId,
       @RequestParam(required = false, value = "elementId") String elementId,
-      @RequestParam(required = false, value = "type") String type) {
-    return getActiveInboundConnectors(bpmnProcessId, elementId, type, tenantId);
+      @RequestParam(required = false, value = "type") String type,
+      @RequestParam(required = false, value = "physicalTenantIds") List<String> physicalTenantIds) {
+    return getActiveInboundConnectors(bpmnProcessId, elementId, type, tenantId, physicalTenantIds);
   }
 
   @GetMapping("/tenants/{tenantId}/inbound/{bpmnProcessId}/{elementId}/logs")
@@ -91,20 +93,29 @@ public class InboundConnectorRestController {
       @PathVariable(value = "tenantId") String tenantId,
       @PathVariable(value = "bpmnProcessId") String bpmnProcessId,
       @PathVariable(value = "elementId") String elementId,
+      @RequestParam(required = false, value = "physicalTenantIds") List<String> physicalTenantIds,
       HttpServletRequest request,
       @RequestHeader(name = X_CAMUNDA_FORWARDED_FOR, required = false) String forwardedFor) {
     return instanceForwardingRouter.forwardToInstancesAndReduceOrLocal(
         request,
         forwardedFor,
-        () -> getActivityLogs(tenantId, bpmnProcessId, elementId, hostname),
+        () -> getActivityLogs(tenantId, bpmnProcessId, elementId, physicalTenantIds, hostname),
         new TypeReference<>() {});
   }
 
   private List<Collection<InstanceAwareModel.InstanceAwareActivity>> getActivityLogs(
-      String tenantId, String bpmnProcessId, String elementId, String hostname) {
+      String tenantId,
+      String bpmnProcessId,
+      String elementId,
+      List<String> physicalTenantIds,
+      String hostname) {
     var result =
         executableRegistry.query(
-            f -> f.bpmnProcessId(bpmnProcessId).elementId(elementId).tenantId(tenantId));
+            f ->
+                f.bpmnProcessId(bpmnProcessId)
+                    .elementId(elementId)
+                    .tenantId(tenantId)
+                    .physicalTenantIds(physicalTenantIds));
     return result.stream()
         .map(ActiveExecutableResponse::logs)
         .filter(Predicate.not(Collection::isEmpty))
@@ -125,10 +136,19 @@ public class InboundConnectorRestController {
   }
 
   private List<ActiveInboundConnectorResponse> getActiveInboundConnectors(
-      String bpmnProcessId, String elementId, String type, String tenantId) {
+      String bpmnProcessId,
+      String elementId,
+      String type,
+      String tenantId,
+      List<String> physicalTenantIds) {
     return executableRegistry
         .query(
-            f -> f.bpmnProcessId(bpmnProcessId).elementId(elementId).type(type).tenantId(tenantId))
+            f ->
+                f.bpmnProcessId(bpmnProcessId)
+                    .elementId(elementId)
+                    .type(type)
+                    .tenantId(tenantId)
+                    .physicalTenantIds(physicalTenantIds))
         .stream()
         .map(connectorDataMapper::createActiveInboundConnectorResponse)
         .collect(Collectors.toList());

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/controller/InboundInstancesRestController.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/controller/InboundInstancesRestController.java
@@ -159,31 +159,19 @@ public class InboundInstancesRestController {
             () -> new DataNotFoundException(ActiveInboundConnectorResponse.class, executableId));
   }
 
-  /** Returns aggregated inbound connector metrics across all connector types. */
+  /**
+   * Returns aggregated inbound connector metrics across all connector types.
+   *
+   * @param physicalTenantIds when non-empty, restricts the aggregate to connectors registered under
+   *     one of these physical tenants (engines) — a distinct dimension from the logical {@code
+   *     tenantId} exposed elsewhere on this API. Omitted or empty sums across every physical
+   *     tenant, matching the pre-existing (unfiltered) behavior of this endpoint.
+   */
   @GetMapping("/metrics")
   public List<InboundConnectorMetrics> getMetrics(
       HttpServletRequest request,
-      @RequestHeader(name = X_CAMUNDA_FORWARDED_FOR, required = false) String forwardedFor) {
-    return instanceForwardingRouter.forwardToInstancesAndReduceOrLocal(
-        request,
-        forwardedFor,
-        () ->
-            meterRegistry == null
-                ? List.of()
-                : List.of(ConnectorMetricsAggregator.inbound(meterRegistry, null, hostname)),
-        new TypeReference<>() {});
-  }
-
-  /**
-   * Returns inbound connector metrics for a specific connector type.
-   *
-   * @param connectorType connector type (e.g. {@code io.camunda:webhook:1})
-   */
-  @GetMapping("/metrics/{connectorType}")
-  public List<InboundConnectorMetrics> getMetricsByType(
-      HttpServletRequest request,
       @RequestHeader(name = X_CAMUNDA_FORWARDED_FOR, required = false) String forwardedFor,
-      @PathVariable(name = "connectorType") String connectorType) {
+      @RequestParam(required = false, value = "physicalTenantIds") List<String> physicalTenantIds) {
     return instanceForwardingRouter.forwardToInstancesAndReduceOrLocal(
         request,
         forwardedFor,
@@ -191,7 +179,35 @@ public class InboundInstancesRestController {
             meterRegistry == null
                 ? List.of()
                 : List.of(
-                    ConnectorMetricsAggregator.inbound(meterRegistry, connectorType, hostname)),
+                    ConnectorMetricsAggregator.inbound(
+                        meterRegistry, null, physicalTenantIds, hostname)),
+        new TypeReference<>() {});
+  }
+
+  /**
+   * Returns inbound connector metrics for a specific connector type.
+   *
+   * @param connectorType connector type (e.g. {@code io.camunda:webhook:1})
+   * @param physicalTenantIds when non-empty, restricts the result to connectors registered under
+   *     one of these physical tenants (engines) — a distinct dimension from the logical {@code
+   *     tenantId} exposed elsewhere on this API. Omitted or empty sums across every physical
+   *     tenant, matching the pre-existing (unfiltered) behavior of this endpoint.
+   */
+  @GetMapping("/metrics/{connectorType}")
+  public List<InboundConnectorMetrics> getMetricsByType(
+      HttpServletRequest request,
+      @RequestHeader(name = X_CAMUNDA_FORWARDED_FOR, required = false) String forwardedFor,
+      @PathVariable(name = "connectorType") String connectorType,
+      @RequestParam(required = false, value = "physicalTenantIds") List<String> physicalTenantIds) {
+    return instanceForwardingRouter.forwardToInstancesAndReduceOrLocal(
+        request,
+        forwardedFor,
+        () ->
+            meterRegistry == null
+                ? List.of()
+                : List.of(
+                    ConnectorMetricsAggregator.inbound(
+                        meterRegistry, connectorType, physicalTenantIds, hostname)),
         new TypeReference<>() {});
   }
 }

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/controller/InboundInstancesRestController.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/controller/InboundInstancesRestController.java
@@ -73,11 +73,12 @@ public class InboundInstancesRestController {
   @GetMapping()
   public List<ConnectorInstances> getConnectorInstances(
       HttpServletRequest request,
-      @RequestHeader(name = X_CAMUNDA_FORWARDED_FOR, required = false) String forwardedFor) {
+      @RequestHeader(name = X_CAMUNDA_FORWARDED_FOR, required = false) String forwardedFor,
+      @RequestParam(required = false, value = "physicalTenantIds") List<String> physicalTenantIds) {
     return instanceForwardingRouter.forwardToInstancesAndReduceOrLocal(
         request,
         forwardedFor,
-        inboundInstancesService::findAllConnectorInstances,
+        () -> inboundInstancesService.findAllConnectorInstances(physicalTenantIds),
         new TypeReference<>() {});
   }
 
@@ -85,12 +86,13 @@ public class InboundInstancesRestController {
   public ConnectorInstances getConnectorInstance(
       HttpServletRequest request,
       @RequestHeader(name = X_CAMUNDA_FORWARDED_FOR, required = false) String forwardedFor,
-      @PathVariable(name = "type") String type) {
+      @PathVariable(name = "type") String type,
+      @RequestParam(required = false, value = "physicalTenantIds") List<String> physicalTenantIds) {
     return Optional.ofNullable(
             instanceForwardingRouter.forwardToInstancesAndReduceOrLocal(
                 request,
                 forwardedFor,
-                () -> inboundInstancesService.findConnectorInstancesOfType(type),
+                () -> inboundInstancesService.findConnectorInstancesOfType(type, physicalTenantIds),
                 new TypeReference<>() {}))
         .orElseThrow(() -> new DataNotFoundException(ConnectorInstances.class, type));
   }

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/executable/ActiveExecutableQuery.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/executable/ActiveExecutableQuery.java
@@ -17,6 +17,7 @@
 package io.camunda.connector.runtime.inbound.executable;
 
 import io.camunda.connector.runtime.core.inbound.ExecutableId;
+import java.util.List;
 
 /** Mutable filter used with the consumer-based {@code query} API. */
 public class ActiveExecutableQuery {
@@ -26,6 +27,7 @@ public class ActiveExecutableQuery {
   private String type;
   private String tenantId;
   private ExecutableId executableId;
+  private List<String> physicalTenantIds;
 
   public ActiveExecutableQuery bpmnProcessId(String bpmnProcessId) {
     this.bpmnProcessId = bpmnProcessId;
@@ -57,6 +59,11 @@ public class ActiveExecutableQuery {
     return this;
   }
 
+  public ActiveExecutableQuery physicalTenantIds(List<String> physicalTenantIds) {
+    this.physicalTenantIds = physicalTenantIds;
+    return this;
+  }
+
   public String bpmnProcessId() {
     return bpmnProcessId;
   }
@@ -75,5 +82,9 @@ public class ActiveExecutableQuery {
 
   public ExecutableId executableId() {
     return executableId;
+  }
+
+  public List<String> physicalTenantIds() {
+    return physicalTenantIds;
   }
 }

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/executable/ConnectorDataMapper.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/executable/ConnectorDataMapper.java
@@ -85,6 +85,7 @@ public class ConnectorDataMapper {
     var logs = connector.logs();
     var type = elements.getFirst().type();
     var tenantId = elements.getFirst().element().tenantId();
+    var physicalTenantId = elements.getFirst().physicalTenantId();
     return new ActiveInboundConnectorResponse(
         connector.executableId(),
         type,
@@ -95,6 +96,7 @@ public class ConnectorDataMapper {
             this.appendPhysicalTenantAndTenantToPath && appendPhysicalTenantAndTenantToPath),
         connector.health(),
         connector.activationTimestamp(),
-        logs);
+        logs,
+        physicalTenantId);
   }
 }

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/executable/InboundExecutableQueryService.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/executable/InboundExecutableQueryService.java
@@ -97,6 +97,11 @@ public class InboundExecutableQueryService {
     if (query.tenantId() != null && !query.tenantId().equals(firstElement.tenantId())) {
       return false;
     }
+    if (query.physicalTenantIds() != null
+        && !query.physicalTenantIds().isEmpty()
+        && !query.physicalTenantIds().contains(firstElement.physicalTenantId())) {
+      return false;
+    }
     if (query.bpmnProcessId() != null
         && !query.bpmnProcessId().equals(firstElement.element().bpmnProcessId())) {
       return false;

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/instances/service/InboundInstancesService.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/instances/service/InboundInstancesService.java
@@ -100,7 +100,18 @@ public class InboundInstancesService {
   }
 
   public ConnectorInstances findConnectorInstancesOfType(String type) {
-    var connectorInstances = getConnectorsInstances(f -> f.type(type));
+    return findConnectorInstancesOfType(type, null);
+  }
+
+  /**
+   * @param physicalTenantIds when non-empty, restricts results to connectors registered under one
+   *     of these physical tenants (engines) — a distinct dimension from the logical {@code
+   *     tenantId} exposed elsewhere on this API.
+   */
+  public ConnectorInstances findConnectorInstancesOfType(
+      String type, List<String> physicalTenantIds) {
+    var connectorInstances =
+        getConnectorsInstances(f -> f.type(type).physicalTenantIds(physicalTenantIds));
     if (connectorInstances.isEmpty()) {
       throw new DataNotFoundException(ConnectorInstances.class, type);
     }
@@ -108,7 +119,16 @@ public class InboundInstancesService {
   }
 
   public List<ConnectorInstances> findAllConnectorInstances() {
-    return getConnectorsInstances(null);
+    return findAllConnectorInstances(null);
+  }
+
+  /**
+   * @param physicalTenantIds when non-empty, restricts results to connectors registered under one
+   *     of these physical tenants (engines) — a distinct dimension from the logical {@code
+   *     tenantId} exposed elsewhere on this API.
+   */
+  public List<ConnectorInstances> findAllConnectorInstances(List<String> physicalTenantIds) {
+    return getConnectorsInstances(f -> f.physicalTenantIds(physicalTenantIds));
   }
 
   /**

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/metrics/ConnectorMetrics.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/metrics/ConnectorMetrics.java
@@ -30,6 +30,7 @@ public class ConnectorMetrics {
     public static final String ACTION = "action";
     public static final String ELEMENT_TEMPLATE_VERSION = "elementTemplateVersion";
     public static final String RESULT = "result";
+    public static final String PHYSICAL_TENANT_ID = "physicalTenantId";
   }
 
   public static class Outbound {

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/metrics/ConnectorMetricsAggregator.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/metrics/ConnectorMetricsAggregator.java
@@ -225,17 +225,31 @@ public final class ConnectorMetricsAggregator {
    */
   public static InboundConnectorMetrics inbound(
       MeterRegistry registry, String connectorType, String runtimeId) {
+    return inbound(registry, connectorType, null, runtimeId);
+  }
+
+  /**
+   * @param physicalTenantIds when non-null and non-empty, restricts the sums to meters recorded for
+   *     one of these physical tenants (engines) — a distinct dimension from connector {@code type}.
+   *     {@code null}/empty sums across every physical tenant, matching the pre-existing behavior of
+   *     this method.
+   */
+  public static InboundConnectorMetrics inbound(
+      MeterRegistry registry,
+      String connectorType,
+      List<String> physicalTenantIds,
+      String runtimeId) {
     if (registry == null) {
       return new InboundConnectorMetrics(runtimeId, null, null, null);
     }
     if (connectorType != null && !connectorType.isBlank()) {
-      return buildInbound(registry, connectorType, runtimeId);
+      return buildInbound(registry, connectorType, physicalTenantIds, runtimeId);
     }
-    return buildInboundAggregate(registry, runtimeId);
+    return buildInboundAggregate(registry, physicalTenantIds, runtimeId);
   }
 
   private static InboundConnectorMetrics buildInboundAggregate(
-      MeterRegistry registry, String runtimeId) {
+      MeterRegistry registry, List<String> physicalTenantIds, String runtimeId) {
     Set<String> types = discoverTypes(registry, null, allInboundMetricNames());
 
     long activated = 0, deactivated = 0, activationFailed = 0;
@@ -249,51 +263,66 @@ public final class ConnectorMetricsAggregator {
               registry,
               ConnectorMetrics.Inbound.METRIC_NAME_ACTIVATIONS,
               type,
-              ConnectorMetrics.Inbound.ACTION_ACTIVATED);
+              ConnectorMetrics.Inbound.ACTION_ACTIVATED,
+              physicalTenantIds);
       deactivated +=
           sumCounterByAction(
               registry,
               ConnectorMetrics.Inbound.METRIC_NAME_ACTIVATIONS,
               type,
-              ConnectorMetrics.Inbound.ACTION_DEACTIVATED);
+              ConnectorMetrics.Inbound.ACTION_DEACTIVATED,
+              physicalTenantIds);
       activationFailed +=
           sumCounterByAction(
               registry,
               ConnectorMetrics.Inbound.METRIC_NAME_ACTIVATIONS,
               type,
-              ConnectorMetrics.Inbound.ACTION_ACTIVATION_FAILED);
+              ConnectorMetrics.Inbound.ACTION_ACTIVATION_FAILED,
+              physicalTenantIds);
       triggered +=
           sumCounterByAction(
               registry,
               ConnectorMetrics.Inbound.METRIC_NAME_TRIGGERS,
               type,
-              ConnectorMetrics.Inbound.ACTION_TRIGGERED);
+              ConnectorMetrics.Inbound.ACTION_TRIGGERED,
+              physicalTenantIds);
       correlated +=
           sumCounterByAction(
               registry,
               ConnectorMetrics.Inbound.METRIC_NAME_TRIGGERS,
               type,
-              ConnectorMetrics.Inbound.ACTION_CORRELATED);
+              ConnectorMetrics.Inbound.ACTION_CORRELATED,
+              physicalTenantIds);
       correlationFailed +=
           sumCounterByAction(
               registry,
               ConnectorMetrics.Inbound.METRIC_NAME_TRIGGERS,
               type,
-              ConnectorMetrics.Inbound.ACTION_CORRELATION_FAILED);
+              ConnectorMetrics.Inbound.ACTION_CORRELATION_FAILED,
+              physicalTenantIds);
       activationConditionFailed +=
           sumCounterByAction(
               registry,
               ConnectorMetrics.Inbound.METRIC_NAME_TRIGGERS,
               type,
-              ConnectorMetrics.Inbound.ACTION_ACTIVATION_CONDITION_FAILED);
+              ConnectorMetrics.Inbound.ACTION_ACTIVATION_CONDITION_FAILED,
+              physicalTenantIds);
       maxLastActivated =
           Math.max(
               maxLastActivated,
-              readGauge(registry, ConnectorMetrics.Inbound.METRIC_NAME_LAST_ACTIVATED, type));
+              readGauge(
+                  registry,
+                  ConnectorMetrics.Inbound.METRIC_NAME_LAST_ACTIVATED,
+                  type,
+                  physicalTenantIds));
       maxLastTriggered =
           Math.max(
               maxLastTriggered,
-              readGauge(registry, ConnectorMetrics.Inbound.METRIC_NAME_LAST_TRIGGERED, type));
+              readGauge(
+                  registry,
+                  ConnectorMetrics.Inbound.METRIC_NAME_LAST_TRIGGERED,
+                  type,
+                  physicalTenantIds));
     }
 
     return new InboundConnectorMetrics(
@@ -310,7 +339,7 @@ public final class ConnectorMetricsAggregator {
   }
 
   private static InboundConnectorMetrics buildInbound(
-      MeterRegistry registry, String type, String runtimeId) {
+      MeterRegistry registry, String type, List<String> physicalTenantIds, String runtimeId) {
     return new InboundConnectorMetrics(
         runtimeId,
         new InboundConnectorMetrics.Runtime(readRuntimeUptime(registry)),
@@ -319,42 +348,57 @@ public final class ConnectorMetricsAggregator {
                 registry,
                 ConnectorMetrics.Inbound.METRIC_NAME_ACTIVATIONS,
                 type,
-                ConnectorMetrics.Inbound.ACTION_ACTIVATED),
+                ConnectorMetrics.Inbound.ACTION_ACTIVATED,
+                physicalTenantIds),
             sumCounterByAction(
                 registry,
                 ConnectorMetrics.Inbound.METRIC_NAME_ACTIVATIONS,
                 type,
-                ConnectorMetrics.Inbound.ACTION_DEACTIVATED),
+                ConnectorMetrics.Inbound.ACTION_DEACTIVATED,
+                physicalTenantIds),
             sumCounterByAction(
                 registry,
                 ConnectorMetrics.Inbound.METRIC_NAME_ACTIVATIONS,
                 type,
-                ConnectorMetrics.Inbound.ACTION_ACTIVATION_FAILED),
+                ConnectorMetrics.Inbound.ACTION_ACTIVATION_FAILED,
+                physicalTenantIds),
             epochMsToInstant(
-                readGauge(registry, ConnectorMetrics.Inbound.METRIC_NAME_LAST_ACTIVATED, type))),
+                readGauge(
+                    registry,
+                    ConnectorMetrics.Inbound.METRIC_NAME_LAST_ACTIVATED,
+                    type,
+                    physicalTenantIds))),
         new InboundConnectorMetrics.Trigger(
             sumCounterByAction(
                 registry,
                 ConnectorMetrics.Inbound.METRIC_NAME_TRIGGERS,
                 type,
-                ConnectorMetrics.Inbound.ACTION_TRIGGERED),
+                ConnectorMetrics.Inbound.ACTION_TRIGGERED,
+                physicalTenantIds),
             sumCounterByAction(
                 registry,
                 ConnectorMetrics.Inbound.METRIC_NAME_TRIGGERS,
                 type,
-                ConnectorMetrics.Inbound.ACTION_CORRELATED),
+                ConnectorMetrics.Inbound.ACTION_CORRELATED,
+                physicalTenantIds),
             sumCounterByAction(
                 registry,
                 ConnectorMetrics.Inbound.METRIC_NAME_TRIGGERS,
                 type,
-                ConnectorMetrics.Inbound.ACTION_CORRELATION_FAILED),
+                ConnectorMetrics.Inbound.ACTION_CORRELATION_FAILED,
+                physicalTenantIds),
             sumCounterByAction(
                 registry,
                 ConnectorMetrics.Inbound.METRIC_NAME_TRIGGERS,
                 type,
-                ConnectorMetrics.Inbound.ACTION_ACTIVATION_CONDITION_FAILED),
+                ConnectorMetrics.Inbound.ACTION_ACTIVATION_CONDITION_FAILED,
+                physicalTenantIds),
             epochMsToInstant(
-                readGauge(registry, ConnectorMetrics.Inbound.METRIC_NAME_LAST_TRIGGERED, type))));
+                readGauge(
+                    registry,
+                    ConnectorMetrics.Inbound.METRIC_NAME_LAST_TRIGGERED,
+                    type,
+                    physicalTenantIds))));
   }
 
   // -------------------------------------------------------------------------
@@ -392,6 +436,41 @@ public final class ConnectorMetricsAggregator {
     return (long) sum;
   }
 
+  /**
+   * Physical-tenant-aware variant used by inbound aggregation only — see {@link
+   * #matchesPhysicalTenantIds}. Outbound aggregation has no physical-tenant dimension yet and keeps
+   * using the 4-arg overload above unchanged.
+   */
+  private static long sumCounterByAction(
+      MeterRegistry registry,
+      String metricName,
+      String type,
+      String action,
+      List<String> physicalTenantIds) {
+    double sum =
+        registry
+            .find(metricName)
+            .tag(ConnectorMetrics.Tag.TYPE, type)
+            .tag(ConnectorMetrics.Tag.ACTION, action)
+            .counters()
+            .stream()
+            .filter(counter -> matchesPhysicalTenantIds(counter.getId(), physicalTenantIds))
+            .mapToDouble(Counter::count)
+            .sum();
+    return (long) sum;
+  }
+
+  /**
+   * @return {@code true} when {@code physicalTenantIds} is {@code null}/empty (no filtering — sums
+   *     across every physical tenant, matching the pre-existing behavior of this aggregator) or the
+   *     meter's own {@code physicalTenantId} tag is one of the requested values.
+   */
+  private static boolean matchesPhysicalTenantIds(Meter.Id id, List<String> physicalTenantIds) {
+    return physicalTenantIds == null
+        || physicalTenantIds.isEmpty()
+        || physicalTenantIds.contains(id.getTag(ConnectorMetrics.Tag.PHYSICAL_TENANT_ID));
+  }
+
   private static double sumCounter(MeterRegistry registry, String metricName, String type) {
     return registry.find(metricName).tag(ConnectorMetrics.Tag.TYPE, type).counters().stream()
         .mapToDouble(Counter::count)
@@ -418,6 +497,16 @@ public final class ConnectorMetricsAggregator {
    */
   private static long readGauge(MeterRegistry registry, String metricName, String type) {
     return registry.find(metricName).tag(ConnectorMetrics.Tag.TYPE, type).gauges().stream()
+        .mapToLong(g -> (long) g.value())
+        .max()
+        .orElse(0L);
+  }
+
+  /** Physical-tenant-aware variant used by inbound aggregation only — see {@link #readGauge}. */
+  private static long readGauge(
+      MeterRegistry registry, String metricName, String type, List<String> physicalTenantIds) {
+    return registry.find(metricName).tag(ConnectorMetrics.Tag.TYPE, type).gauges().stream()
+        .filter(gauge -> matchesPhysicalTenantIds(gauge.getId(), physicalTenantIds))
         .mapToLong(g -> (long) g.value())
         .max()
         .orElse(0L);

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/metrics/ConnectorsInboundMetrics.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/metrics/ConnectorsInboundMetrics.java
@@ -61,9 +61,10 @@ public class ConnectorsInboundMetrics {
                     .tag(ConnectorMetrics.Tag.TYPE, result.type())
                     .tag(ConnectorMetrics.Tag.ELEMENT_TEMPLATE_ID, result.id())
                     .tag(ConnectorMetrics.Tag.ELEMENT_TEMPLATE_VERSION, result.version())
+                    .tag(ConnectorMetrics.Tag.PHYSICAL_TENANT_ID, result.physicalTenantId())
                     .register(meterRegistry))
         .increment();
-    recordLastActivated(result.type());
+    recordLastActivated(result.type(), result.physicalTenantId());
   }
 
   public void increaseDeactivation(InboundConnectorElement connectorElement) {
@@ -77,6 +78,7 @@ public class ConnectorsInboundMetrics {
                     .tag(ConnectorMetrics.Tag.TYPE, result.type())
                     .tag(ConnectorMetrics.Tag.ELEMENT_TEMPLATE_ID, result.id())
                     .tag(ConnectorMetrics.Tag.ELEMENT_TEMPLATE_VERSION, result.version())
+                    .tag(ConnectorMetrics.Tag.PHYSICAL_TENANT_ID, result.physicalTenantId())
                     .register(meterRegistry))
         .increment();
   }
@@ -94,6 +96,7 @@ public class ConnectorsInboundMetrics {
                     .tag(ConnectorMetrics.Tag.TYPE, result.type())
                     .tag(ConnectorMetrics.Tag.ELEMENT_TEMPLATE_ID, result.id())
                     .tag(ConnectorMetrics.Tag.ELEMENT_TEMPLATE_VERSION, result.version())
+                    .tag(ConnectorMetrics.Tag.PHYSICAL_TENANT_ID, result.physicalTenantId())
                     .register(meterRegistry))
         .increment();
   }
@@ -109,6 +112,7 @@ public class ConnectorsInboundMetrics {
                     .tag(ConnectorMetrics.Tag.TYPE, result.type())
                     .tag(ConnectorMetrics.Tag.ELEMENT_TEMPLATE_ID, result.id())
                     .tag(ConnectorMetrics.Tag.ELEMENT_TEMPLATE_VERSION, result.version())
+                    .tag(ConnectorMetrics.Tag.PHYSICAL_TENANT_ID, result.physicalTenantId())
                     .register(meterRegistry))
         .increment();
   }
@@ -126,6 +130,7 @@ public class ConnectorsInboundMetrics {
                     .tag(ConnectorMetrics.Tag.TYPE, result.type())
                     .tag(ConnectorMetrics.Tag.ELEMENT_TEMPLATE_ID, result.id())
                     .tag(ConnectorMetrics.Tag.ELEMENT_TEMPLATE_VERSION, result.version())
+                    .tag(ConnectorMetrics.Tag.PHYSICAL_TENANT_ID, result.physicalTenantId())
                     .register(meterRegistry))
         .increment();
   }
@@ -141,9 +146,10 @@ public class ConnectorsInboundMetrics {
                     .tag(ConnectorMetrics.Tag.TYPE, result.type())
                     .tag(ConnectorMetrics.Tag.ELEMENT_TEMPLATE_ID, result.id())
                     .tag(ConnectorMetrics.Tag.ELEMENT_TEMPLATE_VERSION, result.version())
+                    .tag(ConnectorMetrics.Tag.PHYSICAL_TENANT_ID, result.physicalTenantId())
                     .register(meterRegistry))
         .increment();
-    recordLastTriggered(result.type());
+    recordLastTriggered(result.type(), result.physicalTenantId());
   }
 
   public void increaseActivationConditionFailure(InboundConnectorElement connectorElement) {
@@ -159,6 +165,7 @@ public class ConnectorsInboundMetrics {
                     .tag(ConnectorMetrics.Tag.TYPE, result.type())
                     .tag(ConnectorMetrics.Tag.ELEMENT_TEMPLATE_ID, result.id())
                     .tag(ConnectorMetrics.Tag.ELEMENT_TEMPLATE_VERSION, result.version())
+                    .tag(ConnectorMetrics.Tag.PHYSICAL_TENANT_ID, result.physicalTenantId())
                     .register(meterRegistry))
         .increment();
   }
@@ -178,30 +185,32 @@ public class ConnectorsInboundMetrics {
     processStateChangePublishFailureCounter.increment();
   }
 
-  private void recordLastActivated(String type) {
+  private void recordLastActivated(String type, String physicalTenantId) {
     lastActivatedGauges
         .computeIfAbsent(
-            type,
+            type + "_" + physicalTenantId,
             t -> {
               AtomicLong holder = new AtomicLong(0);
               Gauge.builder(
                       ConnectorMetrics.Inbound.METRIC_NAME_LAST_ACTIVATED, holder, AtomicLong::get)
-                  .tag(ConnectorMetrics.Tag.TYPE, t)
+                  .tag(ConnectorMetrics.Tag.TYPE, type)
+                  .tag(ConnectorMetrics.Tag.PHYSICAL_TENANT_ID, physicalTenantId)
                   .register(meterRegistry);
               return holder;
             })
         .set(Instant.now().toEpochMilli());
   }
 
-  private void recordLastTriggered(String type) {
+  private void recordLastTriggered(String type, String physicalTenantId) {
     lastTriggeredGauges
         .computeIfAbsent(
-            type,
+            type + "_" + physicalTenantId,
             t -> {
               AtomicLong holder = new AtomicLong(0);
               Gauge.builder(
                       ConnectorMetrics.Inbound.METRIC_NAME_LAST_TRIGGERED, holder, AtomicLong::get)
-                  .tag(ConnectorMetrics.Tag.TYPE, t)
+                  .tag(ConnectorMetrics.Tag.TYPE, type)
+                  .tag(ConnectorMetrics.Tag.PHYSICAL_TENANT_ID, physicalTenantId)
                   .register(meterRegistry);
               return holder;
             })

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/metrics/Result.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/metrics/Result.java
@@ -22,14 +22,15 @@ import io.camunda.connector.runtime.core.inbound.InboundConnectorElement;
 import io.camunda.connector.runtime.core.inbound.ProcessElementWithRuntimeData;
 import java.util.Optional;
 
-public record Result(String type, String id, String version, String key) {
+public record Result(String type, String id, String version, String physicalTenantId, String key) {
 
   public static Result getResult(ActivatedJob job) {
     String type = job.getType();
     String id = job.getCustomHeaders().getOrDefault("elementTemplateId", "unknown");
     String version = job.getCustomHeaders().getOrDefault("elementTemplateVersion", "unknown");
+    String physicalTenantId = job.getPhysicalTenantId();
     String key = type + "_" + id + "_" + version;
-    return new Result(type, id, version, key);
+    return new Result(type, id, version, physicalTenantId, key);
   }
 
   public static Result getResult(InboundConnectorElement connectorElement) {
@@ -46,8 +47,9 @@ public record Result(String type, String id, String version, String key) {
             .map(ProcessElementWithRuntimeData::elementTemplateDetails)
             .map(ElementTemplateDetails::version)
             .orElse("unknown");
-    String key = type + "_" + id + "_" + version;
-    return new Result(type, id, version, key);
+    String physicalTenantId = connectorElement.physicalTenantId();
+    String key = type + "_" + id + "_" + version + "_" + physicalTenantId;
+    return new Result(type, id, version, physicalTenantId, key);
   }
 
   public String createKey(String actionActivated) {

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/inbound/executable/ConnectorDataMapperTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/inbound/executable/ConnectorDataMapperTest.java
@@ -102,4 +102,13 @@ class ConnectorDataMapperTest {
     assertThat(response.data().get("inbound.context"))
         .isEqualTo("myPhysicalTenant/myTenant/myPath");
   }
+
+  @Test
+  void physicalTenantIdIsPopulatedFromTheFirstElement() {
+    var mapper = new ConnectorDataMapper(false);
+
+    var response = mapper.createActiveInboundConnectorResponse(webhookResponse());
+
+    assertThat(response.physicalTenantId()).isEqualTo("myPhysicalTenant");
+  }
 }

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/inbound/executable/InboundExecutableQueryServiceTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/inbound/executable/InboundExecutableQueryServiceTest.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.when;
 
+import io.camunda.connector.api.inbound.ElementTemplateDetails;
 import io.camunda.connector.api.inbound.Health;
 import io.camunda.connector.api.inbound.InboundConnectorExecutable;
 import io.camunda.connector.runtime.core.inbound.ExecutableId;
@@ -72,9 +73,38 @@ class InboundExecutableQueryServiceTest {
         new ProcessElementWithRuntimeData("processId", 0, 0, "elementId", "tenant"));
   }
 
+  private InboundConnectorElement testElement(String physicalTenantId) {
+    return new InboundConnectorElement(
+        Map.of("inbound.type", "test-type"),
+        new StartEventCorrelationPoint("processId", 0, 0),
+        new ProcessElementWithRuntimeData(
+            "processId",
+            null,
+            null,
+            0,
+            0,
+            "elementId",
+            null,
+            null,
+            "tenant",
+            physicalTenantId,
+            new ElementTemplateDetails("test", "1", "icon"),
+            Map.of()));
+  }
+
   private ValidInboundConnectorDetails testValidDetails(String dedupId) {
     return new ValidInboundConnectorDetails(
         "test-type", "tenant", dedupId, Map.of(), List.of(testElement()), "processId");
+  }
+
+  private ValidInboundConnectorDetails testValidDetails(String dedupId, String physicalTenantId) {
+    return new ValidInboundConnectorDetails(
+        "test-type",
+        "tenant",
+        dedupId,
+        Map.of(),
+        List.of(testElement(physicalTenantId)),
+        "processId");
   }
 
   private InvalidInboundConnectorDetails testInvalidDetails(String dedupId) {
@@ -263,5 +293,63 @@ class InboundExecutableQueryServiceTest {
     assertThat(executableHealth.getLastUpdatedAt())
         .as("lastUpdatedAt should be preserved after enrichment, not reset to query time")
         .isEqualTo(originalTimestamp);
+  }
+
+  private void putActivated(ExecutableId id, String physicalTenantId) {
+    stateStore.put(
+        id,
+        new RegisteredExecutable.FailedToActivate(
+            testValidDetails(id.getId(), physicalTenantId),
+            "n/a",
+            id,
+            Health.down(new RuntimeException("n/a"))));
+  }
+
+  @Test
+  void query_withPhysicalTenantIdsFilter_returnsOnlyMatchingExecutables() {
+    var tenantAId = ExecutableId.fromDeduplicationId("tenant-a-executable");
+    var tenantBId = ExecutableId.fromDeduplicationId("tenant-b-executable");
+    putActivated(tenantAId, "tenant-a");
+    putActivated(tenantBId, "tenant-b");
+
+    var result =
+        queryService.query(new ActiveExecutableQuery().physicalTenantIds(List.of("tenant-a")));
+
+    assertThat(result)
+        .extracting(ActiveExecutableResponse::executableId)
+        .containsExactly(tenantAId);
+  }
+
+  @Test
+  void query_withPhysicalTenantIdsFilterMatchingMultiple_returnsAllMatches() {
+    var tenantAId = ExecutableId.fromDeduplicationId("tenant-a-executable");
+    var tenantBId = ExecutableId.fromDeduplicationId("tenant-b-executable");
+    var tenantCId = ExecutableId.fromDeduplicationId("tenant-c-executable");
+    putActivated(tenantAId, "tenant-a");
+    putActivated(tenantBId, "tenant-b");
+    putActivated(tenantCId, "tenant-c");
+
+    var result =
+        queryService.query(
+            new ActiveExecutableQuery().physicalTenantIds(List.of("tenant-a", "tenant-b")));
+
+    assertThat(result)
+        .extracting(ActiveExecutableResponse::executableId)
+        .containsExactlyInAnyOrder(tenantAId, tenantBId);
+  }
+
+  @Test
+  void query_withNullOrEmptyPhysicalTenantIdsFilter_appliesNoFiltering() {
+    var tenantAId = ExecutableId.fromDeduplicationId("tenant-a-executable");
+    var tenantBId = ExecutableId.fromDeduplicationId("tenant-b-executable");
+    putActivated(tenantAId, "tenant-a");
+    putActivated(tenantBId, "tenant-b");
+
+    assertThat(queryService.query(new ActiveExecutableQuery().physicalTenantIds(null)))
+        .extracting(ActiveExecutableResponse::executableId)
+        .containsExactlyInAnyOrder(tenantAId, tenantBId);
+    assertThat(queryService.query(new ActiveExecutableQuery().physicalTenantIds(List.of())))
+        .extracting(ActiveExecutableResponse::executableId)
+        .containsExactlyInAnyOrder(tenantAId, tenantBId);
   }
 }

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/instances/helpers/ActiveInboundConnectorResponseHelper.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/instances/helpers/ActiveInboundConnectorResponseHelper.java
@@ -53,7 +53,8 @@ public class ActiveInboundConnectorResponseHelper {
         Map.of("dataKey", "dataValue"),
         health,
         activationTimestamp,
-        List.of());
+        List.of(),
+        "physicalTenantId");
   }
 
   public static Stream<Arguments> getConnectorInstancesWithExpectedResult() {
@@ -88,6 +89,7 @@ public class ActiveInboundConnectorResponseHelper {
     assertThat(actualResult.executableId()).isEqualTo(expectedResult.executableId());
     assertThat(actualResult.type()).isEqualTo(expectedResult.type());
     assertThat(actualResult.tenantId()).isEqualTo(expectedResult.tenantId());
+    assertThat(actualResult.physicalTenantId()).isEqualTo(expectedResult.physicalTenantId());
     assertThat(actualResult.data()).isEqualTo(expectedResult.data());
     assertThat(actualResult.health().getStatus()).isEqualTo(expectedResult.health().getStatus());
     assertThat(actualResult.health().getDetails()).isEqualTo(expectedResult.health().getDetails());

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/instances/helpers/ConnectorInstancesListResponseHelper.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/instances/helpers/ConnectorInstancesListResponseHelper.java
@@ -54,7 +54,8 @@ public class ConnectorInstancesListResponseHelper {
         Map.of("dataKey", "dataValue"),
         health,
         activationTimestamp,
-        List.of());
+        List.of(),
+        "physicalTenantId");
   }
 
   public static Stream<Arguments> getConnectorInstancesListsWithExpectedResult() {

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/instances/reducer/ActiveInboundConnectorResponseReducerTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/instances/reducer/ActiveInboundConnectorResponseReducerTest.java
@@ -88,7 +88,8 @@ public class ActiveInboundConnectorResponseReducerTest {
             Map.of("dataKey", "dataValue"),
             health1,
             activationTime1,
-            List.of());
+            List.of(),
+            "physicalTenantId");
     ActiveInboundConnectorResponse response2 =
         new ActiveInboundConnectorResponse(
             ExecutableId.fromDeduplicationId("executableId"),
@@ -98,7 +99,8 @@ public class ActiveInboundConnectorResponseReducerTest {
             Map.of("dataKey", "dataValue"),
             health2,
             activationTime2,
-            List.of());
+            List.of(),
+            "physicalTenantId");
 
     // when
     ActiveInboundConnectorResponse reducedResponse = reducer.reduce(response1, response2);

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/instances/service/DefaultInstanceForwardingServiceTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/instances/service/DefaultInstanceForwardingServiceTest.java
@@ -52,7 +52,8 @@ public class DefaultInstanceForwardingServiceTest {
                     Map.of("dataKey", "dataValue"),
                     Health.down(),
                     System.currentTimeMillis(),
-                    List.of())));
+                    List.of(),
+                    "physicalTenantId")));
     DefaultInstanceForwardingService service =
         new DefaultInstanceForwardingService(mockHttpClient, "localhost");
     var mockHttpServletRequest = new MockHttpServletRequest(method, path);

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/metrics/ConnectorsInboundMetricsPhysicalTenantTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/metrics/ConnectorsInboundMetricsPhysicalTenantTest.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.runtime.metrics;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.connector.api.inbound.ElementTemplateDetails;
+import io.camunda.connector.runtime.core.inbound.InboundConnectorElement;
+import io.camunda.connector.runtime.core.inbound.ProcessElementWithRuntimeData;
+import io.camunda.connector.runtime.core.inbound.correlation.StartEventCorrelationPoint;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Exercises the physical-tenant dimension added to {@link ConnectorsInboundMetrics}/{@link
+ * ConnectorMetricsAggregator}: two physical tenants recording the exact same connector
+ * type/element-template/version must land in separate, correctly-tagged meters (not share one
+ * miscounted/mistagged {@code Counter}/{@code Gauge} via {@link Result}'s cache key), and {@link
+ * ConnectorMetricsAggregator#inbound} must sum across all tenants when unfiltered and scope down
+ * correctly when a {@code physicalTenantIds} filter is given.
+ */
+class ConnectorsInboundMetricsPhysicalTenantTest {
+
+  private static InboundConnectorElement elementFor(String physicalTenantId) {
+    return new InboundConnectorElement(
+        Map.of("inbound.type", "test-type"),
+        new StartEventCorrelationPoint("processId", 0, 0),
+        new ProcessElementWithRuntimeData(
+            "processId",
+            null,
+            null,
+            0,
+            0,
+            "elementId",
+            null,
+            null,
+            "tenant",
+            physicalTenantId,
+            new ElementTemplateDetails("test-template", "1", "icon"),
+            Map.of()));
+  }
+
+  @Test
+  void sameTypeAndTemplateAcrossTwoPhysicalTenants_recordsSeparatelyTaggedCounters() {
+    var registry = new SimpleMeterRegistry();
+    var metrics = new ConnectorsInboundMetrics(registry);
+
+    metrics.increaseActivation(elementFor("tenant-a"));
+    metrics.increaseActivation(elementFor("tenant-a"));
+    metrics.increaseActivation(elementFor("tenant-b"));
+
+    var tenantACount =
+        registry
+            .find(ConnectorMetrics.Inbound.METRIC_NAME_ACTIVATIONS)
+            .tag(ConnectorMetrics.Tag.ACTION, ConnectorMetrics.Inbound.ACTION_ACTIVATED)
+            .tag(ConnectorMetrics.Tag.PHYSICAL_TENANT_ID, "tenant-a")
+            .counter()
+            .count();
+    var tenantBCount =
+        registry
+            .find(ConnectorMetrics.Inbound.METRIC_NAME_ACTIVATIONS)
+            .tag(ConnectorMetrics.Tag.ACTION, ConnectorMetrics.Inbound.ACTION_ACTIVATED)
+            .tag(ConnectorMetrics.Tag.PHYSICAL_TENANT_ID, "tenant-b")
+            .counter()
+            .count();
+
+    assertThat(tenantACount).isEqualTo(2.0);
+    assertThat(tenantBCount).isEqualTo(1.0);
+  }
+
+  @Test
+  void aggregatorInbound_withoutFilter_sumsAcrossAllPhysicalTenants() {
+    var registry = new SimpleMeterRegistry();
+    var metrics = new ConnectorsInboundMetrics(registry);
+    metrics.increaseActivation(elementFor("tenant-a"));
+    metrics.increaseActivation(elementFor("tenant-b"));
+
+    var result = ConnectorMetricsAggregator.inbound(registry, "test-type", null, "runtime-1");
+
+    assertThat(result.activation().activated()).isEqualTo(2);
+  }
+
+  @Test
+  void aggregatorInbound_withFilter_scopesToMatchingPhysicalTenantsOnly() {
+    var registry = new SimpleMeterRegistry();
+    var metrics = new ConnectorsInboundMetrics(registry);
+    metrics.increaseActivation(elementFor("tenant-a"));
+    metrics.increaseActivation(elementFor("tenant-a"));
+    metrics.increaseActivation(elementFor("tenant-b"));
+
+    var tenantAOnly =
+        ConnectorMetricsAggregator.inbound(registry, "test-type", List.of("tenant-a"), "runtime-1");
+    var bothTenants =
+        ConnectorMetricsAggregator.inbound(
+            registry, "test-type", List.of("tenant-a", "tenant-b"), "runtime-1");
+    var unknownTenant =
+        ConnectorMetricsAggregator.inbound(
+            registry, "test-type", List.of("nonexistent-tenant"), "runtime-1");
+
+    assertThat(tenantAOnly.activation().activated()).isEqualTo(2);
+    assertThat(bothTenants.activation().activated()).isEqualTo(3);
+    assertThat(unknownTenant.activation().activated()).isEqualTo(0);
+  }
+
+  @Test
+  void aggregatorInbound_aggregateAcrossTypes_appliesFilterConsistently() {
+    var registry = new SimpleMeterRegistry();
+    var metrics = new ConnectorsInboundMetrics(registry);
+    metrics.increaseActivation(elementFor("tenant-a"));
+    metrics.increaseActivation(elementFor("tenant-b"));
+
+    // connectorType == null -> aggregate across all discovered types
+    var unfiltered = ConnectorMetricsAggregator.inbound(registry, null, null, "runtime-1");
+    var filtered =
+        ConnectorMetricsAggregator.inbound(registry, null, List.of("tenant-a"), "runtime-1");
+
+    assertThat(unfiltered.activation().activated()).isEqualTo(2);
+    assertThat(filtered.activation().activated()).isEqualTo(1);
+  }
+}

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/inbound/BaseMultiInstancesTest.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/inbound/BaseMultiInstancesTest.java
@@ -348,6 +348,11 @@ abstract class BaseMultiInstancesTest {
     if (query.tenantId() != null && !query.tenantId().equals(firstElement.tenantId())) {
       return false;
     }
+    if (query.physicalTenantIds() != null
+        && !query.physicalTenantIds().isEmpty()
+        && !query.physicalTenantIds().contains(firstElement.physicalTenantId())) {
+      return false;
+    }
     if (query.bpmnProcessId() != null
         && !query.bpmnProcessId().equals(firstElement.element().bpmnProcessId())) {
       return false;

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/inbound/InboundConnectorRestControllerMultiInstancesTest.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/inbound/InboundConnectorRestControllerMultiInstancesTest.java
@@ -74,6 +74,34 @@ class InboundConnectorRestControllerMultiInstancesTest extends BaseMultiInstance
   }
 
   @Test
+  public void shouldReturnActivityLogs_whenPhysicalTenantIdsFilterMatches() {
+    ResponseEntity<List<Collection<InstanceAwareModel.InstanceAwareActivity>>> response =
+        restTemplate.exchange(
+            "http://localhost:"
+                + port1
+                + "/tenants/tenantId/inbound/ProcessC/id2/logs?physicalTenantIds=default",
+            HttpMethod.GET,
+            null,
+            new ParameterizedTypeReference<>() {});
+    var logs = response.getBody();
+    assertEquals(2, logs.size());
+  }
+
+  @Test
+  public void shouldReturnNoActivityLogs_whenPhysicalTenantIdsFilterDoesNotMatch() {
+    ResponseEntity<List<Collection<InstanceAwareModel.InstanceAwareActivity>>> response =
+        restTemplate.exchange(
+            "http://localhost:"
+                + port1
+                + "/tenants/tenantId/inbound/ProcessC/id2/logs?physicalTenantIds=nonexistent-tenant",
+            HttpMethod.GET,
+            null,
+            new ParameterizedTypeReference<>() {});
+    var logs = response.getBody();
+    assertTrue(logs.isEmpty());
+  }
+
+  @Test
   public void shouldNotReturnActivityLogs_whenNoLogs() {
     ResponseEntity<List<Collection<InstanceAwareModel.InstanceAwareActivity>>> response =
         restTemplate.exchange(

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/inbound/InboundEndpointTest.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/inbound/InboundEndpointTest.java
@@ -88,7 +88,7 @@ public class InboundEndpointTest {
     InboundConnectorRestController statusController =
         new InboundConnectorRestController(executableRegistry, new LocalInstanceForwardingRouter());
 
-    var response = statusController.getActiveInboundConnectors(null, null, null);
+    var response = statusController.getActiveInboundConnectors(null, null, null, null);
     assertEquals(1, response.size());
     assertEquals("myPath", response.getFirst().data().get("inbound.context"));
   }
@@ -131,7 +131,7 @@ public class InboundEndpointTest {
             new LocalInstanceForwardingRouter(),
             new WebhookConnectorRegistry(true));
 
-    var response = statusController.getActiveInboundConnectors(null, null, null);
+    var response = statusController.getActiveInboundConnectors(null, null, null, null);
     assertEquals(1, response.size());
     assertEquals(
         "myPhysicalTenant/myTenant/myPath", response.getFirst().data().get("inbound.context"));
@@ -179,7 +179,7 @@ public class InboundEndpointTest {
             new LocalInstanceForwardingRouter(),
             new WebhookConnectorRegistry(true));
 
-    var response = statusController.getActiveInboundConnectors(null, null, null);
+    var response = statusController.getActiveInboundConnectors(null, null, null, null);
     assertEquals(1, response.size());
     assertEquals(
         "myPhysicalTenant/myTenant/myPath", response.getFirst().data().get("inbound.context"));
@@ -207,7 +207,7 @@ public class InboundEndpointTest {
     InboundConnectorRestController statusController =
         new InboundConnectorRestController(executableRegistry, new LocalInstanceForwardingRouter());
 
-    var response = statusController.getActiveInboundConnectors(null, null, null);
+    var response = statusController.getActiveInboundConnectors(null, null, null, null);
     assertEquals(1, response.size());
     assertEquals(Health.down(), (response.getFirst()).health());
   }

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/inbound/InboundInstancesRestControllerMultiInstancesTest.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/inbound/InboundInstancesRestControllerMultiInstancesTest.java
@@ -399,4 +399,42 @@ class InboundInstancesRestControllerMultiInstancesTest extends BaseMultiInstance
     assertTrue(metrics.stream().anyMatch(m -> "instance1".equals(m.runtimeId())));
     assertTrue(metrics.stream().anyMatch(m -> "instance2".equals(m.runtimeId())));
   }
+
+  @Test
+  public void shouldAcceptPhysicalTenantIdsFilter_onAggregateMetricsEndpoint() throws Exception {
+    ResponseEntity<String> response =
+        restTemplate.exchange(
+            "http://localhost:" + port1 + "/inbound-instances/metrics?physicalTenantIds=default",
+            HttpMethod.GET,
+            null,
+            String.class);
+
+    assertEquals(200, response.getStatusCode().value());
+    List<InboundConnectorMetrics> metrics =
+        ConnectorsObjectMapperSupplier.getCopy()
+            .readValue(response.getBody(), new TypeReference<>() {});
+    // still one entry per pod — the filter narrows each pod's own sums, not the pod fan-out itself
+    assertEquals(2, metrics.size());
+  }
+
+  @Test
+  public void shouldAcceptPhysicalTenantIdsFilter_onMetricsByTypeEndpoint() throws Exception {
+    ResponseEntity<String> response =
+        restTemplate.exchange(
+            "http://localhost:"
+                + port1
+                + "/inbound-instances/metrics/"
+                + TYPE_1
+                + "?physicalTenantIds=nonexistent-tenant",
+            HttpMethod.GET,
+            null,
+            String.class);
+
+    assertEquals(200, response.getStatusCode().value());
+    List<InboundConnectorMetrics> metrics =
+        ConnectorsObjectMapperSupplier.getCopy()
+            .readValue(response.getBody(), new TypeReference<>() {});
+    assertEquals(2, metrics.size());
+    assertTrue(metrics.stream().allMatch(m -> m.activation().activated() == 0));
+  }
 }

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/inbound/InboundInstancesRestControllerTest.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/inbound/InboundInstancesRestControllerTest.java
@@ -249,6 +249,58 @@ class InboundInstancesRestControllerTest {
   }
 
   @Test
+  public void shouldReturnConnectorInstances_whenPhysicalTenantIdsFilterMatches() throws Exception {
+    var response =
+        mockMvc
+            .perform(
+                get("/inbound-instances")
+                    .param(
+                        "physicalTenantIds",
+                        ProcessElementWithRuntimeData.DEFAULT_PHYSICAL_TENANT_ID))
+            .andExpect(status().isOk())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+
+    List<ConnectorInstances> instance =
+        ConnectorsObjectMapperSupplier.getCopy().readValue(response, new TypeReference<>() {});
+    assertEquals(2, instance.size());
+  }
+
+  @Test
+  public void shouldReturnNoConnectorInstances_whenPhysicalTenantIdsFilterDoesNotMatch()
+      throws Exception {
+    var response =
+        mockMvc
+            .perform(get("/inbound-instances").param("physicalTenantIds", "nonexistent-tenant"))
+            .andExpect(status().isOk())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+
+    List<ConnectorInstances> instance =
+        ConnectorsObjectMapperSupplier.getCopy().readValue(response, new TypeReference<>() {});
+    assertTrue(instance.isEmpty());
+  }
+
+  @Test
+  public void shouldReturnPhysicalTenantIdOnEachInstance() throws Exception {
+    var response =
+        mockMvc
+            .perform(get("/inbound-instances/" + TYPE_1))
+            .andExpect(status().isOk())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+
+    ConnectorInstances instance =
+        ConnectorsObjectMapperSupplier.getCopy().readValue(response, ConnectorInstances.class);
+    assertEquals(
+        ProcessElementWithRuntimeData.DEFAULT_PHYSICAL_TENANT_ID,
+        instance.instances().get(0).physicalTenantId());
+  }
+
+  @Test
   public void shouldReturn404_whenUnknownConnectorType() throws Exception {
     mockMvc
         .perform(get("/inbound-instances/UNKNOWN-ID"))
@@ -494,6 +546,11 @@ class InboundInstancesRestControllerTest {
       return false;
     }
     if (query.tenantId() != null && !query.tenantId().equals(firstElement.tenantId())) {
+      return false;
+    }
+    if (query.physicalTenantIds() != null
+        && !query.physicalTenantIds().isEmpty()
+        && !query.physicalTenantIds().contains(firstElement.physicalTenantId())) {
       return false;
     }
     if (query.bpmnProcessId() != null


### PR DESCRIPTION
## Description

Adds a `physicalTenantId` filter/response dimension to the inbound connector management endpoints (list active connectors, logs, instances), distinct from the existing logical `tenantId`.

**Note on scope**: the issue assumes per-engine `InboundExecutableRegistry` *instances* exist (from #6962) and that these endpoints need to fan out across them. That's not what #6962 actually delivered — there's a single shared registry, and `physicalTenantId` is a per-element attribute on every registered executable, not yet exposed as a filter or response field. This PR does that instead, which is a materially smaller and simpler change than the issue describes:

- Adds a `physicalTenantIds` (`List<String>`) filter to `ActiveExecutableQuery`, applied in `InboundExecutableQueryService.matchesQuery` alongside the existing `type`/`tenantId`/`bpmnProcessId` checks.
- Adds a `physicalTenantId` field to `ActiveInboundConnectorResponse`, populated the same way `type`/`tenantId` already are.
- Wires a `physicalTenantIds` query param through `InboundConnectorRestController`'s list/logs endpoints and `InboundInstancesRestController`'s `getConnectorInstances`/`getConnectorInstance`.

Since every physical tenant's executables already live together in one `InboundExecutableRegistry` per pod, there's no second fan-out axis to build — the filter just composes with the existing per-pod `InstanceForwardingRouter` forwarding as-is.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #7964 

## Checklist

- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest
  release, as this branch will be rebased onto main before the next release. Example backport labels:
    - `backport stable/8.8`: for changes that should be included in the next 8.8.x release.
    - **or** `backport release-8.8.7`: for changes that should be included in the specific release 8.8.7, and this
      *release has already been created*. The release branch will be merged back into stable/8.8 later, so the change
      will be included in future 8.8.x releases as well.
- [ ] Tests/Integration tests for the changes have been added if applicable.
- [ ] If the change requires a documentation update, it has been added to the appropriate section in the documentation.


