### PR TITLE
fix(runtime): reuse overridden document store for single-physical-tenant outbound wiring

### DIFF
--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/OutboundConnectorRuntimeConfiguration.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/OutboundConnectorRuntimeConfiguration.java
@@ -285,17 +285,19 @@ public class OutboundConnectorRuntimeConfiguration {
   }
 
   /**
-   * Builds the per-physical-tenant {@link DocumentFactory} map. In the single-physical-tenant case
-   * (no {@link CamundaClientRegistry}), the already-resolved {@code injectedDocumentFactory} bean
-   * is reused instead of always constructing a new client-backed one: this preserves pre-#6961
-   * behavior for single-client/custom runtimes that override the {@code documentFactory} bean (e.g.
-   * an in-memory document store in tests), which would otherwise be silently bypassed.
+   * Builds the per-physical-tenant {@link DocumentFactory} map. In the single-physical-tenant case,
+   * the already-resolved {@code injectedDocumentFactory} bean is reused instead of always
+   * constructing a new client-backed one: this preserves pre-#6961 behavior for single-client/
+   * custom runtimes that override the {@code documentFactory} bean (e.g. an in-memory document
+   * store in tests), which would otherwise be silently bypassed. Note this must check the actual
+   * client count rather than {@code registry == null}: {@link CamundaClientRegistry} is registered
+   * unconditionally by the camunda-client Spring Boot starter, so it is never actually null.
    */
   private static Map<String, DocumentFactory> buildDocumentFactoriesByPhysicalTenantId(
       CamundaClientRegistry registry,
       CamundaClient legacyCamundaClient,
       DocumentFactory injectedDocumentFactory) {
-    if (registry == null && injectedDocumentFactory != null) {
+    if (injectedDocumentFactory != null && clientNames(registry, legacyCamundaClient).size() <= 1) {
       return clientNames(registry, legacyCamundaClient).stream()
           .collect(
               toMapByPhysicalTenantId(
@@ -523,7 +525,7 @@ public class OutboundConnectorRuntimeConfiguration {
             registry, legacyCamundaClient, secretKeyCacheManager, secretFilterMode);
     var objectMappersByPhysicalTenantId =
         buildOutboundConnectorObjectMappersByPhysicalTenantId(
-            registry, documentFactoriesByPhysicalTenantId, outboundConnectorObjectMapper);
+            documentFactoriesByPhysicalTenantId, outboundConnectorObjectMapper);
     return new OutboundConnectorManager(
         jobWorkerManager,
         connectorFactory,
@@ -541,12 +543,14 @@ public class OutboundConnectorRuntimeConfiguration {
    * Per-physical-tenant outbound {@link ObjectMapper}s, each wired to that tenant's {@link
    * DocumentFactory} so that {@code Document}-typed job variables are deserialized through the
    * correct engine's document store (see #6961) instead of always going through a single
-   * globally-cached mapper. When {@code registry == null} (no {@link CamundaClientRegistry}
-   * configured), the already-built {@code outboundConnectorObjectMapper} instance (injected above)
-   * is reused as-is: this mirrors {@link #buildDocumentFactoriesByPhysicalTenantId}'s own condition
-   * for reusing the injected {@link DocumentFactory} bean in that case, so a custom/overridden
-   * {@code DocumentFactory} bean (e.g. an in-memory one in tests) and the {@code ObjectMapper} that
-   * deserializes {@code Document}-typed variables stay backed by the very same factory instance.
+   * globally-cached mapper. In the single-physical-tenant case, the already-built {@code
+   * outboundConnectorObjectMapper} instance (injected above) is reused as-is: this mirrors {@link
+   * #buildDocumentFactoriesByPhysicalTenantId}'s own condition for reusing the injected {@link
+   * DocumentFactory} bean in that case — {@code documentFactoriesByPhysicalTenantId} has exactly
+   * one entry, and it is (by construction) the very same {@code DocumentFactory} instance that
+   * {@code outboundConnectorObjectMapper} was built from — so a custom/overridden {@code
+   * DocumentFactory} bean (e.g. an in-memory one in tests) and the {@code ObjectMapper} that
+   * deserializes {@code Document}-typed variables stay backed by the same factory instance.
    *
    * <p>Deliberately a plain (non-{@code @Bean}) static method rather than a {@code Map<String,
    * ObjectMapper>}-typed {@code @Bean}: as documented above for the document/secret-filter maps,
@@ -556,10 +560,9 @@ public class OutboundConnectorRuntimeConfiguration {
    * "outboundConnectorObjectMapper"} instead of physical tenant IDs.
    */
   private static Map<String, ObjectMapper> buildOutboundConnectorObjectMappersByPhysicalTenantId(
-      CamundaClientRegistry registry,
       Map<String, DocumentFactory> documentFactoriesByPhysicalTenantId,
       ObjectMapper outboundConnectorObjectMapper) {
-    if (registry == null) {
+    if (documentFactoriesByPhysicalTenantId.size() <= 1) {
       return documentFactoriesByPhysicalTenantId.keySet().stream()
           .collect(Collectors.toMap(id -> id, id -> outboundConnectorObjectMapper));
     }


### PR DESCRIPTION
## Description

Two outbound-side helpers in `OutboundConnectorRuntimeConfiguration` — `buildDocumentFactoriesByPhysicalTenantId` and `buildOutboundConnectorObjectMappersByPhysicalTenantId` — guarded their single-physical-tenant "reuse the overridden document store" path on `registry == null`. `CamundaClientRegistry` is registered unconditionally by the camunda-client Spring Boot starter (`@ConditionalOnMissingBean`), so it is **never actually null** in any real Spring context. The guard was dead code: outbound job processing always built a fresh, real, client-backed `CamundaDocumentStoreImpl`/`ObjectMapper` per physical tenant, silently bypassing any overridden `documentStore`/`documentFactory` bean — e.g. a test's `@MockitoSpyBean CamundaDocumentStore` / `@Primary DocumentFactory`, or a custom in-memory store in a non-multi-tenant deployment.

The correct version of this same check already exists inbound-side, in `PhysicalTenantIds.java`: it checks the actual resolved client count (`clientNames(...).size() <= 1`), not registry nullness. This PR mirrors that pattern on the outbound side.

### How this was found

Two e2e suites started failing on `main`:
- `connectors-e2e-test-intrinsic-functions`: `IntrinsicFunctionsTests#createLinkIntrinsic_returnsLink`
- `connectors-e2e-test-agentic-ai`: `AgentTaskMemoryStorageTests#camundaDocumentStorage`, `AgentSubProcessMemoryStorageTests#camundaDocumentStorage`

All three failed the same way — `awaitility` timeout waiting for process completion. The CI console log doesn't show the real exception (`redirectTestOutputToFile=true` sends test-JVM stdout to `target/surefire-reports/*-output.txt`, uploaded as a separate artifact, not printed to the job console). Pulling that artifact showed the real errors were engine-side REST failures:
- `createLink`: `ProblemException 403 Forbidden — "The in-memory document store does not support creating links"`
- `camundaDocumentStorage`: `ProblemException 404 Not Found — "Document with id '...' not found"`

Both are consistent with the outbound path silently talking to the *real* engine-backed document store instead of the test-overridden one (each test's own `@MockitoSpyBean CamundaDocumentStore` / test document-store config), because of the dead `registry == null` guard described above.

PR #8089 was the first suspect (it touched document-store/physical-tenant code and landed right before these started failing), but reverting it alone doesn't fix the tests — the actual guard bug was introduced earlier, in #8026 ("multi-engine support for outbound connectors"), and is unchanged (byte-for-byte identical) between #8026 and #8089. #8089 is blameless; it's just the first commit for which this e2e workflow happened to run in CI after #8026 landed.

## Fix

- `buildDocumentFactoriesByPhysicalTenantId`: `registry == null && injectedDocumentFactory != null` → `injectedDocumentFactory != null && clientNames(registry, legacyCamundaClient).size() <= 1`
- `buildOutboundConnectorObjectMappersByPhysicalTenantId`: `registry == null` → `documentFactoriesByPhysicalTenantId.size() <= 1` (its map is, by construction, already keyed per resolved physical tenant, so this is equivalent and needed no extra parameters)

## Verification

Rebuilt `connector-runtime-spring` + dependents and ran the three previously-failing tests locally — all pass:
- `IntrinsicFunctionsTests#createLinkIntrinsic_returnsLink` — PASS
- `AgentTaskMemoryStorageTests#camundaDocumentStorage` — PASS
- `AgentSubProcessMemoryStorageTests#camundaDocumentStorage` — PASS

## Related issues

Root-caused from CI failures reported in Slack (E2E test run on `main`, run [30603435913](https://github.com/camunda/connectors/actions/runs/30603435913)).

## Checklist

- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest release, as this branch will be rebased onto main before the next release.
- [x] Tests/Integration tests for the changes have been added if applicable. (existing e2e tests now cover this — no new test needed, the regression is fully covered by `createLinkIntrinsic_returnsLink` and `camundaDocumentStorage`)
- [ ] If the change requires a documentation update, it has been added to the appropriate section in the documentation.