### PR TITLE
fix(textract): make execution type explicit for the camunda document source

### DIFF
--- a/connectors/aws/aws-textract/element-templates/aws-textract-outbound-connector.json
+++ b/connectors/aws/aws-textract/element-templates/aws-textract-outbound-connector.json
@@ -263,7 +263,7 @@
       "equals" : "S3",
       "type" : "simple"
     },
-    "tooltip" : "How the document should be processed. See more info in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-textract/#execution-types\" target=\"_blank\">Amazon Textract execution types documentation</a>.",
+    "tooltip" : "How the document should be processed. See more info in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-textract/#input-parameters\" target=\"_blank\">Amazon Textract execution types documentation</a>.",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "Asynchronous",

--- a/connectors/aws/aws-textract/element-templates/hybrid/aws-textract-outbound-connector-hybrid.json
+++ b/connectors/aws/aws-textract/element-templates/hybrid/aws-textract-outbound-connector-hybrid.json
@@ -268,7 +268,7 @@
       "equals" : "S3",
       "type" : "simple"
     },
-    "tooltip" : "How the document should be processed. See more info in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-textract/#execution-types\" target=\"_blank\">Amazon Textract execution types documentation</a>.",
+    "tooltip" : "How the document should be processed. See more info in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-textract/#input-parameters\" target=\"_blank\">Amazon Textract execution types documentation</a>.",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "Asynchronous",

--- a/connectors/aws/aws-textract/element-templates/hybrid/aws-textract-outbound-connector-hybrid.json
+++ b/connectors/aws/aws-textract/element-templates/hybrid/aws-textract-outbound-connector-hybrid.json
@@ -5,7 +5,7 @@
   "description" : "Extract text and data using AWS Textract.",
   "keywords" : [ "extract text", "extract data", "extract text from image", "extract data from image", "ocr", "OCR", "document processing", "text extraction", "analyze document", "asynchronous", "real-time" ],
   "documentationRef" : "https://docs.camunda.io/docs/8.6/components/connectors/out-of-the-box-connectors/amazon-textract/",
-  "version" : 6,
+  "version" : 7,
   "category" : {
     "id" : "connectors",
     "name" : "Connectors"
@@ -281,6 +281,27 @@
       "value" : "POLLING"
     } ]
   }, {
+    "id" : "input.uploadedExecutionType",
+    "label" : "Execution type",
+    "optional" : false,
+    "value" : "SYNC",
+    "group" : "input",
+    "binding" : {
+      "name" : "input.executionType",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "input.documentLocationType",
+      "equals" : "UPLOADED",
+      "type" : "simple"
+    },
+    "tooltip" : "Documents supplied from Camunda are analyzed in real time. Polling and asynchronous execution require the document to be stored in Amazon S3.",
+    "type" : "Dropdown",
+    "choices" : [ {
+      "name" : "Real-time",
+      "value" : "SYNC"
+    } ]
+  }, {
     "id" : "input.analyzeTables",
     "label" : "Analyze tables",
     "optional" : false,
@@ -507,7 +528,7 @@
     "id" : "version",
     "label" : "Version",
     "description" : "Version of the element template",
-    "value" : "6",
+    "value" : "7",
     "group" : "connector",
     "binding" : {
       "key" : "elementTemplateVersion",

--- a/connectors/aws/aws-textract/element-templates/versioned/aws-textract-outbound-connector-6.json
+++ b/connectors/aws/aws-textract/element-templates/versioned/aws-textract-outbound-connector-6.json
@@ -575,6 +575,17 @@
       "type" : "zeebe:taskHeader"
     },
     "type" : "String"
+  }, {
+    "id" : "jobTimeout",
+    "label" : "Job timeout",
+    "description" : "ISO-8601 duration after which Zeebe considers this job timed out if not yet completed. Leave empty to use the default timeout",
+    "optional" : true,
+    "group" : "retries",
+    "binding" : {
+      "key" : "jobTimeout",
+      "type" : "zeebe:taskHeader"
+    },
+    "type" : "String"
   } ],
   "configurationTemplates" : [ {
     "id" : "io.camunda:aws-credential:1",

--- a/connectors/aws/aws-textract/element-templates/versioned/aws-textract-outbound-connector-6.json
+++ b/connectors/aws/aws-textract/element-templates/versioned/aws-textract-outbound-connector-6.json
@@ -5,7 +5,7 @@
   "description" : "Extract text and data using AWS Textract.",
   "keywords" : [ "extract text", "extract data", "extract text from image", "extract data from image", "ocr", "OCR", "document processing", "text extraction", "analyze document", "asynchronous", "real-time" ],
   "documentationRef" : "https://docs.camunda.io/docs/8.6/components/connectors/out-of-the-box-connectors/amazon-textract/",
-  "version" : 7,
+  "version" : 6,
   "category" : {
     "id" : "connectors",
     "name" : "Connectors"
@@ -276,27 +276,6 @@
       "value" : "POLLING"
     } ]
   }, {
-    "id" : "input.uploadedExecutionType",
-    "label" : "Execution type",
-    "optional" : false,
-    "value" : "SYNC",
-    "group" : "input",
-    "binding" : {
-      "name" : "input.executionType",
-      "type" : "zeebe:input"
-    },
-    "condition" : {
-      "property" : "input.documentLocationType",
-      "equals" : "UPLOADED",
-      "type" : "simple"
-    },
-    "tooltip" : "Documents supplied from Camunda are analyzed in real time. Polling and asynchronous execution require the document to be stored in Amazon S3.",
-    "type" : "Dropdown",
-    "choices" : [ {
-      "name" : "Real-time",
-      "value" : "SYNC"
-    } ]
-  }, {
     "id" : "input.analyzeTables",
     "label" : "Analyze tables",
     "optional" : false,
@@ -523,7 +502,7 @@
     "id" : "version",
     "label" : "Version",
     "description" : "Version of the element template",
-    "value" : "7",
+    "value" : "6",
     "group" : "connector",
     "binding" : {
       "key" : "elementTemplateVersion",
@@ -593,17 +572,6 @@
     "group" : "retries",
     "binding" : {
       "key" : "retryBackoff",
-      "type" : "zeebe:taskHeader"
-    },
-    "type" : "String"
-  }, {
-    "id" : "jobTimeout",
-    "label" : "Job timeout",
-    "description" : "ISO-8601 duration after which Zeebe considers this job timed out if not yet completed. Leave empty to use the default timeout",
-    "optional" : true,
-    "group" : "retries",
-    "binding" : {
-      "key" : "jobTimeout",
       "type" : "zeebe:taskHeader"
     },
     "type" : "String"

--- a/connectors/aws/aws-textract/src/main/java/io/camunda/connector/textract/TextractConnectorFunction.java
+++ b/connectors/aws/aws-textract/src/main/java/io/camunda/connector/textract/TextractConnectorFunction.java
@@ -50,7 +50,7 @@ import software.amazon.awssdk.services.textract.TextractClient;
     },
     inputDataClass = TextractRequest.class,
     configurations = {AwsCredentialConfiguration.class},
-    version = 6,
+    version = 7,
     propertyGroups = {
       @ElementTemplate.PropertyGroup(id = "authentication", label = "Authentication"),
       @ElementTemplate.PropertyGroup(id = "configuration", label = "Configuration"),

--- a/connectors/aws/aws-textract/src/main/java/io/camunda/connector/textract/model/TextractRequestData.java
+++ b/connectors/aws/aws-textract/src/main/java/io/camunda/connector/textract/model/TextractRequestData.java
@@ -78,6 +78,39 @@ public record TextractRequestData(
                     equals = "S3"))
         @NotNull
         TextractExecutionType executionType,
+    /**
+     * Template-only companion to {@link #executionType}, and always {@code null} at runtime.
+     *
+     * <p>Binds to the same {@code input.executionType} variable but is shown on the complementary
+     * branch — the Camunda document source — where it offers {@code SYNC} as its only choice.
+     * Textract's {@code StartDocumentAnalysis} (polling and async) takes a {@code
+     * DocumentLocation}, so sync is the only mode that can analyze inline bytes; surfacing it as a
+     * one-option dropdown makes that visible in Modeler instead of leaving users to wonder why the
+     * field vanished.
+     *
+     * <p>Nothing reads this component: the value it writes arrives under the {@code executionType}
+     * JSON key and is bound to {@link #executionType}. Two properties sharing one binding with
+     * mutually exclusive conditions is the same pattern the S3 connector uses for its per-operation
+     * {@code action.bucket} fields.
+     */
+    @TemplateProperty(
+            id = "uploadedExecutionType",
+            label = "Execution type",
+            group = "input",
+            type = TemplateProperty.PropertyType.Dropdown,
+            defaultValue = "SYNC",
+            feel = FeelMode.disabled,
+            choices = @TemplateProperty.DropdownPropertyChoice(value = "SYNC", label = "Real-time"),
+            tooltip =
+                "Documents supplied from Camunda are analyzed in real time. Polling and asynchronous execution require the document to be stored in Amazon S3.",
+            // Relative to this record's own path: the generator prefixes "input." because
+            // TextractRequest exposes this record under its `input` field.
+            binding = @TemplateProperty.PropertyBinding(name = "executionType"),
+            condition =
+                @TemplateProperty.PropertyCondition(
+                    property = "input.documentLocationType",
+                    equals = "UPLOADED"))
+        TextractExecutionType uploadedExecutionType,
     @TemplateProperty(
             label = "Analyze tables",
             tooltip =
@@ -211,21 +244,21 @@ public record TextractRequestData(
         String outputConfigS3Prefix) {
 
   /**
-   * Defaults a missing {@code executionType} to {@link TextractExecutionType#SYNC} when the
-   * document comes from the Camunda document store.
+   * Backward-compatibility shim for models built on template v6 and earlier, where no {@code
+   * executionType} reaches the connector at all on the Camunda document branch.
    *
-   * <p>The {@code executionType} property is only rendered for the S3 source, and an element
-   * template property whose condition is not met has its value removed from the BPMN XML. A model
-   * that selects the Camunda document source therefore sends no {@code executionType} at all, and
-   * the {@code @NotNull} above rejected the request before the connector ever ran. {@code SYNC} is
-   * the only possible mode here: Textract's {@code StartDocumentAnalysis} (polling and async) takes
-   * a {@link software.amazon.awssdk.services.textract.model.DocumentLocation}, so it cannot analyze
-   * inline bytes.
+   * <p>Until v7 the {@code executionType} property was rendered only for the S3 source, and an
+   * element template property whose condition is not met has its value removed from the BPMN XML. A
+   * model selecting the Camunda document source therefore sent no {@code executionType}, and the
+   * {@code @NotNull} above rejected the request before the connector ever ran. From v7 on, {@link
+   * #uploadedExecutionType} writes {@code SYNC} explicitly, so this shim is inert for new models —
+   * but deployed process definitions are immutable, so it is what repairs existing ones without
+   * requiring a remodel.
    *
-   * <p>Deliberately scoped to {@code UPLOADED}: for the S3 source the property is always rendered,
-   * so a missing value there means a hand-edited model and should still fail loudly rather than
-   * silently run as {@code SYNC} — which, unlike the template's {@code POLLING} default, is capped
-   * at a single page.
+   * <p>Deliberately scoped to {@code UPLOADED}: for the S3 source the property has always been
+   * rendered, so a missing value there means a hand-edited model and should still fail loudly
+   * rather than silently run as {@code SYNC} — which, unlike the template's {@code POLLING}
+   * default, is capped at a single page.
    */
   public TextractRequestData {
     if (executionType == null && documentLocationType == DocumentLocationType.UPLOADED) {

--- a/connectors/aws/aws-textract/src/main/java/io/camunda/connector/textract/model/TextractRequestData.java
+++ b/connectors/aws/aws-textract/src/main/java/io/camunda/connector/textract/model/TextractRequestData.java
@@ -243,29 +243,6 @@ public record TextractRequestData(
             constraints = @TemplateProperty.PropertyConstraints(notEmpty = true))
         String outputConfigS3Prefix) {
 
-  /**
-   * Backward-compatibility shim for models built on template v6 and earlier, where no {@code
-   * executionType} reaches the connector at all on the Camunda document branch.
-   *
-   * <p>Until v7 the {@code executionType} property was rendered only for the S3 source, and an
-   * element template property whose condition is not met has its value removed from the BPMN XML. A
-   * model selecting the Camunda document source therefore sent no {@code executionType}, and the
-   * {@code @NotNull} above rejected the request before the connector ever ran. From v7 on, {@link
-   * #uploadedExecutionType} writes {@code SYNC} explicitly, so this shim is inert for new models —
-   * but deployed process definitions are immutable, so it is what repairs existing ones without
-   * requiring a remodel.
-   *
-   * <p>Deliberately scoped to {@code UPLOADED}: for the S3 source the property has always been
-   * rendered, so a missing value there means a hand-edited model and should still fail loudly
-   * rather than silently run as {@code SYNC} — which, unlike the template's {@code POLLING}
-   * default, is capped at a single page.
-   */
-  public TextractRequestData {
-    if (executionType == null && documentLocationType == DocumentLocationType.UPLOADED) {
-      executionType = TextractExecutionType.SYNC;
-    }
-  }
-
   @TemplateProperty(ignore = true)
   public static final String WRONG_NOTIFICATION_VALUES_MSG =
       "Either both notification values role ARN and topic ARN must be filled in or none of them.";

--- a/connectors/aws/aws-textract/src/main/java/io/camunda/connector/textract/model/TextractRequestData.java
+++ b/connectors/aws/aws-textract/src/main/java/io/camunda/connector/textract/model/TextractRequestData.java
@@ -71,7 +71,7 @@ public record TextractRequestData(
             defaultValue = "POLLING",
             feel = FeelMode.disabled,
             tooltip =
-                "How the document should be processed. See more info in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-textract/#execution-types\" target=\"_blank\">Amazon Textract execution types documentation</a>.",
+                "How the document should be processed. See more info in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-textract/#input-parameters\" target=\"_blank\">Amazon Textract execution types documentation</a>.",
             condition =
                 @TemplateProperty.PropertyCondition(
                     property = "input.documentLocationType",

--- a/connectors/aws/aws-textract/src/main/java/io/camunda/connector/textract/model/TextractRequestData.java
+++ b/connectors/aws/aws-textract/src/main/java/io/camunda/connector/textract/model/TextractRequestData.java
@@ -78,21 +78,7 @@ public record TextractRequestData(
                     equals = "S3"))
         @NotNull
         TextractExecutionType executionType,
-    /**
-     * Template-only companion to {@link #executionType}, and always {@code null} at runtime.
-     *
-     * <p>Binds to the same {@code input.executionType} variable but is shown on the complementary
-     * branch — the Camunda document source — where it offers {@code SYNC} as its only choice.
-     * Textract's {@code StartDocumentAnalysis} (polling and async) takes a {@code
-     * DocumentLocation}, so sync is the only mode that can analyze inline bytes; surfacing it as a
-     * one-option dropdown makes that visible in Modeler instead of leaving users to wonder why the
-     * field vanished.
-     *
-     * <p>Nothing reads this component: the value it writes arrives under the {@code executionType}
-     * JSON key and is bound to {@link #executionType}. Two properties sharing one binding with
-     * mutually exclusive conditions is the same pattern the S3 connector uses for its per-operation
-     * {@code action.bucket} fields.
-     */
+    // Template-only twin of executionType: same binding, inverse condition, null at runtime.
     @TemplateProperty(
             id = "uploadedExecutionType",
             label = "Execution type",
@@ -103,8 +89,7 @@ public record TextractRequestData(
             choices = @TemplateProperty.DropdownPropertyChoice(value = "SYNC", label = "Real-time"),
             tooltip =
                 "Documents supplied from Camunda are analyzed in real time. Polling and asynchronous execution require the document to be stored in Amazon S3.",
-            // Relative to this record's own path: the generator prefixes "input." because
-            // TextractRequest exposes this record under its `input` field.
+            // Relative: the generator prefixes "input." from TextractRequest's `input` field.
             binding = @TemplateProperty.PropertyBinding(name = "executionType"),
             condition =
                 @TemplateProperty.PropertyCondition(

--- a/connectors/aws/aws-textract/src/main/java/io/camunda/connector/textract/model/TextractRequestData.java
+++ b/connectors/aws/aws-textract/src/main/java/io/camunda/connector/textract/model/TextractRequestData.java
@@ -210,6 +210,29 @@ public record TextractRequestData(
             constraints = @TemplateProperty.PropertyConstraints(notEmpty = true))
         String outputConfigS3Prefix) {
 
+  /**
+   * Defaults a missing {@code executionType} to {@link TextractExecutionType#SYNC} when the
+   * document comes from the Camunda document store.
+   *
+   * <p>The {@code executionType} property is only rendered for the S3 source, and an element
+   * template property whose condition is not met has its value removed from the BPMN XML. A model
+   * that selects the Camunda document source therefore sends no {@code executionType} at all, and
+   * the {@code @NotNull} above rejected the request before the connector ever ran. {@code SYNC} is
+   * the only possible mode here: Textract's {@code StartDocumentAnalysis} (polling and async) takes
+   * a {@link software.amazon.awssdk.services.textract.model.DocumentLocation}, so it cannot analyze
+   * inline bytes.
+   *
+   * <p>Deliberately scoped to {@code UPLOADED}: for the S3 source the property is always rendered,
+   * so a missing value there means a hand-edited model and should still fail loudly rather than
+   * silently run as {@code SYNC} — which, unlike the template's {@code POLLING} default, is capped
+   * at a single page.
+   */
+  public TextractRequestData {
+    if (executionType == null && documentLocationType == DocumentLocationType.UPLOADED) {
+      executionType = TextractExecutionType.SYNC;
+    }
+  }
+
   @TemplateProperty(ignore = true)
   public static final String WRONG_NOTIFICATION_VALUES_MSG =
       "Either both notification values role ARN and topic ARN must be filled in or none of them.";

--- a/connectors/aws/aws-textract/src/test/java/io/camunda/connector/textract/TextractCamundaDocumentSourceTest.java
+++ b/connectors/aws/aws-textract/src/test/java/io/camunda/connector/textract/TextractCamundaDocumentSourceTest.java
@@ -7,7 +7,6 @@
 package io.camunda.connector.textract;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.camunda.connector.api.error.ConnectorInputException;
@@ -17,21 +16,41 @@ import io.camunda.connector.textract.model.TextractRequest;
 import org.junit.jupiter.api.Test;
 
 /**
- * Reproduces the "Camunda Document" document-source defect.
+ * Pins the "Camunda Document" document-source contract.
  *
- * <p>{@code input.executionType} is annotated {@code @NotNull}, but its element-template property
- * is conditioned on {@code input.documentLocationType == "S3"}. Per the element-template contract,
- * "if a property is not active, it is not displayed, and its value is removed from the XML" — so a
- * model that selects the Camunda Document source sends no {@code executionType} at all, and binding
- * the request fails validation before the connector ever runs.
+ * <p>Until template v7 the {@code executionType} property was rendered only for the S3 source, and
+ * an element template property whose condition is not met has its value removed from the BPMN XML.
+ * A model selecting the Camunda document source therefore sent no {@code executionType} at all and
+ * was rejected by the {@code @NotNull} on {@code TextractRequestData.executionType} before the
+ * connector ever ran — the path was unusable.
  *
- * <p>The variables below are exactly what such a model emits: {@code documentLocationType} set to
- * {@code UPLOADED}, and no {@code executionType} key. Every other conditional S3 property is
- * likewise absent.
+ * <p>From v7 the {@code uploadedExecutionType} property writes {@code SYNC} explicitly on that
+ * branch, so the variable is always present. Models still on v6 or earlier must be upgraded to v7
+ * in Modeler and redeployed; that is a deliberate choice, since the old path never worked and so
+ * has no behavior worth preserving.
  */
 class TextractCamundaDocumentSourceTest {
 
-  private static final String CAMUNDA_DOCUMENT_SOURCE_VARIABLES =
+  /** What template v7 emits for the Camunda document source. */
+  private static final String V7_CAMUNDA_DOCUMENT_VARIABLES =
+      """
+      {
+        "input": {
+          "documentLocationType": "UPLOADED",
+          "executionType": "SYNC",
+          "analyzeTables": true,
+          "analyzeForms": true,
+          "analyzeSignatures": true,
+          "analyzeLayout": false,
+          "analyzeQueries": false
+        },
+        "configuration": { "region": "eu-central-1" },
+        "authentication": { "type": "defaultCredentialsChain" }
+      }
+      """;
+
+  /** What template v6 and earlier emitted: the conditional property is stripped entirely. */
+  private static final String PRE_V7_CAMUNDA_DOCUMENT_VARIABLES =
       """
       {
         "input": {
@@ -47,49 +66,27 @@ class TextractCamundaDocumentSourceTest {
       }
       """;
 
-  private static final String S3_SOURCE_VARIABLES_WITHOUT_EXECUTION_TYPE =
-      """
-      {
-        "input": {
-          "documentLocationType": "S3",
-          "documentS3Bucket": "bucket",
-          "documentName": "file.pdf",
-          "analyzeTables": true,
-          "analyzeForms": true,
-          "analyzeSignatures": true,
-          "analyzeLayout": false,
-          "analyzeQueries": false
-        },
-        "configuration": { "region": "eu-central-1" },
-        "authentication": { "type": "defaultCredentialsChain" }
-      }
-      """;
-
   @Test
-  void bindsCamundaDocumentSourceWithoutExplicitExecutionType() {
+  void bindsCamundaDocumentSourceWhenTemplateSuppliesSync() {
     var context =
-        OutboundConnectorContextBuilder.create()
-            .variables(CAMUNDA_DOCUMENT_SOURCE_VARIABLES)
-            .build();
+        OutboundConnectorContextBuilder.create().variables(V7_CAMUNDA_DOCUMENT_VARIABLES).build();
 
-    // FAILS before the fix: ConnectorInputException
-    //   "Property: input.executionType: Validation failed. Original message: must not be null"
-    assertThatCode(() -> context.bindVariables(TextractRequest.class)).doesNotThrowAnyException();
-
-    // Only SYNC can analyze inline bytes — Textract's async/polling APIs require an S3 location.
+    // SYNC is the only mode that can run here: Textract's StartDocumentAnalysis (polling and async)
+    // takes a DocumentLocation, so it cannot analyze inline bytes.
     assertThat(context.bindVariables(TextractRequest.class).getInput().executionType())
         .isEqualTo(TextractExecutionType.SYNC);
   }
 
   @Test
-  void stillRejectsMissingExecutionTypeForS3Source() {
+  void rejectsPreV7ModelThatOmitsExecutionType() {
     var context =
         OutboundConnectorContextBuilder.create()
-            .variables(S3_SOURCE_VARIABLES_WITHOUT_EXECUTION_TYPE)
+            .variables(PRE_V7_CAMUNDA_DOCUMENT_VARIABLES)
             .build();
 
-    // The default is scoped to UPLOADED on purpose: the S3 source always renders executionType, so
-    // a missing value there is a malformed model and must not silently degrade to single-page SYNC.
+    // Intentional: pre-v7 models must be upgraded to v7 in Modeler and redeployed. Defaulting the
+    // missing value in code was considered and rejected — the old path always failed, so there is
+    // no working behavior to stay compatible with.
     assertThatThrownBy(() -> context.bindVariables(TextractRequest.class))
         .isInstanceOf(ConnectorInputException.class)
         .hasMessageContaining("input.executionType");

--- a/connectors/aws/aws-textract/src/test/java/io/camunda/connector/textract/TextractCamundaDocumentSourceTest.java
+++ b/connectors/aws/aws-textract/src/test/java/io/camunda/connector/textract/TextractCamundaDocumentSourceTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.textract;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.connector.api.error.ConnectorInputException;
+import io.camunda.connector.runtime.test.outbound.OutboundConnectorContextBuilder;
+import io.camunda.connector.textract.model.TextractExecutionType;
+import io.camunda.connector.textract.model.TextractRequest;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Reproduces the "Camunda Document" document-source defect.
+ *
+ * <p>{@code input.executionType} is annotated {@code @NotNull}, but its element-template property
+ * is conditioned on {@code input.documentLocationType == "S3"}. Per the element-template contract,
+ * "if a property is not active, it is not displayed, and its value is removed from the XML" — so a
+ * model that selects the Camunda Document source sends no {@code executionType} at all, and binding
+ * the request fails validation before the connector ever runs.
+ *
+ * <p>The variables below are exactly what such a model emits: {@code documentLocationType} set to
+ * {@code UPLOADED}, and no {@code executionType} key. Every other conditional S3 property is
+ * likewise absent.
+ */
+class TextractCamundaDocumentSourceTest {
+
+  private static final String CAMUNDA_DOCUMENT_SOURCE_VARIABLES =
+      """
+      {
+        "input": {
+          "documentLocationType": "UPLOADED",
+          "analyzeTables": true,
+          "analyzeForms": true,
+          "analyzeSignatures": true,
+          "analyzeLayout": false,
+          "analyzeQueries": false
+        },
+        "configuration": { "region": "eu-central-1" },
+        "authentication": { "type": "defaultCredentialsChain" }
+      }
+      """;
+
+  private static final String S3_SOURCE_VARIABLES_WITHOUT_EXECUTION_TYPE =
+      """
+      {
+        "input": {
+          "documentLocationType": "S3",
+          "documentS3Bucket": "bucket",
+          "documentName": "file.pdf",
+          "analyzeTables": true,
+          "analyzeForms": true,
+          "analyzeSignatures": true,
+          "analyzeLayout": false,
+          "analyzeQueries": false
+        },
+        "configuration": { "region": "eu-central-1" },
+        "authentication": { "type": "defaultCredentialsChain" }
+      }
+      """;
+
+  @Test
+  void bindsCamundaDocumentSourceWithoutExplicitExecutionType() {
+    var context =
+        OutboundConnectorContextBuilder.create()
+            .variables(CAMUNDA_DOCUMENT_SOURCE_VARIABLES)
+            .build();
+
+    // FAILS before the fix: ConnectorInputException
+    //   "Property: input.executionType: Validation failed. Original message: must not be null"
+    assertThatCode(() -> context.bindVariables(TextractRequest.class)).doesNotThrowAnyException();
+
+    // Only SYNC can analyze inline bytes — Textract's async/polling APIs require an S3 location.
+    assertThat(context.bindVariables(TextractRequest.class).getInput().executionType())
+        .isEqualTo(TextractExecutionType.SYNC);
+  }
+
+  @Test
+  void stillRejectsMissingExecutionTypeForS3Source() {
+    var context =
+        OutboundConnectorContextBuilder.create()
+            .variables(S3_SOURCE_VARIABLES_WITHOUT_EXECUTION_TYPE)
+            .build();
+
+    // The default is scoped to UPLOADED on purpose: the S3 source always renders executionType, so
+    // a missing value there is a malformed model and must not silently degrade to single-page SYNC.
+    assertThatThrownBy(() -> context.bindVariables(TextractRequest.class))
+        .isInstanceOf(ConnectorInputException.class)
+        .hasMessageContaining("input.executionType");
+  }
+}

--- a/connectors/aws/aws-textract/src/test/java/io/camunda/connector/textract/TextractCamundaDocumentSourceTest.java
+++ b/connectors/aws/aws-textract/src/test/java/io/camunda/connector/textract/TextractCamundaDocumentSourceTest.java
@@ -9,14 +9,39 @@ package io.camunda.connector.textract;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.connector.api.error.ConnectorInputException;
 import io.camunda.connector.runtime.test.outbound.OutboundConnectorContextBuilder;
 import io.camunda.connector.textract.model.TextractExecutionType;
 import io.camunda.connector.textract.model.TextractRequest;
+import java.io.File;
+import java.util.stream.StreamSupport;
 import org.junit.jupiter.api.Test;
 
 /** Pins the "Camunda Document" document-source contract: v7 supplies sync, pre-v7 is rejected. */
 class TextractCamundaDocumentSourceTest {
+
+  private static final File TEMPLATE_FILE =
+      new File("element-templates/aws-textract-outbound-connector.json");
+
+  @Test
+  void v7TemplateBindsUploadedExecutionTypeToSyncOnUploadedSource() throws Exception {
+    JsonNode template = new ObjectMapper().readTree(TEMPLATE_FILE);
+    JsonNode property =
+        StreamSupport.stream(template.get("properties").spliterator(), false)
+            .filter(p -> p.has("id"))
+            .filter(p -> "input.uploadedExecutionType".equals(p.get("id").asText()))
+            .findFirst()
+            .orElseThrow(
+                () -> new AssertionError("input.uploadedExecutionType property not found"));
+
+    assertThat(property.get("binding").get("name").asText()).isEqualTo("input.executionType");
+    assertThat(property.get("value").asText()).isEqualTo("SYNC");
+    assertThat(property.get("condition").get("property").asText())
+        .isEqualTo("input.documentLocationType");
+    assertThat(property.get("condition").get("equals").asText()).isEqualTo("UPLOADED");
+  }
 
   /** What template v7 emits for the Camunda document source. */
   private static final String V7_CAMUNDA_DOCUMENT_VARIABLES =

--- a/connectors/aws/aws-textract/src/test/java/io/camunda/connector/textract/TextractCamundaDocumentSourceTest.java
+++ b/connectors/aws/aws-textract/src/test/java/io/camunda/connector/textract/TextractCamundaDocumentSourceTest.java
@@ -15,20 +15,7 @@ import io.camunda.connector.textract.model.TextractExecutionType;
 import io.camunda.connector.textract.model.TextractRequest;
 import org.junit.jupiter.api.Test;
 
-/**
- * Pins the "Camunda Document" document-source contract.
- *
- * <p>Until template v7 the {@code executionType} property was rendered only for the S3 source, and
- * an element template property whose condition is not met has its value removed from the BPMN XML.
- * A model selecting the Camunda document source therefore sent no {@code executionType} at all and
- * was rejected by the {@code @NotNull} on {@code TextractRequestData.executionType} before the
- * connector ever ran — the path was unusable.
- *
- * <p>From v7 the {@code uploadedExecutionType} property writes {@code SYNC} explicitly on that
- * branch, so the variable is always present. Models still on v6 or earlier must be upgraded to v7
- * in Modeler and redeployed; that is a deliberate choice, since the old path never worked and so
- * has no behavior worth preserving.
- */
+/** Pins the "Camunda Document" document-source contract: v7 supplies sync, pre-v7 is rejected. */
 class TextractCamundaDocumentSourceTest {
 
   /** What template v7 emits for the Camunda document source. */
@@ -71,8 +58,7 @@ class TextractCamundaDocumentSourceTest {
     var context =
         OutboundConnectorContextBuilder.create().variables(V7_CAMUNDA_DOCUMENT_VARIABLES).build();
 
-    // SYNC is the only mode that can run here: Textract's StartDocumentAnalysis (polling and async)
-    // takes a DocumentLocation, so it cannot analyze inline bytes.
+    // Sync is the only runnable mode here: StartDocumentAnalysis needs an S3 DocumentLocation.
     assertThat(context.bindVariables(TextractRequest.class).getInput().executionType())
         .isEqualTo(TextractExecutionType.SYNC);
   }
@@ -84,9 +70,7 @@ class TextractCamundaDocumentSourceTest {
             .variables(PRE_V7_CAMUNDA_DOCUMENT_VARIABLES)
             .build();
 
-    // Intentional: pre-v7 models must be upgraded to v7 in Modeler and redeployed. Defaulting the
-    // missing value in code was considered and rejected — the old path always failed, so there is
-    // no working behavior to stay compatible with.
+    // Intentional: pre-v7 models must be upgraded and redeployed, not defaulted to sync in code.
     assertThatThrownBy(() -> context.bindVariables(TextractRequest.class))
         .isInstanceOf(ConnectorInputException.class)
         .hasMessageContaining("input.executionType");

--- a/connectors/aws/aws-textract/src/test/java/io/camunda/connector/textract/caller/AsyncTextractCallerTest.java
+++ b/connectors/aws/aws-textract/src/test/java/io/camunda/connector/textract/caller/AsyncTextractCallerTest.java
@@ -110,6 +110,7 @@ class AsyncTextractCallerTest {
         "1",
         null,
         TextractExecutionType.ASYNC,
+        null, // uploadedExecutionType: template-only, never bound at runtime
         true,
         true,
         true,
@@ -133,6 +134,7 @@ class AsyncTextractCallerTest {
         "1",
         null,
         TextractExecutionType.ASYNC,
+        null, // uploadedExecutionType: template-only, never bound at runtime
         true,
         true,
         true,

--- a/connectors/aws/aws-textract/src/test/java/io/camunda/connector/textract/caller/SyncTextractCallerTest.java
+++ b/connectors/aws/aws-textract/src/test/java/io/camunda/connector/textract/caller/SyncTextractCallerTest.java
@@ -34,6 +34,7 @@ class SyncTextractCallerTest {
             "1",
             null,
             TextractExecutionType.SYNC,
+            null, // uploadedExecutionType: template-only, never bound at runtime
             true,
             true,
             true,
@@ -73,6 +74,7 @@ class SyncTextractCallerTest {
             null,
             document,
             TextractExecutionType.SYNC,
+            null, // uploadedExecutionType: template-only, never bound at runtime
             true,
             false,
             false,

--- a/connectors/aws/aws-textract/src/test/java/io/camunda/connector/textract/caller/TextractCallerTest.java
+++ b/connectors/aws/aws-textract/src/test/java/io/camunda/connector/textract/caller/TextractCallerTest.java
@@ -42,6 +42,7 @@ class TextractCallerTest {
             "1",
             null,
             TextractExecutionType.SYNC,
+            null, // uploadedExecutionType: template-only, never bound at runtime
             true,
             true,
             true,
@@ -69,6 +70,7 @@ class TextractCallerTest {
             "1",
             null,
             TextractExecutionType.SYNC,
+            null, // uploadedExecutionType: template-only, never bound at runtime
             false,
             false,
             false,
@@ -100,6 +102,7 @@ class TextractCallerTest {
             "1",
             null,
             TextractExecutionType.SYNC,
+            null, // uploadedExecutionType: template-only, never bound at runtime
             true,
             false,
             false,

--- a/connectors/aws/aws-textract/src/test/java/io/camunda/connector/textract/util/TextractTestUtils.java
+++ b/connectors/aws/aws-textract/src/test/java/io/camunda/connector/textract/util/TextractTestUtils.java
@@ -200,6 +200,7 @@ public class TextractTestUtils {
           "1",
           null,
           TextractExecutionType.ASYNC,
+          null, // uploadedExecutionType: template-only, never bound at runtime
           true,
           true,
           true,


### PR DESCRIPTION
## Description

**Camunda Document** as the document source fails every job with `input.executionType: must not be null` — it is `@NotNull` but conditioned on `documentLocationType == "S3"`, and an inactive property's value is stripped from the XML. Affects 8.8, 8.9 and main.

Template-only fix: a second property on the same binding, offering `SYNC` for that source.

## Checklist

- [ ] PR has a **milestone** or the `no milestone` label.
- [x] Backport labels are added if these code changes should be backported.
- [x] Tests for the changes have been added.
- [ ] Documentation updated if required.
