### PR TITLE
fix(microsoft-email-inbound): correct docs link anchor for mailbox config

### DIFF
--- a/connectors/microsoft/email-inbound/element-templates/hybrid/hybrid-microsoft-o365-email-boundary-event-connector-hybrid.json
+++ b/connectors/microsoft/email-inbound/element-templates/hybrid/hybrid-microsoft-o365-email-boundary-event-connector-hybrid.json
@@ -234,7 +234,7 @@
       "name" : "pollingConfig.userId",
       "type" : "zeebe:property"
     },
-    "tooltip" : "The email address or user ID of the mailbox to monitor. <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/microsoft-o365-mail-inbound/#configuration\" target=\"_blank\">Microsoft O365 Mail connector configuration</a>",
+    "tooltip" : "The email address or user ID of the mailbox to monitor. <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/microsoft-o365-mail-inbound/#mailbox-configuration\" target=\"_blank\">Microsoft O365 Mail connector configuration</a>",
     "placeholder" : "user@example.com",
     "type" : "String"
   }, {

--- a/connectors/microsoft/email-inbound/element-templates/hybrid/hybrid-microsoft-o365-email-intermediate-catch-event-connector-hybrid.json
+++ b/connectors/microsoft/email-inbound/element-templates/hybrid/hybrid-microsoft-o365-email-intermediate-catch-event-connector-hybrid.json
@@ -234,7 +234,7 @@
       "name" : "pollingConfig.userId",
       "type" : "zeebe:property"
     },
-    "tooltip" : "The email address or user ID of the mailbox to monitor. <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/microsoft-o365-mail-inbound/#configuration\" target=\"_blank\">Microsoft O365 Mail connector configuration</a>",
+    "tooltip" : "The email address or user ID of the mailbox to monitor. <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/microsoft-o365-mail-inbound/#mailbox-configuration\" target=\"_blank\">Microsoft O365 Mail connector configuration</a>",
     "placeholder" : "user@example.com",
     "type" : "String"
   }, {

--- a/connectors/microsoft/email-inbound/element-templates/hybrid/hybrid-microsoft-o365-email-message-start-event-connector-hybrid.json
+++ b/connectors/microsoft/email-inbound/element-templates/hybrid/hybrid-microsoft-o365-email-message-start-event-connector-hybrid.json
@@ -234,7 +234,7 @@
       "name" : "pollingConfig.userId",
       "type" : "zeebe:property"
     },
-    "tooltip" : "The email address or user ID of the mailbox to monitor. <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/microsoft-o365-mail-inbound/#configuration\" target=\"_blank\">Microsoft O365 Mail connector configuration</a>",
+    "tooltip" : "The email address or user ID of the mailbox to monitor. <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/microsoft-o365-mail-inbound/#mailbox-configuration\" target=\"_blank\">Microsoft O365 Mail connector configuration</a>",
     "placeholder" : "user@example.com",
     "type" : "String"
   }, {

--- a/connectors/microsoft/email-inbound/element-templates/microsoft-o365-email-boundary-event-connector.json
+++ b/connectors/microsoft/email-inbound/element-templates/microsoft-o365-email-boundary-event-connector.json
@@ -229,7 +229,7 @@
       "name" : "pollingConfig.userId",
       "type" : "zeebe:property"
     },
-    "tooltip" : "The email address or user ID of the mailbox to monitor. <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/microsoft-o365-mail-inbound/#configuration\" target=\"_blank\">Microsoft O365 Mail connector configuration</a>",
+    "tooltip" : "The email address or user ID of the mailbox to monitor. <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/microsoft-o365-mail-inbound/#mailbox-configuration\" target=\"_blank\">Microsoft O365 Mail connector configuration</a>",
     "placeholder" : "user@example.com",
     "type" : "String"
   }, {

--- a/connectors/microsoft/email-inbound/element-templates/microsoft-o365-email-intermediate-catch-event-connector.json
+++ b/connectors/microsoft/email-inbound/element-templates/microsoft-o365-email-intermediate-catch-event-connector.json
@@ -229,7 +229,7 @@
       "name" : "pollingConfig.userId",
       "type" : "zeebe:property"
     },
-    "tooltip" : "The email address or user ID of the mailbox to monitor. <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/microsoft-o365-mail-inbound/#configuration\" target=\"_blank\">Microsoft O365 Mail connector configuration</a>",
+    "tooltip" : "The email address or user ID of the mailbox to monitor. <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/microsoft-o365-mail-inbound/#mailbox-configuration\" target=\"_blank\">Microsoft O365 Mail connector configuration</a>",
     "placeholder" : "user@example.com",
     "type" : "String"
   }, {

--- a/connectors/microsoft/email-inbound/element-templates/microsoft-o365-email-message-start-event-connector.json
+++ b/connectors/microsoft/email-inbound/element-templates/microsoft-o365-email-message-start-event-connector.json
@@ -229,7 +229,7 @@
       "name" : "pollingConfig.userId",
       "type" : "zeebe:property"
     },
-    "tooltip" : "The email address or user ID of the mailbox to monitor. <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/microsoft-o365-mail-inbound/#configuration\" target=\"_blank\">Microsoft O365 Mail connector configuration</a>",
+    "tooltip" : "The email address or user ID of the mailbox to monitor. <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/microsoft-o365-mail-inbound/#mailbox-configuration\" target=\"_blank\">Microsoft O365 Mail connector configuration</a>",
     "placeholder" : "user@example.com",
     "type" : "String"
   }, {

--- a/connectors/microsoft/email-inbound/src/main/java/io/camunda/connector/microsoft/email/model/config/EmailPollingConfig.java
+++ b/connectors/microsoft/email-inbound/src/main/java/io/camunda/connector/microsoft/email/model/config/EmailPollingConfig.java
@@ -20,7 +20,7 @@ public record EmailPollingConfig(
             feel = FeelMode.optional,
             placeholder = "user@example.com",
             tooltip =
-                "The email address or user ID of the mailbox to monitor. <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/microsoft-o365-mail-inbound/#configuration\" target=\"_blank\">Microsoft O365 Mail connector configuration</a>")
+                "The email address or user ID of the mailbox to monitor. <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/microsoft-o365-mail-inbound/#mailbox-configuration\" target=\"_blank\">Microsoft O365 Mail connector configuration</a>")
         @NotBlank
         @FEEL
         String userId,


### PR DESCRIPTION
## Summary
- Fixed a broken docs link anchor (`#configuration` → `#mailbox-configuration`) in the Microsoft O365 Mail inbound connector's mailbox config description
- Regenerated the affected element templates to match

## Test plan
- [x] Regenerated templates via `mvn process-classes` and confirmed the only diff is the anchor change