### PR TITLE
feat(agentic-ai): add experimental Local Toolbox gateway tool connector

### DIFF
--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/AbstractConnectorContext.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/AbstractConnectorContext.java
@@ -20,6 +20,7 @@ import io.camunda.connector.api.secret.SecretProvider;
 import io.camunda.connector.api.validation.ValidationProvider;
 import io.camunda.connector.runtime.core.secret.SecretFilter;
 import io.camunda.connector.runtime.core.secret.SecretHandler;
+import io.camunda.connector.runtime.core.secret.SecretResolverMode;
 import org.jspecify.annotations.Nullable;
 
 public abstract class AbstractConnectorContext {
@@ -30,10 +31,20 @@ public abstract class AbstractConnectorContext {
 
   protected final ValidationProvider validationProvider;
 
+  private final SecretResolverMode secretResolverMode;
+
   protected AbstractConnectorContext(
       final SecretProvider secretProvider,
-      SecretFilter secretFilter,
+      final SecretFilter secretFilter,
       final ValidationProvider validationProvider) {
+    this(secretProvider, secretFilter, validationProvider, SecretResolverMode.ALL);
+  }
+
+  protected AbstractConnectorContext(
+      final SecretProvider secretProvider,
+      final SecretFilter secretFilter,
+      final ValidationProvider validationProvider,
+      final SecretResolverMode secretResolverMode) {
     if (secretFilter == null) {
       throw new IllegalArgumentException(
           "Secret filter required in Connector context but was null");
@@ -48,11 +59,13 @@ public abstract class AbstractConnectorContext {
       throw new RuntimeException("Validation provider required in Connector context but was null");
     }
     this.validationProvider = validationProvider;
+    this.secretResolverMode =
+        secretResolverMode != null ? secretResolverMode : SecretResolverMode.ALL;
   }
 
   public SecretHandler getSecretHandler() {
     if (secretHandler == null) {
-      secretHandler = new SecretHandler(secretProvider, secretFilter);
+      secretHandler = new SecretHandler(secretProvider, secretFilter, secretResolverMode);
     }
     return secretHandler;
   }

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/outbound/JobHandlerContext.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/outbound/JobHandlerContext.java
@@ -34,6 +34,7 @@ import io.camunda.connector.api.secret.SecretProvider;
 import io.camunda.connector.api.validation.ValidationProvider;
 import io.camunda.connector.runtime.core.AbstractConnectorContext;
 import io.camunda.connector.runtime.core.secret.SecretFilter;
+import io.camunda.connector.runtime.core.secret.SecretResolverMode;
 import java.util.Objects;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
@@ -62,7 +63,25 @@ public class JobHandlerContext extends AbstractConnectorContext
       final DocumentFactory documentFactory,
       final ObjectMapper objectMapper,
       final SecretFilter secretFilter) {
-    super(secretProvider, secretFilter, validationProvider);
+    this(
+        job,
+        secretProvider,
+        validationProvider,
+        documentFactory,
+        objectMapper,
+        secretFilter,
+        SecretResolverMode.ALL);
+  }
+
+  public JobHandlerContext(
+      final ActivatedJob job,
+      final SecretProvider secretProvider,
+      final ValidationProvider validationProvider,
+      final DocumentFactory documentFactory,
+      final ObjectMapper objectMapper,
+      final SecretFilter secretFilter,
+      final SecretResolverMode secretResolverMode) {
+    super(secretProvider, secretFilter, validationProvider, secretResolverMode);
     this.documentFactory = documentFactory;
     this.job = job;
     this.objectMapper = objectMapper;

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretHandler.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretHandler.java
@@ -31,8 +31,14 @@ public class SecretHandler {
 
   protected SecretReplacer secretReplacer;
 
-  public SecretHandler(final SecretProvider secretProvider, SecretFilter secretFilter) {
+  protected final SecretResolverMode mode;
+
+  public SecretHandler(
+      final SecretProvider secretProvider,
+      final SecretFilter secretFilter,
+      final SecretResolverMode mode) {
     this.secretProvider = secretProvider;
+    this.mode = mode;
     secretReplacer =
         (name, context) -> {
           if (secretFilter.isAllowed(name)) {
@@ -48,6 +54,6 @@ public class SecretHandler {
   }
 
   public String replaceSecrets(String input, SecretContext context) {
-    return SecretUtil.replaceSecrets(input, context, secretReplacer);
+    return SecretUtil.replaceSecrets(input, context, secretReplacer, mode);
   }
 }

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretResolverMode.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretResolverMode.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.runtime.core.secret;
+
+public enum SecretResolverMode {
+  /** Resolve both {@code {{secrets.KEY}}} and the legacy unbraced {@code secrets.KEY} pattern. */
+  ALL,
+  /**
+   * Resolve only {@code {{secrets.KEY}}}. The legacy unbraced {@code secrets.KEY} pattern is
+   * ignored, preventing accidental matches in arbitrary text such as third-party documentation.
+   */
+  BRACES_ONLY
+}

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretUtil.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretUtil.java
@@ -37,13 +37,17 @@ public class SecretUtil {
   private static final Pattern SECRET_PATTERN_PARENTHESES =
       Pattern.compile("\\{\\{\\s*secrets\\.(?<secret>\\S+?\\s*)}}");
 
+  private SecretUtil() {}
+
   public static String replaceSecrets(
-      String input, SecretContext context, SecretReplacer secretReplacer) {
+      String input, SecretContext context, SecretReplacer secretReplacer, SecretResolverMode mode) {
     if (input == null) {
       throw new IllegalStateException("input cant be null.");
     }
     input = replaceSecretsWithParentheses(input, context, secretReplacer);
-    input = replaceSecretsWithoutParentheses(input, context, secretReplacer);
+    if (mode == SecretResolverMode.ALL) {
+      input = replaceSecretsWithoutParentheses(input, context, secretReplacer);
+    }
     return input;
   }
 
@@ -103,14 +107,19 @@ public class SecretUtil {
     return output.toString();
   }
 
-  public static List<String> retrieveSecretKeysInInput(String input) {
-    return Objects.isNull(input)
-        ? List.of()
-        : Stream.of(SECRET_PATTERN_PARENTHESES, SECRET_PATTERN_SECRETS)
-            .map(pattern -> pattern.matcher(input))
-            .flatMap(Matcher::results)
-            .map(matchResult -> matchResult.group("secret"))
-            .distinct()
-            .toList();
+  public static List<String> retrieveSecretKeysInInput(String input, SecretResolverMode mode) {
+    if (Objects.isNull(input)) {
+      return List.of();
+    }
+    var patterns =
+        mode == SecretResolverMode.ALL
+            ? Stream.of(SECRET_PATTERN_PARENTHESES, SECRET_PATTERN_SECRETS)
+            : Stream.of(SECRET_PATTERN_PARENTHESES);
+    return patterns
+        .map(pattern -> pattern.matcher(input))
+        .flatMap(Matcher::results)
+        .map(matchResult -> matchResult.group("secret"))
+        .distinct()
+        .toList();
   }
 }

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/SecretUtilTests.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/SecretUtilTests.java
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.verifyNoInteractions;
 
 import io.camunda.connector.api.secret.SecretContext;
 import io.camunda.connector.runtime.core.secret.SecretReplacer;
+import io.camunda.connector.runtime.core.secret.SecretResolverMode;
 import io.camunda.connector.runtime.core.secret.SecretUtil;
 import java.util.List;
 import java.util.Map;
@@ -57,12 +58,36 @@ public class SecretUtilTests {
   })
   void testSecretPattern(String input, String secret, Boolean shouldDetect) {
     var secretReplacer = mock(SecretReplacer.class);
-    SecretUtil.replaceSecrets(input, null, secretReplacer);
+    SecretUtil.replaceSecrets(input, null, secretReplacer, SecretResolverMode.ALL);
     if (shouldDetect) {
       verify(secretReplacer).replaceSecrets(eq(secret), any());
     } else {
       verifyNoInteractions(secretReplacer);
     }
+  }
+
+  @Test
+  void bracesOnly_secretsDotKeyNotReplaced() {
+    var secretReplacer = mock(SecretReplacer.class);
+    SecretUtil.replaceSecrets(
+        "secrets.MY_SECRET", null, secretReplacer, SecretResolverMode.BRACES_ONLY);
+    verifyNoInteractions(secretReplacer);
+  }
+
+  @Test
+  void bracesOnly_bracesPatternStillReplaced() {
+    var secretReplacer = mock(SecretReplacer.class);
+    SecretUtil.replaceSecrets(
+        "{{secrets.MY_SECRET}}", null, secretReplacer, SecretResolverMode.BRACES_ONLY);
+    verify(secretReplacer).replaceSecrets(eq("MY_SECRET"), any());
+  }
+
+  @Test
+  void bracesOnly_retrieveSecretKeysExcludesUnbracedKeys() {
+    var keys =
+        SecretUtil.retrieveSecretKeysInInput(
+            "secrets.A and {{secrets.B}}", SecretResolverMode.BRACES_ONLY);
+    assertThat(keys).containsExactly("B");
   }
 
   Map<String, String> secrets =
@@ -82,7 +107,7 @@ public class SecretUtilTests {
       delimiter = '|') // delimiter is needed to escape the comma in the json
   void testSecretReplacementWithJsonInput(String input, String output) {
     SecretReplacer secretReplacer = (name, context) -> secrets.get(name);
-    var result = SecretUtil.replaceSecrets(input, null, secretReplacer);
+    var result = SecretUtil.replaceSecrets(input, null, secretReplacer, SecretResolverMode.ALL);
     assertThat(result).isEqualTo(output);
   }
 
@@ -93,7 +118,8 @@ public class SecretUtilTests {
         (name, context) -> allowList.contains(name) ? secrets.get(name) : null;
     String content = "Hello {{secrets.KEY1}} and {{secrets.KEY2}} and {{secrets.KEY3}}";
     SecretContext secretContext = new SecretContext("tenantId", "processId");
-    String replacedContent = SecretUtil.replaceSecrets(content, secretContext, secretReplacer);
+    String replacedContent =
+        SecretUtil.replaceSecrets(content, secretContext, secretReplacer, SecretResolverMode.ALL);
     assertThat(replacedContent).isEqualTo("Hello VALUE1 and VALUE2 and {{secrets.KEY3}}");
   }
 }

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/OutboundConnectorRuntimeConfiguration.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/OutboundConnectorRuntimeConfiguration.java
@@ -35,6 +35,7 @@ import io.camunda.connector.runtime.core.outbound.DefaultOutboundConnectorFactor
 import io.camunda.connector.runtime.core.outbound.OutboundConnectorFactory;
 import io.camunda.connector.runtime.core.secret.SecretFilterFactory;
 import io.camunda.connector.runtime.core.secret.SecretProviderAggregator;
+import io.camunda.connector.runtime.core.secret.SecretResolverMode;
 import io.camunda.connector.runtime.core.validation.ValidationUtil;
 import io.camunda.connector.runtime.instances.InstanceForwardingConfiguration;
 import io.camunda.connector.runtime.instances.service.OutboundConnectorsService;
@@ -187,7 +188,8 @@ public class OutboundConnectorRuntimeConfiguration {
       DocumentFactory documentFactory,
       @OutboundConnectorObjectMapper ObjectMapper objectMapper,
       SecretFilterFactory secretFilterFactory,
-      Optional<MeterRegistry> meterRegistry) {
+      Optional<MeterRegistry> meterRegistry,
+      SecretResolverMode secretResolverMode) {
     return new OutboundConnectorManager(
         jobWorkerManager,
         connectorFactory,
@@ -198,6 +200,7 @@ public class OutboundConnectorRuntimeConfiguration {
         objectMapper,
         metricsRecorder,
         secretFilterFactory,
-        meterRegistry.orElse(null));
+        meterRegistry.orElse(null),
+        secretResolverMode);
   }
 }

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/OutboundConnectorExceptionHandler.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/OutboundConnectorExceptionHandler.java
@@ -27,6 +27,7 @@ import io.camunda.connector.api.secret.SecretProvider;
 import io.camunda.connector.runtime.core.error.InvalidBackOffDurationException;
 import io.camunda.connector.runtime.core.outbound.ConnectorResult;
 import io.camunda.connector.runtime.core.secret.SecretFilter;
+import io.camunda.connector.runtime.core.secret.SecretResolverMode;
 import io.camunda.connector.runtime.core.secret.SecretUtil;
 import java.time.Duration;
 import java.util.*;
@@ -38,9 +39,11 @@ public class OutboundConnectorExceptionHandler {
   private static final Logger LOGGER =
       LoggerFactory.getLogger(OutboundConnectorExceptionHandler.class);
   private final SecretProvider secretProvider;
+  private final SecretResolverMode mode;
 
-  public OutboundConnectorExceptionHandler(SecretProvider secretProvider) {
+  public OutboundConnectorExceptionHandler(SecretProvider secretProvider, SecretResolverMode mode) {
     this.secretProvider = secretProvider;
+    this.mode = mode;
   }
 
   private static Map<String, Object> exceptionToMap(Exception wrappedException) {
@@ -72,7 +75,7 @@ public class OutboundConnectorExceptionHandler {
     List<String> secrets;
     try {
       var allowedKeys =
-          SecretUtil.retrieveSecretKeysInInput(job.getVariables()).stream()
+          SecretUtil.retrieveSecretKeysInInput(job.getVariables(), mode).stream()
               .filter(secretFilter::isAllowed)
               .toList();
       secrets =
@@ -173,7 +176,7 @@ public class OutboundConnectorExceptionHandler {
   public ConnectorResult.ErrorResult handleFinalResultException(
       Exception ex, ActivatedJob job, SecretFilter secretFilter) {
     var allowedKeys =
-        SecretUtil.retrieveSecretKeysInInput(job.getVariables()).stream()
+        SecretUtil.retrieveSecretKeysInInput(job.getVariables(), mode).stream()
             .filter(secretFilter::isAllowed)
             .toList();
     List<String> secrets =

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/SpringConnectorJobHandler.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/SpringConnectorJobHandler.java
@@ -63,6 +63,7 @@ import io.camunda.connector.runtime.core.secret.SecretFilterFactory;
 import io.camunda.connector.runtime.core.secret.SecretFilterFactory.SecretFilterContext;
 import io.camunda.connector.runtime.core.secret.SecretProviderAggregator;
 import io.camunda.connector.runtime.core.secret.SecretProviderDiscovery;
+import io.camunda.connector.runtime.core.secret.SecretResolverMode;
 import io.camunda.connector.runtime.metrics.ConnectorMetrics;
 import io.camunda.connector.runtime.metrics.ConnectorOutboundMetrics;
 import java.time.Duration;
@@ -95,6 +96,7 @@ public class SpringConnectorJobHandler implements JobHandler {
   private final DocumentFactory documentFactory;
   private final ObjectMapper objectMapper;
   private final SecretFilterFactory secretFilterFactory;
+  private final SecretResolverMode secretResolverMode;
 
   public SpringConnectorJobHandler(
       MetricsRecorder outboundMetrics,
@@ -104,7 +106,8 @@ public class SpringConnectorJobHandler implements JobHandler {
       DocumentFactory documentFactory,
       ObjectMapper objectMapper,
       OutboundConnectorFunction connectorFunction,
-      SecretFilterFactory secretFilterFactory) {
+      SecretFilterFactory secretFilterFactory,
+      SecretResolverMode secretResolverMode) {
     this(
         new ConnectorOutboundMetrics(outboundMetrics, null),
         jobCallbackCommandWrapperFactory,
@@ -113,7 +116,8 @@ public class SpringConnectorJobHandler implements JobHandler {
         documentFactory,
         objectMapper,
         connectorFunction,
-        secretFilterFactory);
+        secretFilterFactory,
+        secretResolverMode);
   }
 
   public SpringConnectorJobHandler(
@@ -124,15 +128,17 @@ public class SpringConnectorJobHandler implements JobHandler {
       DocumentFactory documentFactory,
       ObjectMapper objectMapper,
       OutboundConnectorFunction connectorFunction,
-      SecretFilterFactory secretFilterFactory) {
+      SecretFilterFactory secretFilterFactory,
+      SecretResolverMode secretResolverMode) {
     this.call = connectorFunction;
     this.secretProvider = secretProviderAggregator;
     this.validationProvider = validationProvider;
     this.documentFactory = documentFactory;
     this.objectMapper = objectMapper;
     this.secretFilterFactory = secretFilterFactory;
+    this.secretResolverMode = secretResolverMode;
     this.outboundConnectorExceptionHandler =
-        new OutboundConnectorExceptionHandler(getSecretProvider());
+        new OutboundConnectorExceptionHandler(getSecretProvider(), secretResolverMode);
     this.connectorResultHandler = new ConnectorResultHandler(objectMapper);
     this.jobCallbackCommandWrapperFactory = jobCallbackCommandWrapperFactory;
     this.connectorsOutboundMetrics = outboundMetrics;
@@ -190,7 +196,8 @@ public class SpringConnectorJobHandler implements JobHandler {
             validationProvider,
             documentFactory,
             objectMapper,
-            secretFilter);
+            secretFilter,
+            secretResolverMode);
     ConnectorResult result = getConnectorResult(job, context, secretFilter);
     processFinalResult(client, job, context, result, counterMetricsContext, secretFilter);
   }

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/lifecycle/OutboundConnectorManager.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/lifecycle/OutboundConnectorManager.java
@@ -34,6 +34,7 @@ import io.camunda.connector.runtime.core.config.OutboundConnectorConfiguration;
 import io.camunda.connector.runtime.core.outbound.OutboundConnectorFactory;
 import io.camunda.connector.runtime.core.secret.SecretFilterFactory;
 import io.camunda.connector.runtime.core.secret.SecretProviderAggregator;
+import io.camunda.connector.runtime.core.secret.SecretResolverMode;
 import io.camunda.connector.runtime.metrics.ConnectorOutboundMetrics;
 import io.camunda.connector.runtime.outbound.job.SpringConnectorJobHandler;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -57,6 +58,7 @@ public class OutboundConnectorManager implements CamundaClientLifecycleAware {
   private final MetricsRecorder metricsRecorder;
   private final SecretFilterFactory secretFilterFactory;
   private final MeterRegistry meterRegistry;
+  private final SecretResolverMode secretResolverMode;
 
   public OutboundConnectorManager(
       JobWorkerManager jobWorkerManager,
@@ -68,7 +70,8 @@ public class OutboundConnectorManager implements CamundaClientLifecycleAware {
       ObjectMapper objectMapper,
       MetricsRecorder metricsRecorder,
       SecretFilterFactory secretFilterFactory,
-      MeterRegistry meterRegistry) {
+      MeterRegistry meterRegistry,
+      SecretResolverMode secretResolverMode) {
     this.jobWorkerManager = jobWorkerManager;
     this.connectorFactory = connectorFactory;
     this.jobCallbackCommandWrapperFactory = jobCallbackCommandWrapperFactory;
@@ -79,6 +82,7 @@ public class OutboundConnectorManager implements CamundaClientLifecycleAware {
     this.metricsRecorder = metricsRecorder;
     this.secretFilterFactory = secretFilterFactory;
     this.meterRegistry = meterRegistry;
+    this.secretResolverMode = secretResolverMode;
   }
 
   @Override
@@ -125,7 +129,8 @@ public class OutboundConnectorManager implements CamundaClientLifecycleAware {
                 documentFactory,
                 objectMapper,
                 connectorFunction,
-                secretFilterFactory);
+                secretFilterFactory,
+                secretResolverMode);
     jobWorkerManager.createJobWorker(
         client, new ManagedJobWorker(jobWorkerValue, jobHandlerFactory), this);
   }

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/secret/ProcessDefinitionSecretKeyCache.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/secret/ProcessDefinitionSecretKeyCache.java
@@ -18,6 +18,7 @@ package io.camunda.connector.runtime.outbound.secret;
 
 import io.camunda.client.CamundaClient;
 import io.camunda.connector.api.inbound.ElementTemplateDetails;
+import io.camunda.connector.runtime.core.secret.SecretResolverMode;
 import io.camunda.connector.runtime.core.secret.SecretUtil;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
@@ -107,7 +108,10 @@ public class ProcessDefinitionSecretKeyCache implements SecretKeyCache {
 
   private List<String> extractSecrets(List<ZeebeInput> inputs) {
     return inputs.stream()
-        .flatMap(input -> SecretUtil.retrieveSecretKeysInInput(input.getSource()).stream())
+        .flatMap(
+            input ->
+                SecretUtil.retrieveSecretKeysInInput(input.getSource(), SecretResolverMode.ALL)
+                    .stream())
         .map(String::trim)
         .distinct()
         .toList();

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/job/SpringConnectorJobHandlerTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/job/SpringConnectorJobHandlerTest.java
@@ -62,6 +62,7 @@ import io.camunda.connector.runtime.TestValidation;
 import io.camunda.connector.runtime.core.Keywords;
 import io.camunda.connector.runtime.core.secret.SecretFilter;
 import io.camunda.connector.runtime.core.secret.SecretProviderAggregator;
+import io.camunda.connector.runtime.core.secret.SecretResolverMode;
 import io.camunda.connector.runtime.secret.FooBarSecretProvider;
 import io.camunda.connector.validation.impl.DefaultValidationProvider;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
@@ -128,7 +129,8 @@ class SpringConnectorJobHandlerTest {
         mock(DocumentFactory.class),
         TestObjectMapperSupplier.INSTANCE,
         call,
-        job -> SecretFilter.allowAll());
+        job -> SecretFilter.allowAll(),
+        SecretResolverMode.ALL);
   }
 
   private SpringConnectorJobHandler newConnectorJobHandler(
@@ -143,7 +145,8 @@ class SpringConnectorJobHandlerTest {
         mock(DocumentFactory.class),
         TestObjectMapperSupplier.INSTANCE,
         call,
-        job -> SecretFilter.allowAll());
+        job -> SecretFilter.allowAll(),
+        SecretResolverMode.ALL);
   }
 
   @Nested

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/main/java/io/camunda/connector/runtime/ConnectorProperties.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/main/java/io/camunda/connector/runtime/ConnectorProperties.java
@@ -16,6 +16,7 @@
  */
 package io.camunda.connector.runtime;
 
+import io.camunda.connector.runtime.core.secret.SecretResolverMode;
 import java.time.Duration;
 import java.util.List;
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -26,6 +27,7 @@ public record ConnectorProperties(
     Polling polling,
     Webhook webhook,
     SecretProvider secretProvider,
+    Secrets secrets,
     VirtualThreads virtualThreads,
     Inbound inbound,
     OAuth oauth,
@@ -55,6 +57,13 @@ public record ConnectorProperties(
       boolean enabled, String prefix, boolean tenantAware, boolean processDefinitionAware) {}
 
   public record ConsoleSecretProvider(boolean enabled, String endpoint, String audience) {}
+
+  /** Configuration for secret resolution behaviour. */
+  public record Secrets(SecretResolverMode resolverMode) {
+    public Secrets() {
+      this(SecretResolverMode.ALL);
+    }
+  }
 
   /** Configuration for inbound connector processing. */
   public record Inbound(ProcessDefinitionCache processDefinitionCache) {}

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/main/java/io/camunda/connector/runtime/OutboundConnectorsAutoConfiguration.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/main/java/io/camunda/connector/runtime/OutboundConnectorsAutoConfiguration.java
@@ -20,11 +20,13 @@ import io.camunda.client.jobhandling.CamundaClientExecutorService;
 import io.camunda.client.metrics.MeteredCamundaClientExecutorService;
 import io.camunda.client.spring.configuration.CamundaAutoConfiguration;
 import io.camunda.client.spring.configuration.ExecutorServiceConfiguration;
+import io.camunda.connector.runtime.core.secret.SecretResolverMode;
 import io.camunda.connector.runtime.instances.InstanceForwardingConfiguration;
 import io.camunda.connector.runtime.outbound.OutboundConnectorRuntimeConfiguration;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
@@ -37,6 +39,15 @@ import org.springframework.context.annotation.Import;
 @AutoConfigureBefore({CamundaAutoConfiguration.class, ExecutorServiceConfiguration.class})
 @Import({OutboundConnectorRuntimeConfiguration.class, InstanceForwardingConfiguration.class})
 public class OutboundConnectorsAutoConfiguration {
+
+  @Bean
+  @ConditionalOnMissingBean(SecretResolverMode.class)
+  public SecretResolverMode secretResolverMode(
+      ObjectProvider<ConnectorProperties> connectorProperties) {
+    var props = connectorProperties.getIfAvailable();
+    var secrets = props != null ? props.secrets() : null;
+    return secrets != null ? secrets.resolverMode() : SecretResolverMode.ALL;
+  }
 
   @Bean(name = {"connectorCamundaClientExecutorService", "camundaClientExecutorService"})
   @ConditionalOnMissingBean

--- a/connectors/agentic-ai/connector-agentic-ai/element-templates/README.md
+++ b/connectors/agentic-ai/connector-agentic-ai/element-templates/README.md
@@ -63,6 +63,23 @@ See the [A2A Client connector documentation](https://docs.camunda.io/docs/next/c
 | A2A Client Webhook — Intermediate Catch Event | 8.9 | 0 | [`agenticai-a2a-client-webhook-inbound-connector-intermediate.json`](./agenticai-a2a-client-webhook-inbound-connector-intermediate.json) |
 | A2A Client Webhook — Receive Task             | 8.9 | 0 | [`agenticai-a2a-client-webhook-inbound-connector-receive.json`](./agenticai-a2a-client-webhook-inbound-connector-receive.json) |
 
+## Local Toolbox connectors (experimental)
+
+Experimental "local toolbox" pattern: an AI Agent gateway tool referencing another deployed
+process's own ad-hoc sub-process as a reusable, auto-discovered set of tools within the same
+cluster, without an MCP server round-trip. See
+[camunda/product-hub#3772](https://github.com/camunda/product-hub/issues/3772). Opt-in via
+`camunda.connector.agenticai.local-toolbox.enabled=true`; not part of the shipped default set.
+
+| Connector            | Minimum Camunda version | Template version | File |
+| --- | --- | --- | --- |
+| Local Toolbox Client | 8.9 | 1 | [`agenticai-localtoolbox-client-outbound-connector.json`](./agenticai-localtoolbox-client-outbound-connector.json) |
+
+`Local Toolbox Router` (the toolbox process's own ad-hoc sub-process driver,
+`io.camunda.agenticai:localtoolboxrouter:1`) has no generated element template yet — wire
+`zeebe:taskDefinition` onto the toolbox's ad-hoc sub-process manually, mirroring how the AI Agent
+Sub-process template itself is derived rather than directly annotated.
+
 ## Ad-hoc tools schema connector
 
 Resolves the tools available in an ad-hoc sub-process.

--- a/connectors/agentic-ai/connector-agentic-ai/element-templates/agenticai-localtoolbox-client-outbound-connector.json
+++ b/connectors/agentic-ai/connector-agentic-ai/element-templates/agenticai-localtoolbox-client-outbound-connector.json
@@ -1,0 +1,217 @@
+{
+  "$schema" : "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+  "name" : "Local Toolbox Client",
+  "id" : "io.camunda.connectors.agenticai.localtoolbox.client.v0",
+  "description" : "Gateway tool referencing another deployed process as a reusable, auto-discovered set of AI Agent tools within the same cluster.",
+  "version" : 1,
+  "category" : {
+    "id" : "aiTools",
+    "name" : "AI Tools"
+  },
+  "appliesTo" : [ "bpmn:Task" ],
+  "elementType" : {
+    "value" : "bpmn:ServiceTask"
+  },
+  "engines" : {
+    "camunda" : "^8.9"
+  },
+  "groups" : [ {
+    "id" : "toolbox",
+    "label" : "Toolbox"
+  }, {
+    "id" : "operation",
+    "label" : "Operation"
+  }, {
+    "id" : "connector",
+    "label" : "Connector"
+  }, {
+    "id" : "output",
+    "label" : "Output mapping"
+  }, {
+    "id" : "error",
+    "label" : "Error handling"
+  }, {
+    "id" : "retries",
+    "label" : "Retries"
+  } ],
+  "properties" : [ {
+    "value" : "io.camunda.agenticai:localtoolboxclient:1",
+    "binding" : {
+      "property" : "type",
+      "type" : "zeebe:taskDefinition"
+    },
+    "type" : "Hidden"
+  }, {
+    "value" : "localToolbox",
+    "binding" : {
+      "name" : "io.camunda.agenticai.gateway.type",
+      "type" : "zeebe:property"
+    },
+    "type" : "Hidden"
+  }, {
+    "id" : "data.processId",
+    "label" : "Process ID",
+    "description" : "The BPMN process ID of the toolbox process to invoke.",
+    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "toolbox",
+    "binding" : {
+      "name" : "data.processId",
+      "type" : "zeebe:input"
+    },
+    "type" : "String"
+  }, {
+    "id" : "data.version",
+    "label" : "Version",
+    "description" : "Pins the toolbox process to a specific version. Leave empty to always use the latest deployed version.",
+    "optional" : true,
+    "feel" : "optional",
+    "group" : "toolbox",
+    "binding" : {
+      "name" : "data.version",
+      "type" : "zeebe:input"
+    },
+    "tooltip" : "The discovered tool schema is resolved once, at agent initialization. Pinning a version keeps that schema stable for the life of the conversation, even if a new toolbox version is deployed later.",
+    "type" : "Number"
+  }, {
+    "id" : "data.containerElementId",
+    "label" : "Tool container element ID",
+    "description" : "The ID of the ad-hoc sub-process inside the toolbox process whose tool elements should be discovered and exposed to the calling agent.",
+    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "toolbox",
+    "binding" : {
+      "name" : "data.containerElementId",
+      "type" : "zeebe:input"
+    },
+    "type" : "String"
+  }, {
+    "id" : "data.meta",
+    "label" : "Meta",
+    "description" : "Deterministic (non-LLM) variables forwarded unmodified to the toolbox process instance alongside the tool call, bypassing the LLM entirely.",
+    "optional" : true,
+    "feel" : "required",
+    "group" : "toolbox",
+    "binding" : {
+      "name" : "data.meta",
+      "type" : "zeebe:input"
+    },
+    "type" : "String"
+  }, {
+    "id" : "data.operation.method",
+    "label" : "Method",
+    "description" : "The local toolbox operation to be performed.",
+    "optional" : false,
+    "value" : "=toolCall.method",
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "operation",
+    "binding" : {
+      "name" : "data.operation.method",
+      "type" : "zeebe:input"
+    },
+    "type" : "String"
+  }, {
+    "id" : "data.operation.params",
+    "label" : "Parameters",
+    "description" : "The parameters to be passed to the operation.",
+    "optional" : true,
+    "value" : "=toolCall.params",
+    "feel" : "required",
+    "group" : "operation",
+    "binding" : {
+      "name" : "data.operation.params",
+      "type" : "zeebe:input"
+    },
+    "type" : "String"
+  }, {
+    "id" : "version",
+    "label" : "Version",
+    "description" : "Version of the element template",
+    "value" : "1",
+    "group" : "connector",
+    "binding" : {
+      "key" : "elementTemplateVersion",
+      "type" : "zeebe:taskHeader"
+    },
+    "type" : "Hidden"
+  }, {
+    "id" : "id",
+    "label" : "ID",
+    "description" : "ID of the element template",
+    "value" : "io.camunda.connectors.agenticai.localtoolbox.client.v0",
+    "group" : "connector",
+    "binding" : {
+      "key" : "elementTemplateId",
+      "type" : "zeebe:taskHeader"
+    },
+    "type" : "Hidden"
+  }, {
+    "id" : "resultVariable",
+    "label" : "Result variable",
+    "description" : "Name of variable to store the response in. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-variable\" target=\"_blank\">documentation</a>.",
+    "value" : "toolCallResult",
+    "group" : "output",
+    "binding" : {
+      "key" : "resultVariable",
+      "type" : "zeebe:taskHeader"
+    },
+    "type" : "String"
+  }, {
+    "id" : "resultExpression",
+    "label" : "Result expression",
+    "description" : "Expression to map the response into process variables. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-expression\" target=\"_blank\">documentation</a>.",
+    "feel" : "required",
+    "group" : "output",
+    "binding" : {
+      "key" : "resultExpression",
+      "type" : "zeebe:taskHeader"
+    },
+    "type" : "Text"
+  }, {
+    "id" : "errorExpression",
+    "label" : "Error expression",
+    "description" : "Expression to handle errors. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/\" target=\"_blank\">documentation</a>.",
+    "feel" : "required",
+    "group" : "error",
+    "binding" : {
+      "key" : "errorExpression",
+      "type" : "zeebe:taskHeader"
+    },
+    "type" : "Text"
+  }, {
+    "id" : "retryCount",
+    "label" : "Retries",
+    "description" : "Number of retries",
+    "value" : "3",
+    "feel" : "optional",
+    "group" : "retries",
+    "binding" : {
+      "property" : "retries",
+      "type" : "zeebe:taskDefinition"
+    },
+    "type" : "String"
+  }, {
+    "id" : "retryBackoff",
+    "label" : "Retry backoff",
+    "description" : "ISO-8601 duration to wait between retries",
+    "value" : "PT30S",
+    "group" : "retries",
+    "binding" : {
+      "key" : "retryBackoff",
+      "type" : "zeebe:taskHeader"
+    },
+    "type" : "String"
+  } ],
+  "icon" : {
+    "contents" : "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyMDAiIGhlaWdodD0iMjAwIiBmaWxsPSJub25lIiB2aWV3Qm94PSIwIDAgMjAwIDIwMCI+CiAgICA8cmVjdCB4PSIzMCIgeT0iODAiIHdpZHRoPSIxNDAiIGhlaWdodD0iOTAiIHJ4PSIxMCIgc3Ryb2tlPSJibGFjayIgc3Ryb2tlLXdpZHRoPSIxMiIvPgogICAgPHBhdGggZD0iTTcwIDgwVjU1QzcwIDQzIDc5IDM0IDkxIDM0SDEwOUMxMjEgMzQgMTMwIDQzIDEzMCA1NVY4MCIgc3Ryb2tlPSJibGFjayIgc3Ryb2tlLXdpZHRoPSIxMiIgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIi8+CiAgICA8bGluZSB4MT0iMzAiIHkxPSIxMTUiIHgyPSIxNzAiIHkyPSIxMTUiIHN0cm9rZT0iYmxhY2siIHN0cm9rZS13aWR0aD0iMTIiLz4KPC9zdmc+Cg=="
+  }
+}

--- a/connectors/agentic-ai/connector-agentic-ai/pom.xml
+++ b/connectors/agentic-ai/connector-agentic-ai/pom.xml
@@ -479,6 +479,17 @@
               <writeMetaInfFileGeneration>false</writeMetaInfFileGeneration>
             </connector>
             <connector>
+              <connectorClass>io.camunda.connector.agenticai.localtoolbox.client.LocalToolboxClientFunction</connectorClass>
+              <files>
+                <file>
+                  <templateId>io.camunda.connectors.agenticai.localtoolbox.client.v0</templateId>
+                  <templateFileName>agenticai-localtoolbox-client-outbound-connector.json</templateFileName>
+                </file>
+              </files>
+              <generateHybridTemplates>false</generateHybridTemplates>
+              <writeMetaInfFileGeneration>false</writeMetaInfFileGeneration>
+            </connector>
+            <connector>
               <connectorClass>io.camunda.connector.agenticai.a2a.client.outbound.A2aClientOutboundConnectorFunction
               </connectorClass>
               <files>

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/autoconfigure/AgenticAiConnectorsAutoConfiguration.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/autoconfigure/AgenticAiConnectorsAutoConfiguration.java
@@ -61,6 +61,7 @@ import io.camunda.connector.agenticai.aiagent.tool.GatewayToolHandlerRegistry;
 import io.camunda.connector.agenticai.aiagent.tool.GatewayToolHandlerRegistryImpl;
 import io.camunda.connector.agenticai.common.AgenticAiHttpProxySupport;
 import io.camunda.connector.agenticai.common.util.retry.CamundaApiRetry.Sleeper;
+import io.camunda.connector.agenticai.localtoolbox.configuration.LocalToolboxConfiguration;
 import io.camunda.connector.agenticai.mcp.client.configuration.McpClientConfiguration;
 import io.camunda.connector.agenticai.mcp.client.configuration.McpRemoteClientConfiguration;
 import io.camunda.connector.agenticai.mcp.discovery.configuration.McpDiscoveryConfiguration;
@@ -89,7 +90,8 @@ import org.springframework.context.annotation.Import;
   A2aClientOutboundConnectorConfiguration.class,
   A2aClientAgenticToolConfiguration.class,
   A2aClientPollingConfiguration.class,
-  A2aClientWebhookConfiguration.class
+  A2aClientWebhookConfiguration.class,
+  LocalToolboxConfiguration.class
 })
 public class AgenticAiConnectorsAutoConfiguration {
 

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/localtoolbox/LocalToolboxErrorCodes.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/localtoolbox/LocalToolboxErrorCodes.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.agenticai.localtoolbox;
+
+public class LocalToolboxErrorCodes {
+
+  public static final String ERROR_CODE_INVALID_METHOD = "LOCAL_TOOLBOX_INVALID_METHOD";
+
+  public static final String ERROR_CODE_PROCESS_DEFINITION_NOT_FOUND =
+      "LOCAL_TOOLBOX_PROCESS_DEFINITION_NOT_FOUND";
+
+  public static final String ERROR_CODE_INVALID_TOOL_DEFINITIONS =
+      "LOCAL_TOOLBOX_INVALID_TOOL_DEFINITIONS";
+
+  private LocalToolboxErrorCodes() {}
+}

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/localtoolbox/client/LocalToolboxClientFunction.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/localtoolbox/client/LocalToolboxClientFunction.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.agenticai.localtoolbox.client;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.connector.agenticai.adhoctoolsschema.processdefinition.ProcessDefinitionAdHocToolElementsResolver;
+import io.camunda.connector.agenticai.adhoctoolsschema.schema.AdHocToolsSchemaResolver;
+import io.camunda.connector.agenticai.adhoctoolsschema.schema.GatewayToolDefinitionResolver;
+import io.camunda.connector.agenticai.localtoolbox.LocalToolboxErrorCodes;
+import io.camunda.connector.agenticai.localtoolbox.client.model.LocalToolboxClientRequest;
+import io.camunda.connector.agenticai.localtoolbox.client.model.LocalToolboxClientRequest.LocalToolboxClientRequestData;
+import io.camunda.connector.agenticai.localtoolbox.client.model.LocalToolboxOperation;
+import io.camunda.connector.agenticai.localtoolbox.client.model.result.LocalToolboxCallToolResult;
+import io.camunda.connector.agenticai.localtoolbox.client.model.result.LocalToolboxClientResult;
+import io.camunda.connector.agenticai.localtoolbox.client.model.result.LocalToolboxListToolsResult;
+import io.camunda.connector.agenticai.localtoolbox.discovery.LocalToolboxGatewayToolHandler;
+import io.camunda.connector.api.annotation.OutboundConnector;
+import io.camunda.connector.api.error.ConnectorException;
+import io.camunda.connector.api.outbound.OutboundConnectorContext;
+import io.camunda.connector.api.outbound.OutboundConnectorFunction;
+import io.camunda.connector.generator.java.annotation.ElementTemplate;
+import java.util.Map;
+
+@OutboundConnector(
+    name = "Local Toolbox Client",
+    inputVariables = {"data"},
+    type = "io.camunda.agenticai:localtoolboxclient:1")
+@ElementTemplate(
+    id = "io.camunda.connectors.agenticai.localtoolbox.client.v0",
+    name = "Local Toolbox Client",
+    description =
+        "Gateway tool referencing another deployed process as a reusable, auto-discovered set of"
+            + " AI Agent tools within the same cluster.",
+    engineVersion = "^8.9",
+    version = 1,
+    category = @ElementTemplate.Category(id = "aiTools", name = "AI Tools"),
+    inputDataClass = LocalToolboxClientRequest.class,
+    defaultResultVariable = "toolCallResult",
+    propertyGroups = {
+      @ElementTemplate.PropertyGroup(id = "toolbox", label = "Toolbox"),
+      @ElementTemplate.PropertyGroup(id = "operation", label = "Operation"),
+    },
+    extensionProperties = {
+      @ElementTemplate.ExtensionProperty(
+          name = GatewayToolDefinitionResolver.GATEWAY_TYPE_EXTENSION,
+          value = LocalToolboxGatewayToolHandler.GATEWAY_TYPE)
+    },
+    icon = "localtoolbox-client.svg")
+public class LocalToolboxClientFunction implements OutboundConnectorFunction {
+
+  private final LocalToolboxProcessDefinitionResolver processDefinitionResolver;
+  private final ProcessDefinitionAdHocToolElementsResolver toolElementsResolver;
+  private final AdHocToolsSchemaResolver toolsSchemaResolver;
+  private final CamundaClient camundaClient;
+
+  public LocalToolboxClientFunction(
+      LocalToolboxProcessDefinitionResolver processDefinitionResolver,
+      ProcessDefinitionAdHocToolElementsResolver toolElementsResolver,
+      AdHocToolsSchemaResolver toolsSchemaResolver,
+      CamundaClient camundaClient) {
+    this.processDefinitionResolver = processDefinitionResolver;
+    this.toolElementsResolver = toolElementsResolver;
+    this.toolsSchemaResolver = toolsSchemaResolver;
+    this.camundaClient = camundaClient;
+  }
+
+  @Override
+  public LocalToolboxClientResult execute(OutboundConnectorContext context) {
+    final LocalToolboxClientRequestData data =
+        context.bindVariables(LocalToolboxClientRequest.class).data();
+    final LocalToolboxOperation operation =
+        LocalToolboxOperation.of(data.operation().method(), paramsOf(data));
+
+    return switch (operation.method()) {
+      case LIST_TOOLS -> listTools(data);
+      case CALL_TOOL -> callTool(data, operation);
+    };
+  }
+
+  private Map<String, Object> paramsOf(LocalToolboxClientRequestData data) {
+    return data.operation().params() == null ? Map.of() : data.operation().params();
+  }
+
+  private LocalToolboxListToolsResult listTools(LocalToolboxClientRequestData data) {
+    final Long processDefinitionKey =
+        processDefinitionResolver.resolveProcessDefinitionKey(data.processId(), data.version());
+    final var elements =
+        toolElementsResolver.resolveToolElements(processDefinitionKey, data.containerElementId());
+    final var schema = toolsSchemaResolver.resolveAdHocToolsSchema(elements);
+    return new LocalToolboxListToolsResult(schema.toolDefinitions());
+  }
+
+  @SuppressWarnings("unchecked")
+  private LocalToolboxCallToolResult callTool(
+      LocalToolboxClientRequestData data, LocalToolboxOperation operation) {
+    final String toolName = (String) operation.params().get("name");
+    if (toolName == null || toolName.isBlank()) {
+      throw new ConnectorException(
+          LocalToolboxErrorCodes.ERROR_CODE_INVALID_TOOL_DEFINITIONS,
+          "Local toolbox call is missing the target tool name");
+    }
+
+    final Map<String, Object> arguments =
+        (Map<String, Object>) operation.params().getOrDefault("arguments", Map.of());
+    final Map<String, Object> variables =
+        Map.of(
+            "toolCall",
+            Map.of("name", toolName, "arguments", arguments),
+            "meta",
+            data.meta() == null ? Map.of() : data.meta());
+
+    final var commandStep =
+        camundaClient.newCreateInstanceCommand().bpmnProcessId(data.processId());
+    final var versionedStep =
+        data.version() != null ? commandStep.version(data.version()) : commandStep.latestVersion();
+    final var result = versionedStep.variables(variables).withResult().send().join();
+
+    final Object content = result.getVariablesAsMap().get("toolCallResult");
+    return new LocalToolboxCallToolResult(toolName, content);
+  }
+}

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/localtoolbox/client/LocalToolboxProcessDefinitionResolver.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/localtoolbox/client/LocalToolboxProcessDefinitionResolver.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.agenticai.localtoolbox.client;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.search.response.ProcessDefinition;
+import io.camunda.connector.agenticai.autoconfigure.AgenticAiConnectorsConfigurationProperties.RetriesProperties;
+import io.camunda.connector.agenticai.common.util.retry.CamundaApiRetry;
+import io.camunda.connector.agenticai.common.util.retry.CamundaApiRetry.FailureReason;
+import io.camunda.connector.agenticai.common.util.retry.CamundaApiRetry.Sleeper;
+import io.camunda.connector.agenticai.common.util.retry.ErrorClassifier;
+import io.camunda.connector.agenticai.localtoolbox.LocalToolboxErrorCodes;
+import io.camunda.connector.api.error.ConnectorException;
+import java.util.List;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Resolves a BPMN process id (+ optional version) to the numeric process definition key that {@link
+ * io.camunda.connector.agenticai.adhoctoolsschema.processdefinition.ProcessDefinitionAdHocToolElementsResolver}
+ * operates on. Version is optional: when omitted, the latest deployed version is used.
+ */
+public class LocalToolboxProcessDefinitionResolver {
+
+  private final CamundaClient camundaClient;
+  private final RetriesProperties retriesProperties;
+
+  public LocalToolboxProcessDefinitionResolver(
+      CamundaClient camundaClient, RetriesProperties retriesProperties) {
+    this.camundaClient = camundaClient;
+    this.retriesProperties = retriesProperties;
+  }
+
+  public Long resolveProcessDefinitionKey(String processId, @Nullable Integer version) {
+    final List<ProcessDefinition> processDefinitions =
+        CamundaApiRetry.execute(
+            () ->
+                camundaClient
+                    .newProcessDefinitionSearchRequest()
+                    .filter(filter -> filter.processDefinitionId(processId))
+                    .sort(sort -> sort.version().asc())
+                    .send()
+                    .join()
+                    .items(),
+            ErrorClassifier.onAllExceptions(),
+            retriesProperties.maxRetries(),
+            retriesProperties.initialRetryDelay(),
+            (cause, attempt, reason) -> buildFetchException(processId, cause, attempt, reason),
+            Sleeper.threadSleep());
+
+    if (processDefinitions.isEmpty()) {
+      throw notFoundException(processId, version);
+    }
+
+    if (version == null) {
+      // sorted ascending by version -> the last item is the latest deployed version
+      return processDefinitions.getLast().getProcessDefinitionKey();
+    }
+
+    return processDefinitions.stream()
+        .filter(processDefinition -> processDefinition.getVersion() == version)
+        .findFirst()
+        .map(ProcessDefinition::getProcessDefinitionKey)
+        .orElseThrow(() -> notFoundException(processId, version));
+  }
+
+  private ConnectorException notFoundException(String processId, @Nullable Integer version) {
+    return new ConnectorException(
+        LocalToolboxErrorCodes.ERROR_CODE_PROCESS_DEFINITION_NOT_FOUND,
+        version == null
+            ? "No deployed process definition found with process id '%s'.".formatted(processId)
+            : "No deployed process definition found with process id '%s' and version %d."
+                .formatted(processId, version));
+  }
+
+  private ConnectorException buildFetchException(
+      String processId, Throwable cause, int attempt, FailureReason reason) {
+    final String message =
+        switch (reason) {
+          case INTERRUPTED ->
+              "Interrupted while retrying to look up process definitions with process id '%s'."
+                  .formatted(processId);
+          case RETRIES_EXHAUSTED, PERMANENT_ERROR ->
+              "Failed to look up process definitions with process id '%s' after %d attempt(s): %s"
+                  .formatted(processId, attempt, cause.getMessage());
+        };
+    return new ConnectorException(
+        LocalToolboxErrorCodes.ERROR_CODE_PROCESS_DEFINITION_NOT_FOUND, message, cause);
+  }
+}

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/localtoolbox/client/model/LocalToolboxClientRequest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/localtoolbox/client/model/LocalToolboxClientRequest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.agenticai.localtoolbox.client.model;
+
+import io.camunda.connector.generator.java.annotation.FeelMode;
+import io.camunda.connector.generator.java.annotation.TemplateProperty;
+import io.camunda.connector.generator.java.annotation.TemplateProperty.PropertyConstraints;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.util.Map;
+import org.jspecify.annotations.Nullable;
+
+public record LocalToolboxClientRequest(@Valid @NotNull LocalToolboxClientRequestData data) {
+
+  public record LocalToolboxClientRequestData(
+      @TemplateProperty(
+              group = "toolbox",
+              label = "Process ID",
+              description = "The BPMN process ID of the toolbox process to invoke.",
+              type = TemplateProperty.PropertyType.String,
+              feel = FeelMode.optional,
+              constraints = @PropertyConstraints(notEmpty = true))
+          @NotBlank
+          String processId,
+      @TemplateProperty(
+              group = "toolbox",
+              label = "Version",
+              description =
+                  "Pins the toolbox process to a specific version. Leave empty to always use the latest deployed version.",
+              tooltip =
+                  "The discovered tool schema is resolved once, at agent initialization. Pinning a"
+                      + " version keeps that schema stable for the life of the conversation, even"
+                      + " if a new toolbox version is deployed later.",
+              type = TemplateProperty.PropertyType.Number,
+              feel = FeelMode.optional,
+              optional = true)
+          @Nullable Integer version,
+      @TemplateProperty(
+              group = "toolbox",
+              label = "Tool container element ID",
+              description =
+                  "The ID of the ad-hoc sub-process inside the toolbox process whose tool elements"
+                      + " should be discovered and exposed to the calling agent.",
+              type = TemplateProperty.PropertyType.String,
+              feel = FeelMode.optional,
+              constraints = @PropertyConstraints(notEmpty = true))
+          @NotBlank
+          String containerElementId,
+      @TemplateProperty(
+              group = "toolbox",
+              label = "Meta",
+              description =
+                  "Deterministic (non-LLM) variables forwarded unmodified to the toolbox process"
+                      + " instance alongside the tool call, bypassing the LLM entirely.",
+              feel = FeelMode.required,
+              optional = true)
+          @Nullable Map<String, Object> meta,
+      @Valid @NotNull LocalToolboxOperationConfiguration operation) {
+
+    public record LocalToolboxOperationConfiguration(
+        @TemplateProperty(
+                group = "operation",
+                label = "Method",
+                description = "The local toolbox operation to be performed.",
+                type = TemplateProperty.PropertyType.String,
+                feel = FeelMode.optional,
+                defaultValue = "=toolCall.method",
+                constraints = @PropertyConstraints(notEmpty = true))
+            @NotBlank
+            String method,
+        @TemplateProperty(
+                group = "operation",
+                label = "Parameters",
+                description = "The parameters to be passed to the operation.",
+                feel = FeelMode.required,
+                defaultValue = "=toolCall.params",
+                optional = true)
+            @Nullable Map<String, Object> params) {}
+  }
+}

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/localtoolbox/client/model/LocalToolboxOperation.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/localtoolbox/client/model/LocalToolboxOperation.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.agenticai.localtoolbox.client.model;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonValue;
+import io.camunda.connector.agenticai.localtoolbox.LocalToolboxErrorCodes;
+import io.camunda.connector.api.error.ConnectorException;
+import java.util.Collections;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * The operation requested of a {@code LocalToolboxClientFunction} activation, mirroring the MCP
+ * client's {@code McpClientOperation} shape: a method discriminator plus a parameter map. The
+ * gateway tool handler rewrites the operation at runtime (tool discovery vs. a specific tool call)
+ * before the element is activated; the element template's default values simply read it back from
+ * the injected {@code toolCall} variable.
+ */
+public sealed interface LocalToolboxOperation
+    permits LocalToolboxOperation.LocalToolboxOperationImpl {
+
+  LocalToolboxMethod method();
+
+  Map<String, Object> params();
+
+  static LocalToolboxOperation of(String method) {
+    return of(method, Collections.emptyMap());
+  }
+
+  static LocalToolboxOperation of(String method, Map<String, Object> params) {
+    return new LocalToolboxOperationImpl(LocalToolboxMethod.valueFrom(method), params);
+  }
+
+  enum LocalToolboxMethod {
+    LIST_TOOLS("tools/list"),
+    CALL_TOOL("tools/call");
+
+    private static String supportedMethods() {
+      return Stream.of(LocalToolboxMethod.values())
+          .map(op -> op.methodName)
+          .collect(Collectors.joining("', '"));
+    }
+
+    @JsonCreator
+    public static LocalToolboxMethod valueFrom(String rawMethod) {
+      for (LocalToolboxMethod method : values()) {
+        if (method.methodName.equals(rawMethod)) {
+          return method;
+        }
+      }
+      throw new ConnectorException(
+          LocalToolboxErrorCodes.ERROR_CODE_INVALID_METHOD,
+          "Unsupported local toolbox method '%s'. Supported methods: '%s'"
+              .formatted(rawMethod, supportedMethods()));
+    }
+
+    @JsonValue private final String methodName;
+
+    LocalToolboxMethod(String methodName) {
+      this.methodName = methodName;
+    }
+
+    public String methodName() {
+      return methodName;
+    }
+  }
+
+  record LocalToolboxOperationImpl(
+      LocalToolboxMethod method,
+      @JsonInclude(JsonInclude.Include.NON_EMPTY) Map<String, Object> params)
+      implements LocalToolboxOperation {}
+}

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/localtoolbox/client/model/LocalToolboxOperationDefinitions.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/localtoolbox/client/model/LocalToolboxOperationDefinitions.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.agenticai.localtoolbox.client.model;
+
+import java.util.Map;
+
+/** Convenience factories for {@link LocalToolboxOperation} instances used by the framework. */
+public class LocalToolboxOperationDefinitions {
+
+  public static LocalToolboxOperation listTools() {
+    return LocalToolboxOperation.of(
+        LocalToolboxOperation.LocalToolboxMethod.LIST_TOOLS.methodName());
+  }
+
+  public static LocalToolboxOperation callTool(String toolName, Map<String, Object> toolArguments) {
+    return LocalToolboxOperation.of(
+        LocalToolboxOperation.LocalToolboxMethod.CALL_TOOL.methodName(),
+        Map.of("name", toolName, "arguments", toolArguments));
+  }
+
+  private LocalToolboxOperationDefinitions() {}
+}

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/localtoolbox/client/model/package-info.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/localtoolbox/client/model/package-info.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+@NullMarked
+package io.camunda.connector.agenticai.localtoolbox.client.model;
+
+import org.jspecify.annotations.NullMarked;

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/localtoolbox/client/model/result/LocalToolboxCallToolResult.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/localtoolbox/client/model/result/LocalToolboxCallToolResult.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.agenticai.localtoolbox.client.model.result;
+
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Result of a {@code tools/call} operation: the toolbox process instance's {@code toolCallResult}
+ * output variable, after the router drove exactly one tool element to completion.
+ */
+public record LocalToolboxCallToolResult(String name, @Nullable Object content)
+    implements LocalToolboxClientResult {}

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/localtoolbox/client/model/result/LocalToolboxClientResult.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/localtoolbox/client/model/result/LocalToolboxClientResult.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.agenticai.localtoolbox.client.model.result;
+
+public sealed interface LocalToolboxClientResult
+    permits LocalToolboxListToolsResult, LocalToolboxCallToolResult {}

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/localtoolbox/client/model/result/LocalToolboxListToolsResult.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/localtoolbox/client/model/result/LocalToolboxListToolsResult.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.agenticai.localtoolbox.client.model.result;
+
+import io.camunda.connector.agenticai.aiagent.model.tool.ToolDefinition;
+import java.util.List;
+
+/**
+ * Result of a {@code tools/list} operation: the tool schema resolved by introspecting the toolbox
+ * process's ad-hoc sub-process, reusing {@link ToolDefinition} directly since discovery goes
+ * through the same {@code AdHocToolsSchemaResolver} the calling agent uses for its own tools.
+ */
+public record LocalToolboxListToolsResult(List<ToolDefinition> toolDefinitions)
+    implements LocalToolboxClientResult {}

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/localtoolbox/client/model/result/package-info.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/localtoolbox/client/model/result/package-info.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+@NullMarked
+package io.camunda.connector.agenticai.localtoolbox.client.model.result;
+
+import org.jspecify.annotations.NullMarked;

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/localtoolbox/client/package-info.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/localtoolbox/client/package-info.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+@NullMarked
+package io.camunda.connector.agenticai.localtoolbox.client;
+
+import org.jspecify.annotations.NullMarked;

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/localtoolbox/configuration/LocalToolboxConfiguration.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/localtoolbox/configuration/LocalToolboxConfiguration.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.agenticai.localtoolbox.configuration;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.client.CamundaClient;
+import io.camunda.connector.agenticai.adhoctoolsschema.processdefinition.ProcessDefinitionAdHocToolElementsResolver;
+import io.camunda.connector.agenticai.adhoctoolsschema.schema.AdHocToolsSchemaResolver;
+import io.camunda.connector.agenticai.autoconfigure.AgenticAiConnectorsConfigurationProperties;
+import io.camunda.connector.agenticai.localtoolbox.client.LocalToolboxClientFunction;
+import io.camunda.connector.agenticai.localtoolbox.client.LocalToolboxProcessDefinitionResolver;
+import io.camunda.connector.agenticai.localtoolbox.discovery.LocalToolboxGatewayToolDefinitionResolver;
+import io.camunda.connector.agenticai.localtoolbox.discovery.LocalToolboxGatewayToolHandler;
+import io.camunda.connector.agenticai.localtoolbox.router.LocalToolboxRouterFunction;
+import io.camunda.connector.runtime.annotation.ConnectorsObjectMapper;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBooleanProperty;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Wires the local toolbox experiment: opt-in (default off), since it both introspects arbitrary
+ * process definitions and creates process instances - same posture as the MCP client connector.
+ */
+@Configuration
+@ConditionalOnBooleanProperty(
+    value = "camunda.connector.agenticai.local-toolbox.enabled",
+    matchIfMissing = false)
+public class LocalToolboxConfiguration {
+
+  @Bean
+  @ConditionalOnMissingBean
+  public LocalToolboxGatewayToolDefinitionResolver localToolboxGatewayToolDefinitionResolver() {
+    return new LocalToolboxGatewayToolDefinitionResolver();
+  }
+
+  @Bean
+  @ConditionalOnMissingBean
+  public LocalToolboxGatewayToolHandler localToolboxGatewayToolHandler(
+      @ConnectorsObjectMapper ObjectMapper objectMapper) {
+    return new LocalToolboxGatewayToolHandler(objectMapper);
+  }
+
+  @Bean
+  @ConditionalOnMissingBean
+  public LocalToolboxProcessDefinitionResolver localToolboxProcessDefinitionResolver(
+      CamundaClient camundaClient, AgenticAiConnectorsConfigurationProperties configuration) {
+    return new LocalToolboxProcessDefinitionResolver(
+        camundaClient, configuration.tools().processDefinition().retries());
+  }
+
+  @Bean
+  @ConditionalOnMissingBean
+  public LocalToolboxClientFunction localToolboxClientFunction(
+      LocalToolboxProcessDefinitionResolver processDefinitionResolver,
+      ProcessDefinitionAdHocToolElementsResolver toolElementsResolver,
+      AdHocToolsSchemaResolver toolsSchemaResolver,
+      CamundaClient camundaClient) {
+    return new LocalToolboxClientFunction(
+        processDefinitionResolver, toolElementsResolver, toolsSchemaResolver, camundaClient);
+  }
+
+  @Bean
+  @ConditionalOnMissingBean
+  public LocalToolboxRouterFunction localToolboxRouterFunction() {
+    return new LocalToolboxRouterFunction();
+  }
+}

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/localtoolbox/configuration/package-info.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/localtoolbox/configuration/package-info.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+@NullMarked
+package io.camunda.connector.agenticai.localtoolbox.configuration;
+
+import org.jspecify.annotations.NullMarked;

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/localtoolbox/discovery/LocalToolboxGatewayToolDefinitionResolver.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/localtoolbox/discovery/LocalToolboxGatewayToolDefinitionResolver.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.agenticai.localtoolbox.discovery;
+
+import io.camunda.connector.agenticai.adhoctoolsschema.schema.TypePropertyBasedGatewayToolDefinitionResolver;
+
+public class LocalToolboxGatewayToolDefinitionResolver
+    extends TypePropertyBasedGatewayToolDefinitionResolver {
+
+  public LocalToolboxGatewayToolDefinitionResolver() {
+    super(LocalToolboxGatewayToolHandler.GATEWAY_TYPE);
+  }
+}

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/localtoolbox/discovery/LocalToolboxGatewayToolHandler.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/localtoolbox/discovery/LocalToolboxGatewayToolHandler.java
@@ -1,0 +1,277 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.agenticai.localtoolbox.discovery;
+
+import static io.camunda.connector.agenticai.localtoolbox.discovery.LocalToolboxToolCallIdentifier.LOCAL_TOOLBOX_NAMESPACE_SEPARATOR;
+import static io.camunda.connector.agenticai.localtoolbox.discovery.LocalToolboxToolCallIdentifier.LOCAL_TOOLBOX_PREFIX;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.connector.agenticai.aiagent.model.AgentContext;
+import io.camunda.connector.agenticai.aiagent.model.tool.GatewayToolDefinition;
+import io.camunda.connector.agenticai.aiagent.model.tool.ToolCall;
+import io.camunda.connector.agenticai.aiagent.model.tool.ToolCallResult;
+import io.camunda.connector.agenticai.aiagent.model.tool.ToolDefinition;
+import io.camunda.connector.agenticai.aiagent.tool.GatewayToolDefinitionUpdates;
+import io.camunda.connector.agenticai.aiagent.tool.GatewayToolDiscoveryInitiationResult;
+import io.camunda.connector.agenticai.aiagent.tool.GatewayToolHandler;
+import io.camunda.connector.agenticai.common.util.CollectionUtils;
+import io.camunda.connector.agenticai.common.util.ObjectMapperConstants;
+import io.camunda.connector.agenticai.localtoolbox.LocalToolboxErrorCodes;
+import io.camunda.connector.agenticai.localtoolbox.client.model.LocalToolboxOperationDefinitions;
+import io.camunda.connector.agenticai.localtoolbox.client.model.result.LocalToolboxCallToolResult;
+import io.camunda.connector.agenticai.localtoolbox.client.model.result.LocalToolboxListToolsResult;
+import io.camunda.connector.api.error.ConnectorException;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Gateway tool handler for the local toolbox pattern: a gateway element referencing another
+ * deployed process whose ad-hoc sub-process tools are discovered via {@code
+ * LocalToolboxClientFunction} (process-definition introspection, not a live tool call to an
+ * external server) and executed by creating an instance of the referenced process, driven by {@code
+ * LocalToolboxRouterFunction}. Mirrors {@code McpClientGatewayToolHandler}.
+ */
+public class LocalToolboxGatewayToolHandler implements GatewayToolHandler {
+
+  private static final Logger LOGGER =
+      LoggerFactory.getLogger(LocalToolboxGatewayToolHandler.class);
+
+  public static final String GATEWAY_TYPE = "localToolbox";
+  public static final String PROPERTY_LOCAL_TOOLBOX_CLIENTS = "localToolboxClients";
+  public static final String LOCAL_TOOLBOX_TOOLS_DISCOVERY_PREFIX =
+      LOCAL_TOOLBOX_PREFIX + "toolsList_";
+
+  private final ObjectMapper objectMapper;
+
+  public LocalToolboxGatewayToolHandler(ObjectMapper objectMapper) {
+    this.objectMapper = objectMapper;
+  }
+
+  @Override
+  public String type() {
+    return GATEWAY_TYPE;
+  }
+
+  @Override
+  public boolean isGatewayManaged(String toolName) {
+    return LocalToolboxToolCallIdentifier.isLocalToolboxToolCallIdentifier(toolName);
+  }
+
+  @Override
+  public String resolveElementId(String toolName) {
+    return LocalToolboxToolCallIdentifier.fromToolCallName(toolName).elementId();
+  }
+
+  @Override
+  public GatewayToolDiscoveryInitiationResult initiateToolDiscovery(
+      AgentContext agentContext, List<GatewayToolDefinition> gatewayToolDefinitions) {
+    final var localToolboxGatewayToolDefinitions =
+        extractGatewayToolDefinitions(gatewayToolDefinitions);
+
+    if (localToolboxGatewayToolDefinitions.isEmpty()) {
+      return new GatewayToolDiscoveryInitiationResult(agentContext, List.of());
+    }
+
+    validateToolDefinitions(localToolboxGatewayToolDefinitions);
+
+    final var updatedAgentContext =
+        agentContext.withProperty(
+            PROPERTY_LOCAL_TOOLBOX_CLIENTS,
+            localToolboxGatewayToolDefinitions.stream().map(GatewayToolDefinition::name).toList());
+
+    final var listToolsOperation = operationAsMap(LocalToolboxOperationDefinitions.listTools());
+    final List<ToolCall> discoveryToolCalls =
+        localToolboxGatewayToolDefinitions.stream()
+            .map(
+                gatewayToolDefinition ->
+                    new ToolCall(
+                        LOCAL_TOOLBOX_TOOLS_DISCOVERY_PREFIX + gatewayToolDefinition.name(),
+                        gatewayToolDefinition.name(),
+                        listToolsOperation))
+            .toList();
+
+    return new GatewayToolDiscoveryInitiationResult(updatedAgentContext, discoveryToolCalls);
+  }
+
+  private void validateToolDefinitions(List<GatewayToolDefinition> gatewayToolDefinitions) {
+    final var invalidElementIds =
+        gatewayToolDefinitions.stream()
+            .map(GatewayToolDefinition::name)
+            .filter(name -> name.contains(LOCAL_TOOLBOX_NAMESPACE_SEPARATOR))
+            .toList();
+
+    if (!invalidElementIds.isEmpty()) {
+      throw new ConnectorException(
+          LocalToolboxErrorCodes.ERROR_CODE_INVALID_TOOL_DEFINITIONS,
+          "Invalid local toolbox activity ID(s) detected: [%s]. Activity IDs must not contain the reserved separator '%s'. Please rename the affected activities in the BPMN model."
+              .formatted(
+                  invalidElementIds.stream()
+                      .map("'%s'"::formatted)
+                      .collect(Collectors.joining(", ")),
+                  LOCAL_TOOLBOX_NAMESPACE_SEPARATOR));
+    }
+  }
+
+  @Override
+  public GatewayToolDefinitionUpdates resolveUpdatedGatewayToolDefinitions(
+      AgentContext agentContext, List<GatewayToolDefinition> gatewayToolDefinitions) {
+    final var localToolboxClientIds = getLocalToolboxClientIds(agentContext);
+    final var localToolboxGatewayToolDefinitionIds =
+        extractGatewayToolDefinitions(gatewayToolDefinitions).stream()
+            .map(GatewayToolDefinition::name)
+            .toList();
+
+    return CollectionUtils.computeListItemChanges(
+        localToolboxClientIds,
+        localToolboxGatewayToolDefinitionIds,
+        GatewayToolDefinitionUpdates::new);
+  }
+
+  @Override
+  public boolean allToolDiscoveryResultsPresent(
+      AgentContext agentContext, List<ToolCallResult> toolCallResults) {
+    final var localToolboxClientIds = getLocalToolboxClientIds(agentContext);
+    if (localToolboxClientIds.isEmpty()) {
+      return true;
+    }
+
+    final var toolCallResultIds =
+        toolCallResults.stream().map(ToolCallResult::id).collect(Collectors.toSet());
+    final var missingToolDiscoveryResults =
+        localToolboxClientIds.stream()
+            .filter(
+                clientId ->
+                    !toolCallResultIds.contains(LOCAL_TOOLBOX_TOOLS_DISCOVERY_PREFIX + clientId))
+            .toList();
+
+    if (!missingToolDiscoveryResults.isEmpty()) {
+      LOGGER.debug(
+          "Missing local toolbox tool discovery results for clients: {}",
+          missingToolDiscoveryResults);
+      return false;
+    }
+
+    return true;
+  }
+
+  @Override
+  public boolean handlesToolDiscoveryResult(ToolCallResult toolCallResult) {
+    if (StringUtils.isBlank(toolCallResult.id())) {
+      return false;
+    }
+
+    return toolCallResult.id().startsWith(LOCAL_TOOLBOX_TOOLS_DISCOVERY_PREFIX);
+  }
+
+  @Override
+  public List<ToolDefinition> handleToolDiscoveryResults(
+      AgentContext agentContext, List<ToolCallResult> toolDiscoveryResults) {
+    return toolDiscoveryResults.stream()
+        .map(this::toolDefinitionsFromDiscoveryResult)
+        .flatMap(List::stream)
+        .toList();
+  }
+
+  private List<ToolDefinition> toolDefinitionsFromDiscoveryResult(ToolCallResult toolCallResult) {
+    final var name = toolCallResult.name();
+    if (name == null) {
+      throw new ConnectorException(
+          LocalToolboxErrorCodes.ERROR_CODE_INVALID_TOOL_DEFINITIONS,
+          "Tool call result is missing name");
+    }
+
+    final var listToolsResult =
+        objectMapper.convertValue(toolCallResult.content(), LocalToolboxListToolsResult.class);
+    return listToolsResult.toolDefinitions().stream()
+        .map(
+            toolDefinition ->
+                toolDefinition.withName(
+                    new LocalToolboxToolCallIdentifier(name, toolDefinition.name())
+                        .fullyQualifiedName()))
+        .toList();
+  }
+
+  @Override
+  public List<ToolCall> transformToolCalls(AgentContext agentContext, List<ToolCall> toolCalls) {
+    return toolCalls.stream()
+        .map(
+            toolCall -> {
+              String toolCallName = toolCall.name();
+              if (isGatewayManaged(toolCallName)) {
+                final var identifier =
+                    LocalToolboxToolCallIdentifier.fromToolCallName(toolCallName);
+                return new ToolCall(
+                    toolCall.id(),
+                    identifier.elementId(),
+                    operationAsMap(
+                        LocalToolboxOperationDefinitions.callTool(
+                            identifier.toolName(), toolCall.arguments())));
+              }
+
+              return toolCall;
+            })
+        .toList();
+  }
+
+  @Override
+  public List<ToolCallResult> transformToolCallResults(
+      AgentContext agentContext, List<ToolCallResult> toolCallResults) {
+    final var localToolboxClientIds = getLocalToolboxClientIds(agentContext);
+    return toolCallResults.stream()
+        .map(
+            toolCallResult -> {
+              if (!localToolboxClientIds.contains(toolCallResult.name())) {
+                return toolCallResult;
+              }
+              return toolCallResultFromLocalToolboxCall(toolCallResult);
+            })
+        .toList();
+  }
+
+  private ToolCallResult toolCallResultFromLocalToolboxCall(ToolCallResult toolCallResult) {
+    final var name = toolCallResult.name();
+    if (name == null) {
+      throw new ConnectorException(
+          LocalToolboxErrorCodes.ERROR_CODE_INVALID_TOOL_DEFINITIONS,
+          "Tool call result is missing name");
+    }
+
+    final var callToolResult =
+        objectMapper.convertValue(toolCallResult.content(), LocalToolboxCallToolResult.class);
+    final var identifier = new LocalToolboxToolCallIdentifier(name, callToolResult.name());
+
+    return ToolCallResult.builder()
+        .id(toolCallResult.id())
+        .name(identifier.fullyQualifiedName())
+        .content(callToolResult.content())
+        // completedAt has no fallback resolution on the gateway envelope unwrap - copy explicitly
+        .completedAt(toolCallResult.completedAt())
+        .build();
+  }
+
+  private List<GatewayToolDefinition> extractGatewayToolDefinitions(
+      List<GatewayToolDefinition> gatewayToolDefinitions) {
+    return gatewayToolDefinitions.stream()
+        .filter(gatewayToolDefinition -> GATEWAY_TYPE.equals(gatewayToolDefinition.type()))
+        .toList();
+  }
+
+  @SuppressWarnings("unchecked")
+  private List<String> getLocalToolboxClientIds(AgentContext agentContext) {
+    return (List<String>)
+        agentContext.properties().getOrDefault(PROPERTY_LOCAL_TOOLBOX_CLIENTS, List.of());
+  }
+
+  private Map<String, Object> operationAsMap(Object operation) {
+    return objectMapper.convertValue(
+        operation, ObjectMapperConstants.STRING_OBJECT_MAP_TYPE_REFERENCE);
+  }
+}

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/localtoolbox/discovery/LocalToolboxToolCallIdentifier.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/localtoolbox/discovery/LocalToolboxToolCallIdentifier.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.agenticai.localtoolbox.discovery;
+
+import java.util.regex.Pattern;
+
+/**
+ * Holds a fully qualified local toolbox tool definition name (including the BPMN element ID of the
+ * gateway element in the calling AHSP + the tool name discovered inside the toolbox process).
+ *
+ * <p>For example, a gateway element with BPMN element ID "myToolbox" exposing a discovered tool
+ * named "mySharedTool" is represented as: "LOCALTOOLBOX_myToolbox___mySharedTool". This is the name
+ * passed to the LLM as a unique tool name, mirroring {@code McpToolCallIdentifier}.
+ */
+public record LocalToolboxToolCallIdentifier(String elementId, String toolName) {
+  public static final String LOCAL_TOOLBOX_PREFIX = "LOCALTOOLBOX_";
+  public static final String LOCAL_TOOLBOX_NAMESPACE_SEPARATOR = "___";
+
+  private static final Pattern LOCAL_TOOLBOX_TOOL_CALL_PATTERN =
+      Pattern.compile(
+          "^"
+              + LOCAL_TOOLBOX_PREFIX
+              + "(?<elementId>\\S+?)"
+              + LOCAL_TOOLBOX_NAMESPACE_SEPARATOR
+              + "(?<toolName>\\S+)$");
+
+  public String fullyQualifiedName() {
+    return LOCAL_TOOLBOX_PREFIX + elementId + LOCAL_TOOLBOX_NAMESPACE_SEPARATOR + toolName;
+  }
+
+  public static boolean isLocalToolboxToolCallIdentifier(String toolCallName) {
+    return toolCallName != null && LOCAL_TOOLBOX_TOOL_CALL_PATTERN.matcher(toolCallName).matches();
+  }
+
+  public static LocalToolboxToolCallIdentifier fromToolCallName(String toolCallName) {
+    var matcher = LOCAL_TOOLBOX_TOOL_CALL_PATTERN.matcher(toolCallName);
+    if (!matcher.matches()) {
+      throw invalidToolCallNameException(toolCallName);
+    }
+    return new LocalToolboxToolCallIdentifier(
+        matcher.group("elementId"), matcher.group("toolName"));
+  }
+
+  private static IllegalArgumentException invalidToolCallNameException(String toolCallName) {
+    return new IllegalArgumentException(
+        "Failed to parse local toolbox tool call identifier from '%s'".formatted(toolCallName));
+  }
+}

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/localtoolbox/discovery/package-info.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/localtoolbox/discovery/package-info.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+@NullMarked
+package io.camunda.connector.agenticai.localtoolbox.discovery;
+
+import org.jspecify.annotations.NullMarked;

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/localtoolbox/package-info.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/localtoolbox/package-info.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+@NullMarked
+package io.camunda.connector.agenticai.localtoolbox;
+
+import org.jspecify.annotations.NullMarked;

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/localtoolbox/router/LocalToolboxRouterConnectorResponse.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/localtoolbox/router/LocalToolboxRouterConnectorResponse.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.agenticai.localtoolbox.router;
+
+import io.camunda.connector.agenticai.common.AgenticAiRecord;
+import io.camunda.connector.api.outbound.ConnectorResponse.AdHocSubProcessConnectorResponse;
+import java.util.List;
+import java.util.Map;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Response driving the toolbox's own ad-hoc sub-process: either activates the single requested tool
+ * element, or - once its result is available in {@code toolCallResults} - completes the sub-process
+ * with that result copied to the process-level {@code toolCallResult} variable.
+ *
+ * <p>The non-agentic counterpart of {@code AiAgentSubProcessConnectorResponse}: same {@link
+ * AdHocSubProcessConnectorResponse} contract, without the LLM-specific response/completion-listener
+ * fields.
+ */
+@AgenticAiRecord
+public record LocalToolboxRouterConnectorResponse(
+    @Nullable Object responseValue,
+    Map<String, Object> variables,
+    List<ElementActivation> elementActivations,
+    boolean completionConditionFulfilled,
+    boolean cancelRemainingInstances)
+    implements AdHocSubProcessConnectorResponse, LocalToolboxRouterConnectorResponseBuilder.With {
+
+  public static LocalToolboxRouterConnectorResponseBuilder builder() {
+    return LocalToolboxRouterConnectorResponseBuilder.builder();
+  }
+
+  public record ToolCallElementActivation(String elementId, Map<String, Object> variables)
+      implements ElementActivation {}
+}

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/localtoolbox/router/LocalToolboxRouterFunction.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/localtoolbox/router/LocalToolboxRouterFunction.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.agenticai.localtoolbox.router;
+
+import io.camunda.connector.agenticai.aiagent.model.tool.ToolCallProcessVariable;
+import io.camunda.connector.agenticai.aiagent.model.tool.ToolCallResult;
+import io.camunda.connector.agenticai.localtoolbox.LocalToolboxErrorCodes;
+import io.camunda.connector.agenticai.localtoolbox.router.LocalToolboxRouterConnectorResponse.ToolCallElementActivation;
+import io.camunda.connector.api.annotation.OutboundConnector;
+import io.camunda.connector.api.error.ConnectorException;
+import io.camunda.connector.api.outbound.OutboundConnectorContext;
+import io.camunda.connector.api.outbound.OutboundConnectorFunction;
+import java.util.List;
+import java.util.Map;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Drives the toolbox process's own ad-hoc sub-process: a small, non-LLM two-phase state machine
+ * mirroring the core agent loop ({@code ai-agent.md} §8-9), simplified to a single, pre-selected
+ * tool call decided up front by {@code LocalToolboxClientFunction} instead of chosen per turn by an
+ * LLM.
+ *
+ * <p>Applied to the toolbox's ad-hoc sub-process activity in place of the AI Agent Sub-process
+ * template - the referenced process must NOT have the AI Agent template applied.
+ *
+ * <p>No element template is generated for this connector in v1 (mirroring {@code AiAgentJobWorker},
+ * whose ad-hoc sub-process template is produced by a separate transform rather than its own
+ * annotations); wire {@code zeebe:taskDefinition type="io.camunda.agenticai:localtoolboxrouter:1"}
+ * onto the toolbox's ad-hoc sub-process manually until a dedicated template is added.
+ */
+@OutboundConnector(
+    name = "Local Toolbox Router",
+    type = "io.camunda.agenticai:localtoolboxrouter:1",
+    inputVariables = {
+      LocalToolboxRouterFunction.TOOL_CALL_VARIABLE,
+      LocalToolboxRouterFunction.TOOL_CALL_RESULTS_VARIABLE
+    })
+public class LocalToolboxRouterFunction implements OutboundConnectorFunction {
+
+  public static final String TOOL_CALL_VARIABLE = "toolCall";
+  public static final String TOOL_CALL_RESULTS_VARIABLE = "toolCallResults";
+  public static final String TOOL_CALL_RESULT_VARIABLE = "toolCallResult";
+
+  private static final String CALL_ID = "call-1";
+
+  @Override
+  public LocalToolboxRouterConnectorResponse execute(OutboundConnectorContext context) {
+    final var request = context.bindVariables(LocalToolboxRouterRequest.class);
+    final var toolCallResults =
+        request.toolCallResults() == null ? List.<ToolCallResult>of() : request.toolCallResults();
+
+    final var existingResult =
+        toolCallResults.stream().filter(result -> CALL_ID.equals(result.id())).findFirst();
+    if (existingResult.isPresent()) {
+      return LocalToolboxRouterConnectorResponse.builder()
+          .responseValue(null)
+          .variables(Map.of(TOOL_CALL_RESULT_VARIABLE, existingResult.get().content()))
+          .elementActivations(List.of())
+          .completionConditionFulfilled(true)
+          .cancelRemainingInstances(false)
+          .build();
+    }
+
+    final var toolCall = request.toolCall();
+    if (toolCall == null) {
+      throw new ConnectorException(
+          LocalToolboxErrorCodes.ERROR_CODE_INVALID_TOOL_DEFINITIONS,
+          "Local toolbox router activated without a '%s' variable".formatted(TOOL_CALL_VARIABLE));
+    }
+
+    final var toolCallProcessVariable =
+        new ToolCallProcessVariable(CALL_ID, toolCall.name(), toolCall.arguments());
+    return LocalToolboxRouterConnectorResponse.builder()
+        .responseValue(null)
+        .variables(Map.of())
+        .elementActivations(
+            List.of(
+                new ToolCallElementActivation(
+                    toolCall.name(),
+                    Map.of(
+                        TOOL_CALL_VARIABLE,
+                        toolCallProcessVariable,
+                        TOOL_CALL_RESULT_VARIABLE,
+                        ""))))
+        .completionConditionFulfilled(false)
+        .cancelRemainingInstances(false)
+        .build();
+  }
+
+  public record LocalToolboxRouterRequest(
+      @Nullable ToolCallRequest toolCall, @Nullable List<ToolCallResult> toolCallResults) {
+
+    public record ToolCallRequest(String name, Map<String, Object> arguments) {}
+  }
+}

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/localtoolbox/router/package-info.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/localtoolbox/router/package-info.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+@NullMarked
+package io.camunda.connector.agenticai.localtoolbox.router;
+
+import org.jspecify.annotations.NullMarked;

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/resources/localtoolbox-client.svg
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/resources/localtoolbox-client.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200" fill="none" viewBox="0 0 200 200">
+    <rect x="30" y="80" width="140" height="90" rx="10" stroke="black" stroke-width="12"/>
+    <path d="M70 80V55C70 43 79 34 91 34H109C121 34 130 43 130 55V80" stroke="black" stroke-width="12" stroke-linecap="round"/>
+    <line x1="30" y1="115" x2="170" y2="115" stroke="black" stroke-width="12"/>
+</svg>

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/localtoolbox/client/LocalToolboxClientFunctionTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/localtoolbox/client/LocalToolboxClientFunctionTest.java
@@ -1,0 +1,200 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.agenticai.localtoolbox.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.connector.agenticai.adhoctoolsschema.model.AdHocToolElement;
+import io.camunda.connector.agenticai.adhoctoolsschema.model.AdHocToolsSchemaResponse;
+import io.camunda.connector.agenticai.adhoctoolsschema.processdefinition.ProcessDefinitionAdHocToolElementsResolver;
+import io.camunda.connector.agenticai.adhoctoolsschema.schema.AdHocToolsSchemaResolver;
+import io.camunda.connector.agenticai.aiagent.model.tool.ToolDefinition;
+import io.camunda.connector.agenticai.localtoolbox.client.model.LocalToolboxClientRequest;
+import io.camunda.connector.agenticai.localtoolbox.client.model.LocalToolboxClientRequest.LocalToolboxClientRequestData;
+import io.camunda.connector.agenticai.localtoolbox.client.model.LocalToolboxClientRequest.LocalToolboxClientRequestData.LocalToolboxOperationConfiguration;
+import io.camunda.connector.agenticai.localtoolbox.client.model.result.LocalToolboxCallToolResult;
+import io.camunda.connector.agenticai.localtoolbox.client.model.result.LocalToolboxListToolsResult;
+import io.camunda.connector.api.outbound.OutboundConnectorContext;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class LocalToolboxClientFunctionTest {
+
+  private static final String PROCESS_ID = "toolbox-process";
+  private static final String CONTAINER_ELEMENT_ID = "Tools";
+  private static final Long PROCESS_DEFINITION_KEY = 123456L;
+
+  @Mock private LocalToolboxProcessDefinitionResolver processDefinitionResolver;
+  @Mock private ProcessDefinitionAdHocToolElementsResolver toolElementsResolver;
+  @Mock private AdHocToolsSchemaResolver toolsSchemaResolver;
+
+  @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+  private CamundaClient camundaClient;
+
+  private LocalToolboxClientFunction function;
+
+  @BeforeEach
+  void setUp() {
+    function =
+        new LocalToolboxClientFunction(
+            processDefinitionResolver, toolElementsResolver, toolsSchemaResolver, camundaClient);
+  }
+
+  @Nested
+  class ListTools {
+
+    @Test
+    void resolvesToolSchemaFromReferencedProcess() {
+      var elements = List.of(mock(AdHocToolElement.class));
+      var toolDefinitions =
+          List.of(ToolDefinition.builder().name("tool1").inputSchema(Map.of()).build());
+
+      when(processDefinitionResolver.resolveProcessDefinitionKey(PROCESS_ID, null))
+          .thenReturn(PROCESS_DEFINITION_KEY);
+      when(toolElementsResolver.resolveToolElements(PROCESS_DEFINITION_KEY, CONTAINER_ELEMENT_ID))
+          .thenReturn(elements);
+      when(toolsSchemaResolver.resolveAdHocToolsSchema(elements))
+          .thenReturn(new AdHocToolsSchemaResponse(toolDefinitions, List.of()));
+
+      var result = function.execute(context(request(null, "tools/list", Map.of())));
+
+      assertThat(result).isInstanceOf(LocalToolboxListToolsResult.class);
+      assertThat(((LocalToolboxListToolsResult) result).toolDefinitions())
+          .isEqualTo(toolDefinitions);
+    }
+
+    @Test
+    void resolvesPinnedVersion() {
+      when(processDefinitionResolver.resolveProcessDefinitionKey(PROCESS_ID, 3))
+          .thenReturn(PROCESS_DEFINITION_KEY);
+      when(toolElementsResolver.resolveToolElements(PROCESS_DEFINITION_KEY, CONTAINER_ELEMENT_ID))
+          .thenReturn(List.of());
+      when(toolsSchemaResolver.resolveAdHocToolsSchema(List.of()))
+          .thenReturn(new AdHocToolsSchemaResponse(List.of(), List.of()));
+
+      function.execute(context(request(3, "tools/list", Map.of())));
+
+      verify(processDefinitionResolver).resolveProcessDefinitionKey(PROCESS_ID, 3);
+    }
+  }
+
+  @Nested
+  class CallTool {
+
+    @Test
+    void createsToolboxInstance_usingLatestVersion() {
+      var arguments = Map.<String, Object>of("x", "y");
+      when(camundaClient
+              .newCreateInstanceCommand()
+              .bpmnProcessId(PROCESS_ID)
+              .latestVersion()
+              .variables(anyMap())
+              .withResult()
+              .send()
+              .join()
+              .getVariablesAsMap())
+          .thenReturn(Map.of("toolCallResult", "the result"));
+
+      var result =
+          function.execute(
+              context(
+                  request(
+                      null, "tools/call", Map.of("name", "mySharedTool", "arguments", arguments))));
+
+      assertThat(result).isInstanceOf(LocalToolboxCallToolResult.class);
+      var callToolResult = (LocalToolboxCallToolResult) result;
+      assertThat(callToolResult.name()).isEqualTo("mySharedTool");
+      assertThat(callToolResult.content()).isEqualTo("the result");
+    }
+
+    @Test
+    void createsToolboxInstance_usingPinnedVersion() {
+      when(camundaClient
+              .newCreateInstanceCommand()
+              .bpmnProcessId(PROCESS_ID)
+              .version(2)
+              .variables(anyMap())
+              .withResult()
+              .send()
+              .join()
+              .getVariablesAsMap())
+          .thenReturn(Map.of("toolCallResult", "pinned result"));
+
+      var result =
+          function.execute(
+              context(
+                  request(2, "tools/call", Map.of("name", "mySharedTool", "arguments", Map.of()))));
+
+      assertThat(((LocalToolboxCallToolResult) result).content()).isEqualTo("pinned result");
+    }
+
+    @Test
+    void passesToolCallAndMetaVariablesToTheCreatedInstance() {
+      when(camundaClient
+              .newCreateInstanceCommand()
+              .bpmnProcessId(PROCESS_ID)
+              .latestVersion()
+              .variables(anyMap())
+              .withResult()
+              .send()
+              .join()
+              .getVariablesAsMap())
+          .thenReturn(Map.of());
+
+      function.execute(
+          context(
+              request(
+                  null,
+                  "tools/call",
+                  Map.of("name", "mySharedTool", "arguments", Map.of("x", "y")),
+                  Map.of("tenantId", "t-1"))));
+
+      verify(camundaClient.newCreateInstanceCommand().bpmnProcessId(PROCESS_ID).latestVersion())
+          .variables(
+              eq(
+                  Map.of(
+                      "toolCall", Map.of("name", "mySharedTool", "arguments", Map.of("x", "y")),
+                      "meta", Map.of("tenantId", "t-1"))));
+    }
+  }
+
+  private LocalToolboxClientRequest request(
+      Integer version, String method, Map<String, Object> params) {
+    return request(version, method, params, null);
+  }
+
+  private LocalToolboxClientRequest request(
+      Integer version, String method, Map<String, Object> params, Map<String, Object> meta) {
+    return new LocalToolboxClientRequest(
+        new LocalToolboxClientRequestData(
+            PROCESS_ID,
+            version,
+            CONTAINER_ELEMENT_ID,
+            meta,
+            new LocalToolboxOperationConfiguration(method, params)));
+  }
+
+  private OutboundConnectorContext context(LocalToolboxClientRequest request) {
+    var context = mock(OutboundConnectorContext.class);
+    when(context.bindVariables(LocalToolboxClientRequest.class)).thenReturn(request);
+    return context;
+  }
+}

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/localtoolbox/client/LocalToolboxProcessDefinitionResolverTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/localtoolbox/client/LocalToolboxProcessDefinitionResolverTest.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.agenticai.localtoolbox.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.when;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.search.response.ProcessDefinition;
+import io.camunda.connector.agenticai.autoconfigure.AgenticAiConnectorsConfigurationProperties.RetriesProperties;
+import io.camunda.connector.api.error.ConnectorException;
+import java.time.Duration;
+import java.util.List;
+import java.util.function.Consumer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class LocalToolboxProcessDefinitionResolverTest {
+
+  private static final String PROCESS_ID = "toolbox-process";
+  private static final RetriesProperties RETRIES = new RetriesProperties(2, Duration.ofMillis(10));
+
+  @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+  private CamundaClient camundaClient;
+
+  private LocalToolboxProcessDefinitionResolver resolver;
+
+  @BeforeEach
+  void setUp() {
+    resolver = new LocalToolboxProcessDefinitionResolver(camundaClient, RETRIES);
+  }
+
+  @Test
+  void resolvesLatestVersion_whenVersionNotSpecified() {
+    var v1 = processDefinition(1, 100L);
+    var v2 = processDefinition(2, 200L);
+    when(camundaClient
+            .newProcessDefinitionSearchRequest()
+            .filter(any(Consumer.class))
+            .sort(any(Consumer.class))
+            .send()
+            .join()
+            .items())
+        .thenReturn(List.of(v1, v2));
+
+    var result = resolver.resolveProcessDefinitionKey(PROCESS_ID, null);
+
+    assertThat(result).isEqualTo(200L);
+  }
+
+  @Test
+  void resolvesPinnedVersion_whenVersionSpecified() {
+    var v1 = processDefinition(1, 100L);
+    var v2 = processDefinition(2, 200L);
+    when(camundaClient
+            .newProcessDefinitionSearchRequest()
+            .filter(any(Consumer.class))
+            .sort(any(Consumer.class))
+            .send()
+            .join()
+            .items())
+        .thenReturn(List.of(v1, v2));
+
+    var result = resolver.resolveProcessDefinitionKey(PROCESS_ID, 1);
+
+    assertThat(result).isEqualTo(100L);
+  }
+
+  @Test
+  void throwsException_whenNoProcessDefinitionsFound() {
+    when(camundaClient
+            .newProcessDefinitionSearchRequest()
+            .filter(any(Consumer.class))
+            .sort(any(Consumer.class))
+            .send()
+            .join()
+            .items())
+        .thenReturn(List.of());
+
+    assertThatThrownBy(() -> resolver.resolveProcessDefinitionKey(PROCESS_ID, null))
+        .isInstanceOfSatisfying(
+            ConnectorException.class,
+            e -> {
+              assertThat(e.getErrorCode()).isEqualTo("LOCAL_TOOLBOX_PROCESS_DEFINITION_NOT_FOUND");
+              assertThat(e.getMessage())
+                  .isEqualTo(
+                      "No deployed process definition found with process id 'toolbox-process'.");
+            });
+  }
+
+  @Test
+  void throwsException_whenPinnedVersionNotFound() {
+    var v1 = processDefinition(1, 100L);
+    when(camundaClient
+            .newProcessDefinitionSearchRequest()
+            .filter(any(Consumer.class))
+            .sort(any(Consumer.class))
+            .send()
+            .join()
+            .items())
+        .thenReturn(List.of(v1));
+
+    assertThatThrownBy(() -> resolver.resolveProcessDefinitionKey(PROCESS_ID, 5))
+        .isInstanceOfSatisfying(
+            ConnectorException.class,
+            e -> {
+              assertThat(e.getErrorCode()).isEqualTo("LOCAL_TOOLBOX_PROCESS_DEFINITION_NOT_FOUND");
+              assertThat(e.getMessage())
+                  .isEqualTo(
+                      "No deployed process definition found with process id 'toolbox-process' and version 5.");
+            });
+  }
+
+  private ProcessDefinition processDefinition(int version, long key) {
+    // lenient: not every scenario exercises both accessors for every list entry (e.g. version
+    // lookup short-circuits on first match; the no-version branch never reads getVersion() at all)
+    var processDefinition = org.mockito.Mockito.mock(ProcessDefinition.class);
+    lenient().when(processDefinition.getVersion()).thenReturn(version);
+    lenient().when(processDefinition.getProcessDefinitionKey()).thenReturn(key);
+    return processDefinition;
+  }
+}

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/localtoolbox/discovery/LocalToolboxGatewayToolHandlerTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/localtoolbox/discovery/LocalToolboxGatewayToolHandlerTest.java
@@ -1,0 +1,311 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.agenticai.localtoolbox.discovery;
+
+import static io.camunda.connector.agenticai.localtoolbox.discovery.LocalToolboxGatewayToolHandler.PROPERTY_LOCAL_TOOLBOX_CLIENTS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.connector.agenticai.aiagent.model.AgentContext;
+import io.camunda.connector.agenticai.aiagent.model.tool.GatewayToolDefinition;
+import io.camunda.connector.agenticai.aiagent.model.tool.ToolCall;
+import io.camunda.connector.agenticai.aiagent.model.tool.ToolCallResult;
+import io.camunda.connector.agenticai.aiagent.model.tool.ToolDefinition;
+import io.camunda.connector.agenticai.localtoolbox.client.model.result.LocalToolboxCallToolResult;
+import io.camunda.connector.agenticai.localtoolbox.client.model.result.LocalToolboxListToolsResult;
+import io.camunda.connector.api.error.ConnectorException;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+import org.assertj.core.api.InstanceOfAssertFactories;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class LocalToolboxGatewayToolHandlerTest {
+
+  private final ObjectMapper objectMapper = new ObjectMapper();
+  private LocalToolboxGatewayToolHandler handler;
+
+  @BeforeEach
+  void setUp() {
+    handler = new LocalToolboxGatewayToolHandler(objectMapper);
+  }
+
+  @Nested
+  class TypeIdentification {
+
+    @Test
+    void returnsCorrectType() {
+      assertThat(handler.type()).isEqualTo("localToolbox");
+    }
+
+    @Test
+    void resolvesElementIdFromNamespacedToolName() {
+      assertThat(handler.resolveElementId("LOCALTOOLBOX_myElement___myTool"))
+          .isEqualTo("myElement");
+    }
+  }
+
+  @Nested
+  class ToolDiscoveryInitiation {
+
+    @Test
+    void returnsEmptyResult_whenNoLocalToolboxGatewayToolDefinitions() {
+      var agentContext = AgentContext.empty();
+      var gatewayToolDefinitions =
+          List.of(
+              createGatewayToolDefinition("other", "tool1"),
+              createGatewayToolDefinition("mcpClient", "tool2"));
+
+      var result = handler.initiateToolDiscovery(agentContext, gatewayToolDefinitions);
+
+      assertThat(result.agentContext()).isEqualTo(agentContext);
+      assertThat(result.toolDiscoveryToolCalls()).isEmpty();
+    }
+
+    @Test
+    void createsDiscoveryToolCalls_whenLocalToolboxGatewayToolDefinitionsPresent() {
+      var agentContext = AgentContext.empty();
+      var gatewayToolDefinitions =
+          List.of(
+              createGatewayToolDefinition("localToolbox", "toolbox1"),
+              createGatewayToolDefinition("localToolbox", "toolbox2"));
+
+      var result = handler.initiateToolDiscovery(agentContext, gatewayToolDefinitions);
+
+      assertThat(result.agentContext().properties())
+          .containsEntry(PROPERTY_LOCAL_TOOLBOX_CLIENTS, List.of("toolbox1", "toolbox2"));
+      assertThat(result.toolDiscoveryToolCalls()).hasSize(2);
+      assertThat(result.toolDiscoveryToolCalls())
+          .satisfiesExactly(
+              toolCall -> {
+                assertThat(toolCall.id()).isEqualTo("LOCALTOOLBOX_toolsList_toolbox1");
+                assertThat(toolCall.name()).isEqualTo("toolbox1");
+                assertThat(toolCall.arguments()).containsExactly(Map.entry("method", "tools/list"));
+              },
+              toolCall -> {
+                assertThat(toolCall.id()).isEqualTo("LOCALTOOLBOX_toolsList_toolbox2");
+                assertThat(toolCall.name()).isEqualTo("toolbox2");
+              });
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"toolbox___client", "name___", "___name"})
+    void throwsException_whenGatewayToolDefinitionNameContainsSeparator(String invalidName) {
+      var agentContext = AgentContext.empty();
+      var gatewayToolDefinitions =
+          List.of(createGatewayToolDefinition("localToolbox", invalidName));
+
+      assertThatThrownBy(() -> handler.initiateToolDiscovery(agentContext, gatewayToolDefinitions))
+          .isInstanceOf(ConnectorException.class)
+          .asInstanceOf(InstanceOfAssertFactories.type(ConnectorException.class))
+          .satisfies(
+              e ->
+                  assertThat(e.getErrorCode()).isEqualTo("LOCAL_TOOLBOX_INVALID_TOOL_DEFINITIONS"));
+    }
+  }
+
+  @Nested
+  class AllToolDiscoveryResultsPresent {
+
+    @Test
+    void returnsTrue_whenAllDiscoveryResultsPresent() {
+      var agentContext =
+          AgentContext.empty()
+              .withProperty(PROPERTY_LOCAL_TOOLBOX_CLIENTS, List.of("toolbox1", "toolbox2"));
+      var toolCallResults =
+          List.of(
+              ToolCallResult.builder()
+                  .id("LOCALTOOLBOX_toolsList_toolbox1")
+                  .name("toolbox1")
+                  .content("result1")
+                  .build(),
+              ToolCallResult.builder()
+                  .id("LOCALTOOLBOX_toolsList_toolbox2")
+                  .name("toolbox2")
+                  .content("result2")
+                  .build());
+
+      assertThat(handler.allToolDiscoveryResultsPresent(agentContext, toolCallResults)).isTrue();
+    }
+
+    @Test
+    void returnsFalse_whenSomeDiscoveryResultsMissing() {
+      var agentContext =
+          AgentContext.empty()
+              .withProperty(PROPERTY_LOCAL_TOOLBOX_CLIENTS, List.of("toolbox1", "toolbox2"));
+      var toolCallResults =
+          List.of(
+              ToolCallResult.builder()
+                  .id("LOCALTOOLBOX_toolsList_toolbox1")
+                  .name("toolbox1")
+                  .content("result1")
+                  .build());
+
+      assertThat(handler.allToolDiscoveryResultsPresent(agentContext, toolCallResults)).isFalse();
+    }
+
+    @Test
+    void returnsTrue_whenNoClientsConfigured() {
+      assertThat(handler.allToolDiscoveryResultsPresent(AgentContext.empty(), List.of())).isTrue();
+    }
+  }
+
+  @Nested
+  class ToolDiscoveryResultHandling {
+
+    @ParameterizedTest
+    @MethodSource("toolDiscoveryResultScenarios")
+    void handlesToolDiscoveryResult_correctly(String toolCallId, boolean expected) {
+      var toolCallResult =
+          ToolCallResult.builder().id(toolCallId).name("toolbox1").content("result").build();
+
+      assertThat(handler.handlesToolDiscoveryResult(toolCallResult)).isEqualTo(expected);
+    }
+
+    static Stream<Arguments> toolDiscoveryResultScenarios() {
+      return Stream.of(
+          arguments("LOCALTOOLBOX_toolsList_toolbox1", true),
+          arguments("regular_tool_call", false),
+          arguments((Object) null, false));
+    }
+
+    @Test
+    void convertsDiscoveryResults_toToolDefinitions() {
+      var agentContext = AgentContext.empty();
+      var listToolsResult =
+          new LocalToolboxListToolsResult(
+              List.of(
+                  ToolDefinition.builder()
+                      .name("tool1")
+                      .description("Tool 1 description")
+                      .inputSchema(Map.of("type", "object"))
+                      .build(),
+                  ToolDefinition.builder()
+                      .name("tool2")
+                      .description("Tool 2 description")
+                      .inputSchema(Map.of("type", "object"))
+                      .build()));
+      var toolDiscoveryResults =
+          List.of(
+              createToolCallResultWithContent(
+                  "LOCALTOOLBOX_toolsList_toolbox1", "toolbox1", listToolsResult));
+
+      var result = handler.handleToolDiscoveryResults(agentContext, toolDiscoveryResults);
+
+      assertThat(result)
+          .satisfiesExactly(
+              toolDefinition -> {
+                assertThat(toolDefinition.name()).isEqualTo("LOCALTOOLBOX_toolbox1___tool1");
+                assertThat(toolDefinition.description()).isEqualTo("Tool 1 description");
+              },
+              toolDefinition ->
+                  assertThat(toolDefinition.name()).isEqualTo("LOCALTOOLBOX_toolbox1___tool2"));
+    }
+  }
+
+  @Nested
+  class ToolCallTransformation {
+
+    @Test
+    void transformsLocalToolboxToolCalls_toOperations() {
+      var agentContext = AgentContext.empty();
+      var toolCalls =
+          List.of(
+              new ToolCall("call1", "LOCALTOOLBOX_toolbox1___tool1", Map.of("arg1", "value1")),
+              new ToolCall("call2", "regular_tool", Map.of("arg2", "value2")));
+
+      var result = handler.transformToolCalls(agentContext, toolCalls);
+
+      assertThat(result)
+          .satisfiesExactly(
+              toolCall -> {
+                assertThat(toolCall.id()).isEqualTo("call1");
+                assertThat(toolCall.name()).isEqualTo("toolbox1");
+                assertThat(toolCall.arguments().get("method")).isEqualTo("tools/call");
+                assertThat(toolCall.arguments().get("params"))
+                    .isEqualTo(Map.of("name", "tool1", "arguments", Map.of("arg1", "value1")));
+              },
+              toolCall -> assertThat(toolCall).isEqualTo(toolCalls.get(1)));
+    }
+  }
+
+  @Nested
+  class ToolCallResultTransformation {
+
+    @Test
+    void transformsResults_toFullyQualifiedToolCallResults() {
+      var agentContext =
+          AgentContext.empty().withProperty(PROPERTY_LOCAL_TOOLBOX_CLIENTS, List.of("toolbox1"));
+      var callToolResult = new LocalToolboxCallToolResult("tool1", "Tool result");
+      var toolCallResults =
+          List.of(createToolCallResultWithContent("call1", "toolbox1", callToolResult));
+
+      var result = handler.transformToolCallResults(agentContext, toolCallResults);
+
+      assertThat(result)
+          .singleElement()
+          .satisfies(
+              toolCallResult -> {
+                assertThat(toolCallResult.id()).isEqualTo("call1");
+                assertThat(toolCallResult.name()).isEqualTo("LOCALTOOLBOX_toolbox1___tool1");
+                assertThat(toolCallResult.content()).isEqualTo("Tool result");
+              });
+    }
+
+    @Test
+    void preservesCompletedAtFromTheOriginalResult() {
+      var agentContext =
+          AgentContext.empty().withProperty(PROPERTY_LOCAL_TOOLBOX_CLIENTS, List.of("toolbox1"));
+      var callToolResult = new LocalToolboxCallToolResult("tool1", "Tool result");
+      var completedAt = OffsetDateTime.parse("2026-07-02T10:00:00Z");
+      var toolCallResult =
+          createToolCallResultWithContent("call1", "toolbox1", callToolResult)
+              .withCompletedAt(completedAt);
+
+      var result = handler.transformToolCallResults(agentContext, List.of(toolCallResult));
+
+      assertThat(result).singleElement().extracting("completedAt").isEqualTo(completedAt);
+    }
+
+    @Test
+    void preservesOriginalResult_whenNotLocalToolboxClient() {
+      var agentContext =
+          AgentContext.empty().withProperty(PROPERTY_LOCAL_TOOLBOX_CLIENTS, List.of("toolbox1"));
+      var toolCallResults = List.of(createToolCallResult("call1", "other_tool"));
+
+      var result = handler.transformToolCallResults(agentContext, toolCallResults);
+
+      assertThat(result).isEqualTo(toolCallResults);
+    }
+  }
+
+  private GatewayToolDefinition createGatewayToolDefinition(String type, String name) {
+    return GatewayToolDefinition.builder()
+        .type(type)
+        .name(name)
+        .description("Description for " + name)
+        .properties(Map.of())
+        .build();
+  }
+
+  private ToolCallResult createToolCallResult(String id, String name) {
+    return ToolCallResult.builder().id(id).name(name).content("result content").build();
+  }
+
+  private ToolCallResult createToolCallResultWithContent(String id, String name, Object content) {
+    return ToolCallResult.builder().id(id).name(name).content(content).build();
+  }
+}

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/localtoolbox/discovery/LocalToolboxToolCallIdentifierTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/localtoolbox/discovery/LocalToolboxToolCallIdentifierTest.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.agenticai.localtoolbox.discovery;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class LocalToolboxToolCallIdentifierTest {
+
+  @Nested
+  class FullyQualifiedNameGeneration {
+
+    @Test
+    void generatesCorrectName_whenValidElementAndToolName() {
+      var identifier = new LocalToolboxToolCallIdentifier("myElement", "myTool");
+
+      var result = identifier.fullyQualifiedName();
+
+      assertThat(result).isEqualTo("LOCALTOOLBOX_myElement___myTool");
+    }
+
+    @Test
+    void generatesCorrectName_whenNamesContainSpecialCharacters() {
+      var identifier = new LocalToolboxToolCallIdentifier("my-element_123", "file-read");
+
+      var result = identifier.fullyQualifiedName();
+
+      assertThat(result).isEqualTo("LOCALTOOLBOX_my-element_123___file-read");
+    }
+  }
+
+  @Nested
+  class ToolCallIdentifierValidation {
+
+    @ParameterizedTest
+    @MethodSource("validToolCallNames")
+    void returnsTrue_whenValidLocalToolboxToolCallIdentifier(String toolCallName) {
+      assertThat(LocalToolboxToolCallIdentifier.isLocalToolboxToolCallIdentifier(toolCallName))
+          .isTrue();
+    }
+
+    @ParameterizedTest
+    @MethodSource("invalidToolCallNames")
+    void returnsFalse_whenInvalidLocalToolboxToolCallIdentifier(String toolCallName) {
+      assertThat(LocalToolboxToolCallIdentifier.isLocalToolboxToolCallIdentifier(toolCallName))
+          .isFalse();
+    }
+
+    static Stream<Arguments> validToolCallNames() {
+      return Stream.of(
+          arguments("LOCALTOOLBOX_element___tool"),
+          arguments("LOCALTOOLBOX_my-element___my-tool"),
+          arguments("LOCALTOOLBOX_a___b"),
+          arguments("LOCALTOOLBOX_element___tool___with___separators"));
+    }
+
+    static Stream<Arguments> invalidToolCallNames() {
+      return Stream.of(
+          arguments("element___tool"), // missing prefix
+          arguments("LOCALTOOLBOX_element_tool"), // missing separator
+          arguments("LOCALTOOLBOX_element___"), // missing tool name
+          arguments("LOCALTOOLBOX____tool"), // missing element name
+          arguments("LOCALTOOLBOX___"), // missing both
+          arguments(""), // empty
+          arguments("MCP_element___tool")); // wrong prefix
+    }
+  }
+
+  @Nested
+  class ToolCallNameParsing {
+
+    @Test
+    void parsesCorrectly_whenValidToolCallName() {
+      var result =
+          LocalToolboxToolCallIdentifier.fromToolCallName("LOCALTOOLBOX_myElement___myTool");
+
+      assertThat(result.elementId()).isEqualTo("myElement");
+      assertThat(result.toolName()).isEqualTo("myTool");
+    }
+
+    @Test
+    void parsesCorrectly_whenToolNameHasSeparator() {
+      var result =
+          LocalToolboxToolCallIdentifier.fromToolCallName(
+              "LOCALTOOLBOX_Activity_1mlgkr7___loan-affordability___loan-affordability");
+
+      assertThat(result.elementId()).isEqualTo("Activity_1mlgkr7");
+      assertThat(result.toolName()).isEqualTo("loan-affordability___loan-affordability");
+    }
+
+    @ParameterizedTest
+    @ValueSource(
+        strings = {
+          "LOCALTOOLBOX_element___",
+          "LOCALTOOLBOX____tool",
+          "LOCALTOOLBOX___",
+          "element___tool",
+          "LOCALTOOLBOX_element_tool"
+        })
+    void throwsException_whenInvalidToolCallName(String invalidToolCallName) {
+      assertThatThrownBy(() -> LocalToolboxToolCallIdentifier.fromToolCallName(invalidToolCallName))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessage(
+              "Failed to parse local toolbox tool call identifier from '%s'"
+                  .formatted(invalidToolCallName));
+    }
+  }
+
+  @Nested
+  class RoundTripConsistency {
+
+    @ParameterizedTest
+    @MethodSource("roundTripScenarios")
+    void maintainsConsistency_whenGeneratingAndParsingNames(String elementName, String toolName) {
+      var original = new LocalToolboxToolCallIdentifier(elementName, toolName);
+      var fullyQualifiedName = original.fullyQualifiedName();
+      var parsed = LocalToolboxToolCallIdentifier.fromToolCallName(fullyQualifiedName);
+
+      assertThat(parsed).isEqualTo(original);
+      assertThat(parsed.elementId()).isEqualTo(elementName);
+      assertThat(parsed.toolName()).isEqualTo(toolName);
+    }
+
+    static Stream<Arguments> roundTripScenarios() {
+      return Stream.of(
+          arguments("element", "tool"),
+          arguments("my-element", "my-tool"),
+          arguments("element_123", "tool_action"),
+          arguments("Activity_1mlgkr7", "loan-affordability___loan-affordability"));
+    }
+  }
+}

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/localtoolbox/router/LocalToolboxRouterFunctionTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/localtoolbox/router/LocalToolboxRouterFunctionTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.agenticai.localtoolbox.router;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.camunda.connector.agenticai.aiagent.model.tool.ToolCallProcessVariable;
+import io.camunda.connector.agenticai.aiagent.model.tool.ToolCallResult;
+import io.camunda.connector.agenticai.localtoolbox.router.LocalToolboxRouterFunction.LocalToolboxRouterRequest;
+import io.camunda.connector.agenticai.localtoolbox.router.LocalToolboxRouterFunction.LocalToolboxRouterRequest.ToolCallRequest;
+import io.camunda.connector.api.error.ConnectorException;
+import io.camunda.connector.api.outbound.OutboundConnectorContext;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class LocalToolboxRouterFunctionTest {
+
+  private final LocalToolboxRouterFunction function = new LocalToolboxRouterFunction();
+
+  @Nested
+  class FirstInvocation {
+
+    @Test
+    void activatesTheRequestedToolElement() {
+      var toolCall = new ToolCallRequest("mySharedTool", Map.of("x", "y"));
+
+      var result = function.execute(context(new LocalToolboxRouterRequest(toolCall, List.of())));
+
+      assertThat(result.completionConditionFulfilled()).isFalse();
+      assertThat(result.cancelRemainingInstances()).isFalse();
+      assertThat(result.elementActivations())
+          .singleElement()
+          .satisfies(
+              activation -> {
+                assertThat(activation.elementId()).isEqualTo("mySharedTool");
+                var variables = activation.variables();
+                assertThat(variables).containsEntry("toolCallResult", "");
+                assertThat(variables.get("toolCall"))
+                    .isEqualTo(
+                        new ToolCallProcessVariable("call-1", "mySharedTool", Map.of("x", "y")));
+              });
+    }
+
+    @Test
+    void throwsException_whenToolCallVariableIsMissing() {
+      assertThatThrownBy(
+              () -> function.execute(context(new LocalToolboxRouterRequest(null, List.of()))))
+          .isInstanceOfSatisfying(
+              ConnectorException.class,
+              e ->
+                  assertThat(e.getErrorCode()).isEqualTo("LOCAL_TOOLBOX_INVALID_TOOL_DEFINITIONS"));
+    }
+  }
+
+  @Nested
+  class SecondInvocation {
+
+    @Test
+    void completesWithTheToolResult_onceResultIsPresent() {
+      var toolCall = new ToolCallRequest("mySharedTool", Map.of("x", "y"));
+      var toolCallResults =
+          List.of(
+              ToolCallResult.builder()
+                  .id("call-1")
+                  .name("mySharedTool")
+                  .content("the tool result")
+                  .build());
+
+      var result =
+          function.execute(context(new LocalToolboxRouterRequest(toolCall, toolCallResults)));
+
+      assertThat(result.completionConditionFulfilled()).isTrue();
+      assertThat(result.elementActivations()).isEmpty();
+      assertThat(result.variables()).containsEntry("toolCallResult", "the tool result");
+    }
+
+    @Test
+    void ignoresUnrelatedToolCallResults() {
+      var toolCall = new ToolCallRequest("mySharedTool", Map.of());
+      var toolCallResults =
+          List.of(ToolCallResult.builder().id("other-call").name("other").content("x").build());
+
+      var result =
+          function.execute(context(new LocalToolboxRouterRequest(toolCall, toolCallResults)));
+
+      assertThat(result.completionConditionFulfilled()).isFalse();
+      assertThat(result.elementActivations())
+          .singleElement()
+          .satisfies(activation -> assertThat(activation.elementId()).isEqualTo("mySharedTool"));
+    }
+  }
+
+  private OutboundConnectorContext context(LocalToolboxRouterRequest request) {
+    var context = mock(OutboundConnectorContext.class);
+    when(context.bindVariables(LocalToolboxRouterRequest.class)).thenReturn(request);
+    return context;
+  }
+}

--- a/connectors/agentic-ai/examples/ai-agent/service-task/ai-agent-chat-mcp/ai-agent-service-task-chat-with-mcp.bpmn
+++ b/connectors/agentic-ai/examples/ai-agent/service-task/ai-agent-chat-mcp/ai-agent-service-task-chat-with-mcp.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bioc="http://bpmn.io/schema/bpmn/biocolor/1.0" xmlns:color="http://www.omg.org/spec/BPMN/non-normative/color/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_18jxukq" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.44.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.9.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bioc="http://bpmn.io/schema/bpmn/biocolor/1.0" xmlns:color="http://www.omg.org/spec/BPMN/non-normative/color/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_18jxukq" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.49.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.9.0">
   <bpmn:process id="ai-agent-service-task-chat-with-mcp" name="AI Agent Service Task Chat With MCP" isExecutable="true">
     <bpmn:startEvent id="StartEvent_1">
       <bpmn:extensionElements>
@@ -224,7 +224,7 @@ else
           </zeebe:ioMapping>
         </bpmn:extensionElements>
       </bpmn:scriptTask>
-      <bpmn:serviceTask id="Fetch_URL" name="Fetch URL" zeebe:modelerTemplate="io.camunda.connectors.agenticai.mcp.remoteclient.v0" zeebe:modelerTemplateVersion="3" zeebe:modelerTemplateIcon="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyMDAiIGhlaWdodD0iMjAwIiBmaWxsPSJub25lIiB2aWV3Qm94PSIwIDAgMjAwIDIwMCI+CiAgICA8cGF0aCBkPSJNMjUgOTcuODUyOEw5Mi44ODIzIDI5Ljk3MDZDMTAyLjI1NSAyMC41OTggMTE3LjQ1MSAyMC41OTggMTI2LjgyMyAyOS45NzA2VjI5Ljk3MDZDMTM2LjE5NiAzOS4zNDMxIDEzNi4xOTYgNTQuNTM5MSAxMjYuODIzIDYzLjkxMTdMNzUuNTU4MSAxMTUuMTc3IiBzdHJva2U9ImJsYWNrIiBzdHJva2Utd2lkdGg9IjEyIiBzdHJva2UtbGluZWNhcD0icm91bmQiLz4KICAgIDxwYXRoIGQ9Ik03Ni4yNjUzIDExNC40N0wxMjYuODIzIDYzLjkxMTdDMTM2LjE5NiA1NC41MzkxIDE1MS4zOTIgNTQuNTM5MSAxNjAuNzY1IDYzLjkxMTdMMTYxLjExOCA2NC4yNjUyQzE3MC40OTEgNzMuNjM3OCAxNzAuNDkxIDg4LjgzMzggMTYxLjExOCA5OC4yMDYzTDk5LjcyNDggMTU5LjZDOTYuNjAwNiAxNjIuNzI0IDk2LjYwMDYgMTY3Ljc4OSA5OS43MjQ4IDE3MC45MTNMMTEyLjMzMSAxODMuNTIiIHN0cm9rZT0iYmxhY2siIHN0cm9rZS13aWR0aD0iMTIiIHN0cm9rZS1saW5lY2FwPSJyb3VuZCIvPgogICAgPHBhdGggZD0iTTEwOS44NTMgNDYuOTQxMUw1OS42NDgyIDk3LjE0NTdDNTAuMjc1NyAxMDYuNTE4IDUwLjI3NTcgMTIxLjcxNCA1OS42NDgyIDEzMS4wODdWMTMxLjA4N0M2OS4wMjA4IDE0MC40NTkgODQuMjE2OCAxNDAuNDU5IDkzLjU4OTQgMTMxLjA4N0wxNDMuNzk0IDgwLjg4MjIiIHN0cm9rZT0iYmxhY2siIHN0cm9rZS13aWR0aD0iMTIiIHN0cm9rZS1saW5lY2FwPSJyb3VuZCIvPgo8L3N2Zz4K">
+      <bpmn:serviceTask id="Fetch_URL" name="Fetch URL">
         <bpmn:extensionElements>
           <zeebe:taskDefinition type="io.camunda.agenticai:mcpremoteclient:1" retries="3" />
           <zeebe:ioMapping>
@@ -360,20 +360,20 @@ The outside brain &lt;AI Agent&gt; will take that information to instruct the mo
       <bpmndi:BPMNShape id="Activity_0ke4gic_di" bpmnElement="Activity_0mdux6v">
         <dc:Bounds x="805" y="915" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="BPMNShape_0x0a1hy" bpmnElement="SuperfluxProduct">
-        <dc:Bounds x="780" y="1058" width="100" height="80" />
-        <bpmndi:BPMNLabel />
+      <bpmndi:BPMNShape id="BPMNShape_0nv9xyn" bpmnElement="Deepwiki">
+        <dc:Bounds x="1010" y="607" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="BPMNShape_11biggn" bpmnElement="Time">
         <dc:Bounds x="720" y="607" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0x0a1hy" bpmnElement="SuperfluxProduct">
+        <dc:Bounds x="780" y="1058" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_09n08ly_di" bpmnElement="Fetch_URL">
         <dc:Bounds x="870" y="607" width="100" height="80" />
         <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="BPMNShape_0nv9xyn" bpmnElement="Deepwiki">
-        <dc:Bounds x="1010" y="607" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNEdge id="Flow_085l1z3_di" bpmnElement="Flow_085l1z3">
         <di:waypoint x="783" y="815" />

--- a/connectors/agentic-ai/local-toolbox-epic.md
+++ b/connectors/agentic-ai/local-toolbox-epic.md
@@ -1,0 +1,132 @@
+---
+title: 'Local Toolbox: reusable AI Agent tool sets via a process-reference gateway tool'
+labels: kind:epic, component:ai, component:connectors
+repo: camunda/product-hub
+filed: https://github.com/camunda/product-hub/issues/3772
+---
+
+# Value Proposition Statement
+
+Let an AI Agent Sub-process (AHSP) reference another deployed process — by process ID and
+optional version — as a single gateway tool. That referenced process is itself just a plain
+ad-hoc sub-process (start event → tool AHSP, no AI Agent template applied → end event); its tool
+elements get auto-discovered and exposed to the calling agent exactly the way MCP/A2A tools are
+today, without standing up an external MCP server or redefining the same tools in every process.
+A dedicated `meta` argument, exposed on the gateway's element template, lets the caller pass
+deterministic configuration straight through to the toolbox instance, bypassing the LLM entirely.
+
+# User Problem
+
+**Context**: building "Ticket Genie" (Jira support-ticket automation), we need several AI Agent
+processes to share one tool set — attachment handling (notably for Self-Managed), Jira lookups,
+support-phrasing guidelines. Today nothing is shared: every AHSP that hosts an agent has to define
+its own tool elements, so the same tool gets modeled N times across N processes with no single
+source of truth.
+
+We looked at three ways to reuse tools across agent processes in the same cluster:
+
+- **Cluster MCP + MCP start event** — works with the already-shipped MCP gateway resolver, but
+  adds a network round-trip through an MCP server, gives poor traceability of which tools are
+  actually exposed, and has no deterministic-variable channel: every argument has to come from the
+  model until a `meta`-argument mechanism exists.
+- **Separate AHSP + Agent worker** — genuine reuse, but forces every consuming process into a
+  single combined diagram, and falls back to an older/deprecated worker-composition pattern.
+- **A new gateway/call-activity type** — reuse the AI Agent's existing gateway-tool extensibility
+  (the same mechanism MCP and A2A already use) with a process reference as the backing "server."
+  Open questions: does every calling process get upgraded automatically when a new toolbox version
+  is deployed, and is this non-standard BPMN.
+
+None of these give us, today, a way to say "this element is itself a toolbox — discover its tools
+and expose them to me" the way an MCP client element already does generically. And there's no
+channel for deterministic (non-LLM) inputs into a gateway-resolved tool at all.
+
+Two structural constraints shape the solution:
+- **AHSP config is frozen at sub-process entry** (existing architecture invariant) — a toolbox's
+  discovered schema must stay stable for the life of a calling agent's conversation, which argues
+  for referencing an explicit process **version**, not "latest" binding.
+- **In-process tool refresh can't be standardized** — detecting that a running agent's tools
+  changed mid-conversation (e.g. an MCP server's tool list changing) isn't reliably solvable in
+  general; version pinning is the practical answer, and the responsibility for a compatible
+  upgrade shifts to whoever deploys a new toolbox version.
+
+This isn't only an internal need — customers already ask for reusable, auto-discovered tool sets
+within their own cluster, independent of the broader cross-cluster MCP-exposure work in
+[camunda/product-hub#3353](https://github.com/camunda/product-hub/issues/3353).
+
+# User Stories
+
+- As an agent process author, I want to reference another deployed process (by process ID,
+  optionally pinned to a version) as a single gateway element in my AHSP, so I can reuse a shared
+  tool set without redefining it or standing up an MCP server.
+- As an agent process author, I want the referenced process's own AHSP tool elements — including
+  their `fromAi()`-tagged parameters — to be discovered automatically and exposed to my agent as
+  regular tools, the same way MCP/A2A tools are discovered today.
+- As an agent process author, I want to pass a fixed set of deterministic variables (tenant ID,
+  connection config, feature flags, …) into the toolbox instance via a `meta` argument on the
+  gateway element, separate from the LLM-controlled `fromAi()` arguments, and have that argument
+  surfaced as a first-class property on the gateway's element template.
+- As a toolbox author, I want my toolbox process to be a plain ad-hoc sub-process (start event →
+  AHSP → end event) with no AI Agent template applied, so it's discovered as a tool host, not
+  treated as an agent itself.
+- As a platform engineer, I want the toolbox reference to require an explicit process ID/version,
+  so deploying a new toolbox version can't silently change the tool contract of an
+  already-running agent conversation.
+- As a Camunda engineer evaluating this before productizing it, I want a hacky/local experiment —
+  built as a custom connector outside the shipped AI Agent code, with the built-in gateway runtime
+  disabled where needed — so we validate discovery, versioning, and meta-arg wiring before
+  deciding what (if anything) belongs in the core AI Agent gateway-tool framework.
+
+# Implementation Notes
+
+- Reuse the **Gateway Tool Pattern**
+  ([`ai-agent.md` §19](https://github.com/camunda/connectors/blob/17bc53f190c65cbb943a920b40af13e0a13d9afa/connectors/agentic-ai/docs/reference/ai-agent.md#19-gateway-tool-pattern)):
+  add a new `GatewayToolHandler` (e.g. `type = "localToolbox"`), detected via the same
+  `io.camunda.agenticai.gateway.type` extension property already used for `mcpClient`/`a2aClient`
+  ([`TypePropertyBasedGatewayToolDefinitionResolver`](https://github.com/camunda/connectors/blob/17bc53f190c65cbb943a920b40af13e0a13d9afa/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/adhoctoolsschema/schema/TypePropertyBasedGatewayToolDefinitionResolver.java)).
+- **Discovery** without an MCP round-trip: resolve the toolbox's schema the way the Task-flavor
+  connector already resolves its *own* AHSP — fetch the referenced process's BPMN XML
+  (`GET /process-definitions/{key}/xml`, as `ProcessDefinitionAdHocToolElementsResolver` does),
+  locate its ad-hoc sub-process, and run the existing `fromAi()` FEEL-parameter extraction
+  (`AdHocToolElementParameterExtractor`, `AdHocToolSchemaGeneratorImpl` — see
+  [`ai-agent.md` §7](https://github.com/camunda/connectors/blob/17bc53f190c65cbb943a920b40af13e0a13d9afa/connectors/agentic-ai/docs/reference/ai-agent.md#7-tool-resolution))
+  over it — the identical machinery already used for the calling agent's own tool elements. This
+  turns a `(processId, version)` reference into a `GatewayToolDefinition`, then N
+  `ToolDefinition`s once resolved, mirroring the MCP `tools/list` discovery flow (`INITIALIZING` →
+  `TOOL_DISCOVERY` → `READY`).
+- **Execution**: model the gateway element as a multi-instance activity looping over routed tool
+  calls, each instance starting the toolbox process (start event → tool AHSP → end event) and
+  folding the result back — the same namespacing `transformToolCalls`/`transformToolCallResults`
+  already do for MCP/A2A (LLM sees `LocalToolbox_<elementId>___<toolName>`; the process activates
+  the real toolbox element with `{toolCall: {...}}`).
+- **Modeling contract**: the referenced process must be start event → tool sub-process (AHSP) →
+  end event, and must **not** have the AI Agent Sub-process template applied — it's a plain tool
+  host, not an agent.
+- **`meta` argument**: a fixed, non-`fromAi()` input on the gateway element's element template,
+  mapped straight into the toolbox instance's start-event variables — deterministic config that
+  never passes through the LLM. This is the missing piece the Cluster-MCP option lacked.
+- **Versioning**: explicit process ID + optional version, resolved once at AHSP entry (consistent
+  with the existing "sub-process config frozen at entry" invariant,
+  [`ai-agent.md` §17](https://github.com/camunda/connectors/blob/17bc53f190c65cbb943a920b40af13e0a13d9afa/connectors/agentic-ai/docs/reference/ai-agent.md#17-migration)).
+  No in-process tool-refresh support in v1 — deliberately out of scope; customers pin versions
+  rather than binding to latest.
+- **Sequencing**: build first as a local/hacky experiment (custom connector + element template,
+  hybrid cluster setup) outside the shipped AI Agent connector; report back on developer
+  experience before deciding whether to fold any of it into the core gateway-tool framework for a
+  future release (informally floated as a candidate scope for 8.11 — not a commitment).
+- **Related work** — this is a lighter-weight, same-cluster complement, not a replacement:
+  - [camunda/product-hub#3353 — Exposing Camunda Processes as MCP Tools](https://github.com/camunda/product-hub/issues/3353) —
+    the heavier cross-cluster MCP-server direction (targets 8.10-alpha4); Local Toolbox trades
+    that scope for immediate, no-server, in-cluster reuse.
+  - [camunda/product-hub#2616 — Input/output specification (data contract) for reusable assets](https://github.com/camunda/product-hub/issues/2616) —
+    same underlying need for typed contracts on reusable BPMN assets; could eventually replace the
+    `fromAi()`-scraping approach used here.
+  - [camunda/product-hub#3065 — Process Instance Migration: Support Migration for Ad-Hoc Subprocess Instances](https://github.com/camunda/product-hub/issues/3065) and
+    [camunda/product-hub#3069 — [QA-Issue] Migrate ad-hoc subprocess instances](https://github.com/camunda/product-hub/issues/3069) —
+    relevant to how version pinning/migration of a toolbox's own process definition should behave
+    long-term.
+  - [camunda/product-hub#2743 — AI Agent Connector for Ad-Hoc Subprocess](https://github.com/camunda/product-hub/issues/2743) and
+    [camunda/product-hub#2779 — AI Agent connector - memory management and tools orchestration](https://github.com/camunda/product-hub/issues/2779) —
+    the existing gateway-tool foundation (MCP/A2A) this epic reuses.
+  - Reference implementation pointer for the concrete gateway-element wiring pattern to mirror:
+    [`ai-agent-chat-with-mcp.bpmn` (AHSP flavor)](https://github.com/camunda/connectors/blob/17bc53f190c65cbb943a920b40af13e0a13d9afa/connectors/agentic-ai/examples/ai-agent/ad-hoc-sub-process/ai-agent-chat-mcp/ai-agent-chat-with-mcp.bpmn) and
+    [`ai-agent-service-task-chat-with-mcp.bpmn` (Task flavor)](https://github.com/camunda/connectors/blob/17bc53f190c65cbb943a920b40af13e0a13d9afa/connectors/agentic-ai/examples/ai-agent/service-task/ai-agent-chat-mcp/ai-agent-service-task-chat-with-mcp.bpmn).


### PR DESCRIPTION
## Summary

Experimental, opt-in (`camunda.connector.agenticai.local-toolbox.enabled`, default `false`) "Local
Toolbox" gateway tool: lets an AI Agent Sub-process reference another deployed process by process
id (+ optional version) as a single gateway element. That referenced process is a plain ad-hoc
sub-process (start event → tool AHSP → end event, **no** AI Agent template applied); its tool
elements are auto-discovered and executed without standing up an MCP server, and a `meta` argument
passes deterministic (non-LLM) config straight through to the toolbox instance.

Tracked by [camunda/product-hub#3772](https://github.com/camunda/product-hub/issues/3772). This PR
builds and unit-tests the mechanism in isolation; actual BPMN wiring and end-to-end validation
happens separately in `camunda/eaat`, per the plan discussed there.

## What's in this PR

- **`LocalToolboxClientFunction`** — the gateway element placed in the calling agent's own AHSP.
  - Discovery (`tools/list`): resolves `(processId, version)` → `processDefinitionKey`
    (new `LocalToolboxProcessDefinitionResolver`, via
    `CamundaClient.newProcessDefinitionSearchRequest()`), then reuses the **existing**
    `ProcessDefinitionAdHocToolElementsResolver` + `AdHocToolsSchemaResolver` unmodified — the same
    machinery the Task-flavor connector already uses to resolve its own tools, just pointed at a
    different process.
  - Execution (`tools/call`): `CamundaClient.newCreateInstanceCommand()...withResult()` creates a
    toolbox instance and synchronously waits for its result — no polling needed.
- **`LocalToolboxGatewayToolHandler`** — the `GatewayToolHandler` SPI implementation, mirroring
  `McpClientGatewayToolHandler`'s namespacing (`LOCALTOOLBOX_<elementId>___<toolName>`),
  discovery-initiation, and tool-call/result transform pattern.
- **`LocalToolboxRouterFunction`** — the toolbox process's own ad-hoc sub-process driver (no LLM):
  a small two-phase state machine mirroring the core agent loop (`ai-agent.md` §8-9), simplified to
  a single tool call decided up front instead of chosen per turn. Implements
  `ConnectorResponse.AdHocSubProcessConnectorResponse` directly — a generic SDK interface
  previously only implemented by the AI Agent connector itself (`AiAgentSubProcessConnectorResponse`).
- New element template for the client (`agenticai-localtoolbox-client-outbound-connector.json`).
  The router has **no** generated template yet (mirrors `AiAgentJobWorker`, whose own ad-hoc
  sub-process template is produced by a transform rather than direct annotations) — wire
  `zeebe:taskDefinition type="io.camunda.agenticai:localtoolboxrouter:1"` onto the toolbox's AHSP
  manually for now.
- Unit tests for all of the above (55 new tests); full existing suite (1492 total) still passes.

## Explicitly out of scope for v1

- In-process tool refresh / hot reload of a toolbox's tool set (version pinning is the answer;
  matches the meeting's own conclusion that this can't be reliably standardized).
- Nested gateway tools inside a toolbox process (e.g. a toolbox that itself contains an MCP client).
- A generated element template for the router / a polished modeling experience for the toolbox
  side — deferred until the pattern is validated in `camunda/eaat`.

## Test plan

- [x] `mvn clean install -f connectors/agentic-ai/pom.xml` — 1492 tests pass (55 new).
- [x] `mvn clean compile`/`process-classes -f connectors/agentic-ai/pom.xml` — element template
      regenerates cleanly; JSON diff reviewed.
- [x] `mvn spotless:apply license:format -f connectors/agentic-ai/pom.xml` — clean.
- [ ] End-to-end BPMN wiring and validation — tracked separately in `camunda/eaat`.
