### PR TITLE
fix(deps): close renovate.json gap for google-auth-library-credentials

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -145,13 +145,14 @@
       "allowedVersions": "!/-(ce|ccs|cp\\d*)$/"
     },
     {
-      "description": "Disable minor/major updates for google-auth-library-oauth2-http — 1.50.0+ removes the setSecurityProvider method used by connector-google-gemini's vertexai client, breaking its tests. Requires code migration.",
+      "description": "Disable minor/major updates for google-auth-library-oauth2-http — 1.50.0+ removes the setSecurityProvider method used by connector-google-gemini's vertexai client, breaking its tests. Requires code migration. google-auth-library-credentials is included because parent/pom.xml pins both to the same version.google-auth-library-oauth2-http property, so leaving it unblocked would let Renovate bump the shared property through that dependency instead.",
       "matchUpdateTypes": [
         "major",
         "minor"
       ],
       "matchPackageNames": [
-        "com.google.auth:google-auth-library-oauth2-http"
+        "com.google.auth:google-auth-library-oauth2-http",
+        "com.google.auth:google-auth-library-credentials"
       ],
       "enabled": false
     },


### PR DESCRIPTION
## Summary
- Follow-up to #8182. Copilot correctly pointed out that the `google-auth-library-oauth2-http` block added there had a gap: `parent/pom.xml` pins `google-auth-library-credentials` to the exact same `version.google-auth-library-oauth2-http` property, so Renovate could still bump the shared property through the unblocked `credentials` artifact — reintroducing the `setSecurityProvider` breakage in `connector-google-gemini`.
- Adds `com.google.auth:google-auth-library-credentials` to the same `packageRules` block.

## Test plan
- [x] `renovate.json` validated as syntactically correct JSON
- N/A functional tests — config-only change