### PR TITLE
fix: add missing retryCount/retryBackoff/jobTimeout to hand-maintained templates

### DIFF
--- a/connectors/asana/element-templates/asana-connector.json
+++ b/connectors/asana/element-templates/asana-connector.json
@@ -54,6 +54,10 @@
     {
       "id": "errors",
       "label": "Error handling"
+    },
+    {
+      "id": "retries",
+      "label": "Retries"
     }
   ],
   "properties": [
@@ -702,6 +706,42 @@
         "type": "zeebe:taskHeader",
         "key": "errorExpression"
       }
+    },
+    {
+      "id": "retryCount",
+      "label": "Retries",
+      "value": "3",
+      "feel": "optional",
+      "group": "retries",
+      "binding": {
+        "property": "retries",
+        "type": "zeebe:taskDefinition"
+      },
+      "type": "String"
+    },
+    {
+      "id": "retryBackoff",
+      "label": "Retry backoff",
+      "tooltip": "ISO-8601 duration to wait between retries",
+      "value": "PT30S",
+      "group": "retries",
+      "binding": {
+        "key": "retryBackoff",
+        "type": "zeebe:taskHeader"
+      },
+      "type": "String"
+    },
+    {
+      "id": "jobTimeout",
+      "label": "Job timeout",
+      "description": "ISO-8601 duration after which Zeebe considers this job timed out if not yet completed. Leave empty to use the default timeout",
+      "optional": true,
+      "group": "retries",
+      "binding": {
+        "key": "jobTimeout",
+        "type": "zeebe:taskHeader"
+      },
+      "type": "String"
     }
   ],
   "steps": [

--- a/connectors/blue-prism/element-templates/blue-prism-connector.json
+++ b/connectors/blue-prism/element-templates/blue-prism-connector.json
@@ -55,6 +55,10 @@
     {
       "id": "errors",
       "label": "Error handling"
+    },
+    {
+      "id": "retries",
+      "label": "Retries"
     }
   ],
   "properties": [
@@ -559,6 +563,42 @@
           "createItemInQueue"
         ]
       }
+    },
+    {
+      "id": "retryCount",
+      "label": "Retries",
+      "value": "3",
+      "feel": "optional",
+      "group": "retries",
+      "binding": {
+        "property": "retries",
+        "type": "zeebe:taskDefinition"
+      },
+      "type": "String"
+    },
+    {
+      "id": "retryBackoff",
+      "label": "Retry backoff",
+      "tooltip": "ISO-8601 duration to wait between retries",
+      "value": "PT30S",
+      "group": "retries",
+      "binding": {
+        "key": "retryBackoff",
+        "type": "zeebe:taskHeader"
+      },
+      "type": "String"
+    },
+    {
+      "id": "jobTimeout",
+      "label": "Job timeout",
+      "description": "ISO-8601 duration after which Zeebe considers this job timed out if not yet completed. Leave empty to use the default timeout",
+      "optional": true,
+      "group": "retries",
+      "binding": {
+        "key": "jobTimeout",
+        "type": "zeebe:taskHeader"
+      },
+      "type": "String"
     }
   ],
   "steps": [

--- a/connectors/easy-post/element-templates/easy-post-connector.json
+++ b/connectors/easy-post/element-templates/easy-post-connector.json
@@ -1028,6 +1028,18 @@
       "type": "Hidden"
     },
     {
+      "id": "retryCount",
+      "label": "Retries",
+      "value": "3",
+      "feel": "optional",
+      "group": "retries",
+      "binding": {
+        "property": "retries",
+        "type": "zeebe:taskDefinition"
+      },
+      "type": "String"
+    },
+    {
       "id": "retryBackoff",
       "label": "Retry backoff",
       "description": "ISO-8601 duration to wait between retries",

--- a/connectors/github/element-templates/github-connector.json
+++ b/connectors/github/element-templates/github-connector.json
@@ -83,6 +83,10 @@
     {
       "id": "errors",
       "label": "Error handling"
+    },
+    {
+      "id": "retries",
+      "label": "Retries"
     }
   ],
   "properties": [
@@ -3977,6 +3981,42 @@
         "type": "zeebe:taskHeader"
       },
       "type": "Hidden"
+    },
+    {
+      "id": "retryCount",
+      "label": "Retries",
+      "value": "3",
+      "feel": "optional",
+      "group": "retries",
+      "binding": {
+        "property": "retries",
+        "type": "zeebe:taskDefinition"
+      },
+      "type": "String"
+    },
+    {
+      "id": "retryBackoff",
+      "label": "Retry backoff",
+      "tooltip": "ISO-8601 duration to wait between retries",
+      "value": "PT30S",
+      "group": "retries",
+      "binding": {
+        "key": "retryBackoff",
+        "type": "zeebe:taskHeader"
+      },
+      "type": "String"
+    },
+    {
+      "id": "jobTimeout",
+      "label": "Job timeout",
+      "description": "ISO-8601 duration after which Zeebe considers this job timed out if not yet completed. Leave empty to use the default timeout",
+      "optional": true,
+      "group": "retries",
+      "binding": {
+        "key": "jobTimeout",
+        "type": "zeebe:taskHeader"
+      },
+      "type": "String"
     }
   ],
   "steps": [

--- a/connectors/gitlab/element-templates/gitlab-connector.json
+++ b/connectors/gitlab/element-templates/gitlab-connector.json
@@ -57,6 +57,10 @@
     {
       "id": "errors",
       "label": "Error handling"
+    },
+    {
+      "id": "retries",
+      "label": "Retries"
     }
   ],
   "properties": [
@@ -1777,6 +1781,42 @@
         "type": "zeebe:taskHeader"
       },
       "type": "Hidden"
+    },
+    {
+      "id": "retryCount",
+      "label": "Retries",
+      "value": "3",
+      "feel": "optional",
+      "group": "retries",
+      "binding": {
+        "property": "retries",
+        "type": "zeebe:taskDefinition"
+      },
+      "type": "String"
+    },
+    {
+      "id": "retryBackoff",
+      "label": "Retry backoff",
+      "tooltip": "ISO-8601 duration to wait between retries",
+      "value": "PT30S",
+      "group": "retries",
+      "binding": {
+        "key": "retryBackoff",
+        "type": "zeebe:taskHeader"
+      },
+      "type": "String"
+    },
+    {
+      "id": "jobTimeout",
+      "label": "Job timeout",
+      "description": "ISO-8601 duration after which Zeebe considers this job timed out if not yet completed. Leave empty to use the default timeout",
+      "optional": true,
+      "group": "retries",
+      "binding": {
+        "key": "jobTimeout",
+        "type": "zeebe:taskHeader"
+      },
+      "type": "String"
     }
   ],
   "steps": [

--- a/connectors/google-maps-platform/element-templates/google-maps-platform-connector.json
+++ b/connectors/google-maps-platform/element-templates/google-maps-platform-connector.json
@@ -52,6 +52,10 @@
     {
       "id": "errors",
       "label": "Error handling"
+    },
+    {
+      "id": "retries",
+      "label": "Retries"
     }
   ],
   "properties": [
@@ -536,6 +540,42 @@
         "type": "zeebe:taskHeader"
       },
       "type": "Hidden"
+    },
+    {
+      "id": "retryCount",
+      "label": "Retries",
+      "value": "3",
+      "feel": "optional",
+      "group": "retries",
+      "binding": {
+        "property": "retries",
+        "type": "zeebe:taskDefinition"
+      },
+      "type": "String"
+    },
+    {
+      "id": "retryBackoff",
+      "label": "Retry backoff",
+      "tooltip": "ISO-8601 duration to wait between retries",
+      "value": "PT30S",
+      "group": "retries",
+      "binding": {
+        "key": "retryBackoff",
+        "type": "zeebe:taskHeader"
+      },
+      "type": "String"
+    },
+    {
+      "id": "jobTimeout",
+      "label": "Job timeout",
+      "description": "ISO-8601 duration after which Zeebe considers this job timed out if not yet completed. Leave empty to use the default timeout",
+      "optional": true,
+      "group": "retries",
+      "binding": {
+        "key": "jobTimeout",
+        "type": "zeebe:taskHeader"
+      },
+      "type": "String"
     }
   ],
   "steps": [

--- a/connectors/hugging-face/element-templates/hugging-face-connector.json
+++ b/connectors/hugging-face/element-templates/hugging-face-connector.json
@@ -50,6 +50,10 @@
     {
       "id": "errors",
       "label": "Error handling"
+    },
+    {
+      "id": "retries",
+      "label": "Retries"
     }
   ],
   "properties": [
@@ -214,6 +218,42 @@
         "type": "zeebe:taskHeader"
       },
       "type": "Hidden"
+    },
+    {
+      "id": "retryCount",
+      "label": "Retries",
+      "value": "3",
+      "feel": "optional",
+      "group": "retries",
+      "binding": {
+        "property": "retries",
+        "type": "zeebe:taskDefinition"
+      },
+      "type": "String"
+    },
+    {
+      "id": "retryBackoff",
+      "label": "Retry backoff",
+      "tooltip": "ISO-8601 duration to wait between retries",
+      "value": "PT30S",
+      "group": "retries",
+      "binding": {
+        "key": "retryBackoff",
+        "type": "zeebe:taskHeader"
+      },
+      "type": "String"
+    },
+    {
+      "id": "jobTimeout",
+      "label": "Job timeout",
+      "description": "ISO-8601 duration after which Zeebe considers this job timed out if not yet completed. Leave empty to use the default timeout",
+      "optional": true,
+      "group": "retries",
+      "binding": {
+        "key": "jobTimeout",
+        "type": "zeebe:taskHeader"
+      },
+      "type": "String"
     }
   ],
   "icon": {

--- a/connectors/openai/element-templates/openai-connector.json
+++ b/connectors/openai/element-templates/openai-connector.json
@@ -59,6 +59,10 @@
     {
       "id": "errors",
       "label": "Error handling"
+    },
+    {
+      "id": "retries",
+      "label": "Retries"
     }
   ],
   "properties": [
@@ -451,6 +455,42 @@
         "type": "zeebe:taskHeader"
       },
       "type": "Hidden"
+    },
+    {
+      "id": "retryCount",
+      "label": "Retries",
+      "value": "3",
+      "feel": "optional",
+      "group": "retries",
+      "binding": {
+        "property": "retries",
+        "type": "zeebe:taskDefinition"
+      },
+      "type": "String"
+    },
+    {
+      "id": "retryBackoff",
+      "label": "Retry backoff",
+      "tooltip": "ISO-8601 duration to wait between retries",
+      "value": "PT30S",
+      "group": "retries",
+      "binding": {
+        "key": "retryBackoff",
+        "type": "zeebe:taskHeader"
+      },
+      "type": "String"
+    },
+    {
+      "id": "jobTimeout",
+      "label": "Job timeout",
+      "description": "ISO-8601 duration after which Zeebe considers this job timed out if not yet completed. Leave empty to use the default timeout",
+      "optional": true,
+      "group": "retries",
+      "binding": {
+        "key": "jobTimeout",
+        "type": "zeebe:taskHeader"
+      },
+      "type": "String"
     }
   ],
   "steps": [

--- a/connectors/operate/element-templates/operate-connector.json
+++ b/connectors/operate/element-templates/operate-connector.json
@@ -63,6 +63,10 @@
     {
       "id": "errors",
       "label": "Error handling"
+    },
+    {
+      "id": "retries",
+      "label": "Retries"
     }
   ],
   "properties": [
@@ -568,6 +572,42 @@
         "type": "zeebe:taskHeader"
       },
       "type": "Hidden"
+    },
+    {
+      "id": "retryCount",
+      "label": "Retries",
+      "value": "3",
+      "feel": "optional",
+      "group": "retries",
+      "binding": {
+        "property": "retries",
+        "type": "zeebe:taskDefinition"
+      },
+      "type": "String"
+    },
+    {
+      "id": "retryBackoff",
+      "label": "Retry backoff",
+      "tooltip": "ISO-8601 duration to wait between retries",
+      "value": "PT30S",
+      "group": "retries",
+      "binding": {
+        "key": "retryBackoff",
+        "type": "zeebe:taskHeader"
+      },
+      "type": "String"
+    },
+    {
+      "id": "jobTimeout",
+      "label": "Job timeout",
+      "description": "ISO-8601 duration after which Zeebe considers this job timed out if not yet completed. Leave empty to use the default timeout",
+      "optional": true,
+      "group": "retries",
+      "binding": {
+        "key": "jobTimeout",
+        "type": "zeebe:taskHeader"
+      },
+      "type": "String"
     }
   ],
   "icon": {

--- a/connectors/orchestration/element-templates/orchestration-connector.json
+++ b/connectors/orchestration/element-templates/orchestration-connector.json
@@ -37,7 +37,8 @@
     {"id": "parameters", "label": "Parameters"},
     {"id": "connector", "label": "Connector"},
     {"id": "output", "label": "Response mapping"},
-    {"id": "errors", "label": "Error handling"}
+    {"id": "errors", "label": "Error handling"},
+    {"id": "retries", "label": "Retries"}
   ],
   "properties": [
     {"type":"Hidden","value":"io.camunda:http-json:1","binding":{"type":"zeebe:taskDefinition","property":"type"}},
@@ -75,7 +76,10 @@
     {"label":"Connection timeout","group":"errors","type":"String","value":"20","binding":{"type":"zeebe:input","name":"connectionTimeoutInSeconds"},"optional":true,"feel":"optional","constraints":{"notEmpty":false,"pattern":{"value":"^(=.*|[0-9]+|\\{\\{secrets\\..+\\}\\})$","message":"Must be a non-negative integer, a {{secrets.NAME}} reference, or a FEEL expression starting with ="}},"tooltip":"Seconds to wait when establishing the TCP connection. <code>0</code> disables the timeout (not recommended in production)."},
     {"label":"Error expression","group":"errors","type":"Text","feel":"required","binding":{"type":"zeebe:taskHeader","key":"errorExpression"},"tooltip":"FEEL expression that maps connector errors to a BPMN error. Example: <code>=if error.code = \"404\" then bpmnError(\"NOT_FOUND\", error.message) else null</code>. See <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#bpmn-errors\" target=\"_blank\">BPMN errors docs</a>."},
     {"id":"version","label":"Version","value":"2","group":"connector","binding":{"key":"elementTemplateVersion","type":"zeebe:taskHeader"},"type":"Hidden","tooltip":"Version of the element template"},
-    {"id":"id","label":"ID","value":"io.camunda.connectors.CamundaOrchestrationCluster.v1","group":"connector","binding":{"key":"elementTemplateId","type":"zeebe:taskHeader"},"type":"Hidden","tooltip":"ID of the element template"}
+    {"id":"id","label":"ID","value":"io.camunda.connectors.CamundaOrchestrationCluster.v1","group":"connector","binding":{"key":"elementTemplateId","type":"zeebe:taskHeader"},"type":"Hidden","tooltip":"ID of the element template"},
+    {"id":"retryCount","label":"Retries","value":"3","feel":"optional","group":"retries","binding":{"property":"retries","type":"zeebe:taskDefinition"},"type":"String"},
+    {"id":"retryBackoff","label":"Retry backoff","tooltip":"ISO-8601 duration to wait between retries","value":"PT30S","group":"retries","binding":{"key":"retryBackoff","type":"zeebe:taskHeader"},"type":"String"},
+    {"id":"jobTimeout","label":"Job timeout","description":"ISO-8601 duration after which Zeebe considers this job timed out if not yet completed. Leave empty to use the default timeout","optional":true,"group":"retries","binding":{"key":"jobTimeout","type":"zeebe:taskHeader"},"type":"String"}
   ],
   "steps" : [ {
     "name" : "Process instances",

--- a/connectors/power-automate/element-templates/power-automate-connector.json
+++ b/connectors/power-automate/element-templates/power-automate-connector.json
@@ -55,6 +55,10 @@
     {
       "id": "errors",
       "label": "Error handling"
+    },
+    {
+      "id": "retries",
+      "label": "Retries"
     }
   ],
   "properties": [
@@ -618,6 +622,42 @@
         "type": "zeebe:taskHeader",
         "key": "errorExpression"
       }
+    },
+    {
+      "id": "retryCount",
+      "label": "Retries",
+      "value": "3",
+      "feel": "optional",
+      "group": "retries",
+      "binding": {
+        "property": "retries",
+        "type": "zeebe:taskDefinition"
+      },
+      "type": "String"
+    },
+    {
+      "id": "retryBackoff",
+      "label": "Retry backoff",
+      "tooltip": "ISO-8601 duration to wait between retries",
+      "value": "PT30S",
+      "group": "retries",
+      "binding": {
+        "key": "retryBackoff",
+        "type": "zeebe:taskHeader"
+      },
+      "type": "String"
+    },
+    {
+      "id": "jobTimeout",
+      "label": "Job timeout",
+      "description": "ISO-8601 duration after which Zeebe considers this job timed out if not yet completed. Leave empty to use the default timeout",
+      "optional": true,
+      "group": "retries",
+      "binding": {
+        "key": "jobTimeout",
+        "type": "zeebe:taskHeader"
+      },
+      "type": "String"
     }
   ]
 }

--- a/connectors/rpa/element-templates/rpa-connector.json
+++ b/connectors/rpa/element-templates/rpa-connector.json
@@ -47,6 +47,10 @@
     {
       "id": "input",
       "label": "Input"
+    },
+    {
+      "id": "retries",
+      "label": "Retries"
     }
   ],
   "properties": [
@@ -331,6 +335,42 @@
         "name": "camundaRpaTaskInput"
       },
       "optional": true
+    },
+    {
+      "id": "retryCount",
+      "label": "Retries",
+      "value": "3",
+      "feel": "optional",
+      "group": "retries",
+      "binding": {
+        "property": "retries",
+        "type": "zeebe:taskDefinition"
+      },
+      "type": "String"
+    },
+    {
+      "id": "retryBackoff",
+      "label": "Retry backoff",
+      "tooltip": "ISO-8601 duration to wait between retries",
+      "value": "PT30S",
+      "group": "retries",
+      "binding": {
+        "key": "retryBackoff",
+        "type": "zeebe:taskHeader"
+      },
+      "type": "String"
+    },
+    {
+      "id": "jobTimeout",
+      "label": "Job timeout",
+      "description": "ISO-8601 duration after which Zeebe considers this job timed out if not yet completed. Leave empty to use the default timeout",
+      "optional": true,
+      "group": "retries",
+      "binding": {
+        "key": "jobTimeout",
+        "type": "zeebe:taskHeader"
+      },
+      "type": "String"
     }
   ],
   "icon": {

--- a/connectors/twilio/element-templates/twilio-connector.json
+++ b/connectors/twilio/element-templates/twilio-connector.json
@@ -59,6 +59,10 @@
     {
       "id": "errors",
       "label": "Error handling"
+    },
+    {
+      "id": "retries",
+      "label": "Retries"
     }
   ],
   "properties": [
@@ -776,6 +780,42 @@
         "type": "zeebe:taskHeader"
       },
       "type": "Hidden"
+    },
+    {
+      "id": "retryCount",
+      "label": "Retries",
+      "value": "3",
+      "feel": "optional",
+      "group": "retries",
+      "binding": {
+        "property": "retries",
+        "type": "zeebe:taskDefinition"
+      },
+      "type": "String"
+    },
+    {
+      "id": "retryBackoff",
+      "label": "Retry backoff",
+      "tooltip": "ISO-8601 duration to wait between retries",
+      "value": "PT30S",
+      "group": "retries",
+      "binding": {
+        "key": "retryBackoff",
+        "type": "zeebe:taskHeader"
+      },
+      "type": "String"
+    },
+    {
+      "id": "jobTimeout",
+      "label": "Job timeout",
+      "description": "ISO-8601 duration after which Zeebe considers this job timed out if not yet completed. Leave empty to use the default timeout",
+      "optional": true,
+      "group": "retries",
+      "binding": {
+        "key": "jobTimeout",
+        "type": "zeebe:taskHeader"
+      },
+      "type": "String"
     }
   ],
   "steps": [

--- a/connectors/uipath/element-templates/uipath-connector.json
+++ b/connectors/uipath/element-templates/uipath-connector.json
@@ -59,6 +59,10 @@
     {
       "id": "errors",
       "label": "Error handling"
+    },
+    {
+      "id": "retries",
+      "label": "Retries"
     }
   ],
   "properties": [
@@ -605,6 +609,42 @@
         "type": "zeebe:taskHeader"
       },
       "type": "Hidden"
+    },
+    {
+      "id": "retryCount",
+      "label": "Retries",
+      "value": "3",
+      "feel": "optional",
+      "group": "retries",
+      "binding": {
+        "property": "retries",
+        "type": "zeebe:taskDefinition"
+      },
+      "type": "String"
+    },
+    {
+      "id": "retryBackoff",
+      "label": "Retry backoff",
+      "tooltip": "ISO-8601 duration to wait between retries",
+      "value": "PT30S",
+      "group": "retries",
+      "binding": {
+        "key": "retryBackoff",
+        "type": "zeebe:taskHeader"
+      },
+      "type": "String"
+    },
+    {
+      "id": "jobTimeout",
+      "label": "Job timeout",
+      "description": "ISO-8601 duration after which Zeebe considers this job timed out if not yet completed. Leave empty to use the default timeout",
+      "optional": true,
+      "group": "retries",
+      "binding": {
+        "key": "jobTimeout",
+        "type": "zeebe:taskHeader"
+      },
+      "type": "String"
     }
   ],
   "steps": [

--- a/connectors/whatsapp/element-templates/whatsapp-connector.json
+++ b/connectors/whatsapp/element-templates/whatsapp-connector.json
@@ -54,6 +54,10 @@
     {
       "id": "errors",
       "label": "Error handling"
+    },
+    {
+      "id": "retries",
+      "label": "Retries"
     }
   ],
   "properties": [
@@ -327,6 +331,42 @@
         "type": "zeebe:taskHeader"
       },
       "type": "Hidden"
+    },
+    {
+      "id": "retryCount",
+      "label": "Retries",
+      "value": "3",
+      "feel": "optional",
+      "group": "retries",
+      "binding": {
+        "property": "retries",
+        "type": "zeebe:taskDefinition"
+      },
+      "type": "String"
+    },
+    {
+      "id": "retryBackoff",
+      "label": "Retry backoff",
+      "tooltip": "ISO-8601 duration to wait between retries",
+      "value": "PT30S",
+      "group": "retries",
+      "binding": {
+        "key": "retryBackoff",
+        "type": "zeebe:taskHeader"
+      },
+      "type": "String"
+    },
+    {
+      "id": "jobTimeout",
+      "label": "Job timeout",
+      "description": "ISO-8601 duration after which Zeebe considers this job timed out if not yet completed. Leave empty to use the default timeout",
+      "optional": true,
+      "group": "retries",
+      "binding": {
+        "key": "jobTimeout",
+        "type": "zeebe:taskHeader"
+      },
+      "type": "String"
     }
   ],
   "steps": [


### PR DESCRIPTION
## Summary

Follow-up to #8170 / #4365, addressing #8172.

15 outbound element templates that live outside the Maven reactor never pick up shared runtime properties (`retryCount`, `retryBackoff`, `jobTimeout`) because they don't go through `ClassBasedTemplateGenerator`. This adds the `retries` group with all three properties, hand-patched to match #8170's precedent (hubspot, servicenow, etc.) exactly:

- **New retries group added** (had none at all): `asana`, `blue-prism`, `github`, `gitlab`, `google-maps-platform`, `hugging-face`, `openai`, `operate`, `orchestration`, `power-automate`, `rpa`, `twilio`, `uipath`, `whatsapp`.
- **Pre-existing bug fixed**: `easy-post` already had a `retries` group (`retryBackoff` + `jobTimeout`) but was missing `retryCount` entirely — unrelated to jobTimeout, just an existing gap.

Scope notes (from triage on the linked issue):
- The issue's original 20-connector list included `salesforce`, which is actually in the Maven reactor (via #7957's generator pattern) — excluded here since it's a different (Java) fix path. It's independently missing all three retries properties for an unrelated reason (its generator explicitly drops all inherited property groups from `http-json` and never re-declares one) — worth a separate follow-up.
- `easy-post`'s `retryBackoff` field is typed `Hidden` (uneditable in Modeler) while `jobTimeout` next to it is `String` — left as-is, out of scope for this fix.
- Only the outbound `ServiceTask` template per connector was touched; inbound/webhook templates never carry a retries group (consistent with generated connectors), and nothing under `element-templates/versioned/` was touched.

## Test plan

- [x] All 15 modified templates validated against the real `zeebe-element-templates-json-schema` schema (fetched live) — all pass.
- [x] Verified no connector already binds `zeebe:taskDefinition` → `retries` (no duplicate-binding risk).
- [x] Confirmed property/group shape matches #8170's already-merged hand-patches character-for-character.
- [x] Re-ran a full-repo inventory: every non-versioned `ServiceTask` element template now has `retryCount`, `retryBackoff`, and `jobTimeout` (except `salesforce`, tracked separately).
- [ ] Manual Modeler check that the Retries group renders correctly for a couple of these (e.g. `github`, `rpa`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)