### PR TITLE
ci: skip AlwaysGreen Slack alerts for draft PRs

### DIFF
--- a/.github/actions/post-failure-feedback/action.yml
+++ b/.github/actions/post-failure-feedback/action.yml
@@ -38,6 +38,21 @@ inputs:
       (refs/heads/gh-readonly-queue/<base>/pr-<N>-<sha>). Empty to skip the PR comment.
     required: false
     default: ""
+  pr_is_draft:
+    description: >
+      Draft state of `pr` when the caller already knows it — on a pull_request
+      trigger pass ${{ github.event.pull_request.draft }}, on merge_group pass
+      "false" (a draft cannot enter a merge queue). Empty means resolve it via
+      the API, which needs github_token.
+    required: false
+    default: ""
+  skip_on_draft:
+    description: >
+      Skip the Slack message when `pr` is a draft PR. The job summary and the PR
+      comment are still posted, so the author keeps the verdict in place. Set to
+      "false" to alert on drafts too.
+    required: false
+    default: "true"
   cookbook_url:
     description: "Debugging cookbook link"
     required: false
@@ -70,6 +85,8 @@ runs:
         FB_EVIDENCE: ${{ inputs.evidence }}
         FB_REPO: ${{ inputs.repo || github.repository }}
         FB_PR: ${{ inputs.pr }}
+        FB_PR_IS_DRAFT: ${{ inputs.pr_is_draft }}
+        FB_SKIP_ON_DRAFT: ${{ inputs.skip_on_draft }}
         FB_COOKBOOK_URL: ${{ inputs.cookbook_url }}
         FB_SLACK_CHANNEL: ${{ inputs.slack_channel }}
         SLACK_BOT_TOKEN: ${{ inputs.slack_bot_token }}

--- a/.github/actions/post-failure-feedback/feedback.mjs
+++ b/.github/actions/post-failure-feedback/feedback.mjs
@@ -6,6 +6,8 @@
 //   FB_EVIDENCE        optional free-text evidence (e.g. failing step name)
 //   FB_REPO            owner/repo of the failing run (for links)
 //   FB_PR              PR number, or a merge_group head_ref to extract it from, or empty
+//   FB_PR_IS_DRAFT     "true"/"false" when the caller knows it; empty → resolve via API
+//   FB_SKIP_ON_DRAFT   "false" to Slack-alert on draft PRs too (default: skip)
 //   FB_COOKBOOK_URL    debugging cookbook link
 //   FB_SLACK_CHANNEL   Slack channel id/name (optional → skip Slack)
 //   GH_TOKEN           token with PR write on FB_REPO (optional → skip PR comment)
@@ -22,6 +24,18 @@ const MARKER = '<!-- alwaysgreen-feedback -->'; // upsert anchor
 const ASK = 'https://camunda.slack.com/archives/C0AQ378VBEV'; // #ask-alwaysgreen
 const RELIABILITY =
   'https://camunda.slack.com/archives/C0AK0AVKRL0'; // #alwaysgreen-reliability
+
+// Owner→medic Slack subteam map — keep in sync with the streak detectors.
+const MEDIC = {
+  '@camunda/test-automation-team': '<!subteam^S09UF0EV0HG|test-automation-medic>',
+  '@camunda/distribution': '<!subteam^S053K7C7QKU|distribution-medic>',
+  '@camunda/engineering-operations': '<!subteam^S07D6C6B18T|monorepo-ci-medic>',
+  '@camunda/core-features': '<!subteam^S08P2CU9V8W|core-features-medic>',
+};
+// No fallback: an unmapped/missing owner (e.g. the "unknown" default) must not
+// silently page monorepo-ci-medic. Returns '' (nothing to concatenate) when
+// there's no mapping, so callers don't need to worry about spacing either.
+const medicMention = (owner) => (MEDIC[owner] ? ` ${MEDIC[owner]}` : '');
 
 const CATALOG = {
   product: {
@@ -102,6 +116,8 @@ function model() {
     repo: env('FB_REPO'),
     cookbook: env('FB_COOKBOOK_URL'),
     pr,
+    prIsDraft: env('FB_PR_IS_DRAFT').toLowerCase(),
+    skipOnDraft: env('FB_SKIP_ON_DRAFT', 'true').toLowerCase() !== 'false',
   };
 }
 
@@ -141,7 +157,7 @@ function slackText(m) {
   ]
     .filter(Boolean)
     .join(' · ');
-  return `${m.emoji} *AlwaysGreen — ${m.title}*\n*Stage:* \`${m.stage}\` · *Category:* \`${m.category}\` · *Owner:* ${m.owner}${prLink}\n*Evidence:* ${ev}\n*Next steps:*\n${steps}\n${links}`;
+  return `${m.emoji} *AlwaysGreen — ${m.title}*\n*Stage:* \`${m.stage}\` · *Category:* \`${m.category}\` · *Owner:* ${m.owner}${medicMention(m.owner)}${prLink}\n*Evidence:* ${ev}\n*Next steps:*\n${steps}\n${links}`;
 }
 
 const gh = (args) => exec('gh', args, {maxBuffer: 64 * 1024 * 1024});
@@ -194,12 +210,50 @@ async function upsertPrComment(m, md) {
   }
 }
 
+// Draft state of m.pr: the caller-supplied value first (no API call), then the
+// API. Returns null when it can't be determined — that is treated as "not a
+// draft" so an unresolvable lookup never silences a real failure.
+async function resolveDraft(m) {
+  if (!m.pr) return false;
+  if (m.prIsDraft === 'true') return true;
+  if (m.prIsDraft === 'false') return false;
+  if (!m.repo || !env('GH_TOKEN')) return null;
+  try {
+    const {stdout} = await gh([
+      'api',
+      `repos/${m.repo}/pulls/${m.pr}`,
+      '--jq',
+      '.draft',
+    ]);
+    const draft = stdout.trim();
+    if (draft === 'true') return true;
+    if (draft === 'false') return false;
+    return null;
+  } catch (e) {
+    console.error(`[feedback] draft lookup failed: ${e.message || e}`);
+    return null;
+  }
+}
+
 async function postSlack(m) {
   const channel = env('FB_SLACK_CHANNEL');
   const token = env('SLACK_BOT_TOKEN');
   if (!channel || !token) {
     console.log('[feedback] Slack skipped (no channel/token)');
     return;
+  }
+  // Draft PRs are work in progress: their failures are expected often enough
+  // that alerting on them is noise for everyone but the author, who still gets
+  // the job summary and the PR comment.
+  if (m.skipOnDraft) {
+    const draft = await resolveDraft(m);
+    if (draft === true) {
+      console.log(`[feedback] Slack skipped (PR #${m.pr} is a draft)`);
+      return;
+    }
+    if (draft === null) {
+      console.log('[feedback] draft state unresolved — posting to Slack anyway');
+    }
   }
   try {
     const res = await fetch('https://slack.com/api/chat.postMessage', {

--- a/.github/actions/post-failure-feedback/feedback.mjs
+++ b/.github/actions/post-failure-feedback/feedback.mjs
@@ -211,8 +211,9 @@ async function upsertPrComment(m, md) {
 }
 
 // Draft state of m.pr: the caller-supplied value first (no API call), then the
-// API. Returns null when it can't be determined — that is treated as "not a
-// draft" so an unresolvable lookup never silences a real failure.
+// API. Returns false when there is no PR at all (e.g. a push run), and null when
+// a PR exists but the state can't be determined — null is treated as "not a
+// draft", so an unresolvable lookup never silences a real failure.
 async function resolveDraft(m) {
   if (!m.pr) return false;
   if (m.prIsDraft === 'true') return true;

--- a/.github/actions/post-failure-feedback/feedback.mjs
+++ b/.github/actions/post-failure-feedback/feedback.mjs
@@ -25,7 +25,9 @@ const ASK = 'https://camunda.slack.com/archives/C0AQ378VBEV'; // #ask-alwaysgree
 const RELIABILITY =
   'https://camunda.slack.com/archives/C0AK0AVKRL0'; // #alwaysgreen-reliability
 
-// Owner→medic Slack subteam map — keep in sync with the streak detectors.
+// Owner→medic Slack subteam map. Each AlwaysGreen repo's streak detector
+// carries these same subteam IDs in its own MEDIC_* env vars, so a changed
+// subteam has to be updated in both places.
 const MEDIC = {
   '@camunda/test-automation-team': '<!subteam^S09UF0EV0HG|test-automation-medic>',
   '@camunda/distribution': '<!subteam^S053K7C7QKU|distribution-medic>',

--- a/.github/workflows/MERGE_QUEUE_HELM_TEST.yaml
+++ b/.github/workflows/MERGE_QUEUE_HELM_TEST.yaml
@@ -211,6 +211,10 @@ jobs:
           status: failure
           evidence: "SM E2E / Helm Integration Tests failed."
           pr: ${{ github.event.merge_group.head_ref }}
+          # This job only runs on merge_group, and a draft PR cannot enter a
+          # merge queue — so state the draft answer instead of paying for an
+          # API lookup that would also need pull-requests: read.
+          pr_is_draft: "false"
           # Shared AlwaysGreen channel (#alwaysgreen-reliability) — consistent
           # across all AlwaysGreen repos. The connectors bot must be a member.
           slack_channel: "C0AK0AVKRL0"

--- a/.github/workflows/MERGE_QUEUE_HELM_TEST.yaml
+++ b/.github/workflows/MERGE_QUEUE_HELM_TEST.yaml
@@ -211,9 +211,9 @@ jobs:
           status: failure
           evidence: "SM E2E / Helm Integration Tests failed."
           pr: ${{ github.event.merge_group.head_ref }}
-          # This job only runs on merge_group, and a draft PR cannot enter a
-          # merge queue — so state the draft answer instead of paying for an
-          # API lookup that would also need pull-requests: read.
+          # merge_group is the only trigger here that supplies a PR, and a
+          # draft cannot enter a merge queue — so state the answer instead of
+          # paying for a lookup that would also need pull-requests: read.
           pr_is_draft: "false"
           # Shared AlwaysGreen channel (#alwaysgreen-reliability) — consistent
           # across all AlwaysGreen repos. The connectors bot must be a member.


### PR DESCRIPTION
Ports the AlwaysGreen draft-PR gate into this repo's copy of `post-failure-feedback`, from the canonical action in camunda/team-test-automation#158. Agreed in [this thread](https://camunda.slack.com/archives/C0AK0AVKRL0/p1785831294832409) with Web Modeler and QA: alerting `#alwaysgreen-reliability` on expected failures from unfinished work is noise, and we'll see more of it while large refactors are in progress.

`skip_on_draft` (default `true`) suppresses **the Slack message only** for draft PRs — the job summary and the upserted PR comment still render, so the author keeps the verdict where they're working.

## No behaviour change here today

This pipeline runs on `merge_group`, and a draft PR can't enter a merge queue. So this is convergence — one shared behaviour across the AlwaysGreen repos — not a fix for live noise here. The live path was in `camunda-hub` (camunda/camunda-hub#27154).

## The caller states the draft answer instead of looking it up

```yaml
pr_is_draft: "false"
```

Cheaper and, more importantly, permission-independent: the API fallback (`GET /repos/{owner}/{repo}/pulls/{n}`) needs `pull-requests: read`, which this job doesn't grant — reviewers caught exactly that on the hub PR, where the lookup 403'd and the gate silently fell through to fail-open. Stating `"false"` is correct by construction here and can't regress that way.

## Fails open

An unresolvable draft lookup is treated as *not* a draft, so a token or API problem can never silently mute alerting.

## Also synced: the owner→medic mention map

The canonical copy carries it and this one didn't, so the Slack message named an owner team but pinged nobody. Inert here as well — this repo's `owner_team` isn't in the map, so it stays named-but-not-paged (deliberate: an unmapped or `unknown` owner must not page a team by accident).

## Verification

- `feedback.mjs` exercised against a stubbed `gh`: draft-via-API, ready-via-API, caller-supplied draft/ready (confirms no API call is made), `skip_on_draft=false`, failed lookup, no-PR, and the `merge_group` `head_ref` form.
- Slack payload captured with a `fetch` stub using this repo's exact caller arguments — byte-identical to today's message, confirming the sync is inert.
- `actionlint` on the changed workflow reports nothing new.
- Applied with an idempotent sync script (re-running produces no diff), so the local comment-upsert implementation is preserved.
