### PR TITLE
fix: bump tomcat-embed-core to 11.0.24 (stable/8.9)

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -95,7 +95,7 @@ limitations under the License.</license.inlineheader>
     <version.hamcrest>3.0</version.hamcrest>
 
     <version.spring-boot>4.1.0</version.spring-boot>
-    <tomcat.version>11.0.23</tomcat.version>
+    <tomcat.version>11.0.24</tomcat.version>
     <version.netty>4.2.16.Final</version.netty>
     <version.spring-cloud-gcp-starter-logging>8.1.0</version.spring-cloud-gcp-starter-logging>
     <version.logback>1.6.1</version.logback>


### PR DESCRIPTION
## Summary

Bumps `org.apache.tomcat.embed:tomcat-embed-core` from `11.0.23` to `11.0.24` by overriding the `tomcat.version` property in `parent/pom.xml`.

Security fix. Details in the internal tracking issue: camunda/team-connectors#1252