### PR TITLE
fix(pom): add flatten-maven-plugin configuration for OSSRH deployment

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -1361,6 +1361,27 @@ See: https://nvd.nist.gov/vuln/detail/CVE-2026-59949
               </rules>
             </configuration>
           </plugin>
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>flatten-maven-plugin</artifactId>
+            <version>1.6.0</version>
+            <configuration>
+              <flattenMode>ossrh</flattenMode>
+              <updatePomFile>true</updatePomFile>
+            </configuration>
+            <executions>
+              <execution>
+                <id>flatten</id>
+                <phase>process-resources</phase>
+                <goals><goal>flatten</goal></goals>
+              </execution>
+              <execution>
+                <id>flatten-clean</id>
+                <phase>clean</phase>
+                <goals><goal>clean</goal></goals>
+              </execution>
+            </executions>
+          </plugin>
         </plugins>
       </build>
     </profile>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -1368,6 +1368,11 @@ See: https://nvd.nist.gov/vuln/detail/CVE-2026-59949
             <configuration>
               <flattenMode>ossrh</flattenMode>
               <updatePomFile>true</updatePomFile>
+              <pomElements>
+                <properties>keep</properties>
+                <dependencyManagement>keep</dependencyManagement>
+                <build>keep</build>
+              </pomElements>
             </configuration>
             <executions>
               <execution>


### PR DESCRIPTION
This pull request adds the `flatten-maven-plugin` to the `parent/pom.xml` build configuration. This plugin is configured to run during the resource processing and clean phases, which helps produce a simplified, flattened POM file suitable for deployment to public repositories.

Build process improvements:

* Added the `org.codehaus.mojo:flatten-maven-plugin` (version 1.6.0) to the `parent/pom.xml` to flatten the project’s POM file during the `process-resources` and `clean` phases, improving compatibility with OSSRH and deployment workflows.