### PR TITLE
chore(pom): update Camunda version to 8.10.0-alpha4

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -70,7 +70,7 @@ limitations under the License.</license.inlineheader>
     <nexus.release.repository>https://artifacts.camunda.com/artifactory/connectors/</nexus.release.repository>
 
     <!-- Camunda internal libraries -->
-    <version.camunda>8.10.0-SNAPSHOT</version.camunda>
+    <version.camunda>8.10.0-alpha4</version.camunda>
     <version.feel-engine>1.22.0</version.feel-engine>
     <version.camunda-xml-model>7.24.0</version.camunda-xml-model>
 


### PR DESCRIPTION
This pull request updates the Camunda dependency version in the project configuration to use a specific alpha release instead of a snapshot version.

Dependency version update:

* Changed the `version.camunda` property in `parent/pom.xml` from `8.10.0-SNAPSHOT` to `8.10.0-alpha4`, ensuring the project uses a stable alpha release rather than a moving snapshot.