### PR TITLE
fix: name the failing header/property in FEEL evaluation errors

### DIFF
--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/ConnectorResultHandler.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/ConnectorResultHandler.java
@@ -204,7 +204,7 @@ public class ConnectorResultHandler {
       return feelExpressionEvaluator.evaluateToJson(expression, variables);
     } catch (FeelEngineWrapperException e) {
       throw new ConnectorInputException(
-          "%s could not be evaluated: %s".formatted(expressionNameForError, e.getReason()), e);
+          "%s could not be evaluated: %s".formatted(expressionNameForError, e.getMessage()), e);
     }
   }
 

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/ConnectorResultHandler.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/ConnectorResultHandler.java
@@ -106,8 +106,11 @@ public class ConnectorResultHandler {
       FeelConnectorFunctionProvider.beginCreateDocumentEvaluationScope();
       try {
         var mappedResponseJson =
-            feelExpressionEvaluator.evaluateToJson(
-                resultExpression, responseContent, wrapResponse(responseContent));
+            evaluateToJsonOrThrow(
+                resultExpression,
+                "Result expression",
+                responseContent,
+                wrapResponse(responseContent));
         if (mappedResponseJson != null) {
           verifyNoForbiddenLiterals(mappedResponseJson);
           var resolvedResponseJson =
@@ -144,8 +147,12 @@ public class ConnectorResultHandler {
     FeelConnectorFunctionProvider.beginCreateDocumentEvaluationScope();
     try {
       var evaluatedJson =
-          feelExpressionEvaluator.evaluateToJson(
-              errorExpression, responseContent, wrapResponse(responseContent), jobContext);
+          evaluateToJsonOrThrow(
+              errorExpression,
+              "Error expression",
+              responseContent,
+              wrapResponse(responseContent),
+              jobContext);
       if (evaluatedJson != null) {
         verifyNoForbiddenLiterals(evaluatedJson);
       }
@@ -182,6 +189,22 @@ public class ConnectorResultHandler {
               });
     } finally {
       FeelConnectorFunctionProvider.endCreateDocumentEvaluationScope();
+    }
+  }
+
+  /**
+   * Evaluates a FEEL expression to JSON, re-throwing a {@link FeelEngineWrapperException} as a
+   * {@link ConnectorInputException} naming which expression ({@code expressionNameForError}) failed
+   * — otherwise the failure surfaces as an incident with no indication of which header or property
+   * caused it.
+   */
+  private String evaluateToJsonOrThrow(
+      final String expression, final String expressionNameForError, final Object... variables) {
+    try {
+      return feelExpressionEvaluator.evaluateToJson(expression, variables);
+    } catch (FeelEngineWrapperException e) {
+      throw new ConnectorInputException(
+          "%s could not be evaluated: %s".formatted(expressionNameForError, e.getReason()), e);
     }
   }
 

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/correlation/ActivationConditionEvaluator.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/correlation/ActivationConditionEvaluator.java
@@ -94,7 +94,7 @@ public class ActivationConditionEvaluator {
       return Boolean.TRUE.equals(shouldActivate);
     } catch (FeelEngineWrapperException e) {
       throw new ConnectorInputException(
-          "Activation condition could not be evaluated: %s".formatted(e.getReason()), e);
+          "Activation condition could not be evaluated: %s".formatted(e.getMessage()), e);
     }
   }
 

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/correlation/ActivationConditionEvaluator.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/correlation/ActivationConditionEvaluator.java
@@ -93,7 +93,8 @@ public class ActivationConditionEvaluator {
       LOG.debug("Activation condition evaluated to: {}", shouldActivate);
       return Boolean.TRUE.equals(shouldActivate);
     } catch (FeelEngineWrapperException e) {
-      throw new ConnectorInputException(e);
+      throw new ConnectorInputException(
+          "Activation condition could not be evaluated: %s".formatted(e.getReason()), e);
     }
   }
 

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/ConnectorResultHandlerTest.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/ConnectorResultHandlerTest.java
@@ -104,6 +104,35 @@ class ConnectorResultHandlerTest {
   }
 
   @Test
+  void resultExpressionParseFailureNamesTheExpression() {
+    // Regression test: an invalid FEEL expression previously surfaced as a bare
+    // "Failed to evaluate expression '...'" incident with no indication of which header/property
+    // was the culprit.
+    final var exception =
+        assertThrows(
+            ConnectorInputException.class,
+            () -> connectorResultHandler.createOutputVariables(Map.of(), null, "=", null));
+
+    assertThat(exception).hasMessageContaining("Result expression could not be evaluated");
+  }
+
+  @Test
+  void errorExpressionParseFailureNamesTheExpression() {
+    final Map<String, String> jobHeaders = Map.of(Keywords.ERROR_EXPRESSION_KEYWORD, "=");
+    final ErrorExpressionJobContext jobContext =
+        new ErrorExpressionJobContext(new ErrorExpressionJobContext.ErrorExpressionJob(3));
+
+    final var exception =
+        assertThrows(
+            ConnectorInputException.class,
+            () ->
+                connectorResultHandler.examineErrorExpression(
+                    Map.of(), jobHeaders, jobContext, null));
+
+    assertThat(exception).hasMessageContaining("Error expression could not be evaluated");
+  }
+
+  @Test
   void ensureCanNotProduceIntrinsicFunction() {
     final String resultExpression =
         """

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/inbound/correlation/ActivationConditionEvaluatorTest.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/inbound/correlation/ActivationConditionEvaluatorTest.java
@@ -17,9 +17,11 @@
 package io.camunda.connector.runtime.core.inbound.correlation;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import io.camunda.connector.api.error.ConnectorInputException;
 import io.camunda.connector.api.inbound.ActivationCheckResult;
 import io.camunda.connector.feel.LocalFeelExpressionEvaluator;
 import io.camunda.connector.runtime.core.inbound.InboundConnectorElement;
@@ -94,6 +96,22 @@ public class ActivationConditionEvaluatorTest {
         .thenReturn(new ProcessElementWithRuntimeData("process1", 0, 0, elementId, "default"));
     when(element.activationCondition()).thenReturn(activationCondition);
     return element;
+  }
+
+  @Test
+  @DisplayName("Invalid activation condition FEEL expression names the failing property")
+  void invalidActivationCondition_namesTheExpression() {
+    // Regression test: an invalid FEEL expression previously surfaced as a bare
+    // "Failed to evaluate expression '...'" incident with no indication of which property caused
+    // it.
+    var element = createStartEventElement("elem1", "=");
+
+    var exception =
+        assertThrows(
+            ConnectorInputException.class,
+            () -> evaluator.isActivationConditionMet(element, Map.of()));
+
+    assertThat(exception).hasMessageContaining("Activation condition could not be evaluated");
   }
 
   @Nested


### PR DESCRIPTION
## Summary
- `resultExpression`, `errorExpression`, and `activationCondition` FEEL evaluation failures previously surfaced as a bare `Failed to evaluate expression '...'` incident with no indication of which header/property caused it.
- Wraps the evaluation call sites in `ConnectorResultHandler` (`resultExpression`/`errorExpression`) and `ActivationConditionEvaluator` (`activationCondition`) to re-throw as a `ConnectorInputException` naming the failing expression, e.g. `Result expression could not be evaluated: ...`.
- Deliberately does not change the `FeelExpressionEvaluator` interface — it's used broadly beyond header evaluation, so the fix is scoped to the specific call sites that evaluate connector header/property FEEL expressions.

Closes #8224

## Test plan
- [x] Added regression tests for `resultExpression`/`errorExpression` parse failures in `ConnectorResultHandlerTest`
- [x] Added a regression test for `activationCondition` parse failure in `ActivationConditionEvaluatorTest`
- [x] `connector-runtime-core` module test suite passes (313/313)

🤖 Generated with [Claude Code](https://claude.com/claude-code)