### PR TITLE
fix(connectors): retry instead of incidenting when error-expression evaluation is interrupted during shutdown

### DIFF
--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/SpringConnectorJobHandler.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/SpringConnectorJobHandler.java
@@ -168,6 +168,18 @@ public class SpringConnectorJobHandler implements JobHandler {
           error -> handleBPMNError(client, job, error),
           () -> handleSuccessResult(client, job, finalResult));
     } catch (Exception ex) {
+      if (Thread.currentThread().isInterrupted()) {
+        LOGGER.error(
+            "Job {} for tenant {} was interrupted while evaluating its error expression, likely "
+                + "because the runtime is shutting down; abandoning the job so Zeebe's activation "
+                + "timeout reassigns it. WARNING: the connector call for this job already ran to "
+                + "completion before the interrupt was noticed, so reassignment will re-execute it "
+                + "- verify the connector's side effects are idempotent before relying on this",
+            job.getKey(),
+            job.getTenantId(),
+            ex);
+        return;
+      }
       failJob(
           client, job, this.outboundConnectorExceptionHandler.handleFinalResultException(ex, job));
     }

--- a/connector-runtime/feel-wrapper/src/main/java/io/camunda/connector/feel/FeelEngineWrapper.java
+++ b/connector-runtime/feel-wrapper/src/main/java/io/camunda/connector/feel/FeelEngineWrapper.java
@@ -144,7 +144,29 @@ public class FeelEngineWrapper {
     try {
       return (T) evaluateInternal(expression, variables);
     } catch (Exception e) {
-      throw new FeelEngineWrapperException(e.getMessage(), expression, variables, e);
+      throw wrapEvaluationException(e, expression, variables);
+    }
+  }
+
+  private FeelEngineWrapperException wrapEvaluationException(
+      final Exception e, final String expression, final Object[] variables) {
+    if (e instanceof InterruptedException) {
+      Thread.currentThread().interrupt();
+      return new FeelEngineWrapperException(
+          "the evaluating thread was interrupted, likely because the connector runtime is shutting down",
+          expression,
+          describeContext(variables),
+          e);
+    }
+    return new FeelEngineWrapperException(
+        e.getMessage(), expression, describeContext(variables), e);
+  }
+
+  private Object describeContext(final Object[] variables) {
+    try {
+      return mergeMapVariables(variables);
+    } catch (Exception ex) {
+      return variables;
     }
   }
 
@@ -247,7 +269,10 @@ public class FeelEngineWrapper {
       }
     } catch (Exception e) {
       throw new FeelEngineWrapperException(
-          "Failed to convert FEEL evaluation result to the target type", expression, variables, e);
+          "Failed to convert FEEL evaluation result to the target type",
+          expression,
+          describeContext(variables),
+          e);
     }
   }
 
@@ -267,7 +292,7 @@ public class FeelEngineWrapper {
         return resultToJson(result);
       } else return null;
     } catch (Exception e) {
-      throw new FeelEngineWrapperException(e.getMessage(), expression, variables, e);
+      throw wrapEvaluationException(e, expression, variables);
     }
   }
 


### PR DESCRIPTION
Closes #8239.

Incident: [#inc-support-34047-incident-created-while-evaluating-feel-expression](https://camunda.slack.com/archives/C0BMY3LPS10) ([SUPPORT-34047](https://jira.camunda.com/browse/SUPPORT-34047))

`stable/8.8` never received #7960 (merged to `main`, backported to `8.9` via #8006), so it still crashes with a message-less `InterruptedException` and an incident instead of a clean retry when a job's thread is interrupted mid-evaluation during graceful shutdown.