### PR TITLE
fix(connectors): retry instead of incidenting when error-expression evaluation is interrupted during shutdown

### DIFF
--- a/connector-runtime/connector-feel/src/main/java/io/camunda/connector/feel/FeelEngineWrapperUtil.java
+++ b/connector-runtime/connector-feel/src/main/java/io/camunda/connector/feel/FeelEngineWrapperUtil.java
@@ -84,9 +84,6 @@ public class FeelEngineWrapperUtil {
     try {
       return Optional.of(objectMapper.convertValue(o, MAP_TYPE_REFERENCE));
     } catch (RuntimeException ex) {
-      // A single variable failing to convert (e.g. its serialization is interrupted mid-flight
-      // during a runtime shutdown) must not take down the whole FEEL evaluation - drop it from
-      // the context instead.
       LOG.warn(ex.getMessage(), ex);
       return Optional.empty();
     }

--- a/connector-runtime/connector-feel/src/main/java/io/camunda/connector/feel/FeelEngineWrapperUtil.java
+++ b/connector-runtime/connector-feel/src/main/java/io/camunda/connector/feel/FeelEngineWrapperUtil.java
@@ -83,7 +83,10 @@ public class FeelEngineWrapperUtil {
       ObjectMapper objectMapper, Object o) {
     try {
       return Optional.of(objectMapper.convertValue(o, MAP_TYPE_REFERENCE));
-    } catch (IllegalArgumentException ex) {
+    } catch (RuntimeException ex) {
+      // A single variable failing to convert (e.g. its serialization is interrupted mid-flight
+      // during a runtime shutdown) must not take down the whole FEEL evaluation - drop it from
+      // the context instead.
       LOG.warn(ex.getMessage(), ex);
       return Optional.empty();
     }

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/OutboundConnectorExceptionHandler.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/OutboundConnectorExceptionHandler.java
@@ -186,9 +186,6 @@ public class OutboundConnectorExceptionHandler {
         job.getTenantId(),
         newException.getMessage(),
         ex);
-    // Retry with the job's normal remaining retries rather than forcing an immediate incident:
-    // a crash while evaluating the (optional) error/result expression can be transient (e.g. tied
-    // to a runtime shutdown mid-flight) and often succeeds on the next attempt.
     return new ConnectorResult.ErrorResult(
         Map.of("error", exceptionToMap(newException)), newException, job.getRetries() - 1);
   }

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/OutboundConnectorExceptionHandler.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/OutboundConnectorExceptionHandler.java
@@ -184,8 +184,12 @@ public class OutboundConnectorExceptionHandler {
         "Exception while processing job: {} for tenant: {}, message: {}",
         job.getKey(),
         job.getTenantId(),
-        ex.getMessage());
+        newException.getMessage(),
+        ex);
+    // Retry with the job's normal remaining retries rather than forcing an immediate incident:
+    // a crash while evaluating the (optional) error/result expression can be transient (e.g. tied
+    // to a runtime shutdown mid-flight) and often succeeds on the next attempt.
     return new ConnectorResult.ErrorResult(
-        Map.of("error", exceptionToMap(newException)), newException, 0);
+        Map.of("error", exceptionToMap(newException)), newException, job.getRetries() - 1);
   }
 }


### PR DESCRIPTION
Closes #8239.

Incident: [#inc-support-34047-incident-created-while-evaluating-feel-expression](https://camunda.slack.com/archives/C0BMY3LPS10) ([SUPPORT-34047](https://jira.camunda.com/browse/SUPPORT-34047))

Backport of #8235.

## Original fix
#8006 (backport of #7960) already handles the incident's specific trigger on this branch: a job's thread gets interrupted during graceful shutdown, feel-scala throws a bare, message-less `InterruptedException` while evaluating the error/result expression, bypassing FEEL's normal error handling. #8006 detects this and **abandons the job** instead of raising a misleading incident, letting Zeebe's activation timeout reassign it.

## What this PR extends
Two remaining gaps in the same code path, for exceptions other than the interrupted-thread case:
1. `FeelEngineWrapperUtil.tryConvertToMap` only caught `IllegalArgumentException`, so other message-less exceptions could crash the whole evaluation instead of just the bad variable. Broadened to `RuntimeException`.
2. `OutboundConnectorExceptionHandler.handleFinalResultException` logged `ex.getMessage()` instead of `ex` (no stack trace ever captured) and hardcoded `retries=0`. Now logs the real throwable and retries with `job.getRetries() - 1`.

## Reproduced against
Rebuilt `camunda/connectors-bundle` from this fix, ran it in a real docker-compose stack with a slow mock endpoint, and did a real `docker stop`/`start` cycle mid-flight. Confirmed: clear reason instead of `null`, retries, and the retried attempt succeeds after restart.

## Test plan
- [x] `connector-runtime/connector-feel` tests pass (32/32)
- [x] `connector-runtime/connector-runtime-spring` tests pass (253/253)
- [x] End-to-end repro against a real docker-compose stack (crash → retry → success)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
