### PR TITLE
breaking: default connector secret provider prefix to SECRET_

### DIFF
--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/secret/EnvironmentSecretProvider.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/secret/EnvironmentSecretProvider.java
@@ -39,8 +39,14 @@ public class EnvironmentSecretProvider implements SecretProvider {
   @PostConstruct
   public void init() {
     if (!StringUtils.hasText(prefix)) {
-      LOG.info(
-          "No prefix has been configured, all environment variables are available as connector secrets");
+      LOG.warn(
+          """
+                You are using connector environment secrets in unsafe mode. \
+                All environment variables are accessible as connector secrets. \
+                Please configure a meaningful secret prefix using \
+                `camunda.connector.secretprovider.environment.prefix` \
+                or `CAMUNDA_CONNECTOR_SECRETPROVIDER_ENVIRONMENT_PREFIX`.
+                """);
     } else {
       LOG.debug(
           "Prefix '{}' has been configured, only environment variables with this prefix are available as connector secrets",
@@ -50,31 +56,48 @@ public class EnvironmentSecretProvider implements SecretProvider {
 
   @Override
   public String getSecret(String name, SecretContext context) {
-    String secretName =
-        tenantAware ? composeSecretNameTenantAware(name, context) : composeSecretName(name);
+    String secretName = composeSecretNameWithPrefix(name, context, prefix);
     LOG.debug("Getting secret value for name '{}'", secretName);
-    return environment.getProperty(secretName);
+
+    String secretValue = environment.getProperty(secretName);
+    if (secretValue != null) {
+      return secretValue;
+    }
+
+    // If prefix is configured and value was not found, check whether the unprefixed key exists.
+    // If so, log a warning explaining that the secret was rejected because it is missing the
+    // configured prefix.
+    if (StringUtils.hasText(prefix)) {
+      String unprefixedName = composeSecretNameWithPrefix(name, context, "");
+      if (environment.containsProperty(unprefixedName)) {
+        LOG.warn(
+            "Rejected connector secret '{}': environment variable '{}' exists but does not match "
+                + "the configured prefix '{}'. Rename it to '{}' to make it available as a "
+                + "connector secret.",
+            name,
+            unprefixedName,
+            prefix,
+            secretName);
+      }
+    }
+
+    return null;
   }
 
   /**
-   * returns the secret name in format ${prefix}${name}
-   *
-   * @param name the secrets' name to find the value for
-   * @return the final secret name
-   */
-  private String composeSecretName(String name) {
-    return String.format("%s%s", StringUtils.hasText(prefix) ? prefix : "", name);
-  }
-
-  /**
-   * returns the secret name in format ${prefix}${tenantId}_${name}
+   * Composes the full secret name in format {@code ${prefix}${name}}, or {@code
+   * ${prefix}${tenantId}_${name}} when tenant-aware.
    *
    * @param name the secrets' name to find the value for
    * @param context the context of where the secret is originated
+   * @param effectivePrefix the prefix to prepend (may be empty for unprefixed lookup)
    * @return the final secret name
    */
-  private String composeSecretNameTenantAware(String name, SecretContext context) {
-    return String.format(
-        "%s%s_%s", StringUtils.hasText(prefix) ? prefix : "", context.tenantId(), name);
+  private String composeSecretNameWithPrefix(
+      String name, SecretContext context, String effectivePrefix) {
+    String resolvedPrefix = StringUtils.hasText(effectivePrefix) ? effectivePrefix : "";
+    return tenantAware
+        ? String.format("%s%s_%s", resolvedPrefix, context.tenantId(), name)
+        : String.format("%s%s", resolvedPrefix, name);
   }
 }

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/secret/EnvironmentSecretProviderTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/secret/EnvironmentSecretProviderTest.java
@@ -62,4 +62,14 @@ public class EnvironmentSecretProviderTest {
         secretProvider.getSecret("my-total-secret", new SecretContext("my-tenant"));
     assertThat(myTotalSecret).isEqualTo("beebop");
   }
+
+  @Test
+  void shouldRejectSecretWithoutConfiguredPrefix() {
+    MockEnvironment env = new MockEnvironment();
+    env.setProperty("my-total-secret", "beebop");
+    EnvironmentSecretProvider secretProvider =
+        new EnvironmentSecretProvider(env, "secrets.", false);
+    String myTotalSecret = secretProvider.getSecret("my-total-secret", null);
+    assertThat(myTotalSecret).isNull();
+  }
 }

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/main/java/io/camunda/connector/runtime/OutboundConnectorsAutoConfiguration.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/main/java/io/camunda/connector/runtime/OutboundConnectorsAutoConfiguration.java
@@ -64,7 +64,7 @@ public class OutboundConnectorsAutoConfiguration {
   @Value("${camunda.connector.secretprovider.discovery.enabled:true}")
   Boolean secretProviderLookupEnabled;
 
-  @Value("${camunda.connector.secretprovider.environment.prefix:}")
+  @Value("${camunda.connector.secretprovider.environment.prefix:SECRET_}")
   String environmentSecretProviderPrefix;
 
   @Value("${camunda.connector.secretprovider.environment.tenantaware:false}")

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/secret/DefaultSecretProviderPrefixTest.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/secret/DefaultSecretProviderPrefixTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.runtime.secret;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.connector.runtime.app.TestConnectorRuntimeApplication;
+import io.camunda.connector.runtime.core.secret.SecretProviderAggregator;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+/**
+ * Verifies that when no prefix is explicitly configured, the environment secret provider falls
+ * back to the {@code SECRET_} default rather than exposing all environment variables.
+ */
+@SpringBootTest(
+    classes = {TestConnectorRuntimeApplication.class},
+    properties = {
+      "camunda.connector.secretprovider.discovery.enabled=false",
+      "test.secret=unprefixed value",
+      "SECRET_test.secret=default prefixed value",
+      "secret-without-prefix=leaked value"
+    })
+public class DefaultSecretProviderPrefixTest {
+
+  @Autowired SecretProviderAggregator secretProviderAggregator;
+
+  @Test
+  void shouldDefaultToSecretPrefix() {
+    var actualSecretValue = secretProviderAggregator.getSecret("test.secret", null);
+    assertThat(actualSecretValue).isEqualTo("default prefixed value");
+  }
+
+  @Test
+  void shouldNotResolveUnprefixedSecretByDefault() {
+    var actualSecretValue = secretProviderAggregator.getSecret("secret-without-prefix", null);
+    assertThat(actualSecretValue).isNull();
+  }
+}

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/secret/DefaultSecretProviderPrefixTest.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/secret/DefaultSecretProviderPrefixTest.java
@@ -25,8 +25,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 /**
- * Verifies that when no prefix is explicitly configured, the environment secret provider falls
- * back to the {@code SECRET_} default rather than exposing all environment variables.
+ * Verifies that when no prefix is explicitly configured, the environment secret provider falls back
+ * to the {@code SECRET_} default rather than exposing all environment variables.
  */
 @SpringBootTest(
     classes = {TestConnectorRuntimeApplication.class},


### PR DESCRIPTION
## Summary

- The environment-based connector secret provider (`EnvironmentSecretProvider`) exposed every environment variable as a connector secret when no prefix was configured, which was the default. A BPMN process author with deploy access could exploit this to read environment variables belonging to other components sharing the same runtime environment (for example, credentials injected by a Helm chart).
- Changes the default for `camunda.connector.secretprovider.environment.prefix` / `CAMUNDA_CONNECTOR_SECRETPROVIDER_ENVIRONMENT_PREFIX` from empty to `SECRET_`. Unprefixed environment variables no longer resolve as connector secrets unless the prefix is explicitly set to an empty value.
- Adds a warning log when a secret is rejected because a matching unprefixed environment variable exists but doesn't carry the configured prefix, to make it easier to diagnose broken processes after upgrading.

This is a backport of the equivalent 8.9 fix (#6779) to stable/8.7, scoped to the config-default change plus the diagnostic warning.

**This is a breaking change**: any deployment relying on unprefixed environment variables as connector secrets will need to either rename them with the `SECRET_` prefix, configure a custom prefix, or explicitly set an empty prefix to restore the previous (unsafe) behavior.

## Test plan

- [x] `EnvironmentSecretProviderTest` (connector-runtime-spring): 5/5 passing, including new `shouldRejectSecretWithoutConfiguredPrefix`
- [x] `EnvironmentSecretProviderTest` (spring-boot-starter-camunda-connectors): 1/1 passing (explicit prefix override, unaffected by default change)
- [x] `DefaultSecretProviderPrefixTest` (new): 2/2 passing, verifying the `SECRET_` default is applied and unprefixed secrets are not resolved
- [x] `mvn spotless:check` / `mvn license:check` clean