### PR TITLE
[Backport stable/8.9] chore(aws-sns): close doc/test gaps on the accepted AWS SDK v1 exception

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -563,6 +563,18 @@ Key workflow files in `.github/workflows/`:
 - **Docker images**: Use `DockerImages.get()` utility for Testcontainers, add images to `docker-images.properties`
 - **Integration tests**: Mark with `@SlowTest` to exclude from regular unit test runs
 - **FEEL expressions**: Use `@FEEL` annotation for properties that need runtime evaluation
+- **AWS SDK v1 in aws-sns**: the inbound webhook keeps `aws-java-sdk-sns` (v1) for
+  `SnsMessageManager`, which verifies SNS webhook signatures — v2 has no equivalent
+  (see https://github.com/aws/aws-sdk-java-v2/issues/1302) — and for
+  `SnsSubscriptionConfirmation#confirmSubscription`, called on the object `SnsMessageManager`
+  already returns. This is the one accepted v1 exception in the AWS v1→v2 migration; any other
+  v1 usage is a regression, not precedent.
+- **Investigating `camunda-client-java` / `camunda-spring-boot-starter` behavior**: don't decompile
+  the jars (`javap`, unzip + bytecode reading, etc.). If the `camunda/camunda` monorepo is checked
+  out locally (often as a sibling of this repo, e.g. `../camunda`), read the actual source instead
+  — e.g. `clients/java/src/main/java/io/camunda/client/...` or
+  `clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/...`. Only fall back
+  to decompiling if that checkout isn't available.
 
 ## Reference Implementations
 

--- a/connectors/aws/aws-sns/pom.xml
+++ b/connectors/aws/aws-sns/pom.xml
@@ -60,12 +60,29 @@ except in compliance with the proprietary license.</license.inlineheader>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>sdk-core</artifactId>
     </dependency>
-    <!-- v1 SDK kept for SnsMessageManager used in inbound webhook (no v2 equivalent).
-         See: https://github.com/aws/aws-sdk-java-v2/issues/1302 -->
+    <!-- v1 SDK kept for the inbound webhook: SnsMessageManager verifies SNS webhook signatures,
+         no v2 equivalent (https://github.com/aws/aws-sdk-java-v2/issues/1302). Production code
+         also calls SnsSubscriptionConfirmation#confirmSubscription on the object SnsMessageManager
+         already returns; that's a coupling, not a separate blocker, but SnsMessageManager alone
+         still requires v1.
+         Excludes aws-java-sdk-sqs and jmespath-java: unused transitive deps, confirmed by a
+         bytecode scan of aws-java-sdk-sns (only com.amazonaws.services.sns.util.Topics references
+         SQS, and this connector never calls it; jmespath is referenced by nothing). Re-check by
+         bytecode scan, not just a green test suite, when version.aws-java-sdk is bumped. -->
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-java-sdk-sns</artifactId>
       <version>${version.aws-java-sdk}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.amazonaws</groupId>
+          <artifactId>aws-java-sdk-sqs</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.amazonaws</groupId>
+          <artifactId>jmespath-java</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
   </dependencies>
 

--- a/connectors/aws/aws-sns/src/test/java/io/camunda/connector/sns/inbound/SnsWebhookExecutableTest.java
+++ b/connectors/aws/aws-sns/src/test/java/io/camunda/connector/sns/inbound/SnsWebhookExecutableTest.java
@@ -6,6 +6,7 @@
  */
 package io.camunda.connector.sns.inbound;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -285,6 +286,44 @@ class SnsWebhookExecutableTest {
 
     // then
     Assertions.assertThat(result.connectorData()).containsEntry("snsEventType", "Notification");
+    // Ensures the happy path actually goes through signature verification, not a mocked no-op.
+    verify(messageManager).parseMessage(any());
+  }
+
+  /**
+   * Signature verification failures from parseMessage() must propagate, not resolve to a
+   * WebhookResult (#7974).
+   */
+  @Test
+  void triggerWebhook_SignatureVerificationFails_PropagatesException() throws Exception {
+    // Configure connector
+    Map<String, Object> actualBPMNProperties =
+        Map.of(
+            "inbound",
+            Map.of(
+                "context", "snstest",
+                "securitySubscriptionAllowedFor", "any"));
+
+    ctx = createConnectorContext(actualBPMNProperties);
+
+    // Configure payload
+    final var headers = new HashMap<>(snsRequestHeaders);
+    headers.put("x-amz-sns-message-type", "Notification");
+    final var payload = mock(WebhookProcessingPayload.class);
+    when(payload.method()).thenReturn("GET");
+    when(payload.headers()).thenReturn(headers);
+    when(payload.rawBody()).thenReturn(NOTIFICATION_REQUEST.getBytes(StandardCharsets.UTF_8));
+
+    // Real SnsMessageManager throws an unchecked exception (e.g. SdkClientException) when the
+    // cryptographic signature or signing-cert-URL check fails.
+    when(messageManager.parseMessage(any()))
+        .thenThrow(new RuntimeException("Signature in SNS message was invalid"));
+
+    // when & then
+    testObject.activate(ctx);
+    assertThatThrownBy(() -> testObject.triggerWebhook(payload))
+        .isInstanceOf(RuntimeException.class)
+        .hasMessageContaining("Signature in SNS message was invalid");
   }
 
   @Test

--- a/connectors/aws/aws-sns/src/test/java/io/camunda/connector/sns/inbound/SnsWebhookSignatureVerificationTest.java
+++ b/connectors/aws/aws-sns/src/test/java/io/camunda/connector/sns/inbound/SnsWebhookSignatureVerificationTest.java
@@ -1,0 +1,210 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.sns.inbound;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.amazonaws.services.sns.message.SnsMessage;
+import com.amazonaws.services.sns.message.SnsMessageManager;
+import com.amazonaws.services.sns.message.SnsNotification;
+import io.camunda.connector.sns.suppliers.SnsClientSupplier;
+import java.io.ByteArrayInputStream;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.PublicKey;
+import java.security.Signature;
+import java.util.Base64;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Exercises the real (unmocked) AWS SDK v1 {@link SnsMessageManager} that {@link
+ * SnsWebhookExecutable} relies on to verify inbound SNS webhook signatures. {@link
+ * SnsWebhookExecutableTest} mocks {@link SnsMessageManager}, so it never runs real
+ * signature/cert-URL verification; these tests do, covering: a spoofed {@code SigningCertURL}, a
+ * validly-signed message, a tampered message, and a missing signature.
+ *
+ * <p>The certificate-download step is skipped by seeding {@code SnsMessageManager}'s internal
+ * certificate cache via reflection with a self-generated RSA key, so the crypto check runs fully
+ * offline. The cache's own {@code add} call is also invoked via reflection rather than a direct
+ * import, to avoid a compile-time dependency on {@code aws-java-sdk-core} (where the cache type
+ * lives) that {@code dependency:analyze-only} would flag as declared-but-unused.
+ *
+ * <p>Not covered: certificate download/parsing, hostname verification, and expiry checks — those
+ * are bypassed by seeding the cache directly instead of exercising them.
+ */
+class SnsWebhookSignatureVerificationTest {
+
+  private static final String SIGNING_CERT_URL =
+      "https://sns.eu-central-1.amazonaws.com/SimpleNotificationService-56e67fcb41f6fec09b0196692625d385.pem";
+
+  @Test
+  void spoofedSigningCertUrl_isRejectedBeforeAnyNetworkCall() {
+    // Real, unmocked supplier and manager - exercises SigningCertUrlVerifier for real.
+    SnsMessageManager manager = new SnsClientSupplier().messageManager("eu-central-1");
+    String payloadWithSpoofedCertUrl =
+        """
+        {
+          "Type": "Notification",
+          "MessageId": "2e062e6b-a527-5e68-b69b-72a8e42add60",
+          "TopicArn": "arn:aws:sns:eu-central-1:111222333444:SNSWebhook",
+          "Message": "Hello, world",
+          "Timestamp": "2023-04-26T15:10:05.479Z",
+          "SignatureVersion": "1",
+          "Signature": "does-not-matter-cert-url-check-runs-first",
+          "SigningCertURL": "https://evil.example.com/fake-cert.pem"
+        }
+        """;
+
+    assertThatThrownBy(
+            () ->
+                manager.parseMessage(
+                    new ByteArrayInputStream(
+                        payloadWithSpoofedCertUrl.getBytes(StandardCharsets.UTF_8))))
+        .isInstanceOf(RuntimeException.class)
+        // Matches either SigningCertUrlVerifier rejection message (wrong host or non-HTTPS).
+        .hasMessageContaining("SigningCert");
+  }
+
+  @Test
+  void validSignature_isAccepted() throws Exception {
+    KeyPair keyPair = generateRsaKeyPair();
+    Map<String, String> fields = notificationFields("Hello, world");
+    String signature = sign(fields, keyPair);
+
+    SnsMessageManager manager = new SnsClientSupplier().messageManager("eu-central-1");
+    seedCertificateCache(manager, keyPair.getPublic());
+
+    SnsMessage message =
+        manager.parseMessage(
+            new ByteArrayInputStream(toJson(fields, signature).getBytes(StandardCharsets.UTF_8)));
+
+    assertThat(message).isInstanceOf(SnsNotification.class);
+    assertThat(((SnsNotification) message).getMessage()).isEqualTo("Hello, world");
+  }
+
+  @Test
+  void tamperedMessage_isRejected() throws Exception {
+    KeyPair keyPair = generateRsaKeyPair();
+    Map<String, String> originalFields = notificationFields("Hello, world");
+    String signatureOverOriginal = sign(originalFields, keyPair);
+
+    Map<String, String> tamperedFields = new LinkedHashMap<>(originalFields);
+    tamperedFields.put("Message", "Tampered message!");
+
+    SnsMessageManager manager = new SnsClientSupplier().messageManager("eu-central-1");
+    seedCertificateCache(manager, keyPair.getPublic());
+
+    assertThatThrownBy(
+            () ->
+                manager.parseMessage(
+                    new ByteArrayInputStream(
+                        toJson(tamperedFields, signatureOverOriginal)
+                            .getBytes(StandardCharsets.UTF_8))))
+        .hasMessageContaining("Signature in SNS message was invalid");
+  }
+
+  @Test
+  void missingSignature_isRejected() throws Exception {
+    KeyPair keyPair = generateRsaKeyPair();
+    Map<String, String> fields = notificationFields("Hello, world");
+
+    SnsMessageManager manager = new SnsClientSupplier().messageManager("eu-central-1");
+    seedCertificateCache(manager, keyPair.getPublic());
+
+    assertThatThrownBy(
+            () ->
+                manager.parseMessage(
+                    new ByteArrayInputStream(
+                        toJson(fields, null).getBytes(StandardCharsets.UTF_8))))
+        .hasMessageContaining("Message cannot have null values");
+  }
+
+  private static KeyPair generateRsaKeyPair() throws Exception {
+    KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance("RSA");
+    keyPairGenerator.initialize(2048);
+    return keyPairGenerator.generateKeyPair();
+  }
+
+  private static Map<String, String> notificationFields(String message) {
+    Map<String, String> fields = new LinkedHashMap<>();
+    fields.put("Type", "Notification");
+    fields.put("MessageId", "2e062e6b-a527-5e68-b69b-72a8e42add60");
+    fields.put("TopicArn", "arn:aws:sns:eu-central-1:111222333444:SNSWebhook");
+    fields.put("Subject", "test subject");
+    fields.put("Message", message);
+    fields.put("Timestamp", "2023-04-26T15:10:05.479Z");
+    // Not part of the signed field set (see canonicalStringToSign below) but required by
+    // SnsNotification's constructor, which builds a java.net.URL from it.
+    fields.put(
+        "UnsubscribeURL",
+        "https://sns.eu-central-1.amazonaws.com/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:eu-central-1:111222333444:SNSWebhook:abc");
+    return fields;
+  }
+
+  /**
+   * AWS's canonical "string to sign" for a Notification: present fields, sorted by key, as
+   * "Key\nValue\n".
+   */
+  private static String canonicalStringToSign(Map<String, String> fields) {
+    String[] keysInSortedOrder = {
+      "Message", "MessageId", "Subject", "Timestamp", "TopicArn", "Type"
+    };
+    StringBuilder builder = new StringBuilder();
+    for (String key : keysInSortedOrder) {
+      String value = fields.get(key);
+      if (value != null) {
+        builder.append(key).append('\n').append(value).append('\n');
+      }
+    }
+    return builder.toString();
+  }
+
+  private static String sign(Map<String, String> fields, KeyPair keyPair) throws Exception {
+    Signature signer = Signature.getInstance("SHA1withRSA");
+    signer.initSign(keyPair.getPrivate());
+    signer.update(canonicalStringToSign(fields).getBytes(StandardCharsets.UTF_8));
+    return Base64.getEncoder().encodeToString(signer.sign());
+  }
+
+  private static String toJson(Map<String, String> fields, String signature) {
+    StringBuilder json = new StringBuilder("{\n");
+    fields.forEach(
+        (key, value) ->
+            json.append("  \"")
+                .append(key)
+                .append("\": \"")
+                .append(value.replace("\n", "\\n"))
+                .append("\",\n"));
+    json.append("  \"SignatureVersion\": \"1\",\n");
+    if (signature != null) {
+      json.append("  \"Signature\": \"").append(signature).append("\",\n");
+    }
+    json.append("  \"SigningCertURL\": \"").append(SIGNING_CERT_URL).append("\"\n}");
+    return json.toString();
+  }
+
+  /** Seeds the certificate cache via reflection so verification runs offline; see class javadoc. */
+  private static void seedCertificateCache(SnsMessageManager manager, PublicKey publicKey)
+      throws Exception {
+    Field signatureVerifierField = SnsMessageManager.class.getDeclaredField("signatureVerifier");
+    signatureVerifierField.setAccessible(true);
+    Object signatureVerifier = signatureVerifierField.get(manager);
+
+    Field certificateCacheField = signatureVerifier.getClass().getDeclaredField("certificateCache");
+    certificateCacheField.setAccessible(true);
+    Object certificateCache = certificateCacheField.get(signatureVerifier);
+
+    Method addMethod = certificateCache.getClass().getMethod("add", String.class, Object.class);
+    addMethod.invoke(certificateCache, SIGNING_CERT_URL, publicKey);
+  }
+}


### PR DESCRIPTION
# Description
Backport of #8112 to `stable/8.9`.

Manual cherry-pick — the automated backport failed with a conflict in `.github/copilot-instructions.md` (AGENTS.md symlink target). Resolved by keeping both the new AWS SDK v1 exception bullet and the pre-existing `camunda-client-java` investigation bullet, in the same order as `main`. `connectors/aws/aws-sns` module tests pass on this branch.