### PR TITLE
[Backport stable/8.9] refactor(aws): consolidate AWS SDK v2 client construction onto AwsClientSupport

### DIFF
--- a/connectors/aws/aws-base/src/test/java/io/camunda/connector/aws/AwsClientSupportTest.java
+++ b/connectors/aws/aws-base/src/test/java/io/camunda/connector/aws/AwsClientSupportTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.aws;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import io.camunda.connector.aws.model.impl.AwsAuthentication.AwsStaticCredentialsAuthentication;
+import io.camunda.connector.aws.model.impl.AwsBaseConfiguration;
+import io.camunda.connector.aws.model.impl.AwsBaseRequest;
+import java.net.URI;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.awscore.client.builder.AwsClientBuilder;
+import software.amazon.awssdk.regions.Region;
+
+/**
+ * Exercises {@link AwsClientSupport#configureClient} against a mocked {@link AwsClientBuilder}
+ * seam, shared by every AWS SDK v2 connector migrated onto this helper (issue #7083).
+ *
+ * <p>This is deliberately a mock-based test, not a "build a real client and assert
+ * isNotNull()"-style test: a real client build succeeds whether or not the credentials provider was
+ * ever wired onto the builder (the SDK falls back to its own default resolution), so an isNotNull
+ * assertion cannot detect a regression that silently stops wiring credentials from the request.
+ * Verifying the exact calls made on the builder can.
+ */
+class AwsClientSupportTest {
+
+  private interface TestClient extends AutoCloseable {}
+
+  private interface TestBuilder extends AwsClientBuilder<TestBuilder, TestClient> {}
+
+  private static AwsBaseRequest requestWith(final String region, final String endpoint) {
+    var request = new AwsBaseRequest();
+    request.setAuthentication(new AwsStaticCredentialsAuthentication("key", "secret"));
+    request.setConfiguration(new AwsBaseConfiguration(region, endpoint));
+    return request;
+  }
+
+  @Test
+  void configureClientWiresCredentialsProviderDerivedFromRequest() {
+    TestBuilder builder = mock(TestBuilder.class);
+    ArgumentCaptor<AwsCredentialsProvider> captor =
+        ArgumentCaptor.forClass(AwsCredentialsProvider.class);
+
+    AwsClientSupport.configureClient(builder, requestWith("eu-central-1", null));
+
+    verify(builder).credentialsProvider(captor.capture());
+    var resolved = captor.getValue().resolveCredentials();
+    assertThat(resolved.accessKeyId()).isEqualTo("key");
+    assertThat(resolved.secretAccessKey()).isEqualTo("secret");
+  }
+
+  @Test
+  void configureClientAppliesRegionWhenPresent() {
+    TestBuilder builder = mock(TestBuilder.class);
+
+    AwsClientSupport.configureClient(builder, requestWith("eu-central-1", null));
+
+    verify(builder).region(Region.of("eu-central-1"));
+  }
+
+  @Test
+  void configureClientOmitsRegionWhenAbsent() {
+    TestBuilder builder = mock(TestBuilder.class);
+
+    AwsClientSupport.configureClient(builder, requestWith(null, null));
+
+    verify(builder, never()).region(any());
+  }
+
+  @Test
+  void configureClientAppliesEndpointOverrideWhenSet() {
+    TestBuilder builder = mock(TestBuilder.class);
+
+    AwsClientSupport.configureClient(builder, requestWith("eu-central-1", "http://localhost:4566"));
+
+    verify(builder).endpointOverride(URI.create("http://localhost:4566"));
+  }
+
+  @Test
+  void configureClientSkipsEndpointOverrideWhenNull() {
+    TestBuilder builder = mock(TestBuilder.class);
+
+    AwsClientSupport.configureClient(builder, requestWith("eu-central-1", null));
+
+    verify(builder, never()).endpointOverride(any());
+  }
+
+  /**
+   * Regression guard for the blank-endpoint bug documented across the migrated connectors: a blank
+   * (non-null) endpoint must not reach {@code endpointOverride(URI.create(""))}, which throws at
+   * construction time.
+   */
+  @Test
+  void configureClientSkipsEndpointOverrideWhenBlank() {
+    TestBuilder builder = mock(TestBuilder.class);
+
+    AwsClientSupport.configureClient(builder, requestWith("eu-central-1", "   "));
+
+    verify(builder, never()).endpointOverride(any());
+  }
+}

--- a/connectors/aws/aws-bedrock/pom.xml
+++ b/connectors/aws/aws-bedrock/pom.xml
@@ -56,16 +56,6 @@
     </dependency>
 
     <dependency>
-      <groupId>software.amazon.awssdk</groupId>
-      <artifactId>auth</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>software.amazon.awssdk</groupId>
-      <artifactId>regions</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>org.apache.tika</groupId>
       <artifactId>tika-core</artifactId>
       <version>3.3.2</version>

--- a/connectors/aws/aws-bedrock/src/main/java/io/camunda/connector/aws/bedrock/core/BedrockExecutor.java
+++ b/connectors/aws/aws-bedrock/src/main/java/io/camunda/connector/aws/bedrock/core/BedrockExecutor.java
@@ -6,11 +6,10 @@
  */
 package io.camunda.connector.aws.bedrock.core;
 
-import io.camunda.connector.aws.CredentialsProviderSupportV2;
+import io.camunda.connector.aws.AwsClientSupport;
 import io.camunda.connector.aws.ObjectMapperSupplier;
 import io.camunda.connector.aws.bedrock.model.BedrockRequest;
 import io.camunda.connector.aws.bedrock.model.RequestData;
-import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.bedrockruntime.BedrockRuntimeClient;
 
 public class BedrockExecutor {
@@ -23,12 +22,10 @@ public class BedrockExecutor {
     this.requestData = requestData;
   }
 
+  // Delegates to AwsClientSupport (issue #7083); endpoint override is now honored, not ignored.
   public static BedrockExecutor create(BedrockRequest bedrockRequest) {
     return new BedrockExecutor(
-        BedrockRuntimeClient.builder()
-            .credentialsProvider(CredentialsProviderSupportV2.credentialsProvider(bedrockRequest))
-            .region(Region.of(bedrockRequest.getConfiguration().region()))
-            .build(),
+        AwsClientSupport.createClient(BedrockRuntimeClient.builder(), bedrockRequest),
         bedrockRequest.getData());
   }
 

--- a/connectors/aws/aws-bedrock/src/test/java/io/camunda/connector/aws/bedrock/core/BedrockExecutorTest.java
+++ b/connectors/aws/aws-bedrock/src/test/java/io/camunda/connector/aws/bedrock/core/BedrockExecutorTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.aws.bedrock.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import io.camunda.connector.aws.bedrock.model.BedrockRequest;
+import io.camunda.connector.aws.model.impl.AwsAuthentication.AwsStaticCredentialsAuthentication;
+import io.camunda.connector.aws.model.impl.AwsBaseConfiguration;
+import org.junit.jupiter.api.Test;
+
+class BedrockExecutorTest {
+
+  private static BedrockRequest requestWith(final String endpoint) {
+    var request = new BedrockRequest();
+    request.setAuthentication(new AwsStaticCredentialsAuthentication("key", "secret"));
+    request.setConfiguration(new AwsBaseConfiguration("eu-central-1", endpoint));
+    return request;
+  }
+
+  @Test
+  void buildsExecutorWithRegionOnly() {
+    BedrockExecutor executor = BedrockExecutor.create(requestWith(null));
+    assertThat(executor).isNotNull();
+  }
+
+  @Test
+  void buildsExecutorWithEndpointOverrideWhenEndpointIsSet() {
+    BedrockExecutor executor = BedrockExecutor.create(requestWith("http://localhost:4566"));
+    assertThat(executor).isNotNull();
+  }
+
+  /**
+   * Regression guard for the blank-endpoint bug: a blank (non-null) endpoint must be treated as "no
+   * endpoint", not fed to {@code URI.create("")} / {@code endpointOverride}.
+   */
+  @Test
+  void buildsExecutorWithoutEndpointOverrideWhenEndpointIsBlank() {
+    assertThatCode(() -> BedrockExecutor.create(requestWith(""))).doesNotThrowAnyException();
+    assertThatCode(() -> BedrockExecutor.create(requestWith("   "))).doesNotThrowAnyException();
+  }
+}

--- a/connectors/aws/aws-eventbridge/pom.xml
+++ b/connectors/aws/aws-eventbridge/pom.xml
@@ -51,10 +51,6 @@
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
-      <artifactId>auth</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>software.amazon.awssdk</groupId>
       <artifactId>sdk-core</artifactId>
     </dependency>
     <dependency>
@@ -67,6 +63,16 @@
 
   <build>
     <plugins>
+      <!-- sdk-core kept declared (issue #7083 removed its last bytecode reference here): javac
+           still needs it for SdkRequest/SdkPojo/SdkClient supertypes used in this module. -->
+      <plugin>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <configuration>
+          <ignoredNonTestScopedDependencies combine.children="append">
+            <dependency>software.amazon.awssdk:sdk-core</dependency>
+          </ignoredNonTestScopedDependencies>
+        </configuration>
+      </plugin>
       <plugin>
         <groupId>io.camunda.connector</groupId>
         <artifactId>element-template-generator-maven-plugin</artifactId>

--- a/connectors/aws/aws-eventbridge/src/main/java/io/camunda/connector/aws/eventbridge/AwsEventBridgeClientSupplier.java
+++ b/connectors/aws/aws-eventbridge/src/main/java/io/camunda/connector/aws/eventbridge/AwsEventBridgeClientSupplier.java
@@ -6,29 +6,18 @@
  */
 package io.camunda.connector.aws.eventbridge;
 
-import java.net.URI;
-import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import io.camunda.connector.aws.AwsClientSupport;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.eventbridge.EventBridgeClient;
 
 public class AwsEventBridgeClientSupplier {
 
+  // Delegates to AwsClientSupport (issue #7083); region param kept only for signature symmetry
+  // with lambda/sns, which do have a real per-resource fallback to apply.
   public EventBridgeClient getAmazonEventBridgeClient(
-      final AwsCredentialsProvider credentialsProvider, final String region) {
-    return EventBridgeClient.builder()
-        .credentialsProvider(credentialsProvider)
+      final AwsEventBridgeRequest request, final String region) {
+    return AwsClientSupport.configureClient(EventBridgeClient.builder(), request)
         .region(Region.of(region))
-        .build();
-  }
-
-  public EventBridgeClient getAmazonEventBridgeClient(
-      final AwsCredentialsProvider credentialsProvider,
-      final String region,
-      final String endpoint) {
-    return EventBridgeClient.builder()
-        .credentialsProvider(credentialsProvider)
-        .region(Region.of(region))
-        .endpointOverride(URI.create(endpoint))
         .build();
   }
 }

--- a/connectors/aws/aws-eventbridge/src/main/java/io/camunda/connector/aws/eventbridge/EventBridgeFunction.java
+++ b/connectors/aws/aws-eventbridge/src/main/java/io/camunda/connector/aws/eventbridge/EventBridgeFunction.java
@@ -13,11 +13,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.connector.api.annotation.OutboundConnector;
 import io.camunda.connector.api.outbound.OutboundConnectorContext;
 import io.camunda.connector.api.outbound.OutboundConnectorFunction;
-import io.camunda.connector.aws.CredentialsProviderSupportV2;
 import io.camunda.connector.aws.ObjectMapperSupplier;
-import io.camunda.connector.aws.model.impl.AwsBaseConfiguration;
 import io.camunda.connector.generator.java.annotation.ElementTemplate;
-import java.util.Optional;
 import software.amazon.awssdk.services.eventbridge.EventBridgeClient;
 import software.amazon.awssdk.services.eventbridge.model.PutEventsRequest;
 import software.amazon.awssdk.services.eventbridge.model.PutEventsRequestEntry;
@@ -71,20 +68,9 @@ public class EventBridgeFunction implements OutboundConnectorFunction {
   }
 
   private EventBridgeClient createEventBridgeClient(final AwsEventBridgeRequest request) {
-    Optional<String> endpoint =
-        Optional.ofNullable(request.getConfiguration()).map(AwsBaseConfiguration::endpoint);
-    var credentialsProvider = CredentialsProviderSupportV2.credentialsProvider(request);
     var region =
         extractRegionOrDefault(request.getConfiguration(), request.getConfiguration().region());
-    return endpoint
-        .map(
-            ep ->
-                awsEventBridgeClientSupplier.getAmazonEventBridgeClient(
-                    credentialsProvider, region, ep))
-        .orElseGet(
-            () ->
-                awsEventBridgeClientSupplier.getAmazonEventBridgeClient(
-                    credentialsProvider, region));
+    return awsEventBridgeClientSupplier.getAmazonEventBridgeClient(request, region);
   }
 
   public PutEventsResponse putEvents(

--- a/connectors/aws/aws-eventbridge/src/test/java/io/camunda/connector/aws/eventbridge/AwsEventBridgeClientSupplierTest.java
+++ b/connectors/aws/aws-eventbridge/src/test/java/io/camunda/connector/aws/eventbridge/AwsEventBridgeClientSupplierTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.aws.eventbridge;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import io.camunda.connector.aws.model.impl.AwsAuthentication.AwsStaticCredentialsAuthentication;
+import io.camunda.connector.aws.model.impl.AwsBaseConfiguration;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.services.eventbridge.EventBridgeClient;
+
+class AwsEventBridgeClientSupplierTest {
+
+  private final AwsEventBridgeClientSupplier supplier = new AwsEventBridgeClientSupplier();
+
+  private static AwsEventBridgeRequest requestWith(final String endpoint) {
+    var request = new AwsEventBridgeRequest();
+    request.setAuthentication(new AwsStaticCredentialsAuthentication("key", "secret"));
+    request.setConfiguration(new AwsBaseConfiguration("eu-central-1", endpoint));
+    return request;
+  }
+
+  @Test
+  void buildsClientWithRegionOnly() {
+    try (EventBridgeClient client =
+        supplier.getAmazonEventBridgeClient(requestWith(null), "eu-central-1")) {
+      assertThat(client).isNotNull();
+    }
+  }
+
+  @Test
+  void buildsClientWithEndpointOverrideWhenEndpointIsSet() {
+    try (EventBridgeClient client =
+        supplier.getAmazonEventBridgeClient(requestWith("http://localhost:4566"), "eu-central-1")) {
+      assertThat(client).isNotNull();
+    }
+  }
+
+  /**
+   * Regression guard for the blank-endpoint bug: a blank (non-null) endpoint must be treated as "no
+   * endpoint", not fed to {@code URI.create("")} / {@code endpointOverride}.
+   */
+  @Test
+  void buildsClientWithoutEndpointOverrideWhenEndpointIsBlank() {
+    assertThatCode(
+            () -> {
+              try (EventBridgeClient client =
+                  supplier.getAmazonEventBridgeClient(requestWith(""), "eu-central-1")) {
+                assertThat(client).isNotNull();
+              }
+              try (EventBridgeClient client =
+                  supplier.getAmazonEventBridgeClient(requestWith("   "), "eu-central-1")) {
+                assertThat(client).isNotNull();
+              }
+            })
+        .doesNotThrowAnyException();
+  }
+}

--- a/connectors/aws/aws-eventbridge/src/test/java/io/camunda/connector/aws/eventbridge/EventBridgeFunctionTest.java
+++ b/connectors/aws/aws-eventbridge/src/test/java/io/camunda/connector/aws/eventbridge/EventBridgeFunctionTest.java
@@ -18,6 +18,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.connector.api.error.ConnectorInputException;
 import io.camunda.connector.api.outbound.OutboundConnectorContext;
 import io.camunda.connector.aws.ObjectMapperSupplier;
+import io.camunda.connector.aws.model.impl.AwsAuthentication;
 import io.camunda.connector.jackson.ConnectorsObjectMapperSupplier;
 import io.camunda.connector.runtime.test.outbound.OutboundConnectorContextBuilder;
 import io.camunda.connector.validation.impl.DefaultValidationProvider;
@@ -35,8 +36,6 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import software.amazon.awssdk.auth.credentials.AwsCredentials;
-import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.awscore.DefaultAwsResponseMetadata;
 import software.amazon.awssdk.http.SdkHttpResponse;
 import software.amazon.awssdk.services.eventbridge.EventBridgeClient;
@@ -77,7 +76,7 @@ class EventBridgeFunctionTest {
   private EventBridgeFunction function;
   @Mock private AwsEventBridgeClientSupplier clientSupplier;
   @Mock private EventBridgeClient client;
-  @Captor private ArgumentCaptor<AwsCredentialsProvider> credentialsProviderArgumentCaptor;
+  @Captor private ArgumentCaptor<AwsEventBridgeRequest> eventBridgeRequestArgumentCaptor;
   @Captor private ArgumentCaptor<PutEventsRequest> putEventsRequestArgumentCaptor;
   private ObjectMapper objectMapper;
 
@@ -97,7 +96,7 @@ class EventBridgeFunctionTest {
             .validation(new DefaultValidationProvider())
             .build();
     when(clientSupplier.getAmazonEventBridgeClient(
-            credentialsProviderArgumentCaptor.capture(), eq(REGION)))
+            eventBridgeRequestArgumentCaptor.capture(), eq(REGION)))
         .thenReturn(client);
     when(client.putEvents(putEventsRequestArgumentCaptor.capture()))
         .thenReturn(
@@ -118,9 +117,13 @@ class EventBridgeFunctionTest {
     assertThat(resultEntry.errorCode()).isNull();
     assertThat(resultEntry.errorMessage()).isNull();
 
-    AwsCredentials credentials = credentialsProviderArgumentCaptor.getValue().resolveCredentials();
-    assertThat(credentials.accessKeyId()).isEqualTo(ACCESS_KEY);
-    assertThat(credentials.secretAccessKey()).isEqualTo(SECRET_KEY);
+    var capturedAuthentication = eventBridgeRequestArgumentCaptor.getValue().getAuthentication();
+    assertThat(capturedAuthentication)
+        .isInstanceOf(AwsAuthentication.AwsStaticCredentialsAuthentication.class);
+    var staticAuthentication =
+        (AwsAuthentication.AwsStaticCredentialsAuthentication) capturedAuthentication;
+    assertThat(staticAuthentication.accessKey()).isEqualTo(ACCESS_KEY);
+    assertThat(staticAuthentication.secretKey()).isEqualTo(SECRET_KEY);
 
     var request = context.bindVariables(AwsEventBridgeRequest.class);
 

--- a/connectors/aws/aws-lambda/pom.xml
+++ b/connectors/aws/aws-lambda/pom.xml
@@ -48,10 +48,6 @@
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
-      <artifactId>auth</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>software.amazon.awssdk</groupId>
       <artifactId>sdk-core</artifactId>
     </dependency>
   </dependencies>

--- a/connectors/aws/aws-lambda/src/main/java/io/camunda/connector/awslambda/AwsLambdaSupplier.java
+++ b/connectors/aws/aws-lambda/src/main/java/io/camunda/connector/awslambda/AwsLambdaSupplier.java
@@ -6,29 +6,18 @@
  */
 package io.camunda.connector.awslambda;
 
-import java.net.URI;
-import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import io.camunda.connector.aws.AwsClientSupport;
+import io.camunda.connector.awslambda.model.AwsLambdaRequest;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.lambda.LambdaClient;
 
 public class AwsLambdaSupplier {
 
-  public LambdaClient awsLambdaService(
-      final AwsCredentialsProvider credentialsProvider, final String region) {
-    return LambdaClient.builder()
-        .credentialsProvider(credentialsProvider)
+  // Delegates to AwsClientSupport (issue #7083); region is passed explicitly since the caller
+  // resolves the deprecated per-function fallback itself.
+  public LambdaClient awsLambdaService(final AwsLambdaRequest request, final String region) {
+    return AwsClientSupport.configureClient(LambdaClient.builder(), request)
         .region(Region.of(region))
-        .build();
-  }
-
-  public LambdaClient awsLambdaService(
-      final AwsCredentialsProvider credentialsProvider,
-      final String region,
-      final String endpoint) {
-    return LambdaClient.builder()
-        .credentialsProvider(credentialsProvider)
-        .region(Region.of(region))
-        .endpointOverride(URI.create(endpoint))
         .build();
   }
 }

--- a/connectors/aws/aws-lambda/src/main/java/io/camunda/connector/awslambda/LambdaConnectorFunction.java
+++ b/connectors/aws/aws-lambda/src/main/java/io/camunda/connector/awslambda/LambdaConnectorFunction.java
@@ -12,13 +12,10 @@ import io.camunda.connector.api.annotation.OutboundConnector;
 import io.camunda.connector.api.outbound.OutboundConnectorContext;
 import io.camunda.connector.api.outbound.OutboundConnectorFunction;
 import io.camunda.connector.aws.AwsUtils;
-import io.camunda.connector.aws.CredentialsProviderSupportV2;
 import io.camunda.connector.aws.ObjectMapperSupplier;
-import io.camunda.connector.aws.model.impl.AwsBaseConfiguration;
 import io.camunda.connector.awslambda.model.AwsLambdaRequest;
 import io.camunda.connector.awslambda.model.AwsLambdaResult;
 import io.camunda.connector.generator.java.annotation.ElementTemplate;
-import java.util.Optional;
 import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.services.lambda.LambdaClient;
 import software.amazon.awssdk.services.lambda.model.InvokeRequest;
@@ -67,10 +64,8 @@ public class LambdaConnectorFunction implements OutboundConnectorFunction {
   }
 
   private InvokeResponse invokeLambdaFunction(AwsLambdaRequest request) {
-    var region =
-        AwsUtils.extractRegionOrDefault(
-            request.getConfiguration(), request.getAwsFunction().getRegion());
-    LambdaClient lambdaClient = createAwsLambdaClient(request, region);
+    var region = resolveRegion(request);
+    LambdaClient lambdaClient = awsLambdaSupplier.awsLambdaService(request, region);
     try {
       final InvokeRequest invokeRequest =
           InvokeRequest.builder()
@@ -89,13 +84,10 @@ public class LambdaConnectorFunction implements OutboundConnectorFunction {
     }
   }
 
-  private LambdaClient createAwsLambdaClient(AwsLambdaRequest request, String region) {
-    Optional<String> endpoint =
-        Optional.ofNullable(request.getConfiguration()).map(AwsBaseConfiguration::endpoint);
-
-    var credentialsProvider = CredentialsProviderSupportV2.credentialsProvider(request);
-    return endpoint
-        .map(ep -> awsLambdaSupplier.awsLambdaService(credentialsProvider, region, ep))
-        .orElseGet(() -> awsLambdaSupplier.awsLambdaService(credentialsProvider, region));
+  // Deprecation bridge: honors the legacy per-function region for existing process definitions.
+  @SuppressWarnings("deprecation")
+  static String resolveRegion(AwsLambdaRequest request) {
+    return AwsUtils.extractRegionOrDefault(
+        request.getConfiguration(), request.getAwsFunction().getRegion());
   }
 }

--- a/connectors/aws/aws-lambda/src/test/java/io/camunda/connector/awslambda/AwsLambdaSupplierTest.java
+++ b/connectors/aws/aws-lambda/src/test/java/io/camunda/connector/awslambda/AwsLambdaSupplierTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.awslambda;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import io.camunda.connector.aws.model.impl.AwsAuthentication.AwsStaticCredentialsAuthentication;
+import io.camunda.connector.aws.model.impl.AwsBaseConfiguration;
+import io.camunda.connector.awslambda.model.AwsLambdaRequest;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.services.lambda.LambdaClient;
+
+class AwsLambdaSupplierTest {
+
+  private final AwsLambdaSupplier supplier = new AwsLambdaSupplier();
+
+  private static AwsLambdaRequest requestWith(final String endpoint) {
+    var request = new AwsLambdaRequest();
+    request.setAuthentication(new AwsStaticCredentialsAuthentication("key", "secret"));
+    request.setConfiguration(new AwsBaseConfiguration("eu-central-1", endpoint));
+    return request;
+  }
+
+  @Test
+  void buildsClientWithRegionOnly() {
+    try (LambdaClient client = supplier.awsLambdaService(requestWith(null), "eu-central-1")) {
+      assertThat(client).isNotNull();
+    }
+  }
+
+  @Test
+  void buildsClientWithEndpointOverrideWhenEndpointIsSet() {
+    try (LambdaClient client =
+        supplier.awsLambdaService(requestWith("http://localhost:4566"), "eu-central-1")) {
+      assertThat(client).isNotNull();
+    }
+  }
+
+  /**
+   * Regression guard for the blank-endpoint bug: a blank (non-null) endpoint must be treated as "no
+   * endpoint", not fed to {@code URI.create("")} / {@code endpointOverride}.
+   */
+  @Test
+  void buildsClientWithoutEndpointOverrideWhenEndpointIsBlank() {
+    assertThatCode(
+            () -> {
+              try (LambdaClient client =
+                  supplier.awsLambdaService(requestWith(""), "eu-central-1")) {
+                assertThat(client).isNotNull();
+              }
+              try (LambdaClient client =
+                  supplier.awsLambdaService(requestWith("   "), "eu-central-1")) {
+                assertThat(client).isNotNull();
+              }
+            })
+        .doesNotThrowAnyException();
+  }
+}

--- a/connectors/aws/aws-lambda/src/test/java/io/camunda/connector/awslambda/LambdaConnectorFunctionTest.java
+++ b/connectors/aws/aws-lambda/src/test/java/io/camunda/connector/awslambda/LambdaConnectorFunctionTest.java
@@ -14,11 +14,13 @@ import static org.mockito.Mockito.when;
 
 import io.camunda.connector.api.error.ConnectorInputException;
 import io.camunda.connector.api.outbound.OutboundConnectorContext;
+import io.camunda.connector.awslambda.model.AwsLambdaRequest;
 import io.camunda.connector.awslambda.model.AwsLambdaResult;
 import io.camunda.connector.validation.impl.DefaultValidationProvider;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.ArgumentCaptor;
 import software.amazon.awssdk.services.lambda.LambdaClient;
 import software.amazon.awssdk.services.lambda.model.InvokeRequest;
 import software.amazon.awssdk.services.lambda.model.InvokeResponse;
@@ -48,7 +50,8 @@ class LambdaConnectorFunctionTest extends BaseTest {
   public void execute_shouldExecuteAndReturnStatusOkAndActualPayload(String input) {
     // Given valid data
     OutboundConnectorContext context = getContextBuilderWithSecrets().variables(input).build();
-    when(supplier.awsLambdaService(any(), any())).thenReturn(lambdaClient);
+    ArgumentCaptor<String> regionCaptor = ArgumentCaptor.forClass(String.class);
+    when(supplier.awsLambdaService(any(), regionCaptor.capture())).thenReturn(lambdaClient);
     when(lambdaClient.invoke(any(InvokeRequest.class))).thenReturn(invokeResponse);
     // When connector execute
     Object execute = function.execute(context);
@@ -57,6 +60,9 @@ class LambdaConnectorFunctionTest extends BaseTest {
     AwsLambdaResult result = (AwsLambdaResult) execute;
     assertThat(result.getStatusCode()).isEqualTo(200);
     assertThat(result.getPayload()).isEqualTo(ACTUAL_PAYLOAD);
+    // Then the captured region must match what LambdaConnectorFunction resolves, not just any()
+    var request = context.bindVariables(AwsLambdaRequest.class);
+    assertThat(regionCaptor.getValue()).isEqualTo(LambdaConnectorFunction.resolveRegion(request));
   }
 
   @ParameterizedTest(name = "execute connector with invalid data # {index}")

--- a/connectors/aws/aws-s3/pom.xml
+++ b/connectors/aws/aws-s3/pom.xml
@@ -46,15 +46,6 @@
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
-      <artifactId>regions</artifactId>
-      <version>${version.aws-sdk2}</version>
-    </dependency>
-    <dependency>
-      <groupId>software.amazon.awssdk</groupId>
-      <artifactId>auth</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>software.amazon.awssdk</groupId>
       <artifactId>sdk-core</artifactId>
     </dependency>
     <dependency>

--- a/connectors/aws/aws-s3/src/main/java/io/camunda/connector/aws/s3/core/S3Executor.java
+++ b/connectors/aws/aws-s3/src/main/java/io/camunda/connector/aws/s3/core/S3Executor.java
@@ -9,7 +9,7 @@ package io.camunda.connector.aws.s3.core;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.connector.api.document.Document;
 import io.camunda.connector.api.document.DocumentCreationRequest;
-import io.camunda.connector.aws.CredentialsProviderSupportV2;
+import io.camunda.connector.aws.AwsClientSupport;
 import io.camunda.connector.aws.s3.model.request.*;
 import io.camunda.connector.aws.s3.model.response.DeleteResponse;
 import io.camunda.connector.aws.s3.model.response.DownloadResponse;
@@ -24,7 +24,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.core.ResponseInputStream;
 import software.amazon.awssdk.core.sync.RequestBody;
-import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
@@ -42,14 +41,12 @@ public class S3Executor {
     this.createDocument = createDocument;
   }
 
+  // Delegates to AwsClientSupport (issue #7083); endpoint override is now honored, not ignored.
+  // No forcePathStyle option here, so a custom endpoint won't work against LocalStack/MinIO.
   public static S3Executor create(
       S3Request s3Request, Function<DocumentCreationRequest, Document> createDocument) {
     return new S3Executor(
-        S3Client.builder()
-            .credentialsProvider(CredentialsProviderSupportV2.credentialsProvider(s3Request))
-            .region(Region.of(s3Request.getConfiguration().region()))
-            .build(),
-        createDocument);
+        AwsClientSupport.createClient(S3Client.builder(), s3Request), createDocument);
   }
 
   public Object execute(S3Action s3Action) {

--- a/connectors/aws/aws-s3/src/test/java/io/camunda/connector/aws/s3/core/S3ExecutorCreateTest.java
+++ b/connectors/aws/aws-s3/src/test/java/io/camunda/connector/aws/s3/core/S3ExecutorCreateTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.aws.s3.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import io.camunda.connector.aws.model.impl.AwsAuthentication.AwsStaticCredentialsAuthentication;
+import io.camunda.connector.aws.model.impl.AwsBaseConfiguration;
+import io.camunda.connector.aws.s3.model.request.S3Request;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Exercises {@link S3Executor#create} (the real {@code AwsClientSupport}-backed client construction
+ * path), as opposed to {@code S3ExecutorTest}, which only ever constructs {@link S3Executor}
+ * directly with a pre-built (mocked) {@code S3Client}.
+ */
+class S3ExecutorCreateTest {
+
+  private static S3Request requestWith(final String endpoint) {
+    var request = new S3Request();
+    request.setAuthentication(new AwsStaticCredentialsAuthentication("key", "secret"));
+    request.setConfiguration(new AwsBaseConfiguration("eu-central-1", endpoint));
+    return request;
+  }
+
+  @Test
+  void buildsExecutorWithRegionOnly() {
+    S3Executor executor = S3Executor.create(requestWith(null), req -> null);
+    assertThat(executor).isNotNull();
+  }
+
+  @Test
+  void buildsExecutorWithEndpointOverrideWhenEndpointIsSet() {
+    S3Executor executor = S3Executor.create(requestWith("http://localhost:4566"), req -> null);
+    assertThat(executor).isNotNull();
+  }
+
+  /**
+   * Regression guard for the blank-endpoint bug: a blank (non-null) endpoint must be treated as "no
+   * endpoint", not fed to {@code URI.create("")} / {@code endpointOverride}.
+   */
+  @Test
+  void buildsExecutorWithoutEndpointOverrideWhenEndpointIsBlank() {
+    assertThatCode(() -> S3Executor.create(requestWith(""), req -> null))
+        .doesNotThrowAnyException();
+    assertThatCode(() -> S3Executor.create(requestWith("   "), req -> null))
+        .doesNotThrowAnyException();
+  }
+}

--- a/connectors/aws/aws-sagemaker/pom.xml
+++ b/connectors/aws/aws-sagemaker/pom.xml
@@ -48,10 +48,6 @@
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
-      <artifactId>regions</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>software.amazon.awssdk</groupId>
       <artifactId>sdk-core</artifactId>
     </dependency>
 

--- a/connectors/aws/aws-sagemaker/src/main/java/io/camunda/connector/sagemaker/SagemakerConnectorFunction.java
+++ b/connectors/aws/aws-sagemaker/src/main/java/io/camunda/connector/sagemaker/SagemakerConnectorFunction.java
@@ -9,7 +9,6 @@ package io.camunda.connector.sagemaker;
 import io.camunda.connector.api.annotation.OutboundConnector;
 import io.camunda.connector.api.outbound.OutboundConnectorContext;
 import io.camunda.connector.api.outbound.OutboundConnectorFunction;
-import io.camunda.connector.aws.CredentialsProviderSupportV2;
 import io.camunda.connector.generator.java.annotation.ElementTemplate;
 import io.camunda.connector.sagemaker.caller.SageMakerAsyncCaller;
 import io.camunda.connector.sagemaker.caller.SageMakerSyncCaller;
@@ -78,17 +77,11 @@ public class SagemakerConnectorFunction implements OutboundConnectorFunction {
   public Object execute(OutboundConnectorContext context) {
     final var request = context.bindVariables(SageMakerRequest.class);
     if (request.getInput().invocationType() == SageMakerInvocationType.ASYNC) {
-      try (var client =
-          sageMakeClientSupplier.getAsyncClient(
-              CredentialsProviderSupportV2.credentialsProvider(request),
-              request.getConfiguration().region())) {
+      try (var client = sageMakeClientSupplier.getAsyncClient(request)) {
         return asyncCallerFunction.apply(client, request);
       }
     } else {
-      try (var client =
-          sageMakeClientSupplier.getSyncClient(
-              CredentialsProviderSupportV2.credentialsProvider(request),
-              request.getConfiguration().region())) {
+      try (var client = sageMakeClientSupplier.getSyncClient(request)) {
         return syncCallerFunction.apply(client, request);
       }
     }

--- a/connectors/aws/aws-sagemaker/src/main/java/io/camunda/connector/sagemaker/suppliers/SageMakeClientSupplier.java
+++ b/connectors/aws/aws-sagemaker/src/main/java/io/camunda/connector/sagemaker/suppliers/SageMakeClientSupplier.java
@@ -6,26 +6,21 @@
  */
 package io.camunda.connector.sagemaker.suppliers;
 
-import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
-import software.amazon.awssdk.regions.Region;
+import io.camunda.connector.aws.AwsClientSupport;
+import io.camunda.connector.sagemaker.model.SageMakerRequest;
 import software.amazon.awssdk.services.sagemakerruntime.SageMakerRuntimeAsyncClient;
 import software.amazon.awssdk.services.sagemakerruntime.SageMakerRuntimeClient;
 
 public class SageMakeClientSupplier {
 
-  public SageMakerRuntimeClient getSyncClient(
-      final AwsCredentialsProvider credentialsProvider, final String region) {
-    return SageMakerRuntimeClient.builder()
-        .credentialsProvider(credentialsProvider)
-        .region(Region.of(region))
-        .build();
+  // Delegates to AwsClientSupport (issue #7083); endpoint override is now honored, and a missing
+  // region falls through to the SDK's default chain instead of throwing NullPointerException.
+  public SageMakerRuntimeClient getSyncClient(final SageMakerRequest request) {
+    return AwsClientSupport.createClient(SageMakerRuntimeClient.builder(), request);
   }
 
-  public SageMakerRuntimeAsyncClient getAsyncClient(
-      final AwsCredentialsProvider credentialsProvider, final String region) {
-    return SageMakerRuntimeAsyncClient.builder()
-        .credentialsProvider(credentialsProvider)
-        .region(Region.of(region))
-        .build();
+  // Async counterpart of getSyncClient; same behavior notes apply.
+  public SageMakerRuntimeAsyncClient getAsyncClient(final SageMakerRequest request) {
+    return AwsClientSupport.createClient(SageMakerRuntimeAsyncClient.builder(), request);
   }
 }

--- a/connectors/aws/aws-sagemaker/src/test/java/io/camunda/connector/sagemaker/SagemakerConnectorFunctionTest.java
+++ b/connectors/aws/aws-sagemaker/src/test/java/io/camunda/connector/sagemaker/SagemakerConnectorFunctionTest.java
@@ -9,16 +9,15 @@ package io.camunda.connector.sagemaker;
 import static org.mockito.ArgumentMatchers.any;
 
 import io.camunda.connector.runtime.test.outbound.OutboundConnectorContextBuilder;
+import io.camunda.connector.sagemaker.model.SageMakerRequest;
 import io.camunda.connector.sagemaker.suppliers.SageMakeClientSupplier;
 import io.camunda.connector.sagemaker.testutils.SageMakerTestUtils;
 import java.util.function.BiFunction;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
-import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.services.sagemakerruntime.SageMakerRuntimeAsyncClient;
 import software.amazon.awssdk.services.sagemakerruntime.SageMakerRuntimeClient;
 
@@ -37,9 +36,7 @@ class SagemakerConnectorFunctionTest {
     var syncRuntime = Mockito.mock(SageMakerRuntimeClient.class);
 
     var sageMakeClientSupplier = Mockito.mock(SageMakeClientSupplier.class);
-    Mockito.when(
-            sageMakeClientSupplier.getSyncClient(
-                any(AwsCredentialsProvider.class), ArgumentMatchers.anyString()))
+    Mockito.when(sageMakeClientSupplier.getSyncClient(any(SageMakerRequest.class)))
         .thenReturn(syncRuntime);
 
     var syncCallerFunction = Mockito.mock(BiFunction.class);
@@ -71,9 +68,7 @@ class SagemakerConnectorFunctionTest {
     var asyncRuntime = Mockito.mock(SageMakerRuntimeAsyncClient.class);
 
     var sageMakeClientSupplier = Mockito.mock(SageMakeClientSupplier.class);
-    Mockito.when(
-            sageMakeClientSupplier.getAsyncClient(
-                any(AwsCredentialsProvider.class), ArgumentMatchers.anyString()))
+    Mockito.when(sageMakeClientSupplier.getAsyncClient(any(SageMakerRequest.class)))
         .thenReturn(asyncRuntime);
 
     var syncCallerFunction = Mockito.mock(BiFunction.class);

--- a/connectors/aws/aws-sagemaker/src/test/java/io/camunda/connector/sagemaker/suppliers/SageMakeClientSupplierTest.java
+++ b/connectors/aws/aws-sagemaker/src/test/java/io/camunda/connector/sagemaker/suppliers/SageMakeClientSupplierTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ *       under one or more contributor license agreements. Licensed under a proprietary license.
+ *       See the License.txt file for more information. You may not use this file
+ *       except in compliance with the proprietary license.
+ */
+package io.camunda.connector.sagemaker.suppliers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import io.camunda.connector.aws.model.impl.AwsAuthentication.AwsStaticCredentialsAuthentication;
+import io.camunda.connector.aws.model.impl.AwsBaseConfiguration;
+import io.camunda.connector.sagemaker.model.SageMakerRequest;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.services.sagemakerruntime.SageMakerRuntimeAsyncClient;
+import software.amazon.awssdk.services.sagemakerruntime.SageMakerRuntimeClient;
+
+class SageMakeClientSupplierTest {
+
+  private final SageMakeClientSupplier supplier = new SageMakeClientSupplier();
+
+  private static SageMakerRequest requestWith(final String endpoint) {
+    var request = new SageMakerRequest();
+    request.setAuthentication(new AwsStaticCredentialsAuthentication("key", "secret"));
+    request.setConfiguration(new AwsBaseConfiguration("eu-central-1", endpoint));
+    return request;
+  }
+
+  @Test
+  void buildsSyncClientWithRegionOnly() {
+    try (SageMakerRuntimeClient client = supplier.getSyncClient(requestWith(null))) {
+      assertThat(client).isNotNull();
+    }
+  }
+
+  @Test
+  void buildsAsyncClientWithRegionOnly() {
+    try (SageMakerRuntimeAsyncClient client = supplier.getAsyncClient(requestWith(null))) {
+      assertThat(client).isNotNull();
+    }
+  }
+
+  @Test
+  void buildsSyncClientWithEndpointOverrideWhenEndpointIsSet() {
+    try (SageMakerRuntimeClient client =
+        supplier.getSyncClient(requestWith("http://localhost:4566"))) {
+      assertThat(client).isNotNull();
+    }
+  }
+
+  /**
+   * Regression guard for the blank-endpoint bug: a blank (non-null) endpoint must be treated as "no
+   * endpoint", not fed to {@code URI.create("")} / {@code endpointOverride}.
+   */
+  @Test
+  void buildsClientWithoutEndpointOverrideWhenEndpointIsBlank() {
+    assertThatCode(
+            () -> {
+              try (SageMakerRuntimeClient client = supplier.getSyncClient(requestWith(""))) {
+                assertThat(client).isNotNull();
+              }
+              try (SageMakerRuntimeClient client = supplier.getSyncClient(requestWith("   "))) {
+                assertThat(client).isNotNull();
+              }
+            })
+        .doesNotThrowAnyException();
+  }
+}

--- a/connectors/aws/aws-sns/pom.xml
+++ b/connectors/aws/aws-sns/pom.xml
@@ -54,10 +54,6 @@ except in compliance with the proprietary license.</license.inlineheader>
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
-      <artifactId>auth</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>software.amazon.awssdk</groupId>
       <artifactId>sdk-core</artifactId>
     </dependency>
     <!-- v1 SDK kept for SnsMessageManager used in inbound webhook (no v2 equivalent).
@@ -71,6 +67,16 @@ except in compliance with the proprietary license.</license.inlineheader>
 
   <build>
     <plugins>
+      <!-- sdk-core kept declared (issue #7083 removed its last bytecode reference here): javac
+           needs it for SdkRequest/SdkPojo/SdkClient supertypes, and tests assert its SdkException. -->
+      <plugin>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <configuration>
+          <ignoredNonTestScopedDependencies combine.children="append">
+            <dependency>software.amazon.awssdk:sdk-core</dependency>
+          </ignoredNonTestScopedDependencies>
+        </configuration>
+      </plugin>
       <plugin>
         <groupId>io.camunda.connector</groupId>
         <artifactId>element-template-generator-maven-plugin</artifactId>

--- a/connectors/aws/aws-sns/src/main/java/io/camunda/connector/sns/outbound/SnsConnectorFunction.java
+++ b/connectors/aws/aws-sns/src/main/java/io/camunda/connector/sns/outbound/SnsConnectorFunction.java
@@ -13,14 +13,11 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.connector.api.annotation.OutboundConnector;
 import io.camunda.connector.api.outbound.OutboundConnectorContext;
 import io.camunda.connector.api.outbound.OutboundConnectorFunction;
-import io.camunda.connector.aws.CredentialsProviderSupportV2;
 import io.camunda.connector.aws.ObjectMapperSupplier;
-import io.camunda.connector.aws.model.impl.AwsBaseConfiguration;
 import io.camunda.connector.generator.java.annotation.ElementTemplate;
 import io.camunda.connector.sns.outbound.model.SnsConnectorRequest;
 import io.camunda.connector.sns.outbound.model.SnsConnectorResult;
 import io.camunda.connector.sns.suppliers.SnsClientSupplier;
-import java.util.Optional;
 import software.amazon.awssdk.services.sns.SnsClient;
 import software.amazon.awssdk.services.sns.model.PublishRequest;
 import software.amazon.awssdk.services.sns.model.PublishResponse;
@@ -68,14 +65,8 @@ public class SnsConnectorFunction implements OutboundConnectorFunction {
   }
 
   private SnsClient createSnsClient(final SnsConnectorRequest request) {
-    Optional<String> endpoint =
-        Optional.ofNullable(request.getConfiguration()).map(AwsBaseConfiguration::endpoint);
-    var credentialsProvider = CredentialsProviderSupportV2.credentialsProvider(request);
     var region = extractRegionOrDefault(request.getConfiguration(), request.getTopic().getRegion());
-
-    return endpoint
-        .map(ep -> snsClientSupplier.getSnsClient(credentialsProvider, region, ep))
-        .orElseGet(() -> snsClientSupplier.getSnsClient(credentialsProvider, region));
+    return snsClientSupplier.getSnsClient(request, region);
   }
 
   private PublishResponse sendMsgToSns(final SnsClient snsClient, SnsConnectorRequest request) {

--- a/connectors/aws/aws-sns/src/main/java/io/camunda/connector/sns/suppliers/SnsClientSupplier.java
+++ b/connectors/aws/aws-sns/src/main/java/io/camunda/connector/sns/suppliers/SnsClientSupplier.java
@@ -7,29 +7,19 @@
 package io.camunda.connector.sns.suppliers;
 
 import com.amazonaws.services.sns.message.SnsMessageManager;
-import java.net.URI;
-import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import io.camunda.connector.aws.AwsClientSupport;
+import io.camunda.connector.sns.outbound.model.SnsConnectorRequest;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.sns.SnsClient;
 
 public class SnsClientSupplier {
 
-  public SnsClient getSnsClient(
-      final AwsCredentialsProvider credentialsProvider, final String region) {
-    return SnsClient.builder()
-        .credentialsProvider(credentialsProvider)
+  // Delegates to AwsClientSupport (issue #7083); region is passed explicitly since the caller
+  // resolves the deprecated per-topic fallback itself. A blank endpoint is now a no-op instead
+  // of failing at construction time.
+  public SnsClient getSnsClient(final SnsConnectorRequest request, final String region) {
+    return AwsClientSupport.configureClient(SnsClient.builder(), request)
         .region(Region.of(region))
-        .build();
-  }
-
-  public SnsClient getSnsClient(
-      final AwsCredentialsProvider credentialsProvider,
-      final String region,
-      final String endpoint) {
-    return SnsClient.builder()
-        .credentialsProvider(credentialsProvider)
-        .region(Region.of(region))
-        .endpointOverride(URI.create(endpoint))
         .build();
   }
 

--- a/connectors/aws/aws-sns/src/test/java/io/camunda/connector/sns/outbound/SnsConnectorFunctionParametrizedTest.java
+++ b/connectors/aws/aws-sns/src/test/java/io/camunda/connector/sns/outbound/SnsConnectorFunctionParametrizedTest.java
@@ -45,7 +45,6 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.services.sns.SnsClient;
 import software.amazon.awssdk.services.sns.model.PublishRequest;
 import software.amazon.awssdk.services.sns.model.PublishResponse;
@@ -93,7 +92,7 @@ class SnsConnectorFunctionParametrizedTest {
   void execute_ShouldSucceedSuccessCases(final SnsConnectorRequest expectedRequest)
       throws JsonProcessingException {
     // given
-    when(snsClientSupplier.getSnsClient(any(AwsCredentialsProvider.class), eq(ACTUAL_TOPIC_REGION)))
+    when(snsClientSupplier.getSnsClient(any(SnsConnectorRequest.class), eq(ACTUAL_TOPIC_REGION)))
         .thenReturn(snsClient);
     PublishResponse publishResponse = mock(PublishResponse.class);
     when(publishResponse.messageId()).thenReturn(MSG_ID);

--- a/connectors/aws/aws-sns/src/test/java/io/camunda/connector/sns/outbound/SnsConnectorFunctionTest.java
+++ b/connectors/aws/aws-sns/src/test/java/io/camunda/connector/sns/outbound/SnsConnectorFunctionTest.java
@@ -12,6 +12,7 @@ import static org.mockito.ArgumentMatchers.any;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import io.camunda.connector.api.outbound.OutboundConnectorContext;
 import io.camunda.connector.runtime.test.outbound.OutboundConnectorContextBuilder;
+import io.camunda.connector.sns.outbound.model.SnsConnectorRequest;
 import io.camunda.connector.sns.outbound.model.SnsConnectorResult;
 import io.camunda.connector.sns.suppliers.SnsClientSupplier;
 import org.assertj.core.api.Assertions;
@@ -24,7 +25,6 @@ import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
-import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.core.exception.SdkException;
 import software.amazon.awssdk.services.sns.SnsClient;
 import software.amazon.awssdk.services.sns.model.PublishRequest;
@@ -71,7 +71,7 @@ public class SnsConnectorFunctionTest extends BaseTest {
     SnsClientSupplier snsClientSupplier = Mockito.mock(SnsClientSupplier.class);
     Mockito.when(
             snsClientSupplier.getSnsClient(
-                any(AwsCredentialsProvider.class), ArgumentMatchers.anyString()))
+                any(SnsConnectorRequest.class), ArgumentMatchers.anyString()))
         .thenReturn(snsClient);
     connector = new SnsConnectorFunction(snsClientSupplier, objectMapper);
 
@@ -93,7 +93,7 @@ public class SnsConnectorFunctionTest extends BaseTest {
     SnsClientSupplier snsClientSupplier = Mockito.mock(SnsClientSupplier.class);
     Mockito.when(
             snsClientSupplier.getSnsClient(
-                any(AwsCredentialsProvider.class), ArgumentMatchers.anyString()))
+                any(SnsConnectorRequest.class), ArgumentMatchers.anyString()))
         .thenReturn(snsClient);
     connector = new SnsConnectorFunction(snsClientSupplier, objectMapper);
     context =
@@ -119,7 +119,7 @@ public class SnsConnectorFunctionTest extends BaseTest {
     SnsClientSupplier snsClientSupplier = Mockito.mock(SnsClientSupplier.class);
     Mockito.when(
             snsClientSupplier.getSnsClient(
-                any(AwsCredentialsProvider.class), ArgumentMatchers.anyString()))
+                any(SnsConnectorRequest.class), ArgumentMatchers.anyString()))
         .thenReturn(snsClient);
     connector = new SnsConnectorFunction(snsClientSupplier, objectMapper);
     context =

--- a/connectors/aws/aws-sns/src/test/java/io/camunda/connector/sns/suppliers/SnsClientSupplierTest.java
+++ b/connectors/aws/aws-sns/src/test/java/io/camunda/connector/sns/suppliers/SnsClientSupplierTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.sns.suppliers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import io.camunda.connector.aws.model.impl.AwsAuthentication.AwsStaticCredentialsAuthentication;
+import io.camunda.connector.aws.model.impl.AwsBaseConfiguration;
+import io.camunda.connector.sns.outbound.model.SnsConnectorRequest;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.services.sns.SnsClient;
+
+class SnsClientSupplierTest {
+
+  private final SnsClientSupplier supplier = new SnsClientSupplier();
+
+  private static SnsConnectorRequest requestWith(final String endpoint) {
+    var request = new SnsConnectorRequest();
+    request.setAuthentication(new AwsStaticCredentialsAuthentication("key", "secret"));
+    request.setConfiguration(new AwsBaseConfiguration("eu-central-1", endpoint));
+    return request;
+  }
+
+  @Test
+  void buildsClientWithRegionOnly() {
+    try (SnsClient client = supplier.getSnsClient(requestWith(null), "eu-central-1")) {
+      assertThat(client).isNotNull();
+    }
+  }
+
+  @Test
+  void buildsClientWithEndpointOverrideWhenEndpointIsSet() {
+    try (SnsClient client =
+        supplier.getSnsClient(requestWith("http://localhost:4566"), "eu-central-1")) {
+      assertThat(client).isNotNull();
+    }
+  }
+
+  /**
+   * Regression guard for the blank-endpoint bug: a blank (non-null) endpoint must be treated as "no
+   * endpoint", not fed to {@code URI.create("")} / {@code endpointOverride}.
+   */
+  @Test
+  void buildsClientWithoutEndpointOverrideWhenEndpointIsBlank() {
+    assertThatCode(
+            () -> {
+              try (SnsClient client = supplier.getSnsClient(requestWith(""), "eu-central-1")) {
+                assertThat(client).isNotNull();
+              }
+              try (SnsClient client = supplier.getSnsClient(requestWith("   "), "eu-central-1")) {
+                assertThat(client).isNotNull();
+              }
+            })
+        .doesNotThrowAnyException();
+  }
+}

--- a/connectors/aws/aws-sqs/pom.xml
+++ b/connectors/aws/aws-sqs/pom.xml
@@ -48,10 +48,6 @@
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
-      <artifactId>auth</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>software.amazon.awssdk</groupId>
       <artifactId>sdk-core</artifactId>
     </dependency>
     <dependency>

--- a/connectors/aws/aws-sqs/src/main/java/io/camunda/connector/common/suppliers/AmazonSQSClientSupplier.java
+++ b/connectors/aws/aws-sqs/src/main/java/io/camunda/connector/common/suppliers/AmazonSQSClientSupplier.java
@@ -6,11 +6,12 @@
  */
 package io.camunda.connector.common.suppliers;
 
-import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import io.camunda.connector.aws.model.impl.AwsBaseRequest;
 import software.amazon.awssdk.services.sqs.SqsClient;
 
+// Client-supplier seam for the AWS SDK v2 SqsClient (issue #7083), mirroring
+// DynamoDbClientSupplier. Takes the whole AwsBaseRequest (serves both outbound and inbound
+// request types) so the implementation can delegate to AwsClientSupport.
 public interface AmazonSQSClientSupplier {
-  SqsClient sqsClient(AwsCredentialsProvider credentialsProvider, String region);
-
-  SqsClient sqsClient(AwsCredentialsProvider credentialsProvider, String region, String endpoint);
+  SqsClient sqsClient(AwsBaseRequest request, String region);
 }

--- a/connectors/aws/aws-sqs/src/main/java/io/camunda/connector/common/suppliers/DefaultAmazonSQSClientSupplier.java
+++ b/connectors/aws/aws-sqs/src/main/java/io/camunda/connector/common/suppliers/DefaultAmazonSQSClientSupplier.java
@@ -6,29 +6,19 @@
  */
 package io.camunda.connector.common.suppliers;
 
-import java.net.URI;
-import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import io.camunda.connector.aws.AwsClientSupport;
+import io.camunda.connector.aws.model.impl.AwsBaseRequest;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.sqs.SqsClient;
 
 public class DefaultAmazonSQSClientSupplier implements AmazonSQSClientSupplier {
 
-  public SqsClient sqsClient(
-      final AwsCredentialsProvider credentialsProvider, final String region) {
-    return SqsClient.builder()
-        .credentialsProvider(credentialsProvider)
+  // Delegates to AwsClientSupport (issue #7083). A blank endpoint is now a no-op instead of
+  // failing, and the inbound path now honors a custom endpoint (previously unreachable).
+  @Override
+  public SqsClient sqsClient(final AwsBaseRequest request, final String region) {
+    return AwsClientSupport.configureClient(SqsClient.builder(), request)
         .region(Region.of(region))
-        .build();
-  }
-
-  public SqsClient sqsClient(
-      final AwsCredentialsProvider credentialsProvider,
-      final String region,
-      final String endpoint) {
-    return SqsClient.builder()
-        .credentialsProvider(credentialsProvider)
-        .region(Region.of(region))
-        .endpointOverride(URI.create(endpoint))
         .build();
   }
 }

--- a/connectors/aws/aws-sqs/src/main/java/io/camunda/connector/inbound/SqsExecutable.java
+++ b/connectors/aws/aws-sqs/src/main/java/io/camunda/connector/inbound/SqsExecutable.java
@@ -12,7 +12,6 @@ import io.camunda.connector.api.inbound.InboundConnectorContext;
 import io.camunda.connector.api.inbound.InboundConnectorExecutable;
 import io.camunda.connector.api.inbound.Severity;
 import io.camunda.connector.aws.AwsUtils;
-import io.camunda.connector.aws.CredentialsProviderSupportV2;
 import io.camunda.connector.common.suppliers.AmazonSQSClientSupplier;
 import io.camunda.connector.common.suppliers.DefaultAmazonSQSClientSupplier;
 import io.camunda.connector.generator.java.annotation.BpmnType;
@@ -116,9 +115,7 @@ public class SqsExecutable implements InboundConnectorExecutable<InboundConnecto
     var region =
         AwsUtils.extractRegionOrDefault(
             properties.getConfiguration(), properties.getQueue().region());
-    sqsClient =
-        sqsClientSupplier.sqsClient(
-            CredentialsProviderSupportV2.credentialsProvider(properties), region);
+    sqsClient = sqsClientSupplier.sqsClient(properties, region);
 
     try {
       sqsClient.getQueueAttributes(

--- a/connectors/aws/aws-sqs/src/main/java/io/camunda/connector/outbound/SqsConnectorFunction.java
+++ b/connectors/aws/aws-sqs/src/main/java/io/camunda/connector/outbound/SqsConnectorFunction.java
@@ -12,16 +12,13 @@ import io.camunda.connector.api.annotation.OutboundConnector;
 import io.camunda.connector.api.outbound.OutboundConnectorContext;
 import io.camunda.connector.api.outbound.OutboundConnectorFunction;
 import io.camunda.connector.aws.AwsUtils;
-import io.camunda.connector.aws.CredentialsProviderSupportV2;
 import io.camunda.connector.aws.ObjectMapperSupplier;
-import io.camunda.connector.aws.model.impl.AwsBaseConfiguration;
 import io.camunda.connector.common.suppliers.AmazonSQSClientSupplier;
 import io.camunda.connector.common.suppliers.DefaultAmazonSQSClientSupplier;
 import io.camunda.connector.generator.java.annotation.ElementTemplate;
 import io.camunda.connector.outbound.model.QueueRequestData;
 import io.camunda.connector.outbound.model.SqsConnectorRequest;
 import io.camunda.connector.outbound.model.SqsConnectorResult;
-import java.util.Optional;
 import software.amazon.awssdk.services.sqs.SqsClient;
 import software.amazon.awssdk.services.sqs.model.SendMessageRequest;
 import software.amazon.awssdk.services.sqs.model.SendMessageResponse;
@@ -78,12 +75,7 @@ public class SqsConnectorFunction implements OutboundConnectorFunction {
   private SqsClient createAwsSqsClient(SqsConnectorRequest request) {
     var region =
         AwsUtils.extractRegionOrDefault(request.getConfiguration(), request.getQueue().getRegion());
-    Optional<String> endpoint =
-        Optional.ofNullable(request.getConfiguration()).map(AwsBaseConfiguration::endpoint);
-    var credentialsProvider = CredentialsProviderSupportV2.credentialsProvider(request);
-    return endpoint
-        .map(ep -> sqsClientSupplier.sqsClient(credentialsProvider, region, ep))
-        .orElseGet(() -> sqsClientSupplier.sqsClient(credentialsProvider, region));
+    return sqsClientSupplier.sqsClient(request, region);
   }
 
   private SendMessageResponse sendMsgToSqs(

--- a/connectors/aws/aws-sqs/src/test/java/io/camunda/connector/common/suppliers/DefaultAmazonSQSClientSupplierTest.java
+++ b/connectors/aws/aws-sqs/src/test/java/io/camunda/connector/common/suppliers/DefaultAmazonSQSClientSupplierTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.common.suppliers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import io.camunda.connector.aws.model.impl.AwsAuthentication.AwsStaticCredentialsAuthentication;
+import io.camunda.connector.aws.model.impl.AwsBaseConfiguration;
+import io.camunda.connector.aws.model.impl.AwsBaseRequest;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.services.sqs.SqsClient;
+
+class DefaultAmazonSQSClientSupplierTest {
+
+  private final DefaultAmazonSQSClientSupplier supplier = new DefaultAmazonSQSClientSupplier();
+
+  private static AwsBaseRequest requestWith(final String endpoint) {
+    AwsBaseRequest request = new AwsBaseRequest();
+    request.setAuthentication(new AwsStaticCredentialsAuthentication("key", "secret"));
+    request.setConfiguration(new AwsBaseConfiguration("eu-central-1", endpoint));
+    return request;
+  }
+
+  @Test
+  void buildsClientWithRegionOnly() {
+    try (SqsClient client = supplier.sqsClient(requestWith(null), "eu-central-1")) {
+      assertThat(client).isNotNull();
+    }
+  }
+
+  @Test
+  void buildsClientWithEndpointOverrideWhenEndpointIsSet() {
+    try (SqsClient client =
+        supplier.sqsClient(requestWith("http://localhost:4566"), "eu-central-1")) {
+      assertThat(client).isNotNull();
+    }
+  }
+
+  /**
+   * Regression guard for the blank-endpoint bug: an endpoint that arrives as an empty or blank
+   * string must be treated as "no endpoint" (the region-only client path), not fed to {@code
+   * URI.create("")} / {@code endpointOverride}.
+   */
+  @Test
+  void buildsClientWithoutEndpointOverrideWhenEndpointIsBlank() {
+    assertThatCode(
+            () -> {
+              try (SqsClient client = supplier.sqsClient(requestWith(""), "eu-central-1")) {
+                assertThat(client).isNotNull();
+              }
+              try (SqsClient client = supplier.sqsClient(requestWith("   "), "eu-central-1")) {
+                assertThat(client).isNotNull();
+              }
+            })
+        .doesNotThrowAnyException();
+  }
+}

--- a/connectors/aws/aws-sqs/src/test/java/io/camunda/connector/inbound/SqsExecutableTest.java
+++ b/connectors/aws/aws-sqs/src/test/java/io/camunda/connector/inbound/SqsExecutableTest.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.connector.api.inbound.*;
 import io.camunda.connector.aws.ObjectMapperSupplier;
+import io.camunda.connector.aws.model.impl.AwsBaseRequest;
 import io.camunda.connector.common.suppliers.AmazonSQSClientSupplier;
 import io.camunda.connector.inbound.model.SqsInboundProperties;
 import io.camunda.connector.runtime.core.inbound.ProcessElementWithRuntimeData;
@@ -43,7 +44,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.services.sqs.SqsClient;
 import software.amazon.awssdk.services.sqs.model.GetQueueAttributesRequest;
 import software.amazon.awssdk.services.sqs.model.Message;
@@ -101,7 +101,7 @@ class SqsExecutableTest {
             .receiptHandle("receiptHandle")
             .build();
     Message message1 = spy(message);
-    when(supplier.sqsClient(any(AwsCredentialsProvider.class), eq(ACTUAL_QUEUE_REGION)))
+    when(supplier.sqsClient(any(AwsBaseRequest.class), eq(ACTUAL_QUEUE_REGION)))
         .thenReturn(sqsClient);
     when(sqsClient.receiveMessage(any(ReceiveMessageRequest.class)))
         .thenReturn(ReceiveMessageResponse.builder().messages(message1).build());
@@ -130,7 +130,7 @@ class SqsExecutableTest {
   public void deactivateTest() {
     // Given
     when(sqsClient.getQueueAttributes(any(GetQueueAttributesRequest.class))).thenReturn(null);
-    when(supplier.sqsClient(any(AwsCredentialsProvider.class), eq(ACTUAL_QUEUE_REGION)))
+    when(supplier.sqsClient(any(AwsBaseRequest.class), eq(ACTUAL_QUEUE_REGION)))
         .thenReturn(sqsClient);
     Map<String, Object> properties =
         Map.of(
@@ -160,7 +160,7 @@ class SqsExecutableTest {
     // Given
     when(sqsClient.getQueueAttributes(any(GetQueueAttributesRequest.class)))
         .thenThrow(QueueDoesNotExistException.builder().message("").build());
-    when(supplier.sqsClient(any(AwsCredentialsProvider.class), eq(ACTUAL_QUEUE_REGION)))
+    when(supplier.sqsClient(any(AwsBaseRequest.class), eq(ACTUAL_QUEUE_REGION)))
         .thenReturn(sqsClient);
     Map<String, Object> properties =
         Map.of(

--- a/connectors/aws/aws-sqs/src/test/java/io/camunda/connector/outbound/SqsConnectorFunctionParametrizedTest.java
+++ b/connectors/aws/aws-sqs/src/test/java/io/camunda/connector/outbound/SqsConnectorFunctionParametrizedTest.java
@@ -29,6 +29,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.connector.api.outbound.OutboundConnectorContext;
 import io.camunda.connector.aws.ObjectMapperSupplier;
+import io.camunda.connector.aws.model.impl.AwsBaseRequest;
 import io.camunda.connector.common.suppliers.AmazonSQSClientSupplier;
 import io.camunda.connector.outbound.model.SqsConnectorRequest;
 import io.camunda.connector.outbound.model.SqsConnectorResult;
@@ -48,7 +49,6 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
-import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.services.sqs.SqsClient;
 import software.amazon.awssdk.services.sqs.model.SendMessageRequest;
 import software.amazon.awssdk.services.sqs.model.SendMessageResponse;
@@ -79,7 +79,7 @@ class SqsConnectorFunctionParametrizedTest {
   @MethodSource("successRequestCases")
   void execute_ShouldSucceedSuccessCases(final String input) throws JsonProcessingException {
     // given
-    when(sqsClientSupplier.sqsClient(any(AwsCredentialsProvider.class), eq(ACTUAL_QUEUE_REGION)))
+    when(sqsClientSupplier.sqsClient(any(AwsBaseRequest.class), eq(ACTUAL_QUEUE_REGION)))
         .thenReturn(sqsClient);
     SendMessageResponse sendMessageResponse = mock(SendMessageResponse.class);
     when(sendMessageResponse.messageId()).thenReturn(MSG_ID);
@@ -111,7 +111,7 @@ class SqsConnectorFunctionParametrizedTest {
   @MockitoSettings(strictness = Strictness.LENIENT)
   void execute_ShouldThrowExceptionOnMalformedRequests(final String incomingJson) {
     // given
-    when(sqsClientSupplier.sqsClient(any(AwsCredentialsProvider.class), eq(ACTUAL_QUEUE_REGION)))
+    when(sqsClientSupplier.sqsClient(any(AwsBaseRequest.class), eq(ACTUAL_QUEUE_REGION)))
         .thenReturn(sqsClient);
     SendMessageResponse sendMessageResponse = mock(SendMessageResponse.class);
     when(sendMessageResponse.messageId()).thenReturn(MSG_ID);

--- a/connectors/aws/aws-sqs/src/test/java/io/camunda/connector/outbound/SqsConnectorFunctionTest.java
+++ b/connectors/aws/aws-sqs/src/test/java/io/camunda/connector/outbound/SqsConnectorFunctionTest.java
@@ -11,6 +11,7 @@ import static org.mockito.ArgumentMatchers.any;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import io.camunda.connector.api.outbound.OutboundConnectorContext;
+import io.camunda.connector.aws.model.impl.AwsBaseRequest;
 import io.camunda.connector.common.suppliers.AmazonSQSClientSupplier;
 import io.camunda.connector.outbound.model.SqsConnectorResult;
 import io.camunda.connector.runtime.test.outbound.OutboundConnectorContextBuilder;
@@ -20,7 +21,6 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
-import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.core.exception.SdkException;
 import software.amazon.awssdk.services.sqs.SqsClient;
 import software.amazon.awssdk.services.sqs.model.SendMessageRequest;
@@ -64,8 +64,7 @@ public class SqsConnectorFunctionTest extends BaseTest {
         .thenReturn(sendMessageResponse);
     AmazonSQSClientSupplier sqsClientSupplier = Mockito.mock(AmazonSQSClientSupplier.class);
     Mockito.when(
-            sqsClientSupplier.sqsClient(
-                any(AwsCredentialsProvider.class), ArgumentMatchers.anyString()))
+            sqsClientSupplier.sqsClient(any(AwsBaseRequest.class), ArgumentMatchers.anyString()))
         .thenReturn(sqsClient);
     connector = new SqsConnectorFunction(sqsClientSupplier, objectMapper);
 
@@ -89,8 +88,7 @@ public class SqsConnectorFunctionTest extends BaseTest {
         .thenReturn(sendMessageResponse);
     AmazonSQSClientSupplier sqsClientSupplier = Mockito.mock(AmazonSQSClientSupplier.class);
     Mockito.when(
-            sqsClientSupplier.sqsClient(
-                any(AwsCredentialsProvider.class), ArgumentMatchers.anyString()))
+            sqsClientSupplier.sqsClient(any(AwsBaseRequest.class), ArgumentMatchers.anyString()))
         .thenReturn(sqsClient);
     ArgumentCaptor<SendMessageRequest> captor = ArgumentCaptor.forClass(SendMessageRequest.class);
     Mockito.when(sqsClient.sendMessage(captor.capture()))
@@ -121,8 +119,7 @@ public class SqsConnectorFunctionTest extends BaseTest {
         .thenReturn(sendMessageResponse);
     AmazonSQSClientSupplier sqsClientSupplier = Mockito.mock(AmazonSQSClientSupplier.class);
     Mockito.when(
-            sqsClientSupplier.sqsClient(
-                any(AwsCredentialsProvider.class), ArgumentMatchers.anyString()))
+            sqsClientSupplier.sqsClient(any(AwsBaseRequest.class), ArgumentMatchers.anyString()))
         .thenReturn(sqsClient);
     ArgumentCaptor<SendMessageRequest> captor = ArgumentCaptor.forClass(SendMessageRequest.class);
     Mockito.when(sqsClient.sendMessage(captor.capture()))


### PR DESCRIPTION
# Description
Backport of #8120 to `stable/8.9`.

Manual cherry-pick — the automated backport failed with conflicts in 7 files (EventBridgeFunction, LambdaConnectorFunction, S3Executor, SagemakerConnectorFunction, SnsConnectorFunction, SqsExecutable, SqsConnectorFunction). All conflicts were the same shape: on `main`, an unrelated, not-yet-backported feature (the Configuration ETG POC's `AwsCredentialConfiguration`/`configurations()` element-template attribute, and in `S3Executor` the `DocumentReturn` conversion path) sits on the same lines #8120 touches. Resolved by applying only #8120's actual diff (verified via `git diff 04d420c898^ 04d420c898` per file) on top of `stable/8.9`, without introducing those unrelated main-only types/attributes that don't exist on this branch.

All affected modules (`aws-base`, `aws-bedrock`, `aws-eventbridge`, `aws-lambda`, `aws-s3`, `aws-sagemaker`, `aws-sns`, `aws-sqs`) build and test green on this branch.