### PR TITLE
fix(csv): update e2e tests for document input and response format properties

### DIFF
--- a/connectors-e2e-test/connectors-e2e-test-csv/src/test/java/io/camunda/connector/e2e/csv/CsvConnectorTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-csv/src/test/java/io/camunda/connector/e2e/csv/CsvConnectorTests.java
@@ -63,7 +63,9 @@ public class CsvConnectorTests {
     var elementTemplate =
         ElementTemplate.from(ELEMENT_TEMPLATE_PATH)
             .property("operation", "readCsv")
-            .property("readCsv:data", "name,age,city\nAlice,30,Paris\nBob,25,London")
+            .property("readCsv:document_documentSource", "inline")
+            .property(
+                "readCsv:document_inline_content", "name,age,city\nAlice,30,Paris\nBob,25,London")
             .property("readCsv:format.delimiter", ",")
             .property("readCsv:format.skipHeaderRecord", "true")
             .property("readCsv:format.headers", "=[\"name\", \"age\", \"city\"]")
@@ -94,7 +96,9 @@ public class CsvConnectorTests {
     var elementTemplate =
         ElementTemplate.from(ELEMENT_TEMPLATE_PATH)
             .property("operation", "readCsv")
-            .property("readCsv:data", "name;age;city\nAlice;30;Paris\nBob;25;London")
+            .property("readCsv:document_documentSource", "inline")
+            .property(
+                "readCsv:document_inline_content", "name;age;city\nAlice;30;Paris\nBob;25;London")
             .property("readCsv:format.delimiter", ";")
             .property("readCsv:format.skipHeaderRecord", "true")
             .property("readCsv:format.headers", "=[\"name\", \"age\", \"city\"]")
@@ -130,7 +134,7 @@ public class CsvConnectorTests {
                 "=[{\"name\": \"Alice\", \"age\": 30}, {\"name\": \"Bob\", \"age\": 25}]")
             .property("writeCsv:format.delimiter", ",")
             .property("writeCsv:format.headers", "=[\"name\", \"age\"]")
-            .property("writeCsv:createDocument", "false")
+            .property("writeCsv:documentReturnFormat", "TEXT")
             .property("resultVariable", "csvResult")
             .writeTo(new File(tempDir, "template.json"));
 
@@ -159,8 +163,10 @@ public class CsvConnectorTests {
     var elementTemplate =
         ElementTemplate.from(ELEMENT_TEMPLATE_PATH)
             .property("operation", "readCsv")
+            .property("readCsv:document_documentSource", "inline")
             .property(
-                "readCsv:data", "name,age,city\nAlice,30,Paris\nBob,25,London\nCharlie,35,Berlin")
+                "readCsv:document_inline_content",
+                "name,age,city\nAlice,30,Paris\nBob,25,London\nCharlie,35,Berlin")
             .property("readCsv:format.delimiter", ",")
             .property("readCsv:format.skipHeaderRecord", "true")
             .property("readCsv:format.headers", "=[\"name\", \"age\", \"city\"]")
@@ -195,8 +201,9 @@ public class CsvConnectorTests {
     var elementTemplate =
         ElementTemplate.from(ELEMENT_TEMPLATE_PATH)
             .property("operation", "readCsv")
+            .property("readCsv:document_documentSource", "inline")
             .property(
-                "readCsv:data",
+                "readCsv:document_inline_content",
                 "product,price,quantity\nWireless Mouse,29.99,10\nOffice Chair,149.5,5\nUSB Cable,12.99,50")
             .property("readCsv:format.delimiter", ",")
             .property("readCsv:format.skipHeaderRecord", "true")
@@ -238,8 +245,9 @@ public class CsvConnectorTests {
     var elementTemplate =
         ElementTemplate.from(ELEMENT_TEMPLATE_PATH)
             .property("operation", "readCsv")
+            .property("readCsv:document_documentSource", "inline")
             .property(
-                "readCsv:data",
+                "readCsv:document_inline_content",
                 "product,price,quantity\nWireless Mouse,29.99,10\nOffice Chair,149.5,5\nUSB Cable,12.99,50\nMonitor Stand,45,8")
             .property("readCsv:format.delimiter", ",")
             .property("readCsv:format.skipHeaderRecord", "true")


### PR DESCRIPTION
## Summary
- PR #8025 replaced the `readCsv` connector's plain-text `data` input with a document-source dropdown (`document_documentSource` / `document_inline_content` / etc.) and replaced the `writeCsv:createDocument` boolean with a `documentReturnFormat` dropdown, but `CsvConnectorTests` (e2e) still referenced the removed property IDs, so all 6 tests failed with `PathNotFoundException: Property path not found for property ID: readCsv:data` / `writeCsv:createDocument`.
- Updated the e2e tests to set the new property IDs: `readCsv:document_documentSource=inline` + `readCsv:document_inline_content=<csv text>` for read tests, and `writeCsv:documentReturnFormat=TEXT` in place of the removed `createDocument` flag.

## Test plan
- [x] `mvn test -pl connectors-e2e-test/connectors-e2e-test-csv -Dtest=CsvConnectorTests` — 6/6 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)