### PR TITLE
docs: condense AGENTS.md to repo-specific essentials

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,703 +1,129 @@
-# Camunda Connectors Development Guide
+# AGENTS.md
 
-This repository contains the Camunda Connectors ecosystem - a comprehensive framework for building and managing
-connectors for Camunda Platform 8.
+## Role & boundary
 
-## Project Architecture
+Camunda Connectors is the connector ecosystem for Camunda Platform 8: an SDK for building connectors,
+a runtime that executes them, and 30+ out-of-the-box connectors (AWS, HTTP, Kafka, etc.). Java 21
+(SDK: Java 17). Product docs: https://docs.camunda.io/docs/components/connectors/overview/
 
-### Core Components
+Don't overengineer — follow YAGNI and KISS. No abstractions for single-use code, no error handling
+for impossible scenarios, no unrequested flexibility. Touch only what the task requires; don't
+"improve" adjacent code or delete pre-existing dead code you didn't cause.
 
-- **`connector-sdk/`**: SDK for building connectors (Java 17)
-    - `core/`: Core interfaces (`OutboundConnectorFunction`, `InboundConnectorExecutable`)
-    - `validation/`: Jakarta Bean Validation support
-    - `test/`: Testing utilities for connector development
-- **`connector-runtime/`**: Execution environment for connectors
-    - `connector-runtime-core/`: Framework-independent runtime
-    - `connector-runtime-spring/`: Spring-based runtime
-    - `spring-boot-starter-camunda-connectors/`: Spring Boot starter (recommended)
-- **`connectors/`**: 30+ out-of-the-box connectors (AWS, HTTP, Kafka, etc.)
-- **`element-template-generator/`**: Automated generation of Camunda Modeler templates
-- **`bundle/`**: Docker images bundling runtime + connectors
-- **`connector-commons/`**: Shared utilities
-    - `connector-object-mapper/`: Jackson ObjectMapper configuration
-    - `connector-test-utils/`: Testing utilities including `@SlowTest`, `DockerImages`
-    - `http-client/`: Shared HTTP client implementation
+**Path map:**
 
-### Multi-License Structure
+| Module                        | Description                                                        |
+|--------------------------------|---------------------------------------------------------------------|
+| `connector-sdk/`               | SDK for building connectors (Java 17): `core/`, `validation/`, `test/` |
+| `connector-runtime/`           | Execution environment — `connector-runtime-core/`, `-spring/`, `spring-boot-starter-camunda-connectors/` |
+| `connectors/`                  | Out-of-the-box connectors (one Maven module per connector)          |
+| `element-template-generator/`  | Generates Camunda Modeler element templates from annotations        |
+| `bundle/`                      | Docker images bundling runtime + connectors                         |
+| `connector-commons/`           | Shared utilities: `connector-object-mapper/`, `connector-test-utils/`, `http-client/` |
+| `secret-providers/`            | Secret provider implementations                                     |
+| `connectors-e2e-test/`         | End-to-end test modules                                              |
+| `docs/adr/`                    | Architecture decision records                                       |
 
-- **Apache 2.0**: SDK, Runtime, HTTP REST Connector, Element Template Generator
-- **Camunda Self-Managed Free Edition**: Most out-of-the-box connectors
+**License split:** Apache 2.0 (SDK, Runtime, HTTP REST connector, Element Template Generator) vs.
+Camunda Self-Managed Free Edition (most out-of-the-box connectors) — check a module's `pom.xml`/`LICENSE`
+before copying code across the boundary.
 
-## Connector Development Patterns
+**Ask first:** adding dependencies to `pom.xml`, changing SDK public API (`connector-sdk/core`),
+modifying shared runtime behavior (`connector-runtime-core/`).
 
-### Using Docker images in tests
+**Never:** decompile `camunda-client-java` / `camunda-spring-boot-starter` — if `camunda/camunda` is
+checked out locally (often a sibling directory, e.g. `../camunda`), read the source there instead.
 
-When writing integration or end-to-end tests that require a service (like a database, message broker, etc.), it's
-recommended to use Docker images to ensure consistency and isolation. You can use libraries like Testcontainers to
-manage the lifecycle of these containers during your tests.
-
-When doing so, make sure to use `io.camunda.connector.test.utils.DockerImages`.
-You need to add your image in a docker-images.properties file (in the test `resources` folder), for
-example:
-
-```
-# In docker-images.properties
-localstack=localstack/localstack:4.8
-kafka=confluentinc/cp-kafka:7.4.0
-```
-
-Then add a constant in `io.camunda.connector.test.utils.docker.DockerImages` and you can use it in your tests like this:
-
-```java
-new GenericContainer<>(DockerImageName.
-
-parse(DockerImages.get(SCHEMA_REGISTRY)));
-```
-
-### Standard Connector Structure
-
-```
-my-connector/
-├── pom.xml                           # Maven module
-├── src/main/java/
-│   └── io/camunda/connector/
-│       ├── MyConnectorFunction.java  # Main implementation
-│       └── model/
-│           ├── MyRequest.java        # Input model
-│           └── MyResponse.java       # Output model
-├── src/test/java/
-│   ├── MyConnectorTest.java         # Unit tests
-│   ├── BaseTest.java                # Shared test utilities
-│   └── GenerateElementTemplate.java # Template generation
-├── src/test/resources/
-│   └── docker-images.properties     # Docker images for integration tests
-└── element-templates/               # Generated templates
-    └── my-connector.json
-```
-
-### Outbound Connector Implementation
-
-```java
-
-@OutboundConnector(
-        name = "MY_CONNECTOR",
-        inputVariables = {"field1", "field2"},
-        type = "io.camunda.connector:my-connector:1")
-@ElementTemplate(
-        id = "io.camunda.connectors.MyConnector.v1",
-        name = "My Connector",
-        inputDataClass = MyRequest.class,
-        outputDataClass = MyResponse.class,
-        propertyGroups = {
-                @PropertyGroup(id = "auth", label = "Authentication"),
-                @PropertyGroup(id = "config", label = "Configuration")
-        })
-public class MyConnectorFunction implements OutboundConnectorFunction {
-
-    @Override
-    public Object execute(OutboundConnectorContext context) throws Exception {
-        var request = context.bindVariables(MyRequest.class);
-        // Implementation logic
-        return new MyResponse(result);
-    }
-}
-```
-
-### Operation-Based Outbound Connector Implementation (New Preferred Syntax)
-
-For connectors that involve multiple operations, the new operation-based syntax is preferred. This approach uses
-`@Operation` annotations to define multiple operations within a single connector class:
-
-```java
-
-@OutboundConnector(name = "CSV Connector", type = "io.camunda:csv-connector")
-@ElementTemplate(
-        name = "CSV Connector",
-        id = "io.camunda.connectors.csv",
-        version = 1,
-        engineVersion = "^8.8",
-        icon = "icon.svg")
-public class CsvConnector implements OutboundConnectorProvider {
-
-    @Operation(id = "readCsv", name = "Read CSV")
-    public ReadCsvResult readCsv(
-            @Variable ReadCsvRequest request,
-            @Header(name = "recordMapper", required = false)
-            @TemplateProperty(
-                    label = "Record mapping",
-                    tooltip = "FEEL function that allows to map each record",
-                    feel = TemplateProperty.FeelMode.required)
-            Function<Map<String, Object>, Object> mapper) {
-        // Read CSV implementation
-        return readCsvRequest(/* ... */);
-    }
-
-    @Operation(id = "writeCsv", name = "Write CSV")
-    public Object writeCsv(@Variable WriteCsvRequest request, OutboundConnectorContext context) {
-        // Write CSV implementation
-        var csv = createCsv(request.data(), request.format());
-        return new WriteCsvResult(csv);
-    }
-}
-```
-
-**Key differences from traditional syntax:**
-
-- Implements `OutboundConnectorProvider` instead of `OutboundConnectorFunction`
-- Uses `@Operation` annotations to define multiple operations
-- Each operation method can have different input/output types
-- Uses `@Variable` and `@Header` annotations for parameter binding
-- Better suited for connectors with multiple distinct operations
-
-**Note:** Both syntaxes are still supported. Use the operation-based syntax for connectors with multiple operations, and
-the traditional syntax for simple single-operation connectors.
-
-### Inbound Connector Implementation
-
-```java
-
-@InboundConnector(
-        name = "MY_INBOUND",
-        type = "io.camunda.connector:my-inbound:1")
-public class MyInboundConnector implements InboundConnectorExecutable {
-
-    @Override
-    public void activate(InboundConnectorContext context) throws Exception {
-        var props = context.bindProperties(MyProperties.class);
-        // Setup subscription/polling logic
-        // Use context.correlateWithResult(data) to trigger processes
-    }
-
-    @Override
-    public void deactivate() throws Exception {
-        // Cleanup resources
-    }
-}
-```
-
-## Input Model Patterns
-
-### Authentication Pattern
-
-Use sealed interfaces with `@JsonTypeInfo` for authentication types:
-
-```java
-
-@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
-@JsonSubTypes({
-        @JsonSubTypes.Type(value = BasicAuthentication.class, name = BasicAuthentication.TYPE),
-        @JsonSubTypes.Type(value = NoAuthentication.class, name = NoAuthentication.TYPE),
-        @JsonSubTypes.Type(value = OAuthAuthentication.class, name = OAuthAuthentication.TYPE),
-        @JsonSubTypes.Type(value = BearerAuthentication.class, name = BearerAuthentication.TYPE),
-        @JsonSubTypes.Type(value = ApiKeyAuthentication.class, name = ApiKeyAuthentication.TYPE)
-})
-@TemplateDiscriminatorProperty(
-        label = "Type",
-        group = "authentication",
-        name = "type",
-        defaultValue = NoAuthentication.TYPE,
-        description = "Choose the authentication type")
-public sealed interface Authentication
-        permits ApiKeyAuthentication, BasicAuthentication, BearerAuthentication,
-        NoAuthentication, OAuthAuthentication {
-}
-```
-
-### Property Validation
-
-Use Jakarta Bean Validation annotations that are automatically converted to element template constraints:
-
-```java
-public record MyRequest(
-        @NotEmpty
-        @TemplateProperty(group = "config", label = "URL")
-        String url,
-
-        @NotBlank  // Results in notEmpty constraint
-        @TemplateProperty(group = "config", label = "Name")
-        String name,
-
-        @Size(min = 1, max = 100)  // Results in minLength/maxLength constraints
-        @TemplateProperty(group = "config", label = "Description")
-        String description,
-
-        @Pattern(regexp = "^https?://.*")
-        @TemplateProperty(group = "config", label = "Endpoint")
-        String endpoint
-) {
-}
-```
-
-Supported annotations: `@NotEmpty`, `@NotBlank`, `@NotNull`, `@Size`, `@Pattern`
-
-### FEEL Expression Support
-
-Use `@FEEL` annotation for properties that should support FEEL expressions:
-
-```java
-public record MyRequest(
-        @FEEL
-        @NotEmpty
-        @TemplateProperty(group = "config", label = "Dynamic Value")
-        String dynamicValue
-) {
-}
-```
-
-### Document Handling
-
-For file upload/download operations, use the `Document` type and `DocumentCreationRequest`:
-
-```java
-// Uploading a document
-public record UploadRequest(
-                @NotNull
-                @TemplateProperty(
-                        label = "Document",
-                        type = TemplateProperty.PropertyType.String,
-                        feel = TemplateProperty.FeelMode.required)
-                Document document
-        ) {
-}
-
-// Creating a document from bytes
-Document document = context.create(
-        DocumentCreationRequest.from(content)
-                .fileName("file.txt")
-                .contentType("text/plain")
-                .build());
-```
-
-## Build & Development Workflows
-
-### Pull Request Guidelines
-
-When creating pull requests:
-
-- **Always use the PR template**: Located at `.github/PULL_REQUEST_TEMPLATE.md`
-- Fill out all sections:
-    - **Description**: Explain the changes and provide context
-    - **Related issues**: Link to related issues (use `closes #` for issues this PR resolves)
-    - **Checklist**: Verify milestone and backport labels are appropriate
-- Update the PR description after creation if you initially missed the template
-
-### Maven Structure
-
-- **Parent POM**: `parent/pom.xml` defines versions and common configuration
-- **Multi-module**: Root `pom.xml` orchestrates all modules
-- **Java Versions**:
-    - SDK uses Java 17 (`version.java.connector-sdk`)
-    - Rest of project uses Java 21 (`version.java`)
-- **Profiles**: `e2eExcluded` profile skips E2E tests
-
-### Essential Commands
+## Build & test
 
 ```bash
-# Full build
-mvn clean package
-
-# Quick build, skip long-running tests (faster development)
-mvn clean package -Dquickly
-
-# Quick build with Maven cache (fastest for incremental builds)
-mvn clean install -DskipTests -DskipChecks -Dquickly -Dmaven.build.cache.enabled=true -T 1C
-
-# Generate element templates for connectors
-./connectors/create-element-templates-symlinks.sh
-
-# Build Docker bundle
-cd bundle && docker build -t camunda/connectors-bundle:latest .
-
-# Run specific test class
-mvn test -pl connectors/http/rest -Dtest=HttpJsonFunctionTest
-
-# Run integration tests (requires Docker)
-mvn verify -pl connectors/kafka
+mvn clean package                    # full build
+mvn clean package -Dquickly          # skip long-running tests
+mvn test -pl connectors/http/rest -Dtest=HttpJsonFunctionTest   # single test class
+mvn verify -pl connectors/kafka      # integration tests (requires Docker)
 ```
 
-### Element Template Generation
-
-Every connector should include a `GenerateElementTemplate.java` test class:
-
-```java
-public class GenerateElementTemplate {
-    public static void main(String[] args) throws JsonProcessingException {
-        System.out.println(new ObjectMapper().writeValueAsString(
-                new ClassBasedTemplateGenerator().generate(MyConnectorFunction.class)));
-    }
-}
-```
-
-## Development Conventions
-
-### Package Structure
-
-- Connectors: `io.camunda.connector.{service}`
-- Models: `io.camunda.connector.{service}.model`
-- Tests follow same package structure in `src/test/java`
-
-### Dependency Management
-
-- Set connector SDK dependencies to `<scope>provided</scope>`
-- Runtime provides core classes, connectors only add implementation
-- Use `connector-http-base` for HTTP-related connectors
-
-### ObjectMapper Usage
-
-Always use `ConnectorsObjectMapperSupplier.getCopy()` for JSON serialization:
-
-```java
-import io.camunda.connector.jackson.ConnectorsObjectMapperSupplier;
-
-// Get a pre-configured ObjectMapper instance
-ObjectMapper objectMapper = ConnectorsObjectMapperSupplier.getCopy();
-```
-
-The default configuration includes:
-
-- Java 8 date/time support (`JavaTimeModule`)
-- Case-insensitive enum handling
-- Single value to array conversion
-- Unknown properties are ignored
-
-### Error Handling
-
-Use `ConnectorException` and `ConnectorRetryException` for proper error handling:
-
-```java
-// Simple error
-throw new ConnectorException("ERROR_CODE","Error message");
-
-// Retryable error with custom retry configuration
-throw ConnectorRetryException.
-
-builder()
-    .
-
-errorCode("TRANSIENT_ERROR")
-    .
-
-message("Temporary failure")
-    .
-
-retries(3)
-    .
-
-backoffDuration(Duration.ofSeconds(10))
-        .
-
-build();
-
-// BPMN error (caught by error boundary events)
-throw new
-
-BpmnError("VALIDATION_ERROR","Input validation failed");
-```
-
-### Testing Patterns
-
-- **Unit tests**: `*Test.java` classes
-- **Input validation**: `*InputValidationTest.java`
-- **Secrets handling**: `*SecretsTest.java`
-- **Integration**: Use WireMock for HTTP mocking
-- **E2E**: Separate `connectors-e2e-test/` modules
-- **Slow tests**: Add `@SlowTest` annotation to integration tests
-
-#### BaseTest Pattern
-
-Create a `BaseTest` class for shared test utilities:
-
-```java
-public abstract class BaseTest {
-    protected interface ActualValue {
-        String TOKEN = "test-token";
-        // Other actual values
-    }
-
-    protected interface SecretsConstant {
-        String TOKEN = "TOKEN_KEY";
-        // Other secret keys
-    }
-
-    protected static OutboundConnectorContextBuilder getContextBuilderWithSecrets() {
-        return OutboundConnectorContextBuilder.create()
-                .validation(new DefaultValidationProvider())
-                .secret(SecretsConstant.TOKEN, ActualValue.TOKEN);
-    }
-
-    protected static Stream<String> loadTestCasesFromResourceFile(String path) throws IOException {
-        // Load JSON test cases from resources
-    }
-}
-```
-
-#### WireMock Integration
-
-```java
-
-@WireMockTest
-public class MyConnectorIntegrationTest {
-    @BeforeAll
-    public static void setup(WireMockRuntimeInfo wmRuntimeInfo) {
-        stubFor(get(urlEqualTo("/api/resource"))
-                .willReturn(aResponse()
-                        .withHeader("Content-Type", "application/json")
-                        .withBody("{\"result\": \"success\"}")));
-    }
-}
-```
-
-#### Parameterized Tests with JSON Files
-
-```java
-
-@ParameterizedTest
-@MethodSource("successTestCases")
-void shouldExecuteSuccessfully(String input) throws Exception {
-    var context = getContextBuilderWithSecrets().variables(input).build();
-    var result = connector.execute(context);
-    assertThat(result).isNotNull();
-}
-
-private static Stream<String> successTestCases() throws IOException {
-    return loadTestCasesFromResourceFile("src/test/resources/success-cases.json");
-}
-```
-
-### Secret Handling
-
-```java
-// In connector implementation
-var apiKey = context.getSecretStore().getSecret("MY_API_KEY");
-
-// In tests, mock the context
-when(context.getSecretStore().
-
-getSecret("MY_API_KEY")).
-
-thenReturn("test-key");
-```
-
-## Runtime Configuration
-
-### Spring Boot Properties
-
-```properties
-# Camunda SaaS connection
-camunda.client.cloud.cluster-id=xxx
-camunda.client.auth.client-id=xxx
-camunda.client.auth.client-secret=xxx
-camunda.client.cloud.region=bru-2
-# Local Zeebe connection
-camunda.client.grpc-address=http://127.0.0.1:26500
-# Connector runtime settings
-camunda.connector.polling.enabled=true
-camunda.connector.polling.interval=5000
-camunda.connector.webhook.enabled=true
-# Secret provider configuration
-camunda.connector.secretProvider.environment.enabled=true
-camunda.connector.secretProvider.environment.prefix=
-```
-
-### Environment Variable Overrides
-
-Connector configuration can be overridden via environment variables:
-
-- `CONNECTOR_{NAME}_FUNCTION`: Function class to register
-- `CONNECTOR_{NAME}_TYPE`: Job type override
-- `CONNECTOR_{NAME}_INPUT_VARIABLES`: Variables to fetch
-
-Example:
-
-```bash
-CONNECTOR_HTTPJSON_FUNCTION=io.camunda.connector.http.rest.HttpJsonFunction
-CONNECTOR_HTTPJSON_TYPE=custom-http-type
-```
-
-## Key Integration Points
-
-### Service Discovery
-
-Connectors are discovered via Java ServiceLoader. Create `META-INF/services/` files:
-
-- `io.camunda.connector.api.outbound.OutboundConnectorFunction`
-- `io.camunda.connector.api.inbound.InboundConnectorExecutable`
-
-### Runtime Integration
-
-- **Standalone**: Use `connector-runtime-application`
-- **Spring Boot**: Add `spring-boot-starter-camunda-connectors` dependency
-- **Docker**: Extend `camunda/connectors-bundle` image
-
-### Element Template Deployment
-
-Templates auto-link to Camunda Modeler via `create-element-templates-symlinks.sh` script targeting
-`~/Library/Application Support/camunda-modeler/resources/element-templates/` (macOS).
-
-## CI/CD Workflows
-
-Key workflow files in `.github/workflows/`:
-
-- **`DEPLOY_SNAPSHOTS.yaml`**: Deploys snapshot artifacts on push to `main`, `stable/**`, `alpha/**`
-- **`RELEASE.yaml`**: Handles releases
-- **`INTEGRATION_TEST.yml`**: Runs integration tests
-- **`NIGHTLY_E2E.yml`**: Nightly E2E test runs
-- **`CHECK_LICENSES.yml`**: License compliance checks
-
-### Branch Naming
-
-- `main`: Main development branch
-- `stable/**`: Stable release branches
-- `alpha/**`: Alpha release branches
-
-## Common Pitfalls
-
-- **Wrong Java version**: SDK requires Java 17, ensure connector modules inherit correct version
-- **Missing annotations**: Both `@OutboundConnector/@InboundConnector` AND `@ElementTemplate` required
-- **Scope issues**: Use `provided` scope for SDK dependencies
-- **Service registration**: Don't forget ServiceLoader registration files
-- **Template generation**: Run `GenerateElementTemplate` after model changes
-- **File structure changes**: When modifying file or folder structure, always check for references in CI workflows (
-  `.github/workflows/`), READMEs, and this copilot instructions file
-- **ObjectMapper**: Always use `ConnectorsObjectMapperSupplier.getCopy()` instead of creating new instances
-- **Docker images**: Use `DockerImages.get()` utility for Testcontainers, add images to `docker-images.properties`
-- **Integration tests**: Mark with `@SlowTest` to exclude from regular unit test runs
-- **FEEL expressions**: Use `@FEEL` annotation for properties that need runtime evaluation
-- **AWS SDK v1 in aws-sns**: the inbound webhook keeps `aws-java-sdk-sns` (v1) for
-  `SnsMessageManager`, which verifies SNS webhook signatures — v2 has no equivalent
-  (see https://github.com/aws/aws-sdk-java-v2/issues/1302) — and for
-  `SnsSubscriptionConfirmation#confirmSubscription`, called on the object `SnsMessageManager`
-  already returns. This is the one accepted v1 exception in the AWS v1→v2 migration; any other
-  v1 usage is a regression, not precedent.
-- **Investigating `camunda-client-java` / `camunda-spring-boot-starter` behavior**: don't decompile
-  the jars (`javap`, unzip + bytecode reading, etc.). If the `camunda/camunda` monorepo is checked
-  out locally (often as a sibling of this repo, e.g. `../camunda`), read the actual source instead
-  — e.g. `clients/java/src/main/java/io/camunda/client/...` or
-  `clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/...`. Only fall back
-  to decompiling if that checkout isn't available.
-
-## Reference Implementations
-
-For examples, see existing connectors in `connectors/` directory:
-
-- **HTTP REST connector** (`connectors/http/rest/`): Reference implementation for outbound connectors
-- **Webhook connector** (`connectors/webhook/`): Reference implementation for inbound connectors
-- **Kafka connector** (`connectors/kafka/`): Example of both inbound and outbound patterns
-- **Azure Blob Storage** (`connectors/microsoft/azure-blobstorage/`): Document handling example
-
-## Architecture Decision Records (ADRs)
-
-Significant architectural decisions are recorded in [`docs/adr/`](../docs/adr/). Read [`docs/adr/README.md`](../docs/adr/README.md) for the full process, template, and agent instructions before creating or updating an ADR.
-
-**When to write one:** a decision that affects multiple modules, involves a meaningful trade-off, or changes an established pattern in the SDK, runtime, or out-of-box connectors.
-
-**Quick start:**
-1. Find the next sequence number from the index in `docs/adr/README.md`.
-2. Create `docs/adr/ADR-NNNN-<kebab-title>.md` using the template in that README.
-3. Add a one-line entry to the index table in `docs/adr/README.md`.
+- Root `pom.xml` orchestrates all modules; `parent/pom.xml` defines shared versions/config.
+- `e2eExcluded` Maven profile skips E2E tests.
+- After changing an SDK model class, regenerate its template via the connector's
+  `GenerateElementTemplate` test class.
+- Docker-based tests use `io.camunda.connector.test.utils.DockerImages` — add the image to
+  `docker-images.properties` in `src/test/resources`, then a constant in `DockerImages`.
+
+## Connector implementation patterns
+
+- **Every connector needs both** `@OutboundConnector`/`@InboundConnector` **and** `@ElementTemplate`
+  — missing either is the most common mistake.
+- **Operation-based syntax** (preferred for multi-operation connectors): implement
+  `OutboundConnectorProvider`, annotate methods with `@Operation`. Single-operation connectors may
+  still implement `OutboundConnectorFunction` directly — both are supported.
+- Reference implementations: `connectors/http/rest/` (outbound), `connectors/webhook/` (inbound),
+  `connectors/kafka/` (both), `connectors/microsoft/azure-blobstorage/` (document handling).
+- **Auth types**: model as a `sealed interface` with `@JsonTypeInfo`/`@JsonSubTypes` +
+  `@TemplateDiscriminatorProperty` (see any connector's `Authentication` interface for the shape).
+- **Property validation**: Jakarta Bean Validation (`@NotEmpty`, `@NotBlank`, `@NotNull`, `@Size`,
+  `@Pattern`) is auto-converted to element template constraints.
+- **FEEL expressions**: annotate the field with `@FEEL`.
+- **Files**: use the `Document` type + `DocumentCreationRequest`, never raw byte arrays, for
+  upload/download.
+- **ObjectMapper**: always `ConnectorsObjectMapperSupplier.getCopy()`, never a fresh instance —
+  it configures `JavaTimeModule`, case-insensitive enums, and lenient array/unknown-property handling.
+- **Errors**: throw `ConnectorException` (fatal) or `ConnectorRetryException` (transient, configurable
+  retries/backoff); throw `BpmnError` only when a boundary event should catch it.
+- **Secrets**: read via `context.getSecretStore().getSecret(...)`; SDK dependencies stay
+  `<scope>provided</scope>` in connector modules.
+- **Service registration**: connectors are discovered via `ServiceLoader` —
+  `META-INF/services/io.camunda.connector.api.{outbound,inbound}.*` files are required, easy to forget.
+
+## Testing conventions
+
+- `*Test.java` unit, `*InputValidationTest.java`, `*SecretsTest.java`, WireMock (`@WireMockTest`) for
+  HTTP integration, `@SlowTest` on anything that shouldn't run in the fast unit-test loop.
+- Shared fixtures live in a per-connector `BaseTest` (secrets, context builder, JSON test-case loading)
+  — follow the existing pattern rather than inventing a new one per connector.
+
+## Code comments
+
+Before writing an inline comment, name the reader and what they would do differently for having
+read it. If you can't name both, don't write it.
+
+## Architecture Decision Records
+
+Read `docs/adr/README.md` for process, template, and the current index before creating or updating one.
+Write one when a decision affects multiple modules, involves a real trade-off, or changes an
+established SDK/runtime/connector pattern. Sequence number and index entry come from that same README.
+
+## Pull requests & commits
+
+- Use the PR template (`.github/PULL_REQUEST_TEMPLATE.md`).
+- PR title should be clear and descriptive; reference the issue number in the description
+  (e.g. `closes #1234`).
+- Keep PRs focused on a single concern.
+- Describe why the change is necessary and note alternatives considered — keep it brief and concise.
+- Write for the reader, not the diff: avoid leaking implementation details (variable names, internal
+  function names, code structure) into the description — say what changed and why in plain terms;
+  the diff already shows the how.
+- For bug fixes: ask the engineer whether the fix needs backporting to stable branches before
+  opening the PR. If yes, add the `backport stable/X.Y` label(s) when creating it.
+- Commits follow [Conventional Commits](https://www.conventionalcommits.org/) — see
+  `CONTRIBUTING.md#commit-message-guidelines`.
+- Backports run through `korthout/backport-action` (`.github/workflows/BACKPORT_PR.yml`) via a
+  `backport stable/X.Y` label or a `/backport` comment — never cherry-pick a backport by hand.
+
+## Common pitfalls
+
+- SDK modules require Java 17 even though the rest of the repo is on Java 21 — check inherited
+  compiler settings before assuming a module picked up the wrong version.
+- File/folder restructuring breaks references silently — check `.github/workflows/`, module
+  `README.md`s, and this file for paths that need updating.
+- **AWS SDK v1 in `aws-sns`**: the inbound webhook keeps `aws-java-sdk-sns` (v1) for
+  `SnsMessageManager` (verifies SNS webhook signatures — no v2 equivalent, see
+  [aws-sdk-java-v2#1302](https://github.com/aws/aws-sdk-java-v2/issues/1302)) and for
+  `SnsSubscriptionConfirmation#confirmSubscription`. This is the one accepted v1 exception in the
+  v1→v2 migration; any other new v1 usage is a regression, not precedent.
 
 ## Documentation
 
-For detailed documentation, see
-the [Camunda Connectors Documentation](https://docs.camunda.io/docs/components/connectors/overview/). This includes:
-
-- Getting Started Guide
-- Connector Development Best Practices
-- Runtime Configuration
-- Troubleshooting Guide
-
-It's important that pull requests that introduce changes to connector development patterns, runtime configuration, or
-testing strategies also update the official documentation to keep everything in sync.
-You can open documentation pull request in this repository: https://github.com/camunda/camunda-docs
-
-## Guidelines
-
-Behavioral guidelines to reduce common LLM coding mistakes. Merge with project-specific instructions as needed.
-
-**Tradeoff:** These guidelines bias toward caution over speed. For trivial tasks, use judgment.
-
-### 1. Think Before Coding
-
-**Don't assume. Don't hide confusion. Surface tradeoffs.**
-
-Before implementing:
-
-- State your assumptions explicitly. If uncertain, ask.
-- If multiple interpretations exist, present them - don't pick silently.
-- If a simpler approach exists, say so. Push back when warranted.
-- If something is unclear, stop. Name what's confusing. Ask.
-
-### 2. Simplicity First
-
-**Minimum code that solves the problem. Nothing speculative.**
-
-- No features beyond what was asked.
-- No abstractions for single-use code.
-- No "flexibility" or "configurability" that wasn't requested.
-- No error handling for impossible scenarios.
-- If you write 200 lines and it could be 50, rewrite it.
-
-Ask yourself: "Would a senior engineer say this is overcomplicated?" If yes, simplify.
-
-### 3. Surgical Changes
-
-**Touch only what you must. Clean up only your own mess.**
-
-When editing existing code:
-
-- Don't "improve" adjacent code, comments, or formatting.
-- Don't refactor things that aren't broken.
-- Match existing style, even if you'd do it differently.
-- If you notice unrelated dead code, mention it - don't delete it.
-
-When your changes create orphans:
-
-- Remove imports/variables/functions that YOUR changes made unused.
-- Don't remove pre-existing dead code unless asked.
-
-The test: Every changed line should trace directly to the user's request.
-
-### 4. Goal-Driven Execution
-
-**Define success criteria. Loop until verified.**
-
-Transform tasks into verifiable goals:
-
-- "Add validation" → "Write tests for invalid inputs, then make them pass"
-- "Fix the bug" → "Write a test that reproduces it, then make it pass"
-- "Refactor X" → "Ensure tests pass before and after"
-
-For multi-step tasks, state a brief plan:
-
-```
-1. [Step] → verify: [check]
-2. [Step] → verify: [check]
-3. [Step] → verify: [check]
-```
-
-Strong success criteria let you loop independently. Weak criteria ("make it work") require constant clarification.
-
-### 5. Terminal Commands — Disable Pagers
-
-**Always prevent interactive pagers in terminal commands.**
-
-Any command that may open a pager (e.g. `git log`, `git diff`, `git show`, `man`, `less`) must be run with pager disabled so the output is returned inline without requiring user interaction:
-
-- Use `git --no-pager <command>` for git commands
-- Or pipe to `cat`: `git log | cat`
-
-Example:
-
-```bash
-# ✅ Correct
-git --no-pager log --oneline -10
-git --no-pager diff HEAD
-
-# ❌ Wrong — blocks waiting for "q"
-git log --oneline -10
-```
-
----
-
-**These guidelines are working if:** fewer unnecessary changes in diffs, fewer rewrites due to overcomplication, and
-clarifying questions come before implementation rather than after mistakes.
+Connector-development-pattern, runtime-configuration, or testing-strategy changes should also update
+[docs.camunda.io](https://docs.camunda.io/docs/components/connectors/overview/) — open a PR against
+`camunda/camunda-docs`.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -70,7 +70,8 @@ mvn verify -pl connectors/kafka      # integration tests (requires Docker)
   it configures `JavaTimeModule`, case-insensitive enums, and lenient array/unknown-property handling.
 - **Errors**: throw `ConnectorException` (fatal) or `ConnectorRetryException` (transient, configurable
   retries/backoff); throw `BpmnError` only when a boundary event should catch it.
-- **Secrets**: read via `context.getSecretStore().getSecret(...)`; SDK dependencies stay
+- **Secrets**: reference them as `{{secrets.NAME}}` in connector inputs; `bindVariables(...)` and
+  `bindProperties(...)` resolve them through registered `SecretProvider`s. SDK dependencies stay
   `<scope>provided</scope>` in connector modules.
 - **Service registration**: connectors are discovered via `ServiceLoader` —
   `META-INF/services/io.camunda.connector.api.{outbound,inbound}.*` files are required, easy to forget.


### PR DESCRIPTION
## Summary
- AGENTS.md (`.github/copilot-instructions.md`) had grown to 700+ lines mixing generic LLM coding advice with verbose full-length code samples, which made it hard to find the conventions that actually matter here.
- Restructured around a path map, build/test commands, connector implementation patterns, testing conventions, ADR process, PR/commit conventions (including a code-comment guideline and a note on keeping PR descriptions free of implementation-detail noise), and known pitfalls (AWS SDK v1 exception, Java version mismatch, ServiceLoader registration).
- Dropped content that duplicated generic engineering advice or was trivially discoverable elsewhere (CI workflow file listing, branch naming, full code samples for every pattern).

## Test plan
- [x] `./mvnw spotless:check` / license check via pre-commit hooks (passed on commit)
- [ ] Have a teammate skim the new AGENTS.md for anything load-bearing that got cut

🤖 Generated with [Claude Code](https://claude.com/claude-code)