### PR TITLE
WIP: Migrate jackson v3

### DIFF
--- a/bundle/camunda-saas-bundle/pom.xml
+++ b/bundle/camunda-saas-bundle/pom.xml
@@ -205,7 +205,7 @@
         <artifactId>maven-dependency-plugin</artifactId>
             <configuration>
               <ignoredDependencies>
-                <dependency>com.fasterxml.jackson.core:jackson-databind</dependency>
+                <dependency>tools.jackson.core:jackson-databind</dependency>
                 <dependency>io.camunda.connector:connector-object-mapper</dependency>
                 <dependency>org.springframework.security:spring-security-core</dependency>
                 <dependency>org.springframework.boot:spring-boot</dependency>

--- a/connector-commons/connector-object-mapper/pom.xml
+++ b/connector-commons/connector-object-mapper/pom.xml
@@ -17,20 +17,8 @@
   <dependencies>
     <!-- Jackson dependencies -->
     <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-core</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
+      <groupId>tools.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>com.fasterxml.jackson.datatype</groupId>
-      <artifactId>jackson-datatype-jsr310</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>com.fasterxml.jackson.datatype</groupId>
-      <artifactId>jackson-datatype-jdk8</artifactId>
     </dependency>
 
     <!-- Test dependencies -->
@@ -44,18 +32,11 @@
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
-
-  <build>
-    <plugins>
-      <plugin>
-        <artifactId>maven-dependency-plugin</artifactId>
-        <configuration>
-          <!-- jackson-core is used in both main and test code. Ignore the warning about test-only usage. -->
-          <ignoreAllNonTestScoped>true</ignoreAllNonTestScoped>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
 
 </project>

--- a/connector-commons/connector-object-mapper/src/main/java/io/camunda/connector/jackson/ConnectorsObjectMapperSupplier.java
+++ b/connector-commons/connector-object-mapper/src/main/java/io/camunda/connector/jackson/ConnectorsObjectMapperSupplier.java
@@ -16,33 +16,35 @@
  */
 package io.camunda.connector.jackson;
 
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.MapperFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.databind.json.JsonMapper;
-import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import tools.jackson.databind.DeserializationFeature;
+import tools.jackson.databind.MapperFeature;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.SerializationFeature;
+import tools.jackson.databind.cfg.DateTimeFeature;
+import tools.jackson.databind.cfg.EnumFeature;
+import tools.jackson.databind.json.JsonMapper;
 
 /** Default ObjectMapper supplier to be used by OOTB connectors and the Connector runtime. */
 public class ConnectorsObjectMapperSupplier {
 
   private static final ObjectMapper DEFAULT_MAPPER =
       JsonMapper.builder()
-          .addModules(new Jdk8Module(), new JavaTimeModule())
           .disable(SerializationFeature.FAIL_ON_EMPTY_BEANS)
           .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+          // Jackson 3 flips this feature's default to enabled; disabled here to keep this
+          // mapper's null-handling identical to its Jackson 2 behavior.
+          .disable(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES)
           .enable(MapperFeature.ACCEPT_CASE_INSENSITIVE_ENUMS)
-          .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
-          .disable(SerializationFeature.WRITE_DURATIONS_AS_TIMESTAMPS)
+          .disable(DateTimeFeature.WRITE_DATES_AS_TIMESTAMPS)
+          .disable(DateTimeFeature.WRITE_DURATIONS_AS_TIMESTAMPS)
           .enable(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY)
           .enable(DeserializationFeature.UNWRAP_SINGLE_VALUE_ARRAYS)
-          .enable(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE)
+          .enable(EnumFeature.READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE)
           .build();
 
   private ConnectorsObjectMapperSupplier() {}
 
   public static ObjectMapper getCopy() {
-    return DEFAULT_MAPPER.copy();
+    return DEFAULT_MAPPER.rebuild().build();
   }
 }

--- a/connector-commons/connector-object-mapper/src/test/java/io/camunda/connector/jackson/ConnectorsObjectMapperSupplierTest.java
+++ b/connector-commons/connector-object-mapper/src/test/java/io/camunda/connector/jackson/ConnectorsObjectMapperSupplierTest.java
@@ -19,19 +19,18 @@ package io.camunda.connector.jackson;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.annotation.JsonEnumDefaultValue;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.exc.MismatchedInputException;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.exc.MismatchedInputException;
 
 class ConnectorsObjectMapperSupplierTest {
 
   @Test
-  void java8DatesShouldBeSupported() throws JsonProcessingException {
+  void java8DatesShouldBeSupported() {
     final var objectMapper = ConnectorsObjectMapperSupplier.getCopy();
     final var json = "{\"data\":\"2024-01-01\"}";
     final var jsonDeserialized = Map.of("data", LocalDate.of(2024, 1, 1));
@@ -41,7 +40,7 @@ class ConnectorsObjectMapperSupplierTest {
   }
 
   @Test
-  void singlePrimitiveValueShouldBeAcceptedAsArray() throws JsonProcessingException {
+  void singlePrimitiveValueShouldBeAcceptedAsArray() {
     final var objectMapper = ConnectorsObjectMapperSupplier.getCopy();
     final var json = "1";
     var actual = objectMapper.readValue(json, int[].class);
@@ -49,7 +48,7 @@ class ConnectorsObjectMapperSupplierTest {
   }
 
   @Test
-  void singleElementStringArrayBindingToObject() throws JsonProcessingException {
+  void singleElementStringArrayBindingToObject() {
     final var objectMapper = ConnectorsObjectMapperSupplier.getCopy();
     final var json = "{\"value\":" + objectMapper.writeValueAsString(List.of("hey")) + "}";
     var actual = objectMapper.readValue(json, TestRecordWithString.class);
@@ -57,7 +56,7 @@ class ConnectorsObjectMapperSupplierTest {
   }
 
   @Test
-  void multipleElementStringArrayShouldNotBindToObject() throws JsonProcessingException {
+  void multipleElementStringArrayShouldNotBindToObject() {
     final var objectMapper = ConnectorsObjectMapperSupplier.getCopy();
     final var json = "{\"value\":" + objectMapper.writeValueAsString(List.of("hey", "yo")) + "}";
     Assertions.assertThatThrownBy(() -> objectMapper.readValue(json, TestRecordWithString.class))
@@ -67,7 +66,7 @@ class ConnectorsObjectMapperSupplierTest {
   private record TestRecordWithString(String value) {}
 
   @Test
-  void unknownEnumValueShouldBeDeserializedUsingDefaultValue() throws JsonProcessingException {
+  void unknownEnumValueShouldBeDeserializedUsingDefaultValue() {
     final var objectMapper = ConnectorsObjectMapperSupplier.getCopy();
     final var json = "{\"status\":\"PAUSED\"}";
     var actual = objectMapper.readValue(json, TestRecordWithEnum.class);

--- a/connector-commons/http-client/pom.xml
+++ b/connector-commons/http-client/pom.xml
@@ -15,7 +15,6 @@
   <artifactId>http-client</artifactId>
   <packaging>jar</packaging>
 
-
   <properties>
     <license.inlineheader>Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
 under one or more contributor license agreements. See the NOTICE file
@@ -39,16 +38,8 @@ limitations under the License.</license.inlineheader>
       <artifactId>slf4j-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
+      <groupId>tools.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>com.fasterxml.jackson.datatype</groupId>
-      <artifactId>jackson-datatype-jdk8</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>com.fasterxml.jackson.datatype</groupId>
-      <artifactId>jackson-datatype-jsr310</artifactId>
     </dependency>
     <dependency>
       <groupId>com.google.http-client</groupId>

--- a/connector-commons/http-client/src/main/java/io/camunda/connector/http/client/HttpClientObjectMapperSupplier.java
+++ b/connector-commons/http-client/src/main/java/io/camunda/connector/http/client/HttpClientObjectMapperSupplier.java
@@ -16,13 +16,13 @@
  */
 package io.camunda.connector.http.client;
 
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.MapperFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.databind.json.JsonMapper;
-import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import tools.jackson.databind.DeserializationFeature;
+import tools.jackson.databind.MapperFeature;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.SerializationFeature;
+import tools.jackson.databind.cfg.DateTimeFeature;
+import tools.jackson.databind.cfg.EnumFeature;
+import tools.jackson.databind.json.JsonMapper;
 
 /**
  * ObjectMapper instance supplier for HTTP client operations. This is separate from the shared
@@ -34,20 +34,22 @@ public class HttpClientObjectMapperSupplier {
 
   private static final ObjectMapper DEFAULT_MAPPER =
       JsonMapper.builder()
-          .addModules(new Jdk8Module(), new JavaTimeModule())
           .disable(SerializationFeature.FAIL_ON_EMPTY_BEANS)
           .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+          // Jackson 3 flips this feature's default to enabled; disabled here to keep this
+          // mapper's null-handling identical to its Jackson 2 behavior.
+          .disable(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES)
           .enable(MapperFeature.ACCEPT_CASE_INSENSITIVE_ENUMS)
-          .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
-          .disable(SerializationFeature.WRITE_DURATIONS_AS_TIMESTAMPS)
+          .disable(DateTimeFeature.WRITE_DATES_AS_TIMESTAMPS)
+          .disable(DateTimeFeature.WRITE_DURATIONS_AS_TIMESTAMPS)
           .enable(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY)
           .enable(DeserializationFeature.UNWRAP_SINGLE_VALUE_ARRAYS)
-          .enable(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE)
+          .enable(EnumFeature.READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE)
           .build();
 
   private HttpClientObjectMapperSupplier() {}
 
   public static ObjectMapper getCopy() {
-    return DEFAULT_MAPPER.copy();
+    return DEFAULT_MAPPER.rebuild().build();
   }
 }

--- a/connector-commons/http-client/src/main/java/io/camunda/connector/http/client/authentication/OAuthService.java
+++ b/connector-commons/http-client/src/main/java/io/camunda/connector/http/client/authentication/OAuthService.java
@@ -16,8 +16,6 @@
  */
 package io.camunda.connector.http.client.authentication;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.connector.api.error.ConnectorException;
 import io.camunda.connector.http.client.HttpClientObjectMapperSupplier;
 import io.camunda.connector.http.client.mapper.ResponseMappers;
@@ -31,6 +29,8 @@ import java.util.Map;
 import java.util.Optional;
 import org.apache.hc.core5.http.ContentType;
 import org.apache.hc.core5.http.HttpHeaders;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
 
 public class OAuthService {
 

--- a/connector-commons/http-client/src/main/java/io/camunda/connector/http/client/client/apache/builder/parts/ApacheRequestBodyBuilder.java
+++ b/connector-commons/http-client/src/main/java/io/camunda/connector/http/client/client/apache/builder/parts/ApacheRequestBodyBuilder.java
@@ -20,8 +20,6 @@ import static org.apache.hc.core5.http.ContentType.MULTIPART_FORM_DATA;
 import static org.apache.hc.core5.http.HttpHeaders.CONTENT_TYPE;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.connector.api.document.Document;
 import io.camunda.connector.api.error.ConnectorException;
 import io.camunda.connector.http.client.HttpClientObjectMapperSupplier;
@@ -39,6 +37,8 @@ import org.apache.hc.core5.http.io.support.ClassicRequestBuilder;
 import org.apache.hc.core5.http.message.BasicNameValuePair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
 
 /**
  * Maps the request body of a {@link HttpClientRequest} to an Apache {@link ClassicRequestBuilder}.
@@ -50,7 +50,10 @@ public class ApacheRequestBodyBuilder implements ApacheRequestPartBuilder {
   public static final String EMPTY_BODY = "";
   public static final ObjectMapper mapperIgnoreNull =
       HttpClientObjectMapperSupplier.getCopy()
-          .setSerializationInclusion(JsonInclude.Include.NON_NULL);
+          .rebuild()
+          .changeDefaultPropertyInclusion(
+              incl -> incl.withValueInclusion(JsonInclude.Include.NON_NULL))
+          .build();
   public static final ObjectMapper mapperSendNull = HttpClientObjectMapperSupplier.getCopy();
 
   @Override
@@ -113,7 +116,7 @@ public class ApacheRequestBodyBuilder implements ApacheRequestPartBuilder {
                   ? mapperIgnoreNull.writeValueAsString(body)
                   : mapperSendNull.writeValueAsString(body),
               contentType.orElse(ContentType.APPLICATION_JSON.withCharset(StandardCharsets.UTF_8)));
-    } catch (JsonProcessingException e) {
+    } catch (JacksonException e) {
       throw new ConnectorException("Failed to serialize request body:" + body, e);
     }
   }

--- a/connector-commons/http-client/src/main/java/io/camunda/connector/http/client/mapper/ResponseMappers.java
+++ b/connector-commons/http-client/src/main/java/io/camunda/connector/http/client/mapper/ResponseMappers.java
@@ -16,15 +16,15 @@
  */
 package io.camunda.connector.http.client.mapper;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.connector.api.error.ConnectorException;
 import io.camunda.connector.http.client.utils.EnvVarHelper;
 import io.camunda.connector.http.client.utils.JsonHelper;
 import java.io.IOException;
 import java.util.function.Supplier;
 import org.apache.commons.lang3.StringUtils;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
 
 /**
  * Common {@link ResponseMapper} implementations.
@@ -53,7 +53,7 @@ public final class ResponseMappers {
       var mapper = objectMapperSupplier.get();
       try {
         return mapper.readValue(asString(response), valueType);
-      } catch (IOException e) {
+      } catch (JacksonException e) {
         throw new ConnectorException(
             "Failed to map response body to type " + valueType.getSimpleName(), e);
       }
@@ -114,7 +114,7 @@ public final class ResponseMappers {
     }
     try {
       return objectMapper.readTree(stringBody);
-    } catch (JsonProcessingException e) {
+    } catch (JacksonException e) {
       throw new ConnectorException("Failed to parse JSON string: " + stringBody, e);
     }
   }

--- a/connector-commons/http-client/src/main/java/io/camunda/connector/http/client/utils/JsonHelper.java
+++ b/connector-commons/http-client/src/main/java/io/camunda/connector/http/client/utils/JsonHelper.java
@@ -16,10 +16,10 @@
  */
 package io.camunda.connector.http.client.utils;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.connector.http.client.HttpClientObjectMapperSupplier;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
 
 public class JsonHelper {
 
@@ -32,7 +32,7 @@ public class JsonHelper {
     try {
       JsonNode jsonNode = objectMapper.readTree(jsonString);
       return jsonNode.isObject() || jsonNode.isArray();
-    } catch (JsonProcessingException e) {
+    } catch (JacksonException e) {
       return false;
     }
   }

--- a/connector-commons/http-client/src/test/java/io/camunda/connector/http/client/authentication/OAuthRefreshTokenServiceTest.java
+++ b/connector-commons/http-client/src/test/java/io/camunda/connector/http/client/authentication/OAuthRefreshTokenServiceTest.java
@@ -19,8 +19,6 @@ package io.camunda.connector.http.client.authentication;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.connector.api.error.ConnectorException;
 import io.camunda.connector.http.client.HttpClientObjectMapperSupplier;
 import io.camunda.connector.http.client.mapper.StreamingHttpResponse;
@@ -30,6 +28,7 @@ import java.io.ByteArrayInputStream;
 import java.util.Map;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import tools.jackson.databind.ObjectMapper;
 
 public class OAuthRefreshTokenServiceTest {
 
@@ -88,7 +87,7 @@ public class OAuthRefreshTokenServiceTest {
   class ExtractTokenFromRefreshTokenResponseTests {
 
     @Test
-    void shouldReturnToken_whenResponseContainsAccessToken() throws JsonProcessingException {
+    void shouldReturnToken_whenResponseContainsAccessToken() {
       var body =
           Map.of(
               "access_token", "myAccessToken",

--- a/connector-commons/http-client/src/test/java/io/camunda/connector/http/client/authentication/OAuthServiceTest.java
+++ b/connector-commons/http-client/src/test/java/io/camunda/connector/http/client/authentication/OAuthServiceTest.java
@@ -19,8 +19,6 @@ package io.camunda.connector.http.client.authentication;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.connector.api.error.ConnectorException;
 import io.camunda.connector.http.client.HttpClientObjectMapperSupplier;
 import io.camunda.connector.http.client.mapper.StreamingHttpResponse;
@@ -30,6 +28,7 @@ import java.io.ByteArrayInputStream;
 import java.util.Map;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import tools.jackson.databind.ObjectMapper;
 
 public class OAuthServiceTest {
 
@@ -116,8 +115,7 @@ public class OAuthServiceTest {
     }
 
     @Test
-    public void shouldReturnToken_whenExtractingTokenFromValidJson()
-        throws JsonProcessingException {
+    public void shouldReturnToken_whenExtractingTokenFromValidJson() {
       // Given
       var body =
           Map.of(

--- a/connector-commons/http-client/src/test/java/io/camunda/connector/http/client/client/apache/CustomApacheHttpClientTest.java
+++ b/connector-commons/http-client/src/test/java/io/camunda/connector/http/client/client/apache/CustomApacheHttpClientTest.java
@@ -23,8 +23,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static uk.org.webcompere.systemstubs.SystemStubs.restoreSystemProperties;
 import static uk.org.webcompere.systemstubs.SystemStubs.withEnvironmentVariables;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
 import com.github.tomakehurst.wiremock.junit5.WireMockTest;
@@ -61,6 +59,8 @@ import org.testcontainers.Testcontainers;
 import org.testcontainers.containers.BindMode;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.utility.DockerImageName;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
 import wiremock.com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import wiremock.com.fasterxml.jackson.databind.node.POJONode;
 

--- a/connector-commons/http-client/src/test/java/io/camunda/connector/http/client/client/apache/CustomResponseHandlerTest.java
+++ b/connector-commons/http-client/src/test/java/io/camunda/connector/http/client/client/apache/CustomResponseHandlerTest.java
@@ -19,7 +19,6 @@ package io.camunda.connector.http.client.client.apache;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import io.camunda.connector.api.error.ConnectorException;
 import io.camunda.connector.http.client.HttpClientObjectMapperSupplier;
 import io.camunda.connector.http.client.mapper.HttpResponse;
@@ -32,6 +31,7 @@ import org.apache.hc.core5.http.io.entity.StringEntity;
 import org.apache.hc.core5.http.message.BasicClassicHttpResponse;
 import org.apache.hc.core5.http.message.BasicHeader;
 import org.junit.jupiter.api.Test;
+import tools.jackson.databind.JsonNode;
 
 public class CustomResponseHandlerTest {
 

--- a/connector-runtime/connector-feel/pom.xml
+++ b/connector-runtime/connector-feel/pom.xml
@@ -28,10 +28,6 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>io.camunda.connector</groupId>
-      <artifactId>connector-object-mapper</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.camunda.feel</groupId>
       <artifactId>feel-engine</artifactId>
     </dependency>

--- a/connector-runtime/connector-feel/src/main/java/io/camunda/connector/feel/FeelEngineWrapperUtil.java
+++ b/connector-runtime/connector-feel/src/main/java/io/camunda/connector/feel/FeelEngineWrapperUtil.java
@@ -16,10 +16,10 @@
  */
 package io.camunda.connector.feel;
 
+import static io.camunda.connector.feel.JacksonSupport.DEFAULT_OBJECT_MAPPER;
 import static io.camunda.connector.feel.JacksonSupport.MAP_TYPE_REFERENCE;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.camunda.connector.jackson.ConnectorsObjectMapperSupplier;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
@@ -33,8 +33,6 @@ public class FeelEngineWrapperUtil {
 
   private static final Logger LOG = LoggerFactory.getLogger(FeelEngineWrapperUtil.class);
   private static final String ERROR_CONTEXT_IS_NULL = "Context is null";
-  private static final ObjectMapper DEFAULT_OBJECT_MAPPER =
-      ConnectorsObjectMapperSupplier.getCopy();
 
   public static Map<String, Object> wrapResponse(Object response) {
     Map<String, Object> responseContext = new HashMap<>();

--- a/connector-runtime/connector-feel/src/main/java/io/camunda/connector/feel/FeelExpressionEvaluatorBuilder.java
+++ b/connector-runtime/connector-feel/src/main/java/io/camunda/connector/feel/FeelExpressionEvaluatorBuilder.java
@@ -18,7 +18,6 @@ package io.camunda.connector.feel;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.client.CamundaClient;
-import io.camunda.connector.jackson.ConnectorsObjectMapperSupplier;
 
 /**
  * Step builder for {@link FeelExpressionEvaluator} instances. The entry points return distinct
@@ -93,7 +92,7 @@ public final class FeelExpressionEvaluatorBuilder {
 
     public FeelExpressionEvaluator build() {
       ObjectMapper mapper =
-          objectMapper != null ? objectMapper : ConnectorsObjectMapperSupplier.getCopy();
+          objectMapper != null ? objectMapper : JacksonSupport.DEFAULT_OBJECT_MAPPER;
       return new CamundaClientFeelExpressionEvaluator(camundaClient, tenantId, scopeKey, mapper);
     }
   }

--- a/connector-runtime/connector-feel/src/main/java/io/camunda/connector/feel/JacksonSupport.java
+++ b/connector-runtime/connector-feel/src/main/java/io/camunda/connector/feel/JacksonSupport.java
@@ -17,9 +17,34 @@
 package io.camunda.connector.feel;
 
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.MapperFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import java.util.Map;
 
 public class JacksonSupport {
   public static final TypeReference<Map<String, Object>> MAP_TYPE_REFERENCE =
       new TypeReference<>() {};
+
+  /**
+   * Deliberately a standalone Jackson 2 mapper rather than {@code ConnectorsObjectMapperSupplier} —
+   * this module stays on Jackson 2 because it depends on jackson-module-scala, which has no Jackson
+   * 3 release yet, and {@code ConnectorsObjectMapperSupplier} is Jackson 3-only.
+   */
+  public static final ObjectMapper DEFAULT_OBJECT_MAPPER =
+      JsonMapper.builder()
+          .addModules(new Jdk8Module(), new JavaTimeModule())
+          .disable(SerializationFeature.FAIL_ON_EMPTY_BEANS)
+          .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+          .enable(MapperFeature.ACCEPT_CASE_INSENSITIVE_ENUMS)
+          .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+          .disable(SerializationFeature.WRITE_DURATIONS_AS_TIMESTAMPS)
+          .enable(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY)
+          .enable(DeserializationFeature.UNWRAP_SINGLE_VALUE_ARRAYS)
+          .enable(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE)
+          .build();
 }

--- a/connector-runtime/connector-runtime-core/pom.xml
+++ b/connector-runtime/connector-runtime-core/pom.xml
@@ -31,7 +31,7 @@
     </dependency>
 
     <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
+      <groupId>tools.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
     </dependency>
 
@@ -173,14 +173,22 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.fasterxml.jackson.datatype</groupId>
-      <artifactId>jackson-datatype-jdk8</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>jakarta.validation</groupId>
       <artifactId>jakarta.validation-api</artifactId>
       <scope>test</scope>
+    </dependency>
+    <!-- Jackson 2: several classes in this module (e.g. InstanceForwardingHttpClient,
+         DeduplicationPropertyResolver, GetJsonFunction, SecretUtil) are still Jackson 2-only, not
+         yet migrated as part of #5910. Declared explicitly at compile scope rather than relying on
+         the transitive dependency from connector-feel, whose scope a closer (test-scoped)
+         declaration here would otherwise have shadowed. -->
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
     </dependency>
 
   </dependencies>

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/ConnectorResultHandler.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/ConnectorResultHandler.java
@@ -19,15 +19,12 @@ package io.camunda.connector.runtime.core;
 import static io.camunda.connector.feel.FeelEngineWrapperUtil.wrapResponse;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.connector.api.document.DocumentFactory;
 import io.camunda.connector.api.error.ConnectorInputException;
 import io.camunda.connector.api.inbound.InboundConnectorExecutable;
 import io.camunda.connector.api.outbound.OutboundConnectorFunction;
 import io.camunda.connector.document.jackson.IntrinsicFunctionModel;
-import io.camunda.connector.document.jackson.JacksonModuleDocumentSerializer;
+import io.camunda.connector.document.jackson.v3.JacksonModuleDocumentSerializer;
 import io.camunda.connector.feel.FeelConnectorFunctionProvider;
 import io.camunda.connector.feel.FeelEngineWrapperException;
 import io.camunda.connector.feel.FeelExpressionEvaluator;
@@ -36,12 +33,14 @@ import io.camunda.connector.runtime.core.document.ResultDocumentResolver;
 import io.camunda.connector.runtime.core.error.BpmnError;
 import io.camunda.connector.runtime.core.error.ConnectorError;
 import io.camunda.connector.runtime.core.outbound.ErrorExpressionJobContext;
-import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import org.jspecify.annotations.Nullable;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
 
 public class ConnectorResultHandler {
 
@@ -57,22 +56,24 @@ public class ConnectorResultHandler {
   /**
    * @param objectMapper used for everything except serializing a resolved {@link
    *     io.camunda.connector.api.document.Document} back to JSON, which instead uses a private
-   *     {@code .copy()} with {@code JacksonModuleDocumentSerializer} registered on it: a caller
-   *     that omitted that module on {@code objectMapper} would otherwise not fail loudly — since
-   *     {@code ConnectorsObjectMapperSupplier} disables {@code FAIL_ON_EMPTY_BEANS} — but instead
-   *     silently serialize the just-created {@code Document} as {@code {}}, uploading it and then
-   *     losing the only reference to it. Copying rather than mutating {@code objectMapper} in place
-   *     avoids surprising callers who share that instance for unrelated serialization. Falls back
-   *     to {@code objectMapper} itself if {@code copy()} returns {@code null} — a real {@code
+   *     rebuild with {@code JacksonModuleDocumentSerializer} added to it: a caller that omitted
+   *     that module on {@code objectMapper} would otherwise not fail loudly — since {@code
+   *     ConnectorsObjectMapperSupplier} disables {@code FAIL_ON_EMPTY_BEANS} — but instead silently
+   *     serialize the just-created {@code Document} as {@code {}}, uploading it and then losing the
+   *     only reference to it. Rebuilding rather than mutating {@code objectMapper} in place avoids
+   *     surprising callers who share that instance for unrelated serialization. Falls back to
+   *     {@code objectMapper} itself if {@code rebuild()} returns {@code null} — a real {@code
    *     ObjectMapper} never does this, but a test double (e.g. a bare {@code
    *     mock(ObjectMapper.class)} with no stubbing) can, and such callers are by construction not
    *     relying on real Document serialization anyway.
    */
   public ConnectorResultHandler(ObjectMapper objectMapper, DocumentFactory documentFactory) {
     this.objectMapper = objectMapper;
-    ObjectMapper copy = objectMapper.copy();
+    var builder = objectMapper.rebuild();
     this.documentSerializingObjectMapper =
-        copy != null ? copy.registerModule(new JacksonModuleDocumentSerializer()) : objectMapper;
+        builder != null
+            ? builder.addModule(new JacksonModuleDocumentSerializer()).build()
+            : objectMapper;
     this.documentResolver = new ResultDocumentResolver(documentFactory);
   }
 
@@ -207,23 +208,14 @@ public class ConnectorResultHandler {
       }
       return objectMapper
           .reader()
+          .forType(type)
           .withAttribute(DocumentFactory.PHYSICAL_TENANT_ID_ATTRIBUTE, physicalTenantId)
-          .readValue(jsonVars, type);
+          .readValue(jsonVars);
     } catch (ConnectorInputException e) {
       // Re-throw our custom exception
       throw e;
-    } catch (JsonProcessingException e) {
+    } catch (JacksonException e) {
       // For other types (like ConnectorError), keep the original message
-      throw new ConnectorInputException(
-          new FeelEngineWrapperException(
-              String.format(ERROR_CANNOT_PARSE_VARIABLES, jsonVars, type.getName()),
-              expression,
-              jsonVars,
-              e));
-    } catch (IOException e) {
-      // ObjectReader#readValue declares the broader IOException (unlike ObjectMapper#readValue's
-      // JsonProcessingException), though in practice this path only ever throws for JSON-parsing
-      // reasons already covered above; kept for exhaustiveness.
       throw new ConnectorInputException(
           new FeelEngineWrapperException(
               String.format(ERROR_CANNOT_PARSE_VARIABLES, jsonVars, type.getName()),
@@ -251,7 +243,7 @@ public class ConnectorResultHandler {
     final JsonNode node;
     try {
       node = objectMapper.readTree(json);
-    } catch (JsonProcessingException e) {
+    } catch (JacksonException e) {
       throw new ConnectorInputException(
           new FeelEngineWrapperException(
               String.format(ERROR_CANNOT_PARSE_VARIABLES, json, Map.class.getName()),
@@ -292,7 +284,7 @@ public class ConnectorResultHandler {
     final Object resolved = documentResolver.resolve(node, physicalTenantId, expectedNonce);
     try {
       return documentSerializingObjectMapper.writeValueAsString(resolved);
-    } catch (JsonProcessingException e) {
+    } catch (JacksonException e) {
       throw new ConnectorInputException(
           new FeelEngineWrapperException(
               String.format(

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/configuration/ConfigurationValidationService.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/configuration/ConfigurationValidationService.java
@@ -16,7 +16,6 @@
  */
 package io.camunda.connector.runtime.core.configuration;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.connector.api.error.ConnectorException;
 import io.camunda.connector.api.secret.SecretContext;
 import io.camunda.connector.api.secret.SecretProvider;
@@ -31,6 +30,7 @@ import io.camunda.connector.runtime.core.secret.SecretHandler;
 import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import tools.jackson.databind.ObjectMapper;
 
 /**
  * Resolves a stored configuration referenced by a validation request, applies bean validation, and

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/document/DocumentReturnProcessor.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/document/DocumentReturnProcessor.java
@@ -16,9 +16,6 @@
  */
 package io.camunda.connector.runtime.core.document;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.connector.api.document.DocumentCreationRequest;
 import io.camunda.connector.api.document.DocumentFactory;
 import io.camunda.connector.api.document.DocumentReturn;
@@ -34,6 +31,9 @@ import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
 
 /**
  * Converts a {@link DocumentReturn} value produced by a connector into the connector's final
@@ -114,7 +114,7 @@ public class DocumentReturnProcessor {
     }
   }
 
-  private Object parseJson(byte[] bytes) throws IOException {
+  private Object parseJson(byte[] bytes) {
     try {
       JsonNode node = objectMapper.readTree(bytes);
       if (node == null || node.isMissingNode()) {
@@ -122,7 +122,7 @@ public class DocumentReturnProcessor {
             "JSON response format selected but payload was empty or could not be parsed.");
       }
       return objectMapper.treeToValue(node, Object.class);
-    } catch (JsonProcessingException e) {
+    } catch (JacksonException e) {
       throw new ConnectorException(
           null,
           "JSON response format selected but payload is not valid JSON: " + e.getMessage(),

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/document/ResultDocumentResolver.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/document/ResultDocumentResolver.java
@@ -16,7 +16,6 @@
  */
 package io.camunda.connector.runtime.core.document;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import io.camunda.connector.api.document.Document;
 import io.camunda.connector.api.document.DocumentCreationRequest;
 import io.camunda.connector.api.document.DocumentFactory;
@@ -29,6 +28,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import org.jspecify.annotations.Nullable;
+import tools.jackson.databind.JsonNode;
 
 /**
  * Resolves {@code createDocument(...)} sentinel markers produced by {@code

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/DefaultInboundConnectorContextFactory.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/DefaultInboundConnectorContextFactory.java
@@ -16,7 +16,6 @@
  */
 package io.camunda.connector.runtime.core.inbound;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.client.CamundaClient;
 import io.camunda.connector.api.document.DocumentFactory;
 import io.camunda.connector.api.inbound.InboundConnectorContext;
@@ -31,6 +30,7 @@ import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.Objects;
 import java.util.function.Consumer;
+import tools.jackson.databind.ObjectMapper;
 
 public class DefaultInboundConnectorContextFactory implements InboundConnectorContextFactory {
   private final ObjectMapper objectMapper;

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/DefaultProcessInstanceContext.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/DefaultProcessInstanceContext.java
@@ -16,8 +16,6 @@
  */
 package io.camunda.connector.runtime.core.inbound;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.search.response.ElementInstance;
 import io.camunda.connector.api.document.DocumentFactory;
@@ -30,7 +28,9 @@ import io.camunda.connector.feel.FeelExpressionEvaluatorBuilder;
 import io.camunda.connector.feel.jackson.FeelContextAwareObjectReader;
 import io.camunda.connector.runtime.core.inbound.correlation.InboundCorrelationHandler;
 import io.camunda.connector.runtime.core.validation.ValidationUtil;
-import java.io.IOException;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
 
 public final class DefaultProcessInstanceContext implements ProcessInstanceContext {
 
@@ -58,11 +58,15 @@ public final class DefaultProcessInstanceContext implements ProcessInstanceConte
             : validationProvider;
     this.correlationHandler = correlationHandler;
     this.objectMapper = objectMapper;
+    // Not passing .objectMapper(objectMapper): connector-feel (and this cluster evaluator) is
+    // Jackson 2-only (blocked on jackson-module-scala shipping a Jackson 3 release), while
+    // objectMapper here is Jackson 3. The evaluator falls back to its own default Jackson 2
+    // mapper, used only to merge input variables into a map for FEEL evaluation — not for final
+    // result deserialization, which goes through FeelContextAwareObjectReader below instead.
     this.evaluator =
         FeelExpressionEvaluatorBuilder.camundaClient(camundaClient)
             .tenantId(context.getDefinition().tenantId())
             .scopeKey(elementInstance.getElementInstanceKey())
-            .objectMapper(objectMapper)
             .build();
     this.processDefinitionProperties = objectMapper.valueToTree(context.getProperties());
   }
@@ -86,10 +90,11 @@ public final class DefaultProcessInstanceContext implements ProcessInstanceConte
               .withAttribute(
                   DocumentFactory.PHYSICAL_TENANT_ID_ATTRIBUTE,
                   context.getDefinition().physicalTenantId())
-              .readValue(processDefinitionProperties, cls);
+              .forType(cls)
+              .readValue(processDefinitionProperties);
       validationProvider.validate(mappedObject);
       return mappedObject;
-    } catch (IOException | FeelEngineWrapperException e) {
+    } catch (JacksonException | FeelEngineWrapperException e) {
       throw new RuntimeException(
           "Failed to bind process instance properties to "
               + cls.getName()

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextImpl.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextImpl.java
@@ -16,7 +16,6 @@
  */
 package io.camunda.connector.runtime.core.inbound;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.client.CamundaClient;
 import io.camunda.connector.api.document.Document;
 import io.camunda.connector.api.document.DocumentCreationRequest;
@@ -51,7 +50,6 @@ import io.camunda.connector.runtime.core.inbound.activitylog.ActivitySource;
 import io.camunda.connector.runtime.core.inbound.correlation.InboundCorrelationHandler;
 import io.camunda.connector.runtime.core.inbound.details.InboundConnectorDetails.ValidInboundConnectorDetails;
 import io.camunda.connector.runtime.core.secret.SecretFilter;
-import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -60,6 +58,8 @@ import java.util.stream.Collectors;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
 
 public class InboundConnectorContextImpl extends AbstractConnectorContext
     implements InboundConnectorContext, InboundConnectorManagementContext {
@@ -100,10 +100,14 @@ public class InboundConnectorContextImpl extends AbstractConnectorContext
     this.activityLogWriter = activityLogWriter;
     this.activationTimestamp = System.currentTimeMillis();
     this.camundaClient = Objects.requireNonNull(camundaClient, "camundaClient must not be null");
+    // Not passing .objectMapper(objectMapper): connector-feel (and this cluster evaluator) is
+    // Jackson 2-only (blocked on jackson-module-scala shipping a Jackson 3 release), while
+    // objectMapper here is Jackson 3. The evaluator falls back to its own default Jackson 2
+    // mapper, used only to merge input variables into a map for FEEL evaluation — not for final
+    // result deserialization, which goes through FeelContextAwareObjectReader below instead.
     this.evaluator =
         FeelExpressionEvaluatorBuilder.camundaClient(camundaClient)
             .tenantId(connectorDetails.tenantId())
-            .objectMapper(objectMapper)
             .build();
   }
 
@@ -318,14 +322,15 @@ public class InboundConnectorContextImpl extends AbstractConnectorContext
   public <T> T bindProperties(Class<T> cls) {
     try {
       var propertiesJson = objectMapper.valueToTree(getPropertiesWithSecrets(properties));
-      var result =
+      T result =
           FeelContextAwareObjectReader.of(objectMapper)
               .withEvaluator(evaluator)
               .withAttribute(DocumentFactory.PHYSICAL_TENANT_ID_ATTRIBUTE, physicalTenantId())
-              .readValue(propertiesJson, cls);
+              .forType(cls)
+              .readValue(propertiesJson);
       getValidationProvider().validate(result);
       return result;
-    } catch (IOException | FeelEngineWrapperException e) {
+    } catch (JacksonException | FeelEngineWrapperException e) {
       throw new RuntimeException(
           "Failed to bind process instance properties to "
               + cls.getName()
@@ -350,14 +355,15 @@ public class InboundConnectorContextImpl extends AbstractConnectorContext
                   connectorDetails.processDefinitionId(),
                   physicalTenantId()));
       var propertiesJson = objectMapper.valueToTree(withSecrets);
-      var result =
+      T result =
           FeelContextAwareObjectReader.of(objectMapper)
               .withEvaluator(evaluator)
               .withAttribute(DocumentFactory.PHYSICAL_TENANT_ID_ATTRIBUTE, physicalTenantId())
-              .readValue(propertiesJson, cls);
+              .forType(cls)
+              .readValue(propertiesJson);
       getValidationProvider().validate(result);
       return result;
-    } catch (IOException | FeelEngineWrapperException e) {
+    } catch (JacksonException | FeelEngineWrapperException e) {
       throw new RuntimeException(
           "Failed to bind element properties to "
               + cls.getName()

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/InboundIntermediateConnectorContextImpl.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/InboundIntermediateConnectorContextImpl.java
@@ -16,7 +16,6 @@
  */
 package io.camunda.connector.runtime.core.inbound;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.search.response.ElementInstance;
 import io.camunda.connector.api.document.Document;
@@ -31,6 +30,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
+import tools.jackson.databind.ObjectMapper;
 
 /**
  * Implementation of {@link InboundIntermediateConnectorContext} that extends {@link

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/InboundPropertyHandler.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/InboundPropertyHandler.java
@@ -16,9 +16,6 @@
  */
 package io.camunda.connector.runtime.core.inbound;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.connector.api.secret.SecretContext;
 import io.camunda.connector.runtime.core.secret.SecretHandler;
 import java.util.Arrays;
@@ -26,6 +23,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.ObjectMapper;
 
 public class InboundPropertyHandler {
 
@@ -117,7 +117,7 @@ public class InboundPropertyHandler {
       var propertiesWithSecretsJson =
           secretHandler.replaceSecrets(propertiesAsJsonString, secretContext);
       return objectMapper.readValue(propertiesWithSecretsJson, new TypeReference<>() {});
-    } catch (JsonProcessingException e) {
+    } catch (JacksonException e) {
       throw new RuntimeException(e);
     }
   }

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/correlation/InboundCorrelationHandler.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/correlation/InboundCorrelationHandler.java
@@ -16,8 +16,6 @@
  */
 package io.camunda.connector.runtime.core.inbound.correlation;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.command.ClientStatusException;
 import io.camunda.client.api.response.CorrelateMessageResponse;
@@ -46,6 +44,8 @@ import java.util.Objects;
 import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
 
 /** Component responsible for calling Zeebe to report an inbound event */
 public class InboundCorrelationHandler {
@@ -403,7 +403,7 @@ public class InboundCorrelationHandler {
     if (variables == null) return;
     try {
       InlineSizeGuard.check(objectMapper.writeValueAsBytes(variables).length);
-    } catch (JsonProcessingException e) {
+    } catch (JacksonException e) {
       throw new RuntimeException("Failed to serialize variables for size check", e);
     }
   }

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/intrinsic/DefaultIntrinsicFunctionExecutor.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/intrinsic/DefaultIntrinsicFunctionExecutor.java
@@ -16,10 +16,11 @@
  */
 package io.camunda.connector.runtime.core.intrinsic;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.connector.document.jackson.IntrinsicFunctionExecutor;
 import io.camunda.connector.document.jackson.IntrinsicFunctionParams;
 import java.util.Arrays;
+import java.util.function.Supplier;
+import tools.jackson.databind.ObjectMapper;
 
 /**
  * An implementation of {@link IntrinsicFunctionExecutor} that discovers operations via the service
@@ -30,7 +31,11 @@ public class DefaultIntrinsicFunctionExecutor implements IntrinsicFunctionExecut
   private final IntrinsicFunctionParameterBinder parameterBinder;
   private final IntrinsicFunctionRegistry registry;
 
-  public DefaultIntrinsicFunctionExecutor(ObjectMapper mapper) {
+  /**
+   * @param mapper resolved lazily: callers typically construct this executor before the final,
+   *     fully-configured {@link ObjectMapper} exists (see {@link MutableObjectMapperSupplier}).
+   */
+  public DefaultIntrinsicFunctionExecutor(Supplier<ObjectMapper> mapper) {
     this.parameterBinder = new IntrinsicFunctionParameterBinder(mapper);
     this.registry = new ServiceLoaderIntrinsicFunctionRegistry();
   }

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/intrinsic/IntrinsicFunctionParameterBinder.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/intrinsic/IntrinsicFunctionParameterBinder.java
@@ -16,19 +16,20 @@
  */
 package io.camunda.connector.runtime.core.intrinsic;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.connector.document.jackson.IntrinsicFunctionParams;
 import jakarta.annotation.Nullable;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.lang.reflect.Parameter;
 import java.util.List;
+import java.util.function.Supplier;
+import tools.jackson.databind.ObjectMapper;
 
 public class IntrinsicFunctionParameterBinder {
 
-  private final ObjectMapper objectMapper;
+  private final Supplier<ObjectMapper> objectMapper;
 
-  public IntrinsicFunctionParameterBinder(ObjectMapper objectMapper) {
+  public IntrinsicFunctionParameterBinder(Supplier<ObjectMapper> objectMapper) {
     this.objectMapper = objectMapper;
   }
 
@@ -65,7 +66,7 @@ public class IntrinsicFunctionParameterBinder {
       }
 
       try {
-        return objectMapper.convertValue(positionalParams.params().get(index), type);
+        return objectMapper.get().convertValue(positionalParams.params().get(index), type);
       } catch (IllegalArgumentException e) {
         throw new IllegalArgumentException(
             "Failed to convert parameter "

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/intrinsic/MutableObjectMapperSupplier.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/intrinsic/MutableObjectMapperSupplier.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.runtime.core.intrinsic;
+
+import java.util.function.Supplier;
+import tools.jackson.databind.ObjectMapper;
+
+/**
+ * Breaks the circular construction between an {@link ObjectMapper} and its document-deserializer
+ * module: the module needs an {@link DefaultIntrinsicFunctionExecutor} that can bind intrinsic
+ * function parameters through the very mapper the module is being registered onto. Jackson 3's
+ * {@code ObjectMapper} is immutable, so that final, fully-configured mapper does not exist yet when
+ * the executor is constructed. Callers construct this holder first, build the executor and
+ * deserializer module from it, build the final mapper, then call {@link #set} with it.
+ */
+public class MutableObjectMapperSupplier implements Supplier<ObjectMapper> {
+
+  private ObjectMapper mapper;
+
+  @Override
+  public ObjectMapper get() {
+    if (mapper == null) {
+      throw new IllegalStateException("ObjectMapper not yet set on this supplier");
+    }
+    return mapper;
+  }
+
+  public void set(ObjectMapper mapper) {
+    this.mapper = mapper;
+  }
+}

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/outbound/DefaultOutboundConnectorFactory.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/outbound/DefaultOutboundConnectorFactory.java
@@ -16,7 +16,6 @@
  */
 package io.camunda.connector.runtime.core.outbound;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.connector.api.annotation.OutboundConnector;
 import io.camunda.connector.api.outbound.OutboundConnectorFunction;
 import io.camunda.connector.api.outbound.OutboundConnectorProvider;
@@ -36,6 +35,7 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import tools.jackson.databind.ObjectMapper;
 
 public class DefaultOutboundConnectorFactory
     extends AbstractConnectorFactory<OutboundConnectorFunction, OutboundConnectorConfiguration>

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/outbound/JobHandlerContext.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/outbound/JobHandlerContext.java
@@ -16,12 +16,6 @@
  */
 package io.camunda.connector.runtime.core.outbound;
 
-import com.fasterxml.jackson.core.JsonParseException;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonMappingException;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.exc.*;
 import io.camunda.client.api.response.ActivatedJob;
 import io.camunda.connector.api.document.Document;
 import io.camunda.connector.api.document.DocumentCreationRequest;
@@ -40,6 +34,14 @@ import io.camunda.connector.runtime.core.secret.SecretFilter;
 import java.util.Objects;
 import java.util.Optional;
 import org.jspecify.annotations.Nullable;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.exc.StreamReadException;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.exc.InvalidFormatException;
+import tools.jackson.databind.exc.InvalidNullException;
+import tools.jackson.databind.exc.InvalidTypeIdException;
+import tools.jackson.databind.exc.PropertyBindingException;
 
 /**
  * Implementation of {@link io.camunda.connector.api.outbound.OutboundConnectorContext} passed on to
@@ -104,7 +106,7 @@ public class JobHandlerContext extends AbstractConnectorContext
     var jsonWithSecrets = getJsonReplacedWithSecrets();
     try {
       return objectMapper.readValue(jsonWithSecrets, cls);
-    } catch (JsonParseException e) {
+    } catch (StreamReadException e) {
       throw new ConnectorInputException("This is not a JSON object", e);
     } catch (InvalidFormatException
         | InvalidNullException
@@ -112,7 +114,7 @@ public class JobHandlerContext extends AbstractConnectorContext
         | PropertyBindingException e) {
       String errorMessage =
           e.getPath().stream()
-              .map(JsonMappingException.Reference::getFieldName)
+              .map(JacksonException.Reference::getPropertyName)
               .reduce((s, s2) -> s.concat(", ").concat(s2))
               .map("Json object contains an invalid field: "::concat)
               .map(
@@ -125,7 +127,7 @@ public class JobHandlerContext extends AbstractConnectorContext
               .orElse("Unexpected Error, Further investigation is needed");
 
       throw new ConnectorInputException(errorMessage, e);
-    } catch (JsonProcessingException e) {
+    } catch (JacksonException e) {
       throw new ConnectorInputException(e.getOriginalMessage(), e);
     }
   }

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/outbound/operation/ConnectorOperations.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/outbound/operation/ConnectorOperations.java
@@ -18,7 +18,6 @@ package io.camunda.connector.runtime.core.outbound.operation;
 
 import static io.camunda.connector.util.reflection.ReflectionUtil.*;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.connector.api.annotation.Header;
 import io.camunda.connector.api.annotation.Operation;
 import io.camunda.connector.api.annotation.Variable;
@@ -32,6 +31,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import tools.jackson.databind.ObjectMapper;
 
 public record ConnectorOperations(Object connector, Map<String, OperationInvoker> operations) {
 

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/outbound/operation/OperationInvoker.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/outbound/operation/OperationInvoker.java
@@ -16,22 +16,20 @@
  */
 package io.camunda.connector.runtime.core.outbound.operation;
 
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.JsonPointer;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JavaType;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.connector.api.error.ConnectorInputException;
 import io.camunda.connector.api.outbound.OutboundConnectorContext;
 import io.camunda.connector.api.validation.ValidationProvider;
 import io.camunda.connector.runtime.core.outbound.JobHandlerContext;
-import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Type;
 import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.JsonPointer;
+import tools.jackson.databind.JavaType;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
 
 public class OperationInvoker {
   private static final Logger log = LoggerFactory.getLogger(OperationInvoker.class);
@@ -128,9 +126,9 @@ public class OperationInvoker {
 
     JavaType javaType = mapper.getTypeFactory().constructType(type);
 
-    try (JsonParser parser = node.traverse(mapper)) {
-      return mapper.readValue(parser, javaType);
-    } catch (IOException ex) {
+    try {
+      return mapper.reader().forType(javaType).readValue(node);
+    } catch (JacksonException ex) {
       throw new RuntimeException(ex);
     }
   }
@@ -138,7 +136,7 @@ public class OperationInvoker {
   private JsonNode readJsonAsTree(String json, ObjectMapper mapper) {
     try {
       return mapper.readTree(json);
-    } catch (JsonProcessingException e) {
+    } catch (JacksonException e) {
       throw new RuntimeException(e);
     }
   }

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/outbound/operation/ParameterDescriptor.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/outbound/operation/ParameterDescriptor.java
@@ -16,8 +16,8 @@
  */
 package io.camunda.connector.runtime.core.outbound.operation;
 
-import com.fasterxml.jackson.core.JsonPointer;
 import java.lang.reflect.Type;
+import tools.jackson.core.JsonPointer;
 
 public sealed interface ParameterDescriptor {
 

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/ConnectorResultHandlerTest.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/ConnectorResultHandlerTest.java
@@ -19,13 +19,12 @@ package io.camunda.connector.runtime.core;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.connector.api.document.Document;
 import io.camunda.connector.api.document.DocumentFactory;
 import io.camunda.connector.api.error.ConnectorInputException;
 import io.camunda.connector.document.jackson.IntrinsicFunctionExecutor;
 import io.camunda.connector.document.jackson.JacksonModuleDocumentDeserializer;
-import io.camunda.connector.document.jackson.JacksonModuleDocumentSerializer;
+import io.camunda.connector.document.jackson.v3.JacksonModuleDocumentSerializer;
 import io.camunda.connector.jackson.ConnectorsObjectMapperSupplier;
 import io.camunda.connector.runtime.core.document.TestDocumentFactory;
 import io.camunda.connector.runtime.core.error.BpmnError;
@@ -40,12 +39,16 @@ import java.util.Map;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 
 class ConnectorResultHandlerTest {
 
   private final ObjectMapper objectMapper =
       ConnectorsObjectMapperSupplier.getCopy()
-          .registerModule(new JacksonModuleDocumentSerializer());
+          .rebuild()
+          .addModule(new JacksonModuleDocumentSerializer())
+          .build();
   private final TestDocumentFactory documentFactory = new TestDocumentFactory();
   private final ConnectorResultHandler connectorResultHandler =
       new ConnectorResultHandler(objectMapper, documentFactory);
@@ -478,12 +481,13 @@ class ConnectorResultHandlerTest {
     var expectedDocument = Mockito.mock(Document.class);
     Mockito.when(factoryB.resolve(Mockito.any())).thenReturn(expectedDocument);
     var multiTenantMapper =
-        new ObjectMapper()
-            .registerModule(
+        JsonMapper.builder()
+            .addModule(
                 new JacksonModuleDocumentDeserializer(
                     Map.of("tenant-a", factoryA, "tenant-b", factoryB),
                     Mockito.mock(IntrinsicFunctionExecutor.class),
-                    JacksonModuleDocumentDeserializer.DocumentModuleSettings.create()));
+                    JacksonModuleDocumentDeserializer.DocumentModuleSettings.create()))
+            .build();
     var handler =
         new ConnectorResultHandler(multiTenantMapper, Mockito.mock(DocumentFactory.class));
 

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/TestObjectMapperSupplier.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/TestObjectMapperSupplier.java
@@ -16,15 +16,16 @@
  */
 package io.camunda.connector.runtime.core;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.connector.document.jackson.JacksonModuleDocumentDeserializer;
 import io.camunda.connector.document.jackson.JacksonModuleDocumentDeserializer.DocumentModuleSettings;
-import io.camunda.connector.document.jackson.JacksonModuleDocumentSerializer;
+import io.camunda.connector.document.jackson.v3.JacksonModuleDocumentSerializer;
 import io.camunda.connector.feel.jackson.JacksonModuleFeelFunction;
 import io.camunda.connector.jackson.ConnectorsObjectMapperSupplier;
 import io.camunda.connector.runtime.core.document.DocumentFactoryImpl;
 import io.camunda.connector.runtime.core.document.store.InMemoryDocumentStore;
 import io.camunda.connector.runtime.core.intrinsic.DefaultIntrinsicFunctionExecutor;
+import io.camunda.connector.runtime.core.intrinsic.MutableObjectMapperSupplier;
+import tools.jackson.databind.ObjectMapper;
 
 public class TestObjectMapperSupplier {
 
@@ -33,13 +34,19 @@ public class TestObjectMapperSupplier {
   public static ObjectMapper getInstance() {
     var copy = ConnectorsObjectMapperSupplier.getCopy();
     var documentFactory = new DocumentFactoryImpl(InMemoryDocumentStore.INSTANCE);
-    var functionExecutor = new DefaultIntrinsicFunctionExecutor(copy);
+    var mapperHolder = new MutableObjectMapperSupplier();
+    var functionExecutor = new DefaultIntrinsicFunctionExecutor(mapperHolder);
     var jacksonModuleDocumentDeserializer =
         new JacksonModuleDocumentDeserializer(
             documentFactory, functionExecutor, DocumentModuleSettings.create());
-    return copy.registerModules(
-        jacksonModuleDocumentDeserializer,
-        new JacksonModuleFeelFunction(),
-        new JacksonModuleDocumentSerializer());
+    var finalMapper =
+        copy.rebuild()
+            .addModules(
+                jacksonModuleDocumentDeserializer,
+                new JacksonModuleFeelFunction(),
+                new JacksonModuleDocumentSerializer())
+            .build();
+    mapperHolder.set(finalMapper);
+    return finalMapper;
   }
 }

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/configuration/ConfigurationValidationServiceTest.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/configuration/ConfigurationValidationServiceTest.java
@@ -19,7 +19,6 @@ package io.camunda.connector.runtime.core.configuration;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.databind.JavaType;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.connector.api.annotation.Configuration;
 import io.camunda.connector.api.error.ConnectorException;
 import io.camunda.connector.api.secret.SecretContext;
@@ -34,6 +33,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
+import tools.jackson.databind.ObjectMapper;
 
 class ConfigurationValidationServiceTest {
 

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/document/BlankObjectMapperDocumentSerializationTest.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/document/BlankObjectMapperDocumentSerializationTest.java
@@ -18,7 +18,6 @@ package io.camunda.connector.runtime.core.document;
 
 import static org.assertj.core.api.Assertions.assertThatNoException;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.connector.document.jackson.DocumentReferenceModel.CamundaDocumentMetadataModel;
 import io.camunda.connector.document.jackson.DocumentReferenceModel.CamundaDocumentReferenceModel;
 import io.camunda.connector.feel.jackson.FeelContextAwareObjectReader;
@@ -26,6 +25,8 @@ import io.camunda.connector.feel.jackson.JacksonModuleFeelFunction;
 import java.util.Map;
 import java.util.function.Supplier;
 import org.junit.jupiter.api.Test;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 
 /**
  * Regression test for GitHub issue #6946.
@@ -59,7 +60,7 @@ class BlankObjectMapperDocumentSerializationTest {
 
   @Test
   void feelEvaluationWithDocumentInContextDoesNotThrow() {
-    ObjectMapper mapper = new ObjectMapper().registerModule(new JacksonModuleFeelFunction());
+    ObjectMapper mapper = JsonMapper.builder().addModule(new JacksonModuleFeelFunction()).build();
 
     var metadata = new CamundaDocumentMetadataModel(null, null, null, null, null, null, null);
     var reference = new CamundaDocumentReferenceModel("store-1", "doc-1", "hash-1", metadata);
@@ -81,6 +82,7 @@ class BlankObjectMapperDocumentSerializationTest {
             () ->
                 FeelContextAwareObjectReader.of(mapper)
                     .withStaticContext(feelContext)
-                    .readValue(json, TargetType.class));
+                    .forType(TargetType.class)
+                    .readValue(json));
   }
 }

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/document/DocumentDeserializationPhysicalTenantIdTest.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/document/DocumentDeserializationPhysicalTenantIdTest.java
@@ -21,18 +21,17 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import io.camunda.connector.api.document.Document;
 import io.camunda.connector.api.document.DocumentFactory;
 import io.camunda.connector.document.jackson.IntrinsicFunctionExecutor;
 import io.camunda.connector.document.jackson.JacksonModuleDocumentDeserializer;
 import io.camunda.connector.runtime.core.document.store.CamundaDocumentStore;
-import java.io.IOException;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 
 /**
  * Exercises the {@code Map<String, DocumentFactory>}-based {@link
@@ -51,26 +50,27 @@ class DocumentDeserializationPhysicalTenantIdTest {
   private final IntrinsicFunctionExecutor operationExecutor = mock(IntrinsicFunctionExecutor.class);
 
   private ObjectMapper mapperFor(Map<String, DocumentFactory> factoriesByPhysicalTenantId) {
-    return new ObjectMapper()
-        .registerModule(
+    return JsonMapper.builder()
+        .addModule(
             new JacksonModuleDocumentDeserializer(
                 factoriesByPhysicalTenantId,
                 operationExecutor,
                 JacksonModuleDocumentDeserializer.DocumentModuleSettings.create()))
-        .registerModule(new Jdk8Module());
+        .build();
   }
 
   @Test
-  void resolvesTheFactoryMatchingTheReaderAttribute() throws IOException {
+  void resolvesTheFactoryMatchingTheReaderAttribute() {
     var objectMapper = mapperFor(Map.of("tenant-a", factoryA, "tenant-b", factoryB));
     var ref = createDocumentMock("Hello from tenant B", null, storeB);
     var payload = Map.of("document", ref);
 
-    var result =
+    TargetTypeDocument result =
         objectMapper
             .reader()
             .withAttribute(DocumentFactory.PHYSICAL_TENANT_ID_ATTRIBUTE, "tenant-b")
-            .readValue(objectMapper.valueToTree(payload).toString(), TargetTypeDocument.class);
+            .forType(TargetTypeDocument.class)
+            .readValue(objectMapper.valueToTree(payload).toString());
 
     assertThat(result.document().reference()).isEqualTo(ref);
   }
@@ -109,8 +109,8 @@ class DocumentDeserializationPhysicalTenantIdTest {
                 objectMapper
                     .reader()
                     .withAttribute(DocumentFactory.PHYSICAL_TENANT_ID_ATTRIBUTE, "tenant-unknown")
-                    .readValue(
-                        objectMapper.valueToTree(payload).toString(), TargetTypeDocument.class))
+                    .forType(TargetTypeDocument.class)
+                    .readValue(objectMapper.valueToTree(payload).toString()))
         .hasCauseInstanceOf(IllegalStateException.class)
         .cause()
         .hasMessageContaining("No DocumentFactory configured for physical tenant 'tenant-unknown'");

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/document/DocumentDeserializationTest.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/document/DocumentDeserializationTest.java
@@ -21,8 +21,6 @@ import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import io.camunda.connector.api.document.Document;
 import io.camunda.connector.api.document.DocumentFactory;
 import io.camunda.connector.document.jackson.DocumentReferenceModel;
@@ -43,6 +41,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 
 @ExtendWith(MockitoExtension.class)
 public class DocumentDeserializationTest {
@@ -56,9 +56,9 @@ public class DocumentDeserializationTest {
   @BeforeEach
   public void initialize() {
     objectMapper =
-        new ObjectMapper()
-            .registerModule(new JacksonModuleDocumentDeserializer(factory, operationExecutor))
-            .registerModule(new Jdk8Module());
+        JsonMapper.builder()
+            .addModule(new JacksonModuleDocumentDeserializer(factory, operationExecutor))
+            .build();
   }
 
   @Test

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/document/DocumentMapperTest.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/document/DocumentMapperTest.java
@@ -18,9 +18,6 @@ package io.camunda.connector.runtime.core.document;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonMappingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.connector.api.document.Document;
 import io.camunda.connector.document.jackson.DocumentReferenceModel.CamundaDocumentReferenceModel;
 import io.camunda.connector.document.jackson.JacksonModuleDocumentDeserializer;
@@ -28,26 +25,37 @@ import io.camunda.connector.document.jackson.JacksonModuleDocumentDeserializer.D
 import io.camunda.connector.jackson.ConnectorsObjectMapperSupplier;
 import io.camunda.connector.runtime.core.document.store.InMemoryDocumentStore;
 import io.camunda.connector.runtime.core.intrinsic.DefaultIntrinsicFunctionExecutor;
+import io.camunda.connector.runtime.core.intrinsic.MutableObjectMapperSupplier;
 import java.util.Base64;
 import java.util.List;
 import java.util.UUID;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.DatabindException;
+import tools.jackson.databind.ObjectMapper;
 
 public class DocumentMapperTest {
 
   public ObjectMapper createObjectMapper() {
     final var objectMapper = ConnectorsObjectMapperSupplier.getCopy();
-    var functionExecutor = new DefaultIntrinsicFunctionExecutor(objectMapper);
-    return objectMapper.registerModule(
-        new JacksonModuleDocumentDeserializer(
-            new DocumentFactoryImpl(InMemoryDocumentStore.INSTANCE),
-            functionExecutor,
-            DocumentModuleSettings.create()));
+    var mapperHolder = new MutableObjectMapperSupplier();
+    var functionExecutor = new DefaultIntrinsicFunctionExecutor(mapperHolder);
+    var finalMapper =
+        objectMapper
+            .rebuild()
+            .addModule(
+                new JacksonModuleDocumentDeserializer(
+                    new DocumentFactoryImpl(InMemoryDocumentStore.INSTANCE),
+                    functionExecutor,
+                    DocumentModuleSettings.create()))
+            .build();
+    mapperHolder.set(finalMapper);
+    return finalMapper;
   }
 
   @Test
-  void singleDocumentShouldBeAcceptedAsArray() throws JsonProcessingException {
+  void singleDocumentShouldBeAcceptedAsArray() throws JacksonException {
     var objectMapper = createObjectMapper();
     final var documentReference =
         new CamundaDocumentReferenceModel("default", UUID.randomUUID().toString(), "hash", null);
@@ -58,7 +66,7 @@ public class DocumentMapperTest {
   }
 
   @Test
-  void singleElementDocumentArrayShouldBeAcceptedAsObject() throws JsonProcessingException {
+  void singleElementDocumentArrayShouldBeAcceptedAsObject() throws JacksonException {
     var objectMapper = createObjectMapper();
     final var documentReference =
         new CamundaDocumentReferenceModel("default", UUID.randomUUID().toString(), "hash", null);
@@ -70,7 +78,7 @@ public class DocumentMapperTest {
   }
 
   @Test
-  void multipleElementDocumentArrayShouldNotBeAcceptedAsObject() throws JsonProcessingException {
+  void multipleElementDocumentArrayShouldNotBeAcceptedAsObject() throws JacksonException {
     var objectMapper = createObjectMapper();
     final var documentReference =
         new CamundaDocumentReferenceModel("default", UUID.randomUUID().toString(), "hash", null);
@@ -79,12 +87,12 @@ public class DocumentMapperTest {
             + objectMapper.writeValueAsString(List.of(documentReference, documentReference))
             + "}";
     Assertions.assertThatThrownBy(() -> objectMapper.readValue(json, TestRecordWithDocument.class))
-        .isInstanceOf(JsonMappingException.class)
+        .isInstanceOf(DatabindException.class)
         .hasCauseInstanceOf(IllegalArgumentException.class);
   }
 
   @Test
-  void intrinsicFunctionShouldBeDeserialized() throws JsonProcessingException {
+  void intrinsicFunctionShouldBeDeserialized() throws JacksonException {
     var objectMapper = createObjectMapper();
 
     final var json =

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/document/DocumentReturnProcessorTest.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/document/DocumentReturnProcessorTest.java
@@ -19,7 +19,6 @@ package io.camunda.connector.runtime.core.document;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.connector.api.document.Document;
 import io.camunda.connector.api.document.DocumentReturn;
 import io.camunda.connector.api.document.DocumentReturnChoice;
@@ -34,6 +33,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
+import tools.jackson.databind.ObjectMapper;
 
 class DocumentReturnProcessorTest {
 

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/document/DocumentSerializationTest.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/document/DocumentSerializationTest.java
@@ -19,20 +19,20 @@ package io.camunda.connector.runtime.core.document;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import io.camunda.connector.api.document.Document;
 import io.camunda.connector.api.document.DocumentFactory;
 import io.camunda.connector.document.jackson.DocumentReferenceModel.CamundaDocumentMetadataModel;
 import io.camunda.connector.document.jackson.DocumentReferenceModel.CamundaDocumentReferenceModel;
 import io.camunda.connector.document.jackson.IntrinsicFunctionExecutor;
 import io.camunda.connector.document.jackson.JacksonModuleDocumentDeserializer;
-import io.camunda.connector.document.jackson.JacksonModuleDocumentSerializer;
+import io.camunda.connector.document.jackson.v3.JacksonModuleDocumentSerializer;
 import org.json.JSONException;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.skyscreamer.jsonassert.JSONAssert;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 
 public class DocumentSerializationTest {
 
@@ -40,13 +40,14 @@ public class DocumentSerializationTest {
   @Mock private IntrinsicFunctionExecutor operationExecutor;
 
   private final ObjectMapper objectMapper =
-      new ObjectMapper()
-          .registerModule(new JacksonModuleDocumentDeserializer(factory, operationExecutor))
-          .registerModule(new JacksonModuleDocumentSerializer())
-          .registerModule(new Jdk8Module());
+      JsonMapper.builder()
+          .addModules(
+              new JacksonModuleDocumentDeserializer(factory, operationExecutor),
+              new JacksonModuleDocumentSerializer())
+          .build();
 
   @Test
-  void sourceTypeDocument_jacksonInternalModel() throws JsonProcessingException, JSONException {
+  void sourceTypeDocument_jacksonInternalModel() throws JacksonException, JSONException {
     var metadata = new CamundaDocumentMetadataModel(null, null, null, null, null, null, null);
     var ref = new CamundaDocumentReferenceModel("test", "test", "hash", metadata);
     var document = mock(Document.class);
@@ -69,7 +70,7 @@ public class DocumentSerializationTest {
   }
 
   @Test
-  void sourceTypeDocument_connectorSdkModel() throws JsonProcessingException, JSONException {
+  void sourceTypeDocument_connectorSdkModel() throws JacksonException, JSONException {
     var metadata = new CamundaDocumentMetadataModel(null, null, null, null, null, null, null);
     var ref = new CamundaDocumentReferenceImpl("test", "test", "hash", metadata);
     var document = mock(Document.class);

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/document/InlineDocumentRoundtripTest.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/document/InlineDocumentRoundtripTest.java
@@ -20,7 +20,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.connector.api.document.Document;
 import io.camunda.connector.document.jackson.DocumentReferenceModel;
 import io.camunda.connector.document.jackson.DocumentReferenceModel.InlineDocumentReferenceModel;
@@ -29,17 +28,24 @@ import io.camunda.connector.runtime.core.document.store.CamundaDocumentStore;
 import org.json.JSONException;
 import org.junit.jupiter.api.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
+import tools.jackson.databind.json.JsonMapper;
 
 /**
  * Verifies the JSON → factory → {@code Document.reference()} → JSON path for inline documents,
  * including the intentional asymmetry where a missing {@code name} on input becomes a generated
  * UUID on output (because the factory mints a UUID at construction time).
+ *
+ * <p>{@code modelMapper} (read side) is Jackson 3, matching {@link InlineDocumentReferenceModel}'s
+ * {@code @JsonDeserialize} annotation. {@code serializingMapper} (write side) is deliberately
+ * Jackson 2, using the legacy {@link JacksonModuleDocumentSerializer} — see that class' javadoc.
+ * The two ends of the round-trip don't need to share a Jackson major version.
  */
 class InlineDocumentRoundtripTest {
 
-  private final ObjectMapper modelMapper = new ObjectMapper();
-  private final ObjectMapper serializingMapper =
-      new ObjectMapper().registerModule(new JacksonModuleDocumentSerializer());
+  private final tools.jackson.databind.ObjectMapper modelMapper = JsonMapper.builder().build();
+  private final com.fasterxml.jackson.databind.ObjectMapper serializingMapper =
+      new com.fasterxml.jackson.databind.ObjectMapper()
+          .registerModule(new JacksonModuleDocumentSerializer());
   private final DocumentFactoryImpl factory =
       new DocumentFactoryImpl(mock(CamundaDocumentStore.class));
 

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/document/ResultDocumentResolverTest.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/document/ResultDocumentResolverTest.java
@@ -21,8 +21,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.connector.api.document.Document;
 import io.camunda.connector.api.document.DocumentCreationRequest;
 import io.camunda.connector.api.document.DocumentFactory;
@@ -36,6 +34,8 @@ import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
 
 class ResultDocumentResolverTest {
 

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/inbound/DefaultInboundConnectorContextFactoryTest.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/inbound/DefaultInboundConnectorContextFactoryTest.java
@@ -18,7 +18,6 @@ package io.camunda.connector.runtime.core.inbound;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.client.CamundaClient;
 import io.camunda.connector.api.document.DocumentFactory;
 import io.camunda.connector.api.inbound.InboundConnectorContext;
@@ -35,6 +34,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import tools.jackson.databind.ObjectMapper;
 
 @ExtendWith(MockitoExtension.class)
 class DefaultInboundConnectorContextFactoryTest {

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/inbound/DefaultProcessInstanceContextTest.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/inbound/DefaultProcessInstanceContextTest.java
@@ -25,8 +25,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.command.EvaluateExpressionCommandStep1.EvaluateExpressionCommandStep2;
 import io.camunda.client.api.response.EvaluateExpressionResponse;
@@ -44,6 +42,8 @@ import io.camunda.connector.runtime.core.document.store.CamundaDocumentStore;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 
 class DefaultProcessInstanceContextTest {
 
@@ -125,13 +125,13 @@ class DefaultProcessInstanceContextTest {
     var factoryA = new DocumentFactoryImpl(storeA);
     var factoryB = new DocumentFactoryImpl(storeB);
     var multiTenantMapper =
-        new ObjectMapper()
-            .registerModule(
+        JsonMapper.builder()
+            .addModule(
                 new JacksonModuleDocumentDeserializer(
                     Map.of("tenant-a", factoryA, "tenant-b", factoryB),
                     Mockito.mock(IntrinsicFunctionExecutor.class),
                     JacksonModuleDocumentDeserializer.DocumentModuleSettings.create()))
-            .registerModule(new Jdk8Module());
+            .build();
 
     var ref = DocumentDeserializationTest.createDocumentMock("hello from tenant b", null, storeB);
 

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextImplTest.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextImplTest.java
@@ -22,7 +22,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.command.EvaluateExpressionCommandStep1.EvaluateExpressionCommandStep2;
 import io.camunda.client.api.response.EvaluateExpressionResponse;
@@ -54,6 +53,7 @@ import java.util.Map;
 import java.util.Objects;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
+import tools.jackson.databind.ObjectMapper;
 
 class InboundConnectorContextImplTest {
   private final SecretProvider secretProvider = new FooBarSecretProvider();

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/intrinsic/IntrinsicFunctionDeserializationTest.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/intrinsic/IntrinsicFunctionDeserializationTest.java
@@ -22,15 +22,11 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonMappingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import io.camunda.connector.api.document.DocumentFactory;
 import io.camunda.connector.document.jackson.IntrinsicFunctionExecutor;
 import io.camunda.connector.document.jackson.JacksonModuleDocumentDeserializer;
 import io.camunda.connector.document.jackson.JacksonModuleDocumentDeserializer.DocumentModuleSettings;
-import io.camunda.connector.document.jackson.JacksonModuleDocumentSerializer;
+import io.camunda.connector.document.jackson.v3.JacksonModuleDocumentSerializer;
 import io.camunda.connector.runtime.core.document.DocumentFactoryImpl;
 import io.camunda.connector.runtime.core.document.store.CamundaDocumentStore;
 import java.nio.charset.StandardCharsets;
@@ -39,30 +35,39 @@ import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.DatabindException;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 
 @ExtendWith(MockitoExtension.class)
 public class IntrinsicFunctionDeserializationTest {
 
   private final CamundaDocumentStore documentStore = mock(CamundaDocumentStore.class);
 
-  private final ObjectMapper objectMapper = new ObjectMapper();
+  private final ObjectMapper objectMapper;
 
   public IntrinsicFunctionDeserializationTest() {
     /*
      * Order of initialization is important here. The operationExecutor is created first and then
      * the objectMapper is created with the operationExecutor. This is because the operationExecutor
-     * needs an objectMapper configured with the same modules.
+     * needs an objectMapper configured with the same modules. ObjectMapper is immutable in Jackson
+     * 3, so a MutableObjectMapperSupplier bridges the executor to the final, fully-built mapper.
      */
+    var mapperHolder = new MutableObjectMapperSupplier();
     IntrinsicFunctionExecutor operationExecutor =
-        spy(new DefaultIntrinsicFunctionExecutor(objectMapper));
+        spy(new DefaultIntrinsicFunctionExecutor(mapperHolder));
 
     final var settings = DocumentModuleSettings.create();
     settings.setMaxIntrinsicFunctions(2);
     final DocumentFactory factory = new DocumentFactoryImpl(documentStore);
-    objectMapper
-        .registerModule(new JacksonModuleDocumentDeserializer(factory, operationExecutor, settings))
-        .registerModule(new JacksonModuleDocumentSerializer())
-        .registerModule(new Jdk8Module());
+    objectMapper =
+        JsonMapper.builder()
+            .addModules(
+                new JacksonModuleDocumentDeserializer(factory, operationExecutor, settings),
+                new JacksonModuleDocumentSerializer())
+            .build();
+    mapperHolder.set(objectMapper);
   }
 
   private record StringResultModel(String result) {}
@@ -90,9 +95,10 @@ public class IntrinsicFunctionDeserializationTest {
         Map.of("result", Map.of("camunda.function.type", "wrong", "params", List.of(ref)));
     final var e =
         assertThrows(
-            IllegalArgumentException.class,
+            DatabindException.class,
             () -> objectMapper.convertValue(payload, StringResultModel.class));
 
+    assertThat(e).hasCauseInstanceOf(IllegalArgumentException.class);
     assertThat(e).hasMessageContaining("No intrinsic function found with name: wrong");
   }
 
@@ -148,7 +154,7 @@ public class IntrinsicFunctionDeserializationTest {
   }
 
   @Test
-  void operationWithObjectParameter_acceptsString() throws JsonProcessingException {
+  void operationWithObjectParameter_acceptsString() throws JacksonException {
     var string = "Hello World";
 
     final var payload =
@@ -161,7 +167,7 @@ public class IntrinsicFunctionDeserializationTest {
   }
 
   @Test
-  void operationWithObjectParameter_nestedOperation() throws JsonProcessingException {
+  void operationWithObjectParameter_nestedOperation() throws JacksonException {
     var contentString = " World";
     var ref = createDocumentMock(contentString, null, documentStore);
 
@@ -203,7 +209,7 @@ public class IntrinsicFunctionDeserializationTest {
             """;
 
     var exception =
-        assertThrows(JsonMappingException.class, () -> objectMapper.readValue(payload, Map.class));
+        assertThrows(DatabindException.class, () -> objectMapper.readValue(payload, Map.class));
 
     assertThat(exception).hasMessageContaining("Intrinsic function limit exceeded");
   }
@@ -234,7 +240,7 @@ public class IntrinsicFunctionDeserializationTest {
             """;
 
     var exception =
-        assertThrows(JsonMappingException.class, () -> objectMapper.readValue(payload, Map.class));
+        assertThrows(DatabindException.class, () -> objectMapper.readValue(payload, Map.class));
 
     assertThat(exception).hasMessageContaining("Intrinsic function limit exceeded");
   }

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/outbound/AnnotatedOperationTests.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/outbound/AnnotatedOperationTests.java
@@ -20,7 +20,6 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.client.api.response.ActivatedJob;
 import io.camunda.connector.api.annotation.OutboundConnector;
 import io.camunda.connector.api.error.ConnectorInputException;
@@ -38,6 +37,8 @@ import java.util.HashMap;
 import java.util.Map;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 
 public class AnnotatedOperationTests {
 
@@ -200,7 +201,7 @@ public class AnnotatedOperationTests {
    */
   @Test
   public void shouldUseContextObjectMapper_notRegistrationTimeMapper_forVariableResolution() {
-    var strictRegistrationMapper = new ObjectMapper();
+    var strictRegistrationMapper = JsonMapper.builder().build();
     var mismatchedInvoker =
         new OutboundConnectorOperationFunction(
             ConnectorOperations.from(connector, strictRegistrationMapper, validationProvider));
@@ -220,7 +221,7 @@ public class AnnotatedOperationTests {
   public void shouldUseContextObjectMapper_notRegistrationTimeMapper_forHeaderResolution() {
     // a bare ObjectMapper has no FEEL support, so it cannot convert the "=x+2" header string into
     // the Function<Map<String, Integer>, Integer> parameter type that myOperation5 expects.
-    var registrationMapperWithoutFeelSupport = new ObjectMapper();
+    var registrationMapperWithoutFeelSupport = JsonMapper.builder().build();
     var mismatchedInvoker =
         new OutboundConnectorOperationFunction(
             ConnectorOperations.from(

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/outbound/DefaultOutboundConnectorFactoryTest.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/outbound/DefaultOutboundConnectorFactoryTest.java
@@ -18,11 +18,11 @@ package io.camunda.connector.runtime.core.outbound;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.connector.runtime.core.validation.ValidationUtil;
 import java.util.List;
 import java.util.NoSuchElementException;
 import org.junit.jupiter.api.Test;
+import tools.jackson.databind.ObjectMapper;
 
 public class DefaultOutboundConnectorFactoryTest {
 

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/outbound/DiscoveryUtils.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/outbound/DiscoveryUtils.java
@@ -16,18 +16,18 @@
  */
 package io.camunda.connector.runtime.core.outbound;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.connector.api.outbound.OutboundConnectorFunction;
 import io.camunda.connector.runtime.core.validation.ValidationUtil;
 import java.util.Arrays;
 import java.util.List;
+import tools.jackson.databind.json.JsonMapper;
 
 public class DiscoveryUtils {
   private DiscoveryUtils() {}
 
   static OutboundConnectorFactory getFactory(OutboundConnectorFunction... functions) {
     return new DefaultOutboundConnectorFactory(
-        new ObjectMapper(),
+        JsonMapper.builder().build(),
         ValidationUtil.discoverDefaultValidationProviderImplementation(),
         Arrays.asList(functions),
         List.of(),

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/outbound/JobHandlerContextTest.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/outbound/JobHandlerContextTest.java
@@ -22,7 +22,6 @@ import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.client.api.response.ActivatedJob;
 import io.camunda.connector.api.document.DocumentCreationRequest;
 import io.camunda.connector.api.document.DocumentFactory;
@@ -44,6 +43,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import tools.jackson.databind.DeserializationFeature;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 
 @ExtendWith(MockitoExtension.class)
 class JobHandlerContextTest {
@@ -53,7 +55,10 @@ class JobHandlerContextTest {
   @Mock private ValidationProvider validationProvider;
   @Mock private DocumentFactory documentFactory;
 
-  private final ObjectMapper objectMapper = new ObjectMapper();
+  // Jackson 3 defaults FAIL_ON_UNKNOWN_PROPERTIES to false (unlike Jackson 2's bare
+  // ObjectMapper); enabled explicitly so the invalid-field tests below still exercise that path.
+  private final ObjectMapper objectMapper =
+      JsonMapper.builder().enable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES).build();
   private JobHandlerContext jobHandlerContext;
 
   @BeforeEach

--- a/connector-runtime/connector-runtime-spring/pom.xml
+++ b/connector-runtime/connector-runtime-spring/pom.xml
@@ -86,8 +86,18 @@
     </dependency>
 
     <dependency>
+      <groupId>tools.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
+    <!-- Jackson 2: io.camunda.connector.runtime.core.http.InstanceForwardingHttpClient (used from
+         this module) is still Jackson 2-only, not yet migrated as part of #5910. -->
+    <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
     </dependency>
 
     <!-- The runtime provides enhanced metrics for logback if it is present -->
@@ -202,6 +212,13 @@
     <dependency>
       <groupId>io.camunda.connector</groupId>
       <artifactId>connector-test-utils</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <!-- Jackson 2: DefaultInstanceForwardingServiceIntegrationTest exercises the still-Jackson-2-only
+         InstanceForwardingHttpClient with a standalone mapper that needs JavaTimeModule. -->
+    <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-jsr310</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/configuration/ConfigurationValidationConfiguration.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/configuration/ConfigurationValidationConfiguration.java
@@ -20,7 +20,6 @@ import static io.camunda.connector.runtime.tenant.PhysicalTenantClients.clientNa
 import static io.camunda.connector.runtime.tenant.PhysicalTenantClients.resolveClient;
 import static io.camunda.connector.runtime.tenant.PhysicalTenantClients.toMapByPhysicalTenantId;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.client.CamundaClient;
 import io.camunda.client.spring.bean.CamundaClientRegistry;
 import io.camunda.connector.api.validation.ConfigurationValidator;
@@ -39,6 +38,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
+import tools.jackson.databind.ObjectMapper;
 
 /**
  * Wires configuration (credential) validation. This is <b>direction-agnostic</b>: the same

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/InboundConnectorRuntimeConfiguration.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/InboundConnectorRuntimeConfiguration.java
@@ -16,7 +16,6 @@
  */
 package io.camunda.connector.runtime.inbound;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import io.camunda.client.CamundaClient;
 import io.camunda.client.spring.bean.CamundaClientRegistry;
@@ -64,6 +63,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.core.env.Environment;
+import tools.jackson.databind.ObjectMapper;
 
 @Configuration
 @Import({

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/InboundCorrelationConfiguration.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/InboundCorrelationConfiguration.java
@@ -16,7 +16,6 @@
  */
 package io.camunda.connector.runtime.inbound;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.client.CamundaClient;
 import io.camunda.client.spring.bean.CamundaClientRegistry;
 import io.camunda.connector.api.document.DocumentFactory;
@@ -30,6 +29,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Lazy;
+import tools.jackson.databind.ObjectMapper;
 
 /**
  * Per-physical-tenant {@link InboundCorrelationHandler} beans, split out of {@link

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/MeteredInboundCorrelationHandler.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/MeteredInboundCorrelationHandler.java
@@ -16,7 +16,6 @@
  */
 package io.camunda.connector.runtime.inbound;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.client.CamundaClient;
 import io.camunda.connector.api.document.DocumentFactory;
 import io.camunda.connector.api.inbound.CorrelationRequest;
@@ -26,6 +25,7 @@ import io.camunda.connector.runtime.core.inbound.correlation.InboundCorrelationH
 import io.camunda.connector.runtime.metrics.ConnectorsInboundMetrics;
 import java.time.Duration;
 import java.util.List;
+import tools.jackson.databind.ObjectMapper;
 
 public class MeteredInboundCorrelationHandler extends InboundCorrelationHandler {
 

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/OutboundConnectorRuntimeConfiguration.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/OutboundConnectorRuntimeConfiguration.java
@@ -21,7 +21,6 @@ import static io.camunda.connector.runtime.tenant.PhysicalTenantClients.resolveC
 import static io.camunda.connector.runtime.tenant.PhysicalTenantClients.resolvePhysicalTenantId;
 import static io.camunda.connector.runtime.tenant.PhysicalTenantClients.toMapByPhysicalTenantId;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import io.camunda.client.CamundaClient;
 import io.camunda.client.jobhandling.JobCallbackCommandWrapperFactory;
@@ -34,7 +33,7 @@ import io.camunda.connector.api.outbound.OutboundConnectorFunction;
 import io.camunda.connector.api.outbound.OutboundConnectorProvider;
 import io.camunda.connector.api.validation.ValidationProvider;
 import io.camunda.connector.document.jackson.JacksonModuleDocumentDeserializer;
-import io.camunda.connector.document.jackson.JacksonModuleDocumentSerializer;
+import io.camunda.connector.document.jackson.v3.JacksonModuleDocumentSerializer;
 import io.camunda.connector.feel.FeelExpressionEvaluatorBuilder;
 import io.camunda.connector.feel.jackson.JacksonModuleFeelFunction;
 import io.camunda.connector.jackson.ConnectorsObjectMapperSupplier;
@@ -44,6 +43,7 @@ import io.camunda.connector.runtime.core.document.DocumentFactoryImpl;
 import io.camunda.connector.runtime.core.document.store.CamundaDocumentStore;
 import io.camunda.connector.runtime.core.document.store.CamundaDocumentStoreImpl;
 import io.camunda.connector.runtime.core.intrinsic.DefaultIntrinsicFunctionExecutor;
+import io.camunda.connector.runtime.core.intrinsic.MutableObjectMapperSupplier;
 import io.camunda.connector.runtime.core.outbound.DefaultOutboundConnectorFactory;
 import io.camunda.connector.runtime.core.outbound.OutboundConnectorFactory;
 import io.camunda.connector.runtime.core.secret.SecretFilterFactory;
@@ -80,6 +80,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.core.env.Environment;
+import tools.jackson.databind.ObjectMapper;
 
 @Configuration
 @Import({OutboundConnectorsRestController.class, InstanceForwardingConfiguration.class})
@@ -577,7 +578,8 @@ public class OutboundConnectorRuntimeConfiguration {
 
   private static ObjectMapper buildOutboundConnectorObjectMapper(DocumentFactory documentFactory) {
     final ObjectMapper copy = ConnectorsObjectMapperSupplier.getCopy();
-    var functionExecutor = new DefaultIntrinsicFunctionExecutor(copy);
+    var mapperHolder = new MutableObjectMapperSupplier();
+    var functionExecutor = new DefaultIntrinsicFunctionExecutor(mapperHolder);
 
     var jacksonModuleDocumentDeserializer =
         new JacksonModuleDocumentDeserializer(
@@ -585,11 +587,17 @@ public class OutboundConnectorRuntimeConfiguration {
             functionExecutor,
             JacksonModuleDocumentDeserializer.DocumentModuleSettings.create());
 
-    return copy.registerModules(
-        jacksonModuleDocumentDeserializer,
-        new JacksonModuleFeelFunction(
-            false,
-            FeelExpressionEvaluatorBuilder.local().build()), // FEEL annotation processing disabled
-        new JacksonModuleDocumentSerializer());
+    var finalMapper =
+        copy.rebuild()
+            .addModules(
+                jacksonModuleDocumentDeserializer,
+                new JacksonModuleFeelFunction(
+                    false,
+                    FeelExpressionEvaluatorBuilder.local()
+                        .build()), // FEEL annotation processing disabled
+                new JacksonModuleDocumentSerializer())
+            .build();
+    mapperHolder.set(finalMapper);
+    return finalMapper;
   }
 }

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/SpringConnectorJobHandler.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/SpringConnectorJobHandler.java
@@ -18,8 +18,6 @@ package io.camunda.connector.runtime.outbound.job;
 
 import static java.util.Objects.requireNonNullElse;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.command.ClientHttpException;
 import io.camunda.client.api.command.ClientStatusException;
@@ -82,6 +80,8 @@ import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
 
 /**
  * An enhanced implementation of a {@link JobHandler} that adds metrics, asynchronous command
@@ -758,7 +758,7 @@ public class SpringConnectorJobHandler implements JobHandler {
     if (variables == null || variables.isEmpty()) return;
     try {
       InlineSizeGuard.check(objectMapper.writeValueAsBytes(variables).length);
-    } catch (JsonProcessingException e) {
+    } catch (JacksonException e) {
       throw new RuntimeException("Failed to serialize variables for size check", e);
     }
   }

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/jobstream/BrokerJobStreamClient.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/jobstream/BrokerJobStreamClient.java
@@ -16,7 +16,6 @@
  */
 package io.camunda.connector.runtime.outbound.jobstream;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.client.CamundaClient;
 import java.io.IOException;
 import java.net.URI;
@@ -25,6 +24,7 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.util.ArrayList;
 import java.util.List;
+import tools.jackson.databind.ObjectMapper;
 
 /**
  * Fetches remote (broker-side) job-stream data from each Zeebe broker's monitoring endpoint ({@code

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/lifecycle/OutboundConnectorManager.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/lifecycle/OutboundConnectorManager.java
@@ -16,7 +16,6 @@
  */
 package io.camunda.connector.runtime.outbound.lifecycle;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.client.CamundaClient;
 import io.camunda.client.annotation.value.JobWorkerValue;
 import io.camunda.client.annotation.value.SourceAware;
@@ -45,6 +44,7 @@ import java.util.TreeSet;
 import java.util.concurrent.ConcurrentHashMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import tools.jackson.databind.ObjectMapper;
 
 public class OutboundConnectorManager implements CamundaClientLifecycleAware {
 

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/secret/console/ConsoleSecretApiClient.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/secret/console/ConsoleSecretApiClient.java
@@ -16,8 +16,6 @@
  */
 package io.camunda.connector.runtime.secret.console;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.connector.jackson.ConnectorsObjectMapperSupplier;
 import io.camunda.connector.runtime.secret.console.TokenResponseMapper.JacksonTokenResponseMapper;
 import java.io.IOException;
@@ -28,6 +26,8 @@ import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
 import org.apache.hc.core5.http.ClassicHttpResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.ObjectMapper;
 
 public class ConsoleSecretApiClient {
 

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/secret/console/TokenResponseMapper.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/secret/console/TokenResponseMapper.java
@@ -16,8 +16,8 @@
  */
 package io.camunda.connector.runtime.secret.console;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
 
 public interface TokenResponseMapper {
   TokenResponse readToken(String token);
@@ -33,7 +33,7 @@ public interface TokenResponseMapper {
     public TokenResponse readToken(String token) {
       try {
         return objectMapper.readValue(token, TokenResponse.class);
-      } catch (JsonProcessingException e) {
+      } catch (JacksonException e) {
         throw new RuntimeException("Error while reading token " + token, e);
       }
     }

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/TestObjectMapperSupplier.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/TestObjectMapperSupplier.java
@@ -16,15 +16,16 @@
  */
 package io.camunda.connector.runtime;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.connector.document.jackson.JacksonModuleDocumentDeserializer;
 import io.camunda.connector.document.jackson.JacksonModuleDocumentDeserializer.DocumentModuleSettings;
-import io.camunda.connector.document.jackson.JacksonModuleDocumentSerializer;
+import io.camunda.connector.document.jackson.v3.JacksonModuleDocumentSerializer;
 import io.camunda.connector.feel.jackson.JacksonModuleFeelFunction;
 import io.camunda.connector.jackson.ConnectorsObjectMapperSupplier;
 import io.camunda.connector.runtime.core.document.DocumentFactoryImpl;
 import io.camunda.connector.runtime.core.document.store.InMemoryDocumentStore;
 import io.camunda.connector.runtime.core.intrinsic.DefaultIntrinsicFunctionExecutor;
+import io.camunda.connector.runtime.core.intrinsic.MutableObjectMapperSupplier;
+import tools.jackson.databind.ObjectMapper;
 
 public class TestObjectMapperSupplier {
 
@@ -33,13 +34,19 @@ public class TestObjectMapperSupplier {
   public static ObjectMapper getInstance() {
     var copy = ConnectorsObjectMapperSupplier.getCopy();
     var documentFactory = new DocumentFactoryImpl(InMemoryDocumentStore.INSTANCE);
-    var functionExecutor = new DefaultIntrinsicFunctionExecutor(copy);
+    var mapperHolder = new MutableObjectMapperSupplier();
+    var functionExecutor = new DefaultIntrinsicFunctionExecutor(mapperHolder);
     var jacksonModuleDocumentDeserializer =
         new JacksonModuleDocumentDeserializer(
             documentFactory, functionExecutor, DocumentModuleSettings.create());
-    return copy.registerModules(
-        jacksonModuleDocumentDeserializer,
-        new JacksonModuleFeelFunction(),
-        new JacksonModuleDocumentSerializer());
+    var finalMapper =
+        copy.rebuild()
+            .addModules(
+                jacksonModuleDocumentDeserializer,
+                new JacksonModuleFeelFunction(),
+                new JacksonModuleDocumentSerializer())
+            .build();
+    mapperHolder.set(finalMapper);
+    return finalMapper;
   }
 }

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/inbound/InboundCorrelationConfigurationTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/inbound/InboundCorrelationConfigurationTest.java
@@ -25,7 +25,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.client.CamundaClient;
 import io.camunda.client.spring.bean.CamundaClientRegistry;
 import io.camunda.connector.api.document.Document;
@@ -42,6 +41,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
+import tools.jackson.databind.ObjectMapper;
 
 /**
  * Exercises {@link InboundCorrelationConfiguration#inboundCorrelationHandler}, the

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/inbound/executable/InboundExecutableRegistryTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/inbound/executable/InboundExecutableRegistryTest.java
@@ -20,7 +20,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.client.CamundaClient;
 import io.camunda.connector.api.error.ConnectorRetryException;
 import io.camunda.connector.api.inbound.*;
@@ -43,6 +42,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import tools.jackson.databind.ObjectMapper;
 
 public class InboundExecutableRegistryTest {
 

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/inbound/webhook/WebhookTestsBase.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/inbound/webhook/WebhookTestsBase.java
@@ -21,7 +21,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.client.CamundaClient;
 import io.camunda.connector.api.inbound.ElementTemplateDetails;
 import io.camunda.connector.api.inbound.Health;
@@ -44,6 +43,7 @@ import io.camunda.connector.validation.impl.DefaultValidationProvider;
 import java.util.List;
 import java.util.Map;
 import org.mockito.Mockito;
+import tools.jackson.databind.ObjectMapper;
 
 public abstract class WebhookTestsBase {
 

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/instances/service/DefaultInstanceForwardingServiceIntegrationTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/instances/service/DefaultInstanceForwardingServiceIntegrationTest.java
@@ -26,10 +26,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.github.tomakehurst.wiremock.WireMockServer;
 import io.camunda.connector.api.inbound.Health;
 import io.camunda.connector.api.inbound.Severity;
-import io.camunda.connector.jackson.ConnectorsObjectMapperSupplier;
 import io.camunda.connector.runtime.core.http.InstanceForwardingHttpClient;
 import io.camunda.connector.runtime.core.inbound.ExecutableId;
 import io.camunda.connector.runtime.inbound.controller.ActiveInboundConnectorResponse;
@@ -53,11 +54,17 @@ public class DefaultInstanceForwardingServiceIntegrationTest {
   private static final WireMockServer runtime1 = new WireMockServer(options().dynamicPort());
   private static final WireMockServer runtime2 = new WireMockServer(options().dynamicPort());
 
+  // InstanceForwardingHttpClient is still Jackson 2-only (not yet migrated as part of #5910), so
+  // this uses a standalone Jackson 2 mapper rather than the (Jackson 3)
+  // ConnectorsObjectMapperSupplier.
+  private static final ObjectMapper objectMapper =
+      new ObjectMapper().registerModule(new JavaTimeModule());
+
   private static final InstanceForwardingHttpClient instanceForwardingHttpClient =
       new InstanceForwardingHttpClient(
           HttpClient.newHttpClient(),
           (path) -> List.of(runtime1.baseUrl() + path, runtime2.baseUrl() + path),
-          ConnectorsObjectMapperSupplier.getCopy());
+          objectMapper);
 
   @BeforeAll
   static void setup() {
@@ -77,8 +84,7 @@ public class DefaultInstanceForwardingServiceIntegrationTest {
         get(urlPathMatching("/api/forward"))
             .withQueryParam("param", equalTo("value"))
             .withHeader("Authorization", equalTo("Bearer xyz"))
-            .willReturn(
-                ok().withBody(ConnectorsObjectMapperSupplier.getCopy().writeValueAsString(body))));
+            .willReturn(ok().withBody(objectMapper.writeValueAsString(body))));
   }
 
   @Nested

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/lifecycle/OutboundConnectorManagerTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/lifecycle/OutboundConnectorManagerTest.java
@@ -26,7 +26,6 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.client.CamundaClient;
 import io.camunda.client.jobhandling.JobCallbackCommandWrapperFactory;
 import io.camunda.client.jobhandling.JobWorkerManager;
@@ -43,6 +42,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.Supplier;
 import org.junit.jupiter.api.Test;
+import tools.jackson.databind.ObjectMapper;
 
 class OutboundConnectorManagerTest {
 

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/lifecycle/OutboundRegistryTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/lifecycle/OutboundRegistryTest.java
@@ -18,7 +18,6 @@ package io.camunda.connector.runtime.outbound.lifecycle;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.connector.api.annotation.OutboundConnector;
 import io.camunda.connector.api.outbound.OutboundConnectorContext;
 import io.camunda.connector.api.outbound.OutboundConnectorFunction;
@@ -35,6 +34,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Scope;
 import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Component;
+import tools.jackson.databind.ObjectMapper;
 
 class OutboundRegistryTest {
 

--- a/connector-runtime/connector-runtime-test/pom.xml
+++ b/connector-runtime/connector-runtime-test/pom.xml
@@ -52,7 +52,7 @@
     </dependency>
 
     <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
+      <groupId>tools.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
     </dependency>
 

--- a/connector-runtime/connector-runtime-test/src/main/java/io/camunda/connector/runtime/test/inbound/InboundConnectorContextBuilder.java
+++ b/connector-runtime/connector-runtime-test/src/main/java/io/camunda/connector/runtime/test/inbound/InboundConnectorContextBuilder.java
@@ -16,9 +16,6 @@
  */
 package io.camunda.connector.runtime.test.inbound;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.connector.api.document.Document;
 import io.camunda.connector.api.document.DocumentCreationRequest;
 import io.camunda.connector.api.document.DocumentFactory;
@@ -29,7 +26,7 @@ import io.camunda.connector.api.secret.SecretProvider;
 import io.camunda.connector.api.validation.ValidationProvider;
 import io.camunda.connector.document.jackson.JacksonModuleDocumentDeserializer;
 import io.camunda.connector.document.jackson.JacksonModuleDocumentDeserializer.DocumentModuleSettings;
-import io.camunda.connector.document.jackson.JacksonModuleDocumentSerializer;
+import io.camunda.connector.document.jackson.v3.JacksonModuleDocumentSerializer;
 import io.camunda.connector.feel.jackson.JacksonModuleFeelFunction;
 import io.camunda.connector.jackson.ConnectorsObjectMapperSupplier;
 import io.camunda.connector.runtime.core.AbstractConnectorContext;
@@ -40,6 +37,7 @@ import io.camunda.connector.runtime.core.inbound.InboundConnectorManagementConte
 import io.camunda.connector.runtime.core.inbound.ProcessElementWithRuntimeData;
 import io.camunda.connector.runtime.core.inbound.details.InboundConnectorDetails.ValidInboundConnectorDetails;
 import io.camunda.connector.runtime.core.intrinsic.DefaultIntrinsicFunctionExecutor;
+import io.camunda.connector.runtime.core.intrinsic.MutableObjectMapperSupplier;
 import io.camunda.connector.runtime.core.secret.SecretFilter;
 import io.camunda.connector.runtime.core.validation.ValidationUtil;
 import io.camunda.connector.test.ConnectorContextTestUtil;
@@ -53,6 +51,8 @@ import java.util.Optional;
 import java.util.function.Consumer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.ObjectMapper;
 
 /** Test helper class for creating an {@link InboundConnectorContext} with a fluent API. */
 public class InboundConnectorContextBuilder {
@@ -71,27 +71,25 @@ public class InboundConnectorContextBuilder {
   protected ObjectMapper objectMapper = createObjectMapper();
 
   private ObjectMapper createObjectMapper() {
-    var copy = ConnectorsObjectMapperSupplier.getCopy();
-    var functionExecutor = new DefaultIntrinsicFunctionExecutor(copy);
-    var jacksonModuleDocumentDeserializer =
-        new JacksonModuleDocumentDeserializer(
-            documentFactory, functionExecutor, DocumentModuleSettings.create());
-    return copy.registerModules(
-        jacksonModuleDocumentDeserializer,
-        new JacksonModuleFeelFunction(),
-        new JacksonModuleDocumentSerializer());
+    return createObjectMapper(documentFactory);
   }
 
   private ObjectMapper createObjectMapper(DocumentFactory documentFactory) {
     var copy = ConnectorsObjectMapperSupplier.getCopy();
-    var functionExecutor = new DefaultIntrinsicFunctionExecutor(copy);
+    var mapperHolder = new MutableObjectMapperSupplier();
+    var functionExecutor = new DefaultIntrinsicFunctionExecutor(mapperHolder);
     var jacksonModuleDocumentDeserializer =
         new JacksonModuleDocumentDeserializer(
             documentFactory, functionExecutor, DocumentModuleSettings.create());
-    return copy.registerModules(
-        jacksonModuleDocumentDeserializer,
-        new JacksonModuleFeelFunction(),
-        new JacksonModuleDocumentSerializer());
+    var finalMapper =
+        copy.rebuild()
+            .addModules(
+                jacksonModuleDocumentDeserializer,
+                new JacksonModuleFeelFunction(),
+                new JacksonModuleDocumentSerializer())
+            .build();
+    mapperHolder.set(finalMapper);
+    return finalMapper;
   }
 
   public static InboundConnectorContextBuilder create() {
@@ -257,12 +255,8 @@ public class InboundConnectorContextBuilder {
       super(secretProvider, SecretFilter.allowAll(), validationProvider);
       this.result = result;
       this.activationTimestamp = System.currentTimeMillis();
-      try {
-        propertiesWithSecrets =
-            getSecretHandler().replaceSecrets(objectMapper.writeValueAsString(properties), null);
-      } catch (JsonProcessingException e) {
-        throw new RuntimeException(e);
-      }
+      propertiesWithSecrets =
+          getSecretHandler().replaceSecrets(objectMapper.writeValueAsString(properties), null);
     }
 
     protected void correlate(Object variables) {
@@ -300,24 +294,16 @@ public class InboundConnectorContextBuilder {
 
     @Override
     public Map<String, Object> getProperties() {
-      try {
-        return objectMapper.readValue(propertiesWithSecrets, new TypeReference<>() {});
-      } catch (JsonProcessingException e) {
-        throw new RuntimeException(e);
-      }
+      return objectMapper.readValue(propertiesWithSecrets, new TypeReference<>() {});
     }
 
     @Override
     public <T> T bindProperties(Class<T> cls) {
-      try {
-        var mappedObject = objectMapper.readValue(propertiesWithSecrets, cls);
-        if (validationProvider != null) {
-          getValidationProvider().validate(mappedObject);
-        }
-        return mappedObject;
-      } catch (JsonProcessingException e) {
-        throw new RuntimeException(e);
+      var mappedObject = objectMapper.readValue(propertiesWithSecrets, cls);
+      if (validationProvider != null) {
+        getValidationProvider().validate(mappedObject);
       }
+      return mappedObject;
     }
 
     @Override

--- a/connector-runtime/connector-runtime-test/src/main/java/io/camunda/connector/runtime/test/outbound/OutboundConnectorContextBuilder.java
+++ b/connector-runtime/connector-runtime-test/src/main/java/io/camunda/connector/runtime/test/outbound/OutboundConnectorContextBuilder.java
@@ -16,10 +16,6 @@
  */
 package io.camunda.connector.runtime.test.outbound;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.connector.api.document.Document;
 import io.camunda.connector.api.document.DocumentCreationRequest;
 import io.camunda.connector.api.document.DocumentFactory;
@@ -33,13 +29,14 @@ import io.camunda.connector.api.secret.SecretProvider;
 import io.camunda.connector.api.validation.ValidationProvider;
 import io.camunda.connector.document.jackson.JacksonModuleDocumentDeserializer;
 import io.camunda.connector.document.jackson.JacksonModuleDocumentDeserializer.DocumentModuleSettings;
-import io.camunda.connector.document.jackson.JacksonModuleDocumentSerializer;
+import io.camunda.connector.document.jackson.v3.JacksonModuleDocumentSerializer;
 import io.camunda.connector.feel.jackson.JacksonModuleFeelFunction;
 import io.camunda.connector.jackson.ConnectorsObjectMapperSupplier;
 import io.camunda.connector.runtime.core.AbstractConnectorContext;
 import io.camunda.connector.runtime.core.document.DocumentFactoryImpl;
 import io.camunda.connector.runtime.core.document.store.InMemoryDocumentStore;
 import io.camunda.connector.runtime.core.intrinsic.DefaultIntrinsicFunctionExecutor;
+import io.camunda.connector.runtime.core.intrinsic.MutableObjectMapperSupplier;
 import io.camunda.connector.runtime.core.secret.SecretFilter;
 import io.camunda.connector.runtime.core.validation.ValidationUtil;
 import io.camunda.connector.test.ConnectorContextTestUtil;
@@ -47,6 +44,10 @@ import io.camunda.connector.test.MapSecretProvider;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
 
 /** Test helper class for creating a {@link OutboundConnectorContext} with a fluent API. */
 public class OutboundConnectorContextBuilder {
@@ -62,27 +63,25 @@ public class OutboundConnectorContextBuilder {
   private ObjectMapper objectMapper = createObjectMapper();
 
   private ObjectMapper createObjectMapper() {
-    var copy = ConnectorsObjectMapperSupplier.getCopy();
-    var functionExecutor = new DefaultIntrinsicFunctionExecutor(copy);
-    var jacksonModuleDocumentDeserializer =
-        new JacksonModuleDocumentDeserializer(
-            documentFactory, functionExecutor, DocumentModuleSettings.create());
-    return copy.registerModules(
-        jacksonModuleDocumentDeserializer,
-        new JacksonModuleFeelFunction(),
-        new JacksonModuleDocumentSerializer());
+    return createObjectMapper(documentFactory);
   }
 
   private ObjectMapper createObjectMapper(DocumentFactory documentFactory) {
     var copy = ConnectorsObjectMapperSupplier.getCopy();
-    var functionExecutor = new DefaultIntrinsicFunctionExecutor(copy);
+    var mapperHolder = new MutableObjectMapperSupplier();
+    var functionExecutor = new DefaultIntrinsicFunctionExecutor(mapperHolder);
     var jacksonModuleDocumentDeserializer =
         new JacksonModuleDocumentDeserializer(
             documentFactory, functionExecutor, DocumentModuleSettings.create());
-    return copy.registerModules(
-        jacksonModuleDocumentDeserializer,
-        new JacksonModuleFeelFunction(),
-        new JacksonModuleDocumentSerializer());
+    var finalMapper =
+        copy.rebuild()
+            .addModules(
+                jacksonModuleDocumentDeserializer,
+                new JacksonModuleFeelFunction(),
+                new JacksonModuleDocumentSerializer())
+            .build();
+    mapperHolder.set(finalMapper);
+    return finalMapper;
   }
 
   /**
@@ -108,7 +107,7 @@ public class OutboundConnectorContextBuilder {
     this.assertNoVariables();
     try {
       this.variables = objectMapper.readValue(variablesAsJSON, new TypeReference<>() {});
-    } catch (JsonProcessingException e) {
+    } catch (JacksonException e) {
       throw new IllegalArgumentException("Invalid JSON: " + variablesAsJSON, e);
     }
     return this;
@@ -234,12 +233,8 @@ public class OutboundConnectorContextBuilder {
     protected TestConnectorContext(
         SecretProvider secretProvider, ValidationProvider validationProvider) {
       super(secretProvider, SecretFilter.allowAll(), validationProvider);
-      try {
-        var asString = objectMapper.writeValueAsString(variables);
-        variablesWithSecrets = getSecretHandler().replaceSecrets(asString, null);
-      } catch (JsonProcessingException e) {
-        throw new RuntimeException(e);
-      }
+      var asString = objectMapper.writeValueAsString(variables);
+      variablesWithSecrets = getSecretHandler().replaceSecrets(asString, null);
       this.jobContext = new TestJobContext(() -> headers, () -> variablesWithSecrets);
     }
 
@@ -273,15 +268,11 @@ public class OutboundConnectorContextBuilder {
 
     @Override
     public <T> T bindVariables(Class<T> cls) {
-      try {
-        var mappedObject = objectMapper.readValue(variablesWithSecrets, cls);
-        if (validationProvider != null) {
-          getValidationProvider().validate(mappedObject);
-        }
-        return mappedObject;
-      } catch (JsonProcessingException e) {
-        throw new RuntimeException(e);
+      var mappedObject = objectMapper.readValue(variablesWithSecrets, cls);
+      if (validationProvider != null) {
+        getValidationProvider().validate(mappedObject);
       }
+      return mappedObject;
     }
 
     @Override

--- a/connector-runtime/connector-runtime-test/src/test/java/io/camunda/connector/runtime/test/example/outbound/ExampleTestData.java
+++ b/connector-runtime/connector-runtime-test/src/test/java/io/camunda/connector/runtime/test/example/outbound/ExampleTestData.java
@@ -16,21 +16,16 @@
  */
 package io.camunda.connector.runtime.test.example.outbound;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.Arrays;
 import java.util.Collections;
+import tools.jackson.databind.ObjectMapper;
 
 public class ExampleTestData {
 
   static final ObjectMapper objectMapper = new ObjectMapper();
 
   static String toJson(Object value) {
-    try {
-      return objectMapper.writeValueAsString(value);
-    } catch (JsonProcessingException e) {
-      throw new RuntimeException(e);
-    }
+    return objectMapper.writeValueAsString(value);
   }
 
   public static final String Object = toJson(new ExampleOutboundInput("FOO", null));

--- a/connector-runtime/jackson-datatype-document/pom.xml
+++ b/connector-runtime/jackson-datatype-document/pom.xml
@@ -18,7 +18,7 @@
       <artifactId>connector-core</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
+      <groupId>tools.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
     </dependency>
     <dependency>
@@ -26,8 +26,19 @@
       <artifactId>jackson-annotations</artifactId>
     </dependency>
     <dependency>
+      <groupId>tools.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
+    <!-- Jackson 2: the legacy DocumentSerializer variant is kept on Jackson 2 because it is
+         registered onto connector-feel's LocalFeelExpressionEvaluator ObjectMapper, which cannot
+         move to Jackson 3 until jackson-module-scala ships a Jackson 3 release. -->
+    <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>

--- a/connector-runtime/jackson-datatype-document/src/main/java/io/camunda/connector/document/jackson/DocumentReferenceModel.java
+++ b/connector-runtime/jackson-datatype-document/src/main/java/io/camunda/connector/document/jackson/DocumentReferenceModel.java
@@ -23,7 +23,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeInfo.As;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.camunda.connector.api.document.DocumentMetadata;
 import io.camunda.connector.api.document.DocumentReference;
 import io.camunda.connector.document.jackson.DocumentReferenceModel.CamundaDocumentReferenceModel;
@@ -32,6 +31,7 @@ import io.camunda.connector.document.jackson.DocumentReferenceModel.InlineDocume
 import io.camunda.connector.document.jackson.deserializer.InlineContentDeserializer;
 import java.time.OffsetDateTime;
 import java.util.Map;
+import tools.jackson.databind.annotation.JsonDeserialize;
 
 @JsonTypeInfo(
     use = JsonTypeInfo.Id.NAME,

--- a/connector-runtime/jackson-datatype-document/src/main/java/io/camunda/connector/document/jackson/JacksonModuleDocumentDeserializer.java
+++ b/connector-runtime/jackson-datatype-document/src/main/java/io/camunda/connector/document/jackson/JacksonModuleDocumentDeserializer.java
@@ -16,8 +16,6 @@
  */
 package io.camunda.connector.document.jackson;
 
-import com.fasterxml.jackson.core.Version;
-import com.fasterxml.jackson.databind.module.SimpleModule;
 import io.camunda.connector.api.document.Document;
 import io.camunda.connector.api.document.DocumentFactory;
 import io.camunda.connector.document.jackson.deserializer.ByteArrayDeserializer;
@@ -27,6 +25,8 @@ import io.camunda.connector.document.jackson.deserializer.ObjectDeserializer;
 import io.camunda.connector.document.jackson.deserializer.StringDeserializer;
 import java.io.InputStream;
 import java.util.Map;
+import tools.jackson.core.Version;
+import tools.jackson.databind.module.SimpleModule;
 
 public class JacksonModuleDocumentDeserializer extends SimpleModule {
 

--- a/connector-runtime/jackson-datatype-document/src/main/java/io/camunda/connector/document/jackson/JacksonModuleDocumentSerializer.java
+++ b/connector-runtime/jackson-datatype-document/src/main/java/io/camunda/connector/document/jackson/JacksonModuleDocumentSerializer.java
@@ -21,6 +21,12 @@ import com.fasterxml.jackson.databind.module.SimpleModule;
 import io.camunda.connector.api.document.Document;
 import io.camunda.connector.document.jackson.serializer.DocumentSerializer;
 
+/**
+ * Jackson 2 variant, kept only because it is registered onto connector-feel's
+ * LocalFeelExpressionEvaluator ObjectMapper, which cannot move to Jackson 3 until
+ * jackson-module-scala ships a Jackson 3 release. Every other ObjectMapper in the codebase uses
+ * {@link io.camunda.connector.document.jackson.v3.JacksonModuleDocumentSerializer} instead.
+ */
 public class JacksonModuleDocumentSerializer extends SimpleModule {
 
   public JacksonModuleDocumentSerializer() {}

--- a/connector-runtime/jackson-datatype-document/src/main/java/io/camunda/connector/document/jackson/deserializer/AbstractDeserializer.java
+++ b/connector-runtime/jackson-datatype-document/src/main/java/io/camunda/connector/document/jackson/deserializer/AbstractDeserializer.java
@@ -16,15 +16,14 @@
  */
 package io.camunda.connector.document.jackson.deserializer;
 
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JsonDeserializer;
-import com.fasterxml.jackson.databind.JsonNode;
 import io.camunda.connector.document.jackson.JacksonModuleDocumentDeserializer.DocumentModuleSettings;
-import java.io.IOException;
+import tools.jackson.core.JsonParser;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ValueDeserializer;
 
 /** Base class for deserializers within the document module. */
-public abstract class AbstractDeserializer<T> extends JsonDeserializer<T> {
+public abstract class AbstractDeserializer<T> extends ValueDeserializer<T> {
 
   protected final DocumentModuleSettings settings;
 
@@ -33,13 +32,12 @@ public abstract class AbstractDeserializer<T> extends JsonDeserializer<T> {
   }
 
   /**
-   * Base method from {@link JsonDeserializer} to deserialize a JSON node. It will delegate to
+   * Base method from {@link ValueDeserializer} to deserialize a JSON node. It will delegate to
    * {@link #handleJsonNode(JsonNode, DeserializationContext)} to perform the actual
    * deserialization.
    */
   @Override
-  public T deserialize(JsonParser jsonParser, DeserializationContext deserializationContext)
-      throws IOException {
+  public T deserialize(JsonParser jsonParser, DeserializationContext deserializationContext) {
     DeserializationUtil.ensureIntrinsicFunctionCounterInitialized(deserializationContext, settings);
     final JsonNode node = jsonParser.readValueAsTree();
     if (node == null || node.isNull()) {
@@ -54,6 +52,5 @@ public abstract class AbstractDeserializer<T> extends JsonDeserializer<T> {
    * the parser can only be read once. All deserializer-specific logic should be implemented in this
    * method.
    */
-  protected abstract T handleJsonNode(JsonNode node, DeserializationContext context)
-      throws IOException;
+  protected abstract T handleJsonNode(JsonNode node, DeserializationContext context);
 }

--- a/connector-runtime/jackson-datatype-document/src/main/java/io/camunda/connector/document/jackson/deserializer/ByteArrayDeserializer.java
+++ b/connector-runtime/jackson-datatype-document/src/main/java/io/camunda/connector/document/jackson/deserializer/ByteArrayDeserializer.java
@@ -18,21 +18,15 @@ package io.camunda.connector.document.jackson.deserializer;
 
 import static io.camunda.connector.document.jackson.deserializer.DeserializationUtil.isDocumentReference;
 
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JsonDeserializer;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.deser.std.PrimitiveArrayDeserializers;
 import io.camunda.connector.api.document.Document;
 import io.camunda.connector.api.document.DocumentFactory;
 import io.camunda.connector.document.jackson.IntrinsicFunctionExecutor;
 import io.camunda.connector.document.jackson.JacksonModuleDocumentDeserializer.DocumentModuleSettings;
-import java.io.IOException;
 import java.util.Map;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.JsonNode;
 
 public class ByteArrayDeserializer extends AbstractDeserializer<byte[]> {
-
-  private final JsonDeserializer<?> fallbackDeserializer =
-      PrimitiveArrayDeserializers.forType(byte.class);
 
   private final DocumentDeserializer documentDeserializer;
   private final IntrinsicFunctionObjectResultDeserializer intrinsicFunctionDeserializer;
@@ -62,8 +56,7 @@ public class ByteArrayDeserializer extends AbstractDeserializer<byte[]> {
   }
 
   @Override
-  protected byte[] handleJsonNode(JsonNode node, DeserializationContext context)
-      throws IOException {
+  protected byte[] handleJsonNode(JsonNode node, DeserializationContext context) {
 
     if (isDocumentReference(node)) {
       final var document = documentDeserializer.handleJsonNode(node, context);
@@ -79,9 +72,7 @@ public class ByteArrayDeserializer extends AbstractDeserializer<byte[]> {
           "Unsupported operation result, expected a document, got: " + functionResult);
     }
 
-    // if not document or operation, fallback to default deserialization
-    var parser = node.traverse(context.getParser().getCodec());
-    parser.nextToken();
-    return (byte[]) fallbackDeserializer.deserialize(parser, context);
+    // if not document or operation, fall back to base64-decoding the node's binary/text content
+    return node.binaryValue();
   }
 }

--- a/connector-runtime/jackson-datatype-document/src/main/java/io/camunda/connector/document/jackson/deserializer/DeserializationUtil.java
+++ b/connector-runtime/jackson-datatype-document/src/main/java/io/camunda/connector/document/jackson/deserializer/DeserializationUtil.java
@@ -16,11 +16,11 @@
  */
 package io.camunda.connector.document.jackson.deserializer;
 
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JsonNode;
 import io.camunda.connector.document.jackson.DocumentReferenceModel;
 import io.camunda.connector.document.jackson.IntrinsicFunctionModel;
 import io.camunda.connector.document.jackson.JacksonModuleDocumentDeserializer.DocumentModuleSettings;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.JsonNode;
 
 public class DeserializationUtil {
 

--- a/connector-runtime/jackson-datatype-document/src/main/java/io/camunda/connector/document/jackson/deserializer/DocumentDeserializer.java
+++ b/connector-runtime/jackson-datatype-document/src/main/java/io/camunda/connector/document/jackson/deserializer/DocumentDeserializer.java
@@ -19,17 +19,16 @@ package io.camunda.connector.document.jackson.deserializer;
 import static io.camunda.connector.document.jackson.deserializer.DeserializationUtil.isDocumentReference;
 import static io.camunda.connector.document.jackson.deserializer.DeserializationUtil.isIntrinsicFunction;
 
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JsonNode;
 import io.camunda.connector.api.document.Document;
 import io.camunda.connector.api.document.DocumentFactory;
 import io.camunda.connector.document.jackson.DocumentReferenceModel;
 import io.camunda.connector.document.jackson.IntrinsicFunctionExecutor;
 import io.camunda.connector.document.jackson.JacksonModuleDocumentDeserializer.DocumentModuleSettings;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.JsonNode;
 
 /**
  * Deserializer for {@link Document} targets. It supports both the case where the source is a
@@ -96,15 +95,13 @@ public class DocumentDeserializer extends AbstractDeserializer<Document> {
   }
 
   @Override
-  protected Document handleJsonNode(JsonNode node, DeserializationContext context)
-      throws IOException {
+  protected Document handleJsonNode(JsonNode node, DeserializationContext context) {
     if (isDocumentReference(node)) {
       final var reference = context.readTreeAsValue(node, DocumentReferenceModel.class);
       return resolveDocumentFactory(context).resolve(reference);
     }
     if (node.isArray()) {
-      List<JsonNode> elements = new ArrayList<>();
-      node.elements().forEachRemaining(elements::add);
+      List<JsonNode> elements = new ArrayList<>(node.values());
       if (elements.size() == 1 && isDocumentReference(elements.get(0))) {
         final var reference =
             context.readTreeAsValue(elements.get(0), DocumentReferenceModel.class);

--- a/connector-runtime/jackson-datatype-document/src/main/java/io/camunda/connector/document/jackson/deserializer/InlineContentDeserializer.java
+++ b/connector-runtime/jackson-datatype-document/src/main/java/io/camunda/connector/document/jackson/deserializer/InlineContentDeserializer.java
@@ -16,21 +16,20 @@
  */
 package io.camunda.connector.document.jackson.deserializer;
 
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.JsonToken;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JsonDeserializer;
-import com.fasterxml.jackson.databind.JsonNode;
-import java.io.IOException;
+import tools.jackson.core.JsonParser;
+import tools.jackson.core.JsonToken;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ValueDeserializer;
 
 /**
  * Allows inline document content to be provided either as a JSON string or as arbitrary JSON.
  * String values are used as-is; non-string JSON values are captured as compact JSON text.
  */
-public class InlineContentDeserializer extends JsonDeserializer<String> {
+public class InlineContentDeserializer extends ValueDeserializer<String> {
 
   @Override
-  public String deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+  public String deserialize(JsonParser p, DeserializationContext ctxt) {
     JsonToken token = p.currentToken();
     if (token == JsonToken.VALUE_NULL) {
       return null;

--- a/connector-runtime/jackson-datatype-document/src/main/java/io/camunda/connector/document/jackson/deserializer/InputStreamDeserializer.java
+++ b/connector-runtime/jackson-datatype-document/src/main/java/io/camunda/connector/document/jackson/deserializer/InputStreamDeserializer.java
@@ -18,15 +18,14 @@ package io.camunda.connector.document.jackson.deserializer;
 
 import static io.camunda.connector.document.jackson.deserializer.DeserializationUtil.isDocumentReference;
 
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JsonNode;
 import io.camunda.connector.api.document.Document;
 import io.camunda.connector.api.document.DocumentFactory;
 import io.camunda.connector.document.jackson.IntrinsicFunctionExecutor;
 import io.camunda.connector.document.jackson.JacksonModuleDocumentDeserializer.DocumentModuleSettings;
-import java.io.IOException;
 import java.io.InputStream;
 import java.util.Map;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.JsonNode;
 
 public class InputStreamDeserializer extends AbstractDeserializer<InputStream> {
 
@@ -63,8 +62,7 @@ public class InputStreamDeserializer extends AbstractDeserializer<InputStream> {
   }
 
   @Override
-  protected InputStream handleJsonNode(JsonNode node, DeserializationContext context)
-      throws IOException {
+  protected InputStream handleJsonNode(JsonNode node, DeserializationContext context) {
     if (isDocumentReference(node)) {
       final var document = buildDocumentDeserializer().handleJsonNode(node, context);
       return document.asInputStream();

--- a/connector-runtime/jackson-datatype-document/src/main/java/io/camunda/connector/document/jackson/deserializer/IntrinsicFunctionObjectResultDeserializer.java
+++ b/connector-runtime/jackson-datatype-document/src/main/java/io/camunda/connector/document/jackson/deserializer/IntrinsicFunctionObjectResultDeserializer.java
@@ -18,13 +18,12 @@ package io.camunda.connector.document.jackson.deserializer;
 
 import static io.camunda.connector.document.jackson.deserializer.DeserializationUtil.isIntrinsicFunction;
 
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JsonNode;
 import io.camunda.connector.document.jackson.IntrinsicFunctionExecutor;
 import io.camunda.connector.document.jackson.IntrinsicFunctionModel;
 import io.camunda.connector.document.jackson.IntrinsicFunctionParams;
 import io.camunda.connector.document.jackson.JacksonModuleDocumentDeserializer.DocumentModuleSettings;
-import java.io.IOException;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.JsonNode;
 
 public class IntrinsicFunctionObjectResultDeserializer extends AbstractDeserializer<Object> {
 
@@ -37,8 +36,7 @@ public class IntrinsicFunctionObjectResultDeserializer extends AbstractDeseriali
   }
 
   @Override
-  protected Object handleJsonNode(JsonNode node, DeserializationContext context)
-      throws IOException {
+  protected Object handleJsonNode(JsonNode node, DeserializationContext context) {
     if (!isIntrinsicFunction(node)) {
       throw new IllegalArgumentException(
           "Unsupported document format. Expected an operation, got: " + node);

--- a/connector-runtime/jackson-datatype-document/src/main/java/io/camunda/connector/document/jackson/deserializer/ObjectDeserializer.java
+++ b/connector-runtime/jackson-datatype-document/src/main/java/io/camunda/connector/document/jackson/deserializer/ObjectDeserializer.java
@@ -19,16 +19,14 @@ package io.camunda.connector.document.jackson.deserializer;
 import static io.camunda.connector.document.jackson.deserializer.DeserializationUtil.isDocumentReference;
 import static io.camunda.connector.document.jackson.deserializer.DeserializationUtil.isIntrinsicFunction;
 
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.deser.std.UntypedObjectDeserializer;
 import io.camunda.connector.api.document.DocumentFactory;
 import io.camunda.connector.document.jackson.IntrinsicFunctionExecutor;
 import io.camunda.connector.document.jackson.JacksonModuleDocumentDeserializer.DocumentModuleSettings;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.JsonNode;
 
 public class ObjectDeserializer extends AbstractDeserializer<Object> {
 
@@ -60,8 +58,7 @@ public class ObjectDeserializer extends AbstractDeserializer<Object> {
   }
 
   @Override
-  protected Object handleJsonNode(JsonNode node, DeserializationContext context)
-      throws IOException {
+  protected Object handleJsonNode(JsonNode node, DeserializationContext context) {
     if (isDocumentReference(node)) {
       // return Document object
       return documentDeserializer.handleJsonNode(node, context);
@@ -76,16 +73,13 @@ public class ObjectDeserializer extends AbstractDeserializer<Object> {
   }
 
   /** Fallback deserialization when the object is neither a document reference nor an operation. */
-  public Object fallback(JsonNode node, DeserializationContext ctx) throws IOException {
+  public Object fallback(JsonNode node, DeserializationContext ctx) {
     if (node.isObject()) {
-      var fields = node.fields();
+      var fields = node.properties();
       var map = new LinkedHashMap<String, Object>();
-      while (fields.hasNext()) {
-        var field = fields.next();
-        var parser = field.getValue().traverse();
-        parser.setCodec(ctx.getParser().getCodec());
-        // invoke the deserializer for the field
-        map.put(field.getKey(), ctx.readValue(parser, Object.class));
+      for (var field : fields) {
+        // invoke the deserializer for the field, so nested document references are still resolved
+        map.put(field.getKey(), ctx.readTreeAsValue(field.getValue(), Object.class));
       }
       return map;
     }
@@ -93,18 +87,24 @@ public class ObjectDeserializer extends AbstractDeserializer<Object> {
     if (node.isArray()) {
       var list = new ArrayList<>();
       for (int i = 0; i < node.size(); i++) {
-        var parser = node.get(i).traverse();
-        parser.setCodec(ctx.getParser().getCodec());
-        // invoke the deserializer for the element
-        list.add(ctx.readValue(parser, Object.class));
+        // invoke the deserializer for the element, so nested document references are still resolved
+        list.add(ctx.readTreeAsValue(node.get(i), Object.class));
       }
       return list;
     }
 
-    var parser = node.traverse(ctx.getParser().getCodec());
-    parser.nextToken();
-
-    final var fallbackDeserializer = new UntypedObjectDeserializer(null, null);
-    return fallbackDeserializer.deserialize(parser, ctx);
+    if (node.isTextual()) {
+      return node.textValue();
+    }
+    if (node.isNumber()) {
+      return node.numberValue();
+    }
+    if (node.isBoolean()) {
+      return node.booleanValue();
+    }
+    if (node.isBinary()) {
+      return node.binaryValue();
+    }
+    return null;
   }
 }

--- a/connector-runtime/jackson-datatype-document/src/main/java/io/camunda/connector/document/jackson/deserializer/StringDeserializer.java
+++ b/connector-runtime/jackson-datatype-document/src/main/java/io/camunda/connector/document/jackson/deserializer/StringDeserializer.java
@@ -19,18 +19,14 @@ package io.camunda.connector.document.jackson.deserializer;
 import static io.camunda.connector.document.jackson.deserializer.DeserializationUtil.isDocumentReference;
 import static io.camunda.connector.document.jackson.deserializer.DeserializationUtil.isIntrinsicFunction;
 
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JsonNode;
 import io.camunda.connector.api.document.DocumentFactory;
 import io.camunda.connector.document.jackson.IntrinsicFunctionExecutor;
 import io.camunda.connector.document.jackson.JacksonModuleDocumentDeserializer.DocumentModuleSettings;
-import java.io.IOException;
 import java.util.Map;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.JsonNode;
 
 public class StringDeserializer extends AbstractDeserializer<String> {
-
-  private final com.fasterxml.jackson.databind.deser.std.StringDeserializer fallbackDeserializer =
-      new com.fasterxml.jackson.databind.deser.std.StringDeserializer();
 
   private final DocumentDeserializer documentDeserializer;
   private final IntrinsicFunctionObjectResultDeserializer intrinsicFunctionDeserializer;
@@ -60,8 +56,7 @@ public class StringDeserializer extends AbstractDeserializer<String> {
   }
 
   @Override
-  protected String handleJsonNode(JsonNode node, DeserializationContext context)
-      throws IOException {
+  protected String handleJsonNode(JsonNode node, DeserializationContext context) {
     if (isDocumentReference(node)) {
       final var document = documentDeserializer.handleJsonNode(node, context);
       return document.asBase64();
@@ -75,9 +70,7 @@ public class StringDeserializer extends AbstractDeserializer<String> {
       throw new IllegalArgumentException(
           "Unsupported operation result, expected a string, got: " + operationResult);
     }
-    // if not document or operation, fallback to default deserialization
-    var parser = node.traverse(context.getParser().getCodec());
-    parser.nextToken();
-    return fallbackDeserializer.deserialize(parser, context);
+    // if not document or operation, fall back to the node's default text coercion
+    return node.asText();
   }
 }

--- a/connector-runtime/jackson-datatype-document/src/main/java/io/camunda/connector/document/jackson/v3/JacksonModuleDocumentSerializer.java
+++ b/connector-runtime/jackson-datatype-document/src/main/java/io/camunda/connector/document/jackson/v3/JacksonModuleDocumentSerializer.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.document.jackson.v3;
+
+import io.camunda.connector.api.document.Document;
+import io.camunda.connector.document.jackson.v3.serializer.DocumentSerializer;
+import tools.jackson.core.Version;
+import tools.jackson.databind.module.SimpleModule;
+
+/**
+ * Jackson 3 counterpart of {@link
+ * io.camunda.connector.document.jackson.JacksonModuleDocumentSerializer}. See that class' javadoc
+ * for why a separate Jackson 2 variant still exists.
+ */
+public class JacksonModuleDocumentSerializer extends SimpleModule {
+
+  public JacksonModuleDocumentSerializer() {}
+
+  @Override
+  public String getModuleName() {
+    return "JacksonModuleDocumentSerializer";
+  }
+
+  @Override
+  public Version version() {
+    // TODO: get version from pom.xml
+    return new Version(0, 1, 0, null, "io.camunda", "jackson-datatype-document");
+  }
+
+  @Override
+  public void setupModule(SetupContext context) {
+    addSerializer(Document.class, new DocumentSerializer());
+    super.setupModule(context);
+  }
+}

--- a/connector-runtime/jackson-datatype-document/src/main/java/io/camunda/connector/document/jackson/v3/serializer/DocumentSerializer.java
+++ b/connector-runtime/jackson-datatype-document/src/main/java/io/camunda/connector/document/jackson/v3/serializer/DocumentSerializer.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.document.jackson.v3.serializer;
+
+import io.camunda.connector.api.document.Document;
+import io.camunda.connector.api.document.DocumentReference;
+import io.camunda.connector.api.document.DocumentReference.CamundaDocumentReference;
+import io.camunda.connector.api.document.DocumentReference.InlineDocumentReference;
+import io.camunda.connector.document.jackson.DocumentReferenceModel;
+import io.camunda.connector.document.jackson.DocumentReferenceModel.CamundaDocumentMetadataModel;
+import io.camunda.connector.document.jackson.DocumentReferenceModel.CamundaDocumentReferenceModel;
+import io.camunda.connector.document.jackson.DocumentReferenceModel.InlineDocumentReferenceModel;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.databind.SerializationContext;
+import tools.jackson.databind.ValueSerializer;
+
+/**
+ * Jackson 3 counterpart of {@link
+ * io.camunda.connector.document.jackson.serializer.DocumentSerializer}. That legacy variant is kept
+ * on Jackson 2 because it is registered onto connector-feel's LocalFeelExpressionEvaluator
+ * ObjectMapper, which cannot move to Jackson 3 until jackson-module-scala ships a Jackson 3
+ * release. This class is used by every other, Jackson 3-based ObjectMapper.
+ */
+public class DocumentSerializer extends ValueSerializer<Document> {
+
+  public DocumentSerializer() {}
+
+  @Override
+  public void serialize(Document document, JsonGenerator jsonGenerator, SerializationContext ctxt) {
+    var reference = document.reference();
+    if (reference
+        instanceof DocumentReference.ExternalDocumentReference externalDocumentReference) {
+      final var model =
+          new DocumentReferenceModel.ExternalDocumentReferenceModel(
+              externalDocumentReference.url(), externalDocumentReference.name());
+      jsonGenerator.writePOJO(model);
+    } else if (reference instanceof CamundaDocumentReference camundaReference) {
+      final CamundaDocumentReferenceModel model;
+      if (camundaReference instanceof CamundaDocumentReferenceModel camundaModel) {
+        model = camundaModel;
+      } else {
+        model =
+            new CamundaDocumentReferenceModel(
+                camundaReference.getStoreId(),
+                camundaReference.getDocumentId(),
+                camundaReference.getContentHash(),
+                new CamundaDocumentMetadataModel(camundaReference.getMetadata()));
+      }
+      jsonGenerator.writePOJO(model);
+    } else if (reference instanceof InlineDocumentReference inlineReference) {
+      jsonGenerator.writePOJO(
+          new InlineDocumentReferenceModel(
+              inlineReference.content(), inlineReference.name(), inlineReference.contentType()));
+    } else {
+      throw new IllegalArgumentException("Unsupported document reference type: " + reference);
+    }
+  }
+}

--- a/connector-runtime/jackson-datatype-document/src/test/java/io/camunda/connector/document/jackson/InlineDocumentReferenceModelTest.java
+++ b/connector-runtime/jackson-datatype-document/src/test/java/io/camunda/connector/document/jackson/InlineDocumentReferenceModelTest.java
@@ -18,13 +18,14 @@ package io.camunda.connector.document.jackson;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.connector.document.jackson.DocumentReferenceModel.InlineDocumentReferenceModel;
 import org.junit.jupiter.api.Test;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 
 class InlineDocumentReferenceModelTest {
 
-  private final ObjectMapper objectMapper = new ObjectMapper();
+  private final ObjectMapper objectMapper = JsonMapper.builder().build();
 
   @Test
   void deserializeJsonObjectContent_storesAsRawJsonText() throws Exception {

--- a/connector-runtime/jackson-datatype-feel/pom.xml
+++ b/connector-runtime/jackson-datatype-feel/pom.xml
@@ -18,8 +18,18 @@
       <artifactId>connector-feel</artifactId>
     </dependency>
     <dependency>
+      <groupId>tools.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
+    <!-- Jackson 2: the v2 subpackage is kept only for the camundaJsonMapper Spring bean, whose
+         camunda-client-java CamundaObjectMapper wrapper has no Jackson 3 constructor yet. -->
+    <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
     </dependency>
     <dependency>
       <groupId>io.camunda.connector</groupId>
@@ -39,11 +49,6 @@
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.fasterxml.jackson.datatype</groupId>
-      <artifactId>jackson-datatype-jsr310</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/connector-runtime/jackson-datatype-feel/src/main/java/io/camunda/connector/feel/jackson/AbstractFeelDeserializer.java
+++ b/connector-runtime/jackson-datatype-feel/src/main/java/io/camunda/connector/feel/jackson/AbstractFeelDeserializer.java
@@ -16,18 +16,18 @@
  */
 package io.camunda.connector.feel.jackson;
 
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JavaType;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.deser.ContextualDeserializer;
-import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import io.camunda.connector.feel.FeelEngineWrapperException;
 import io.camunda.connector.feel.FeelExpressionEvaluator;
 import io.camunda.connector.jackson.ConnectorsObjectMapperSupplier;
-import java.io.IOException;
+import java.util.Map;
 import java.util.function.Supplier;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.JsonParser;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.JavaType;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.deser.std.StdDeserializer;
 
 /**
  * Base Jackson deserializer for connector FEEL-backed values.
@@ -37,8 +37,7 @@ import java.util.function.Supplier;
  *
  * @param <T> the deserialized target type
  */
-public abstract class AbstractFeelDeserializer<T> extends StdDeserializer<T>
-    implements ContextualDeserializer {
+public abstract class AbstractFeelDeserializer<T> extends StdDeserializer<T> {
 
   /**
    * A blank object mapper object for use in inheriting classes.
@@ -47,7 +46,7 @@ public abstract class AbstractFeelDeserializer<T> extends StdDeserializer<T>
    * aware of any registered modules beyond what's present in the default ObjectMapper. For example,
    * jackson-datatype-document will not be registered. It should not be used to deserialize the
    * final result. For final results, use the {@link DeserializationContext} object passed to {@link
-   * #doDeserialize(JsonNode, JsonNode, DeserializationContext)} instead.
+   * #doDeserialize(JsonNode, Object, DeserializationContext)} instead.
    */
   protected static final ObjectMapper BLANK_OBJECT_MAPPER =
       ConnectorsObjectMapperSupplier.getCopy();
@@ -86,7 +85,7 @@ public abstract class AbstractFeelDeserializer<T> extends StdDeserializer<T>
   }
 
   @Override
-  public T deserialize(JsonParser parser, DeserializationContext context) throws IOException {
+  public T deserialize(JsonParser parser, DeserializationContext context) {
     JsonNode node = parser.readValueAsTree();
     if (node == null || node.isNull()) {
       return null;
@@ -97,21 +96,25 @@ public abstract class AbstractFeelDeserializer<T> extends StdDeserializer<T>
           context.getAttribute(FeelContextAwareObjectReader.FEEL_CONTEXT_ATTRIBUTE);
 
       if (feelContextSupplier == null) {
-        return doDeserialize(node, BLANK_OBJECT_MAPPER.createObjectNode(), context);
+        return doDeserialize(node, Map.of(), context);
       }
       if (feelContextSupplier instanceof Supplier<?> supplier) {
-        return doDeserialize(node, BLANK_OBJECT_MAPPER.valueToTree(supplier.get()), context);
+        // Passed through as-is (not converted via Jackson): the effective evaluator resolved
+        // below may be backed by a different major Jackson version (e.g. the local FEEL
+        // evaluator, which is Jackson 2-only), which would not recognize a Jackson 3 JsonNode as
+        // its own tree type when merging it into the evaluation variables.
+        return doDeserialize(node, supplier.get(), context);
       }
-      throw new IOException(
+      throw new IllegalArgumentException(
           "Attribute "
               + FeelContextAwareObjectReader.FEEL_CONTEXT_ATTRIBUTE
               + " must be a Supplier, but was: "
               + feelContextSupplier.getClass());
     }
-    throw new IOException(
+    throw new IllegalArgumentException(
         "Invalid input: expected a FEEL expression (starting with '=') or a JSON object/array/etc. "
             + "Property name: "
-            + parser.getParsingContext().getCurrentName());
+            + parser.currentName());
   }
 
   /**
@@ -157,7 +160,7 @@ public abstract class AbstractFeelDeserializer<T> extends StdDeserializer<T>
         return (R) BLANK_OBJECT_MAPPER.writeValueAsString(jsonNode);
       }
       return ctx.readTreeAsValue(jsonNode, targetType);
-    } catch (IOException e) {
+    } catch (JacksonException e) {
       throw new FeelEngineWrapperException(
           "Failed to convert FEEL evaluation result to the target type", expression, variables, e);
     }
@@ -170,11 +173,9 @@ public abstract class AbstractFeelDeserializer<T> extends StdDeserializer<T>
    * @param feelContext the FEEL context available during evaluation
    * @param deserializationContext the Jackson deserialization context
    * @return the deserialized value
-   * @throws IOException when deserialization fails
    */
   protected abstract T doDeserialize(
-      JsonNode node, JsonNode feelContext, DeserializationContext deserializationContext)
-      throws IOException;
+      JsonNode node, Object feelContext, DeserializationContext deserializationContext);
 
   private FeelExpressionEvaluator resolveEvaluator(DeserializationContext ctx) {
     // Strict deserializers are used for deferred runtime callbacks like Function/Supplier.

--- a/connector-runtime/jackson-datatype-feel/src/main/java/io/camunda/connector/feel/jackson/FeelAnnotationIntrospector.java
+++ b/connector-runtime/jackson-datatype-feel/src/main/java/io/camunda/connector/feel/jackson/FeelAnnotationIntrospector.java
@@ -16,10 +16,11 @@
  */
 package io.camunda.connector.feel.jackson;
 
-import com.fasterxml.jackson.databind.introspect.Annotated;
-import com.fasterxml.jackson.databind.introspect.JacksonAnnotationIntrospector;
 import io.camunda.connector.api.annotation.FEEL;
 import io.camunda.connector.feel.FeelExpressionEvaluator;
+import tools.jackson.databind.cfg.MapperConfig;
+import tools.jackson.databind.introspect.Annotated;
+import tools.jackson.databind.introspect.JacksonAnnotationIntrospector;
 
 public class FeelAnnotationIntrospector extends JacksonAnnotationIntrospector {
 
@@ -35,11 +36,11 @@ public class FeelAnnotationIntrospector extends JacksonAnnotationIntrospector {
   }
 
   @Override
-  public Object findDeserializer(Annotated a) {
+  public Object findDeserializer(MapperConfig<?> config, Annotated a) {
     FEEL ann = _findAnnotation(a, FEEL.class);
     if (ann != null) {
       return new FeelDeserializer(evaluator);
     }
-    return super.findDeserializer(a);
+    return super.findDeserializer(config, a);
   }
 }

--- a/connector-runtime/jackson-datatype-feel/src/main/java/io/camunda/connector/feel/jackson/FeelContextAwareObjectReader.java
+++ b/connector-runtime/jackson-datatype-feel/src/main/java/io/camunda/connector/feel/jackson/FeelContextAwareObjectReader.java
@@ -16,10 +16,10 @@
  */
 package io.camunda.connector.feel.jackson;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.ObjectReader;
 import io.camunda.connector.feel.FeelExpressionEvaluator;
 import java.util.function.Supplier;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectReader;
 
 /**
  * Shortcut builder-like API for configuring {@link ObjectMapper} instances to contain a FEEL

--- a/connector-runtime/jackson-datatype-feel/src/main/java/io/camunda/connector/feel/jackson/FeelDeserializer.java
+++ b/connector-runtime/jackson-datatype-feel/src/main/java/io/camunda/connector/feel/jackson/FeelDeserializer.java
@@ -16,20 +16,20 @@
  */
 package io.camunda.connector.feel.jackson;
 
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.databind.BeanProperty;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JavaType;
-import com.fasterxml.jackson.databind.JsonDeserializer;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.type.TypeFactory;
 import io.camunda.connector.feel.FeelExpressionEvaluator;
 import io.camunda.connector.feel.LocalFeelExpressionEvaluator;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.JsonParser;
+import tools.jackson.databind.BeanProperty;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.JavaType;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ValueDeserializer;
+import tools.jackson.databind.type.TypeFactory;
 
 /**
  * A Jackson deserializer for FEEL expressions. It can be used to deserialize a string that contains
@@ -63,7 +63,7 @@ public class FeelDeserializer extends AbstractFeelDeserializer<Object> {
 
   @Override
   protected Object doDeserialize(
-      JsonNode node, JsonNode feelContext, DeserializationContext jacksonCtx) throws IOException {
+      JsonNode node, Object feelContext, DeserializationContext jacksonCtx) {
 
     if (isFeelExpression(node.textValue())) {
       return evaluateFeelExpression(jacksonCtx, node.textValue(), outputType, feelContext);
@@ -81,15 +81,15 @@ public class FeelDeserializer extends AbstractFeelDeserializer<Object> {
               || (textValue.startsWith("'") && textValue.endsWith("'")))) {
         return handleNormalJsonNode(node, jacksonCtx);
       } else {
-        var jsonFactory = jacksonCtx.getParser().getCodec().getFactory();
-        try (JsonParser jsonParser = jsonFactory.createParser(textValue)) {
+        try (JsonParser jsonParser =
+            jacksonCtx.tokenStreamFactory().createParser(jacksonCtx, textValue)) {
           // check if this string contains a JSON object/array/etc inside (i.e. it's not just a
           // string)
           JsonNode jsonNode = jsonParser.readValueAsTree();
           if (jsonNode != null && !jsonNode.isNull()) {
             return handleNormalJsonNode(jsonNode, jacksonCtx);
           }
-        } catch (IOException e) {
+        } catch (JacksonException e) {
           // ignore, this is just a string, we will take care of it below
         }
       }
@@ -97,8 +97,7 @@ public class FeelDeserializer extends AbstractFeelDeserializer<Object> {
     return handleNormalJsonNode(node, jacksonCtx);
   }
 
-  protected Object handleNormalJsonNode(JsonNode node, DeserializationContext context)
-      throws IOException {
+  protected Object handleNormalJsonNode(JsonNode node, DeserializationContext context) {
 
     if (node == null || node.isNull()) {
       return null;
@@ -150,7 +149,7 @@ public class FeelDeserializer extends AbstractFeelDeserializer<Object> {
   }
 
   @Override
-  public JsonDeserializer<?> createContextual(DeserializationContext ctxt, BeanProperty property) {
+  public ValueDeserializer<?> createContextual(DeserializationContext ctxt, BeanProperty property) {
     return new FeelDeserializer(evaluator, property.getType());
   }
 }

--- a/connector-runtime/jackson-datatype-feel/src/main/java/io/camunda/connector/feel/jackson/FeelFunctionDeserializer.java
+++ b/connector-runtime/jackson-datatype-feel/src/main/java/io/camunda/connector/feel/jackson/FeelFunctionDeserializer.java
@@ -17,17 +17,16 @@
 package io.camunda.connector.feel.jackson;
 
 import com.fasterxml.jackson.annotation.JsonMerge;
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.BeanProperty;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JavaType;
-import com.fasterxml.jackson.databind.JsonDeserializer;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.type.TypeFactory;
 import io.camunda.connector.feel.FeelExpressionEvaluator;
-import java.io.IOException;
 import java.util.Map;
 import java.util.function.Function;
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.BeanProperty;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.JavaType;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ValueDeserializer;
+import tools.jackson.databind.type.TypeFactory;
 
 class FeelFunctionDeserializer<IN, OUT> extends AbstractFeelDeserializer<Function<IN, OUT>> {
 
@@ -43,7 +42,7 @@ class FeelFunctionDeserializer<IN, OUT> extends AbstractFeelDeserializer<Functio
   @Override
   @SuppressWarnings("unchecked")
   protected Function<IN, OUT> doDeserialize(
-      JsonNode node, JsonNode feelContext, DeserializationContext deserializationContext) {
+      JsonNode node, Object feelContext, DeserializationContext deserializationContext) {
     return (input) -> {
       JsonNode jsonNode =
           BLANK_OBJECT_MAPPER.valueToTree(
@@ -53,23 +52,19 @@ class FeelFunctionDeserializer<IN, OUT> extends AbstractFeelDeserializer<Functio
                   deserializationContext.getTypeFactory().constructType(JsonNode.class),
                   input,
                   feelContext));
-      try {
-        if (jsonNode == null || jsonNode.isNull()) {
-          return null;
-        }
-        if (outputType.getRawClass() == String.class && jsonNode.isObject()) {
-          return (OUT) BLANK_OBJECT_MAPPER.writeValueAsString(jsonNode);
-        } else {
-          return deserializationContext.readTreeAsValue(jsonNode, outputType);
-        }
-      } catch (IOException e) {
-        throw new RuntimeException(e);
+      if (jsonNode == null || jsonNode.isNull()) {
+        return null;
+      }
+      if (outputType.getRawClass() == String.class && jsonNode.isObject()) {
+        return (OUT) BLANK_OBJECT_MAPPER.writeValueAsString(jsonNode);
+      } else {
+        return deserializationContext.readTreeAsValue(jsonNode, outputType);
       }
     };
   }
 
   @Override
-  public JsonDeserializer<?> createContextual(DeserializationContext ctxt, BeanProperty property) {
+  public ValueDeserializer<?> createContextual(DeserializationContext ctxt, BeanProperty property) {
     if (property != null) {
       if (property.getType().containedTypeCount() == 2) {
         var outputType = property.getType().containedType(1);

--- a/connector-runtime/jackson-datatype-feel/src/main/java/io/camunda/connector/feel/jackson/FeelSupplierDeserializer.java
+++ b/connector-runtime/jackson-datatype-feel/src/main/java/io/camunda/connector/feel/jackson/FeelSupplierDeserializer.java
@@ -16,13 +16,13 @@
  */
 package io.camunda.connector.feel.jackson;
 
-import com.fasterxml.jackson.databind.BeanProperty;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JavaType;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.type.TypeFactory;
 import io.camunda.connector.feel.FeelExpressionEvaluator;
 import java.util.function.Supplier;
+import tools.jackson.databind.BeanProperty;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.JavaType;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.type.TypeFactory;
 
 class FeelSupplierDeserializer<OUT> extends AbstractFeelDeserializer<Supplier<OUT>> {
 
@@ -36,7 +36,7 @@ class FeelSupplierDeserializer<OUT> extends AbstractFeelDeserializer<Supplier<OU
   @SuppressWarnings("unchecked")
   @Override
   protected Supplier<OUT> doDeserialize(
-      JsonNode node, JsonNode feelContext, DeserializationContext deserializationContext) {
+      JsonNode node, Object feelContext, DeserializationContext deserializationContext) {
     return () ->
         (OUT)
             evaluateFeelExpression(

--- a/connector-runtime/jackson-datatype-feel/src/main/java/io/camunda/connector/feel/jackson/JacksonModuleFeelFunction.java
+++ b/connector-runtime/jackson-datatype-feel/src/main/java/io/camunda/connector/feel/jackson/JacksonModuleFeelFunction.java
@@ -16,13 +16,13 @@
  */
 package io.camunda.connector.feel.jackson;
 
-import com.fasterxml.jackson.core.Version;
-import com.fasterxml.jackson.databind.module.SimpleModule;
-import com.fasterxml.jackson.databind.type.TypeFactory;
 import io.camunda.connector.feel.FeelExpressionEvaluator;
 import io.camunda.connector.feel.LocalFeelExpressionEvaluator;
 import java.util.function.Function;
 import java.util.function.Supplier;
+import tools.jackson.core.Version;
+import tools.jackson.databind.module.SimpleModule;
+import tools.jackson.databind.type.TypeFactory;
 
 public class JacksonModuleFeelFunction extends SimpleModule {
 

--- a/connector-runtime/jackson-datatype-feel/src/main/java/io/camunda/connector/feel/jackson/v2/AbstractFeelDeserializer.java
+++ b/connector-runtime/jackson-datatype-feel/src/main/java/io/camunda/connector/feel/jackson/v2/AbstractFeelDeserializer.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.feel.jackson.v2;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.MapperFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.deser.ContextualDeserializer;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import io.camunda.connector.feel.FeelEngineWrapperException;
+import io.camunda.connector.feel.FeelExpressionEvaluator;
+import io.camunda.connector.feel.jackson.FeelContextAwareObjectReader;
+import java.io.IOException;
+import java.util.function.Supplier;
+
+/**
+ * Jackson 2 counterpart of {@link io.camunda.connector.feel.jackson.AbstractFeelDeserializer}, used
+ * only by the {@code camundaJsonMapper} Spring bean: that bean is wrapped in camunda-client-java's
+ * {@code CamundaObjectMapper}, whose constructor only accepts a Jackson 2 {@code ObjectMapper} (no
+ * Jackson 3 overload exists yet). Every other ObjectMapper in the codebase uses the Jackson 3
+ * variant instead. {@code DeserializationContext} attribute keys are plain strings, so both
+ * variants share the constants declared on {@link FeelContextAwareObjectReader} even though that
+ * class itself is Jackson 3-typed.
+ *
+ * @param <T> the deserialized target type
+ */
+public abstract class AbstractFeelDeserializer<T> extends StdDeserializer<T>
+    implements ContextualDeserializer {
+
+  /**
+   * A blank object mapper for use in inheriting classes. Deliberately a plain Jackson 2 mapper
+   * rather than a shared supplier — {@code ConnectorsObjectMapperSupplier} is Jackson 3-only.
+   */
+  protected static final ObjectMapper BLANK_OBJECT_MAPPER =
+      JsonMapper.builder()
+          .disable(SerializationFeature.FAIL_ON_EMPTY_BEANS)
+          .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+          .enable(MapperFeature.ACCEPT_CASE_INSENSITIVE_ENUMS)
+          .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+          .disable(SerializationFeature.WRITE_DURATIONS_AS_TIMESTAMPS)
+          .enable(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY)
+          .enable(DeserializationFeature.UNWRAP_SINGLE_VALUE_ARRAYS)
+          .enable(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE)
+          .build();
+
+  /** Evaluator configured for this deserializer instance. */
+  protected final FeelExpressionEvaluator evaluator;
+
+  /**
+   * Controls both accepted input shape and evaluator override behavior. See the Jackson 3 variant's
+   * javadoc for the full explanation.
+   */
+  protected final boolean relaxed;
+
+  protected AbstractFeelDeserializer(FeelExpressionEvaluator evaluator, boolean relaxed) {
+    super(String.class);
+    this.evaluator = evaluator;
+    this.relaxed = relaxed;
+  }
+
+  @Override
+  public T deserialize(JsonParser parser, DeserializationContext context) throws IOException {
+    JsonNode node = parser.readValueAsTree();
+    if (node == null || node.isNull()) {
+      return null;
+    }
+
+    if (isFeelExpression(node.textValue()) || relaxed) {
+      var feelContextSupplier =
+          context.getAttribute(FeelContextAwareObjectReader.FEEL_CONTEXT_ATTRIBUTE);
+
+      if (feelContextSupplier == null) {
+        return doDeserialize(node, BLANK_OBJECT_MAPPER.createObjectNode(), context);
+      }
+      if (feelContextSupplier instanceof Supplier<?> supplier) {
+        return doDeserialize(node, BLANK_OBJECT_MAPPER.valueToTree(supplier.get()), context);
+      }
+      throw new IOException(
+          "Attribute "
+              + FeelContextAwareObjectReader.FEEL_CONTEXT_ATTRIBUTE
+              + " must be a Supplier, but was: "
+              + feelContextSupplier.getClass());
+    }
+    throw new IOException(
+        "Invalid input: expected a FEEL expression (starting with '=') or a JSON object/array/etc. "
+            + "Property name: "
+            + parser.getParsingContext().getCurrentName());
+  }
+
+  protected boolean isFeelExpression(String value) {
+    return value != null && value.startsWith("=");
+  }
+
+  @SuppressWarnings("unchecked")
+  protected <R> R evaluateFeelExpression(
+      final DeserializationContext ctx,
+      final String expression,
+      final JavaType targetType,
+      final Object... variables) {
+    FeelExpressionEvaluator effectiveEvaluator = resolveEvaluator(ctx);
+    Object result = effectiveEvaluator.evaluate(expression, variables);
+
+    try {
+      if (result == null) {
+        return null;
+      }
+      JsonNode jsonNode = BLANK_OBJECT_MAPPER.valueToTree(result);
+      if (targetType.getRawClass() == String.class && jsonNode.isObject()) {
+        return (R) BLANK_OBJECT_MAPPER.writeValueAsString(jsonNode);
+      }
+      return ctx.readTreeAsValue(jsonNode, targetType);
+    } catch (IOException e) {
+      throw new FeelEngineWrapperException(
+          "Failed to convert FEEL evaluation result to the target type", expression, variables, e);
+    }
+  }
+
+  protected abstract T doDeserialize(
+      JsonNode node, JsonNode feelContext, DeserializationContext deserializationContext)
+      throws IOException;
+
+  private FeelExpressionEvaluator resolveEvaluator(DeserializationContext ctx) {
+    if (!relaxed) {
+      return evaluator;
+    }
+    var override = ctx.getAttribute(FeelContextAwareObjectReader.FEEL_EVALUATOR_ATTRIBUTE);
+    if (override == null) {
+      return evaluator;
+    }
+    if (override instanceof FeelExpressionEvaluator feelEvaluator) {
+      return feelEvaluator;
+    }
+    throw new IllegalArgumentException(
+        "Attribute "
+            + FeelContextAwareObjectReader.FEEL_EVALUATOR_ATTRIBUTE
+            + " must be a FeelExpressionEvaluator, but was: "
+            + override.getClass());
+  }
+}

--- a/connector-runtime/jackson-datatype-feel/src/main/java/io/camunda/connector/feel/jackson/v2/FeelAnnotationIntrospector.java
+++ b/connector-runtime/jackson-datatype-feel/src/main/java/io/camunda/connector/feel/jackson/v2/FeelAnnotationIntrospector.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.feel.jackson.v2;
+
+import com.fasterxml.jackson.databind.introspect.Annotated;
+import com.fasterxml.jackson.databind.introspect.JacksonAnnotationIntrospector;
+import io.camunda.connector.api.annotation.FEEL;
+import io.camunda.connector.feel.FeelExpressionEvaluator;
+
+/**
+ * Jackson 2 counterpart of {@link io.camunda.connector.feel.jackson.FeelAnnotationIntrospector}.
+ * See {@link AbstractFeelDeserializer}'s javadoc for why this fork exists.
+ */
+public class FeelAnnotationIntrospector extends JacksonAnnotationIntrospector {
+
+  private final FeelExpressionEvaluator evaluator;
+
+  public FeelAnnotationIntrospector(FeelExpressionEvaluator evaluator) {
+    this.evaluator = evaluator;
+  }
+
+  @Override
+  public Object findDeserializer(Annotated a) {
+    FEEL ann = _findAnnotation(a, FEEL.class);
+    if (ann != null) {
+      return new FeelDeserializer(evaluator);
+    }
+    return super.findDeserializer(a);
+  }
+}

--- a/connector-runtime/jackson-datatype-feel/src/main/java/io/camunda/connector/feel/jackson/v2/FeelDeserializer.java
+++ b/connector-runtime/jackson-datatype-feel/src/main/java/io/camunda/connector/feel/jackson/v2/FeelDeserializer.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.feel.jackson.v2;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.BeanProperty;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.type.TypeFactory;
+import io.camunda.connector.feel.FeelExpressionEvaluator;
+import io.camunda.connector.feel.LocalFeelExpressionEvaluator;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Jackson 2 counterpart of {@link io.camunda.connector.feel.jackson.FeelDeserializer}. See {@link
+ * AbstractFeelDeserializer}'s javadoc for why this fork exists.
+ */
+public class FeelDeserializer extends AbstractFeelDeserializer<Object> {
+
+  private final JavaType outputType;
+  private static final FeelExpressionEvaluator FALLBACK_EVALUATOR =
+      new LocalFeelExpressionEvaluator();
+
+  /** Default constructor for use with @JsonDeserialize annotations. Uses local FEEL engine. */
+  public FeelDeserializer() {
+    this(FALLBACK_EVALUATOR, TypeFactory.unknownType());
+  }
+
+  public FeelDeserializer(FeelExpressionEvaluator evaluator) {
+    this(evaluator, TypeFactory.unknownType());
+  }
+
+  protected FeelDeserializer(FeelExpressionEvaluator evaluator, JavaType outputType) {
+    super(evaluator, true);
+    this.outputType = outputType;
+  }
+
+  @Override
+  protected Object doDeserialize(
+      JsonNode node, JsonNode feelContext, DeserializationContext jacksonCtx) throws IOException {
+
+    if (isFeelExpression(node.textValue())) {
+      return evaluateFeelExpression(jacksonCtx, node.textValue(), outputType, feelContext);
+    }
+
+    if (node.isTextual()) {
+      String textValue = node.textValue();
+      if (outputType.isCollectionLikeType()
+          && outputType.hasContentType()
+          && !textValue.trim().startsWith("[")) {
+        // Support legacy list like formats like: a,b,c | 1,2,3
+        return handleListLikeFormat(textValue);
+      } else if (outputType.isJavaLangObject()
+          && ((textValue.startsWith("\"") && textValue.endsWith("\""))
+              || (textValue.startsWith("'") && textValue.endsWith("'")))) {
+        return handleNormalJsonNode(node, jacksonCtx);
+      } else {
+        var jsonFactory = jacksonCtx.getParser().getCodec().getFactory();
+        try (JsonParser jsonParser = jsonFactory.createParser(textValue)) {
+          // check if this string contains a JSON object/array/etc inside (i.e. it's not just a
+          // string)
+          JsonNode jsonNode = jsonParser.readValueAsTree();
+          if (jsonNode != null && !jsonNode.isNull()) {
+            return handleNormalJsonNode(jsonNode, jacksonCtx);
+          }
+        } catch (IOException e) {
+          // ignore, this is just a string, we will take care of it below
+        }
+      }
+    }
+    return handleNormalJsonNode(node, jacksonCtx);
+  }
+
+  protected Object handleNormalJsonNode(JsonNode node, DeserializationContext context)
+      throws IOException {
+
+    if (node == null || node.isNull()) {
+      return null;
+    }
+    if (outputType.getRawClass() == String.class && node.isObject()) {
+      return BLANK_OBJECT_MAPPER.writeValueAsString(node);
+    }
+    return context.readTreeAsValue(node, outputType);
+  }
+
+  protected Object handleListLikeFormat(String textValue) {
+    if (outputType.getContentType().hasRawClass(Long.class)) {
+      return convertStringToListOfLongs(textValue);
+    } else if (outputType.getContentType().hasRawClass(Integer.class)) {
+      return convertStringToListOfIntegers(textValue);
+    } else if (outputType.getContentType().hasRawClass(String.class)) {
+      return convertStringToListOfStrings(textValue);
+    } else {
+      throw new IllegalArgumentException("Unsupported output type: " + outputType);
+    }
+  }
+
+  private static List<Long> convertStringToListOfLongs(String string) {
+    var value = string.trim();
+    if (value.isBlank()) {
+      return new ArrayList<>();
+    }
+    return Arrays.stream(string.split(","))
+        .map(s -> Long.parseLong(s.trim()))
+        .collect(Collectors.toList());
+  }
+
+  private static List<Integer> convertStringToListOfIntegers(String string) {
+    var value = string.trim();
+    if (value.isBlank()) {
+      return new ArrayList<>();
+    }
+    return Arrays.stream(string.split(","))
+        .map(s -> Integer.parseInt(s.trim()))
+        .collect(Collectors.toList());
+  }
+
+  private static List<String> convertStringToListOfStrings(String string) {
+    var value = string.trim();
+    if (value.isBlank()) {
+      return new ArrayList<>();
+    }
+    return Arrays.stream(string.split(",")).map(String::trim).collect(Collectors.toList());
+  }
+
+  @Override
+  public JsonDeserializer<?> createContextual(DeserializationContext ctxt, BeanProperty property) {
+    return new FeelDeserializer(evaluator, property.getType());
+  }
+}

--- a/connector-runtime/jackson-datatype-feel/src/main/java/io/camunda/connector/feel/jackson/v2/FeelFunctionDeserializer.java
+++ b/connector-runtime/jackson-datatype-feel/src/main/java/io/camunda/connector/feel/jackson/v2/FeelFunctionDeserializer.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.feel.jackson.v2;
+
+import com.fasterxml.jackson.annotation.JsonMerge;
+import com.fasterxml.jackson.databind.BeanProperty;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.type.TypeFactory;
+import io.camunda.connector.feel.FeelExpressionEvaluator;
+import java.io.IOException;
+import java.util.Map;
+import java.util.function.Function;
+
+/**
+ * Jackson 2 counterpart of {@link io.camunda.connector.feel.jackson.FeelFunctionDeserializer}. See
+ * {@link AbstractFeelDeserializer}'s javadoc for why this fork exists.
+ */
+class FeelFunctionDeserializer<IN, OUT> extends AbstractFeelDeserializer<Function<IN, OUT>> {
+
+  private final JavaType outputType;
+
+  public FeelFunctionDeserializer(JavaType outputType, FeelExpressionEvaluator evaluator) {
+    super(evaluator, false);
+    this.outputType = outputType;
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  protected Function<IN, OUT> doDeserialize(
+      JsonNode node, JsonNode feelContext, DeserializationContext deserializationContext) {
+    return (input) -> {
+      JsonNode jsonNode =
+          BLANK_OBJECT_MAPPER.valueToTree(
+              evaluateFeelExpression(
+                  deserializationContext,
+                  node.textValue(),
+                  deserializationContext.getTypeFactory().constructType(JsonNode.class),
+                  input,
+                  feelContext));
+      try {
+        if (jsonNode == null || jsonNode.isNull()) {
+          return null;
+        }
+        if (outputType.getRawClass() == String.class && jsonNode.isObject()) {
+          return (OUT) BLANK_OBJECT_MAPPER.writeValueAsString(jsonNode);
+        } else {
+          return deserializationContext.readTreeAsValue(jsonNode, outputType);
+        }
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
+    };
+  }
+
+  @Override
+  public JsonDeserializer<?> createContextual(DeserializationContext ctxt, BeanProperty property) {
+    if (property != null) {
+      if (property.getType().containedTypeCount() == 2) {
+        var outputType = property.getType().containedType(1);
+        return new FeelFunctionDeserializer<>(outputType, evaluator);
+      }
+    }
+
+    return new FeelFunctionDeserializer<>(TypeFactory.unknownType(), evaluator);
+  }
+
+  private static class MergedContext {
+    @JsonMerge Map<String, Object> context;
+
+    public MergedContext() {
+      this.context = null;
+    }
+
+    public MergedContext(Map<String, Object> context) {
+      this.context = context;
+    }
+
+    public void setContext(Map<String, Object> context) {
+      this.context = context;
+    }
+
+    public Map<String, Object> getContext() {
+      return context;
+    }
+  }
+}

--- a/connector-runtime/jackson-datatype-feel/src/main/java/io/camunda/connector/feel/jackson/v2/FeelSupplierDeserializer.java
+++ b/connector-runtime/jackson-datatype-feel/src/main/java/io/camunda/connector/feel/jackson/v2/FeelSupplierDeserializer.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.feel.jackson.v2;
+
+import com.fasterxml.jackson.databind.BeanProperty;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.type.TypeFactory;
+import io.camunda.connector.feel.FeelExpressionEvaluator;
+import java.util.function.Supplier;
+
+/**
+ * Jackson 2 counterpart of {@link io.camunda.connector.feel.jackson.FeelSupplierDeserializer}. See
+ * {@link AbstractFeelDeserializer}'s javadoc for why this fork exists.
+ */
+class FeelSupplierDeserializer<OUT> extends AbstractFeelDeserializer<Supplier<OUT>> {
+
+  private final JavaType outputType;
+
+  protected FeelSupplierDeserializer(JavaType outputType, FeelExpressionEvaluator evaluator) {
+    super(evaluator, false);
+    this.outputType = outputType;
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  protected Supplier<OUT> doDeserialize(
+      JsonNode node, JsonNode feelContext, DeserializationContext deserializationContext) {
+    return () ->
+        (OUT)
+            evaluateFeelExpression(
+                deserializationContext, node.textValue(), outputType, feelContext);
+  }
+
+  @Override
+  public FeelSupplierDeserializer<?> createContextual(
+      DeserializationContext ctxt, BeanProperty property) {
+
+    if (property.getType().containedTypeCount() == 1) {
+      var outputType = property.getType().containedType(0);
+      return new FeelSupplierDeserializer<>(outputType, evaluator);
+    }
+    return new FeelSupplierDeserializer<>(TypeFactory.unknownType(), evaluator);
+  }
+}

--- a/connector-runtime/jackson-datatype-feel/src/main/java/io/camunda/connector/feel/jackson/v2/JacksonModuleFeelFunction.java
+++ b/connector-runtime/jackson-datatype-feel/src/main/java/io/camunda/connector/feel/jackson/v2/JacksonModuleFeelFunction.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.feel.jackson.v2;
+
+import com.fasterxml.jackson.core.Version;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.databind.type.TypeFactory;
+import io.camunda.connector.feel.FeelExpressionEvaluator;
+import io.camunda.connector.feel.LocalFeelExpressionEvaluator;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+/**
+ * Jackson 2 counterpart of {@link io.camunda.connector.feel.jackson.JacksonModuleFeelFunction}.
+ * Used only by the {@code camundaJsonMapper} Spring bean — see {@link AbstractFeelDeserializer}'s
+ * javadoc for why this fork exists. Every other ObjectMapper uses the Jackson 3 variant instead.
+ */
+public class JacksonModuleFeelFunction extends SimpleModule {
+
+  private final FeelExpressionEvaluator annotationEvaluator;
+  private final FeelExpressionEvaluator functionEvaluator;
+  private final boolean processFEELAnnotation;
+
+  /** Creates a module using local FEEL engine for all evaluations. */
+  public JacksonModuleFeelFunction() {
+    this(true, new LocalFeelExpressionEvaluator(), null);
+  }
+
+  public JacksonModuleFeelFunction(
+      boolean processFEELAnnotation, FeelExpressionEvaluator evaluator) {
+    this(processFEELAnnotation, evaluator, null);
+  }
+
+  public JacksonModuleFeelFunction(
+      boolean processFEELAnnotation,
+      FeelExpressionEvaluator annotationEvaluator,
+      FeelExpressionEvaluator functionEvaluator) {
+    this.processFEELAnnotation = processFEELAnnotation;
+    this.annotationEvaluator =
+        annotationEvaluator != null ? annotationEvaluator : new LocalFeelExpressionEvaluator();
+    this.functionEvaluator =
+        functionEvaluator != null ? functionEvaluator : new LocalFeelExpressionEvaluator();
+  }
+
+  @Override
+  public String getModuleName() {
+    return "JacksonModuleFeelFunction";
+  }
+
+  @Override
+  public Version version() {
+    // TODO: get version from pom.xml
+    return new Version(0, 1, 0, null, "io.camunda", "jackson-datatype-feel");
+  }
+
+  @Override
+  public void setupModule(SetupContext context) {
+    addDeserializer(
+        Function.class,
+        new FeelFunctionDeserializer<>(TypeFactory.unknownType(), functionEvaluator));
+    addDeserializer(
+        Supplier.class,
+        new FeelSupplierDeserializer<>(TypeFactory.unknownType(), functionEvaluator));
+    if (processFEELAnnotation) {
+      context.insertAnnotationIntrospector(new FeelAnnotationIntrospector(annotationEvaluator));
+    }
+    super.setupModule(context);
+  }
+}

--- a/connector-runtime/jackson-datatype-feel/src/test/java/io/camunda/connector/feel/jackson/FeelDeserializerTest.java
+++ b/connector-runtime/jackson-datatype-feel/src/test/java/io/camunda/connector/feel/jackson/FeelDeserializerTest.java
@@ -21,26 +21,23 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonMappingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import io.camunda.connector.api.annotation.FEEL;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
 import org.junit.jupiter.api.Test;
+import tools.jackson.databind.DatabindException;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 
 public class FeelDeserializerTest {
 
   private final ObjectMapper mapper =
-      new ObjectMapper()
-          .registerModule(new JacksonModuleFeelFunction())
-          .registerModule(new JavaTimeModule());
+      JsonMapper.builder().addModule(new JacksonModuleFeelFunction()).build();
 
   @Test
-  void feelDeserializer_deserializeMap() throws JsonProcessingException {
+  void feelDeserializer_deserializeMap() {
     // given
     String json =
         """
@@ -56,7 +53,7 @@ public class FeelDeserializerTest {
   }
 
   @Test
-  void feelDeserializer_deserializeNestedMap() throws JsonProcessingException {
+  void feelDeserializer_deserializeNestedMap() {
     // given
     String json =
         """
@@ -72,7 +69,7 @@ public class FeelDeserializerTest {
   }
 
   @Test
-  void feelDeserializer_deserializePrimitive() throws JsonProcessingException {
+  void feelDeserializer_deserializePrimitive() {
     // given
     String json =
         """
@@ -95,11 +92,11 @@ public class FeelDeserializerTest {
         """;
 
     // when & then
-    assertThrows(JsonMappingException.class, () -> mapper.readValue(json, TargetTypeArray.class));
+    assertThrows(DatabindException.class, () -> mapper.readValue(json, TargetTypeArray.class));
   }
 
   @Test
-  void feelDeserializer_plainString_preserved() throws JsonProcessingException {
+  void feelDeserializer_plainString_preserved() {
     // given
     String json =
         """
@@ -112,7 +109,7 @@ public class FeelDeserializerTest {
   }
 
   @Test
-  void feelDeserializer_handleObjectString() throws JsonProcessingException {
+  void feelDeserializer_handleObjectString() {
     // given, e.g. used in the REST connector body property
     String json =
         """
@@ -223,10 +220,13 @@ public class FeelDeserializerTest {
         { "props": "= { first: a, second: b }" }
         """;
     Supplier<Map<String, String>> supplier = () -> Map.of("a", "value1", "b", "value2");
-    var objectReader = FeelContextAwareObjectReader.of(mapper).withContextSupplier(supplier);
+    var objectReader =
+        mapper
+            .readerFor(TargetTypeMap.class)
+            .withAttribute(FeelContextAwareObjectReader.FEEL_CONTEXT_ATTRIBUTE, supplier);
 
     // when && then
-    var targetType = assertDoesNotThrow(() -> objectReader.readValue(json, TargetTypeMap.class));
+    TargetTypeMap targetType = assertDoesNotThrow(() -> objectReader.readValue(json));
     assertThat(targetType.props).containsEntry("first", "value1");
     assertThat(targetType.props).containsEntry("second", "value2");
   }
@@ -246,7 +246,7 @@ public class FeelDeserializerTest {
                 Map.of("a", "value1", "b", "value2")); // map is not a supplier
 
     // when && then
-    var e = assertThrows(JsonMappingException.class, () -> objectReader.readValue(json));
+    var e = assertThrows(DatabindException.class, () -> objectReader.readValue(json));
     assertThat(e.getMessage()).contains("Attribute FEEL_CONTEXT must be a Supplier");
   }
 
@@ -264,7 +264,7 @@ public class FeelDeserializerTest {
                 FeelContextAwareObjectReader.FEEL_EVALUATOR_ATTRIBUTE, "not an evaluator");
 
     // when && then
-    var e = assertThrows(JsonMappingException.class, () -> objectReader.readValue(json));
+    var e = assertThrows(DatabindException.class, () -> objectReader.readValue(json));
     assertThat(e.getMessage())
         .contains("Attribute FEEL_EVALUATOR must be a FeelExpressionEvaluator");
   }

--- a/connector-runtime/jackson-datatype-feel/src/test/java/io/camunda/connector/feel/jackson/FeelFunctionDeserializerTest.java
+++ b/connector-runtime/jackson-datatype-feel/src/test/java/io/camunda/connector/feel/jackson/FeelFunctionDeserializerTest.java
@@ -18,27 +18,23 @@ package io.camunda.connector.feel.jackson;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JavaType;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import io.camunda.connector.feel.FeelExpressionEvaluator;
-import java.io.IOException;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 import org.junit.jupiter.api.Test;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 
 public class FeelFunctionDeserializerTest {
 
   private final ObjectMapper mapper =
-      new ObjectMapper()
-          .registerModule(new JacksonModuleFeelFunction())
-          .registerModule(new JavaTimeModule());
+      JsonMapper.builder().addModule(new JacksonModuleFeelFunction()).build();
 
   @Test
-  void feelFunctionDeserialization_objectResult() throws JsonProcessingException {
+  void feelFunctionDeserialization_objectResult() {
     // given
     String json =
         """
@@ -56,7 +52,7 @@ public class FeelFunctionDeserializerTest {
   }
 
   @Test
-  void feelFunctionDeserialization_stringResult() throws JsonProcessingException {
+  void feelFunctionDeserialization_stringResult() {
     // given
     String json =
         """
@@ -73,7 +69,7 @@ public class FeelFunctionDeserializerTest {
   }
 
   @Test
-  void feelFunctionDeserialization_booleanResult() throws JsonProcessingException {
+  void feelFunctionDeserialization_booleanResult() {
     // given
     String json =
         """
@@ -90,7 +86,7 @@ public class FeelFunctionDeserializerTest {
   }
 
   @Test
-  void feelFunctionDeserialization_integerResult() throws JsonProcessingException {
+  void feelFunctionDeserialization_integerResult() {
     // given
     String json =
         """
@@ -107,7 +103,7 @@ public class FeelFunctionDeserializerTest {
   }
 
   @Test
-  void feelFunctionDeserialization_nullResult() throws JsonProcessingException {
+  void feelFunctionDeserialization_nullResult() {
     // given
     String json =
         """
@@ -124,7 +120,7 @@ public class FeelFunctionDeserializerTest {
   }
 
   @Test
-  void feelSupplierDeserialization_listResult() throws JsonProcessingException {
+  void feelSupplierDeserialization_listResult() {
     // given
     String json =
         """
@@ -141,7 +137,7 @@ public class FeelFunctionDeserializerTest {
   }
 
   @Test
-  void feelSupplierDeserialization_mapResult() throws JsonProcessingException {
+  void feelSupplierDeserialization_mapResult() {
     // given
     String json =
         """
@@ -158,7 +154,7 @@ public class FeelFunctionDeserializerTest {
   }
 
   @Test
-  void feelSupplierDeserialization_foldedMapResult() throws JsonProcessingException {
+  void feelSupplierDeserialization_foldedMapResult() {
     // given
     String json =
         """
@@ -192,17 +188,19 @@ public class FeelFunctionDeserializerTest {
   }
 
   @Test
-  void feelFunctionDeserialization_contextAware_mergedWithInput() throws IOException {
+  void feelFunctionDeserialization_contextAware_mergedWithInput() {
     // given
     var json =
         """
         { "function": "= { result: a + c }" }
         """;
     var contextualReader =
-        FeelContextAwareObjectReader.of(mapper).withStaticContext(Map.of("c", "bar"));
+        FeelContextAwareObjectReader.of(mapper)
+            .withStaticContext(Map.of("c", "bar"))
+            .forType(TargetTypeObject.class);
 
     // when
-    TargetTypeObject targetType = contextualReader.readValue(json, TargetTypeObject.class);
+    TargetTypeObject targetType = contextualReader.readValue(json);
 
     // then
     InputContextString inputContext = new InputContextString("foo", "some value");
@@ -212,8 +210,7 @@ public class FeelFunctionDeserializerTest {
   }
 
   @Test
-  void feelFunctionDeserialization_withEvaluatorOverride_usesFunctionEvaluator()
-      throws IOException {
+  void feelFunctionDeserialization_withEvaluatorOverride_usesFunctionEvaluator() {
     // given
     var json =
         """
@@ -221,10 +218,11 @@ public class FeelFunctionDeserializerTest {
         """;
     var contextualReader =
         FeelContextAwareObjectReader.of(mapper)
-            .withEvaluator(new ThrowingFeelExpressionEvaluator());
+            .withEvaluator(new ThrowingFeelExpressionEvaluator())
+            .forType(TargetTypeObject.class);
 
     // when
-    TargetTypeObject targetType = contextualReader.readValue(json, TargetTypeObject.class);
+    TargetTypeObject targetType = contextualReader.readValue(json);
 
     // then
     InputContextString inputContext = new InputContextString("foo", "bar");
@@ -234,17 +232,19 @@ public class FeelFunctionDeserializerTest {
   }
 
   @Test
-  void feelFunctionDeserialization_contextAware_knowsJava8Time() throws IOException {
+  void feelFunctionDeserialization_contextAware_knowsJava8Time() {
     // given
     var json =
         """
         { "function": "= string(date(2021, 1, 1))" }
         """;
     var contextualReader =
-        FeelContextAwareObjectReader.of(mapper).withStaticContext(Map.of("c", "bar"));
+        FeelContextAwareObjectReader.of(mapper)
+            .withStaticContext(Map.of("c", "bar"))
+            .forType(TargetTypeJava8Time.class);
 
     // when
-    TargetTypeJava8Time targetType = contextualReader.readValue(json, TargetTypeJava8Time.class);
+    TargetTypeJava8Time targetType = contextualReader.readValue(json);
 
     // then
     InputContextInteger inputContext = new InputContextInteger(3, 5);

--- a/connector-runtime/jackson-datatype-feel/src/test/java/io/camunda/connector/feel/jackson/FeelSupplierDeserializerTest.java
+++ b/connector-runtime/jackson-datatype-feel/src/test/java/io/camunda/connector/feel/jackson/FeelSupplierDeserializerTest.java
@@ -18,25 +18,21 @@ package io.camunda.connector.feel.jackson;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import java.io.IOException;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
 import org.junit.jupiter.api.Test;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 
 public class FeelSupplierDeserializerTest {
 
   private final ObjectMapper mapper =
-      new ObjectMapper()
-          .registerModule(new JacksonModuleFeelFunction())
-          .registerModule(new JavaTimeModule());
+      JsonMapper.builder().addModule(new JacksonModuleFeelFunction()).build();
 
   @Test
-  void feelSupplierDeserialization_objectResult() throws JsonProcessingException {
+  void feelSupplierDeserialization_objectResult() {
     // given
     String json =
         """
@@ -53,7 +49,7 @@ public class FeelSupplierDeserializerTest {
   }
 
   @Test
-  void feelSupplierDeserialization_stringResult() throws JsonProcessingException {
+  void feelSupplierDeserialization_stringResult() {
     // given
     String json =
         """
@@ -69,7 +65,7 @@ public class FeelSupplierDeserializerTest {
   }
 
   @Test
-  void feelSupplierDeserialization_booleanResult() throws JsonProcessingException {
+  void feelSupplierDeserialization_booleanResult() {
     // given
     String json =
         """
@@ -85,7 +81,7 @@ public class FeelSupplierDeserializerTest {
   }
 
   @Test
-  void feelSupplierDeserialization_integerResult() throws JsonProcessingException {
+  void feelSupplierDeserialization_integerResult() {
     // given
     String json =
         """
@@ -101,7 +97,7 @@ public class FeelSupplierDeserializerTest {
   }
 
   @Test
-  void feelSupplierDeserialization_nullResult() throws JsonProcessingException {
+  void feelSupplierDeserialization_nullResult() {
     // given
     String json =
         """
@@ -117,7 +113,7 @@ public class FeelSupplierDeserializerTest {
   }
 
   @Test
-  void feelSupplierDeserialization_listResult() throws JsonProcessingException {
+  void feelSupplierDeserialization_listResult() {
     // given
     String json =
         """
@@ -133,7 +129,7 @@ public class FeelSupplierDeserializerTest {
   }
 
   @Test
-  void feelSupplierDeserialization_mapResult() throws JsonProcessingException {
+  void feelSupplierDeserialization_mapResult() {
     // given
     String json =
         """
@@ -163,7 +159,7 @@ public class FeelSupplierDeserializerTest {
   }
 
   @Test
-  void feelSupplierDeserialization_contextProvided() throws IOException {
+  void feelSupplierDeserialization_contextProvided() {
     // given
     var json =
         """
@@ -175,7 +171,8 @@ public class FeelSupplierDeserializerTest {
     TargetTypeString targetType =
         FeelContextAwareObjectReader.of(mapper)
             .withStaticContext(context)
-            .readValue(json, TargetTypeString.class);
+            .forType(TargetTypeString.class)
+            .readValue(json);
 
     // then
     String result = targetType.supplier().get();
@@ -183,7 +180,7 @@ public class FeelSupplierDeserializerTest {
   }
 
   @Test
-  void feelSupplierDeserialization_java8Time() throws IOException {
+  void feelSupplierDeserialization_java8Time() {
     // given
     var json =
         """

--- a/connector-runtime/spring-boot-starter-camunda-connectors/pom.xml
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/pom.xml
@@ -109,7 +109,7 @@
       <artifactId>spring-boot-starter-cache</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
+      <groupId>tools.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
     </dependency>
     <dependency>
@@ -225,11 +225,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>tools.jackson.core</groupId>
-      <artifactId>jackson-databind</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-web</artifactId>
     </dependency>
@@ -237,6 +232,27 @@
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-jackson2</artifactId>
       <scope>test</scope>
+    </dependency>
+    <!-- Jackson 2: ConnectorsAutoConfiguration's camundaJsonMapper bean, and
+         BaseMultiInstancesTest/BaseOutboundMultiInstancesTest's standalone InstanceForwardingHttpClient
+         mapper, both need JavaTimeModule/Jdk8Module/ObjectMapper. Declared at compile scope rather
+         than test scope: a closer (test-scoped) declaration here would otherwise shadow the
+         transitive compile-scope dependency from connector-feel that main src relies on. -->
+    <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-jsr310</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-jdk8</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
     </dependency>
    </dependencies>
 
@@ -262,6 +278,11 @@
                 <ignoredDependency>org.springframework.boot:spring-boot-starter-actuator</ignoredDependency>
                 <ignoredDependency>org.springframework.boot:spring-boot-starter-web</ignoredDependency>
                 <ignoredDependency>org.springframework.boot:spring-boot-starter-cache</ignoredDependency>
+                <!-- Jackson 2: needed at compile time (JsonMapper.builder() in
+                     ConnectorsAutoConfiguration transitively requires jackson-core's Versioned
+                     class to resolve), but the bytecode analyzer only sees it referenced from
+                     test code. -->
+                <ignoredDependency>com.fasterxml.jackson.core:jackson-core</ignoredDependency>
               </ignoredDependencies>
             </configuration>
           </execution>

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/main/java/io/camunda/connector/runtime/ConnectorsAutoConfiguration.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/main/java/io/camunda/connector/runtime/ConnectorsAutoConfiguration.java
@@ -16,7 +16,6 @@
  */
 package io.camunda.connector.runtime;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.client.CamundaClient;
 import io.camunda.client.impl.CamundaObjectMapper;
 import io.camunda.client.spring.bean.CamundaClientRegistry;
@@ -26,7 +25,7 @@ import io.camunda.connector.api.document.DocumentFactory;
 import io.camunda.connector.api.secret.SecretProvider;
 import io.camunda.connector.api.validation.ValidationProvider;
 import io.camunda.connector.document.jackson.JacksonModuleDocumentDeserializer;
-import io.camunda.connector.document.jackson.JacksonModuleDocumentSerializer;
+import io.camunda.connector.document.jackson.v3.JacksonModuleDocumentSerializer;
 import io.camunda.connector.feel.FeelExpressionEvaluator;
 import io.camunda.connector.feel.FeelExpressionEvaluatorBuilder;
 import io.camunda.connector.feel.jackson.JacksonModuleFeelFunction;
@@ -39,6 +38,7 @@ import io.camunda.connector.jackson.ConnectorsObjectMapperSupplier;
 import io.camunda.connector.runtime.annotation.ConnectorsObjectMapper;
 import io.camunda.connector.runtime.annotation.OutboundConnectorObjectMapper;
 import io.camunda.connector.runtime.core.intrinsic.DefaultIntrinsicFunctionExecutor;
+import io.camunda.connector.runtime.core.intrinsic.MutableObjectMapperSupplier;
 import io.camunda.connector.runtime.core.secret.SecretProviderAggregator;
 import io.camunda.connector.runtime.core.secret.SecretProviderDiscovery;
 import io.camunda.connector.runtime.inbound.PhysicalTenantIds;
@@ -71,6 +71,7 @@ import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.Primary;
 import org.springframework.core.env.Environment;
 import org.springframework.scheduling.annotation.Scheduled;
+import tools.jackson.databind.ObjectMapper;
 
 @AutoConfiguration
 @AutoConfigureBefore({
@@ -214,13 +215,39 @@ public class ConnectorsAutoConfiguration {
     return new ConsoleSecretApiClient(consoleSecretsApiEndpoint, jwtCredential);
   }
 
+  /**
+   * camunda-client-java's {@code CamundaObjectMapper} only has a Jackson 2 constructor (no Jackson
+   * 3 overload exists yet), so this bean is built from a standalone Jackson 2 mapper — mirroring
+   * {@code ConnectorsObjectMapperSupplier}'s configuration, which is Jackson 3-only — plus the
+   * Jackson 2 counterparts of the FEEL and Document modules.
+   */
   @Bean(name = "camundaJsonMapper")
   @ConditionalOnMissingBean
   public CamundaObjectMapper jsonMapper() {
-    return new CamundaObjectMapper(
-        ConnectorsObjectMapperSupplier.getCopy()
-            .registerModules(
-                new JacksonModuleFeelFunction(), new JacksonModuleDocumentSerializer()));
+    com.fasterxml.jackson.databind.ObjectMapper mapper =
+        com.fasterxml.jackson.databind.json.JsonMapper.builder()
+            .addModules(
+                new com.fasterxml.jackson.datatype.jdk8.Jdk8Module(),
+                new com.fasterxml.jackson.datatype.jsr310.JavaTimeModule())
+            .disable(com.fasterxml.jackson.databind.SerializationFeature.FAIL_ON_EMPTY_BEANS)
+            .disable(
+                com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+            .enable(com.fasterxml.jackson.databind.MapperFeature.ACCEPT_CASE_INSENSITIVE_ENUMS)
+            .disable(com.fasterxml.jackson.databind.SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+            .disable(
+                com.fasterxml.jackson.databind.SerializationFeature.WRITE_DURATIONS_AS_TIMESTAMPS)
+            .enable(
+                com.fasterxml.jackson.databind.DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY)
+            .enable(
+                com.fasterxml.jackson.databind.DeserializationFeature.UNWRAP_SINGLE_VALUE_ARRAYS)
+            .enable(
+                com.fasterxml.jackson.databind.DeserializationFeature
+                    .READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE)
+            .addModules(
+                new io.camunda.connector.feel.jackson.v2.JacksonModuleFeelFunction(),
+                new io.camunda.connector.document.jackson.JacksonModuleDocumentSerializer())
+            .build();
+    return new CamundaObjectMapper(mapper);
   }
 
   @Bean(defaultCandidate = false)
@@ -232,11 +259,13 @@ public class ConnectorsAutoConfiguration {
       DocumentFactory legacyDocumentFactory,
       FeelExpressionEvaluator feelExpressionEvaluator) {
     final ObjectMapper copy = ConnectorsObjectMapperSupplier.getCopy();
-    // default intrinsic function contains a pointer of the copy
-    var functionExecutor = new DefaultIntrinsicFunctionExecutor(copy);
+    // default intrinsic function resolves the final mapper lazily, since it doesn't exist yet:
+    // ObjectMapper is immutable in Jackson 3, so the module below can't be added in place.
+    var mapperHolder = new MutableObjectMapperSupplier();
+    var functionExecutor = new DefaultIntrinsicFunctionExecutor(mapperHolder);
 
-    // The deserializer module contains the function executor, which contains the pointer of the
-    // object mapper
+    // The deserializer module contains the function executor, which resolves the object mapper
+    // through mapperHolder
     var documentFactoriesByPhysicalTenantId =
         PhysicalTenantIds.buildDocumentFactoriesByPhysicalTenantId(
             registry, legacyCamundaClient, legacyDocumentFactory);
@@ -248,11 +277,16 @@ public class ConnectorsAutoConfiguration {
 
     // Function/Supplier always use local evaluation to avoid serializing runtime objects
     // (e.g., Documents) to the cluster. The injected evaluator is used for @FEEL-annotated fields.
-    return copy.registerModules(
-        jacksonModuleDocumentDeserializer,
-        new JacksonModuleFeelFunction(
-            true, feelExpressionEvaluator, FeelExpressionEvaluatorBuilder.local().build()),
-        new JacksonModuleDocumentSerializer());
+    var finalMapper =
+        copy.rebuild()
+            .addModules(
+                jacksonModuleDocumentDeserializer,
+                new JacksonModuleFeelFunction(
+                    true, feelExpressionEvaluator, FeelExpressionEvaluatorBuilder.local().build()),
+                new JacksonModuleDocumentSerializer())
+            .build();
+    mapperHolder.set(finalMapper);
+    return finalMapper;
   }
 
   /**
@@ -271,7 +305,8 @@ public class ConnectorsAutoConfiguration {
 
   private static ObjectMapper buildOutboundConnectorObjectMapper(DocumentFactory documentFactory) {
     final ObjectMapper copy = ConnectorsObjectMapperSupplier.getCopy();
-    var functionExecutor = new DefaultIntrinsicFunctionExecutor(copy);
+    var mapperHolder = new MutableObjectMapperSupplier();
+    var functionExecutor = new DefaultIntrinsicFunctionExecutor(mapperHolder);
 
     var jacksonModuleDocumentDeserializer =
         new JacksonModuleDocumentDeserializer(
@@ -279,12 +314,18 @@ public class ConnectorsAutoConfiguration {
             functionExecutor,
             JacksonModuleDocumentDeserializer.DocumentModuleSettings.create());
 
-    return copy.registerModules(
-        jacksonModuleDocumentDeserializer,
-        new JacksonModuleFeelFunction(
-            false,
-            FeelExpressionEvaluatorBuilder.local().build()), // FEEL annotation processing disabled
-        new JacksonModuleDocumentSerializer());
+    var finalMapper =
+        copy.rebuild()
+            .addModules(
+                jacksonModuleDocumentDeserializer,
+                new JacksonModuleFeelFunction(
+                    false,
+                    FeelExpressionEvaluatorBuilder.local()
+                        .build()), // FEEL annotation processing disabled
+                new JacksonModuleDocumentSerializer())
+            .build();
+    mapperHolder.set(finalMapper);
+    return finalMapper;
   }
 
   @Scheduled(fixedRate = 60_000, initialDelay = 60_000)

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/main/java/io/camunda/connector/runtime/WebhookConnectorAutoConfiguration.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/main/java/io/camunda/connector/runtime/WebhookConnectorAutoConfiguration.java
@@ -16,7 +16,6 @@
  */
 package io.camunda.connector.runtime;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.connector.runtime.annotation.ConnectorsObjectMapper;
 import io.camunda.connector.runtime.inbound.WebhookConnectorConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
@@ -25,7 +24,9 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
-import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.http.converter.json.JacksonJsonHttpMessageConverter;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 
 @AutoConfiguration
 @AutoConfigureBefore(InboundConnectorsAutoConfiguration.class)
@@ -36,13 +37,13 @@ import org.springframework.http.converter.json.MappingJackson2HttpMessageConvert
     matchIfMissing = true)
 @Import(WebhookConnectorConfiguration.class)
 public class WebhookConnectorAutoConfiguration {
-  // TODO: Remove this with the Migration to Jackson 3
-  // This is currently required so that Webhook Endpoint responses are correctly
-  // serialized to JSON (e.g. including document support)
+  // This is required so that Webhook Endpoint responses are correctly serialized to JSON (e.g.
+  // including document support) through the same connectorsMapper used everywhere else, instead
+  // of Spring's own default Jackson message converter.
   @Bean
   @ConditionalOnMissingBean
-  public MappingJackson2HttpMessageConverter jackson2HttpMessageConverter(
+  public JacksonJsonHttpMessageConverter jacksonJsonHttpMessageConverter(
       @ConnectorsObjectMapper ObjectMapper connectorsMapper) {
-    return new MappingJackson2HttpMessageConverter(connectorsMapper);
+    return new JacksonJsonHttpMessageConverter((JsonMapper) connectorsMapper);
   }
 }

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/ObjectMapperQualifierTest.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/ObjectMapperQualifierTest.java
@@ -18,8 +18,6 @@ package io.camunda.connector.runtime;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.connector.api.annotation.FEEL;
 import io.camunda.connector.runtime.annotation.ConnectorsObjectMapper;
 import io.camunda.connector.runtime.annotation.OutboundConnectorObjectMapper;
@@ -31,6 +29,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.jackson2.autoconfigure.Jackson2AutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
+import tools.jackson.databind.ObjectMapper;
 
 @SpringBootTest(
     properties = {
@@ -61,7 +60,7 @@ public class ObjectMapperQualifierTest {
   }
 
   @Test
-  void connectorObjectMapperShouldSupportFeelDeserialization() throws JsonProcessingException {
+  void connectorObjectMapperShouldSupportFeelDeserialization() {
     // Test that the connector ObjectMapper has FEEL support
     var json =
         """
@@ -76,7 +75,7 @@ public class ObjectMapperQualifierTest {
   }
 
   @Test
-  void connectorObjectMapperShouldEvaluateFeelFunctions() throws JsonProcessingException {
+  void connectorObjectMapperShouldEvaluateFeelFunctions() {
     // The default ConnectorsObjectMapper should evaluate FEEL functions (Supplier)
     var json =
         """
@@ -91,8 +90,7 @@ public class ObjectMapperQualifierTest {
   }
 
   @Test
-  void outboundConnectorObjectMapperShouldNotEvaluateFeelExpressions()
-      throws JsonProcessingException {
+  void outboundConnectorObjectMapperShouldNotEvaluateFeelExpressions() {
     // The OutboundConnectorObjectMapper has FEEL functions DISABLED
     // So @FEEL annotated fields should NOT evaluate FEEL expressions
     var json =
@@ -108,8 +106,7 @@ public class ObjectMapperQualifierTest {
   }
 
   @Test
-  void outboundConnectorObjectMapperShouldNotEvaluateFeelFunctions()
-      throws JsonProcessingException {
+  void outboundConnectorObjectMapperShouldNotEvaluateFeelFunctions() {
     // The OutboundConnectorObjectMapper has FEEL functions DISABLED
     // So Supplier fields should NOT be evaluated as FEEL expressions
     var json =
@@ -126,7 +123,7 @@ public class ObjectMapperQualifierTest {
   }
 
   @Test
-  void customObjectMapperShouldNotSupportFeelDeserialization() throws JsonProcessingException {
+  void customObjectMapperShouldNotSupportFeelDeserialization() {
     // The custom/default ObjectMapper should NOT support FEEL expressions
     // It will just read the literal string value
     var json =

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/ObjectMapperSerializationTest.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/ObjectMapperSerializationTest.java
@@ -19,9 +19,6 @@ package io.camunda.connector.runtime;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.client.api.JsonMapper;
 import io.camunda.connector.runtime.annotation.ConnectorsObjectMapper;
 import io.camunda.connector.runtime.app.TestConnectorRuntimeApplication;
@@ -33,6 +30,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.ApplicationContext;
 import org.springframework.test.util.ReflectionTestUtils;
+import tools.jackson.databind.DeserializationFeature;
+import tools.jackson.databind.ObjectMapper;
 
 @SpringBootTest(
     properties = {
@@ -47,7 +46,7 @@ public class ObjectMapperSerializationTest {
   @Autowired private ApplicationContext applicationContext;
 
   @Test
-  void getJsonMapper() throws JsonProcessingException {
+  void getJsonMapper() {
     ObjectMapper objectMapper = applicationContext.getBean(ObjectMapper.class);
     assertThat(objectMapper.writeValueAsString(new Date().toInstant().atOffset(ZoneOffset.UTC)))
         .isNotNull();
@@ -64,17 +63,19 @@ public class ObjectMapperSerializationTest {
 
     assertThat(objectMapper).isNotNull();
     assertThat(objectMapper).isInstanceOf(ObjectMapper.class);
-    assertThat(objectMapper.getDeserializationConfig()).isNotNull();
+    assertThat(objectMapper.deserializationConfig()).isNotNull();
     assertThat(
             objectMapper
-                .getDeserializationConfig()
+                .deserializationConfig()
                 .isEnabled(DeserializationFeature.FAIL_ON_IGNORED_PROPERTIES))
         .isFalse();
+    // This is Spring Boot's own default (unconfigured) Jackson 3 ObjectMapper bean, not one of
+    // ours — Jackson 3 flips this feature's default to enabled, unlike Jackson 2.
     assertThat(
             objectMapper
-                .getDeserializationConfig()
+                .deserializationConfig()
                 .isEnabled(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES))
-        .isFalse();
+        .isTrue();
     // should serialise OffsetDateTime
     assertThat(jsonMapper.toJson(new Date().toInstant().atOffset(ZoneOffset.UTC))).isNotNull();
   }

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/OutboundConnectorsAutoConfigurationTest.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/OutboundConnectorsAutoConfigurationTest.java
@@ -21,7 +21,6 @@ import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.client.CamundaClient;
 import io.camunda.client.jobhandling.CamundaClientExecutorService;
 import io.camunda.client.jobhandling.JobCallbackCommandWrapperFactory;
@@ -43,6 +42,7 @@ import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.core.annotation.MergedAnnotations;
+import tools.jackson.databind.ObjectMapper;
 
 class OutboundConnectorsAutoConfigurationTest {
 

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/inbound/BaseMultiInstancesTest.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/inbound/BaseMultiInstancesTest.java
@@ -23,7 +23,6 @@ import io.camunda.connector.api.inbound.*;
 import io.camunda.connector.api.inbound.webhook.WebhookConnectorExecutable;
 import io.camunda.connector.api.inbound.webhook.WebhookProcessingPayload;
 import io.camunda.connector.api.inbound.webhook.WebhookResult;
-import io.camunda.connector.jackson.ConnectorsObjectMapperSupplier;
 import io.camunda.connector.runtime.app.TestConnectorRuntimeApplication;
 import io.camunda.connector.runtime.core.http.InstanceForwardingHttpClient;
 import io.camunda.connector.runtime.core.inbound.ExecutableId;
@@ -61,11 +60,15 @@ abstract class BaseMultiInstancesTest {
   final int port1 = 18080;
   final int port2 = 18081;
 
+  // InstanceForwardingHttpClient is still Jackson 2-only (not yet migrated as part of #5910), so
+  // this uses a standalone Jackson 2 mapper rather than the (Jackson 3)
+  // ConnectorsObjectMapperSupplier.
   final InstanceForwardingHttpClient instanceForwardingHttpClient =
       new InstanceForwardingHttpClient(
           HttpClient.newHttpClient(),
           (path) -> List.of("http://localhost:" + port1 + path, "http://localhost:" + port2 + path),
-          ConnectorsObjectMapperSupplier.getCopy());
+          new com.fasterxml.jackson.databind.ObjectMapper()
+              .registerModule(new com.fasterxml.jackson.datatype.jsr310.JavaTimeModule()));
 
   static final ExecutableId UNKNOWN_ID = ExecutableId.fromHashedId("abcdef");
   static final ExecutableId RANDOM_ID_1 = ExecutableId.fromDeduplicationId("theid1");

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/inbound/InboundConnectorRestControllerTest.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/inbound/InboundConnectorRestControllerTest.java
@@ -22,7 +22,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.fasterxml.jackson.core.type.TypeReference;
 import io.camunda.connector.jackson.ConnectorsObjectMapperSupplier;
 import io.camunda.connector.runtime.app.TestConnectorRuntimeApplication;
 import io.camunda.connector.runtime.inbound.executable.InboundExecutableRegistry;
@@ -39,6 +38,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
+import tools.jackson.core.type.TypeReference;
 
 @SpringBootTest(classes = TestConnectorRuntimeApplication.class)
 @AutoConfigureMockMvc

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/inbound/InboundInstancesRestControllerMultiInstancesTest.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/inbound/InboundInstancesRestControllerMultiInstancesTest.java
@@ -22,7 +22,6 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
-import com.fasterxml.jackson.core.type.TypeReference;
 import io.camunda.connector.api.inbound.*;
 import io.camunda.connector.jackson.ConnectorsObjectMapperSupplier;
 import io.camunda.connector.runtime.core.inbound.ExecutableId;
@@ -42,6 +41,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
+import tools.jackson.core.type.TypeReference;
 
 @ExtendWith(MockitoExtension.class)
 class InboundInstancesRestControllerMultiInstancesTest extends BaseMultiInstancesTest {

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/inbound/InboundInstancesRestControllerTest.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/inbound/InboundInstancesRestControllerTest.java
@@ -27,7 +27,6 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.fasterxml.jackson.core.type.TypeReference;
 import io.camunda.connector.api.inbound.*;
 import io.camunda.connector.api.inbound.webhook.WebhookConnectorExecutable;
 import io.camunda.connector.api.inbound.webhook.WebhookProcessingPayload;
@@ -55,6 +54,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
+import tools.jackson.core.type.TypeReference;
 
 @SpringBootTest(classes = TestConnectorRuntimeApplication.class)
 @AutoConfigureMockMvc

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/inbound/WebhookControllerTestExceptionZeebeTest.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/inbound/WebhookControllerTestExceptionZeebeTest.java
@@ -22,7 +22,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.command.ClientStatusException;
 import io.camunda.connector.api.inbound.webhook.MappedHttpRequest;
@@ -54,6 +53,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.ResponseEntity;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import tools.jackson.databind.ObjectMapper;
 
 @SpringBootTest(
     classes = TestConnectorRuntimeApplication.class,

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/inbound/WebhookControllerTestZeebeTest.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/inbound/WebhookControllerTestZeebeTest.java
@@ -25,7 +25,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.client.CamundaClient;
 import io.camunda.connector.api.inbound.CorrelationResult;
 import io.camunda.connector.api.inbound.ProcessElement;
@@ -63,6 +62,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.mock.web.MockMultipartHttpServletRequest;
+import tools.jackson.databind.ObjectMapper;
 
 @SpringBootTest(
     classes = TestConnectorRuntimeApplication.class,

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/outbound/BaseOutboundMultiInstancesTest.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/outbound/BaseOutboundMultiInstancesTest.java
@@ -18,7 +18,6 @@ package io.camunda.connector.runtime.outbound;
 
 import static org.mockito.Mockito.when;
 
-import io.camunda.connector.jackson.ConnectorsObjectMapperSupplier;
 import io.camunda.connector.runtime.app.TestConnectorRuntimeApplication;
 import io.camunda.connector.runtime.core.common.AbstractConnectorFactory.ConnectorRuntimeConfiguration;
 import io.camunda.connector.runtime.core.config.OutboundConnectorConfiguration;
@@ -53,11 +52,15 @@ abstract class BaseOutboundMultiInstancesTest {
   final OutboundConnectorFactory connectorFactory1 = Mockito.mock(OutboundConnectorFactory.class);
   final OutboundConnectorFactory connectorFactory2 = Mockito.mock(OutboundConnectorFactory.class);
 
+  // InstanceForwardingHttpClient is still Jackson 2-only (not yet migrated as part of #5910), so
+  // this uses a standalone Jackson 2 mapper rather than the (Jackson 3)
+  // ConnectorsObjectMapperSupplier.
   final InstanceForwardingHttpClient instanceForwardingHttpClient =
       new InstanceForwardingHttpClient(
           HttpClient.newHttpClient(),
           (path) -> List.of("http://localhost:" + port1 + path, "http://localhost:" + port2 + path),
-          ConnectorsObjectMapperSupplier.getCopy());
+          new com.fasterxml.jackson.databind.ObjectMapper()
+              .registerModule(new com.fasterxml.jackson.datatype.jsr310.JavaTimeModule()));
 
   final TestRestTemplate restTemplate =
       new TestRestTemplate(

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/outbound/OutboundConnectorsRestControllerMultiInstancesTest.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/outbound/OutboundConnectorsRestControllerMultiInstancesTest.java
@@ -24,7 +24,6 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import com.fasterxml.jackson.core.type.TypeReference;
 import io.camunda.connector.jackson.ConnectorsObjectMapperSupplier;
 import io.camunda.connector.runtime.metrics.OutboundConnectorMetrics;
 import io.camunda.connector.runtime.outbound.controller.OutboundConnectorResponse;
@@ -36,6 +35,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
+import tools.jackson.core.type.TypeReference;
 
 @ExtendWith(MockitoExtension.class)
 class OutboundConnectorsRestControllerMultiInstancesTest extends BaseOutboundMultiInstancesTest {

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/outbound/OutboundConnectorsRestControllerTest.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/outbound/OutboundConnectorsRestControllerTest.java
@@ -25,7 +25,6 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.fasterxml.jackson.core.type.TypeReference;
 import io.camunda.connector.jackson.ConnectorsObjectMapperSupplier;
 import io.camunda.connector.runtime.app.TestConnectorRuntimeApplication;
 import io.camunda.connector.runtime.core.common.AbstractConnectorFactory.ConnectorRuntimeConfiguration;
@@ -47,6 +46,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
+import tools.jackson.core.type.TypeReference;
 
 @SpringBootTest(
     classes = TestConnectorRuntimeApplication.class,

--- a/connector-sdk/core/pom.xml
+++ b/connector-sdk/core/pom.xml
@@ -22,7 +22,7 @@
       </dependency>
 
       <dependency>
-          <groupId>com.fasterxml.jackson.core</groupId>
+          <groupId>tools.jackson.core</groupId>
           <artifactId>jackson-databind</artifactId>
           <scope>provided</scope>
       </dependency>

--- a/connector-sdk/core/src/main/java/io/camunda/connector/api/annotation/FEEL.java
+++ b/connector-sdk/core/src/main/java/io/camunda/connector/api/annotation/FEEL.java
@@ -17,11 +17,11 @@
 package io.camunda.connector.api.annotation;
 
 import com.fasterxml.jackson.annotation.JacksonAnnotationsInside;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import tools.jackson.databind.annotation.JsonDeserialize;
 
 /**
  * Marks a property that needs to be deserialized as FEEL expression.

--- a/connectors-e2e-test/connectors-e2e-test-feel/pom.xml
+++ b/connectors-e2e-test/connectors-e2e-test-feel/pom.xml
@@ -42,10 +42,5 @@
       <scope>test</scope>
     </dependency>
 
-    <dependency>
-      <groupId>com.fasterxml.jackson.datatype</groupId>
-      <artifactId>jackson-datatype-jsr310</artifactId>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 </project>

--- a/connectors-e2e-test/connectors-e2e-test-feel/src/test/java/io/camunda/connector/e2e/feel/FeelDeserializerCamundaClientTest.java
+++ b/connectors-e2e-test/connectors-e2e-test-feel/src/test/java/io/camunda/connector/e2e/feel/FeelDeserializerCamundaClientTest.java
@@ -27,8 +27,8 @@ import io.camunda.client.api.command.ProblemException;
 import io.camunda.connector.api.annotation.FEEL;
 import io.camunda.connector.e2e.app.TestConnectorRuntimeApplication;
 import io.camunda.connector.feel.CamundaClientFeelExpressionEvaluator;
-import io.camunda.connector.feel.jackson.JacksonModuleFeelFunction;
-import io.camunda.connector.jackson.ConnectorsObjectMapperSupplier;
+import io.camunda.connector.feel.JacksonSupport;
+import io.camunda.connector.feel.jackson.v2.JacksonModuleFeelFunction;
 import io.camunda.connector.test.utils.annotation.SlowTest;
 import io.camunda.process.test.api.CamundaSpringProcessTest;
 import java.time.Duration;
@@ -66,7 +66,7 @@ public class FeelDeserializerCamundaClientTest {
   void setup() {
     var evaluator =
         new CamundaClientFeelExpressionEvaluator(
-            camundaClient, ConnectorsObjectMapperSupplier.getCopy());
+            camundaClient, JacksonSupport.DEFAULT_OBJECT_MAPPER);
     mapper =
         new ObjectMapper()
             .registerModule(new JacksonModuleFeelFunction(true, evaluator))

--- a/connectors/agentic-ai/connector-agentic-ai/pom.xml
+++ b/connectors/agentic-ai/connector-agentic-ai/pom.xml
@@ -789,7 +789,7 @@
             <scope>runtime</scope>
           </dependency>
           <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
+            <groupId>tools.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
             <version>${version.jackson-bom}</version>
             <scope>runtime</scope>

--- a/connectors/app-integrations/pom.xml
+++ b/connectors/app-integrations/pom.xml
@@ -40,7 +40,7 @@ except in compliance with the proprietary license.</license.inlineheader>
       <artifactId>http-client</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
+      <groupId>tools.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
       <version>${version.jackson-bom}</version>
     </dependency>

--- a/connectors/aws/aws-base/src/main/java/io/camunda/connector/aws/ObjectMapperSupplier.java
+++ b/connectors/aws/aws-base/src/main/java/io/camunda/connector/aws/ObjectMapperSupplier.java
@@ -6,8 +6,8 @@
  */
 package io.camunda.connector.aws;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.connector.jackson.ConnectorsObjectMapperSupplier;
+import tools.jackson.databind.ObjectMapper;
 
 public final class ObjectMapperSupplier {
 

--- a/connectors/aws/aws-bedrock-agentcore-long-term-memory/element-templates/aws-bedrock-agentcore-long-term-memory-outbound-connector.json
+++ b/connectors/aws/aws-bedrock-agentcore-long-term-memory/element-templates/aws-bedrock-agentcore-long-term-memory-outbound-connector.json
@@ -44,56 +44,48 @@
     "label" : "Retries"
   } ],
   "properties" : [ {
-    "value" : "io.camunda:aws-bedrock-agentcore-lt-memory:1",
     "binding" : {
       "property" : "type",
       "type" : "zeebe:taskDefinition"
     },
-    "type" : "Hidden"
+    "type" : "Hidden",
+    "value" : "io.camunda:aws-bedrock-agentcore-lt-memory:1"
   }, {
-    "id" : "operation.operationDiscriminator",
-    "label" : "Operation",
-    "value" : "retrieve",
-    "group" : "operation",
     "binding" : {
       "name" : "operation.operationDiscriminator",
       "type" : "zeebe:input"
     },
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "Retrieve Memory Records",
       "value" : "retrieve"
     }, {
       "name" : "List Memory Records",
       "value" : "list"
-    } ]
+    } ],
+    "group" : "operation",
+    "id" : "operation.operationDiscriminator",
+    "label" : "Operation",
+    "type" : "Dropdown",
+    "value" : "retrieve"
   }, {
-    "id" : "authentication.type",
-    "label" : "Authentication",
-    "description" : "Specify AWS authentication strategy. Learn more at the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/aws-lambda/#aws-authentication-types\" target=\"_blank\">documentation page</a>",
-    "value" : "credentials",
-    "group" : "authentication",
     "binding" : {
       "name" : "authentication.type",
       "type" : "zeebe:input"
     },
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "Default Credentials Chain (Hybrid/Self-Managed only)",
       "value" : "defaultCredentialsChain"
     }, {
       "name" : "Credentials",
       "value" : "credentials"
-    } ]
-  }, {
-    "id" : "authentication.accessKey",
-    "label" : "Access key",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "feel" : "optional",
+    } ],
+    "description" : "Specify AWS authentication strategy. Learn more at the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/aws-lambda/#aws-authentication-types\" target=\"_blank\">documentation page</a>",
     "group" : "authentication",
+    "id" : "authentication.type",
+    "label" : "Authentication",
+    "type" : "Dropdown",
+    "value" : "credentials"
+  }, {
     "binding" : {
       "name" : "authentication.accessKey",
       "type" : "zeebe:input"
@@ -103,18 +95,18 @@
       "equals" : "credentials",
       "type" : "simple"
     },
-    "tooltip" : "IAM access key of a user with the necessary permissions for this connector",
-    "type" : "String",
-    "secret" : true
-  }, {
-    "id" : "authentication.secretKey",
-    "label" : "Secret key",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "authentication",
+    "id" : "authentication.accessKey",
+    "label" : "Access key",
+    "optional" : false,
+    "secret" : true,
+    "tooltip" : "IAM access key of a user with the necessary permissions for this connector",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "authentication.secretKey",
       "type" : "zeebe:input"
@@ -124,86 +116,85 @@
       "equals" : "credentials",
       "type" : "simple"
     },
-    "tooltip" : "IAM secret key of a user with the necessary permissions for this connector",
-    "type" : "String",
-    "secret" : true
-  }, {
-    "id" : "awsCredential",
-    "label" : "AWS credential",
-    "description" : "Choose a reusable AWS credential. When set, it is bound as a whole to the connector's 'awsCredential' input.",
-    "optional" : true,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
     "group" : "authentication",
+    "id" : "authentication.secretKey",
+    "label" : "Secret key",
+    "optional" : false,
+    "secret" : true,
+    "tooltip" : "IAM secret key of a user with the necessary permissions for this connector",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "awsCredential",
       "type" : "zeebe:input"
     },
-    "type" : "Configuration",
-    "configurationTemplate" : "io.camunda:aws-credential:1"
+    "configurationTemplate" : "io.camunda:aws-credential:1",
+    "description" : "Choose a reusable AWS credential. When set, it is bound as a whole to the connector's 'awsCredential' input.",
+    "group" : "authentication",
+    "id" : "awsCredential",
+    "label" : "AWS credential",
+    "optional" : true,
+    "type" : "Configuration"
   }, {
-    "id" : "memoryId",
-    "label" : "Memory ID",
-    "description" : "The identifier of the AgentCore Memory resource.",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "feel" : "optional",
-    "group" : "configuration",
     "binding" : {
       "name" : "memoryId",
       "type" : "zeebe:input"
     },
-    "type" : "String"
-  }, {
-    "id" : "namespace",
-    "label" : "Namespace",
-    "description" : "Namespace prefix to scope memory records (e.g. 'customer/12345'). Required by AWS.",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
+    "description" : "The identifier of the AgentCore Memory resource.",
     "feel" : "optional",
     "group" : "configuration",
+    "id" : "memoryId",
+    "label" : "Memory ID",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "namespace",
       "type" : "zeebe:input"
     },
-    "type" : "String"
-  }, {
-    "id" : "configuration.region",
-    "label" : "Region",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
+    "description" : "Namespace prefix to scope memory records (e.g. 'customer/12345'). Required by AWS.",
     "feel" : "optional",
     "group" : "configuration",
+    "id" : "namespace",
+    "label" : "Namespace",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "configuration.region",
       "type" : "zeebe:input"
     },
-    "type" : "String"
-  }, {
-    "id" : "configuration.endpoint",
-    "label" : "Endpoint",
-    "description" : "Specify endpoint if need to use custom endpoint",
-    "optional" : true,
-    "group" : "configuration",
-    "binding" : {
-      "name" : "configuration.endpoint",
-      "type" : "zeebe:input"
-    },
-    "type" : "Hidden"
-  }, {
-    "id" : "operation.query",
-    "label" : "Search query",
-    "description" : "Semantic search query to find relevant memory records (up to 10,000 characters).",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
-    "group" : "retrieve",
+    "group" : "configuration",
+    "id" : "configuration.region",
+    "label" : "Region",
+    "optional" : false,
+    "type" : "String"
+  }, {
+    "binding" : {
+      "name" : "configuration.endpoint",
+      "type" : "zeebe:input"
+    },
+    "description" : "Specify endpoint if need to use custom endpoint",
+    "group" : "configuration",
+    "id" : "configuration.endpoint",
+    "label" : "Endpoint",
+    "optional" : true,
+    "type" : "Hidden"
+  }, {
     "binding" : {
       "name" : "operation.query",
       "type" : "zeebe:input"
@@ -213,16 +204,36 @@
       "equals" : "retrieve",
       "type" : "simple"
     },
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "description" : "Semantic search query to find relevant memory records (up to 10,000 characters).",
+    "feel" : "optional",
+    "group" : "retrieve",
+    "id" : "operation.query",
+    "label" : "Search query",
+    "optional" : false,
     "type" : "String"
   }, {
+    "binding" : {
+      "name" : "operation.memoryStrategyId",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "operation.operationDiscriminator",
+      "equals" : "retrieve",
+      "type" : "simple"
+    },
+    "description" : "Optional. Limits the search to memories created by a specific extraction strategy.",
+    "feel" : "optional",
+    "group" : "retrieve",
     "id" : "operation.retrieve.memoryStrategyId",
     "label" : "Memory strategy ID",
-    "description" : "Optional. Limits the search to memories created by a specific extraction strategy.",
     "optional" : true,
-    "feel" : "optional",
-    "group" : "retrieve",
+    "type" : "String"
+  }, {
     "binding" : {
-      "name" : "operation.memoryStrategyId",
+      "name" : "operation.maxResults",
       "type" : "zeebe:input"
     },
     "condition" : {
@@ -230,32 +241,15 @@
       "equals" : "retrieve",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
+    "description" : "Maximum number of results to return (1–100). Defaults to 10.",
+    "feel" : "static",
+    "group" : "retrieve",
     "id" : "operation.retrieve.maxResults",
     "label" : "Max results",
-    "description" : "Maximum number of results to return (1–100). Defaults to 10.",
     "optional" : true,
-    "value" : 10,
-    "feel" : "static",
-    "group" : "retrieve",
-    "binding" : {
-      "name" : "operation.maxResults",
-      "type" : "zeebe:input"
-    },
-    "condition" : {
-      "property" : "operation.operationDiscriminator",
-      "equals" : "retrieve",
-      "type" : "simple"
-    },
-    "type" : "Number"
+    "type" : "Number",
+    "value" : 10
   }, {
-    "id" : "operation.retrieve.nextToken",
-    "label" : "Pagination token",
-    "description" : "Pagination token from a previous response to fetch the next page.",
-    "optional" : true,
-    "feel" : "optional",
-    "group" : "retrieve",
     "binding" : {
       "name" : "operation.nextToken",
       "type" : "zeebe:input"
@@ -265,14 +259,14 @@
       "equals" : "retrieve",
       "type" : "simple"
     },
+    "description" : "Pagination token from a previous response to fetch the next page.",
+    "feel" : "optional",
+    "group" : "retrieve",
+    "id" : "operation.retrieve.nextToken",
+    "label" : "Pagination token",
+    "optional" : true,
     "type" : "String"
   }, {
-    "id" : "operation.list.memoryStrategyId",
-    "label" : "Memory strategy ID",
-    "description" : "Optional. Filter memory records by a specific extraction strategy.",
-    "optional" : true,
-    "feel" : "optional",
-    "group" : "list",
     "binding" : {
       "name" : "operation.memoryStrategyId",
       "type" : "zeebe:input"
@@ -282,15 +276,14 @@
       "equals" : "list",
       "type" : "simple"
     },
+    "description" : "Optional. Filter memory records by a specific extraction strategy.",
+    "feel" : "optional",
+    "group" : "list",
+    "id" : "operation.list.memoryStrategyId",
+    "label" : "Memory strategy ID",
+    "optional" : true,
     "type" : "String"
   }, {
-    "id" : "operation.list.maxResults",
-    "label" : "Max results",
-    "description" : "Maximum number of results to return (1–100). Defaults to 20.",
-    "optional" : true,
-    "value" : 20,
-    "feel" : "static",
-    "group" : "list",
     "binding" : {
       "name" : "operation.maxResults",
       "type" : "zeebe:input"
@@ -300,14 +293,15 @@
       "equals" : "list",
       "type" : "simple"
     },
-    "type" : "Number"
-  }, {
-    "id" : "operation.list.nextToken",
-    "label" : "Pagination token",
-    "description" : "Pagination token from a previous response to fetch the next page.",
-    "optional" : true,
-    "feel" : "optional",
+    "description" : "Maximum number of results to return (1–100). Defaults to 20.",
+    "feel" : "static",
     "group" : "list",
+    "id" : "operation.list.maxResults",
+    "label" : "Max results",
+    "optional" : true,
+    "type" : "Number",
+    "value" : 20
+  }, {
     "binding" : {
       "name" : "operation.nextToken",
       "type" : "zeebe:input"
@@ -317,94 +311,100 @@
       "equals" : "list",
       "type" : "simple"
     },
+    "description" : "Pagination token from a previous response to fetch the next page.",
+    "feel" : "optional",
+    "group" : "list",
+    "id" : "operation.list.nextToken",
+    "label" : "Pagination token",
+    "optional" : true,
     "type" : "String"
   }, {
-    "id" : "version",
-    "label" : "Version",
-    "description" : "Version of the element template",
-    "value" : "3",
-    "group" : "connector",
     "binding" : {
       "key" : "elementTemplateVersion",
       "type" : "zeebe:taskHeader"
     },
-    "type" : "Hidden"
-  }, {
-    "id" : "id",
-    "label" : "ID",
-    "description" : "ID of the element template",
-    "value" : "io.camunda.connectors.aws.bedrock.agentcore.memory.longterm.v1",
+    "description" : "Version of the element template",
     "group" : "connector",
+    "id" : "version",
+    "label" : "Version",
+    "type" : "Hidden",
+    "value" : "3"
+  }, {
     "binding" : {
       "key" : "elementTemplateId",
       "type" : "zeebe:taskHeader"
     },
-    "type" : "Hidden"
+    "description" : "ID of the element template",
+    "group" : "connector",
+    "id" : "id",
+    "label" : "ID",
+    "type" : "Hidden",
+    "value" : "io.camunda.connectors.aws.bedrock.agentcore.memory.longterm.v1"
   }, {
-    "id" : "resultVariable",
-    "label" : "Result variable",
-    "description" : "Name of variable to store the response in. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-variable\" target=\"_blank\">documentation</a>.",
-    "group" : "output",
     "binding" : {
       "key" : "resultVariable",
       "type" : "zeebe:taskHeader"
     },
+    "description" : "Name of variable to store the response in. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-variable\" target=\"_blank\">documentation</a>.",
+    "group" : "output",
+    "id" : "resultVariable",
+    "label" : "Result variable",
     "type" : "String"
   }, {
-    "id" : "resultExpression",
-    "label" : "Result expression",
-    "description" : "Expression to map the response into process variables. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-expression\" target=\"_blank\">documentation</a>.",
-    "feel" : "required",
-    "group" : "output",
     "binding" : {
       "key" : "resultExpression",
       "type" : "zeebe:taskHeader"
     },
+    "description" : "Expression to map the response into process variables. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-expression\" target=\"_blank\">documentation</a>.",
+    "feel" : "required",
+    "group" : "output",
+    "id" : "resultExpression",
+    "label" : "Result expression",
     "type" : "Text"
   }, {
-    "id" : "errorExpression",
-    "label" : "Error expression",
-    "description" : "Expression to handle errors. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/\" target=\"_blank\">documentation</a>.",
-    "feel" : "required",
-    "group" : "error",
     "binding" : {
       "key" : "errorExpression",
       "type" : "zeebe:taskHeader"
     },
+    "description" : "Expression to handle errors. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/\" target=\"_blank\">documentation</a>.",
+    "feel" : "required",
+    "group" : "error",
+    "id" : "errorExpression",
+    "label" : "Error expression",
     "type" : "Text"
   }, {
-    "id" : "retryCount",
-    "label" : "Retries",
-    "description" : "Number of retries",
-    "value" : "3",
-    "feel" : "optional",
-    "group" : "retries",
     "binding" : {
       "property" : "retries",
       "type" : "zeebe:taskDefinition"
     },
-    "type" : "String"
-  }, {
-    "id" : "retryBackoff",
-    "label" : "Retry backoff",
-    "description" : "ISO-8601 duration to wait between retries",
-    "value" : "PT30S",
+    "description" : "Number of retries",
+    "feel" : "optional",
     "group" : "retries",
+    "id" : "retryCount",
+    "label" : "Retries",
+    "type" : "String",
+    "value" : "3"
+  }, {
     "binding" : {
       "key" : "retryBackoff",
       "type" : "zeebe:taskHeader"
     },
-    "type" : "String"
-  }, {
-    "id" : "jobTimeout",
-    "label" : "Job timeout",
-    "description" : "ISO-8601 duration after which Zeebe considers this job timed out if not yet completed. Leave empty to use the default timeout",
-    "optional" : true,
+    "description" : "ISO-8601 duration to wait between retries",
     "group" : "retries",
+    "id" : "retryBackoff",
+    "label" : "Retry backoff",
+    "type" : "String",
+    "value" : "PT30S"
+  }, {
     "binding" : {
       "key" : "jobTimeout",
       "type" : "zeebe:taskHeader"
     },
+    "description" : "ISO-8601 duration after which Zeebe considers this job timed out if not yet completed. Leave empty to use the default timeout",
+    "group" : "retries",
+    "id" : "jobTimeout",
+    "label" : "Job timeout",
+    "optional" : true,
     "type" : "String"
   } ],
   "steps" : [ {
@@ -435,30 +435,24 @@
     "version" : 1,
     "name" : "AWS Credential",
     "properties" : [ {
-      "id" : "authentication.type",
-      "label" : "Authentication",
-      "description" : "Specify AWS authentication strategy. Learn more at the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/aws-lambda/#aws-authentication-types\" target=\"_blank\">documentation page</a>",
-      "value" : "credentials",
-      "group" : "authentication",
       "binding" : {
         "name" : "authentication.type",
         "type" : "property"
       },
-      "type" : "Dropdown",
       "choices" : [ {
         "name" : "Default Credentials Chain (Hybrid/Self-Managed only)",
         "value" : "defaultCredentialsChain"
       }, {
         "name" : "Credentials",
         "value" : "credentials"
-      } ]
-    }, {
-      "id" : "authentication.accessKey",
-      "label" : "Access key",
-      "constraints" : {
-        "notEmpty" : true
-      },
+      } ],
+      "description" : "Specify AWS authentication strategy. Learn more at the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/aws-lambda/#aws-authentication-types\" target=\"_blank\">documentation page</a>",
       "group" : "authentication",
+      "id" : "authentication.type",
+      "label" : "Authentication",
+      "type" : "Dropdown",
+      "value" : "credentials"
+    }, {
       "binding" : {
         "name" : "authentication.accessKey",
         "type" : "property"
@@ -468,16 +462,16 @@
         "equals" : "credentials",
         "type" : "simple"
       },
-      "tooltip" : "IAM access key of a user with the necessary permissions for this connector",
-      "type" : "String",
-      "secret" : true
-    }, {
-      "id" : "authentication.secretKey",
-      "label" : "Secret key",
       "constraints" : {
         "notEmpty" : true
       },
       "group" : "authentication",
+      "id" : "authentication.accessKey",
+      "label" : "Access key",
+      "secret" : true,
+      "tooltip" : "IAM access key of a user with the necessary permissions for this connector",
+      "type" : "String"
+    }, {
       "binding" : {
         "name" : "authentication.secretKey",
         "type" : "property"
@@ -487,20 +481,26 @@
         "equals" : "credentials",
         "type" : "simple"
       },
-      "tooltip" : "IAM secret key of a user with the necessary permissions for this connector",
-      "type" : "String",
-      "secret" : true
-    }, {
-      "id" : "region",
-      "label" : "Region",
       "constraints" : {
         "notEmpty" : true
       },
-      "group" : "configuration",
+      "group" : "authentication",
+      "id" : "authentication.secretKey",
+      "label" : "Secret key",
+      "secret" : true,
+      "tooltip" : "IAM secret key of a user with the necessary permissions for this connector",
+      "type" : "String"
+    }, {
       "binding" : {
         "name" : "region",
         "type" : "property"
       },
+      "constraints" : {
+        "notEmpty" : true
+      },
+      "group" : "configuration",
+      "id" : "region",
+      "label" : "Region",
       "type" : "String"
     } ]
   } ],

--- a/connectors/aws/aws-bedrock-agentcore-long-term-memory/element-templates/hybrid/aws-bedrock-agentcore-long-term-memory-outbound-connector-hybrid.json
+++ b/connectors/aws/aws-bedrock-agentcore-long-term-memory/element-templates/hybrid/aws-bedrock-agentcore-long-term-memory-outbound-connector-hybrid.json
@@ -47,58 +47,50 @@
     "label" : "Retries"
   } ],
   "properties" : [ {
-    "id" : "taskDefinitionType",
-    "value" : "io.camunda:aws-bedrock-agentcore-lt-memory:1",
-    "group" : "taskDefinitionType",
     "binding" : {
       "property" : "type",
       "type" : "zeebe:taskDefinition"
     },
-    "type" : "String"
+    "group" : "taskDefinitionType",
+    "id" : "taskDefinitionType",
+    "type" : "String",
+    "value" : "io.camunda:aws-bedrock-agentcore-lt-memory:1"
   }, {
-    "id" : "operation.operationDiscriminator",
-    "label" : "Operation",
-    "value" : "retrieve",
-    "group" : "operation",
     "binding" : {
       "name" : "operation.operationDiscriminator",
       "type" : "zeebe:input"
     },
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "Retrieve Memory Records",
       "value" : "retrieve"
     }, {
       "name" : "List Memory Records",
       "value" : "list"
-    } ]
+    } ],
+    "group" : "operation",
+    "id" : "operation.operationDiscriminator",
+    "label" : "Operation",
+    "type" : "Dropdown",
+    "value" : "retrieve"
   }, {
-    "id" : "authentication.type",
-    "label" : "Authentication",
-    "description" : "Specify AWS authentication strategy. Learn more at the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/aws-lambda/#aws-authentication-types\" target=\"_blank\">documentation page</a>",
-    "value" : "credentials",
-    "group" : "authentication",
     "binding" : {
       "name" : "authentication.type",
       "type" : "zeebe:input"
     },
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "Default Credentials Chain (Hybrid/Self-Managed only)",
       "value" : "defaultCredentialsChain"
     }, {
       "name" : "Credentials",
       "value" : "credentials"
-    } ]
-  }, {
-    "id" : "authentication.accessKey",
-    "label" : "Access key",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "feel" : "optional",
+    } ],
+    "description" : "Specify AWS authentication strategy. Learn more at the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/aws-lambda/#aws-authentication-types\" target=\"_blank\">documentation page</a>",
     "group" : "authentication",
+    "id" : "authentication.type",
+    "label" : "Authentication",
+    "type" : "Dropdown",
+    "value" : "credentials"
+  }, {
     "binding" : {
       "name" : "authentication.accessKey",
       "type" : "zeebe:input"
@@ -108,18 +100,18 @@
       "equals" : "credentials",
       "type" : "simple"
     },
-    "tooltip" : "IAM access key of a user with the necessary permissions for this connector",
-    "type" : "String",
-    "secret" : true
-  }, {
-    "id" : "authentication.secretKey",
-    "label" : "Secret key",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "authentication",
+    "id" : "authentication.accessKey",
+    "label" : "Access key",
+    "optional" : false,
+    "secret" : true,
+    "tooltip" : "IAM access key of a user with the necessary permissions for this connector",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "authentication.secretKey",
       "type" : "zeebe:input"
@@ -129,86 +121,85 @@
       "equals" : "credentials",
       "type" : "simple"
     },
-    "tooltip" : "IAM secret key of a user with the necessary permissions for this connector",
-    "type" : "String",
-    "secret" : true
-  }, {
-    "id" : "awsCredential",
-    "label" : "AWS credential",
-    "description" : "Choose a reusable AWS credential. When set, it is bound as a whole to the connector's 'awsCredential' input.",
-    "optional" : true,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
     "group" : "authentication",
+    "id" : "authentication.secretKey",
+    "label" : "Secret key",
+    "optional" : false,
+    "secret" : true,
+    "tooltip" : "IAM secret key of a user with the necessary permissions for this connector",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "awsCredential",
       "type" : "zeebe:input"
     },
-    "type" : "Configuration",
-    "configurationTemplate" : "io.camunda:aws-credential:1"
+    "configurationTemplate" : "io.camunda:aws-credential:1",
+    "description" : "Choose a reusable AWS credential. When set, it is bound as a whole to the connector's 'awsCredential' input.",
+    "group" : "authentication",
+    "id" : "awsCredential",
+    "label" : "AWS credential",
+    "optional" : true,
+    "type" : "Configuration"
   }, {
-    "id" : "memoryId",
-    "label" : "Memory ID",
-    "description" : "The identifier of the AgentCore Memory resource.",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "feel" : "optional",
-    "group" : "configuration",
     "binding" : {
       "name" : "memoryId",
       "type" : "zeebe:input"
     },
-    "type" : "String"
-  }, {
-    "id" : "namespace",
-    "label" : "Namespace",
-    "description" : "Namespace prefix to scope memory records (e.g. 'customer/12345'). Required by AWS.",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
+    "description" : "The identifier of the AgentCore Memory resource.",
     "feel" : "optional",
     "group" : "configuration",
+    "id" : "memoryId",
+    "label" : "Memory ID",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "namespace",
       "type" : "zeebe:input"
     },
-    "type" : "String"
-  }, {
-    "id" : "configuration.region",
-    "label" : "Region",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
+    "description" : "Namespace prefix to scope memory records (e.g. 'customer/12345'). Required by AWS.",
     "feel" : "optional",
     "group" : "configuration",
+    "id" : "namespace",
+    "label" : "Namespace",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "configuration.region",
       "type" : "zeebe:input"
     },
-    "type" : "String"
-  }, {
-    "id" : "configuration.endpoint",
-    "label" : "Endpoint",
-    "description" : "Specify endpoint if need to use custom endpoint",
-    "optional" : true,
-    "group" : "configuration",
-    "binding" : {
-      "name" : "configuration.endpoint",
-      "type" : "zeebe:input"
-    },
-    "type" : "Hidden"
-  }, {
-    "id" : "operation.query",
-    "label" : "Search query",
-    "description" : "Semantic search query to find relevant memory records (up to 10,000 characters).",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
-    "group" : "retrieve",
+    "group" : "configuration",
+    "id" : "configuration.region",
+    "label" : "Region",
+    "optional" : false,
+    "type" : "String"
+  }, {
+    "binding" : {
+      "name" : "configuration.endpoint",
+      "type" : "zeebe:input"
+    },
+    "description" : "Specify endpoint if need to use custom endpoint",
+    "group" : "configuration",
+    "id" : "configuration.endpoint",
+    "label" : "Endpoint",
+    "optional" : true,
+    "type" : "Hidden"
+  }, {
     "binding" : {
       "name" : "operation.query",
       "type" : "zeebe:input"
@@ -218,16 +209,36 @@
       "equals" : "retrieve",
       "type" : "simple"
     },
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "description" : "Semantic search query to find relevant memory records (up to 10,000 characters).",
+    "feel" : "optional",
+    "group" : "retrieve",
+    "id" : "operation.query",
+    "label" : "Search query",
+    "optional" : false,
     "type" : "String"
   }, {
+    "binding" : {
+      "name" : "operation.memoryStrategyId",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "operation.operationDiscriminator",
+      "equals" : "retrieve",
+      "type" : "simple"
+    },
+    "description" : "Optional. Limits the search to memories created by a specific extraction strategy.",
+    "feel" : "optional",
+    "group" : "retrieve",
     "id" : "operation.retrieve.memoryStrategyId",
     "label" : "Memory strategy ID",
-    "description" : "Optional. Limits the search to memories created by a specific extraction strategy.",
     "optional" : true,
-    "feel" : "optional",
-    "group" : "retrieve",
+    "type" : "String"
+  }, {
     "binding" : {
-      "name" : "operation.memoryStrategyId",
+      "name" : "operation.maxResults",
       "type" : "zeebe:input"
     },
     "condition" : {
@@ -235,32 +246,15 @@
       "equals" : "retrieve",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
+    "description" : "Maximum number of results to return (1–100). Defaults to 10.",
+    "feel" : "static",
+    "group" : "retrieve",
     "id" : "operation.retrieve.maxResults",
     "label" : "Max results",
-    "description" : "Maximum number of results to return (1–100). Defaults to 10.",
     "optional" : true,
-    "value" : 10,
-    "feel" : "static",
-    "group" : "retrieve",
-    "binding" : {
-      "name" : "operation.maxResults",
-      "type" : "zeebe:input"
-    },
-    "condition" : {
-      "property" : "operation.operationDiscriminator",
-      "equals" : "retrieve",
-      "type" : "simple"
-    },
-    "type" : "Number"
+    "type" : "Number",
+    "value" : 10
   }, {
-    "id" : "operation.retrieve.nextToken",
-    "label" : "Pagination token",
-    "description" : "Pagination token from a previous response to fetch the next page.",
-    "optional" : true,
-    "feel" : "optional",
-    "group" : "retrieve",
     "binding" : {
       "name" : "operation.nextToken",
       "type" : "zeebe:input"
@@ -270,14 +264,14 @@
       "equals" : "retrieve",
       "type" : "simple"
     },
+    "description" : "Pagination token from a previous response to fetch the next page.",
+    "feel" : "optional",
+    "group" : "retrieve",
+    "id" : "operation.retrieve.nextToken",
+    "label" : "Pagination token",
+    "optional" : true,
     "type" : "String"
   }, {
-    "id" : "operation.list.memoryStrategyId",
-    "label" : "Memory strategy ID",
-    "description" : "Optional. Filter memory records by a specific extraction strategy.",
-    "optional" : true,
-    "feel" : "optional",
-    "group" : "list",
     "binding" : {
       "name" : "operation.memoryStrategyId",
       "type" : "zeebe:input"
@@ -287,15 +281,14 @@
       "equals" : "list",
       "type" : "simple"
     },
+    "description" : "Optional. Filter memory records by a specific extraction strategy.",
+    "feel" : "optional",
+    "group" : "list",
+    "id" : "operation.list.memoryStrategyId",
+    "label" : "Memory strategy ID",
+    "optional" : true,
     "type" : "String"
   }, {
-    "id" : "operation.list.maxResults",
-    "label" : "Max results",
-    "description" : "Maximum number of results to return (1–100). Defaults to 20.",
-    "optional" : true,
-    "value" : 20,
-    "feel" : "static",
-    "group" : "list",
     "binding" : {
       "name" : "operation.maxResults",
       "type" : "zeebe:input"
@@ -305,14 +298,15 @@
       "equals" : "list",
       "type" : "simple"
     },
-    "type" : "Number"
-  }, {
-    "id" : "operation.list.nextToken",
-    "label" : "Pagination token",
-    "description" : "Pagination token from a previous response to fetch the next page.",
-    "optional" : true,
-    "feel" : "optional",
+    "description" : "Maximum number of results to return (1–100). Defaults to 20.",
+    "feel" : "static",
     "group" : "list",
+    "id" : "operation.list.maxResults",
+    "label" : "Max results",
+    "optional" : true,
+    "type" : "Number",
+    "value" : 20
+  }, {
     "binding" : {
       "name" : "operation.nextToken",
       "type" : "zeebe:input"
@@ -322,94 +316,100 @@
       "equals" : "list",
       "type" : "simple"
     },
+    "description" : "Pagination token from a previous response to fetch the next page.",
+    "feel" : "optional",
+    "group" : "list",
+    "id" : "operation.list.nextToken",
+    "label" : "Pagination token",
+    "optional" : true,
     "type" : "String"
   }, {
-    "id" : "version",
-    "label" : "Version",
-    "description" : "Version of the element template",
-    "value" : "3",
-    "group" : "connector",
     "binding" : {
       "key" : "elementTemplateVersion",
       "type" : "zeebe:taskHeader"
     },
-    "type" : "Hidden"
-  }, {
-    "id" : "id",
-    "label" : "ID",
-    "description" : "ID of the element template",
-    "value" : "io.camunda.connectors.aws.bedrock.agentcore.memory.longterm.v1",
+    "description" : "Version of the element template",
     "group" : "connector",
+    "id" : "version",
+    "label" : "Version",
+    "type" : "Hidden",
+    "value" : "3"
+  }, {
     "binding" : {
       "key" : "elementTemplateId",
       "type" : "zeebe:taskHeader"
     },
-    "type" : "Hidden"
+    "description" : "ID of the element template",
+    "group" : "connector",
+    "id" : "id",
+    "label" : "ID",
+    "type" : "Hidden",
+    "value" : "io.camunda.connectors.aws.bedrock.agentcore.memory.longterm.v1"
   }, {
-    "id" : "resultVariable",
-    "label" : "Result variable",
-    "description" : "Name of variable to store the response in. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-variable\" target=\"_blank\">documentation</a>.",
-    "group" : "output",
     "binding" : {
       "key" : "resultVariable",
       "type" : "zeebe:taskHeader"
     },
+    "description" : "Name of variable to store the response in. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-variable\" target=\"_blank\">documentation</a>.",
+    "group" : "output",
+    "id" : "resultVariable",
+    "label" : "Result variable",
     "type" : "String"
   }, {
-    "id" : "resultExpression",
-    "label" : "Result expression",
-    "description" : "Expression to map the response into process variables. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-expression\" target=\"_blank\">documentation</a>.",
-    "feel" : "required",
-    "group" : "output",
     "binding" : {
       "key" : "resultExpression",
       "type" : "zeebe:taskHeader"
     },
+    "description" : "Expression to map the response into process variables. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-expression\" target=\"_blank\">documentation</a>.",
+    "feel" : "required",
+    "group" : "output",
+    "id" : "resultExpression",
+    "label" : "Result expression",
     "type" : "Text"
   }, {
-    "id" : "errorExpression",
-    "label" : "Error expression",
-    "description" : "Expression to handle errors. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/\" target=\"_blank\">documentation</a>.",
-    "feel" : "required",
-    "group" : "error",
     "binding" : {
       "key" : "errorExpression",
       "type" : "zeebe:taskHeader"
     },
+    "description" : "Expression to handle errors. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/\" target=\"_blank\">documentation</a>.",
+    "feel" : "required",
+    "group" : "error",
+    "id" : "errorExpression",
+    "label" : "Error expression",
     "type" : "Text"
   }, {
-    "id" : "retryCount",
-    "label" : "Retries",
-    "description" : "Number of retries",
-    "value" : "3",
-    "feel" : "optional",
-    "group" : "retries",
     "binding" : {
       "property" : "retries",
       "type" : "zeebe:taskDefinition"
     },
-    "type" : "String"
-  }, {
-    "id" : "retryBackoff",
-    "label" : "Retry backoff",
-    "description" : "ISO-8601 duration to wait between retries",
-    "value" : "PT30S",
+    "description" : "Number of retries",
+    "feel" : "optional",
     "group" : "retries",
+    "id" : "retryCount",
+    "label" : "Retries",
+    "type" : "String",
+    "value" : "3"
+  }, {
     "binding" : {
       "key" : "retryBackoff",
       "type" : "zeebe:taskHeader"
     },
-    "type" : "String"
-  }, {
-    "id" : "jobTimeout",
-    "label" : "Job timeout",
-    "description" : "ISO-8601 duration after which Zeebe considers this job timed out if not yet completed. Leave empty to use the default timeout",
-    "optional" : true,
+    "description" : "ISO-8601 duration to wait between retries",
     "group" : "retries",
+    "id" : "retryBackoff",
+    "label" : "Retry backoff",
+    "type" : "String",
+    "value" : "PT30S"
+  }, {
     "binding" : {
       "key" : "jobTimeout",
       "type" : "zeebe:taskHeader"
     },
+    "description" : "ISO-8601 duration after which Zeebe considers this job timed out if not yet completed. Leave empty to use the default timeout",
+    "group" : "retries",
+    "id" : "jobTimeout",
+    "label" : "Job timeout",
+    "optional" : true,
     "type" : "String"
   } ],
   "steps" : [ {
@@ -440,30 +440,24 @@
     "version" : 1,
     "name" : "AWS Credential",
     "properties" : [ {
-      "id" : "authentication.type",
-      "label" : "Authentication",
-      "description" : "Specify AWS authentication strategy. Learn more at the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/aws-lambda/#aws-authentication-types\" target=\"_blank\">documentation page</a>",
-      "value" : "credentials",
-      "group" : "authentication",
       "binding" : {
         "name" : "authentication.type",
         "type" : "property"
       },
-      "type" : "Dropdown",
       "choices" : [ {
         "name" : "Default Credentials Chain (Hybrid/Self-Managed only)",
         "value" : "defaultCredentialsChain"
       }, {
         "name" : "Credentials",
         "value" : "credentials"
-      } ]
-    }, {
-      "id" : "authentication.accessKey",
-      "label" : "Access key",
-      "constraints" : {
-        "notEmpty" : true
-      },
+      } ],
+      "description" : "Specify AWS authentication strategy. Learn more at the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/aws-lambda/#aws-authentication-types\" target=\"_blank\">documentation page</a>",
       "group" : "authentication",
+      "id" : "authentication.type",
+      "label" : "Authentication",
+      "type" : "Dropdown",
+      "value" : "credentials"
+    }, {
       "binding" : {
         "name" : "authentication.accessKey",
         "type" : "property"
@@ -473,16 +467,16 @@
         "equals" : "credentials",
         "type" : "simple"
       },
-      "tooltip" : "IAM access key of a user with the necessary permissions for this connector",
-      "type" : "String",
-      "secret" : true
-    }, {
-      "id" : "authentication.secretKey",
-      "label" : "Secret key",
       "constraints" : {
         "notEmpty" : true
       },
       "group" : "authentication",
+      "id" : "authentication.accessKey",
+      "label" : "Access key",
+      "secret" : true,
+      "tooltip" : "IAM access key of a user with the necessary permissions for this connector",
+      "type" : "String"
+    }, {
       "binding" : {
         "name" : "authentication.secretKey",
         "type" : "property"
@@ -492,20 +486,26 @@
         "equals" : "credentials",
         "type" : "simple"
       },
-      "tooltip" : "IAM secret key of a user with the necessary permissions for this connector",
-      "type" : "String",
-      "secret" : true
-    }, {
-      "id" : "region",
-      "label" : "Region",
       "constraints" : {
         "notEmpty" : true
       },
-      "group" : "configuration",
+      "group" : "authentication",
+      "id" : "authentication.secretKey",
+      "label" : "Secret key",
+      "secret" : true,
+      "tooltip" : "IAM secret key of a user with the necessary permissions for this connector",
+      "type" : "String"
+    }, {
       "binding" : {
         "name" : "region",
         "type" : "property"
       },
+      "constraints" : {
+        "notEmpty" : true
+      },
+      "group" : "configuration",
+      "id" : "region",
+      "label" : "Region",
       "type" : "String"
     } ]
   } ],

--- a/connectors/aws/aws-bedrock-codeinterpreter/element-templates/aws-bedrock-codeinterpreter-outbound-connector.json
+++ b/connectors/aws/aws-bedrock-codeinterpreter/element-templates/aws-bedrock-codeinterpreter-outbound-connector.json
@@ -41,39 +41,31 @@
     "label" : "Retries"
   } ],
   "properties" : [ {
-    "value" : "io.camunda:aws-bedrock-codeinterpreter:1",
     "binding" : {
       "property" : "type",
       "type" : "zeebe:taskDefinition"
     },
-    "type" : "Hidden"
+    "type" : "Hidden",
+    "value" : "io.camunda:aws-bedrock-codeinterpreter:1"
   }, {
-    "id" : "authentication.type",
-    "label" : "Authentication",
-    "description" : "Specify AWS authentication strategy. Learn more at the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/aws-lambda/#aws-authentication-types\" target=\"_blank\">documentation page</a>",
-    "value" : "credentials",
-    "group" : "authentication",
     "binding" : {
       "name" : "authentication.type",
       "type" : "zeebe:input"
     },
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "Default Credentials Chain (Hybrid/Self-Managed only)",
       "value" : "defaultCredentialsChain"
     }, {
       "name" : "Credentials",
       "value" : "credentials"
-    } ]
-  }, {
-    "id" : "authentication.accessKey",
-    "label" : "Access key",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "feel" : "optional",
+    } ],
+    "description" : "Specify AWS authentication strategy. Learn more at the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/aws-lambda/#aws-authentication-types\" target=\"_blank\">documentation page</a>",
     "group" : "authentication",
+    "id" : "authentication.type",
+    "label" : "Authentication",
+    "type" : "Dropdown",
+    "value" : "credentials"
+  }, {
     "binding" : {
       "name" : "authentication.accessKey",
       "type" : "zeebe:input"
@@ -83,18 +75,18 @@
       "equals" : "credentials",
       "type" : "simple"
     },
-    "tooltip" : "IAM access key of a user with the necessary permissions for this connector",
-    "type" : "String",
-    "secret" : true
-  }, {
-    "id" : "authentication.secretKey",
-    "label" : "Secret key",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "authentication",
+    "id" : "authentication.accessKey",
+    "label" : "Access key",
+    "optional" : false,
+    "secret" : true,
+    "tooltip" : "IAM access key of a user with the necessary permissions for this connector",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "authentication.secretKey",
       "type" : "zeebe:input"
@@ -104,57 +96,59 @@
       "equals" : "credentials",
       "type" : "simple"
     },
-    "tooltip" : "IAM secret key of a user with the necessary permissions for this connector",
-    "type" : "String",
-    "secret" : true
-  }, {
-    "id" : "awsCredential",
-    "label" : "AWS credential",
-    "description" : "Choose a reusable AWS credential. When set, it is bound as a whole to the connector's 'awsCredential' input.",
-    "optional" : true,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
     "group" : "authentication",
+    "id" : "authentication.secretKey",
+    "label" : "Secret key",
+    "optional" : false,
+    "secret" : true,
+    "tooltip" : "IAM secret key of a user with the necessary permissions for this connector",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "awsCredential",
       "type" : "zeebe:input"
     },
-    "type" : "Configuration",
-    "configurationTemplate" : "io.camunda:aws-credential:1"
+    "configurationTemplate" : "io.camunda:aws-credential:1",
+    "description" : "Choose a reusable AWS credential. When set, it is bound as a whole to the connector's 'awsCredential' input.",
+    "group" : "authentication",
+    "id" : "awsCredential",
+    "label" : "AWS credential",
+    "optional" : true,
+    "type" : "Configuration"
   }, {
-    "id" : "configuration.region",
-    "label" : "Region",
-    "optional" : false,
+    "binding" : {
+      "name" : "configuration.region",
+      "type" : "zeebe:input"
+    },
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "configuration",
-    "binding" : {
-      "name" : "configuration.region",
-      "type" : "zeebe:input"
-    },
+    "id" : "configuration.region",
+    "label" : "Region",
+    "optional" : false,
     "type" : "String"
   }, {
-    "id" : "configuration.endpoint",
-    "label" : "Endpoint",
-    "description" : "Specify endpoint if need to use custom endpoint",
-    "optional" : true,
-    "group" : "configuration",
     "binding" : {
       "name" : "configuration.endpoint",
       "type" : "zeebe:input"
     },
+    "description" : "Specify endpoint if need to use custom endpoint",
+    "group" : "configuration",
+    "id" : "configuration.endpoint",
+    "label" : "Endpoint",
+    "optional" : true,
     "type" : "Hidden"
   }, {
-    "id" : "input.language",
-    "label" : "Language",
-    "description" : "The programming language to use.",
-    "optional" : false,
-    "group" : "codeExecution",
     "binding" : {
       "name" : "input.language",
       "type" : "zeebe:input"
     },
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "Python",
       "value" : "python"
@@ -164,161 +158,167 @@
     }, {
       "name" : "TypeScript",
       "value" : "typescript"
-    } ]
-  }, {
-    "id" : "input.code",
-    "label" : "Code",
-    "description" : "The code to execute in the Code Interpreter sandbox.",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "feel" : "optional",
+    } ],
+    "description" : "The programming language to use.",
     "group" : "codeExecution",
+    "id" : "input.language",
+    "label" : "Language",
+    "optional" : false,
+    "type" : "Dropdown"
+  }, {
     "binding" : {
       "name" : "input.code",
       "type" : "zeebe:input"
     },
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "description" : "The code to execute in the Code Interpreter sandbox.",
+    "feel" : "optional",
+    "group" : "codeExecution",
+    "id" : "input.code",
+    "label" : "Code",
+    "optional" : false,
     "type" : "String"
   }, {
-    "id" : "input.codeInterpreterIdentifier",
-    "label" : "Code Interpreter ID",
-    "description" : "The Code Interpreter identifier. Defaults to the AWS managed default.",
-    "optional" : true,
-    "value" : "aws.codeinterpreter.v1",
-    "feel" : "optional",
-    "group" : "session",
     "binding" : {
       "name" : "input.codeInterpreterIdentifier",
       "type" : "zeebe:input"
     },
-    "type" : "String"
-  }, {
-    "id" : "input.sessionTimeout",
-    "label" : "Session timeout",
-    "description" : "Session timeout as ISO 8601 duration (e.g. PT5M for 5 minutes). Defaults to PT5M.",
-    "optional" : true,
-    "value" : "PT5M",
+    "description" : "The Code Interpreter identifier. Defaults to the AWS managed default.",
     "feel" : "optional",
     "group" : "session",
+    "id" : "input.codeInterpreterIdentifier",
+    "label" : "Code Interpreter ID",
+    "optional" : true,
+    "type" : "String",
+    "value" : "aws.codeinterpreter.v1"
+  }, {
     "binding" : {
       "name" : "input.sessionTimeout",
       "type" : "zeebe:input"
     },
-    "type" : "String"
-  }, {
-    "id" : "input.maxFiles",
-    "label" : "Max files to retrieve",
-    "description" : "Maximum number of generated files to retrieve. Defaults to 10.",
-    "optional" : true,
-    "value" : 10,
-    "feel" : "static",
+    "description" : "Session timeout as ISO 8601 duration (e.g. PT5M for 5 minutes). Defaults to PT5M.",
+    "feel" : "optional",
     "group" : "session",
+    "id" : "input.sessionTimeout",
+    "label" : "Session timeout",
+    "optional" : true,
+    "type" : "String",
+    "value" : "PT5M"
+  }, {
     "binding" : {
       "name" : "input.maxFiles",
       "type" : "zeebe:input"
     },
-    "type" : "Number"
-  }, {
-    "id" : "input.maxTotalFileSize",
-    "label" : "Max total file size",
-    "description" : "Maximum total size of retrieved files in bytes. Defaults to 10 MB.",
-    "optional" : true,
-    "value" : 10485760,
+    "description" : "Maximum number of generated files to retrieve. Defaults to 10.",
     "feel" : "static",
     "group" : "session",
+    "id" : "input.maxFiles",
+    "label" : "Max files to retrieve",
+    "optional" : true,
+    "type" : "Number",
+    "value" : 10
+  }, {
     "binding" : {
       "name" : "input.maxTotalFileSize",
       "type" : "zeebe:input"
     },
-    "type" : "Number"
+    "description" : "Maximum total size of retrieved files in bytes. Defaults to 10 MB.",
+    "feel" : "static",
+    "group" : "session",
+    "id" : "input.maxTotalFileSize",
+    "label" : "Max total file size",
+    "optional" : true,
+    "type" : "Number",
+    "value" : 10485760
   }, {
-    "id" : "version",
-    "label" : "Version",
-    "description" : "Version of the element template",
-    "value" : "2",
-    "group" : "connector",
     "binding" : {
       "key" : "elementTemplateVersion",
       "type" : "zeebe:taskHeader"
     },
-    "type" : "Hidden"
-  }, {
-    "id" : "id",
-    "label" : "ID",
-    "description" : "ID of the element template",
-    "value" : "io.camunda.connectors.aws.bedrock.codeinterpreter.v1",
+    "description" : "Version of the element template",
     "group" : "connector",
+    "id" : "version",
+    "label" : "Version",
+    "type" : "Hidden",
+    "value" : "2"
+  }, {
     "binding" : {
       "key" : "elementTemplateId",
       "type" : "zeebe:taskHeader"
     },
-    "type" : "Hidden"
+    "description" : "ID of the element template",
+    "group" : "connector",
+    "id" : "id",
+    "label" : "ID",
+    "type" : "Hidden",
+    "value" : "io.camunda.connectors.aws.bedrock.codeinterpreter.v1"
   }, {
-    "id" : "resultVariable",
-    "label" : "Result variable",
-    "description" : "Name of variable to store the response in. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-variable\" target=\"_blank\">documentation</a>.",
-    "group" : "output",
     "binding" : {
       "key" : "resultVariable",
       "type" : "zeebe:taskHeader"
     },
+    "description" : "Name of variable to store the response in. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-variable\" target=\"_blank\">documentation</a>.",
+    "group" : "output",
+    "id" : "resultVariable",
+    "label" : "Result variable",
     "type" : "String"
   }, {
-    "id" : "resultExpression",
-    "label" : "Result expression",
-    "description" : "Expression to map the response into process variables. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-expression\" target=\"_blank\">documentation</a>.",
-    "feel" : "required",
-    "group" : "output",
     "binding" : {
       "key" : "resultExpression",
       "type" : "zeebe:taskHeader"
     },
+    "description" : "Expression to map the response into process variables. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-expression\" target=\"_blank\">documentation</a>.",
+    "feel" : "required",
+    "group" : "output",
+    "id" : "resultExpression",
+    "label" : "Result expression",
     "type" : "Text"
   }, {
-    "id" : "errorExpression",
-    "label" : "Error expression",
-    "description" : "Expression to handle errors. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/\" target=\"_blank\">documentation</a>.",
-    "feel" : "required",
-    "group" : "error",
     "binding" : {
       "key" : "errorExpression",
       "type" : "zeebe:taskHeader"
     },
+    "description" : "Expression to handle errors. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/\" target=\"_blank\">documentation</a>.",
+    "feel" : "required",
+    "group" : "error",
+    "id" : "errorExpression",
+    "label" : "Error expression",
     "type" : "Text"
   }, {
-    "id" : "retryCount",
-    "label" : "Retries",
-    "description" : "Number of retries",
-    "value" : "3",
-    "feel" : "optional",
-    "group" : "retries",
     "binding" : {
       "property" : "retries",
       "type" : "zeebe:taskDefinition"
     },
-    "type" : "String"
-  }, {
-    "id" : "retryBackoff",
-    "label" : "Retry backoff",
-    "description" : "ISO-8601 duration to wait between retries",
-    "value" : "PT30S",
+    "description" : "Number of retries",
+    "feel" : "optional",
     "group" : "retries",
+    "id" : "retryCount",
+    "label" : "Retries",
+    "type" : "String",
+    "value" : "3"
+  }, {
     "binding" : {
       "key" : "retryBackoff",
       "type" : "zeebe:taskHeader"
     },
-    "type" : "String"
-  }, {
-    "id" : "jobTimeout",
-    "label" : "Job timeout",
-    "description" : "ISO-8601 duration after which Zeebe considers this job timed out if not yet completed. Leave empty to use the default timeout",
-    "optional" : true,
+    "description" : "ISO-8601 duration to wait between retries",
     "group" : "retries",
+    "id" : "retryBackoff",
+    "label" : "Retry backoff",
+    "type" : "String",
+    "value" : "PT30S"
+  }, {
     "binding" : {
       "key" : "jobTimeout",
       "type" : "zeebe:taskHeader"
     },
+    "description" : "ISO-8601 duration after which Zeebe considers this job timed out if not yet completed. Leave empty to use the default timeout",
+    "group" : "retries",
+    "id" : "jobTimeout",
+    "label" : "Job timeout",
+    "optional" : true,
     "type" : "String"
   } ],
   "configurationTemplates" : [ {
@@ -327,30 +327,24 @@
     "version" : 1,
     "name" : "AWS Credential",
     "properties" : [ {
-      "id" : "authentication.type",
-      "label" : "Authentication",
-      "description" : "Specify AWS authentication strategy. Learn more at the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/aws-lambda/#aws-authentication-types\" target=\"_blank\">documentation page</a>",
-      "value" : "credentials",
-      "group" : "authentication",
       "binding" : {
         "name" : "authentication.type",
         "type" : "property"
       },
-      "type" : "Dropdown",
       "choices" : [ {
         "name" : "Default Credentials Chain (Hybrid/Self-Managed only)",
         "value" : "defaultCredentialsChain"
       }, {
         "name" : "Credentials",
         "value" : "credentials"
-      } ]
-    }, {
-      "id" : "authentication.accessKey",
-      "label" : "Access key",
-      "constraints" : {
-        "notEmpty" : true
-      },
+      } ],
+      "description" : "Specify AWS authentication strategy. Learn more at the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/aws-lambda/#aws-authentication-types\" target=\"_blank\">documentation page</a>",
       "group" : "authentication",
+      "id" : "authentication.type",
+      "label" : "Authentication",
+      "type" : "Dropdown",
+      "value" : "credentials"
+    }, {
       "binding" : {
         "name" : "authentication.accessKey",
         "type" : "property"
@@ -360,16 +354,16 @@
         "equals" : "credentials",
         "type" : "simple"
       },
-      "tooltip" : "IAM access key of a user with the necessary permissions for this connector",
-      "type" : "String",
-      "secret" : true
-    }, {
-      "id" : "authentication.secretKey",
-      "label" : "Secret key",
       "constraints" : {
         "notEmpty" : true
       },
       "group" : "authentication",
+      "id" : "authentication.accessKey",
+      "label" : "Access key",
+      "secret" : true,
+      "tooltip" : "IAM access key of a user with the necessary permissions for this connector",
+      "type" : "String"
+    }, {
       "binding" : {
         "name" : "authentication.secretKey",
         "type" : "property"
@@ -379,20 +373,26 @@
         "equals" : "credentials",
         "type" : "simple"
       },
-      "tooltip" : "IAM secret key of a user with the necessary permissions for this connector",
-      "type" : "String",
-      "secret" : true
-    }, {
-      "id" : "region",
-      "label" : "Region",
       "constraints" : {
         "notEmpty" : true
       },
-      "group" : "configuration",
+      "group" : "authentication",
+      "id" : "authentication.secretKey",
+      "label" : "Secret key",
+      "secret" : true,
+      "tooltip" : "IAM secret key of a user with the necessary permissions for this connector",
+      "type" : "String"
+    }, {
       "binding" : {
         "name" : "region",
         "type" : "property"
       },
+      "constraints" : {
+        "notEmpty" : true
+      },
+      "group" : "configuration",
+      "id" : "region",
+      "label" : "Region",
       "type" : "String"
     } ]
   } ],

--- a/connectors/aws/aws-bedrock-codeinterpreter/element-templates/hybrid/aws-bedrock-codeinterpreter-outbound-connector-hybrid.json
+++ b/connectors/aws/aws-bedrock-codeinterpreter/element-templates/hybrid/aws-bedrock-codeinterpreter-outbound-connector-hybrid.json
@@ -44,41 +44,33 @@
     "label" : "Retries"
   } ],
   "properties" : [ {
-    "id" : "taskDefinitionType",
-    "value" : "io.camunda:aws-bedrock-codeinterpreter:1",
-    "group" : "taskDefinitionType",
     "binding" : {
       "property" : "type",
       "type" : "zeebe:taskDefinition"
     },
-    "type" : "String"
+    "group" : "taskDefinitionType",
+    "id" : "taskDefinitionType",
+    "type" : "String",
+    "value" : "io.camunda:aws-bedrock-codeinterpreter:1"
   }, {
-    "id" : "authentication.type",
-    "label" : "Authentication",
-    "description" : "Specify AWS authentication strategy. Learn more at the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/aws-lambda/#aws-authentication-types\" target=\"_blank\">documentation page</a>",
-    "value" : "credentials",
-    "group" : "authentication",
     "binding" : {
       "name" : "authentication.type",
       "type" : "zeebe:input"
     },
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "Default Credentials Chain (Hybrid/Self-Managed only)",
       "value" : "defaultCredentialsChain"
     }, {
       "name" : "Credentials",
       "value" : "credentials"
-    } ]
-  }, {
-    "id" : "authentication.accessKey",
-    "label" : "Access key",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "feel" : "optional",
+    } ],
+    "description" : "Specify AWS authentication strategy. Learn more at the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/aws-lambda/#aws-authentication-types\" target=\"_blank\">documentation page</a>",
     "group" : "authentication",
+    "id" : "authentication.type",
+    "label" : "Authentication",
+    "type" : "Dropdown",
+    "value" : "credentials"
+  }, {
     "binding" : {
       "name" : "authentication.accessKey",
       "type" : "zeebe:input"
@@ -88,18 +80,18 @@
       "equals" : "credentials",
       "type" : "simple"
     },
-    "tooltip" : "IAM access key of a user with the necessary permissions for this connector",
-    "type" : "String",
-    "secret" : true
-  }, {
-    "id" : "authentication.secretKey",
-    "label" : "Secret key",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "authentication",
+    "id" : "authentication.accessKey",
+    "label" : "Access key",
+    "optional" : false,
+    "secret" : true,
+    "tooltip" : "IAM access key of a user with the necessary permissions for this connector",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "authentication.secretKey",
       "type" : "zeebe:input"
@@ -109,57 +101,59 @@
       "equals" : "credentials",
       "type" : "simple"
     },
-    "tooltip" : "IAM secret key of a user with the necessary permissions for this connector",
-    "type" : "String",
-    "secret" : true
-  }, {
-    "id" : "awsCredential",
-    "label" : "AWS credential",
-    "description" : "Choose a reusable AWS credential. When set, it is bound as a whole to the connector's 'awsCredential' input.",
-    "optional" : true,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
     "group" : "authentication",
+    "id" : "authentication.secretKey",
+    "label" : "Secret key",
+    "optional" : false,
+    "secret" : true,
+    "tooltip" : "IAM secret key of a user with the necessary permissions for this connector",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "awsCredential",
       "type" : "zeebe:input"
     },
-    "type" : "Configuration",
-    "configurationTemplate" : "io.camunda:aws-credential:1"
+    "configurationTemplate" : "io.camunda:aws-credential:1",
+    "description" : "Choose a reusable AWS credential. When set, it is bound as a whole to the connector's 'awsCredential' input.",
+    "group" : "authentication",
+    "id" : "awsCredential",
+    "label" : "AWS credential",
+    "optional" : true,
+    "type" : "Configuration"
   }, {
-    "id" : "configuration.region",
-    "label" : "Region",
-    "optional" : false,
+    "binding" : {
+      "name" : "configuration.region",
+      "type" : "zeebe:input"
+    },
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "configuration",
-    "binding" : {
-      "name" : "configuration.region",
-      "type" : "zeebe:input"
-    },
+    "id" : "configuration.region",
+    "label" : "Region",
+    "optional" : false,
     "type" : "String"
   }, {
-    "id" : "configuration.endpoint",
-    "label" : "Endpoint",
-    "description" : "Specify endpoint if need to use custom endpoint",
-    "optional" : true,
-    "group" : "configuration",
     "binding" : {
       "name" : "configuration.endpoint",
       "type" : "zeebe:input"
     },
+    "description" : "Specify endpoint if need to use custom endpoint",
+    "group" : "configuration",
+    "id" : "configuration.endpoint",
+    "label" : "Endpoint",
+    "optional" : true,
     "type" : "Hidden"
   }, {
-    "id" : "input.language",
-    "label" : "Language",
-    "description" : "The programming language to use.",
-    "optional" : false,
-    "group" : "codeExecution",
     "binding" : {
       "name" : "input.language",
       "type" : "zeebe:input"
     },
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "Python",
       "value" : "python"
@@ -169,161 +163,167 @@
     }, {
       "name" : "TypeScript",
       "value" : "typescript"
-    } ]
-  }, {
-    "id" : "input.code",
-    "label" : "Code",
-    "description" : "The code to execute in the Code Interpreter sandbox.",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "feel" : "optional",
+    } ],
+    "description" : "The programming language to use.",
     "group" : "codeExecution",
+    "id" : "input.language",
+    "label" : "Language",
+    "optional" : false,
+    "type" : "Dropdown"
+  }, {
     "binding" : {
       "name" : "input.code",
       "type" : "zeebe:input"
     },
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "description" : "The code to execute in the Code Interpreter sandbox.",
+    "feel" : "optional",
+    "group" : "codeExecution",
+    "id" : "input.code",
+    "label" : "Code",
+    "optional" : false,
     "type" : "String"
   }, {
-    "id" : "input.codeInterpreterIdentifier",
-    "label" : "Code Interpreter ID",
-    "description" : "The Code Interpreter identifier. Defaults to the AWS managed default.",
-    "optional" : true,
-    "value" : "aws.codeinterpreter.v1",
-    "feel" : "optional",
-    "group" : "session",
     "binding" : {
       "name" : "input.codeInterpreterIdentifier",
       "type" : "zeebe:input"
     },
-    "type" : "String"
-  }, {
-    "id" : "input.sessionTimeout",
-    "label" : "Session timeout",
-    "description" : "Session timeout as ISO 8601 duration (e.g. PT5M for 5 minutes). Defaults to PT5M.",
-    "optional" : true,
-    "value" : "PT5M",
+    "description" : "The Code Interpreter identifier. Defaults to the AWS managed default.",
     "feel" : "optional",
     "group" : "session",
+    "id" : "input.codeInterpreterIdentifier",
+    "label" : "Code Interpreter ID",
+    "optional" : true,
+    "type" : "String",
+    "value" : "aws.codeinterpreter.v1"
+  }, {
     "binding" : {
       "name" : "input.sessionTimeout",
       "type" : "zeebe:input"
     },
-    "type" : "String"
-  }, {
-    "id" : "input.maxFiles",
-    "label" : "Max files to retrieve",
-    "description" : "Maximum number of generated files to retrieve. Defaults to 10.",
-    "optional" : true,
-    "value" : 10,
-    "feel" : "static",
+    "description" : "Session timeout as ISO 8601 duration (e.g. PT5M for 5 minutes). Defaults to PT5M.",
+    "feel" : "optional",
     "group" : "session",
+    "id" : "input.sessionTimeout",
+    "label" : "Session timeout",
+    "optional" : true,
+    "type" : "String",
+    "value" : "PT5M"
+  }, {
     "binding" : {
       "name" : "input.maxFiles",
       "type" : "zeebe:input"
     },
-    "type" : "Number"
-  }, {
-    "id" : "input.maxTotalFileSize",
-    "label" : "Max total file size",
-    "description" : "Maximum total size of retrieved files in bytes. Defaults to 10 MB.",
-    "optional" : true,
-    "value" : 10485760,
+    "description" : "Maximum number of generated files to retrieve. Defaults to 10.",
     "feel" : "static",
     "group" : "session",
+    "id" : "input.maxFiles",
+    "label" : "Max files to retrieve",
+    "optional" : true,
+    "type" : "Number",
+    "value" : 10
+  }, {
     "binding" : {
       "name" : "input.maxTotalFileSize",
       "type" : "zeebe:input"
     },
-    "type" : "Number"
+    "description" : "Maximum total size of retrieved files in bytes. Defaults to 10 MB.",
+    "feel" : "static",
+    "group" : "session",
+    "id" : "input.maxTotalFileSize",
+    "label" : "Max total file size",
+    "optional" : true,
+    "type" : "Number",
+    "value" : 10485760
   }, {
-    "id" : "version",
-    "label" : "Version",
-    "description" : "Version of the element template",
-    "value" : "2",
-    "group" : "connector",
     "binding" : {
       "key" : "elementTemplateVersion",
       "type" : "zeebe:taskHeader"
     },
-    "type" : "Hidden"
-  }, {
-    "id" : "id",
-    "label" : "ID",
-    "description" : "ID of the element template",
-    "value" : "io.camunda.connectors.aws.bedrock.codeinterpreter.v1",
+    "description" : "Version of the element template",
     "group" : "connector",
+    "id" : "version",
+    "label" : "Version",
+    "type" : "Hidden",
+    "value" : "2"
+  }, {
     "binding" : {
       "key" : "elementTemplateId",
       "type" : "zeebe:taskHeader"
     },
-    "type" : "Hidden"
+    "description" : "ID of the element template",
+    "group" : "connector",
+    "id" : "id",
+    "label" : "ID",
+    "type" : "Hidden",
+    "value" : "io.camunda.connectors.aws.bedrock.codeinterpreter.v1"
   }, {
-    "id" : "resultVariable",
-    "label" : "Result variable",
-    "description" : "Name of variable to store the response in. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-variable\" target=\"_blank\">documentation</a>.",
-    "group" : "output",
     "binding" : {
       "key" : "resultVariable",
       "type" : "zeebe:taskHeader"
     },
+    "description" : "Name of variable to store the response in. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-variable\" target=\"_blank\">documentation</a>.",
+    "group" : "output",
+    "id" : "resultVariable",
+    "label" : "Result variable",
     "type" : "String"
   }, {
-    "id" : "resultExpression",
-    "label" : "Result expression",
-    "description" : "Expression to map the response into process variables. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-expression\" target=\"_blank\">documentation</a>.",
-    "feel" : "required",
-    "group" : "output",
     "binding" : {
       "key" : "resultExpression",
       "type" : "zeebe:taskHeader"
     },
+    "description" : "Expression to map the response into process variables. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-expression\" target=\"_blank\">documentation</a>.",
+    "feel" : "required",
+    "group" : "output",
+    "id" : "resultExpression",
+    "label" : "Result expression",
     "type" : "Text"
   }, {
-    "id" : "errorExpression",
-    "label" : "Error expression",
-    "description" : "Expression to handle errors. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/\" target=\"_blank\">documentation</a>.",
-    "feel" : "required",
-    "group" : "error",
     "binding" : {
       "key" : "errorExpression",
       "type" : "zeebe:taskHeader"
     },
+    "description" : "Expression to handle errors. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/\" target=\"_blank\">documentation</a>.",
+    "feel" : "required",
+    "group" : "error",
+    "id" : "errorExpression",
+    "label" : "Error expression",
     "type" : "Text"
   }, {
-    "id" : "retryCount",
-    "label" : "Retries",
-    "description" : "Number of retries",
-    "value" : "3",
-    "feel" : "optional",
-    "group" : "retries",
     "binding" : {
       "property" : "retries",
       "type" : "zeebe:taskDefinition"
     },
-    "type" : "String"
-  }, {
-    "id" : "retryBackoff",
-    "label" : "Retry backoff",
-    "description" : "ISO-8601 duration to wait between retries",
-    "value" : "PT30S",
+    "description" : "Number of retries",
+    "feel" : "optional",
     "group" : "retries",
+    "id" : "retryCount",
+    "label" : "Retries",
+    "type" : "String",
+    "value" : "3"
+  }, {
     "binding" : {
       "key" : "retryBackoff",
       "type" : "zeebe:taskHeader"
     },
-    "type" : "String"
-  }, {
-    "id" : "jobTimeout",
-    "label" : "Job timeout",
-    "description" : "ISO-8601 duration after which Zeebe considers this job timed out if not yet completed. Leave empty to use the default timeout",
-    "optional" : true,
+    "description" : "ISO-8601 duration to wait between retries",
     "group" : "retries",
+    "id" : "retryBackoff",
+    "label" : "Retry backoff",
+    "type" : "String",
+    "value" : "PT30S"
+  }, {
     "binding" : {
       "key" : "jobTimeout",
       "type" : "zeebe:taskHeader"
     },
+    "description" : "ISO-8601 duration after which Zeebe considers this job timed out if not yet completed. Leave empty to use the default timeout",
+    "group" : "retries",
+    "id" : "jobTimeout",
+    "label" : "Job timeout",
+    "optional" : true,
     "type" : "String"
   } ],
   "configurationTemplates" : [ {
@@ -332,30 +332,24 @@
     "version" : 1,
     "name" : "AWS Credential",
     "properties" : [ {
-      "id" : "authentication.type",
-      "label" : "Authentication",
-      "description" : "Specify AWS authentication strategy. Learn more at the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/aws-lambda/#aws-authentication-types\" target=\"_blank\">documentation page</a>",
-      "value" : "credentials",
-      "group" : "authentication",
       "binding" : {
         "name" : "authentication.type",
         "type" : "property"
       },
-      "type" : "Dropdown",
       "choices" : [ {
         "name" : "Default Credentials Chain (Hybrid/Self-Managed only)",
         "value" : "defaultCredentialsChain"
       }, {
         "name" : "Credentials",
         "value" : "credentials"
-      } ]
-    }, {
-      "id" : "authentication.accessKey",
-      "label" : "Access key",
-      "constraints" : {
-        "notEmpty" : true
-      },
+      } ],
+      "description" : "Specify AWS authentication strategy. Learn more at the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/aws-lambda/#aws-authentication-types\" target=\"_blank\">documentation page</a>",
       "group" : "authentication",
+      "id" : "authentication.type",
+      "label" : "Authentication",
+      "type" : "Dropdown",
+      "value" : "credentials"
+    }, {
       "binding" : {
         "name" : "authentication.accessKey",
         "type" : "property"
@@ -365,16 +359,16 @@
         "equals" : "credentials",
         "type" : "simple"
       },
-      "tooltip" : "IAM access key of a user with the necessary permissions for this connector",
-      "type" : "String",
-      "secret" : true
-    }, {
-      "id" : "authentication.secretKey",
-      "label" : "Secret key",
       "constraints" : {
         "notEmpty" : true
       },
       "group" : "authentication",
+      "id" : "authentication.accessKey",
+      "label" : "Access key",
+      "secret" : true,
+      "tooltip" : "IAM access key of a user with the necessary permissions for this connector",
+      "type" : "String"
+    }, {
       "binding" : {
         "name" : "authentication.secretKey",
         "type" : "property"
@@ -384,20 +378,26 @@
         "equals" : "credentials",
         "type" : "simple"
       },
-      "tooltip" : "IAM secret key of a user with the necessary permissions for this connector",
-      "type" : "String",
-      "secret" : true
-    }, {
-      "id" : "region",
-      "label" : "Region",
       "constraints" : {
         "notEmpty" : true
       },
-      "group" : "configuration",
+      "group" : "authentication",
+      "id" : "authentication.secretKey",
+      "label" : "Secret key",
+      "secret" : true,
+      "tooltip" : "IAM secret key of a user with the necessary permissions for this connector",
+      "type" : "String"
+    }, {
       "binding" : {
         "name" : "region",
         "type" : "property"
       },
+      "constraints" : {
+        "notEmpty" : true
+      },
+      "group" : "configuration",
+      "id" : "region",
+      "label" : "Region",
       "type" : "String"
     } ]
   } ],

--- a/connectors/aws/aws-bedrock-knowledgebase/element-templates/aws-bedrock-knowledgebase-outbound-connector.json
+++ b/connectors/aws/aws-bedrock-knowledgebase/element-templates/aws-bedrock-knowledgebase-outbound-connector.json
@@ -41,39 +41,31 @@
     "label" : "Retries"
   } ],
   "properties" : [ {
-    "value" : "io.camunda:aws-bedrock-knowledgebase:1",
     "binding" : {
       "property" : "type",
       "type" : "zeebe:taskDefinition"
     },
-    "type" : "Hidden"
+    "type" : "Hidden",
+    "value" : "io.camunda:aws-bedrock-knowledgebase:1"
   }, {
-    "id" : "authentication.type",
-    "label" : "Authentication",
-    "description" : "Specify AWS authentication strategy. Learn more at the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/aws-lambda/#aws-authentication-types\" target=\"_blank\">documentation page</a>",
-    "value" : "credentials",
-    "group" : "authentication",
     "binding" : {
       "name" : "authentication.type",
       "type" : "zeebe:input"
     },
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "Default Credentials Chain (Hybrid/Self-Managed only)",
       "value" : "defaultCredentialsChain"
     }, {
       "name" : "Credentials",
       "value" : "credentials"
-    } ]
-  }, {
-    "id" : "authentication.accessKey",
-    "label" : "Access key",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "feel" : "optional",
+    } ],
+    "description" : "Specify AWS authentication strategy. Learn more at the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/aws-lambda/#aws-authentication-types\" target=\"_blank\">documentation page</a>",
     "group" : "authentication",
+    "id" : "authentication.type",
+    "label" : "Authentication",
+    "type" : "Dropdown",
+    "value" : "credentials"
+  }, {
     "binding" : {
       "name" : "authentication.accessKey",
       "type" : "zeebe:input"
@@ -83,18 +75,18 @@
       "equals" : "credentials",
       "type" : "simple"
     },
-    "tooltip" : "IAM access key of a user with the necessary permissions for this connector",
-    "type" : "String",
-    "secret" : true
-  }, {
-    "id" : "authentication.secretKey",
-    "label" : "Secret key",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "authentication",
+    "id" : "authentication.accessKey",
+    "label" : "Access key",
+    "optional" : false,
+    "secret" : true,
+    "tooltip" : "IAM access key of a user with the necessary permissions for this connector",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "authentication.secretKey",
       "type" : "zeebe:input"
@@ -104,85 +96,84 @@
       "equals" : "credentials",
       "type" : "simple"
     },
-    "tooltip" : "IAM secret key of a user with the necessary permissions for this connector",
-    "type" : "String",
-    "secret" : true
-  }, {
-    "id" : "awsCredential",
-    "label" : "AWS credential",
-    "description" : "Choose a reusable AWS credential. When set, it is bound as a whole to the connector's 'awsCredential' input.",
-    "optional" : true,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
     "group" : "authentication",
+    "id" : "authentication.secretKey",
+    "label" : "Secret key",
+    "optional" : false,
+    "secret" : true,
+    "tooltip" : "IAM secret key of a user with the necessary permissions for this connector",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "awsCredential",
       "type" : "zeebe:input"
     },
-    "type" : "Configuration",
-    "configurationTemplate" : "io.camunda:aws-credential:1"
+    "configurationTemplate" : "io.camunda:aws-credential:1",
+    "description" : "Choose a reusable AWS credential. When set, it is bound as a whole to the connector's 'awsCredential' input.",
+    "group" : "authentication",
+    "id" : "awsCredential",
+    "label" : "AWS credential",
+    "optional" : true,
+    "type" : "Configuration"
   }, {
-    "id" : "knowledgeBaseId",
-    "label" : "Knowledge Base ID",
-    "description" : "The ID of the Bedrock Knowledge Base to query.",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "feel" : "optional",
-    "group" : "configuration",
     "binding" : {
       "name" : "knowledgeBaseId",
       "type" : "zeebe:input"
     },
-    "type" : "String"
-  }, {
-    "id" : "configuration.region",
-    "label" : "Region",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
+    "description" : "The ID of the Bedrock Knowledge Base to query.",
     "feel" : "optional",
     "group" : "configuration",
+    "id" : "knowledgeBaseId",
+    "label" : "Knowledge Base ID",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "configuration.region",
       "type" : "zeebe:input"
     },
-    "type" : "String"
-  }, {
-    "id" : "configuration.endpoint",
-    "label" : "Endpoint",
-    "description" : "Specify endpoint if need to use custom endpoint",
-    "optional" : true,
-    "group" : "configuration",
-    "binding" : {
-      "name" : "configuration.endpoint",
-      "type" : "zeebe:input"
-    },
-    "type" : "Hidden"
-  }, {
-    "id" : "operation.operationDiscriminator",
-    "label" : "Operation",
-    "value" : "retrieve",
-    "group" : "operation",
-    "binding" : {
-      "name" : "operation.operationDiscriminator",
-      "type" : "zeebe:input"
-    },
-    "type" : "Dropdown",
-    "choices" : [ {
-      "name" : "Retrieve from Knowledge Base",
-      "value" : "retrieve"
-    } ]
-  }, {
-    "id" : "operation.query",
-    "label" : "Query",
-    "description" : "Natural language query to search the knowledge base.",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
-    "group" : "retrieve",
+    "group" : "configuration",
+    "id" : "configuration.region",
+    "label" : "Region",
+    "optional" : false,
+    "type" : "String"
+  }, {
+    "binding" : {
+      "name" : "configuration.endpoint",
+      "type" : "zeebe:input"
+    },
+    "description" : "Specify endpoint if need to use custom endpoint",
+    "group" : "configuration",
+    "id" : "configuration.endpoint",
+    "label" : "Endpoint",
+    "optional" : true,
+    "type" : "Hidden"
+  }, {
+    "binding" : {
+      "name" : "operation.operationDiscriminator",
+      "type" : "zeebe:input"
+    },
+    "choices" : [ {
+      "name" : "Retrieve from Knowledge Base",
+      "value" : "retrieve"
+    } ],
+    "group" : "operation",
+    "id" : "operation.operationDiscriminator",
+    "label" : "Operation",
+    "type" : "Dropdown",
+    "value" : "retrieve"
+  }, {
     "binding" : {
       "name" : "operation.query",
       "type" : "zeebe:input"
@@ -192,15 +183,17 @@
       "equals" : "retrieve",
       "type" : "simple"
     },
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "description" : "Natural language query to search the knowledge base.",
+    "feel" : "optional",
+    "group" : "retrieve",
+    "id" : "operation.query",
+    "label" : "Query",
+    "optional" : false,
     "type" : "String"
   }, {
-    "id" : "operation.numberOfResults",
-    "label" : "Number of results",
-    "description" : "Maximum number of results to return (1–100). Defaults to 5.",
-    "optional" : true,
-    "value" : 5,
-    "feel" : "static",
-    "group" : "retrieve",
     "binding" : {
       "name" : "operation.numberOfResults",
       "type" : "zeebe:input"
@@ -210,94 +203,101 @@
       "equals" : "retrieve",
       "type" : "simple"
     },
-    "type" : "Number"
+    "description" : "Maximum number of results to return (1–100). Defaults to 5.",
+    "feel" : "static",
+    "group" : "retrieve",
+    "id" : "operation.numberOfResults",
+    "label" : "Number of results",
+    "optional" : true,
+    "type" : "Number",
+    "value" : 5
   }, {
-    "id" : "version",
-    "label" : "Version",
-    "description" : "Version of the element template",
-    "value" : "2",
-    "group" : "connector",
     "binding" : {
       "key" : "elementTemplateVersion",
       "type" : "zeebe:taskHeader"
     },
-    "type" : "Hidden"
-  }, {
-    "id" : "id",
-    "label" : "ID",
-    "description" : "ID of the element template",
-    "value" : "io.camunda.connectors.aws.bedrock.knowledgebase.v1",
+    "description" : "Version of the element template",
     "group" : "connector",
+    "id" : "version",
+    "label" : "Version",
+    "type" : "Hidden",
+    "value" : "2"
+  }, {
     "binding" : {
       "key" : "elementTemplateId",
       "type" : "zeebe:taskHeader"
     },
-    "type" : "Hidden"
+    "description" : "ID of the element template",
+    "group" : "connector",
+    "id" : "id",
+    "label" : "ID",
+    "type" : "Hidden",
+    "value" : "io.camunda.connectors.aws.bedrock.knowledgebase.v1"
   }, {
-    "id" : "resultVariable",
-    "label" : "Result variable",
-    "description" : "Name of variable to store the response in. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-variable\" target=\"_blank\">documentation</a>.",
-    "group" : "output",
     "binding" : {
       "key" : "resultVariable",
       "type" : "zeebe:taskHeader"
     },
+    "description" : "Name of variable to store the response in. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-variable\" target=\"_blank\">documentation</a>.",
+    "group" : "output",
+    "id" : "resultVariable",
+    "label" : "Result variable",
     "type" : "String"
   }, {
-    "id" : "resultExpression",
-    "label" : "Result expression",
-    "description" : "Expression to map the response into process variables. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-expression\" target=\"_blank\">documentation</a>.",
-    "feel" : "required",
-    "group" : "output",
     "binding" : {
       "key" : "resultExpression",
       "type" : "zeebe:taskHeader"
     },
+    "description" : "Expression to map the response into process variables. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-expression\" target=\"_blank\">documentation</a>.",
+    "feel" : "required",
+    "group" : "output",
+    "id" : "resultExpression",
+    "label" : "Result expression",
     "type" : "Text"
   }, {
-    "id" : "errorExpression",
-    "label" : "Error expression",
-    "description" : "Expression to handle errors. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/\" target=\"_blank\">documentation</a>.",
-    "feel" : "required",
-    "group" : "error",
     "binding" : {
       "key" : "errorExpression",
       "type" : "zeebe:taskHeader"
     },
+    "description" : "Expression to handle errors. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/\" target=\"_blank\">documentation</a>.",
+    "feel" : "required",
+    "group" : "error",
+    "id" : "errorExpression",
+    "label" : "Error expression",
     "type" : "Text"
   }, {
-    "id" : "retryCount",
-    "label" : "Retries",
-    "description" : "Number of retries",
-    "value" : "3",
-    "feel" : "optional",
-    "group" : "retries",
     "binding" : {
       "property" : "retries",
       "type" : "zeebe:taskDefinition"
     },
-    "type" : "String"
-  }, {
-    "id" : "retryBackoff",
-    "label" : "Retry backoff",
-    "description" : "ISO-8601 duration to wait between retries",
-    "value" : "PT30S",
+    "description" : "Number of retries",
+    "feel" : "optional",
     "group" : "retries",
+    "id" : "retryCount",
+    "label" : "Retries",
+    "type" : "String",
+    "value" : "3"
+  }, {
     "binding" : {
       "key" : "retryBackoff",
       "type" : "zeebe:taskHeader"
     },
-    "type" : "String"
-  }, {
-    "id" : "jobTimeout",
-    "label" : "Job timeout",
-    "description" : "ISO-8601 duration after which Zeebe considers this job timed out if not yet completed. Leave empty to use the default timeout",
-    "optional" : true,
+    "description" : "ISO-8601 duration to wait between retries",
     "group" : "retries",
+    "id" : "retryBackoff",
+    "label" : "Retry backoff",
+    "type" : "String",
+    "value" : "PT30S"
+  }, {
     "binding" : {
       "key" : "jobTimeout",
       "type" : "zeebe:taskHeader"
     },
+    "description" : "ISO-8601 duration after which Zeebe considers this job timed out if not yet completed. Leave empty to use the default timeout",
+    "group" : "retries",
+    "id" : "jobTimeout",
+    "label" : "Job timeout",
+    "optional" : true,
     "type" : "String"
   } ],
   "configurationTemplates" : [ {
@@ -306,30 +306,24 @@
     "version" : 1,
     "name" : "AWS Credential",
     "properties" : [ {
-      "id" : "authentication.type",
-      "label" : "Authentication",
-      "description" : "Specify AWS authentication strategy. Learn more at the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/aws-lambda/#aws-authentication-types\" target=\"_blank\">documentation page</a>",
-      "value" : "credentials",
-      "group" : "authentication",
       "binding" : {
         "name" : "authentication.type",
         "type" : "property"
       },
-      "type" : "Dropdown",
       "choices" : [ {
         "name" : "Default Credentials Chain (Hybrid/Self-Managed only)",
         "value" : "defaultCredentialsChain"
       }, {
         "name" : "Credentials",
         "value" : "credentials"
-      } ]
-    }, {
-      "id" : "authentication.accessKey",
-      "label" : "Access key",
-      "constraints" : {
-        "notEmpty" : true
-      },
+      } ],
+      "description" : "Specify AWS authentication strategy. Learn more at the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/aws-lambda/#aws-authentication-types\" target=\"_blank\">documentation page</a>",
       "group" : "authentication",
+      "id" : "authentication.type",
+      "label" : "Authentication",
+      "type" : "Dropdown",
+      "value" : "credentials"
+    }, {
       "binding" : {
         "name" : "authentication.accessKey",
         "type" : "property"
@@ -339,16 +333,16 @@
         "equals" : "credentials",
         "type" : "simple"
       },
-      "tooltip" : "IAM access key of a user with the necessary permissions for this connector",
-      "type" : "String",
-      "secret" : true
-    }, {
-      "id" : "authentication.secretKey",
-      "label" : "Secret key",
       "constraints" : {
         "notEmpty" : true
       },
       "group" : "authentication",
+      "id" : "authentication.accessKey",
+      "label" : "Access key",
+      "secret" : true,
+      "tooltip" : "IAM access key of a user with the necessary permissions for this connector",
+      "type" : "String"
+    }, {
       "binding" : {
         "name" : "authentication.secretKey",
         "type" : "property"
@@ -358,20 +352,26 @@
         "equals" : "credentials",
         "type" : "simple"
       },
-      "tooltip" : "IAM secret key of a user with the necessary permissions for this connector",
-      "type" : "String",
-      "secret" : true
-    }, {
-      "id" : "region",
-      "label" : "Region",
       "constraints" : {
         "notEmpty" : true
       },
-      "group" : "configuration",
+      "group" : "authentication",
+      "id" : "authentication.secretKey",
+      "label" : "Secret key",
+      "secret" : true,
+      "tooltip" : "IAM secret key of a user with the necessary permissions for this connector",
+      "type" : "String"
+    }, {
       "binding" : {
         "name" : "region",
         "type" : "property"
       },
+      "constraints" : {
+        "notEmpty" : true
+      },
+      "group" : "configuration",
+      "id" : "region",
+      "label" : "Region",
       "type" : "String"
     } ]
   } ],

--- a/connectors/aws/aws-bedrock-knowledgebase/element-templates/hybrid/aws-bedrock-knowledgebase-outbound-connector-hybrid.json
+++ b/connectors/aws/aws-bedrock-knowledgebase/element-templates/hybrid/aws-bedrock-knowledgebase-outbound-connector-hybrid.json
@@ -44,41 +44,33 @@
     "label" : "Retries"
   } ],
   "properties" : [ {
-    "id" : "taskDefinitionType",
-    "value" : "io.camunda:aws-bedrock-knowledgebase:1",
-    "group" : "taskDefinitionType",
     "binding" : {
       "property" : "type",
       "type" : "zeebe:taskDefinition"
     },
-    "type" : "String"
+    "group" : "taskDefinitionType",
+    "id" : "taskDefinitionType",
+    "type" : "String",
+    "value" : "io.camunda:aws-bedrock-knowledgebase:1"
   }, {
-    "id" : "authentication.type",
-    "label" : "Authentication",
-    "description" : "Specify AWS authentication strategy. Learn more at the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/aws-lambda/#aws-authentication-types\" target=\"_blank\">documentation page</a>",
-    "value" : "credentials",
-    "group" : "authentication",
     "binding" : {
       "name" : "authentication.type",
       "type" : "zeebe:input"
     },
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "Default Credentials Chain (Hybrid/Self-Managed only)",
       "value" : "defaultCredentialsChain"
     }, {
       "name" : "Credentials",
       "value" : "credentials"
-    } ]
-  }, {
-    "id" : "authentication.accessKey",
-    "label" : "Access key",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "feel" : "optional",
+    } ],
+    "description" : "Specify AWS authentication strategy. Learn more at the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/aws-lambda/#aws-authentication-types\" target=\"_blank\">documentation page</a>",
     "group" : "authentication",
+    "id" : "authentication.type",
+    "label" : "Authentication",
+    "type" : "Dropdown",
+    "value" : "credentials"
+  }, {
     "binding" : {
       "name" : "authentication.accessKey",
       "type" : "zeebe:input"
@@ -88,18 +80,18 @@
       "equals" : "credentials",
       "type" : "simple"
     },
-    "tooltip" : "IAM access key of a user with the necessary permissions for this connector",
-    "type" : "String",
-    "secret" : true
-  }, {
-    "id" : "authentication.secretKey",
-    "label" : "Secret key",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "authentication",
+    "id" : "authentication.accessKey",
+    "label" : "Access key",
+    "optional" : false,
+    "secret" : true,
+    "tooltip" : "IAM access key of a user with the necessary permissions for this connector",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "authentication.secretKey",
       "type" : "zeebe:input"
@@ -109,85 +101,84 @@
       "equals" : "credentials",
       "type" : "simple"
     },
-    "tooltip" : "IAM secret key of a user with the necessary permissions for this connector",
-    "type" : "String",
-    "secret" : true
-  }, {
-    "id" : "awsCredential",
-    "label" : "AWS credential",
-    "description" : "Choose a reusable AWS credential. When set, it is bound as a whole to the connector's 'awsCredential' input.",
-    "optional" : true,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
     "group" : "authentication",
+    "id" : "authentication.secretKey",
+    "label" : "Secret key",
+    "optional" : false,
+    "secret" : true,
+    "tooltip" : "IAM secret key of a user with the necessary permissions for this connector",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "awsCredential",
       "type" : "zeebe:input"
     },
-    "type" : "Configuration",
-    "configurationTemplate" : "io.camunda:aws-credential:1"
+    "configurationTemplate" : "io.camunda:aws-credential:1",
+    "description" : "Choose a reusable AWS credential. When set, it is bound as a whole to the connector's 'awsCredential' input.",
+    "group" : "authentication",
+    "id" : "awsCredential",
+    "label" : "AWS credential",
+    "optional" : true,
+    "type" : "Configuration"
   }, {
-    "id" : "knowledgeBaseId",
-    "label" : "Knowledge Base ID",
-    "description" : "The ID of the Bedrock Knowledge Base to query.",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "feel" : "optional",
-    "group" : "configuration",
     "binding" : {
       "name" : "knowledgeBaseId",
       "type" : "zeebe:input"
     },
-    "type" : "String"
-  }, {
-    "id" : "configuration.region",
-    "label" : "Region",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
+    "description" : "The ID of the Bedrock Knowledge Base to query.",
     "feel" : "optional",
     "group" : "configuration",
+    "id" : "knowledgeBaseId",
+    "label" : "Knowledge Base ID",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "configuration.region",
       "type" : "zeebe:input"
     },
-    "type" : "String"
-  }, {
-    "id" : "configuration.endpoint",
-    "label" : "Endpoint",
-    "description" : "Specify endpoint if need to use custom endpoint",
-    "optional" : true,
-    "group" : "configuration",
-    "binding" : {
-      "name" : "configuration.endpoint",
-      "type" : "zeebe:input"
-    },
-    "type" : "Hidden"
-  }, {
-    "id" : "operation.operationDiscriminator",
-    "label" : "Operation",
-    "value" : "retrieve",
-    "group" : "operation",
-    "binding" : {
-      "name" : "operation.operationDiscriminator",
-      "type" : "zeebe:input"
-    },
-    "type" : "Dropdown",
-    "choices" : [ {
-      "name" : "Retrieve from Knowledge Base",
-      "value" : "retrieve"
-    } ]
-  }, {
-    "id" : "operation.query",
-    "label" : "Query",
-    "description" : "Natural language query to search the knowledge base.",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
-    "group" : "retrieve",
+    "group" : "configuration",
+    "id" : "configuration.region",
+    "label" : "Region",
+    "optional" : false,
+    "type" : "String"
+  }, {
+    "binding" : {
+      "name" : "configuration.endpoint",
+      "type" : "zeebe:input"
+    },
+    "description" : "Specify endpoint if need to use custom endpoint",
+    "group" : "configuration",
+    "id" : "configuration.endpoint",
+    "label" : "Endpoint",
+    "optional" : true,
+    "type" : "Hidden"
+  }, {
+    "binding" : {
+      "name" : "operation.operationDiscriminator",
+      "type" : "zeebe:input"
+    },
+    "choices" : [ {
+      "name" : "Retrieve from Knowledge Base",
+      "value" : "retrieve"
+    } ],
+    "group" : "operation",
+    "id" : "operation.operationDiscriminator",
+    "label" : "Operation",
+    "type" : "Dropdown",
+    "value" : "retrieve"
+  }, {
     "binding" : {
       "name" : "operation.query",
       "type" : "zeebe:input"
@@ -197,15 +188,17 @@
       "equals" : "retrieve",
       "type" : "simple"
     },
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "description" : "Natural language query to search the knowledge base.",
+    "feel" : "optional",
+    "group" : "retrieve",
+    "id" : "operation.query",
+    "label" : "Query",
+    "optional" : false,
     "type" : "String"
   }, {
-    "id" : "operation.numberOfResults",
-    "label" : "Number of results",
-    "description" : "Maximum number of results to return (1–100). Defaults to 5.",
-    "optional" : true,
-    "value" : 5,
-    "feel" : "static",
-    "group" : "retrieve",
     "binding" : {
       "name" : "operation.numberOfResults",
       "type" : "zeebe:input"
@@ -215,94 +208,101 @@
       "equals" : "retrieve",
       "type" : "simple"
     },
-    "type" : "Number"
+    "description" : "Maximum number of results to return (1–100). Defaults to 5.",
+    "feel" : "static",
+    "group" : "retrieve",
+    "id" : "operation.numberOfResults",
+    "label" : "Number of results",
+    "optional" : true,
+    "type" : "Number",
+    "value" : 5
   }, {
-    "id" : "version",
-    "label" : "Version",
-    "description" : "Version of the element template",
-    "value" : "2",
-    "group" : "connector",
     "binding" : {
       "key" : "elementTemplateVersion",
       "type" : "zeebe:taskHeader"
     },
-    "type" : "Hidden"
-  }, {
-    "id" : "id",
-    "label" : "ID",
-    "description" : "ID of the element template",
-    "value" : "io.camunda.connectors.aws.bedrock.knowledgebase.v1",
+    "description" : "Version of the element template",
     "group" : "connector",
+    "id" : "version",
+    "label" : "Version",
+    "type" : "Hidden",
+    "value" : "2"
+  }, {
     "binding" : {
       "key" : "elementTemplateId",
       "type" : "zeebe:taskHeader"
     },
-    "type" : "Hidden"
+    "description" : "ID of the element template",
+    "group" : "connector",
+    "id" : "id",
+    "label" : "ID",
+    "type" : "Hidden",
+    "value" : "io.camunda.connectors.aws.bedrock.knowledgebase.v1"
   }, {
-    "id" : "resultVariable",
-    "label" : "Result variable",
-    "description" : "Name of variable to store the response in. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-variable\" target=\"_blank\">documentation</a>.",
-    "group" : "output",
     "binding" : {
       "key" : "resultVariable",
       "type" : "zeebe:taskHeader"
     },
+    "description" : "Name of variable to store the response in. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-variable\" target=\"_blank\">documentation</a>.",
+    "group" : "output",
+    "id" : "resultVariable",
+    "label" : "Result variable",
     "type" : "String"
   }, {
-    "id" : "resultExpression",
-    "label" : "Result expression",
-    "description" : "Expression to map the response into process variables. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-expression\" target=\"_blank\">documentation</a>.",
-    "feel" : "required",
-    "group" : "output",
     "binding" : {
       "key" : "resultExpression",
       "type" : "zeebe:taskHeader"
     },
+    "description" : "Expression to map the response into process variables. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-expression\" target=\"_blank\">documentation</a>.",
+    "feel" : "required",
+    "group" : "output",
+    "id" : "resultExpression",
+    "label" : "Result expression",
     "type" : "Text"
   }, {
-    "id" : "errorExpression",
-    "label" : "Error expression",
-    "description" : "Expression to handle errors. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/\" target=\"_blank\">documentation</a>.",
-    "feel" : "required",
-    "group" : "error",
     "binding" : {
       "key" : "errorExpression",
       "type" : "zeebe:taskHeader"
     },
+    "description" : "Expression to handle errors. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/\" target=\"_blank\">documentation</a>.",
+    "feel" : "required",
+    "group" : "error",
+    "id" : "errorExpression",
+    "label" : "Error expression",
     "type" : "Text"
   }, {
-    "id" : "retryCount",
-    "label" : "Retries",
-    "description" : "Number of retries",
-    "value" : "3",
-    "feel" : "optional",
-    "group" : "retries",
     "binding" : {
       "property" : "retries",
       "type" : "zeebe:taskDefinition"
     },
-    "type" : "String"
-  }, {
-    "id" : "retryBackoff",
-    "label" : "Retry backoff",
-    "description" : "ISO-8601 duration to wait between retries",
-    "value" : "PT30S",
+    "description" : "Number of retries",
+    "feel" : "optional",
     "group" : "retries",
+    "id" : "retryCount",
+    "label" : "Retries",
+    "type" : "String",
+    "value" : "3"
+  }, {
     "binding" : {
       "key" : "retryBackoff",
       "type" : "zeebe:taskHeader"
     },
-    "type" : "String"
-  }, {
-    "id" : "jobTimeout",
-    "label" : "Job timeout",
-    "description" : "ISO-8601 duration after which Zeebe considers this job timed out if not yet completed. Leave empty to use the default timeout",
-    "optional" : true,
+    "description" : "ISO-8601 duration to wait between retries",
     "group" : "retries",
+    "id" : "retryBackoff",
+    "label" : "Retry backoff",
+    "type" : "String",
+    "value" : "PT30S"
+  }, {
     "binding" : {
       "key" : "jobTimeout",
       "type" : "zeebe:taskHeader"
     },
+    "description" : "ISO-8601 duration after which Zeebe considers this job timed out if not yet completed. Leave empty to use the default timeout",
+    "group" : "retries",
+    "id" : "jobTimeout",
+    "label" : "Job timeout",
+    "optional" : true,
     "type" : "String"
   } ],
   "configurationTemplates" : [ {
@@ -311,30 +311,24 @@
     "version" : 1,
     "name" : "AWS Credential",
     "properties" : [ {
-      "id" : "authentication.type",
-      "label" : "Authentication",
-      "description" : "Specify AWS authentication strategy. Learn more at the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/aws-lambda/#aws-authentication-types\" target=\"_blank\">documentation page</a>",
-      "value" : "credentials",
-      "group" : "authentication",
       "binding" : {
         "name" : "authentication.type",
         "type" : "property"
       },
-      "type" : "Dropdown",
       "choices" : [ {
         "name" : "Default Credentials Chain (Hybrid/Self-Managed only)",
         "value" : "defaultCredentialsChain"
       }, {
         "name" : "Credentials",
         "value" : "credentials"
-      } ]
-    }, {
-      "id" : "authentication.accessKey",
-      "label" : "Access key",
-      "constraints" : {
-        "notEmpty" : true
-      },
+      } ],
+      "description" : "Specify AWS authentication strategy. Learn more at the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/aws-lambda/#aws-authentication-types\" target=\"_blank\">documentation page</a>",
       "group" : "authentication",
+      "id" : "authentication.type",
+      "label" : "Authentication",
+      "type" : "Dropdown",
+      "value" : "credentials"
+    }, {
       "binding" : {
         "name" : "authentication.accessKey",
         "type" : "property"
@@ -344,16 +338,16 @@
         "equals" : "credentials",
         "type" : "simple"
       },
-      "tooltip" : "IAM access key of a user with the necessary permissions for this connector",
-      "type" : "String",
-      "secret" : true
-    }, {
-      "id" : "authentication.secretKey",
-      "label" : "Secret key",
       "constraints" : {
         "notEmpty" : true
       },
       "group" : "authentication",
+      "id" : "authentication.accessKey",
+      "label" : "Access key",
+      "secret" : true,
+      "tooltip" : "IAM access key of a user with the necessary permissions for this connector",
+      "type" : "String"
+    }, {
       "binding" : {
         "name" : "authentication.secretKey",
         "type" : "property"
@@ -363,20 +357,26 @@
         "equals" : "credentials",
         "type" : "simple"
       },
-      "tooltip" : "IAM secret key of a user with the necessary permissions for this connector",
-      "type" : "String",
-      "secret" : true
-    }, {
-      "id" : "region",
-      "label" : "Region",
       "constraints" : {
         "notEmpty" : true
       },
-      "group" : "configuration",
+      "group" : "authentication",
+      "id" : "authentication.secretKey",
+      "label" : "Secret key",
+      "secret" : true,
+      "tooltip" : "IAM secret key of a user with the necessary permissions for this connector",
+      "type" : "String"
+    }, {
       "binding" : {
         "name" : "region",
         "type" : "property"
       },
+      "constraints" : {
+        "notEmpty" : true
+      },
+      "group" : "configuration",
+      "id" : "region",
+      "label" : "Region",
       "type" : "String"
     } ]
   } ],

--- a/connectors/aws/aws-comprehend/element-templates/aws-comprehend-outbound-connector.json
+++ b/connectors/aws/aws-comprehend/element-templates/aws-comprehend-outbound-connector.json
@@ -43,55 +43,47 @@
     "label" : "Retries"
   } ],
   "properties" : [ {
-    "value" : "io.camunda:aws-comprehend:1",
     "binding" : {
       "property" : "type",
       "type" : "zeebe:taskDefinition"
     },
-    "type" : "Hidden"
+    "type" : "Hidden",
+    "value" : "io.camunda:aws-comprehend:1"
   }, {
-    "id" : "input.type",
-    "label" : "Execution type",
-    "group" : "operation",
     "binding" : {
       "name" : "input.type",
       "type" : "zeebe:input"
     },
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "Sync",
       "value" : "sync"
     }, {
       "name" : "Async",
       "value" : "async"
-    } ]
+    } ],
+    "group" : "operation",
+    "id" : "input.type",
+    "label" : "Execution type",
+    "type" : "Dropdown"
   }, {
-    "id" : "authentication.type",
-    "label" : "Authentication",
-    "description" : "Specify AWS authentication strategy. Learn more at the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/aws-lambda/#aws-authentication-types\" target=\"_blank\">documentation page</a>",
-    "value" : "credentials",
-    "group" : "authentication",
     "binding" : {
       "name" : "authentication.type",
       "type" : "zeebe:input"
     },
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "Default Credentials Chain (Hybrid/Self-Managed only)",
       "value" : "defaultCredentialsChain"
     }, {
       "name" : "Credentials",
       "value" : "credentials"
-    } ]
-  }, {
-    "id" : "authentication.accessKey",
-    "label" : "Access key",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "feel" : "optional",
+    } ],
+    "description" : "Specify AWS authentication strategy. Learn more at the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/aws-lambda/#aws-authentication-types\" target=\"_blank\">documentation page</a>",
     "group" : "authentication",
+    "id" : "authentication.type",
+    "label" : "Authentication",
+    "type" : "Dropdown",
+    "value" : "credentials"
+  }, {
     "binding" : {
       "name" : "authentication.accessKey",
       "type" : "zeebe:input"
@@ -101,18 +93,18 @@
       "equals" : "credentials",
       "type" : "simple"
     },
-    "tooltip" : "IAM access key of a user with the necessary permissions for this connector",
-    "type" : "String",
-    "secret" : true
-  }, {
-    "id" : "authentication.secretKey",
-    "label" : "Secret key",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "authentication",
+    "id" : "authentication.accessKey",
+    "label" : "Access key",
+    "optional" : false,
+    "secret" : true,
+    "tooltip" : "IAM access key of a user with the necessary permissions for this connector",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "authentication.secretKey",
       "type" : "zeebe:input"
@@ -122,55 +114,55 @@
       "equals" : "credentials",
       "type" : "simple"
     },
-    "tooltip" : "IAM secret key of a user with the necessary permissions for this connector",
-    "type" : "String",
-    "secret" : true
-  }, {
-    "id" : "awsCredential",
-    "label" : "AWS credential",
-    "description" : "Choose a reusable AWS credential. When set, it is bound as a whole to the connector's 'awsCredential' input.",
-    "optional" : true,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
     "group" : "authentication",
+    "id" : "authentication.secretKey",
+    "label" : "Secret key",
+    "optional" : false,
+    "secret" : true,
+    "tooltip" : "IAM secret key of a user with the necessary permissions for this connector",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "awsCredential",
       "type" : "zeebe:input"
     },
-    "type" : "Configuration",
-    "configurationTemplate" : "io.camunda:aws-credential:1"
+    "configurationTemplate" : "io.camunda:aws-credential:1",
+    "description" : "Choose a reusable AWS credential. When set, it is bound as a whole to the connector's 'awsCredential' input.",
+    "group" : "authentication",
+    "id" : "awsCredential",
+    "label" : "AWS credential",
+    "optional" : true,
+    "type" : "Configuration"
   }, {
-    "id" : "configuration.region",
-    "label" : "Region",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "feel" : "optional",
-    "group" : "configuration",
     "binding" : {
       "name" : "configuration.region",
       "type" : "zeebe:input"
     },
-    "type" : "String"
-  }, {
-    "id" : "configuration.endpoint",
-    "label" : "Endpoint",
-    "description" : "Specify endpoint if need to use custom endpoint",
-    "optional" : true,
-    "group" : "configuration",
-    "binding" : {
-      "name" : "configuration.endpoint",
-      "type" : "zeebe:input"
-    },
-    "type" : "Hidden"
-  }, {
-    "id" : "input.text",
-    "label" : "Text",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
-    "group" : "input",
+    "group" : "configuration",
+    "id" : "configuration.region",
+    "label" : "Region",
+    "optional" : false,
+    "type" : "String"
+  }, {
+    "binding" : {
+      "name" : "configuration.endpoint",
+      "type" : "zeebe:input"
+    },
+    "description" : "Specify endpoint if need to use custom endpoint",
+    "group" : "configuration",
+    "id" : "configuration.endpoint",
+    "label" : "Endpoint",
+    "optional" : true,
+    "type" : "Hidden"
+  }, {
     "binding" : {
       "name" : "input.text",
       "type" : "zeebe:input"
@@ -180,17 +172,17 @@
       "equals" : "sync",
       "type" : "simple"
     },
-    "tooltip" : "<a href=\"https://docs.aws.amazon.com/comprehend/latest/APIReference/API_ClassifyDocument.html#comprehend-ClassifyDocument-request-Text\">Text</a> to be analyzed.",
-    "type" : "String"
-  }, {
-    "id" : "input.endpointArn",
-    "label" : "Endpoint's ARN",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "input",
+    "id" : "input.text",
+    "label" : "Text",
+    "optional" : false,
+    "tooltip" : "<a href=\"https://docs.aws.amazon.com/comprehend/latest/APIReference/API_ClassifyDocument.html#comprehend-ClassifyDocument-request-Text\">Text</a> to be analyzed.",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "input.endpointArn",
       "type" : "zeebe:input"
@@ -200,28 +192,21 @@
       "equals" : "sync",
       "type" : "simple"
     },
-    "tooltip" : "ARN of the custom model <a href=\"https://docs.aws.amazon.com/comprehend/latest/APIReference/API_ClassifyDocument.html#comprehend-ClassifyDocument-request-EndpointArn\">endpoint</a> used to run the classification.",
-    "type" : "String"
-  }, {
-    "id" : "input.async.documentReadMode",
-    "label" : "Document read mode",
-    "optional" : false,
-    "value" : "SERVICE_DEFAULT",
     "constraints" : {
       "notEmpty" : true
     },
+    "feel" : "optional",
     "group" : "input",
+    "id" : "input.endpointArn",
+    "label" : "Endpoint's ARN",
+    "optional" : false,
+    "tooltip" : "ARN of the custom model <a href=\"https://docs.aws.amazon.com/comprehend/latest/APIReference/API_ClassifyDocument.html#comprehend-ClassifyDocument-request-EndpointArn\">endpoint</a> used to run the classification.",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "input.documentReadMode",
       "type" : "zeebe:input"
     },
-    "condition" : {
-      "property" : "input.type",
-      "equals" : "async",
-      "type" : "simple"
-    },
-    "tooltip" : "Determines <a href=\"https://docs.aws.amazon.com/comprehend/latest/dg/idp-set-textract-options.html\">text extraction actions</a> for PDF files.",
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "Service default",
       "value" : "SERVICE_DEFAULT"
@@ -231,27 +216,27 @@
     }, {
       "name" : "None",
       "value" : "NO_DATA"
-    } ]
-  }, {
-    "id" : "input.async.documentReadAction",
-    "label" : "Document read action",
-    "optional" : false,
-    "value" : "TEXTRACT_DETECT_DOCUMENT_TEXT",
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "group" : "input",
-    "binding" : {
-      "name" : "input.documentReadAction",
-      "type" : "zeebe:input"
-    },
+    } ],
     "condition" : {
       "property" : "input.type",
       "equals" : "async",
       "type" : "simple"
     },
-    "tooltip" : "The Amazon Textract API operation that Amazon Comprehend uses to extract text from PDF files and image files.",
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "group" : "input",
+    "id" : "input.async.documentReadMode",
+    "label" : "Document read mode",
+    "optional" : false,
+    "tooltip" : "Determines <a href=\"https://docs.aws.amazon.com/comprehend/latest/dg/idp-set-textract-options.html\">text extraction actions</a> for PDF files.",
     "type" : "Dropdown",
+    "value" : "SERVICE_DEFAULT"
+  }, {
+    "binding" : {
+      "name" : "input.documentReadAction",
+      "type" : "zeebe:input"
+    },
     "choices" : [ {
       "name" : "Detect document text",
       "value" : "TEXTRACT_DETECT_DOCUMENT_TEXT"
@@ -261,14 +246,23 @@
     }, {
       "name" : "None",
       "value" : "NO_DATA"
-    } ]
-  }, {
-    "id" : "input.async.featureTypeTables",
-    "label" : "Analyze tables",
-    "optional" : false,
-    "value" : false,
-    "feel" : "static",
+    } ],
+    "condition" : {
+      "property" : "input.type",
+      "equals" : "async",
+      "type" : "simple"
+    },
+    "constraints" : {
+      "notEmpty" : true
+    },
     "group" : "input",
+    "id" : "input.async.documentReadAction",
+    "label" : "Document read action",
+    "optional" : false,
+    "tooltip" : "The Amazon Textract API operation that Amazon Comprehend uses to extract text from PDF files and image files.",
+    "type" : "Dropdown",
+    "value" : "TEXTRACT_DETECT_DOCUMENT_TEXT"
+  }, {
     "binding" : {
       "name" : "input.featureTypeTables",
       "type" : "zeebe:input"
@@ -284,14 +278,14 @@
         "type" : "simple"
       } ]
     },
-    "type" : "Boolean"
-  }, {
-    "id" : "input.async.featureTypeForms",
-    "label" : "Analyze forms",
-    "optional" : false,
-    "value" : false,
     "feel" : "static",
     "group" : "input",
+    "id" : "input.async.featureTypeTables",
+    "label" : "Analyze tables",
+    "optional" : false,
+    "type" : "Boolean",
+    "value" : false
+  }, {
     "binding" : {
       "name" : "input.featureTypeForms",
       "type" : "zeebe:input"
@@ -307,16 +301,14 @@
         "type" : "simple"
       } ]
     },
-    "type" : "Boolean"
-  }, {
-    "id" : "input.inputS3Uri",
-    "label" : "Inputs' S3 URI",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "feel" : "optional",
+    "feel" : "static",
     "group" : "input",
+    "id" : "input.async.featureTypeForms",
+    "label" : "Analyze forms",
+    "optional" : false,
+    "type" : "Boolean",
+    "value" : false
+  }, {
     "binding" : {
       "name" : "input.inputS3Uri",
       "type" : "zeebe:input"
@@ -326,25 +318,21 @@
       "equals" : "async",
       "type" : "simple"
     },
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "input",
+    "id" : "input.inputS3Uri",
+    "label" : "Inputs' S3 URI",
+    "optional" : false,
     "tooltip" : "The <a href=\"https://docs.aws.amazon.com/comprehend/latest/APIReference/API_InputDataConfig.html#comprehend-Type-InputDataConfig-S3Uri\">S3Uri</a> for input data.",
     "type" : "String"
   }, {
-    "id" : "input.comprehendInputFormat",
-    "label" : "Input file processing mode",
-    "optional" : false,
-    "value" : "ONE_DOC_PER_FILE",
-    "group" : "input",
     "binding" : {
       "name" : "input.comprehendInputFormat",
       "type" : "zeebe:input"
     },
-    "condition" : {
-      "property" : "input.type",
-      "equals" : "async",
-      "type" : "simple"
-    },
-    "tooltip" : "Specifies how to <a href=\"https://docs.aws.amazon.com/comprehend/latest/APIReference/API_InputDataConfig.html#comprehend-Type-InputDataConfig-InputFormat\">process input data</a>.",
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "Each file is considered a separate document",
       "value" : "ONE_DOC_PER_FILE"
@@ -354,13 +342,20 @@
     }, {
       "name" : "None",
       "value" : "NO_DATA"
-    } ]
-  }, {
-    "id" : "input.clientRequestToken",
-    "label" : "Client request token",
-    "optional" : true,
-    "feel" : "optional",
+    } ],
+    "condition" : {
+      "property" : "input.type",
+      "equals" : "async",
+      "type" : "simple"
+    },
     "group" : "input",
+    "id" : "input.comprehendInputFormat",
+    "label" : "Input file processing mode",
+    "optional" : false,
+    "tooltip" : "Specifies how to <a href=\"https://docs.aws.amazon.com/comprehend/latest/APIReference/API_InputDataConfig.html#comprehend-Type-InputDataConfig-InputFormat\">process input data</a>.",
+    "type" : "Dropdown",
+    "value" : "ONE_DOC_PER_FILE"
+  }, {
     "binding" : {
       "name" : "input.clientRequestToken",
       "type" : "zeebe:input"
@@ -370,17 +365,14 @@
       "equals" : "async",
       "type" : "simple"
     },
+    "feel" : "optional",
+    "group" : "input",
+    "id" : "input.clientRequestToken",
+    "label" : "Client request token",
+    "optional" : true,
     "tooltip" : "<a href=\"https://docs.aws.amazon.com/comprehend/latest/APIReference/API_StartDocumentClassificationJob.html#comprehend-StartDocumentClassificationJob-request-ClientRequestToken\">Unique identifier</a> for the processing.",
     "type" : "String"
   }, {
-    "id" : "input.dataAccessRoleArn",
-    "label" : "Data Access Role's ARN",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "feel" : "optional",
-    "group" : "input",
     "binding" : {
       "name" : "input.dataAccessRoleArn",
       "type" : "zeebe:input"
@@ -390,17 +382,17 @@
       "equals" : "async",
       "type" : "simple"
     },
-    "tooltip" : "ARN of IAM role that grants <a href=\"https://docs.aws.amazon.com/comprehend/latest/APIReference/API_StartDocumentClassificationJob.html#comprehend-StartDocumentClassificationJob-request-DataAccessRoleArn\">Amazon Comprehend read access</a> to input data.",
-    "type" : "String"
-  }, {
-    "id" : "input.documentClassifierArn",
-    "label" : "Document Classifier's ARN",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "input",
+    "id" : "input.dataAccessRoleArn",
+    "label" : "Data Access Role's ARN",
+    "optional" : false,
+    "tooltip" : "ARN of IAM role that grants <a href=\"https://docs.aws.amazon.com/comprehend/latest/APIReference/API_StartDocumentClassificationJob.html#comprehend-StartDocumentClassificationJob-request-DataAccessRoleArn\">Amazon Comprehend read access</a> to input data.",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "input.documentClassifierArn",
       "type" : "zeebe:input"
@@ -410,14 +402,17 @@
       "equals" : "async",
       "type" : "simple"
     },
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "input",
+    "id" : "input.documentClassifierArn",
+    "label" : "Document Classifier's ARN",
+    "optional" : false,
     "tooltip" : "The <a href=\"https://docs.aws.amazon.com/comprehend/latest/APIReference/API_StartDocumentClassificationJob.html#comprehend-StartDocumentClassificationJob-request-DocumentClassifierArn\">ARN of document classifier</a> to process input data.",
     "type" : "String"
   }, {
-    "id" : "input.flywheelArn",
-    "label" : "Flywheel's ARN",
-    "optional" : true,
-    "feel" : "optional",
-    "group" : "input",
     "binding" : {
       "name" : "input.flywheelArn",
       "type" : "zeebe:input"
@@ -427,14 +422,14 @@
       "equals" : "async",
       "type" : "simple"
     },
+    "feel" : "optional",
+    "group" : "input",
+    "id" : "input.flywheelArn",
+    "label" : "Flywheel's ARN",
+    "optional" : true,
     "tooltip" : "ARN of the <a href=\"https://docs.aws.amazon.com/comprehend/latest/APIReference/API_StartDocumentClassificationJob.html#comprehend-StartDocumentClassificationJob-request-FlywheelArn\">flywheel</a> that orchestrates training and versioning of the classification model.",
     "type" : "String"
   }, {
-    "id" : "input.jobName",
-    "label" : "Job name",
-    "optional" : true,
-    "feel" : "optional",
-    "group" : "input",
     "binding" : {
       "name" : "input.jobName",
       "type" : "zeebe:input"
@@ -444,16 +439,13 @@
       "equals" : "async",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "input.outputS3Uri",
-    "label" : "Output's S3 URI",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
     "feel" : "optional",
     "group" : "input",
+    "id" : "input.jobName",
+    "label" : "Job name",
+    "optional" : true,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "input.outputS3Uri",
       "type" : "zeebe:input"
@@ -463,14 +455,17 @@
       "equals" : "async",
       "type" : "simple"
     },
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "input",
+    "id" : "input.outputS3Uri",
+    "label" : "Output's S3 URI",
+    "optional" : false,
     "tooltip" : "The <a href=\"https://docs.aws.amazon.com/comprehend/latest/APIReference/API_InputDataConfig.html#comprehend-Type-OutputDataConfig-S3Uri\">S3Uri</a> for output data.",
     "type" : "String"
   }, {
-    "id" : "input.outputKmsKeyId",
-    "label" : "Outputs KMS Key Id",
-    "optional" : true,
-    "feel" : "optional",
-    "group" : "input",
     "binding" : {
       "name" : "input.outputKmsKeyId",
       "type" : "zeebe:input"
@@ -480,14 +475,14 @@
       "equals" : "async",
       "type" : "simple"
     },
+    "feel" : "optional",
+    "group" : "input",
+    "id" : "input.outputKmsKeyId",
+    "label" : "Outputs KMS Key Id",
+    "optional" : true,
     "tooltip" : "KMS' key Id used to <a href=\"https://docs.aws.amazon.com/comprehend/latest/APIReference/API_OutputDataConfig.html#comprehend-Type-OutputDataConfig-KmsKeyId\">encrypt output data</a>.",
     "type" : "String"
   }, {
-    "id" : "input.tags",
-    "label" : "Tags",
-    "optional" : true,
-    "feel" : "required",
-    "group" : "input",
     "binding" : {
       "name" : "input.tags",
       "type" : "zeebe:input"
@@ -497,14 +492,14 @@
       "equals" : "async",
       "type" : "simple"
     },
+    "feel" : "required",
+    "group" : "input",
+    "id" : "input.tags",
+    "label" : "Tags",
+    "optional" : true,
     "tooltip" : "Tags to <a href=\"https://docs.aws.amazon.com/comprehend/latest/APIReference/API_StartDocumentClassificationJob.html#comprehend-StartDocumentClassificationJob-request-Tags\">associate with the document classification job</a>.",
     "type" : "String"
   }, {
-    "id" : "input.volumeKmsKeyId",
-    "label" : "VolumeKmsKeyId",
-    "optional" : true,
-    "feel" : "optional",
-    "group" : "input",
     "binding" : {
       "name" : "input.volumeKmsKeyId",
       "type" : "zeebe:input"
@@ -514,14 +509,14 @@
       "equals" : "async",
       "type" : "simple"
     },
+    "feel" : "optional",
+    "group" : "input",
+    "id" : "input.volumeKmsKeyId",
+    "label" : "VolumeKmsKeyId",
+    "optional" : true,
     "tooltip" : "<a href=\"https://docs.aws.amazon.com/comprehend/latest/APIReference/API_StartDocumentClassificationJob.html#comprehend-StartDocumentClassificationJob-request-VolumeKmsKeyId\">KMS to encrypt data on storage</a> attached to compute instance.",
     "type" : "String"
   }, {
-    "id" : "input.securityGroupIds",
-    "label" : "Security group Ids",
-    "optional" : true,
-    "feel" : "required",
-    "group" : "input",
     "binding" : {
       "name" : "input.securityGroupIds",
       "type" : "zeebe:input"
@@ -531,14 +526,14 @@
       "equals" : "async",
       "type" : "simple"
     },
+    "feel" : "required",
+    "group" : "input",
+    "id" : "input.securityGroupIds",
+    "label" : "Security group Ids",
+    "optional" : true,
     "tooltip" : "<a href=\"https://docs.aws.amazon.com/comprehend/latest/APIReference/API_VpcConfig.html#comprehend-Type-VpcConfig-SecurityGroupIds\">ID for security group</a> on instance of private VPC.",
     "type" : "String"
   }, {
-    "id" : "input.subnets",
-    "label" : "Subnets",
-    "optional" : true,
-    "feel" : "required",
-    "group" : "input",
     "binding" : {
       "name" : "input.subnets",
       "type" : "zeebe:input"
@@ -548,95 +543,100 @@
       "equals" : "async",
       "type" : "simple"
     },
+    "feel" : "required",
+    "group" : "input",
+    "id" : "input.subnets",
+    "label" : "Subnets",
+    "optional" : true,
     "tooltip" : "ID for each <a href=\"https://docs.aws.amazon.com/comprehend/latest/APIReference/API_VpcConfig.html#comprehend-Type-VpcConfig-Subnets\">subnet used in VPC</a>.",
     "type" : "String"
   }, {
-    "id" : "version",
-    "label" : "Version",
-    "description" : "Version of the element template",
-    "value" : "5",
-    "group" : "connector",
     "binding" : {
       "key" : "elementTemplateVersion",
       "type" : "zeebe:taskHeader"
     },
-    "type" : "Hidden"
-  }, {
-    "id" : "id",
-    "label" : "ID",
-    "description" : "ID of the element template",
-    "value" : "io.camunda.connectors.AWSCOMPREHEND.v1",
+    "description" : "Version of the element template",
     "group" : "connector",
+    "id" : "version",
+    "label" : "Version",
+    "type" : "Hidden",
+    "value" : "5"
+  }, {
     "binding" : {
       "key" : "elementTemplateId",
       "type" : "zeebe:taskHeader"
     },
-    "type" : "Hidden"
+    "description" : "ID of the element template",
+    "group" : "connector",
+    "id" : "id",
+    "label" : "ID",
+    "type" : "Hidden",
+    "value" : "io.camunda.connectors.AWSCOMPREHEND.v1"
   }, {
-    "id" : "resultVariable",
-    "label" : "Result variable",
-    "description" : "Name of variable to store the response in. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-variable\" target=\"_blank\">documentation</a>.",
-    "group" : "output",
     "binding" : {
       "key" : "resultVariable",
       "type" : "zeebe:taskHeader"
     },
+    "description" : "Name of variable to store the response in. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-variable\" target=\"_blank\">documentation</a>.",
+    "group" : "output",
+    "id" : "resultVariable",
+    "label" : "Result variable",
     "type" : "String"
   }, {
-    "id" : "resultExpression",
-    "label" : "Result expression",
-    "description" : "Expression to map the response into process variables. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-expression\" target=\"_blank\">documentation</a>.",
-    "feel" : "required",
-    "group" : "output",
     "binding" : {
       "key" : "resultExpression",
       "type" : "zeebe:taskHeader"
     },
+    "description" : "Expression to map the response into process variables. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-expression\" target=\"_blank\">documentation</a>.",
+    "feel" : "required",
+    "group" : "output",
+    "id" : "resultExpression",
+    "label" : "Result expression",
     "type" : "Text"
   }, {
-    "id" : "errorExpression",
-    "label" : "Error expression",
-    "description" : "Expression to handle errors. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/\" target=\"_blank\">documentation</a>.",
-    "feel" : "required",
-    "group" : "error",
     "binding" : {
       "key" : "errorExpression",
       "type" : "zeebe:taskHeader"
     },
+    "description" : "Expression to handle errors. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/\" target=\"_blank\">documentation</a>.",
+    "feel" : "required",
+    "group" : "error",
+    "id" : "errorExpression",
+    "label" : "Error expression",
     "type" : "Text"
   }, {
-    "id" : "retryCount",
-    "label" : "Retries",
-    "description" : "Number of retries",
-    "value" : "3",
-    "feel" : "optional",
-    "group" : "retries",
     "binding" : {
       "property" : "retries",
       "type" : "zeebe:taskDefinition"
     },
-    "type" : "String"
-  }, {
-    "id" : "retryBackoff",
-    "label" : "Retry backoff",
-    "description" : "ISO-8601 duration to wait between retries",
-    "value" : "PT30S",
+    "description" : "Number of retries",
+    "feel" : "optional",
     "group" : "retries",
+    "id" : "retryCount",
+    "label" : "Retries",
+    "type" : "String",
+    "value" : "3"
+  }, {
     "binding" : {
       "key" : "retryBackoff",
       "type" : "zeebe:taskHeader"
     },
-    "type" : "String"
-  }, {
-    "id" : "jobTimeout",
-    "label" : "Job timeout",
-    "description" : "ISO-8601 duration after which Zeebe considers this job timed out if not yet completed. Leave empty to use the default timeout",
-    "optional" : true,
+    "description" : "ISO-8601 duration to wait between retries",
     "group" : "retries",
+    "id" : "retryBackoff",
+    "label" : "Retry backoff",
+    "type" : "String",
+    "value" : "PT30S"
+  }, {
     "binding" : {
       "key" : "jobTimeout",
       "type" : "zeebe:taskHeader"
     },
+    "description" : "ISO-8601 duration after which Zeebe considers this job timed out if not yet completed. Leave empty to use the default timeout",
+    "group" : "retries",
+    "id" : "jobTimeout",
+    "label" : "Job timeout",
+    "optional" : true,
     "type" : "String"
   } ],
   "steps" : [ {
@@ -667,30 +667,24 @@
     "version" : 1,
     "name" : "AWS Credential",
     "properties" : [ {
-      "id" : "authentication.type",
-      "label" : "Authentication",
-      "description" : "Specify AWS authentication strategy. Learn more at the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/aws-lambda/#aws-authentication-types\" target=\"_blank\">documentation page</a>",
-      "value" : "credentials",
-      "group" : "authentication",
       "binding" : {
         "name" : "authentication.type",
         "type" : "property"
       },
-      "type" : "Dropdown",
       "choices" : [ {
         "name" : "Default Credentials Chain (Hybrid/Self-Managed only)",
         "value" : "defaultCredentialsChain"
       }, {
         "name" : "Credentials",
         "value" : "credentials"
-      } ]
-    }, {
-      "id" : "authentication.accessKey",
-      "label" : "Access key",
-      "constraints" : {
-        "notEmpty" : true
-      },
+      } ],
+      "description" : "Specify AWS authentication strategy. Learn more at the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/aws-lambda/#aws-authentication-types\" target=\"_blank\">documentation page</a>",
       "group" : "authentication",
+      "id" : "authentication.type",
+      "label" : "Authentication",
+      "type" : "Dropdown",
+      "value" : "credentials"
+    }, {
       "binding" : {
         "name" : "authentication.accessKey",
         "type" : "property"
@@ -700,16 +694,16 @@
         "equals" : "credentials",
         "type" : "simple"
       },
-      "tooltip" : "IAM access key of a user with the necessary permissions for this connector",
-      "type" : "String",
-      "secret" : true
-    }, {
-      "id" : "authentication.secretKey",
-      "label" : "Secret key",
       "constraints" : {
         "notEmpty" : true
       },
       "group" : "authentication",
+      "id" : "authentication.accessKey",
+      "label" : "Access key",
+      "secret" : true,
+      "tooltip" : "IAM access key of a user with the necessary permissions for this connector",
+      "type" : "String"
+    }, {
       "binding" : {
         "name" : "authentication.secretKey",
         "type" : "property"
@@ -719,20 +713,26 @@
         "equals" : "credentials",
         "type" : "simple"
       },
-      "tooltip" : "IAM secret key of a user with the necessary permissions for this connector",
-      "type" : "String",
-      "secret" : true
-    }, {
-      "id" : "region",
-      "label" : "Region",
       "constraints" : {
         "notEmpty" : true
       },
-      "group" : "configuration",
+      "group" : "authentication",
+      "id" : "authentication.secretKey",
+      "label" : "Secret key",
+      "secret" : true,
+      "tooltip" : "IAM secret key of a user with the necessary permissions for this connector",
+      "type" : "String"
+    }, {
       "binding" : {
         "name" : "region",
         "type" : "property"
       },
+      "constraints" : {
+        "notEmpty" : true
+      },
+      "group" : "configuration",
+      "id" : "region",
+      "label" : "Region",
       "type" : "String"
     } ]
   } ],

--- a/connectors/aws/aws-comprehend/element-templates/hybrid/aws-comprehend-outbound-connector-hybrid.json
+++ b/connectors/aws/aws-comprehend/element-templates/hybrid/aws-comprehend-outbound-connector-hybrid.json
@@ -46,57 +46,49 @@
     "label" : "Retries"
   } ],
   "properties" : [ {
-    "id" : "taskDefinitionType",
-    "value" : "io.camunda:aws-comprehend:1",
-    "group" : "taskDefinitionType",
     "binding" : {
       "property" : "type",
       "type" : "zeebe:taskDefinition"
     },
-    "type" : "String"
+    "group" : "taskDefinitionType",
+    "id" : "taskDefinitionType",
+    "type" : "String",
+    "value" : "io.camunda:aws-comprehend:1"
   }, {
-    "id" : "input.type",
-    "label" : "Execution type",
-    "group" : "operation",
     "binding" : {
       "name" : "input.type",
       "type" : "zeebe:input"
     },
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "Sync",
       "value" : "sync"
     }, {
       "name" : "Async",
       "value" : "async"
-    } ]
+    } ],
+    "group" : "operation",
+    "id" : "input.type",
+    "label" : "Execution type",
+    "type" : "Dropdown"
   }, {
-    "id" : "authentication.type",
-    "label" : "Authentication",
-    "description" : "Specify AWS authentication strategy. Learn more at the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/aws-lambda/#aws-authentication-types\" target=\"_blank\">documentation page</a>",
-    "value" : "credentials",
-    "group" : "authentication",
     "binding" : {
       "name" : "authentication.type",
       "type" : "zeebe:input"
     },
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "Default Credentials Chain (Hybrid/Self-Managed only)",
       "value" : "defaultCredentialsChain"
     }, {
       "name" : "Credentials",
       "value" : "credentials"
-    } ]
-  }, {
-    "id" : "authentication.accessKey",
-    "label" : "Access key",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "feel" : "optional",
+    } ],
+    "description" : "Specify AWS authentication strategy. Learn more at the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/aws-lambda/#aws-authentication-types\" target=\"_blank\">documentation page</a>",
     "group" : "authentication",
+    "id" : "authentication.type",
+    "label" : "Authentication",
+    "type" : "Dropdown",
+    "value" : "credentials"
+  }, {
     "binding" : {
       "name" : "authentication.accessKey",
       "type" : "zeebe:input"
@@ -106,18 +98,18 @@
       "equals" : "credentials",
       "type" : "simple"
     },
-    "tooltip" : "IAM access key of a user with the necessary permissions for this connector",
-    "type" : "String",
-    "secret" : true
-  }, {
-    "id" : "authentication.secretKey",
-    "label" : "Secret key",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "authentication",
+    "id" : "authentication.accessKey",
+    "label" : "Access key",
+    "optional" : false,
+    "secret" : true,
+    "tooltip" : "IAM access key of a user with the necessary permissions for this connector",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "authentication.secretKey",
       "type" : "zeebe:input"
@@ -127,55 +119,55 @@
       "equals" : "credentials",
       "type" : "simple"
     },
-    "tooltip" : "IAM secret key of a user with the necessary permissions for this connector",
-    "type" : "String",
-    "secret" : true
-  }, {
-    "id" : "awsCredential",
-    "label" : "AWS credential",
-    "description" : "Choose a reusable AWS credential. When set, it is bound as a whole to the connector's 'awsCredential' input.",
-    "optional" : true,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
     "group" : "authentication",
+    "id" : "authentication.secretKey",
+    "label" : "Secret key",
+    "optional" : false,
+    "secret" : true,
+    "tooltip" : "IAM secret key of a user with the necessary permissions for this connector",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "awsCredential",
       "type" : "zeebe:input"
     },
-    "type" : "Configuration",
-    "configurationTemplate" : "io.camunda:aws-credential:1"
+    "configurationTemplate" : "io.camunda:aws-credential:1",
+    "description" : "Choose a reusable AWS credential. When set, it is bound as a whole to the connector's 'awsCredential' input.",
+    "group" : "authentication",
+    "id" : "awsCredential",
+    "label" : "AWS credential",
+    "optional" : true,
+    "type" : "Configuration"
   }, {
-    "id" : "configuration.region",
-    "label" : "Region",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "feel" : "optional",
-    "group" : "configuration",
     "binding" : {
       "name" : "configuration.region",
       "type" : "zeebe:input"
     },
-    "type" : "String"
-  }, {
-    "id" : "configuration.endpoint",
-    "label" : "Endpoint",
-    "description" : "Specify endpoint if need to use custom endpoint",
-    "optional" : true,
-    "group" : "configuration",
-    "binding" : {
-      "name" : "configuration.endpoint",
-      "type" : "zeebe:input"
-    },
-    "type" : "Hidden"
-  }, {
-    "id" : "input.text",
-    "label" : "Text",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
-    "group" : "input",
+    "group" : "configuration",
+    "id" : "configuration.region",
+    "label" : "Region",
+    "optional" : false,
+    "type" : "String"
+  }, {
+    "binding" : {
+      "name" : "configuration.endpoint",
+      "type" : "zeebe:input"
+    },
+    "description" : "Specify endpoint if need to use custom endpoint",
+    "group" : "configuration",
+    "id" : "configuration.endpoint",
+    "label" : "Endpoint",
+    "optional" : true,
+    "type" : "Hidden"
+  }, {
     "binding" : {
       "name" : "input.text",
       "type" : "zeebe:input"
@@ -185,17 +177,17 @@
       "equals" : "sync",
       "type" : "simple"
     },
-    "tooltip" : "<a href=\"https://docs.aws.amazon.com/comprehend/latest/APIReference/API_ClassifyDocument.html#comprehend-ClassifyDocument-request-Text\">Text</a> to be analyzed.",
-    "type" : "String"
-  }, {
-    "id" : "input.endpointArn",
-    "label" : "Endpoint's ARN",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "input",
+    "id" : "input.text",
+    "label" : "Text",
+    "optional" : false,
+    "tooltip" : "<a href=\"https://docs.aws.amazon.com/comprehend/latest/APIReference/API_ClassifyDocument.html#comprehend-ClassifyDocument-request-Text\">Text</a> to be analyzed.",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "input.endpointArn",
       "type" : "zeebe:input"
@@ -205,28 +197,21 @@
       "equals" : "sync",
       "type" : "simple"
     },
-    "tooltip" : "ARN of the custom model <a href=\"https://docs.aws.amazon.com/comprehend/latest/APIReference/API_ClassifyDocument.html#comprehend-ClassifyDocument-request-EndpointArn\">endpoint</a> used to run the classification.",
-    "type" : "String"
-  }, {
-    "id" : "input.async.documentReadMode",
-    "label" : "Document read mode",
-    "optional" : false,
-    "value" : "SERVICE_DEFAULT",
     "constraints" : {
       "notEmpty" : true
     },
+    "feel" : "optional",
     "group" : "input",
+    "id" : "input.endpointArn",
+    "label" : "Endpoint's ARN",
+    "optional" : false,
+    "tooltip" : "ARN of the custom model <a href=\"https://docs.aws.amazon.com/comprehend/latest/APIReference/API_ClassifyDocument.html#comprehend-ClassifyDocument-request-EndpointArn\">endpoint</a> used to run the classification.",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "input.documentReadMode",
       "type" : "zeebe:input"
     },
-    "condition" : {
-      "property" : "input.type",
-      "equals" : "async",
-      "type" : "simple"
-    },
-    "tooltip" : "Determines <a href=\"https://docs.aws.amazon.com/comprehend/latest/dg/idp-set-textract-options.html\">text extraction actions</a> for PDF files.",
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "Service default",
       "value" : "SERVICE_DEFAULT"
@@ -236,27 +221,27 @@
     }, {
       "name" : "None",
       "value" : "NO_DATA"
-    } ]
-  }, {
-    "id" : "input.async.documentReadAction",
-    "label" : "Document read action",
-    "optional" : false,
-    "value" : "TEXTRACT_DETECT_DOCUMENT_TEXT",
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "group" : "input",
-    "binding" : {
-      "name" : "input.documentReadAction",
-      "type" : "zeebe:input"
-    },
+    } ],
     "condition" : {
       "property" : "input.type",
       "equals" : "async",
       "type" : "simple"
     },
-    "tooltip" : "The Amazon Textract API operation that Amazon Comprehend uses to extract text from PDF files and image files.",
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "group" : "input",
+    "id" : "input.async.documentReadMode",
+    "label" : "Document read mode",
+    "optional" : false,
+    "tooltip" : "Determines <a href=\"https://docs.aws.amazon.com/comprehend/latest/dg/idp-set-textract-options.html\">text extraction actions</a> for PDF files.",
     "type" : "Dropdown",
+    "value" : "SERVICE_DEFAULT"
+  }, {
+    "binding" : {
+      "name" : "input.documentReadAction",
+      "type" : "zeebe:input"
+    },
     "choices" : [ {
       "name" : "Detect document text",
       "value" : "TEXTRACT_DETECT_DOCUMENT_TEXT"
@@ -266,14 +251,23 @@
     }, {
       "name" : "None",
       "value" : "NO_DATA"
-    } ]
-  }, {
-    "id" : "input.async.featureTypeTables",
-    "label" : "Analyze tables",
-    "optional" : false,
-    "value" : false,
-    "feel" : "static",
+    } ],
+    "condition" : {
+      "property" : "input.type",
+      "equals" : "async",
+      "type" : "simple"
+    },
+    "constraints" : {
+      "notEmpty" : true
+    },
     "group" : "input",
+    "id" : "input.async.documentReadAction",
+    "label" : "Document read action",
+    "optional" : false,
+    "tooltip" : "The Amazon Textract API operation that Amazon Comprehend uses to extract text from PDF files and image files.",
+    "type" : "Dropdown",
+    "value" : "TEXTRACT_DETECT_DOCUMENT_TEXT"
+  }, {
     "binding" : {
       "name" : "input.featureTypeTables",
       "type" : "zeebe:input"
@@ -289,14 +283,14 @@
         "type" : "simple"
       } ]
     },
-    "type" : "Boolean"
-  }, {
-    "id" : "input.async.featureTypeForms",
-    "label" : "Analyze forms",
-    "optional" : false,
-    "value" : false,
     "feel" : "static",
     "group" : "input",
+    "id" : "input.async.featureTypeTables",
+    "label" : "Analyze tables",
+    "optional" : false,
+    "type" : "Boolean",
+    "value" : false
+  }, {
     "binding" : {
       "name" : "input.featureTypeForms",
       "type" : "zeebe:input"
@@ -312,16 +306,14 @@
         "type" : "simple"
       } ]
     },
-    "type" : "Boolean"
-  }, {
-    "id" : "input.inputS3Uri",
-    "label" : "Inputs' S3 URI",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "feel" : "optional",
+    "feel" : "static",
     "group" : "input",
+    "id" : "input.async.featureTypeForms",
+    "label" : "Analyze forms",
+    "optional" : false,
+    "type" : "Boolean",
+    "value" : false
+  }, {
     "binding" : {
       "name" : "input.inputS3Uri",
       "type" : "zeebe:input"
@@ -331,25 +323,21 @@
       "equals" : "async",
       "type" : "simple"
     },
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "input",
+    "id" : "input.inputS3Uri",
+    "label" : "Inputs' S3 URI",
+    "optional" : false,
     "tooltip" : "The <a href=\"https://docs.aws.amazon.com/comprehend/latest/APIReference/API_InputDataConfig.html#comprehend-Type-InputDataConfig-S3Uri\">S3Uri</a> for input data.",
     "type" : "String"
   }, {
-    "id" : "input.comprehendInputFormat",
-    "label" : "Input file processing mode",
-    "optional" : false,
-    "value" : "ONE_DOC_PER_FILE",
-    "group" : "input",
     "binding" : {
       "name" : "input.comprehendInputFormat",
       "type" : "zeebe:input"
     },
-    "condition" : {
-      "property" : "input.type",
-      "equals" : "async",
-      "type" : "simple"
-    },
-    "tooltip" : "Specifies how to <a href=\"https://docs.aws.amazon.com/comprehend/latest/APIReference/API_InputDataConfig.html#comprehend-Type-InputDataConfig-InputFormat\">process input data</a>.",
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "Each file is considered a separate document",
       "value" : "ONE_DOC_PER_FILE"
@@ -359,13 +347,20 @@
     }, {
       "name" : "None",
       "value" : "NO_DATA"
-    } ]
-  }, {
-    "id" : "input.clientRequestToken",
-    "label" : "Client request token",
-    "optional" : true,
-    "feel" : "optional",
+    } ],
+    "condition" : {
+      "property" : "input.type",
+      "equals" : "async",
+      "type" : "simple"
+    },
     "group" : "input",
+    "id" : "input.comprehendInputFormat",
+    "label" : "Input file processing mode",
+    "optional" : false,
+    "tooltip" : "Specifies how to <a href=\"https://docs.aws.amazon.com/comprehend/latest/APIReference/API_InputDataConfig.html#comprehend-Type-InputDataConfig-InputFormat\">process input data</a>.",
+    "type" : "Dropdown",
+    "value" : "ONE_DOC_PER_FILE"
+  }, {
     "binding" : {
       "name" : "input.clientRequestToken",
       "type" : "zeebe:input"
@@ -375,17 +370,14 @@
       "equals" : "async",
       "type" : "simple"
     },
+    "feel" : "optional",
+    "group" : "input",
+    "id" : "input.clientRequestToken",
+    "label" : "Client request token",
+    "optional" : true,
     "tooltip" : "<a href=\"https://docs.aws.amazon.com/comprehend/latest/APIReference/API_StartDocumentClassificationJob.html#comprehend-StartDocumentClassificationJob-request-ClientRequestToken\">Unique identifier</a> for the processing.",
     "type" : "String"
   }, {
-    "id" : "input.dataAccessRoleArn",
-    "label" : "Data Access Role's ARN",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "feel" : "optional",
-    "group" : "input",
     "binding" : {
       "name" : "input.dataAccessRoleArn",
       "type" : "zeebe:input"
@@ -395,17 +387,17 @@
       "equals" : "async",
       "type" : "simple"
     },
-    "tooltip" : "ARN of IAM role that grants <a href=\"https://docs.aws.amazon.com/comprehend/latest/APIReference/API_StartDocumentClassificationJob.html#comprehend-StartDocumentClassificationJob-request-DataAccessRoleArn\">Amazon Comprehend read access</a> to input data.",
-    "type" : "String"
-  }, {
-    "id" : "input.documentClassifierArn",
-    "label" : "Document Classifier's ARN",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "input",
+    "id" : "input.dataAccessRoleArn",
+    "label" : "Data Access Role's ARN",
+    "optional" : false,
+    "tooltip" : "ARN of IAM role that grants <a href=\"https://docs.aws.amazon.com/comprehend/latest/APIReference/API_StartDocumentClassificationJob.html#comprehend-StartDocumentClassificationJob-request-DataAccessRoleArn\">Amazon Comprehend read access</a> to input data.",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "input.documentClassifierArn",
       "type" : "zeebe:input"
@@ -415,14 +407,17 @@
       "equals" : "async",
       "type" : "simple"
     },
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "input",
+    "id" : "input.documentClassifierArn",
+    "label" : "Document Classifier's ARN",
+    "optional" : false,
     "tooltip" : "The <a href=\"https://docs.aws.amazon.com/comprehend/latest/APIReference/API_StartDocumentClassificationJob.html#comprehend-StartDocumentClassificationJob-request-DocumentClassifierArn\">ARN of document classifier</a> to process input data.",
     "type" : "String"
   }, {
-    "id" : "input.flywheelArn",
-    "label" : "Flywheel's ARN",
-    "optional" : true,
-    "feel" : "optional",
-    "group" : "input",
     "binding" : {
       "name" : "input.flywheelArn",
       "type" : "zeebe:input"
@@ -432,14 +427,14 @@
       "equals" : "async",
       "type" : "simple"
     },
+    "feel" : "optional",
+    "group" : "input",
+    "id" : "input.flywheelArn",
+    "label" : "Flywheel's ARN",
+    "optional" : true,
     "tooltip" : "ARN of the <a href=\"https://docs.aws.amazon.com/comprehend/latest/APIReference/API_StartDocumentClassificationJob.html#comprehend-StartDocumentClassificationJob-request-FlywheelArn\">flywheel</a> that orchestrates training and versioning of the classification model.",
     "type" : "String"
   }, {
-    "id" : "input.jobName",
-    "label" : "Job name",
-    "optional" : true,
-    "feel" : "optional",
-    "group" : "input",
     "binding" : {
       "name" : "input.jobName",
       "type" : "zeebe:input"
@@ -449,16 +444,13 @@
       "equals" : "async",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "input.outputS3Uri",
-    "label" : "Output's S3 URI",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
     "feel" : "optional",
     "group" : "input",
+    "id" : "input.jobName",
+    "label" : "Job name",
+    "optional" : true,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "input.outputS3Uri",
       "type" : "zeebe:input"
@@ -468,14 +460,17 @@
       "equals" : "async",
       "type" : "simple"
     },
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "input",
+    "id" : "input.outputS3Uri",
+    "label" : "Output's S3 URI",
+    "optional" : false,
     "tooltip" : "The <a href=\"https://docs.aws.amazon.com/comprehend/latest/APIReference/API_InputDataConfig.html#comprehend-Type-OutputDataConfig-S3Uri\">S3Uri</a> for output data.",
     "type" : "String"
   }, {
-    "id" : "input.outputKmsKeyId",
-    "label" : "Outputs KMS Key Id",
-    "optional" : true,
-    "feel" : "optional",
-    "group" : "input",
     "binding" : {
       "name" : "input.outputKmsKeyId",
       "type" : "zeebe:input"
@@ -485,14 +480,14 @@
       "equals" : "async",
       "type" : "simple"
     },
+    "feel" : "optional",
+    "group" : "input",
+    "id" : "input.outputKmsKeyId",
+    "label" : "Outputs KMS Key Id",
+    "optional" : true,
     "tooltip" : "KMS' key Id used to <a href=\"https://docs.aws.amazon.com/comprehend/latest/APIReference/API_OutputDataConfig.html#comprehend-Type-OutputDataConfig-KmsKeyId\">encrypt output data</a>.",
     "type" : "String"
   }, {
-    "id" : "input.tags",
-    "label" : "Tags",
-    "optional" : true,
-    "feel" : "required",
-    "group" : "input",
     "binding" : {
       "name" : "input.tags",
       "type" : "zeebe:input"
@@ -502,14 +497,14 @@
       "equals" : "async",
       "type" : "simple"
     },
+    "feel" : "required",
+    "group" : "input",
+    "id" : "input.tags",
+    "label" : "Tags",
+    "optional" : true,
     "tooltip" : "Tags to <a href=\"https://docs.aws.amazon.com/comprehend/latest/APIReference/API_StartDocumentClassificationJob.html#comprehend-StartDocumentClassificationJob-request-Tags\">associate with the document classification job</a>.",
     "type" : "String"
   }, {
-    "id" : "input.volumeKmsKeyId",
-    "label" : "VolumeKmsKeyId",
-    "optional" : true,
-    "feel" : "optional",
-    "group" : "input",
     "binding" : {
       "name" : "input.volumeKmsKeyId",
       "type" : "zeebe:input"
@@ -519,14 +514,14 @@
       "equals" : "async",
       "type" : "simple"
     },
+    "feel" : "optional",
+    "group" : "input",
+    "id" : "input.volumeKmsKeyId",
+    "label" : "VolumeKmsKeyId",
+    "optional" : true,
     "tooltip" : "<a href=\"https://docs.aws.amazon.com/comprehend/latest/APIReference/API_StartDocumentClassificationJob.html#comprehend-StartDocumentClassificationJob-request-VolumeKmsKeyId\">KMS to encrypt data on storage</a> attached to compute instance.",
     "type" : "String"
   }, {
-    "id" : "input.securityGroupIds",
-    "label" : "Security group Ids",
-    "optional" : true,
-    "feel" : "required",
-    "group" : "input",
     "binding" : {
       "name" : "input.securityGroupIds",
       "type" : "zeebe:input"
@@ -536,14 +531,14 @@
       "equals" : "async",
       "type" : "simple"
     },
+    "feel" : "required",
+    "group" : "input",
+    "id" : "input.securityGroupIds",
+    "label" : "Security group Ids",
+    "optional" : true,
     "tooltip" : "<a href=\"https://docs.aws.amazon.com/comprehend/latest/APIReference/API_VpcConfig.html#comprehend-Type-VpcConfig-SecurityGroupIds\">ID for security group</a> on instance of private VPC.",
     "type" : "String"
   }, {
-    "id" : "input.subnets",
-    "label" : "Subnets",
-    "optional" : true,
-    "feel" : "required",
-    "group" : "input",
     "binding" : {
       "name" : "input.subnets",
       "type" : "zeebe:input"
@@ -553,95 +548,100 @@
       "equals" : "async",
       "type" : "simple"
     },
+    "feel" : "required",
+    "group" : "input",
+    "id" : "input.subnets",
+    "label" : "Subnets",
+    "optional" : true,
     "tooltip" : "ID for each <a href=\"https://docs.aws.amazon.com/comprehend/latest/APIReference/API_VpcConfig.html#comprehend-Type-VpcConfig-Subnets\">subnet used in VPC</a>.",
     "type" : "String"
   }, {
-    "id" : "version",
-    "label" : "Version",
-    "description" : "Version of the element template",
-    "value" : "5",
-    "group" : "connector",
     "binding" : {
       "key" : "elementTemplateVersion",
       "type" : "zeebe:taskHeader"
     },
-    "type" : "Hidden"
-  }, {
-    "id" : "id",
-    "label" : "ID",
-    "description" : "ID of the element template",
-    "value" : "io.camunda.connectors.AWSCOMPREHEND.v1",
+    "description" : "Version of the element template",
     "group" : "connector",
+    "id" : "version",
+    "label" : "Version",
+    "type" : "Hidden",
+    "value" : "5"
+  }, {
     "binding" : {
       "key" : "elementTemplateId",
       "type" : "zeebe:taskHeader"
     },
-    "type" : "Hidden"
+    "description" : "ID of the element template",
+    "group" : "connector",
+    "id" : "id",
+    "label" : "ID",
+    "type" : "Hidden",
+    "value" : "io.camunda.connectors.AWSCOMPREHEND.v1"
   }, {
-    "id" : "resultVariable",
-    "label" : "Result variable",
-    "description" : "Name of variable to store the response in. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-variable\" target=\"_blank\">documentation</a>.",
-    "group" : "output",
     "binding" : {
       "key" : "resultVariable",
       "type" : "zeebe:taskHeader"
     },
+    "description" : "Name of variable to store the response in. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-variable\" target=\"_blank\">documentation</a>.",
+    "group" : "output",
+    "id" : "resultVariable",
+    "label" : "Result variable",
     "type" : "String"
   }, {
-    "id" : "resultExpression",
-    "label" : "Result expression",
-    "description" : "Expression to map the response into process variables. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-expression\" target=\"_blank\">documentation</a>.",
-    "feel" : "required",
-    "group" : "output",
     "binding" : {
       "key" : "resultExpression",
       "type" : "zeebe:taskHeader"
     },
+    "description" : "Expression to map the response into process variables. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-expression\" target=\"_blank\">documentation</a>.",
+    "feel" : "required",
+    "group" : "output",
+    "id" : "resultExpression",
+    "label" : "Result expression",
     "type" : "Text"
   }, {
-    "id" : "errorExpression",
-    "label" : "Error expression",
-    "description" : "Expression to handle errors. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/\" target=\"_blank\">documentation</a>.",
-    "feel" : "required",
-    "group" : "error",
     "binding" : {
       "key" : "errorExpression",
       "type" : "zeebe:taskHeader"
     },
+    "description" : "Expression to handle errors. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/\" target=\"_blank\">documentation</a>.",
+    "feel" : "required",
+    "group" : "error",
+    "id" : "errorExpression",
+    "label" : "Error expression",
     "type" : "Text"
   }, {
-    "id" : "retryCount",
-    "label" : "Retries",
-    "description" : "Number of retries",
-    "value" : "3",
-    "feel" : "optional",
-    "group" : "retries",
     "binding" : {
       "property" : "retries",
       "type" : "zeebe:taskDefinition"
     },
-    "type" : "String"
-  }, {
-    "id" : "retryBackoff",
-    "label" : "Retry backoff",
-    "description" : "ISO-8601 duration to wait between retries",
-    "value" : "PT30S",
+    "description" : "Number of retries",
+    "feel" : "optional",
     "group" : "retries",
+    "id" : "retryCount",
+    "label" : "Retries",
+    "type" : "String",
+    "value" : "3"
+  }, {
     "binding" : {
       "key" : "retryBackoff",
       "type" : "zeebe:taskHeader"
     },
-    "type" : "String"
-  }, {
-    "id" : "jobTimeout",
-    "label" : "Job timeout",
-    "description" : "ISO-8601 duration after which Zeebe considers this job timed out if not yet completed. Leave empty to use the default timeout",
-    "optional" : true,
+    "description" : "ISO-8601 duration to wait between retries",
     "group" : "retries",
+    "id" : "retryBackoff",
+    "label" : "Retry backoff",
+    "type" : "String",
+    "value" : "PT30S"
+  }, {
     "binding" : {
       "key" : "jobTimeout",
       "type" : "zeebe:taskHeader"
     },
+    "description" : "ISO-8601 duration after which Zeebe considers this job timed out if not yet completed. Leave empty to use the default timeout",
+    "group" : "retries",
+    "id" : "jobTimeout",
+    "label" : "Job timeout",
+    "optional" : true,
     "type" : "String"
   } ],
   "steps" : [ {
@@ -672,30 +672,24 @@
     "version" : 1,
     "name" : "AWS Credential",
     "properties" : [ {
-      "id" : "authentication.type",
-      "label" : "Authentication",
-      "description" : "Specify AWS authentication strategy. Learn more at the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/aws-lambda/#aws-authentication-types\" target=\"_blank\">documentation page</a>",
-      "value" : "credentials",
-      "group" : "authentication",
       "binding" : {
         "name" : "authentication.type",
         "type" : "property"
       },
-      "type" : "Dropdown",
       "choices" : [ {
         "name" : "Default Credentials Chain (Hybrid/Self-Managed only)",
         "value" : "defaultCredentialsChain"
       }, {
         "name" : "Credentials",
         "value" : "credentials"
-      } ]
-    }, {
-      "id" : "authentication.accessKey",
-      "label" : "Access key",
-      "constraints" : {
-        "notEmpty" : true
-      },
+      } ],
+      "description" : "Specify AWS authentication strategy. Learn more at the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/aws-lambda/#aws-authentication-types\" target=\"_blank\">documentation page</a>",
       "group" : "authentication",
+      "id" : "authentication.type",
+      "label" : "Authentication",
+      "type" : "Dropdown",
+      "value" : "credentials"
+    }, {
       "binding" : {
         "name" : "authentication.accessKey",
         "type" : "property"
@@ -705,16 +699,16 @@
         "equals" : "credentials",
         "type" : "simple"
       },
-      "tooltip" : "IAM access key of a user with the necessary permissions for this connector",
-      "type" : "String",
-      "secret" : true
-    }, {
-      "id" : "authentication.secretKey",
-      "label" : "Secret key",
       "constraints" : {
         "notEmpty" : true
       },
       "group" : "authentication",
+      "id" : "authentication.accessKey",
+      "label" : "Access key",
+      "secret" : true,
+      "tooltip" : "IAM access key of a user with the necessary permissions for this connector",
+      "type" : "String"
+    }, {
       "binding" : {
         "name" : "authentication.secretKey",
         "type" : "property"
@@ -724,20 +718,26 @@
         "equals" : "credentials",
         "type" : "simple"
       },
-      "tooltip" : "IAM secret key of a user with the necessary permissions for this connector",
-      "type" : "String",
-      "secret" : true
-    }, {
-      "id" : "region",
-      "label" : "Region",
       "constraints" : {
         "notEmpty" : true
       },
-      "group" : "configuration",
+      "group" : "authentication",
+      "id" : "authentication.secretKey",
+      "label" : "Secret key",
+      "secret" : true,
+      "tooltip" : "IAM secret key of a user with the necessary permissions for this connector",
+      "type" : "String"
+    }, {
       "binding" : {
         "name" : "region",
         "type" : "property"
       },
+      "constraints" : {
+        "notEmpty" : true
+      },
+      "group" : "configuration",
+      "id" : "region",
+      "label" : "Region",
       "type" : "String"
     } ]
   } ],

--- a/connectors/aws/aws-comprehend/pom.xml
+++ b/connectors/aws/aws-comprehend/pom.xml
@@ -72,7 +72,7 @@
     directly, so the compile-scope dependency inherited from the root connectors POM must be
     narrowed to test scope here. -->
     <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
+      <groupId>tools.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
       <scope>test</scope>
     </dependency>
@@ -120,5 +120,4 @@
   </build>
 
 </project>
-
 

--- a/connectors/aws/aws-s3/element-templates/aws-s3-outbound-connector.json
+++ b/connectors/aws/aws-s3/element-templates/aws-s3-outbound-connector.json
@@ -49,22 +49,17 @@
     "label" : "Retries"
   } ],
   "properties" : [ {
-    "value" : "io.camunda:aws-s3:1",
     "binding" : {
       "property" : "type",
       "type" : "zeebe:taskDefinition"
     },
-    "type" : "Hidden"
+    "type" : "Hidden",
+    "value" : "io.camunda:aws-s3:1"
   }, {
-    "id" : "actionDiscriminator",
-    "label" : "Action",
-    "value" : "uploadObject",
-    "group" : "operation",
     "binding" : {
       "name" : "actionDiscriminator",
       "type" : "zeebe:input"
     },
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "Delete object",
       "value" : "deleteObject"
@@ -74,34 +69,31 @@
     }, {
       "name" : "Upload object",
       "value" : "uploadObject"
-    } ]
+    } ],
+    "group" : "operation",
+    "id" : "actionDiscriminator",
+    "label" : "Action",
+    "type" : "Dropdown",
+    "value" : "uploadObject"
   }, {
-    "id" : "authentication.type",
-    "label" : "Authentication",
-    "description" : "Specify AWS authentication strategy. Learn more at the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/aws-lambda/#aws-authentication-types\" target=\"_blank\">documentation page</a>",
-    "value" : "credentials",
-    "group" : "authentication",
     "binding" : {
       "name" : "authentication.type",
       "type" : "zeebe:input"
     },
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "Default Credentials Chain (Hybrid/Self-Managed only)",
       "value" : "defaultCredentialsChain"
     }, {
       "name" : "Credentials",
       "value" : "credentials"
-    } ]
-  }, {
-    "id" : "authentication.accessKey",
-    "label" : "Access key",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "feel" : "optional",
+    } ],
+    "description" : "Specify AWS authentication strategy. Learn more at the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/aws-lambda/#aws-authentication-types\" target=\"_blank\">documentation page</a>",
     "group" : "authentication",
+    "id" : "authentication.type",
+    "label" : "Authentication",
+    "type" : "Dropdown",
+    "value" : "credentials"
+  }, {
     "binding" : {
       "name" : "authentication.accessKey",
       "type" : "zeebe:input"
@@ -111,18 +103,18 @@
       "equals" : "credentials",
       "type" : "simple"
     },
-    "tooltip" : "IAM access key of a user with the necessary permissions for this connector",
-    "type" : "String",
-    "secret" : true
-  }, {
-    "id" : "authentication.secretKey",
-    "label" : "Secret key",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "authentication",
+    "id" : "authentication.accessKey",
+    "label" : "Access key",
+    "optional" : false,
+    "secret" : true,
+    "tooltip" : "IAM access key of a user with the necessary permissions for this connector",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "authentication.secretKey",
       "type" : "zeebe:input"
@@ -132,75 +124,75 @@
       "equals" : "credentials",
       "type" : "simple"
     },
-    "tooltip" : "IAM secret key of a user with the necessary permissions for this connector",
-    "type" : "String",
-    "secret" : true
-  }, {
-    "id" : "awsCredential",
-    "label" : "AWS credential",
-    "description" : "Choose a reusable AWS credential. When set, it is bound as a whole to the connector's 'awsCredential' input.",
-    "optional" : true,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
     "group" : "authentication",
+    "id" : "authentication.secretKey",
+    "label" : "Secret key",
+    "optional" : false,
+    "secret" : true,
+    "tooltip" : "IAM secret key of a user with the necessary permissions for this connector",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "awsCredential",
       "type" : "zeebe:input"
     },
-    "type" : "Configuration",
-    "configurationTemplate" : "io.camunda:aws-credential:1"
+    "configurationTemplate" : "io.camunda:aws-credential:1",
+    "description" : "Choose a reusable AWS credential. When set, it is bound as a whole to the connector's 'awsCredential' input.",
+    "group" : "authentication",
+    "id" : "awsCredential",
+    "label" : "AWS credential",
+    "optional" : true,
+    "type" : "Configuration"
   }, {
-    "id" : "configuration.region",
-    "label" : "Region",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "feel" : "optional",
-    "group" : "configuration",
     "binding" : {
       "name" : "configuration.region",
       "type" : "zeebe:input"
     },
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "configuration",
+    "id" : "configuration.region",
+    "label" : "Region",
+    "optional" : false,
     "type" : "String"
   }, {
-    "id" : "configuration.endpoint",
-    "label" : "Endpoint",
-    "description" : "Specify endpoint if need to use custom endpoint",
-    "optional" : true,
-    "group" : "configuration",
     "binding" : {
       "name" : "configuration.endpoint",
       "type" : "zeebe:input"
     },
+    "description" : "Specify endpoint if need to use custom endpoint",
+    "group" : "configuration",
+    "id" : "configuration.endpoint",
+    "label" : "Endpoint",
+    "optional" : true,
     "type" : "Hidden"
   }, {
+    "binding" : {
+      "name" : "action.bucket",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "actionDiscriminator",
+      "equals" : "deleteObject",
+      "type" : "simple"
+    },
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "deleteObject",
     "id" : "deleteActionBucket",
     "label" : "AWS bucket",
     "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "feel" : "optional",
-    "group" : "deleteObject",
-    "binding" : {
-      "name" : "action.bucket",
-      "type" : "zeebe:input"
-    },
-    "condition" : {
-      "property" : "actionDiscriminator",
-      "equals" : "deleteObject",
-      "type" : "simple"
-    },
     "tooltip" : "Bucket from where an object should be deleted",
     "type" : "String"
   }, {
-    "id" : "deleteActionKey",
-    "label" : "AWS key",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "feel" : "optional",
-    "group" : "deleteObject",
     "binding" : {
       "name" : "action.key",
       "type" : "zeebe:input"
@@ -210,17 +202,17 @@
       "equals" : "deleteObject",
       "type" : "simple"
     },
-    "tooltip" : "Key of the object which should be deleted",
-    "type" : "String"
-  }, {
-    "id" : "uploadActionBucket",
-    "label" : "AWS bucket",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
-    "group" : "uploadObject",
+    "group" : "deleteObject",
+    "id" : "deleteActionKey",
+    "label" : "AWS key",
+    "optional" : false,
+    "tooltip" : "Key of the object which should be deleted",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "action.bucket",
       "type" : "zeebe:input"
@@ -230,14 +222,17 @@
       "equals" : "uploadObject",
       "type" : "simple"
     },
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "uploadObject",
+    "id" : "uploadActionBucket",
+    "label" : "AWS bucket",
+    "optional" : false,
     "tooltip" : "Bucket from where an object should be uploaded",
     "type" : "String"
   }, {
-    "id" : "uploadActionKey",
-    "label" : "AWS key",
-    "optional" : true,
-    "feel" : "optional",
-    "group" : "uploadObject",
     "binding" : {
       "name" : "action.key",
       "type" : "zeebe:input"
@@ -247,24 +242,18 @@
       "equals" : "uploadObject",
       "type" : "simple"
     },
+    "feel" : "optional",
+    "group" : "uploadObject",
+    "id" : "uploadActionKey",
+    "label" : "AWS key",
+    "optional" : true,
     "tooltip" : "Key of the uploaded object, if not given. The file name from the document metadata will be used",
     "type" : "String"
   }, {
-    "id" : "action_document_documentSource",
-    "label" : "Document source",
-    "value" : "camunda",
-    "group" : "uploadObject",
     "binding" : {
       "name" : "action.action_document_documentSource",
       "type" : "zeebe:input"
     },
-    "condition" : {
-      "property" : "actionDiscriminator",
-      "equals" : "uploadObject",
-      "type" : "simple"
-    },
-    "tooltip" : "Document to be uploaded on AWS S3",
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "Camunda Document",
       "value" : "camunda"
@@ -274,15 +263,19 @@
     }, {
       "name" : "From URL",
       "value" : "external"
-    } ]
-  }, {
-    "id" : "action_document_camundaReference",
-    "label" : "Camunda document",
-    "constraints" : {
-      "notEmpty" : true
+    } ],
+    "condition" : {
+      "property" : "actionDiscriminator",
+      "equals" : "uploadObject",
+      "type" : "simple"
     },
-    "feel" : "required",
     "group" : "uploadObject",
+    "id" : "action_document_documentSource",
+    "label" : "Document source",
+    "tooltip" : "Document to be uploaded on AWS S3",
+    "type" : "Dropdown",
+    "value" : "camunda"
+  }, {
     "binding" : {
       "name" : "action.action_document_camundaReference",
       "type" : "zeebe:input"
@@ -298,15 +291,15 @@
         "type" : "simple"
       } ]
     },
-    "type" : "String"
-  }, {
-    "id" : "action_document_inline_content",
-    "label" : "Content",
     "constraints" : {
       "notEmpty" : true
     },
-    "feel" : "optional",
+    "feel" : "required",
     "group" : "uploadObject",
+    "id" : "action_document_camundaReference",
+    "label" : "Camunda document",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "action.action_document_inline_content",
       "type" : "zeebe:input"
@@ -322,12 +315,15 @@
         "type" : "simple"
       } ]
     },
-    "type" : "String"
-  }, {
-    "id" : "action_document_inline_fileName",
-    "label" : "File name",
+    "constraints" : {
+      "notEmpty" : true
+    },
     "feel" : "optional",
     "group" : "uploadObject",
+    "id" : "action_document_inline_content",
+    "label" : "Content",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "action.action_document_inline_fileName",
       "type" : "zeebe:input"
@@ -343,12 +339,12 @@
         "type" : "simple"
       } ]
     },
-    "type" : "String"
-  }, {
-    "id" : "action_document_inline_contentType",
-    "label" : "Content type",
     "feel" : "optional",
     "group" : "uploadObject",
+    "id" : "action_document_inline_fileName",
+    "label" : "File name",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "action.action_document_inline_contentType",
       "type" : "zeebe:input"
@@ -364,15 +360,12 @@
         "type" : "simple"
       } ]
     },
-    "type" : "String"
-  }, {
-    "id" : "action_document_external_url",
-    "label" : "URL",
-    "constraints" : {
-      "notEmpty" : true
-    },
     "feel" : "optional",
     "group" : "uploadObject",
+    "id" : "action_document_inline_contentType",
+    "label" : "Content type",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "action.action_document_external_url",
       "type" : "zeebe:input"
@@ -388,12 +381,15 @@
         "type" : "simple"
       } ]
     },
-    "type" : "String"
-  }, {
-    "id" : "action_document_external_fileName",
-    "label" : "File name",
+    "constraints" : {
+      "notEmpty" : true
+    },
     "feel" : "optional",
     "group" : "uploadObject",
+    "id" : "action_document_external_url",
+    "label" : "URL",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "action.action_document_external_fileName",
       "type" : "zeebe:input"
@@ -409,11 +405,12 @@
         "type" : "simple"
       } ]
     },
+    "feel" : "optional",
+    "group" : "uploadObject",
+    "id" : "action_document_external_fileName",
+    "label" : "File name",
     "type" : "String"
   }, {
-    "id" : "uploadActionDocument",
-    "value" : "=if action_document_documentSource = \"camunda\" then action_document_camundaReference else if action_document_documentSource = \"inline\" then { \"camunda.document.type\": \"inline\", content: action_document_inline_content, name: action_document_inline_fileName, contentType: action_document_inline_contentType } else if action_document_documentSource = \"external\" then { \"camunda.document.type\": \"external\", url: action_document_external_url, name: action_document_external_fileName } else null",
-    "group" : "uploadObject",
     "binding" : {
       "name" : "action.document",
       "type" : "zeebe:input"
@@ -423,16 +420,11 @@
       "equals" : "uploadObject",
       "type" : "simple"
     },
-    "type" : "Hidden"
+    "group" : "uploadObject",
+    "id" : "uploadActionDocument",
+    "type" : "Hidden",
+    "value" : "=if action_document_documentSource = \"camunda\" then action_document_camundaReference else if action_document_documentSource = \"inline\" then { \"camunda.document.type\": \"inline\", content: action_document_inline_content, name: action_document_inline_fileName, contentType: action_document_inline_contentType } else if action_document_documentSource = \"external\" then { \"camunda.document.type\": \"external\", url: action_document_external_url, name: action_document_external_fileName } else null"
   }, {
-    "id" : "downloadActionBucket",
-    "label" : "AWS bucket",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "feel" : "optional",
-    "group" : "downloadObject",
     "binding" : {
       "name" : "action.bucket",
       "type" : "zeebe:input"
@@ -442,17 +434,17 @@
       "equals" : "downloadObject",
       "type" : "simple"
     },
-    "tooltip" : "Bucket from where an object should be downloaded",
-    "type" : "String"
-  }, {
-    "id" : "downloadActionKey",
-    "label" : "AWS key",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "downloadObject",
+    "id" : "downloadActionBucket",
+    "label" : "AWS bucket",
+    "optional" : false,
+    "tooltip" : "Bucket from where an object should be downloaded",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "action.key",
       "type" : "zeebe:input"
@@ -462,24 +454,21 @@
       "equals" : "downloadObject",
       "type" : "simple"
     },
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "downloadObject",
+    "id" : "downloadActionKey",
+    "label" : "AWS key",
+    "optional" : false,
     "tooltip" : "Key of the object which should be downloaded",
     "type" : "String"
   }, {
-    "id" : "documentReturnFormat",
-    "label" : "Response format",
-    "value" : "DOCUMENT",
-    "group" : "downloadObject",
     "binding" : {
       "name" : "documentReturnFormat.choice",
       "type" : "zeebe:input"
     },
-    "condition" : {
-      "property" : "actionDiscriminator",
-      "equals" : "downloadObject",
-      "type" : "simple"
-    },
-    "tooltip" : "How the downloaded payload should be returned. Document reference uploads the payload to the document store; as text decodes it as a String; as JSON parses it into a structure you can access via dot notation.",
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "Document reference",
       "value" : "DOCUMENT"
@@ -489,14 +478,19 @@
     }, {
       "name" : "as JSON",
       "value" : "JSON"
-    } ]
-  }, {
-    "id" : "documentReturnFormatEncoding",
-    "label" : "Encoding",
-    "description" : "Character set used to decode the response. Default UTF-8.",
-    "value" : "UTF-8",
-    "feel" : "optional",
+    } ],
+    "condition" : {
+      "property" : "actionDiscriminator",
+      "equals" : "downloadObject",
+      "type" : "simple"
+    },
     "group" : "downloadObject",
+    "id" : "documentReturnFormat",
+    "label" : "Response format",
+    "tooltip" : "How the downloaded payload should be returned. Document reference uploads the payload to the document store; as text decodes it as a String; as JSON parses it into a structure you can access via dot notation.",
+    "type" : "Dropdown",
+    "value" : "DOCUMENT"
+  }, {
     "binding" : {
       "name" : "documentReturnFormat.encoding",
       "type" : "zeebe:input"
@@ -512,94 +506,100 @@
         "type" : "simple"
       } ]
     },
-    "type" : "String"
+    "description" : "Character set used to decode the response. Default UTF-8.",
+    "feel" : "optional",
+    "group" : "downloadObject",
+    "id" : "documentReturnFormatEncoding",
+    "label" : "Encoding",
+    "type" : "String",
+    "value" : "UTF-8"
   }, {
-    "id" : "version",
-    "label" : "Version",
-    "description" : "Version of the element template",
-    "value" : "6",
-    "group" : "connector",
     "binding" : {
       "key" : "elementTemplateVersion",
       "type" : "zeebe:taskHeader"
     },
-    "type" : "Hidden"
-  }, {
-    "id" : "id",
-    "label" : "ID",
-    "description" : "ID of the element template",
-    "value" : "io.camunda.connectors.aws.s3.v1",
+    "description" : "Version of the element template",
     "group" : "connector",
+    "id" : "version",
+    "label" : "Version",
+    "type" : "Hidden",
+    "value" : "6"
+  }, {
     "binding" : {
       "key" : "elementTemplateId",
       "type" : "zeebe:taskHeader"
     },
-    "type" : "Hidden"
+    "description" : "ID of the element template",
+    "group" : "connector",
+    "id" : "id",
+    "label" : "ID",
+    "type" : "Hidden",
+    "value" : "io.camunda.connectors.aws.s3.v1"
   }, {
-    "id" : "resultVariable",
-    "label" : "Result variable",
-    "description" : "Name of variable to store the response in. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-variable\" target=\"_blank\">documentation</a>.",
-    "group" : "output",
     "binding" : {
       "key" : "resultVariable",
       "type" : "zeebe:taskHeader"
     },
+    "description" : "Name of variable to store the response in. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-variable\" target=\"_blank\">documentation</a>.",
+    "group" : "output",
+    "id" : "resultVariable",
+    "label" : "Result variable",
     "type" : "String"
   }, {
-    "id" : "resultExpression",
-    "label" : "Result expression",
-    "description" : "Expression to map the response into process variables. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-expression\" target=\"_blank\">documentation</a>.",
-    "feel" : "required",
-    "group" : "output",
     "binding" : {
       "key" : "resultExpression",
       "type" : "zeebe:taskHeader"
     },
+    "description" : "Expression to map the response into process variables. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-expression\" target=\"_blank\">documentation</a>.",
+    "feel" : "required",
+    "group" : "output",
+    "id" : "resultExpression",
+    "label" : "Result expression",
     "type" : "Text"
   }, {
-    "id" : "errorExpression",
-    "label" : "Error expression",
-    "description" : "Expression to handle errors. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/\" target=\"_blank\">documentation</a>.",
-    "feel" : "required",
-    "group" : "error",
     "binding" : {
       "key" : "errorExpression",
       "type" : "zeebe:taskHeader"
     },
+    "description" : "Expression to handle errors. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/\" target=\"_blank\">documentation</a>.",
+    "feel" : "required",
+    "group" : "error",
+    "id" : "errorExpression",
+    "label" : "Error expression",
     "type" : "Text"
   }, {
-    "id" : "retryCount",
-    "label" : "Retries",
-    "description" : "Number of retries",
-    "value" : "3",
-    "feel" : "optional",
-    "group" : "retries",
     "binding" : {
       "property" : "retries",
       "type" : "zeebe:taskDefinition"
     },
-    "type" : "String"
-  }, {
-    "id" : "retryBackoff",
-    "label" : "Retry backoff",
-    "description" : "ISO-8601 duration to wait between retries",
-    "value" : "PT30S",
+    "description" : "Number of retries",
+    "feel" : "optional",
     "group" : "retries",
+    "id" : "retryCount",
+    "label" : "Retries",
+    "type" : "String",
+    "value" : "3"
+  }, {
     "binding" : {
       "key" : "retryBackoff",
       "type" : "zeebe:taskHeader"
     },
-    "type" : "String"
-  }, {
-    "id" : "jobTimeout",
-    "label" : "Job timeout",
-    "description" : "ISO-8601 duration after which Zeebe considers this job timed out if not yet completed. Leave empty to use the default timeout",
-    "optional" : true,
+    "description" : "ISO-8601 duration to wait between retries",
     "group" : "retries",
+    "id" : "retryBackoff",
+    "label" : "Retry backoff",
+    "type" : "String",
+    "value" : "PT30S"
+  }, {
     "binding" : {
       "key" : "jobTimeout",
       "type" : "zeebe:taskHeader"
     },
+    "description" : "ISO-8601 duration after which Zeebe considers this job timed out if not yet completed. Leave empty to use the default timeout",
+    "group" : "retries",
+    "id" : "jobTimeout",
+    "label" : "Job timeout",
+    "optional" : true,
     "type" : "String"
   } ],
   "steps" : [ {
@@ -640,30 +640,24 @@
     "version" : 1,
     "name" : "AWS Credential",
     "properties" : [ {
-      "id" : "authentication.type",
-      "label" : "Authentication",
-      "description" : "Specify AWS authentication strategy. Learn more at the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/aws-lambda/#aws-authentication-types\" target=\"_blank\">documentation page</a>",
-      "value" : "credentials",
-      "group" : "authentication",
       "binding" : {
         "name" : "authentication.type",
         "type" : "property"
       },
-      "type" : "Dropdown",
       "choices" : [ {
         "name" : "Default Credentials Chain (Hybrid/Self-Managed only)",
         "value" : "defaultCredentialsChain"
       }, {
         "name" : "Credentials",
         "value" : "credentials"
-      } ]
-    }, {
-      "id" : "authentication.accessKey",
-      "label" : "Access key",
-      "constraints" : {
-        "notEmpty" : true
-      },
+      } ],
+      "description" : "Specify AWS authentication strategy. Learn more at the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/aws-lambda/#aws-authentication-types\" target=\"_blank\">documentation page</a>",
       "group" : "authentication",
+      "id" : "authentication.type",
+      "label" : "Authentication",
+      "type" : "Dropdown",
+      "value" : "credentials"
+    }, {
       "binding" : {
         "name" : "authentication.accessKey",
         "type" : "property"
@@ -673,16 +667,16 @@
         "equals" : "credentials",
         "type" : "simple"
       },
-      "tooltip" : "IAM access key of a user with the necessary permissions for this connector",
-      "type" : "String",
-      "secret" : true
-    }, {
-      "id" : "authentication.secretKey",
-      "label" : "Secret key",
       "constraints" : {
         "notEmpty" : true
       },
       "group" : "authentication",
+      "id" : "authentication.accessKey",
+      "label" : "Access key",
+      "secret" : true,
+      "tooltip" : "IAM access key of a user with the necessary permissions for this connector",
+      "type" : "String"
+    }, {
       "binding" : {
         "name" : "authentication.secretKey",
         "type" : "property"
@@ -692,20 +686,26 @@
         "equals" : "credentials",
         "type" : "simple"
       },
-      "tooltip" : "IAM secret key of a user with the necessary permissions for this connector",
-      "type" : "String",
-      "secret" : true
-    }, {
-      "id" : "region",
-      "label" : "Region",
       "constraints" : {
         "notEmpty" : true
       },
-      "group" : "configuration",
+      "group" : "authentication",
+      "id" : "authentication.secretKey",
+      "label" : "Secret key",
+      "secret" : true,
+      "tooltip" : "IAM secret key of a user with the necessary permissions for this connector",
+      "type" : "String"
+    }, {
       "binding" : {
         "name" : "region",
         "type" : "property"
       },
+      "constraints" : {
+        "notEmpty" : true
+      },
+      "group" : "configuration",
+      "id" : "region",
+      "label" : "Region",
       "type" : "String"
     } ]
   } ],

--- a/connectors/aws/aws-s3/element-templates/hybrid/aws-s3-outbound-connector-hybrid.json
+++ b/connectors/aws/aws-s3/element-templates/hybrid/aws-s3-outbound-connector-hybrid.json
@@ -52,24 +52,19 @@
     "label" : "Retries"
   } ],
   "properties" : [ {
-    "id" : "taskDefinitionType",
-    "value" : "io.camunda:aws-s3:1",
-    "group" : "taskDefinitionType",
     "binding" : {
       "property" : "type",
       "type" : "zeebe:taskDefinition"
     },
-    "type" : "String"
+    "group" : "taskDefinitionType",
+    "id" : "taskDefinitionType",
+    "type" : "String",
+    "value" : "io.camunda:aws-s3:1"
   }, {
-    "id" : "actionDiscriminator",
-    "label" : "Action",
-    "value" : "uploadObject",
-    "group" : "operation",
     "binding" : {
       "name" : "actionDiscriminator",
       "type" : "zeebe:input"
     },
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "Delete object",
       "value" : "deleteObject"
@@ -79,34 +74,31 @@
     }, {
       "name" : "Upload object",
       "value" : "uploadObject"
-    } ]
+    } ],
+    "group" : "operation",
+    "id" : "actionDiscriminator",
+    "label" : "Action",
+    "type" : "Dropdown",
+    "value" : "uploadObject"
   }, {
-    "id" : "authentication.type",
-    "label" : "Authentication",
-    "description" : "Specify AWS authentication strategy. Learn more at the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/aws-lambda/#aws-authentication-types\" target=\"_blank\">documentation page</a>",
-    "value" : "credentials",
-    "group" : "authentication",
     "binding" : {
       "name" : "authentication.type",
       "type" : "zeebe:input"
     },
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "Default Credentials Chain (Hybrid/Self-Managed only)",
       "value" : "defaultCredentialsChain"
     }, {
       "name" : "Credentials",
       "value" : "credentials"
-    } ]
-  }, {
-    "id" : "authentication.accessKey",
-    "label" : "Access key",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "feel" : "optional",
+    } ],
+    "description" : "Specify AWS authentication strategy. Learn more at the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/aws-lambda/#aws-authentication-types\" target=\"_blank\">documentation page</a>",
     "group" : "authentication",
+    "id" : "authentication.type",
+    "label" : "Authentication",
+    "type" : "Dropdown",
+    "value" : "credentials"
+  }, {
     "binding" : {
       "name" : "authentication.accessKey",
       "type" : "zeebe:input"
@@ -116,18 +108,18 @@
       "equals" : "credentials",
       "type" : "simple"
     },
-    "tooltip" : "IAM access key of a user with the necessary permissions for this connector",
-    "type" : "String",
-    "secret" : true
-  }, {
-    "id" : "authentication.secretKey",
-    "label" : "Secret key",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "authentication",
+    "id" : "authentication.accessKey",
+    "label" : "Access key",
+    "optional" : false,
+    "secret" : true,
+    "tooltip" : "IAM access key of a user with the necessary permissions for this connector",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "authentication.secretKey",
       "type" : "zeebe:input"
@@ -137,75 +129,75 @@
       "equals" : "credentials",
       "type" : "simple"
     },
-    "tooltip" : "IAM secret key of a user with the necessary permissions for this connector",
-    "type" : "String",
-    "secret" : true
-  }, {
-    "id" : "awsCredential",
-    "label" : "AWS credential",
-    "description" : "Choose a reusable AWS credential. When set, it is bound as a whole to the connector's 'awsCredential' input.",
-    "optional" : true,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
     "group" : "authentication",
+    "id" : "authentication.secretKey",
+    "label" : "Secret key",
+    "optional" : false,
+    "secret" : true,
+    "tooltip" : "IAM secret key of a user with the necessary permissions for this connector",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "awsCredential",
       "type" : "zeebe:input"
     },
-    "type" : "Configuration",
-    "configurationTemplate" : "io.camunda:aws-credential:1"
+    "configurationTemplate" : "io.camunda:aws-credential:1",
+    "description" : "Choose a reusable AWS credential. When set, it is bound as a whole to the connector's 'awsCredential' input.",
+    "group" : "authentication",
+    "id" : "awsCredential",
+    "label" : "AWS credential",
+    "optional" : true,
+    "type" : "Configuration"
   }, {
-    "id" : "configuration.region",
-    "label" : "Region",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "feel" : "optional",
-    "group" : "configuration",
     "binding" : {
       "name" : "configuration.region",
       "type" : "zeebe:input"
     },
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "configuration",
+    "id" : "configuration.region",
+    "label" : "Region",
+    "optional" : false,
     "type" : "String"
   }, {
-    "id" : "configuration.endpoint",
-    "label" : "Endpoint",
-    "description" : "Specify endpoint if need to use custom endpoint",
-    "optional" : true,
-    "group" : "configuration",
     "binding" : {
       "name" : "configuration.endpoint",
       "type" : "zeebe:input"
     },
+    "description" : "Specify endpoint if need to use custom endpoint",
+    "group" : "configuration",
+    "id" : "configuration.endpoint",
+    "label" : "Endpoint",
+    "optional" : true,
     "type" : "Hidden"
   }, {
+    "binding" : {
+      "name" : "action.bucket",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "actionDiscriminator",
+      "equals" : "deleteObject",
+      "type" : "simple"
+    },
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "deleteObject",
     "id" : "deleteActionBucket",
     "label" : "AWS bucket",
     "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "feel" : "optional",
-    "group" : "deleteObject",
-    "binding" : {
-      "name" : "action.bucket",
-      "type" : "zeebe:input"
-    },
-    "condition" : {
-      "property" : "actionDiscriminator",
-      "equals" : "deleteObject",
-      "type" : "simple"
-    },
     "tooltip" : "Bucket from where an object should be deleted",
     "type" : "String"
   }, {
-    "id" : "deleteActionKey",
-    "label" : "AWS key",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "feel" : "optional",
-    "group" : "deleteObject",
     "binding" : {
       "name" : "action.key",
       "type" : "zeebe:input"
@@ -215,17 +207,17 @@
       "equals" : "deleteObject",
       "type" : "simple"
     },
-    "tooltip" : "Key of the object which should be deleted",
-    "type" : "String"
-  }, {
-    "id" : "uploadActionBucket",
-    "label" : "AWS bucket",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
-    "group" : "uploadObject",
+    "group" : "deleteObject",
+    "id" : "deleteActionKey",
+    "label" : "AWS key",
+    "optional" : false,
+    "tooltip" : "Key of the object which should be deleted",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "action.bucket",
       "type" : "zeebe:input"
@@ -235,14 +227,17 @@
       "equals" : "uploadObject",
       "type" : "simple"
     },
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "uploadObject",
+    "id" : "uploadActionBucket",
+    "label" : "AWS bucket",
+    "optional" : false,
     "tooltip" : "Bucket from where an object should be uploaded",
     "type" : "String"
   }, {
-    "id" : "uploadActionKey",
-    "label" : "AWS key",
-    "optional" : true,
-    "feel" : "optional",
-    "group" : "uploadObject",
     "binding" : {
       "name" : "action.key",
       "type" : "zeebe:input"
@@ -252,24 +247,18 @@
       "equals" : "uploadObject",
       "type" : "simple"
     },
+    "feel" : "optional",
+    "group" : "uploadObject",
+    "id" : "uploadActionKey",
+    "label" : "AWS key",
+    "optional" : true,
     "tooltip" : "Key of the uploaded object, if not given. The file name from the document metadata will be used",
     "type" : "String"
   }, {
-    "id" : "action_document_documentSource",
-    "label" : "Document source",
-    "value" : "camunda",
-    "group" : "uploadObject",
     "binding" : {
       "name" : "action.action_document_documentSource",
       "type" : "zeebe:input"
     },
-    "condition" : {
-      "property" : "actionDiscriminator",
-      "equals" : "uploadObject",
-      "type" : "simple"
-    },
-    "tooltip" : "Document to be uploaded on AWS S3",
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "Camunda Document",
       "value" : "camunda"
@@ -279,15 +268,19 @@
     }, {
       "name" : "From URL",
       "value" : "external"
-    } ]
-  }, {
-    "id" : "action_document_camundaReference",
-    "label" : "Camunda document",
-    "constraints" : {
-      "notEmpty" : true
+    } ],
+    "condition" : {
+      "property" : "actionDiscriminator",
+      "equals" : "uploadObject",
+      "type" : "simple"
     },
-    "feel" : "required",
     "group" : "uploadObject",
+    "id" : "action_document_documentSource",
+    "label" : "Document source",
+    "tooltip" : "Document to be uploaded on AWS S3",
+    "type" : "Dropdown",
+    "value" : "camunda"
+  }, {
     "binding" : {
       "name" : "action.action_document_camundaReference",
       "type" : "zeebe:input"
@@ -303,15 +296,15 @@
         "type" : "simple"
       } ]
     },
-    "type" : "String"
-  }, {
-    "id" : "action_document_inline_content",
-    "label" : "Content",
     "constraints" : {
       "notEmpty" : true
     },
-    "feel" : "optional",
+    "feel" : "required",
     "group" : "uploadObject",
+    "id" : "action_document_camundaReference",
+    "label" : "Camunda document",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "action.action_document_inline_content",
       "type" : "zeebe:input"
@@ -327,12 +320,15 @@
         "type" : "simple"
       } ]
     },
-    "type" : "String"
-  }, {
-    "id" : "action_document_inline_fileName",
-    "label" : "File name",
+    "constraints" : {
+      "notEmpty" : true
+    },
     "feel" : "optional",
     "group" : "uploadObject",
+    "id" : "action_document_inline_content",
+    "label" : "Content",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "action.action_document_inline_fileName",
       "type" : "zeebe:input"
@@ -348,12 +344,12 @@
         "type" : "simple"
       } ]
     },
-    "type" : "String"
-  }, {
-    "id" : "action_document_inline_contentType",
-    "label" : "Content type",
     "feel" : "optional",
     "group" : "uploadObject",
+    "id" : "action_document_inline_fileName",
+    "label" : "File name",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "action.action_document_inline_contentType",
       "type" : "zeebe:input"
@@ -369,15 +365,12 @@
         "type" : "simple"
       } ]
     },
-    "type" : "String"
-  }, {
-    "id" : "action_document_external_url",
-    "label" : "URL",
-    "constraints" : {
-      "notEmpty" : true
-    },
     "feel" : "optional",
     "group" : "uploadObject",
+    "id" : "action_document_inline_contentType",
+    "label" : "Content type",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "action.action_document_external_url",
       "type" : "zeebe:input"
@@ -393,12 +386,15 @@
         "type" : "simple"
       } ]
     },
-    "type" : "String"
-  }, {
-    "id" : "action_document_external_fileName",
-    "label" : "File name",
+    "constraints" : {
+      "notEmpty" : true
+    },
     "feel" : "optional",
     "group" : "uploadObject",
+    "id" : "action_document_external_url",
+    "label" : "URL",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "action.action_document_external_fileName",
       "type" : "zeebe:input"
@@ -414,11 +410,12 @@
         "type" : "simple"
       } ]
     },
+    "feel" : "optional",
+    "group" : "uploadObject",
+    "id" : "action_document_external_fileName",
+    "label" : "File name",
     "type" : "String"
   }, {
-    "id" : "uploadActionDocument",
-    "value" : "=if action_document_documentSource = \"camunda\" then action_document_camundaReference else if action_document_documentSource = \"inline\" then { \"camunda.document.type\": \"inline\", content: action_document_inline_content, name: action_document_inline_fileName, contentType: action_document_inline_contentType } else if action_document_documentSource = \"external\" then { \"camunda.document.type\": \"external\", url: action_document_external_url, name: action_document_external_fileName } else null",
-    "group" : "uploadObject",
     "binding" : {
       "name" : "action.document",
       "type" : "zeebe:input"
@@ -428,16 +425,11 @@
       "equals" : "uploadObject",
       "type" : "simple"
     },
-    "type" : "Hidden"
+    "group" : "uploadObject",
+    "id" : "uploadActionDocument",
+    "type" : "Hidden",
+    "value" : "=if action_document_documentSource = \"camunda\" then action_document_camundaReference else if action_document_documentSource = \"inline\" then { \"camunda.document.type\": \"inline\", content: action_document_inline_content, name: action_document_inline_fileName, contentType: action_document_inline_contentType } else if action_document_documentSource = \"external\" then { \"camunda.document.type\": \"external\", url: action_document_external_url, name: action_document_external_fileName } else null"
   }, {
-    "id" : "downloadActionBucket",
-    "label" : "AWS bucket",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "feel" : "optional",
-    "group" : "downloadObject",
     "binding" : {
       "name" : "action.bucket",
       "type" : "zeebe:input"
@@ -447,17 +439,17 @@
       "equals" : "downloadObject",
       "type" : "simple"
     },
-    "tooltip" : "Bucket from where an object should be downloaded",
-    "type" : "String"
-  }, {
-    "id" : "downloadActionKey",
-    "label" : "AWS key",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "downloadObject",
+    "id" : "downloadActionBucket",
+    "label" : "AWS bucket",
+    "optional" : false,
+    "tooltip" : "Bucket from where an object should be downloaded",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "action.key",
       "type" : "zeebe:input"
@@ -467,24 +459,21 @@
       "equals" : "downloadObject",
       "type" : "simple"
     },
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "downloadObject",
+    "id" : "downloadActionKey",
+    "label" : "AWS key",
+    "optional" : false,
     "tooltip" : "Key of the object which should be downloaded",
     "type" : "String"
   }, {
-    "id" : "documentReturnFormat",
-    "label" : "Response format",
-    "value" : "DOCUMENT",
-    "group" : "downloadObject",
     "binding" : {
       "name" : "documentReturnFormat.choice",
       "type" : "zeebe:input"
     },
-    "condition" : {
-      "property" : "actionDiscriminator",
-      "equals" : "downloadObject",
-      "type" : "simple"
-    },
-    "tooltip" : "How the downloaded payload should be returned. Document reference uploads the payload to the document store; as text decodes it as a String; as JSON parses it into a structure you can access via dot notation.",
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "Document reference",
       "value" : "DOCUMENT"
@@ -494,14 +483,19 @@
     }, {
       "name" : "as JSON",
       "value" : "JSON"
-    } ]
-  }, {
-    "id" : "documentReturnFormatEncoding",
-    "label" : "Encoding",
-    "description" : "Character set used to decode the response. Default UTF-8.",
-    "value" : "UTF-8",
-    "feel" : "optional",
+    } ],
+    "condition" : {
+      "property" : "actionDiscriminator",
+      "equals" : "downloadObject",
+      "type" : "simple"
+    },
     "group" : "downloadObject",
+    "id" : "documentReturnFormat",
+    "label" : "Response format",
+    "tooltip" : "How the downloaded payload should be returned. Document reference uploads the payload to the document store; as text decodes it as a String; as JSON parses it into a structure you can access via dot notation.",
+    "type" : "Dropdown",
+    "value" : "DOCUMENT"
+  }, {
     "binding" : {
       "name" : "documentReturnFormat.encoding",
       "type" : "zeebe:input"
@@ -517,94 +511,100 @@
         "type" : "simple"
       } ]
     },
-    "type" : "String"
+    "description" : "Character set used to decode the response. Default UTF-8.",
+    "feel" : "optional",
+    "group" : "downloadObject",
+    "id" : "documentReturnFormatEncoding",
+    "label" : "Encoding",
+    "type" : "String",
+    "value" : "UTF-8"
   }, {
-    "id" : "version",
-    "label" : "Version",
-    "description" : "Version of the element template",
-    "value" : "6",
-    "group" : "connector",
     "binding" : {
       "key" : "elementTemplateVersion",
       "type" : "zeebe:taskHeader"
     },
-    "type" : "Hidden"
-  }, {
-    "id" : "id",
-    "label" : "ID",
-    "description" : "ID of the element template",
-    "value" : "io.camunda.connectors.aws.s3.v1",
+    "description" : "Version of the element template",
     "group" : "connector",
+    "id" : "version",
+    "label" : "Version",
+    "type" : "Hidden",
+    "value" : "6"
+  }, {
     "binding" : {
       "key" : "elementTemplateId",
       "type" : "zeebe:taskHeader"
     },
-    "type" : "Hidden"
+    "description" : "ID of the element template",
+    "group" : "connector",
+    "id" : "id",
+    "label" : "ID",
+    "type" : "Hidden",
+    "value" : "io.camunda.connectors.aws.s3.v1"
   }, {
-    "id" : "resultVariable",
-    "label" : "Result variable",
-    "description" : "Name of variable to store the response in. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-variable\" target=\"_blank\">documentation</a>.",
-    "group" : "output",
     "binding" : {
       "key" : "resultVariable",
       "type" : "zeebe:taskHeader"
     },
+    "description" : "Name of variable to store the response in. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-variable\" target=\"_blank\">documentation</a>.",
+    "group" : "output",
+    "id" : "resultVariable",
+    "label" : "Result variable",
     "type" : "String"
   }, {
-    "id" : "resultExpression",
-    "label" : "Result expression",
-    "description" : "Expression to map the response into process variables. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-expression\" target=\"_blank\">documentation</a>.",
-    "feel" : "required",
-    "group" : "output",
     "binding" : {
       "key" : "resultExpression",
       "type" : "zeebe:taskHeader"
     },
+    "description" : "Expression to map the response into process variables. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-expression\" target=\"_blank\">documentation</a>.",
+    "feel" : "required",
+    "group" : "output",
+    "id" : "resultExpression",
+    "label" : "Result expression",
     "type" : "Text"
   }, {
-    "id" : "errorExpression",
-    "label" : "Error expression",
-    "description" : "Expression to handle errors. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/\" target=\"_blank\">documentation</a>.",
-    "feel" : "required",
-    "group" : "error",
     "binding" : {
       "key" : "errorExpression",
       "type" : "zeebe:taskHeader"
     },
+    "description" : "Expression to handle errors. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/\" target=\"_blank\">documentation</a>.",
+    "feel" : "required",
+    "group" : "error",
+    "id" : "errorExpression",
+    "label" : "Error expression",
     "type" : "Text"
   }, {
-    "id" : "retryCount",
-    "label" : "Retries",
-    "description" : "Number of retries",
-    "value" : "3",
-    "feel" : "optional",
-    "group" : "retries",
     "binding" : {
       "property" : "retries",
       "type" : "zeebe:taskDefinition"
     },
-    "type" : "String"
-  }, {
-    "id" : "retryBackoff",
-    "label" : "Retry backoff",
-    "description" : "ISO-8601 duration to wait between retries",
-    "value" : "PT30S",
+    "description" : "Number of retries",
+    "feel" : "optional",
     "group" : "retries",
+    "id" : "retryCount",
+    "label" : "Retries",
+    "type" : "String",
+    "value" : "3"
+  }, {
     "binding" : {
       "key" : "retryBackoff",
       "type" : "zeebe:taskHeader"
     },
-    "type" : "String"
-  }, {
-    "id" : "jobTimeout",
-    "label" : "Job timeout",
-    "description" : "ISO-8601 duration after which Zeebe considers this job timed out if not yet completed. Leave empty to use the default timeout",
-    "optional" : true,
+    "description" : "ISO-8601 duration to wait between retries",
     "group" : "retries",
+    "id" : "retryBackoff",
+    "label" : "Retry backoff",
+    "type" : "String",
+    "value" : "PT30S"
+  }, {
     "binding" : {
       "key" : "jobTimeout",
       "type" : "zeebe:taskHeader"
     },
+    "description" : "ISO-8601 duration after which Zeebe considers this job timed out if not yet completed. Leave empty to use the default timeout",
+    "group" : "retries",
+    "id" : "jobTimeout",
+    "label" : "Job timeout",
+    "optional" : true,
     "type" : "String"
   } ],
   "steps" : [ {
@@ -645,30 +645,24 @@
     "version" : 1,
     "name" : "AWS Credential",
     "properties" : [ {
-      "id" : "authentication.type",
-      "label" : "Authentication",
-      "description" : "Specify AWS authentication strategy. Learn more at the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/aws-lambda/#aws-authentication-types\" target=\"_blank\">documentation page</a>",
-      "value" : "credentials",
-      "group" : "authentication",
       "binding" : {
         "name" : "authentication.type",
         "type" : "property"
       },
-      "type" : "Dropdown",
       "choices" : [ {
         "name" : "Default Credentials Chain (Hybrid/Self-Managed only)",
         "value" : "defaultCredentialsChain"
       }, {
         "name" : "Credentials",
         "value" : "credentials"
-      } ]
-    }, {
-      "id" : "authentication.accessKey",
-      "label" : "Access key",
-      "constraints" : {
-        "notEmpty" : true
-      },
+      } ],
+      "description" : "Specify AWS authentication strategy. Learn more at the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/aws-lambda/#aws-authentication-types\" target=\"_blank\">documentation page</a>",
       "group" : "authentication",
+      "id" : "authentication.type",
+      "label" : "Authentication",
+      "type" : "Dropdown",
+      "value" : "credentials"
+    }, {
       "binding" : {
         "name" : "authentication.accessKey",
         "type" : "property"
@@ -678,16 +672,16 @@
         "equals" : "credentials",
         "type" : "simple"
       },
-      "tooltip" : "IAM access key of a user with the necessary permissions for this connector",
-      "type" : "String",
-      "secret" : true
-    }, {
-      "id" : "authentication.secretKey",
-      "label" : "Secret key",
       "constraints" : {
         "notEmpty" : true
       },
       "group" : "authentication",
+      "id" : "authentication.accessKey",
+      "label" : "Access key",
+      "secret" : true,
+      "tooltip" : "IAM access key of a user with the necessary permissions for this connector",
+      "type" : "String"
+    }, {
       "binding" : {
         "name" : "authentication.secretKey",
         "type" : "property"
@@ -697,20 +691,26 @@
         "equals" : "credentials",
         "type" : "simple"
       },
-      "tooltip" : "IAM secret key of a user with the necessary permissions for this connector",
-      "type" : "String",
-      "secret" : true
-    }, {
-      "id" : "region",
-      "label" : "Region",
       "constraints" : {
         "notEmpty" : true
       },
-      "group" : "configuration",
+      "group" : "authentication",
+      "id" : "authentication.secretKey",
+      "label" : "Secret key",
+      "secret" : true,
+      "tooltip" : "IAM secret key of a user with the necessary permissions for this connector",
+      "type" : "String"
+    }, {
       "binding" : {
         "name" : "region",
         "type" : "property"
       },
+      "constraints" : {
+        "notEmpty" : true
+      },
+      "group" : "configuration",
+      "id" : "region",
+      "label" : "Region",
       "type" : "String"
     } ]
   } ],

--- a/connectors/aws/aws-textract/element-templates/aws-textract-outbound-connector.json
+++ b/connectors/aws/aws-textract/element-templates/aws-textract-outbound-connector.json
@@ -46,39 +46,31 @@
     "label" : "Retries"
   } ],
   "properties" : [ {
-    "value" : "io.camunda:aws-textract:1",
     "binding" : {
       "property" : "type",
       "type" : "zeebe:taskDefinition"
     },
-    "type" : "Hidden"
+    "type" : "Hidden",
+    "value" : "io.camunda:aws-textract:1"
   }, {
-    "id" : "authentication.type",
-    "label" : "Authentication",
-    "description" : "Specify AWS authentication strategy. Learn more at the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/aws-lambda/#aws-authentication-types\" target=\"_blank\">documentation page</a>",
-    "value" : "credentials",
-    "group" : "authentication",
     "binding" : {
       "name" : "authentication.type",
       "type" : "zeebe:input"
     },
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "Default Credentials Chain (Hybrid/Self-Managed only)",
       "value" : "defaultCredentialsChain"
     }, {
       "name" : "Credentials",
       "value" : "credentials"
-    } ]
-  }, {
-    "id" : "authentication.accessKey",
-    "label" : "Access key",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "feel" : "optional",
+    } ],
+    "description" : "Specify AWS authentication strategy. Learn more at the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/aws-lambda/#aws-authentication-types\" target=\"_blank\">documentation page</a>",
     "group" : "authentication",
+    "id" : "authentication.type",
+    "label" : "Authentication",
+    "type" : "Dropdown",
+    "value" : "credentials"
+  }, {
     "binding" : {
       "name" : "authentication.accessKey",
       "type" : "zeebe:input"
@@ -88,18 +80,18 @@
       "equals" : "credentials",
       "type" : "simple"
     },
-    "tooltip" : "IAM access key of a user with the necessary permissions for this connector",
-    "type" : "String",
-    "secret" : true
-  }, {
-    "id" : "authentication.secretKey",
-    "label" : "Secret key",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "authentication",
+    "id" : "authentication.accessKey",
+    "label" : "Access key",
+    "optional" : false,
+    "secret" : true,
+    "tooltip" : "IAM access key of a user with the necessary permissions for this connector",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "authentication.secretKey",
       "type" : "zeebe:input"
@@ -109,74 +101,74 @@
       "equals" : "credentials",
       "type" : "simple"
     },
-    "tooltip" : "IAM secret key of a user with the necessary permissions for this connector",
-    "type" : "String",
-    "secret" : true
-  }, {
-    "id" : "awsCredential",
-    "label" : "AWS credential",
-    "description" : "Choose a reusable AWS credential. When set, it is bound as a whole to the connector's 'awsCredential' input.",
-    "optional" : true,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
     "group" : "authentication",
+    "id" : "authentication.secretKey",
+    "label" : "Secret key",
+    "optional" : false,
+    "secret" : true,
+    "tooltip" : "IAM secret key of a user with the necessary permissions for this connector",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "awsCredential",
       "type" : "zeebe:input"
     },
-    "type" : "Configuration",
-    "configurationTemplate" : "io.camunda:aws-credential:1"
+    "configurationTemplate" : "io.camunda:aws-credential:1",
+    "description" : "Choose a reusable AWS credential. When set, it is bound as a whole to the connector's 'awsCredential' input.",
+    "group" : "authentication",
+    "id" : "awsCredential",
+    "label" : "AWS credential",
+    "optional" : true,
+    "type" : "Configuration"
   }, {
-    "id" : "configuration.region",
-    "label" : "Region",
-    "optional" : false,
+    "binding" : {
+      "name" : "configuration.region",
+      "type" : "zeebe:input"
+    },
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "configuration",
-    "binding" : {
-      "name" : "configuration.region",
-      "type" : "zeebe:input"
-    },
+    "id" : "configuration.region",
+    "label" : "Region",
+    "optional" : false,
     "type" : "String"
   }, {
-    "id" : "configuration.endpoint",
-    "label" : "Endpoint",
-    "description" : "Specify endpoint if need to use custom endpoint",
-    "optional" : true,
-    "group" : "configuration",
     "binding" : {
       "name" : "configuration.endpoint",
       "type" : "zeebe:input"
     },
+    "description" : "Specify endpoint if need to use custom endpoint",
+    "group" : "configuration",
+    "id" : "configuration.endpoint",
+    "label" : "Endpoint",
+    "optional" : true,
     "type" : "Hidden"
   }, {
-    "id" : "input.documentLocationType",
-    "label" : "Document source",
-    "optional" : false,
-    "value" : "S3",
-    "group" : "document",
     "binding" : {
       "name" : "input.documentLocationType",
       "type" : "zeebe:input"
     },
-    "tooltip" : "Source of the input document to be analyzed.",
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "Camunda Document",
       "value" : "UPLOADED"
     }, {
       "name" : "S3",
       "value" : "S3"
-    } ]
-  }, {
-    "id" : "input.documentS3Bucket",
-    "label" : "Document bucket",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "feel" : "optional",
+    } ],
     "group" : "document",
+    "id" : "input.documentLocationType",
+    "label" : "Document source",
+    "optional" : false,
+    "tooltip" : "Source of the input document to be analyzed.",
+    "type" : "Dropdown",
+    "value" : "S3"
+  }, {
     "binding" : {
       "name" : "input.documentS3Bucket",
       "type" : "zeebe:input"
@@ -186,17 +178,17 @@
       "equals" : "S3",
       "type" : "simple"
     },
-    "tooltip" : "S3 bucket that contains the document to be analyzed.",
-    "type" : "String"
-  }, {
-    "id" : "input.documentName",
-    "label" : "Document name",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "document",
+    "id" : "input.documentS3Bucket",
+    "label" : "Document bucket",
+    "optional" : false,
+    "tooltip" : "S3 bucket that contains the document to be analyzed.",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "input.documentName",
       "type" : "zeebe:input"
@@ -206,14 +198,17 @@
       "equals" : "S3",
       "type" : "simple"
     },
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "document",
+    "id" : "input.documentName",
+    "label" : "Document name",
+    "optional" : false,
     "tooltip" : "Name of the document to be analyzed in the S3 bucket.",
     "type" : "String"
   }, {
-    "id" : "input.documentVersion",
-    "label" : "Document version",
-    "optional" : true,
-    "feel" : "optional",
-    "group" : "document",
     "binding" : {
       "name" : "input.documentVersion",
       "type" : "zeebe:input"
@@ -223,17 +218,14 @@
       "equals" : "S3",
       "type" : "simple"
     },
+    "feel" : "optional",
+    "group" : "document",
+    "id" : "input.documentVersion",
+    "label" : "Document version",
+    "optional" : true,
     "tooltip" : "Version of the document to be analyzed in the S3 bucket.",
     "type" : "String"
   }, {
-    "id" : "input.document",
-    "label" : "Camunda Document",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "feel" : "required",
-    "group" : "document",
     "binding" : {
       "name" : "input.document",
       "type" : "zeebe:input"
@@ -243,28 +235,21 @@
       "equals" : "UPLOADED",
       "type" : "simple"
     },
-    "tooltip" : "The Camunda document to be analyzed.",
-    "type" : "String"
-  }, {
-    "id" : "input.executionType",
-    "label" : "Execution type",
-    "optional" : false,
-    "value" : "POLLING",
     "constraints" : {
       "notEmpty" : true
     },
-    "group" : "input",
+    "feel" : "required",
+    "group" : "document",
+    "id" : "input.document",
+    "label" : "Camunda Document",
+    "optional" : false,
+    "tooltip" : "The Camunda document to be analyzed.",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "input.executionType",
       "type" : "zeebe:input"
     },
-    "condition" : {
-      "property" : "input.documentLocationType",
-      "equals" : "S3",
-      "type" : "simple"
-    },
-    "tooltip" : "How the document should be processed. See more info in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-textract/#execution-types\" target=\"_blank\">Amazon Textract execution types documentation</a>.",
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "Asynchronous",
       "value" : "ASYNC"
@@ -274,93 +259,103 @@
     }, {
       "name" : "Polling",
       "value" : "POLLING"
-    } ]
-  }, {
-    "id" : "input.analyzeTables",
-    "label" : "Analyze tables",
-    "optional" : false,
-    "value" : true,
+    } ],
+    "condition" : {
+      "property" : "input.documentLocationType",
+      "equals" : "S3",
+      "type" : "simple"
+    },
     "constraints" : {
       "notEmpty" : true
     },
-    "feel" : "static",
     "group" : "input",
+    "id" : "input.executionType",
+    "label" : "Execution type",
+    "optional" : false,
+    "tooltip" : "How the document should be processed. See more info in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-textract/#execution-types\" target=\"_blank\">Amazon Textract execution types documentation</a>.",
+    "type" : "Dropdown",
+    "value" : "POLLING"
+  }, {
     "binding" : {
       "name" : "input.analyzeTables",
       "type" : "zeebe:input"
     },
-    "tooltip" : "Select this to return information about the tables that are detected in the input document.",
-    "type" : "Boolean"
-  }, {
-    "id" : "input.analyzeForms",
-    "label" : "Analyze form",
-    "optional" : false,
-    "value" : true,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "static",
     "group" : "input",
+    "id" : "input.analyzeTables",
+    "label" : "Analyze tables",
+    "optional" : false,
+    "tooltip" : "Select this to return information about the tables that are detected in the input document.",
+    "type" : "Boolean",
+    "value" : true
+  }, {
     "binding" : {
       "name" : "input.analyzeForms",
       "type" : "zeebe:input"
     },
-    "tooltip" : "Select this to return information about detected form data.",
-    "type" : "Boolean"
-  }, {
-    "id" : "input.analyzeSignatures",
-    "label" : "Analyze signatures",
-    "optional" : false,
-    "value" : true,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "static",
     "group" : "input",
+    "id" : "input.analyzeForms",
+    "label" : "Analyze form",
+    "optional" : false,
+    "tooltip" : "Select this to return information about detected form data.",
+    "type" : "Boolean",
+    "value" : true
+  }, {
     "binding" : {
       "name" : "input.analyzeSignatures",
       "type" : "zeebe:input"
     },
-    "tooltip" : "Select this to return the locations of detected signatures.",
-    "type" : "Boolean"
-  }, {
-    "id" : "input.analyzeLayout",
-    "label" : "Analyze layout",
-    "optional" : false,
-    "value" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "static",
     "group" : "input",
+    "id" : "input.analyzeSignatures",
+    "label" : "Analyze signatures",
+    "optional" : false,
+    "tooltip" : "Select this to return the locations of detected signatures.",
+    "type" : "Boolean",
+    "value" : true
+  }, {
     "binding" : {
       "name" : "input.analyzeLayout",
       "type" : "zeebe:input"
     },
-    "tooltip" : "Select this to return information about the layout of the document.",
-    "type" : "Boolean"
-  }, {
-    "id" : "input.analyzeQueries",
-    "label" : "Analyze queries",
-    "optional" : false,
-    "value" : true,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "static",
     "group" : "input",
+    "id" : "input.analyzeLayout",
+    "label" : "Analyze layout",
+    "optional" : false,
+    "tooltip" : "Select this to return information about the layout of the document.",
+    "type" : "Boolean",
+    "value" : false
+  }, {
     "binding" : {
       "name" : "input.analyzeQueries",
       "type" : "zeebe:input"
     },
-    "tooltip" : "Select this to return an answer to a query run against the document.",
-    "type" : "Boolean"
-  }, {
-    "id" : "input.query",
-    "label" : "Query",
-    "optional" : false,
-    "feel" : "optional",
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "static",
     "group" : "input",
+    "id" : "input.analyzeQueries",
+    "label" : "Analyze queries",
+    "optional" : false,
+    "tooltip" : "Select this to return an answer to a query run against the document.",
+    "type" : "Boolean",
+    "value" : true
+  }, {
     "binding" : {
       "name" : "input.query",
       "type" : "zeebe:input"
@@ -370,18 +365,15 @@
       "equals" : true,
       "type" : "simple"
     },
-    "tooltip" : "A natural-language question applied to the document; Textract returns the extracted answer.",
-    "placeholder" : "What is the IBAN in the invoice?",
-    "type" : "String"
-  }, {
-    "id" : "input.outputConfigS3Bucket",
-    "label" : "Output S3 bucket",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
     "feel" : "optional",
     "group" : "input",
+    "id" : "input.query",
+    "label" : "Query",
+    "optional" : false,
+    "placeholder" : "What is the IBAN in the invoice?",
+    "tooltip" : "A natural-language question applied to the document; Textract returns the extracted answer.",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "input.outputConfigS3Bucket",
       "type" : "zeebe:input"
@@ -391,17 +383,17 @@
       "equals" : "ASYNC",
       "type" : "simple"
     },
-    "tooltip" : "The name of the bucket your output will go to.",
-    "type" : "String"
-  }, {
-    "id" : "input.outputConfigS3Prefix",
-    "label" : "Output S3 prefix",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "input",
+    "id" : "input.outputConfigS3Bucket",
+    "label" : "Output S3 bucket",
+    "optional" : false,
+    "tooltip" : "The name of the bucket your output will go to.",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "input.outputConfigS3Prefix",
       "type" : "zeebe:input"
@@ -411,14 +403,17 @@
       "equals" : "ASYNC",
       "type" : "simple"
     },
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "input",
+    "id" : "input.outputConfigS3Prefix",
+    "label" : "Output S3 prefix",
+    "optional" : false,
     "tooltip" : "The prefix of the object key that the output will be saved to.",
     "type" : "String"
   }, {
-    "id" : "input.clientRequestToken",
-    "label" : "Client request token",
-    "optional" : true,
-    "feel" : "optional",
-    "group" : "advanced",
     "binding" : {
       "name" : "input.clientRequestToken",
       "type" : "zeebe:input"
@@ -428,14 +423,14 @@
       "equals" : "ASYNC",
       "type" : "simple"
     },
+    "feel" : "optional",
+    "group" : "advanced",
+    "id" : "input.clientRequestToken",
+    "label" : "Client request token",
+    "optional" : true,
     "tooltip" : "The idempotent token that you use to identify the start request.",
     "type" : "String"
   }, {
-    "id" : "input.jobTag",
-    "label" : "Job tag",
-    "optional" : true,
-    "feel" : "optional",
-    "group" : "advanced",
     "binding" : {
       "name" : "input.jobTag",
       "type" : "zeebe:input"
@@ -445,14 +440,14 @@
       "equals" : "ASYNC",
       "type" : "simple"
     },
+    "feel" : "optional",
+    "group" : "advanced",
+    "id" : "input.jobTag",
+    "label" : "Job tag",
+    "optional" : true,
     "tooltip" : "An identifier that you specify that's included in the completion notification published to the Amazon SNS topic.",
     "type" : "String"
   }, {
-    "id" : "input.kmsKeyId",
-    "label" : "KMS key ID",
-    "optional" : true,
-    "feel" : "optional",
-    "group" : "advanced",
     "binding" : {
       "name" : "input.kmsKeyId",
       "type" : "zeebe:input"
@@ -462,14 +457,14 @@
       "equals" : "ASYNC",
       "type" : "simple"
     },
+    "feel" : "optional",
+    "group" : "advanced",
+    "id" : "input.kmsKeyId",
+    "label" : "KMS key ID",
+    "optional" : true,
     "tooltip" : "The KMS key used to encrypt the inference results.",
     "type" : "String"
   }, {
-    "id" : "input.notificationChannelRoleArn",
-    "label" : "Notification channel role ARN",
-    "optional" : true,
-    "feel" : "optional",
-    "group" : "advanced",
     "binding" : {
       "name" : "input.notificationChannelRoleArn",
       "type" : "zeebe:input"
@@ -479,14 +474,14 @@
       "equals" : "ASYNC",
       "type" : "simple"
     },
+    "feel" : "optional",
+    "group" : "advanced",
+    "id" : "input.notificationChannelRoleArn",
+    "label" : "Notification channel role ARN",
+    "optional" : true,
     "tooltip" : "The Amazon SNS topic role ARN that you want Amazon Textract to publish the completion status of the operation to.",
     "type" : "String"
   }, {
-    "id" : "input.notificationChannelSnsTopicArn",
-    "label" : "Notification channel SNS topic ARN",
-    "optional" : true,
-    "feel" : "optional",
-    "group" : "advanced",
     "binding" : {
       "name" : "input.notificationChannelSnsTopicArn",
       "type" : "zeebe:input"
@@ -496,95 +491,100 @@
       "equals" : "ASYNC",
       "type" : "simple"
     },
+    "feel" : "optional",
+    "group" : "advanced",
+    "id" : "input.notificationChannelSnsTopicArn",
+    "label" : "Notification channel SNS topic ARN",
+    "optional" : true,
     "tooltip" : "The Amazon SNS topic ARN that you want Amazon Textract to publish the completion status of the operation to.",
     "type" : "String"
   }, {
-    "id" : "version",
-    "label" : "Version",
-    "description" : "Version of the element template",
-    "value" : "6",
-    "group" : "connector",
     "binding" : {
       "key" : "elementTemplateVersion",
       "type" : "zeebe:taskHeader"
     },
-    "type" : "Hidden"
-  }, {
-    "id" : "id",
-    "label" : "ID",
-    "description" : "ID of the element template",
-    "value" : "io.camunda.connectors.AWSTEXTRACT.v1",
+    "description" : "Version of the element template",
     "group" : "connector",
+    "id" : "version",
+    "label" : "Version",
+    "type" : "Hidden",
+    "value" : "6"
+  }, {
     "binding" : {
       "key" : "elementTemplateId",
       "type" : "zeebe:taskHeader"
     },
-    "type" : "Hidden"
+    "description" : "ID of the element template",
+    "group" : "connector",
+    "id" : "id",
+    "label" : "ID",
+    "type" : "Hidden",
+    "value" : "io.camunda.connectors.AWSTEXTRACT.v1"
   }, {
-    "id" : "resultVariable",
-    "label" : "Result variable",
-    "description" : "Name of variable to store the response in. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-variable\" target=\"_blank\">documentation</a>.",
-    "group" : "output",
     "binding" : {
       "key" : "resultVariable",
       "type" : "zeebe:taskHeader"
     },
+    "description" : "Name of variable to store the response in. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-variable\" target=\"_blank\">documentation</a>.",
+    "group" : "output",
+    "id" : "resultVariable",
+    "label" : "Result variable",
     "type" : "String"
   }, {
-    "id" : "resultExpression",
-    "label" : "Result expression",
-    "description" : "Expression to map the response into process variables. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-expression\" target=\"_blank\">documentation</a>.",
-    "feel" : "required",
-    "group" : "output",
     "binding" : {
       "key" : "resultExpression",
       "type" : "zeebe:taskHeader"
     },
+    "description" : "Expression to map the response into process variables. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-expression\" target=\"_blank\">documentation</a>.",
+    "feel" : "required",
+    "group" : "output",
+    "id" : "resultExpression",
+    "label" : "Result expression",
     "type" : "Text"
   }, {
-    "id" : "errorExpression",
-    "label" : "Error expression",
-    "description" : "Expression to handle errors. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/\" target=\"_blank\">documentation</a>.",
-    "feel" : "required",
-    "group" : "error",
     "binding" : {
       "key" : "errorExpression",
       "type" : "zeebe:taskHeader"
     },
+    "description" : "Expression to handle errors. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/\" target=\"_blank\">documentation</a>.",
+    "feel" : "required",
+    "group" : "error",
+    "id" : "errorExpression",
+    "label" : "Error expression",
     "type" : "Text"
   }, {
-    "id" : "retryCount",
-    "label" : "Retries",
-    "description" : "Number of retries",
-    "value" : "3",
-    "feel" : "optional",
-    "group" : "retries",
     "binding" : {
       "property" : "retries",
       "type" : "zeebe:taskDefinition"
     },
-    "type" : "String"
-  }, {
-    "id" : "retryBackoff",
-    "label" : "Retry backoff",
-    "description" : "ISO-8601 duration to wait between retries",
-    "value" : "PT30S",
+    "description" : "Number of retries",
+    "feel" : "optional",
     "group" : "retries",
+    "id" : "retryCount",
+    "label" : "Retries",
+    "type" : "String",
+    "value" : "3"
+  }, {
     "binding" : {
       "key" : "retryBackoff",
       "type" : "zeebe:taskHeader"
     },
-    "type" : "String"
-  }, {
-    "id" : "jobTimeout",
-    "label" : "Job timeout",
-    "description" : "ISO-8601 duration after which Zeebe considers this job timed out if not yet completed. Leave empty to use the default timeout",
-    "optional" : true,
+    "description" : "ISO-8601 duration to wait between retries",
     "group" : "retries",
+    "id" : "retryBackoff",
+    "label" : "Retry backoff",
+    "type" : "String",
+    "value" : "PT30S"
+  }, {
     "binding" : {
       "key" : "jobTimeout",
       "type" : "zeebe:taskHeader"
     },
+    "description" : "ISO-8601 duration after which Zeebe considers this job timed out if not yet completed. Leave empty to use the default timeout",
+    "group" : "retries",
+    "id" : "jobTimeout",
+    "label" : "Job timeout",
+    "optional" : true,
     "type" : "String"
   } ],
   "configurationTemplates" : [ {
@@ -593,30 +593,24 @@
     "version" : 1,
     "name" : "AWS Credential",
     "properties" : [ {
-      "id" : "authentication.type",
-      "label" : "Authentication",
-      "description" : "Specify AWS authentication strategy. Learn more at the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/aws-lambda/#aws-authentication-types\" target=\"_blank\">documentation page</a>",
-      "value" : "credentials",
-      "group" : "authentication",
       "binding" : {
         "name" : "authentication.type",
         "type" : "property"
       },
-      "type" : "Dropdown",
       "choices" : [ {
         "name" : "Default Credentials Chain (Hybrid/Self-Managed only)",
         "value" : "defaultCredentialsChain"
       }, {
         "name" : "Credentials",
         "value" : "credentials"
-      } ]
-    }, {
-      "id" : "authentication.accessKey",
-      "label" : "Access key",
-      "constraints" : {
-        "notEmpty" : true
-      },
+      } ],
+      "description" : "Specify AWS authentication strategy. Learn more at the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/aws-lambda/#aws-authentication-types\" target=\"_blank\">documentation page</a>",
       "group" : "authentication",
+      "id" : "authentication.type",
+      "label" : "Authentication",
+      "type" : "Dropdown",
+      "value" : "credentials"
+    }, {
       "binding" : {
         "name" : "authentication.accessKey",
         "type" : "property"
@@ -626,16 +620,16 @@
         "equals" : "credentials",
         "type" : "simple"
       },
-      "tooltip" : "IAM access key of a user with the necessary permissions for this connector",
-      "type" : "String",
-      "secret" : true
-    }, {
-      "id" : "authentication.secretKey",
-      "label" : "Secret key",
       "constraints" : {
         "notEmpty" : true
       },
       "group" : "authentication",
+      "id" : "authentication.accessKey",
+      "label" : "Access key",
+      "secret" : true,
+      "tooltip" : "IAM access key of a user with the necessary permissions for this connector",
+      "type" : "String"
+    }, {
       "binding" : {
         "name" : "authentication.secretKey",
         "type" : "property"
@@ -645,20 +639,26 @@
         "equals" : "credentials",
         "type" : "simple"
       },
-      "tooltip" : "IAM secret key of a user with the necessary permissions for this connector",
-      "type" : "String",
-      "secret" : true
-    }, {
-      "id" : "region",
-      "label" : "Region",
       "constraints" : {
         "notEmpty" : true
       },
-      "group" : "configuration",
+      "group" : "authentication",
+      "id" : "authentication.secretKey",
+      "label" : "Secret key",
+      "secret" : true,
+      "tooltip" : "IAM secret key of a user with the necessary permissions for this connector",
+      "type" : "String"
+    }, {
       "binding" : {
         "name" : "region",
         "type" : "property"
       },
+      "constraints" : {
+        "notEmpty" : true
+      },
+      "group" : "configuration",
+      "id" : "region",
+      "label" : "Region",
       "type" : "String"
     } ]
   } ],

--- a/connectors/aws/aws-textract/element-templates/hybrid/aws-textract-outbound-connector-hybrid.json
+++ b/connectors/aws/aws-textract/element-templates/hybrid/aws-textract-outbound-connector-hybrid.json
@@ -49,41 +49,33 @@
     "label" : "Retries"
   } ],
   "properties" : [ {
-    "id" : "taskDefinitionType",
-    "value" : "io.camunda:aws-textract:1",
-    "group" : "taskDefinitionType",
     "binding" : {
       "property" : "type",
       "type" : "zeebe:taskDefinition"
     },
-    "type" : "String"
+    "group" : "taskDefinitionType",
+    "id" : "taskDefinitionType",
+    "type" : "String",
+    "value" : "io.camunda:aws-textract:1"
   }, {
-    "id" : "authentication.type",
-    "label" : "Authentication",
-    "description" : "Specify AWS authentication strategy. Learn more at the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/aws-lambda/#aws-authentication-types\" target=\"_blank\">documentation page</a>",
-    "value" : "credentials",
-    "group" : "authentication",
     "binding" : {
       "name" : "authentication.type",
       "type" : "zeebe:input"
     },
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "Default Credentials Chain (Hybrid/Self-Managed only)",
       "value" : "defaultCredentialsChain"
     }, {
       "name" : "Credentials",
       "value" : "credentials"
-    } ]
-  }, {
-    "id" : "authentication.accessKey",
-    "label" : "Access key",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "feel" : "optional",
+    } ],
+    "description" : "Specify AWS authentication strategy. Learn more at the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/aws-lambda/#aws-authentication-types\" target=\"_blank\">documentation page</a>",
     "group" : "authentication",
+    "id" : "authentication.type",
+    "label" : "Authentication",
+    "type" : "Dropdown",
+    "value" : "credentials"
+  }, {
     "binding" : {
       "name" : "authentication.accessKey",
       "type" : "zeebe:input"
@@ -93,18 +85,18 @@
       "equals" : "credentials",
       "type" : "simple"
     },
-    "tooltip" : "IAM access key of a user with the necessary permissions for this connector",
-    "type" : "String",
-    "secret" : true
-  }, {
-    "id" : "authentication.secretKey",
-    "label" : "Secret key",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "authentication",
+    "id" : "authentication.accessKey",
+    "label" : "Access key",
+    "optional" : false,
+    "secret" : true,
+    "tooltip" : "IAM access key of a user with the necessary permissions for this connector",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "authentication.secretKey",
       "type" : "zeebe:input"
@@ -114,74 +106,74 @@
       "equals" : "credentials",
       "type" : "simple"
     },
-    "tooltip" : "IAM secret key of a user with the necessary permissions for this connector",
-    "type" : "String",
-    "secret" : true
-  }, {
-    "id" : "awsCredential",
-    "label" : "AWS credential",
-    "description" : "Choose a reusable AWS credential. When set, it is bound as a whole to the connector's 'awsCredential' input.",
-    "optional" : true,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
     "group" : "authentication",
+    "id" : "authentication.secretKey",
+    "label" : "Secret key",
+    "optional" : false,
+    "secret" : true,
+    "tooltip" : "IAM secret key of a user with the necessary permissions for this connector",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "awsCredential",
       "type" : "zeebe:input"
     },
-    "type" : "Configuration",
-    "configurationTemplate" : "io.camunda:aws-credential:1"
+    "configurationTemplate" : "io.camunda:aws-credential:1",
+    "description" : "Choose a reusable AWS credential. When set, it is bound as a whole to the connector's 'awsCredential' input.",
+    "group" : "authentication",
+    "id" : "awsCredential",
+    "label" : "AWS credential",
+    "optional" : true,
+    "type" : "Configuration"
   }, {
-    "id" : "configuration.region",
-    "label" : "Region",
-    "optional" : false,
+    "binding" : {
+      "name" : "configuration.region",
+      "type" : "zeebe:input"
+    },
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "configuration",
-    "binding" : {
-      "name" : "configuration.region",
-      "type" : "zeebe:input"
-    },
+    "id" : "configuration.region",
+    "label" : "Region",
+    "optional" : false,
     "type" : "String"
   }, {
-    "id" : "configuration.endpoint",
-    "label" : "Endpoint",
-    "description" : "Specify endpoint if need to use custom endpoint",
-    "optional" : true,
-    "group" : "configuration",
     "binding" : {
       "name" : "configuration.endpoint",
       "type" : "zeebe:input"
     },
+    "description" : "Specify endpoint if need to use custom endpoint",
+    "group" : "configuration",
+    "id" : "configuration.endpoint",
+    "label" : "Endpoint",
+    "optional" : true,
     "type" : "Hidden"
   }, {
-    "id" : "input.documentLocationType",
-    "label" : "Document source",
-    "optional" : false,
-    "value" : "S3",
-    "group" : "document",
     "binding" : {
       "name" : "input.documentLocationType",
       "type" : "zeebe:input"
     },
-    "tooltip" : "Source of the input document to be analyzed.",
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "Camunda Document",
       "value" : "UPLOADED"
     }, {
       "name" : "S3",
       "value" : "S3"
-    } ]
-  }, {
-    "id" : "input.documentS3Bucket",
-    "label" : "Document bucket",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "feel" : "optional",
+    } ],
     "group" : "document",
+    "id" : "input.documentLocationType",
+    "label" : "Document source",
+    "optional" : false,
+    "tooltip" : "Source of the input document to be analyzed.",
+    "type" : "Dropdown",
+    "value" : "S3"
+  }, {
     "binding" : {
       "name" : "input.documentS3Bucket",
       "type" : "zeebe:input"
@@ -191,17 +183,17 @@
       "equals" : "S3",
       "type" : "simple"
     },
-    "tooltip" : "S3 bucket that contains the document to be analyzed.",
-    "type" : "String"
-  }, {
-    "id" : "input.documentName",
-    "label" : "Document name",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "document",
+    "id" : "input.documentS3Bucket",
+    "label" : "Document bucket",
+    "optional" : false,
+    "tooltip" : "S3 bucket that contains the document to be analyzed.",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "input.documentName",
       "type" : "zeebe:input"
@@ -211,14 +203,17 @@
       "equals" : "S3",
       "type" : "simple"
     },
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "document",
+    "id" : "input.documentName",
+    "label" : "Document name",
+    "optional" : false,
     "tooltip" : "Name of the document to be analyzed in the S3 bucket.",
     "type" : "String"
   }, {
-    "id" : "input.documentVersion",
-    "label" : "Document version",
-    "optional" : true,
-    "feel" : "optional",
-    "group" : "document",
     "binding" : {
       "name" : "input.documentVersion",
       "type" : "zeebe:input"
@@ -228,17 +223,14 @@
       "equals" : "S3",
       "type" : "simple"
     },
+    "feel" : "optional",
+    "group" : "document",
+    "id" : "input.documentVersion",
+    "label" : "Document version",
+    "optional" : true,
     "tooltip" : "Version of the document to be analyzed in the S3 bucket.",
     "type" : "String"
   }, {
-    "id" : "input.document",
-    "label" : "Camunda Document",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "feel" : "required",
-    "group" : "document",
     "binding" : {
       "name" : "input.document",
       "type" : "zeebe:input"
@@ -248,28 +240,21 @@
       "equals" : "UPLOADED",
       "type" : "simple"
     },
-    "tooltip" : "The Camunda document to be analyzed.",
-    "type" : "String"
-  }, {
-    "id" : "input.executionType",
-    "label" : "Execution type",
-    "optional" : false,
-    "value" : "POLLING",
     "constraints" : {
       "notEmpty" : true
     },
-    "group" : "input",
+    "feel" : "required",
+    "group" : "document",
+    "id" : "input.document",
+    "label" : "Camunda Document",
+    "optional" : false,
+    "tooltip" : "The Camunda document to be analyzed.",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "input.executionType",
       "type" : "zeebe:input"
     },
-    "condition" : {
-      "property" : "input.documentLocationType",
-      "equals" : "S3",
-      "type" : "simple"
-    },
-    "tooltip" : "How the document should be processed. See more info in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-textract/#execution-types\" target=\"_blank\">Amazon Textract execution types documentation</a>.",
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "Asynchronous",
       "value" : "ASYNC"
@@ -279,93 +264,103 @@
     }, {
       "name" : "Polling",
       "value" : "POLLING"
-    } ]
-  }, {
-    "id" : "input.analyzeTables",
-    "label" : "Analyze tables",
-    "optional" : false,
-    "value" : true,
+    } ],
+    "condition" : {
+      "property" : "input.documentLocationType",
+      "equals" : "S3",
+      "type" : "simple"
+    },
     "constraints" : {
       "notEmpty" : true
     },
-    "feel" : "static",
     "group" : "input",
+    "id" : "input.executionType",
+    "label" : "Execution type",
+    "optional" : false,
+    "tooltip" : "How the document should be processed. See more info in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-textract/#execution-types\" target=\"_blank\">Amazon Textract execution types documentation</a>.",
+    "type" : "Dropdown",
+    "value" : "POLLING"
+  }, {
     "binding" : {
       "name" : "input.analyzeTables",
       "type" : "zeebe:input"
     },
-    "tooltip" : "Select this to return information about the tables that are detected in the input document.",
-    "type" : "Boolean"
-  }, {
-    "id" : "input.analyzeForms",
-    "label" : "Analyze form",
-    "optional" : false,
-    "value" : true,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "static",
     "group" : "input",
+    "id" : "input.analyzeTables",
+    "label" : "Analyze tables",
+    "optional" : false,
+    "tooltip" : "Select this to return information about the tables that are detected in the input document.",
+    "type" : "Boolean",
+    "value" : true
+  }, {
     "binding" : {
       "name" : "input.analyzeForms",
       "type" : "zeebe:input"
     },
-    "tooltip" : "Select this to return information about detected form data.",
-    "type" : "Boolean"
-  }, {
-    "id" : "input.analyzeSignatures",
-    "label" : "Analyze signatures",
-    "optional" : false,
-    "value" : true,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "static",
     "group" : "input",
+    "id" : "input.analyzeForms",
+    "label" : "Analyze form",
+    "optional" : false,
+    "tooltip" : "Select this to return information about detected form data.",
+    "type" : "Boolean",
+    "value" : true
+  }, {
     "binding" : {
       "name" : "input.analyzeSignatures",
       "type" : "zeebe:input"
     },
-    "tooltip" : "Select this to return the locations of detected signatures.",
-    "type" : "Boolean"
-  }, {
-    "id" : "input.analyzeLayout",
-    "label" : "Analyze layout",
-    "optional" : false,
-    "value" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "static",
     "group" : "input",
+    "id" : "input.analyzeSignatures",
+    "label" : "Analyze signatures",
+    "optional" : false,
+    "tooltip" : "Select this to return the locations of detected signatures.",
+    "type" : "Boolean",
+    "value" : true
+  }, {
     "binding" : {
       "name" : "input.analyzeLayout",
       "type" : "zeebe:input"
     },
-    "tooltip" : "Select this to return information about the layout of the document.",
-    "type" : "Boolean"
-  }, {
-    "id" : "input.analyzeQueries",
-    "label" : "Analyze queries",
-    "optional" : false,
-    "value" : true,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "static",
     "group" : "input",
+    "id" : "input.analyzeLayout",
+    "label" : "Analyze layout",
+    "optional" : false,
+    "tooltip" : "Select this to return information about the layout of the document.",
+    "type" : "Boolean",
+    "value" : false
+  }, {
     "binding" : {
       "name" : "input.analyzeQueries",
       "type" : "zeebe:input"
     },
-    "tooltip" : "Select this to return an answer to a query run against the document.",
-    "type" : "Boolean"
-  }, {
-    "id" : "input.query",
-    "label" : "Query",
-    "optional" : false,
-    "feel" : "optional",
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "static",
     "group" : "input",
+    "id" : "input.analyzeQueries",
+    "label" : "Analyze queries",
+    "optional" : false,
+    "tooltip" : "Select this to return an answer to a query run against the document.",
+    "type" : "Boolean",
+    "value" : true
+  }, {
     "binding" : {
       "name" : "input.query",
       "type" : "zeebe:input"
@@ -375,18 +370,15 @@
       "equals" : true,
       "type" : "simple"
     },
-    "tooltip" : "A natural-language question applied to the document; Textract returns the extracted answer.",
-    "placeholder" : "What is the IBAN in the invoice?",
-    "type" : "String"
-  }, {
-    "id" : "input.outputConfigS3Bucket",
-    "label" : "Output S3 bucket",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
     "feel" : "optional",
     "group" : "input",
+    "id" : "input.query",
+    "label" : "Query",
+    "optional" : false,
+    "placeholder" : "What is the IBAN in the invoice?",
+    "tooltip" : "A natural-language question applied to the document; Textract returns the extracted answer.",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "input.outputConfigS3Bucket",
       "type" : "zeebe:input"
@@ -396,17 +388,17 @@
       "equals" : "ASYNC",
       "type" : "simple"
     },
-    "tooltip" : "The name of the bucket your output will go to.",
-    "type" : "String"
-  }, {
-    "id" : "input.outputConfigS3Prefix",
-    "label" : "Output S3 prefix",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "input",
+    "id" : "input.outputConfigS3Bucket",
+    "label" : "Output S3 bucket",
+    "optional" : false,
+    "tooltip" : "The name of the bucket your output will go to.",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "input.outputConfigS3Prefix",
       "type" : "zeebe:input"
@@ -416,14 +408,17 @@
       "equals" : "ASYNC",
       "type" : "simple"
     },
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "input",
+    "id" : "input.outputConfigS3Prefix",
+    "label" : "Output S3 prefix",
+    "optional" : false,
     "tooltip" : "The prefix of the object key that the output will be saved to.",
     "type" : "String"
   }, {
-    "id" : "input.clientRequestToken",
-    "label" : "Client request token",
-    "optional" : true,
-    "feel" : "optional",
-    "group" : "advanced",
     "binding" : {
       "name" : "input.clientRequestToken",
       "type" : "zeebe:input"
@@ -433,14 +428,14 @@
       "equals" : "ASYNC",
       "type" : "simple"
     },
+    "feel" : "optional",
+    "group" : "advanced",
+    "id" : "input.clientRequestToken",
+    "label" : "Client request token",
+    "optional" : true,
     "tooltip" : "The idempotent token that you use to identify the start request.",
     "type" : "String"
   }, {
-    "id" : "input.jobTag",
-    "label" : "Job tag",
-    "optional" : true,
-    "feel" : "optional",
-    "group" : "advanced",
     "binding" : {
       "name" : "input.jobTag",
       "type" : "zeebe:input"
@@ -450,14 +445,14 @@
       "equals" : "ASYNC",
       "type" : "simple"
     },
+    "feel" : "optional",
+    "group" : "advanced",
+    "id" : "input.jobTag",
+    "label" : "Job tag",
+    "optional" : true,
     "tooltip" : "An identifier that you specify that's included in the completion notification published to the Amazon SNS topic.",
     "type" : "String"
   }, {
-    "id" : "input.kmsKeyId",
-    "label" : "KMS key ID",
-    "optional" : true,
-    "feel" : "optional",
-    "group" : "advanced",
     "binding" : {
       "name" : "input.kmsKeyId",
       "type" : "zeebe:input"
@@ -467,14 +462,14 @@
       "equals" : "ASYNC",
       "type" : "simple"
     },
+    "feel" : "optional",
+    "group" : "advanced",
+    "id" : "input.kmsKeyId",
+    "label" : "KMS key ID",
+    "optional" : true,
     "tooltip" : "The KMS key used to encrypt the inference results.",
     "type" : "String"
   }, {
-    "id" : "input.notificationChannelRoleArn",
-    "label" : "Notification channel role ARN",
-    "optional" : true,
-    "feel" : "optional",
-    "group" : "advanced",
     "binding" : {
       "name" : "input.notificationChannelRoleArn",
       "type" : "zeebe:input"
@@ -484,14 +479,14 @@
       "equals" : "ASYNC",
       "type" : "simple"
     },
+    "feel" : "optional",
+    "group" : "advanced",
+    "id" : "input.notificationChannelRoleArn",
+    "label" : "Notification channel role ARN",
+    "optional" : true,
     "tooltip" : "The Amazon SNS topic role ARN that you want Amazon Textract to publish the completion status of the operation to.",
     "type" : "String"
   }, {
-    "id" : "input.notificationChannelSnsTopicArn",
-    "label" : "Notification channel SNS topic ARN",
-    "optional" : true,
-    "feel" : "optional",
-    "group" : "advanced",
     "binding" : {
       "name" : "input.notificationChannelSnsTopicArn",
       "type" : "zeebe:input"
@@ -501,95 +496,100 @@
       "equals" : "ASYNC",
       "type" : "simple"
     },
+    "feel" : "optional",
+    "group" : "advanced",
+    "id" : "input.notificationChannelSnsTopicArn",
+    "label" : "Notification channel SNS topic ARN",
+    "optional" : true,
     "tooltip" : "The Amazon SNS topic ARN that you want Amazon Textract to publish the completion status of the operation to.",
     "type" : "String"
   }, {
-    "id" : "version",
-    "label" : "Version",
-    "description" : "Version of the element template",
-    "value" : "6",
-    "group" : "connector",
     "binding" : {
       "key" : "elementTemplateVersion",
       "type" : "zeebe:taskHeader"
     },
-    "type" : "Hidden"
-  }, {
-    "id" : "id",
-    "label" : "ID",
-    "description" : "ID of the element template",
-    "value" : "io.camunda.connectors.AWSTEXTRACT.v1",
+    "description" : "Version of the element template",
     "group" : "connector",
+    "id" : "version",
+    "label" : "Version",
+    "type" : "Hidden",
+    "value" : "6"
+  }, {
     "binding" : {
       "key" : "elementTemplateId",
       "type" : "zeebe:taskHeader"
     },
-    "type" : "Hidden"
+    "description" : "ID of the element template",
+    "group" : "connector",
+    "id" : "id",
+    "label" : "ID",
+    "type" : "Hidden",
+    "value" : "io.camunda.connectors.AWSTEXTRACT.v1"
   }, {
-    "id" : "resultVariable",
-    "label" : "Result variable",
-    "description" : "Name of variable to store the response in. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-variable\" target=\"_blank\">documentation</a>.",
-    "group" : "output",
     "binding" : {
       "key" : "resultVariable",
       "type" : "zeebe:taskHeader"
     },
+    "description" : "Name of variable to store the response in. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-variable\" target=\"_blank\">documentation</a>.",
+    "group" : "output",
+    "id" : "resultVariable",
+    "label" : "Result variable",
     "type" : "String"
   }, {
-    "id" : "resultExpression",
-    "label" : "Result expression",
-    "description" : "Expression to map the response into process variables. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-expression\" target=\"_blank\">documentation</a>.",
-    "feel" : "required",
-    "group" : "output",
     "binding" : {
       "key" : "resultExpression",
       "type" : "zeebe:taskHeader"
     },
+    "description" : "Expression to map the response into process variables. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-expression\" target=\"_blank\">documentation</a>.",
+    "feel" : "required",
+    "group" : "output",
+    "id" : "resultExpression",
+    "label" : "Result expression",
     "type" : "Text"
   }, {
-    "id" : "errorExpression",
-    "label" : "Error expression",
-    "description" : "Expression to handle errors. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/\" target=\"_blank\">documentation</a>.",
-    "feel" : "required",
-    "group" : "error",
     "binding" : {
       "key" : "errorExpression",
       "type" : "zeebe:taskHeader"
     },
+    "description" : "Expression to handle errors. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/\" target=\"_blank\">documentation</a>.",
+    "feel" : "required",
+    "group" : "error",
+    "id" : "errorExpression",
+    "label" : "Error expression",
     "type" : "Text"
   }, {
-    "id" : "retryCount",
-    "label" : "Retries",
-    "description" : "Number of retries",
-    "value" : "3",
-    "feel" : "optional",
-    "group" : "retries",
     "binding" : {
       "property" : "retries",
       "type" : "zeebe:taskDefinition"
     },
-    "type" : "String"
-  }, {
-    "id" : "retryBackoff",
-    "label" : "Retry backoff",
-    "description" : "ISO-8601 duration to wait between retries",
-    "value" : "PT30S",
+    "description" : "Number of retries",
+    "feel" : "optional",
     "group" : "retries",
+    "id" : "retryCount",
+    "label" : "Retries",
+    "type" : "String",
+    "value" : "3"
+  }, {
     "binding" : {
       "key" : "retryBackoff",
       "type" : "zeebe:taskHeader"
     },
-    "type" : "String"
-  }, {
-    "id" : "jobTimeout",
-    "label" : "Job timeout",
-    "description" : "ISO-8601 duration after which Zeebe considers this job timed out if not yet completed. Leave empty to use the default timeout",
-    "optional" : true,
+    "description" : "ISO-8601 duration to wait between retries",
     "group" : "retries",
+    "id" : "retryBackoff",
+    "label" : "Retry backoff",
+    "type" : "String",
+    "value" : "PT30S"
+  }, {
     "binding" : {
       "key" : "jobTimeout",
       "type" : "zeebe:taskHeader"
     },
+    "description" : "ISO-8601 duration after which Zeebe considers this job timed out if not yet completed. Leave empty to use the default timeout",
+    "group" : "retries",
+    "id" : "jobTimeout",
+    "label" : "Job timeout",
+    "optional" : true,
     "type" : "String"
   } ],
   "configurationTemplates" : [ {
@@ -598,30 +598,24 @@
     "version" : 1,
     "name" : "AWS Credential",
     "properties" : [ {
-      "id" : "authentication.type",
-      "label" : "Authentication",
-      "description" : "Specify AWS authentication strategy. Learn more at the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/aws-lambda/#aws-authentication-types\" target=\"_blank\">documentation page</a>",
-      "value" : "credentials",
-      "group" : "authentication",
       "binding" : {
         "name" : "authentication.type",
         "type" : "property"
       },
-      "type" : "Dropdown",
       "choices" : [ {
         "name" : "Default Credentials Chain (Hybrid/Self-Managed only)",
         "value" : "defaultCredentialsChain"
       }, {
         "name" : "Credentials",
         "value" : "credentials"
-      } ]
-    }, {
-      "id" : "authentication.accessKey",
-      "label" : "Access key",
-      "constraints" : {
-        "notEmpty" : true
-      },
+      } ],
+      "description" : "Specify AWS authentication strategy. Learn more at the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/aws-lambda/#aws-authentication-types\" target=\"_blank\">documentation page</a>",
       "group" : "authentication",
+      "id" : "authentication.type",
+      "label" : "Authentication",
+      "type" : "Dropdown",
+      "value" : "credentials"
+    }, {
       "binding" : {
         "name" : "authentication.accessKey",
         "type" : "property"
@@ -631,16 +625,16 @@
         "equals" : "credentials",
         "type" : "simple"
       },
-      "tooltip" : "IAM access key of a user with the necessary permissions for this connector",
-      "type" : "String",
-      "secret" : true
-    }, {
-      "id" : "authentication.secretKey",
-      "label" : "Secret key",
       "constraints" : {
         "notEmpty" : true
       },
       "group" : "authentication",
+      "id" : "authentication.accessKey",
+      "label" : "Access key",
+      "secret" : true,
+      "tooltip" : "IAM access key of a user with the necessary permissions for this connector",
+      "type" : "String"
+    }, {
       "binding" : {
         "name" : "authentication.secretKey",
         "type" : "property"
@@ -650,20 +644,26 @@
         "equals" : "credentials",
         "type" : "simple"
       },
-      "tooltip" : "IAM secret key of a user with the necessary permissions for this connector",
-      "type" : "String",
-      "secret" : true
-    }, {
-      "id" : "region",
-      "label" : "Region",
       "constraints" : {
         "notEmpty" : true
       },
-      "group" : "configuration",
+      "group" : "authentication",
+      "id" : "authentication.secretKey",
+      "label" : "Secret key",
+      "secret" : true,
+      "tooltip" : "IAM secret key of a user with the necessary permissions for this connector",
+      "type" : "String"
+    }, {
       "binding" : {
         "name" : "region",
         "type" : "property"
       },
+      "constraints" : {
+        "notEmpty" : true
+      },
+      "group" : "configuration",
+      "id" : "region",
+      "label" : "Region",
       "type" : "String"
     } ]
   } ],

--- a/connectors/aws/aws-textract/pom.xml
+++ b/connectors/aws/aws-textract/pom.xml
@@ -78,7 +78,7 @@ except in compliance with the proprietary license.</license.inlineheader>
          and assert against the expected JsonNode tree; otherwise only a transitive compile
          dependency via connector-aws-base -->
     <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
+      <groupId>tools.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
       <scope>test</scope>
     </dependency>
@@ -114,5 +114,4 @@ except in compliance with the proprietary license.</license.inlineheader>
   </build>
 
 </project>
-
 

--- a/connectors/box/element-templates/box-outbound-connector.json
+++ b/connectors/box/element-templates/box-outbound-connector.json
@@ -37,23 +37,17 @@
     "label" : "Retries"
   } ],
   "properties" : [ {
-    "value" : "io.camunda:box:1",
     "binding" : {
       "property" : "type",
       "type" : "zeebe:taskDefinition"
     },
-    "type" : "Hidden"
+    "type" : "Hidden",
+    "value" : "io.camunda:box:1"
   }, {
-    "id" : "operation.type",
-    "label" : "Operation",
-    "description" : "The operation to execute.",
-    "value" : "createFolder",
-    "group" : "operation",
     "binding" : {
       "name" : "operation.type",
       "type" : "zeebe:input"
     },
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "Create Folder",
       "value" : "createFolder"
@@ -75,16 +69,14 @@
     }, {
       "name" : "Search",
       "value" : "search"
-    } ]
-  }, {
-    "id" : "operation.createFolderName",
-    "label" : "Folder name",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "feel" : "optional",
+    } ],
+    "description" : "The operation to execute.",
     "group" : "operation",
+    "id" : "operation.type",
+    "label" : "Operation",
+    "type" : "Dropdown",
+    "value" : "createFolder"
+  }, {
     "binding" : {
       "name" : "operation.name",
       "type" : "zeebe:input"
@@ -94,17 +86,16 @@
       "equals" : "createFolder",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "operation.createFolderParentPath",
-    "label" : "Parent path",
-    "optional" : false,
-    "value" : "/",
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "operation",
+    "id" : "operation.createFolderName",
+    "label" : "Folder name",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "operation.folderPath",
       "type" : "zeebe:input"
@@ -114,16 +105,17 @@
       "equals" : "createFolder",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "operation.deleteFolderPath",
-    "label" : "Folder path",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "operation",
+    "id" : "operation.createFolderParentPath",
+    "label" : "Parent path",
+    "optional" : false,
+    "type" : "String",
+    "value" : "/"
+  }, {
     "binding" : {
       "name" : "operation.folderPath",
       "type" : "zeebe:input"
@@ -133,14 +125,16 @@
       "equals" : "deleteFolder",
       "type" : "simple"
     },
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "operation",
+    "id" : "operation.deleteFolderPath",
+    "label" : "Folder path",
+    "optional" : false,
     "type" : "String"
   }, {
-    "id" : "operation.recursive",
-    "label" : "Recursive",
-    "optional" : false,
-    "value" : true,
-    "feel" : "static",
-    "group" : "operation",
     "binding" : {
       "name" : "operation.recursive",
       "type" : "zeebe:input"
@@ -150,17 +144,15 @@
       "equals" : "deleteFolder",
       "type" : "simple"
     },
-    "tooltip" : "Deletes all items contained by the folder",
-    "type" : "Boolean"
-  }, {
-    "id" : "operation.uploadFileName",
-    "label" : "File name",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "feel" : "optional",
+    "feel" : "static",
     "group" : "operation",
+    "id" : "operation.recursive",
+    "label" : "Recursive",
+    "optional" : false,
+    "tooltip" : "Deletes all items contained by the folder",
+    "type" : "Boolean",
+    "value" : true
+  }, {
     "binding" : {
       "name" : "operation.name",
       "type" : "zeebe:input"
@@ -170,16 +162,16 @@
       "equals" : "uploadFile",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "operation.uploadFileFolderPath",
-    "label" : "Folder path",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "operation",
+    "id" : "operation.uploadFileName",
+    "label" : "File name",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "operation.folderPath",
       "type" : "zeebe:input"
@@ -189,23 +181,20 @@
       "equals" : "uploadFile",
       "type" : "simple"
     },
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "operation",
+    "id" : "operation.uploadFileFolderPath",
+    "label" : "Folder path",
+    "optional" : false,
     "type" : "String"
   }, {
-    "id" : "operation.document_documentSource",
-    "label" : "Document source",
-    "value" : "camunda",
-    "group" : "operation",
     "binding" : {
       "name" : "operation.document_documentSource",
       "type" : "zeebe:input"
     },
-    "condition" : {
-      "property" : "operation.type",
-      "equals" : "uploadFile",
-      "type" : "simple"
-    },
-    "tooltip" : "The document reference that will be uploaded",
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "Camunda Document",
       "value" : "camunda"
@@ -215,15 +204,19 @@
     }, {
       "name" : "From URL",
       "value" : "external"
-    } ]
-  }, {
-    "id" : "operation.document_camundaReference",
-    "label" : "Camunda document",
-    "constraints" : {
-      "notEmpty" : true
+    } ],
+    "condition" : {
+      "property" : "operation.type",
+      "equals" : "uploadFile",
+      "type" : "simple"
     },
-    "feel" : "required",
     "group" : "operation",
+    "id" : "operation.document_documentSource",
+    "label" : "Document source",
+    "tooltip" : "The document reference that will be uploaded",
+    "type" : "Dropdown",
+    "value" : "camunda"
+  }, {
     "binding" : {
       "name" : "operation.document_camundaReference",
       "type" : "zeebe:input"
@@ -239,15 +232,15 @@
         "type" : "simple"
       } ]
     },
-    "type" : "String"
-  }, {
-    "id" : "operation.document_inline_content",
-    "label" : "Content",
     "constraints" : {
       "notEmpty" : true
     },
-    "feel" : "optional",
+    "feel" : "required",
     "group" : "operation",
+    "id" : "operation.document_camundaReference",
+    "label" : "Camunda document",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "operation.document_inline_content",
       "type" : "zeebe:input"
@@ -263,12 +256,15 @@
         "type" : "simple"
       } ]
     },
-    "type" : "String"
-  }, {
-    "id" : "operation.document_inline_fileName",
-    "label" : "File name",
+    "constraints" : {
+      "notEmpty" : true
+    },
     "feel" : "optional",
     "group" : "operation",
+    "id" : "operation.document_inline_content",
+    "label" : "Content",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "operation.document_inline_fileName",
       "type" : "zeebe:input"
@@ -284,12 +280,12 @@
         "type" : "simple"
       } ]
     },
-    "type" : "String"
-  }, {
-    "id" : "operation.document_inline_contentType",
-    "label" : "Content type",
     "feel" : "optional",
     "group" : "operation",
+    "id" : "operation.document_inline_fileName",
+    "label" : "File name",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "operation.document_inline_contentType",
       "type" : "zeebe:input"
@@ -305,15 +301,12 @@
         "type" : "simple"
       } ]
     },
-    "type" : "String"
-  }, {
-    "id" : "operation.document_external_url",
-    "label" : "URL",
-    "constraints" : {
-      "notEmpty" : true
-    },
     "feel" : "optional",
     "group" : "operation",
+    "id" : "operation.document_inline_contentType",
+    "label" : "Content type",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "operation.document_external_url",
       "type" : "zeebe:input"
@@ -329,12 +322,15 @@
         "type" : "simple"
       } ]
     },
-    "type" : "String"
-  }, {
-    "id" : "operation.document_external_fileName",
-    "label" : "File name",
+    "constraints" : {
+      "notEmpty" : true
+    },
     "feel" : "optional",
     "group" : "operation",
+    "id" : "operation.document_external_url",
+    "label" : "URL",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "operation.document_external_fileName",
       "type" : "zeebe:input"
@@ -350,11 +346,12 @@
         "type" : "simple"
       } ]
     },
+    "feel" : "optional",
+    "group" : "operation",
+    "id" : "operation.document_external_fileName",
+    "label" : "File name",
     "type" : "String"
   }, {
-    "id" : "operation.uploadFileDocument",
-    "value" : "=if document_documentSource = \"camunda\" then document_camundaReference else if document_documentSource = \"inline\" then { \"camunda.document.type\": \"inline\", content: document_inline_content, name: document_inline_fileName, contentType: document_inline_contentType } else if document_documentSource = \"external\" then { \"camunda.document.type\": \"external\", url: document_external_url, name: document_external_fileName } else null",
-    "group" : "operation",
     "binding" : {
       "name" : "operation.document",
       "type" : "zeebe:input"
@@ -364,13 +361,11 @@
       "equals" : "uploadFile",
       "type" : "simple"
     },
-    "type" : "Hidden"
-  }, {
-    "id" : "operation.downloadFilePath",
-    "label" : "File path",
-    "optional" : false,
-    "feel" : "optional",
     "group" : "operation",
+    "id" : "operation.uploadFileDocument",
+    "type" : "Hidden",
+    "value" : "=if document_documentSource = \"camunda\" then document_camundaReference else if document_documentSource = \"inline\" then { \"camunda.document.type\": \"inline\", content: document_inline_content, name: document_inline_fileName, contentType: document_inline_contentType } else if document_documentSource = \"external\" then { \"camunda.document.type\": \"external\", url: document_external_url, name: document_external_fileName } else null"
+  }, {
     "binding" : {
       "name" : "operation.filePath",
       "type" : "zeebe:input"
@@ -380,24 +375,18 @@
       "equals" : "downloadFile",
       "type" : "simple"
     },
+    "feel" : "optional",
+    "group" : "operation",
+    "id" : "operation.downloadFilePath",
+    "label" : "File path",
+    "optional" : false,
     "tooltip" : "Path to the file item to download",
     "type" : "String"
   }, {
-    "id" : "documentReturnFormat",
-    "label" : "Response format",
-    "value" : "DOCUMENT",
-    "group" : "operation",
     "binding" : {
       "name" : "documentReturnFormat.choice",
       "type" : "zeebe:input"
     },
-    "condition" : {
-      "property" : "operation.type",
-      "equals" : "downloadFile",
-      "type" : "simple"
-    },
-    "tooltip" : "How the downloaded payload should be returned. Document reference uploads the payload to the document store; as text decodes it as a String; as JSON parses it into a structure you can access via dot notation.",
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "Document reference",
       "value" : "DOCUMENT"
@@ -407,14 +396,19 @@
     }, {
       "name" : "as JSON",
       "value" : "JSON"
-    } ]
-  }, {
-    "id" : "documentReturnFormatEncoding",
-    "label" : "Encoding",
-    "description" : "Character set used to decode the response. Default UTF-8.",
-    "value" : "UTF-8",
-    "feel" : "optional",
+    } ],
+    "condition" : {
+      "property" : "operation.type",
+      "equals" : "downloadFile",
+      "type" : "simple"
+    },
     "group" : "operation",
+    "id" : "documentReturnFormat",
+    "label" : "Response format",
+    "tooltip" : "How the downloaded payload should be returned. Document reference uploads the payload to the document store; as text decodes it as a String; as JSON parses it into a structure you can access via dot notation.",
+    "type" : "Dropdown",
+    "value" : "DOCUMENT"
+  }, {
     "binding" : {
       "name" : "documentReturnFormat.encoding",
       "type" : "zeebe:input"
@@ -430,16 +424,14 @@
         "type" : "simple"
       } ]
     },
-    "type" : "String"
-  }, {
-    "id" : "operation.moveFilePath",
-    "label" : "File path",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
+    "description" : "Character set used to decode the response. Default UTF-8.",
     "feel" : "optional",
     "group" : "operation",
+    "id" : "documentReturnFormatEncoding",
+    "label" : "Encoding",
+    "type" : "String",
+    "value" : "UTF-8"
+  }, {
     "binding" : {
       "name" : "operation.filePath",
       "type" : "zeebe:input"
@@ -449,16 +441,16 @@
       "equals" : "moveFile",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "operation.moveFileFolderPath",
-    "label" : "Target folder path",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "operation",
+    "id" : "operation.moveFilePath",
+    "label" : "File path",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "operation.folderPath",
       "type" : "zeebe:input"
@@ -468,16 +460,16 @@
       "equals" : "moveFile",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "operation.deleteFilePath",
-    "label" : "File path",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "operation",
+    "id" : "operation.moveFileFolderPath",
+    "label" : "Target folder path",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "operation.filePath",
       "type" : "zeebe:input"
@@ -487,16 +479,16 @@
       "equals" : "deleteFile",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "operation.searchQuery",
-    "label" : "Search query",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "operation",
+    "id" : "operation.deleteFilePath",
+    "label" : "File path",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "operation.query",
       "type" : "zeebe:input"
@@ -506,17 +498,16 @@
       "equals" : "search",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "operation.searchSortColumn",
-    "label" : "Search sort column",
-    "optional" : false,
-    "value" : "modified_at",
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "operation",
+    "id" : "operation.searchQuery",
+    "label" : "Search query",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "operation.sortColumn",
       "type" : "zeebe:input"
@@ -526,38 +517,41 @@
       "equals" : "search",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "operation.searchSortDirection",
-    "label" : "Search sort direction",
-    "optional" : false,
-    "value" : "DESC",
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
     "group" : "operation",
+    "id" : "operation.searchSortColumn",
+    "label" : "Search sort column",
+    "optional" : false,
+    "type" : "String",
+    "value" : "modified_at"
+  }, {
     "binding" : {
       "name" : "operation.sortDirection",
       "type" : "zeebe:input"
     },
-    "condition" : {
-      "property" : "operation.type",
-      "equals" : "search",
-      "type" : "simple"
-    },
-    "tooltip" : "Sort order for results: ASC (ascending) or DESC (descending)",
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "ASC",
       "value" : "ASC"
     }, {
       "name" : "DESC",
       "value" : "DESC"
-    } ]
-  }, {
-    "id" : "operation.searchOffset",
-    "label" : "Search offset",
-    "optional" : false,
-    "value" : 0,
-    "feel" : "static",
+    } ],
+    "condition" : {
+      "property" : "operation.type",
+      "equals" : "search",
+      "type" : "simple"
+    },
     "group" : "operation",
+    "id" : "operation.searchSortDirection",
+    "label" : "Search sort direction",
+    "optional" : false,
+    "tooltip" : "Sort order for results: ASC (ascending) or DESC (descending)",
+    "type" : "Dropdown",
+    "value" : "DESC"
+  }, {
     "binding" : {
       "name" : "operation.offset",
       "type" : "zeebe:input"
@@ -567,14 +561,14 @@
       "equals" : "search",
       "type" : "simple"
     },
-    "type" : "Number"
-  }, {
-    "id" : "operation.searchLimit",
-    "label" : "Search limit",
-    "optional" : false,
-    "value" : 30,
     "feel" : "static",
     "group" : "operation",
+    "id" : "operation.searchOffset",
+    "label" : "Search offset",
+    "optional" : false,
+    "type" : "Number",
+    "value" : 0
+  }, {
     "binding" : {
       "name" : "operation.limit",
       "type" : "zeebe:input"
@@ -584,18 +578,18 @@
       "equals" : "search",
       "type" : "simple"
     },
-    "type" : "Number"
+    "feel" : "static",
+    "group" : "operation",
+    "id" : "operation.searchLimit",
+    "label" : "Search limit",
+    "optional" : false,
+    "type" : "Number",
+    "value" : 30
   }, {
-    "id" : "authentication.type",
-    "label" : "Authentication",
-    "description" : "Specify authentication strategy. Learn more at the <a href=\"https://developer.box.com/guides/authentication/\" target=\"_blank\">documentation page</a>",
-    "value" : "developerToken",
-    "group" : "authentication",
     "binding" : {
       "name" : "authentication.type",
       "type" : "zeebe:input"
     },
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "Client Credentials Enterprise",
       "value" : "clientCredentialsEnterprise"
@@ -608,16 +602,14 @@
     }, {
       "name" : "JWT JSON Config",
       "value" : "jwtJsonConfig"
-    } ]
-  }, {
-    "id" : "authentication.clientIdEnterprise",
-    "label" : "Client id",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "feel" : "optional",
+    } ],
+    "description" : "Specify authentication strategy. Learn more at the <a href=\"https://developer.box.com/guides/authentication/\" target=\"_blank\">documentation page</a>",
     "group" : "authentication",
+    "id" : "authentication.type",
+    "label" : "Authentication",
+    "type" : "Dropdown",
+    "value" : "developerToken"
+  }, {
     "binding" : {
       "name" : "authentication.clientId",
       "type" : "zeebe:input"
@@ -627,16 +619,16 @@
       "equals" : "clientCredentialsEnterprise",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "authentication.clientSecretEnterprise",
-    "label" : "Client secret",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "authentication",
+    "id" : "authentication.clientIdEnterprise",
+    "label" : "Client id",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "authentication.clientSecret",
       "type" : "zeebe:input"
@@ -646,16 +638,16 @@
       "equals" : "clientCredentialsEnterprise",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "authentication.enterpriseId",
-    "label" : "Enterprise ID",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "authentication",
+    "id" : "authentication.clientSecretEnterprise",
+    "label" : "Client secret",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "authentication.enterpriseId",
       "type" : "zeebe:input"
@@ -665,17 +657,17 @@
       "equals" : "clientCredentialsEnterprise",
       "type" : "simple"
     },
-    "tooltip" : "The enterprise ID to authenticate against",
-    "type" : "String"
-  }, {
-    "id" : "authentication.clientIdUser",
-    "label" : "Client id",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "authentication",
+    "id" : "authentication.enterpriseId",
+    "label" : "Enterprise ID",
+    "optional" : false,
+    "tooltip" : "The enterprise ID to authenticate against",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "authentication.clientId",
       "type" : "zeebe:input"
@@ -685,16 +677,16 @@
       "equals" : "clientCredentialsUser",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "authentication.clientSecretUser",
-    "label" : "Client secret",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "authentication",
+    "id" : "authentication.clientIdUser",
+    "label" : "Client id",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "authentication.clientSecret",
       "type" : "zeebe:input"
@@ -704,16 +696,16 @@
       "equals" : "clientCredentialsUser",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "authentication.userId",
-    "label" : "User ID",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "authentication",
+    "id" : "authentication.clientSecretUser",
+    "label" : "Client secret",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "authentication.userId",
       "type" : "zeebe:input"
@@ -723,17 +715,17 @@
       "equals" : "clientCredentialsUser",
       "type" : "simple"
     },
-    "tooltip" : "The user ID of the account to authenticate against",
-    "type" : "String"
-  }, {
-    "id" : "authentication.accessToken",
-    "label" : "Access key",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "authentication",
+    "id" : "authentication.userId",
+    "label" : "User ID",
+    "optional" : false,
+    "tooltip" : "The user ID of the account to authenticate against",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "authentication.accessToken",
       "type" : "zeebe:input"
@@ -743,17 +735,17 @@
       "equals" : "developerToken",
       "type" : "simple"
     },
-    "tooltip" : "The access key or developer token",
-    "type" : "String"
-  }, {
-    "id" : "authentication.jsonConfig",
-    "label" : "JSON config",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "authentication",
+    "id" : "authentication.accessToken",
+    "label" : "Access key",
+    "optional" : false,
+    "tooltip" : "The access key or developer token",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "authentication.jsonConfig",
       "type" : "zeebe:input"
@@ -763,95 +755,103 @@
       "equals" : "jwtJsonConfig",
       "type" : "simple"
     },
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "authentication",
+    "id" : "authentication.jsonConfig",
+    "label" : "JSON config",
+    "optional" : false,
     "tooltip" : "The JSON config as string",
     "type" : "String"
   }, {
-    "id" : "version",
-    "label" : "Version",
-    "description" : "Version of the element template",
-    "value" : "5",
-    "group" : "connector",
     "binding" : {
       "key" : "elementTemplateVersion",
       "type" : "zeebe:taskHeader"
     },
-    "type" : "Hidden"
-  }, {
-    "id" : "id",
-    "label" : "ID",
-    "description" : "ID of the element template",
-    "value" : "io.camunda.connectors.box",
+    "description" : "Version of the element template",
     "group" : "connector",
+    "id" : "version",
+    "label" : "Version",
+    "type" : "Hidden",
+    "value" : "5"
+  }, {
     "binding" : {
       "key" : "elementTemplateId",
       "type" : "zeebe:taskHeader"
     },
-    "type" : "Hidden"
+    "description" : "ID of the element template",
+    "group" : "connector",
+    "id" : "id",
+    "label" : "ID",
+    "type" : "Hidden",
+    "value" : "io.camunda.connectors.box"
   }, {
-    "id" : "resultVariable",
-    "label" : "Result variable",
-    "description" : "Name of variable to store the response in. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-variable\" target=\"_blank\">documentation</a>.",
-    "group" : "output",
     "binding" : {
       "key" : "resultVariable",
       "type" : "zeebe:taskHeader"
     },
+    "description" : "Name of variable to store the response in. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-variable\" target=\"_blank\">documentation</a>.",
+    "group" : "output",
+    "id" : "resultVariable",
+    "label" : "Result variable",
     "type" : "String"
   }, {
-    "id" : "resultExpression",
-    "label" : "Result expression",
-    "description" : "Expression to map the response into process variables. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-expression\" target=\"_blank\">documentation</a>.",
-    "feel" : "required",
-    "group" : "output",
     "binding" : {
       "key" : "resultExpression",
       "type" : "zeebe:taskHeader"
     },
+    "description" : "Expression to map the response into process variables. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-expression\" target=\"_blank\">documentation</a>.",
+    "feel" : "required",
+    "group" : "output",
+    "id" : "resultExpression",
+    "label" : "Result expression",
     "type" : "Text"
   }, {
-    "id" : "errorExpression",
-    "label" : "Error expression",
-    "description" : "Expression to handle errors. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/\" target=\"_blank\">documentation</a>.",
-    "feel" : "required",
-    "group" : "error",
     "binding" : {
       "key" : "errorExpression",
       "type" : "zeebe:taskHeader"
     },
+    "description" : "Expression to handle errors. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/\" target=\"_blank\">documentation</a>.",
+    "feel" : "required",
+    "group" : "error",
+    "id" : "errorExpression",
+    "label" : "Error expression",
     "type" : "Text"
   }, {
-    "id" : "retryCount",
-    "label" : "Retries",
-    "description" : "Number of retries",
-    "value" : "3",
-    "feel" : "optional",
-    "group" : "retries",
     "binding" : {
       "property" : "retries",
       "type" : "zeebe:taskDefinition"
     },
-    "type" : "String"
-  }, {
-    "id" : "retryBackoff",
-    "label" : "Retry backoff",
-    "description" : "ISO-8601 duration to wait between retries",
-    "value" : "PT30S",
+    "description" : "Number of retries",
+    "feel" : "optional",
     "group" : "retries",
+    "id" : "retryCount",
+    "label" : "Retries",
+    "type" : "String",
+    "value" : "3"
+  }, {
     "binding" : {
       "key" : "retryBackoff",
       "type" : "zeebe:taskHeader"
     },
-    "type" : "String"
-  }, {
-    "id" : "jobTimeout",
-    "label" : "Job timeout",
-    "description" : "ISO-8601 duration after which Zeebe considers this job timed out if not yet completed. Leave empty to use the default timeout",
-    "optional" : true,
+    "description" : "ISO-8601 duration to wait between retries",
     "group" : "retries",
+    "id" : "retryBackoff",
+    "label" : "Retry backoff",
+    "type" : "String",
+    "value" : "PT30S"
+  }, {
     "binding" : {
       "key" : "jobTimeout",
       "type" : "zeebe:taskHeader"
     },
+    "description" : "ISO-8601 duration after which Zeebe considers this job timed out if not yet completed. Leave empty to use the default timeout",
+    "group" : "retries",
+    "id" : "jobTimeout",
+    "label" : "Job timeout",
+    "optional" : true,
     "type" : "String"
   } ],
   "steps" : [ {

--- a/connectors/box/element-templates/hybrid/box-outbound-connector-hybrid.json
+++ b/connectors/box/element-templates/hybrid/box-outbound-connector-hybrid.json
@@ -40,25 +40,19 @@
     "label" : "Retries"
   } ],
   "properties" : [ {
-    "id" : "taskDefinitionType",
-    "value" : "io.camunda:box:1",
-    "group" : "taskDefinitionType",
     "binding" : {
       "property" : "type",
       "type" : "zeebe:taskDefinition"
     },
-    "type" : "String"
+    "group" : "taskDefinitionType",
+    "id" : "taskDefinitionType",
+    "type" : "String",
+    "value" : "io.camunda:box:1"
   }, {
-    "id" : "operation.type",
-    "label" : "Operation",
-    "description" : "The operation to execute.",
-    "value" : "createFolder",
-    "group" : "operation",
     "binding" : {
       "name" : "operation.type",
       "type" : "zeebe:input"
     },
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "Create Folder",
       "value" : "createFolder"
@@ -80,16 +74,14 @@
     }, {
       "name" : "Search",
       "value" : "search"
-    } ]
-  }, {
-    "id" : "operation.createFolderName",
-    "label" : "Folder name",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "feel" : "optional",
+    } ],
+    "description" : "The operation to execute.",
     "group" : "operation",
+    "id" : "operation.type",
+    "label" : "Operation",
+    "type" : "Dropdown",
+    "value" : "createFolder"
+  }, {
     "binding" : {
       "name" : "operation.name",
       "type" : "zeebe:input"
@@ -99,17 +91,16 @@
       "equals" : "createFolder",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "operation.createFolderParentPath",
-    "label" : "Parent path",
-    "optional" : false,
-    "value" : "/",
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "operation",
+    "id" : "operation.createFolderName",
+    "label" : "Folder name",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "operation.folderPath",
       "type" : "zeebe:input"
@@ -119,16 +110,17 @@
       "equals" : "createFolder",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "operation.deleteFolderPath",
-    "label" : "Folder path",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "operation",
+    "id" : "operation.createFolderParentPath",
+    "label" : "Parent path",
+    "optional" : false,
+    "type" : "String",
+    "value" : "/"
+  }, {
     "binding" : {
       "name" : "operation.folderPath",
       "type" : "zeebe:input"
@@ -138,14 +130,16 @@
       "equals" : "deleteFolder",
       "type" : "simple"
     },
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "operation",
+    "id" : "operation.deleteFolderPath",
+    "label" : "Folder path",
+    "optional" : false,
     "type" : "String"
   }, {
-    "id" : "operation.recursive",
-    "label" : "Recursive",
-    "optional" : false,
-    "value" : true,
-    "feel" : "static",
-    "group" : "operation",
     "binding" : {
       "name" : "operation.recursive",
       "type" : "zeebe:input"
@@ -155,17 +149,15 @@
       "equals" : "deleteFolder",
       "type" : "simple"
     },
-    "tooltip" : "Deletes all items contained by the folder",
-    "type" : "Boolean"
-  }, {
-    "id" : "operation.uploadFileName",
-    "label" : "File name",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "feel" : "optional",
+    "feel" : "static",
     "group" : "operation",
+    "id" : "operation.recursive",
+    "label" : "Recursive",
+    "optional" : false,
+    "tooltip" : "Deletes all items contained by the folder",
+    "type" : "Boolean",
+    "value" : true
+  }, {
     "binding" : {
       "name" : "operation.name",
       "type" : "zeebe:input"
@@ -175,16 +167,16 @@
       "equals" : "uploadFile",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "operation.uploadFileFolderPath",
-    "label" : "Folder path",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "operation",
+    "id" : "operation.uploadFileName",
+    "label" : "File name",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "operation.folderPath",
       "type" : "zeebe:input"
@@ -194,23 +186,20 @@
       "equals" : "uploadFile",
       "type" : "simple"
     },
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "operation",
+    "id" : "operation.uploadFileFolderPath",
+    "label" : "Folder path",
+    "optional" : false,
     "type" : "String"
   }, {
-    "id" : "operation.document_documentSource",
-    "label" : "Document source",
-    "value" : "camunda",
-    "group" : "operation",
     "binding" : {
       "name" : "operation.document_documentSource",
       "type" : "zeebe:input"
     },
-    "condition" : {
-      "property" : "operation.type",
-      "equals" : "uploadFile",
-      "type" : "simple"
-    },
-    "tooltip" : "The document reference that will be uploaded",
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "Camunda Document",
       "value" : "camunda"
@@ -220,15 +209,19 @@
     }, {
       "name" : "From URL",
       "value" : "external"
-    } ]
-  }, {
-    "id" : "operation.document_camundaReference",
-    "label" : "Camunda document",
-    "constraints" : {
-      "notEmpty" : true
+    } ],
+    "condition" : {
+      "property" : "operation.type",
+      "equals" : "uploadFile",
+      "type" : "simple"
     },
-    "feel" : "required",
     "group" : "operation",
+    "id" : "operation.document_documentSource",
+    "label" : "Document source",
+    "tooltip" : "The document reference that will be uploaded",
+    "type" : "Dropdown",
+    "value" : "camunda"
+  }, {
     "binding" : {
       "name" : "operation.document_camundaReference",
       "type" : "zeebe:input"
@@ -244,15 +237,15 @@
         "type" : "simple"
       } ]
     },
-    "type" : "String"
-  }, {
-    "id" : "operation.document_inline_content",
-    "label" : "Content",
     "constraints" : {
       "notEmpty" : true
     },
-    "feel" : "optional",
+    "feel" : "required",
     "group" : "operation",
+    "id" : "operation.document_camundaReference",
+    "label" : "Camunda document",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "operation.document_inline_content",
       "type" : "zeebe:input"
@@ -268,12 +261,15 @@
         "type" : "simple"
       } ]
     },
-    "type" : "String"
-  }, {
-    "id" : "operation.document_inline_fileName",
-    "label" : "File name",
+    "constraints" : {
+      "notEmpty" : true
+    },
     "feel" : "optional",
     "group" : "operation",
+    "id" : "operation.document_inline_content",
+    "label" : "Content",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "operation.document_inline_fileName",
       "type" : "zeebe:input"
@@ -289,12 +285,12 @@
         "type" : "simple"
       } ]
     },
-    "type" : "String"
-  }, {
-    "id" : "operation.document_inline_contentType",
-    "label" : "Content type",
     "feel" : "optional",
     "group" : "operation",
+    "id" : "operation.document_inline_fileName",
+    "label" : "File name",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "operation.document_inline_contentType",
       "type" : "zeebe:input"
@@ -310,15 +306,12 @@
         "type" : "simple"
       } ]
     },
-    "type" : "String"
-  }, {
-    "id" : "operation.document_external_url",
-    "label" : "URL",
-    "constraints" : {
-      "notEmpty" : true
-    },
     "feel" : "optional",
     "group" : "operation",
+    "id" : "operation.document_inline_contentType",
+    "label" : "Content type",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "operation.document_external_url",
       "type" : "zeebe:input"
@@ -334,12 +327,15 @@
         "type" : "simple"
       } ]
     },
-    "type" : "String"
-  }, {
-    "id" : "operation.document_external_fileName",
-    "label" : "File name",
+    "constraints" : {
+      "notEmpty" : true
+    },
     "feel" : "optional",
     "group" : "operation",
+    "id" : "operation.document_external_url",
+    "label" : "URL",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "operation.document_external_fileName",
       "type" : "zeebe:input"
@@ -355,11 +351,12 @@
         "type" : "simple"
       } ]
     },
+    "feel" : "optional",
+    "group" : "operation",
+    "id" : "operation.document_external_fileName",
+    "label" : "File name",
     "type" : "String"
   }, {
-    "id" : "operation.uploadFileDocument",
-    "value" : "=if document_documentSource = \"camunda\" then document_camundaReference else if document_documentSource = \"inline\" then { \"camunda.document.type\": \"inline\", content: document_inline_content, name: document_inline_fileName, contentType: document_inline_contentType } else if document_documentSource = \"external\" then { \"camunda.document.type\": \"external\", url: document_external_url, name: document_external_fileName } else null",
-    "group" : "operation",
     "binding" : {
       "name" : "operation.document",
       "type" : "zeebe:input"
@@ -369,13 +366,11 @@
       "equals" : "uploadFile",
       "type" : "simple"
     },
-    "type" : "Hidden"
-  }, {
-    "id" : "operation.downloadFilePath",
-    "label" : "File path",
-    "optional" : false,
-    "feel" : "optional",
     "group" : "operation",
+    "id" : "operation.uploadFileDocument",
+    "type" : "Hidden",
+    "value" : "=if document_documentSource = \"camunda\" then document_camundaReference else if document_documentSource = \"inline\" then { \"camunda.document.type\": \"inline\", content: document_inline_content, name: document_inline_fileName, contentType: document_inline_contentType } else if document_documentSource = \"external\" then { \"camunda.document.type\": \"external\", url: document_external_url, name: document_external_fileName } else null"
+  }, {
     "binding" : {
       "name" : "operation.filePath",
       "type" : "zeebe:input"
@@ -385,24 +380,18 @@
       "equals" : "downloadFile",
       "type" : "simple"
     },
+    "feel" : "optional",
+    "group" : "operation",
+    "id" : "operation.downloadFilePath",
+    "label" : "File path",
+    "optional" : false,
     "tooltip" : "Path to the file item to download",
     "type" : "String"
   }, {
-    "id" : "documentReturnFormat",
-    "label" : "Response format",
-    "value" : "DOCUMENT",
-    "group" : "operation",
     "binding" : {
       "name" : "documentReturnFormat.choice",
       "type" : "zeebe:input"
     },
-    "condition" : {
-      "property" : "operation.type",
-      "equals" : "downloadFile",
-      "type" : "simple"
-    },
-    "tooltip" : "How the downloaded payload should be returned. Document reference uploads the payload to the document store; as text decodes it as a String; as JSON parses it into a structure you can access via dot notation.",
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "Document reference",
       "value" : "DOCUMENT"
@@ -412,14 +401,19 @@
     }, {
       "name" : "as JSON",
       "value" : "JSON"
-    } ]
-  }, {
-    "id" : "documentReturnFormatEncoding",
-    "label" : "Encoding",
-    "description" : "Character set used to decode the response. Default UTF-8.",
-    "value" : "UTF-8",
-    "feel" : "optional",
+    } ],
+    "condition" : {
+      "property" : "operation.type",
+      "equals" : "downloadFile",
+      "type" : "simple"
+    },
     "group" : "operation",
+    "id" : "documentReturnFormat",
+    "label" : "Response format",
+    "tooltip" : "How the downloaded payload should be returned. Document reference uploads the payload to the document store; as text decodes it as a String; as JSON parses it into a structure you can access via dot notation.",
+    "type" : "Dropdown",
+    "value" : "DOCUMENT"
+  }, {
     "binding" : {
       "name" : "documentReturnFormat.encoding",
       "type" : "zeebe:input"
@@ -435,16 +429,14 @@
         "type" : "simple"
       } ]
     },
-    "type" : "String"
-  }, {
-    "id" : "operation.moveFilePath",
-    "label" : "File path",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
+    "description" : "Character set used to decode the response. Default UTF-8.",
     "feel" : "optional",
     "group" : "operation",
+    "id" : "documentReturnFormatEncoding",
+    "label" : "Encoding",
+    "type" : "String",
+    "value" : "UTF-8"
+  }, {
     "binding" : {
       "name" : "operation.filePath",
       "type" : "zeebe:input"
@@ -454,16 +446,16 @@
       "equals" : "moveFile",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "operation.moveFileFolderPath",
-    "label" : "Target folder path",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "operation",
+    "id" : "operation.moveFilePath",
+    "label" : "File path",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "operation.folderPath",
       "type" : "zeebe:input"
@@ -473,16 +465,16 @@
       "equals" : "moveFile",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "operation.deleteFilePath",
-    "label" : "File path",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "operation",
+    "id" : "operation.moveFileFolderPath",
+    "label" : "Target folder path",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "operation.filePath",
       "type" : "zeebe:input"
@@ -492,16 +484,16 @@
       "equals" : "deleteFile",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "operation.searchQuery",
-    "label" : "Search query",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "operation",
+    "id" : "operation.deleteFilePath",
+    "label" : "File path",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "operation.query",
       "type" : "zeebe:input"
@@ -511,17 +503,16 @@
       "equals" : "search",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "operation.searchSortColumn",
-    "label" : "Search sort column",
-    "optional" : false,
-    "value" : "modified_at",
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "operation",
+    "id" : "operation.searchQuery",
+    "label" : "Search query",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "operation.sortColumn",
       "type" : "zeebe:input"
@@ -531,38 +522,41 @@
       "equals" : "search",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "operation.searchSortDirection",
-    "label" : "Search sort direction",
-    "optional" : false,
-    "value" : "DESC",
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
     "group" : "operation",
+    "id" : "operation.searchSortColumn",
+    "label" : "Search sort column",
+    "optional" : false,
+    "type" : "String",
+    "value" : "modified_at"
+  }, {
     "binding" : {
       "name" : "operation.sortDirection",
       "type" : "zeebe:input"
     },
-    "condition" : {
-      "property" : "operation.type",
-      "equals" : "search",
-      "type" : "simple"
-    },
-    "tooltip" : "Sort order for results: ASC (ascending) or DESC (descending)",
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "ASC",
       "value" : "ASC"
     }, {
       "name" : "DESC",
       "value" : "DESC"
-    } ]
-  }, {
-    "id" : "operation.searchOffset",
-    "label" : "Search offset",
-    "optional" : false,
-    "value" : 0,
-    "feel" : "static",
+    } ],
+    "condition" : {
+      "property" : "operation.type",
+      "equals" : "search",
+      "type" : "simple"
+    },
     "group" : "operation",
+    "id" : "operation.searchSortDirection",
+    "label" : "Search sort direction",
+    "optional" : false,
+    "tooltip" : "Sort order for results: ASC (ascending) or DESC (descending)",
+    "type" : "Dropdown",
+    "value" : "DESC"
+  }, {
     "binding" : {
       "name" : "operation.offset",
       "type" : "zeebe:input"
@@ -572,14 +566,14 @@
       "equals" : "search",
       "type" : "simple"
     },
-    "type" : "Number"
-  }, {
-    "id" : "operation.searchLimit",
-    "label" : "Search limit",
-    "optional" : false,
-    "value" : 30,
     "feel" : "static",
     "group" : "operation",
+    "id" : "operation.searchOffset",
+    "label" : "Search offset",
+    "optional" : false,
+    "type" : "Number",
+    "value" : 0
+  }, {
     "binding" : {
       "name" : "operation.limit",
       "type" : "zeebe:input"
@@ -589,18 +583,18 @@
       "equals" : "search",
       "type" : "simple"
     },
-    "type" : "Number"
+    "feel" : "static",
+    "group" : "operation",
+    "id" : "operation.searchLimit",
+    "label" : "Search limit",
+    "optional" : false,
+    "type" : "Number",
+    "value" : 30
   }, {
-    "id" : "authentication.type",
-    "label" : "Authentication",
-    "description" : "Specify authentication strategy. Learn more at the <a href=\"https://developer.box.com/guides/authentication/\" target=\"_blank\">documentation page</a>",
-    "value" : "developerToken",
-    "group" : "authentication",
     "binding" : {
       "name" : "authentication.type",
       "type" : "zeebe:input"
     },
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "Client Credentials Enterprise",
       "value" : "clientCredentialsEnterprise"
@@ -613,16 +607,14 @@
     }, {
       "name" : "JWT JSON Config",
       "value" : "jwtJsonConfig"
-    } ]
-  }, {
-    "id" : "authentication.clientIdEnterprise",
-    "label" : "Client id",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "feel" : "optional",
+    } ],
+    "description" : "Specify authentication strategy. Learn more at the <a href=\"https://developer.box.com/guides/authentication/\" target=\"_blank\">documentation page</a>",
     "group" : "authentication",
+    "id" : "authentication.type",
+    "label" : "Authentication",
+    "type" : "Dropdown",
+    "value" : "developerToken"
+  }, {
     "binding" : {
       "name" : "authentication.clientId",
       "type" : "zeebe:input"
@@ -632,16 +624,16 @@
       "equals" : "clientCredentialsEnterprise",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "authentication.clientSecretEnterprise",
-    "label" : "Client secret",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "authentication",
+    "id" : "authentication.clientIdEnterprise",
+    "label" : "Client id",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "authentication.clientSecret",
       "type" : "zeebe:input"
@@ -651,16 +643,16 @@
       "equals" : "clientCredentialsEnterprise",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "authentication.enterpriseId",
-    "label" : "Enterprise ID",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "authentication",
+    "id" : "authentication.clientSecretEnterprise",
+    "label" : "Client secret",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "authentication.enterpriseId",
       "type" : "zeebe:input"
@@ -670,17 +662,17 @@
       "equals" : "clientCredentialsEnterprise",
       "type" : "simple"
     },
-    "tooltip" : "The enterprise ID to authenticate against",
-    "type" : "String"
-  }, {
-    "id" : "authentication.clientIdUser",
-    "label" : "Client id",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "authentication",
+    "id" : "authentication.enterpriseId",
+    "label" : "Enterprise ID",
+    "optional" : false,
+    "tooltip" : "The enterprise ID to authenticate against",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "authentication.clientId",
       "type" : "zeebe:input"
@@ -690,16 +682,16 @@
       "equals" : "clientCredentialsUser",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "authentication.clientSecretUser",
-    "label" : "Client secret",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "authentication",
+    "id" : "authentication.clientIdUser",
+    "label" : "Client id",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "authentication.clientSecret",
       "type" : "zeebe:input"
@@ -709,16 +701,16 @@
       "equals" : "clientCredentialsUser",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "authentication.userId",
-    "label" : "User ID",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "authentication",
+    "id" : "authentication.clientSecretUser",
+    "label" : "Client secret",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "authentication.userId",
       "type" : "zeebe:input"
@@ -728,17 +720,17 @@
       "equals" : "clientCredentialsUser",
       "type" : "simple"
     },
-    "tooltip" : "The user ID of the account to authenticate against",
-    "type" : "String"
-  }, {
-    "id" : "authentication.accessToken",
-    "label" : "Access key",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "authentication",
+    "id" : "authentication.userId",
+    "label" : "User ID",
+    "optional" : false,
+    "tooltip" : "The user ID of the account to authenticate against",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "authentication.accessToken",
       "type" : "zeebe:input"
@@ -748,17 +740,17 @@
       "equals" : "developerToken",
       "type" : "simple"
     },
-    "tooltip" : "The access key or developer token",
-    "type" : "String"
-  }, {
-    "id" : "authentication.jsonConfig",
-    "label" : "JSON config",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "authentication",
+    "id" : "authentication.accessToken",
+    "label" : "Access key",
+    "optional" : false,
+    "tooltip" : "The access key or developer token",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "authentication.jsonConfig",
       "type" : "zeebe:input"
@@ -768,95 +760,103 @@
       "equals" : "jwtJsonConfig",
       "type" : "simple"
     },
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "authentication",
+    "id" : "authentication.jsonConfig",
+    "label" : "JSON config",
+    "optional" : false,
     "tooltip" : "The JSON config as string",
     "type" : "String"
   }, {
-    "id" : "version",
-    "label" : "Version",
-    "description" : "Version of the element template",
-    "value" : "5",
-    "group" : "connector",
     "binding" : {
       "key" : "elementTemplateVersion",
       "type" : "zeebe:taskHeader"
     },
-    "type" : "Hidden"
-  }, {
-    "id" : "id",
-    "label" : "ID",
-    "description" : "ID of the element template",
-    "value" : "io.camunda.connectors.box",
+    "description" : "Version of the element template",
     "group" : "connector",
+    "id" : "version",
+    "label" : "Version",
+    "type" : "Hidden",
+    "value" : "5"
+  }, {
     "binding" : {
       "key" : "elementTemplateId",
       "type" : "zeebe:taskHeader"
     },
-    "type" : "Hidden"
+    "description" : "ID of the element template",
+    "group" : "connector",
+    "id" : "id",
+    "label" : "ID",
+    "type" : "Hidden",
+    "value" : "io.camunda.connectors.box"
   }, {
-    "id" : "resultVariable",
-    "label" : "Result variable",
-    "description" : "Name of variable to store the response in. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-variable\" target=\"_blank\">documentation</a>.",
-    "group" : "output",
     "binding" : {
       "key" : "resultVariable",
       "type" : "zeebe:taskHeader"
     },
+    "description" : "Name of variable to store the response in. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-variable\" target=\"_blank\">documentation</a>.",
+    "group" : "output",
+    "id" : "resultVariable",
+    "label" : "Result variable",
     "type" : "String"
   }, {
-    "id" : "resultExpression",
-    "label" : "Result expression",
-    "description" : "Expression to map the response into process variables. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-expression\" target=\"_blank\">documentation</a>.",
-    "feel" : "required",
-    "group" : "output",
     "binding" : {
       "key" : "resultExpression",
       "type" : "zeebe:taskHeader"
     },
+    "description" : "Expression to map the response into process variables. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-expression\" target=\"_blank\">documentation</a>.",
+    "feel" : "required",
+    "group" : "output",
+    "id" : "resultExpression",
+    "label" : "Result expression",
     "type" : "Text"
   }, {
-    "id" : "errorExpression",
-    "label" : "Error expression",
-    "description" : "Expression to handle errors. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/\" target=\"_blank\">documentation</a>.",
-    "feel" : "required",
-    "group" : "error",
     "binding" : {
       "key" : "errorExpression",
       "type" : "zeebe:taskHeader"
     },
+    "description" : "Expression to handle errors. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/\" target=\"_blank\">documentation</a>.",
+    "feel" : "required",
+    "group" : "error",
+    "id" : "errorExpression",
+    "label" : "Error expression",
     "type" : "Text"
   }, {
-    "id" : "retryCount",
-    "label" : "Retries",
-    "description" : "Number of retries",
-    "value" : "3",
-    "feel" : "optional",
-    "group" : "retries",
     "binding" : {
       "property" : "retries",
       "type" : "zeebe:taskDefinition"
     },
-    "type" : "String"
-  }, {
-    "id" : "retryBackoff",
-    "label" : "Retry backoff",
-    "description" : "ISO-8601 duration to wait between retries",
-    "value" : "PT30S",
+    "description" : "Number of retries",
+    "feel" : "optional",
     "group" : "retries",
+    "id" : "retryCount",
+    "label" : "Retries",
+    "type" : "String",
+    "value" : "3"
+  }, {
     "binding" : {
       "key" : "retryBackoff",
       "type" : "zeebe:taskHeader"
     },
-    "type" : "String"
-  }, {
-    "id" : "jobTimeout",
-    "label" : "Job timeout",
-    "description" : "ISO-8601 duration after which Zeebe considers this job timed out if not yet completed. Leave empty to use the default timeout",
-    "optional" : true,
+    "description" : "ISO-8601 duration to wait between retries",
     "group" : "retries",
+    "id" : "retryBackoff",
+    "label" : "Retry backoff",
+    "type" : "String",
+    "value" : "PT30S"
+  }, {
     "binding" : {
       "key" : "jobTimeout",
       "type" : "zeebe:taskHeader"
     },
+    "description" : "ISO-8601 duration after which Zeebe considers this job timed out if not yet completed. Leave empty to use the default timeout",
+    "group" : "retries",
+    "id" : "jobTimeout",
+    "label" : "Job timeout",
+    "optional" : true,
     "type" : "String"
   } ],
   "steps" : [ {

--- a/connectors/camunda-message/element-templates/hybrid/hybrid-send-message-connector-intermediate-throw-event-hybrid.json
+++ b/connectors/camunda-message/element-templates/hybrid/hybrid-send-message-connector-intermediate-throw-event-hybrid.json
@@ -36,90 +36,85 @@
     "label" : "Retries"
   } ],
   "properties" : [ {
-    "id" : "taskDefinitionType",
-    "value" : "io.camunda:sendMessage:1",
-    "group" : "taskDefinitionType",
     "binding" : {
       "property" : "type",
       "type" : "zeebe:taskDefinition"
     },
-    "type" : "String"
+    "group" : "taskDefinitionType",
+    "id" : "taskDefinitionType",
+    "type" : "String",
+    "value" : "io.camunda:sendMessage:1"
   }, {
-    "id" : "messageName",
-    "label" : "Message name",
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "feel" : "optional",
     "binding" : {
       "name" : "messageName",
       "type" : "zeebe:input"
     },
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "id" : "messageName",
+    "label" : "Message name",
     "type" : "String"
   }, {
-    "id" : "correlationKey",
-    "label" : "Correlation key",
-    "optional" : true,
-    "feel" : "optional",
     "binding" : {
       "name" : "correlationKey",
       "type" : "zeebe:input"
     },
+    "feel" : "optional",
+    "id" : "correlationKey",
+    "label" : "Correlation key",
+    "optional" : true,
     "type" : "String"
   }, {
-    "id" : "variables",
-    "label" : "Payload",
-    "optional" : true,
-    "feel" : "optional",
     "binding" : {
       "name" : "variables",
       "type" : "zeebe:input"
     },
+    "feel" : "optional",
+    "id" : "variables",
+    "label" : "Payload",
+    "optional" : true,
     "type" : "String"
   }, {
-    "id" : "tenantId",
-    "label" : "Tenant id",
-    "optional" : true,
-    "feel" : "optional",
     "binding" : {
       "name" : "tenantId",
       "type" : "zeebe:input"
     },
+    "feel" : "optional",
+    "id" : "tenantId",
+    "label" : "Tenant id",
+    "optional" : true,
     "type" : "String"
   }, {
-    "id" : "requestTimeout",
-    "label" : "Request timeout",
-    "optional" : true,
-    "feel" : "optional",
     "binding" : {
       "name" : "requestTimeout",
       "type" : "zeebe:input"
     },
+    "feel" : "optional",
+    "id" : "requestTimeout",
+    "label" : "Request timeout",
+    "optional" : true,
     "type" : "String"
   }, {
-    "id" : "correlationType.type",
-    "label" : "Correlation mode",
-    "description" : "Send message with <a href='https://docs.camunda.io/docs/components/concepts/messages/#message-buffering' target='_blank'>buffer (publish)</a> or with <a href='https://docs.camunda.io/docs/components/concepts/messages/#message-response' target='_blank'>result (correlate)</a>",
-    "value" : "publish",
-    "group" : "operation",
     "binding" : {
       "name" : "correlationType.type",
       "type" : "zeebe:input"
     },
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "Correlate message (with result)",
       "value" : "correlate"
     }, {
       "name" : "Publish message (with buffer)",
       "value" : "publish"
-    } ]
-  }, {
-    "id" : "correlationType.timeToLive",
-    "label" : "Time to live (as ISO 8601)",
-    "optional" : true,
-    "feel" : "optional",
+    } ],
+    "description" : "Send message with <a href='https://docs.camunda.io/docs/components/concepts/messages/#message-buffering' target='_blank'>buffer (publish)</a> or with <a href='https://docs.camunda.io/docs/components/concepts/messages/#message-response' target='_blank'>result (correlate)</a>",
     "group" : "operation",
+    "id" : "correlationType.type",
+    "label" : "Correlation mode",
+    "type" : "Dropdown",
+    "value" : "publish"
+  }, {
     "binding" : {
       "name" : "correlationType.timeToLive",
       "type" : "zeebe:input"
@@ -129,14 +124,14 @@
       "equals" : "publish",
       "type" : "simple"
     },
+    "feel" : "optional",
+    "group" : "operation",
+    "id" : "correlationType.timeToLive",
+    "label" : "Time to live (as ISO 8601)",
+    "optional" : true,
     "tooltip" : "Duration for which the message remains buffered",
     "type" : "String"
   }, {
-    "id" : "correlationType.messageId",
-    "label" : "Message id (optional)",
-    "optional" : true,
-    "feel" : "optional",
-    "group" : "operation",
     "binding" : {
       "name" : "correlationType.messageId",
       "type" : "zeebe:input"
@@ -146,94 +141,99 @@
       "equals" : "publish",
       "type" : "simple"
     },
+    "feel" : "optional",
+    "group" : "operation",
+    "id" : "correlationType.messageId",
+    "label" : "Message id (optional)",
+    "optional" : true,
     "type" : "String"
   }, {
-    "id" : "version",
-    "label" : "Version",
-    "description" : "Version of the element template",
-    "value" : "1",
-    "group" : "connector",
     "binding" : {
       "key" : "elementTemplateVersion",
       "type" : "zeebe:taskHeader"
     },
-    "type" : "Hidden"
-  }, {
-    "id" : "id",
-    "label" : "ID",
-    "description" : "ID of the element template",
-    "value" : "io.camunda.connectors.message.v1",
+    "description" : "Version of the element template",
     "group" : "connector",
+    "id" : "version",
+    "label" : "Version",
+    "type" : "Hidden",
+    "value" : "1"
+  }, {
     "binding" : {
       "key" : "elementTemplateId",
       "type" : "zeebe:taskHeader"
     },
-    "type" : "Hidden"
+    "description" : "ID of the element template",
+    "group" : "connector",
+    "id" : "id",
+    "label" : "ID",
+    "type" : "Hidden",
+    "value" : "io.camunda.connectors.message.v1"
   }, {
-    "id" : "resultVariable",
-    "label" : "Result variable",
-    "description" : "Name of variable to store the response in. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-variable\" target=\"_blank\">documentation</a>.",
-    "group" : "output",
     "binding" : {
       "key" : "resultVariable",
       "type" : "zeebe:taskHeader"
     },
+    "description" : "Name of variable to store the response in. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-variable\" target=\"_blank\">documentation</a>.",
+    "group" : "output",
+    "id" : "resultVariable",
+    "label" : "Result variable",
     "type" : "String"
   }, {
-    "id" : "resultExpression",
-    "label" : "Result expression",
-    "description" : "Expression to map the response into process variables. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-expression\" target=\"_blank\">documentation</a>.",
-    "feel" : "required",
-    "group" : "output",
     "binding" : {
       "key" : "resultExpression",
       "type" : "zeebe:taskHeader"
     },
+    "description" : "Expression to map the response into process variables. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-expression\" target=\"_blank\">documentation</a>.",
+    "feel" : "required",
+    "group" : "output",
+    "id" : "resultExpression",
+    "label" : "Result expression",
     "type" : "Text"
   }, {
-    "id" : "errorExpression",
-    "label" : "Error expression",
-    "description" : "Expression to handle errors. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/\" target=\"_blank\">documentation</a>.",
-    "feel" : "required",
-    "group" : "error",
     "binding" : {
       "key" : "errorExpression",
       "type" : "zeebe:taskHeader"
     },
+    "description" : "Expression to handle errors. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/\" target=\"_blank\">documentation</a>.",
+    "feel" : "required",
+    "group" : "error",
+    "id" : "errorExpression",
+    "label" : "Error expression",
     "type" : "Text"
   }, {
-    "id" : "retryCount",
-    "label" : "Retries",
-    "description" : "Number of retries",
-    "value" : "3",
-    "feel" : "optional",
-    "group" : "retries",
     "binding" : {
       "property" : "retries",
       "type" : "zeebe:taskDefinition"
     },
-    "type" : "String"
-  }, {
-    "id" : "retryBackoff",
-    "label" : "Retry backoff",
-    "description" : "ISO-8601 duration to wait between retries",
-    "value" : "PT30S",
+    "description" : "Number of retries",
+    "feel" : "optional",
     "group" : "retries",
+    "id" : "retryCount",
+    "label" : "Retries",
+    "type" : "String",
+    "value" : "3"
+  }, {
     "binding" : {
       "key" : "retryBackoff",
       "type" : "zeebe:taskHeader"
     },
-    "type" : "String"
-  }, {
-    "id" : "jobTimeout",
-    "label" : "Job timeout",
-    "description" : "ISO-8601 duration after which Zeebe considers this job timed out if not yet completed. Leave empty to use the default timeout",
-    "optional" : true,
+    "description" : "ISO-8601 duration to wait between retries",
     "group" : "retries",
+    "id" : "retryBackoff",
+    "label" : "Retry backoff",
+    "type" : "String",
+    "value" : "PT30S"
+  }, {
     "binding" : {
       "key" : "jobTimeout",
       "type" : "zeebe:taskHeader"
     },
+    "description" : "ISO-8601 duration after which Zeebe considers this job timed out if not yet completed. Leave empty to use the default timeout",
+    "group" : "retries",
+    "id" : "jobTimeout",
+    "label" : "Job timeout",
+    "optional" : true,
     "type" : "String"
   } ],
   "steps" : [ {

--- a/connectors/camunda-message/element-templates/hybrid/hybrid-send-message-connector-message-end-event-hybrid.json
+++ b/connectors/camunda-message/element-templates/hybrid/hybrid-send-message-connector-message-end-event-hybrid.json
@@ -36,90 +36,85 @@
     "label" : "Retries"
   } ],
   "properties" : [ {
-    "id" : "taskDefinitionType",
-    "value" : "io.camunda:sendMessage:1",
-    "group" : "taskDefinitionType",
     "binding" : {
       "property" : "type",
       "type" : "zeebe:taskDefinition"
     },
-    "type" : "String"
+    "group" : "taskDefinitionType",
+    "id" : "taskDefinitionType",
+    "type" : "String",
+    "value" : "io.camunda:sendMessage:1"
   }, {
-    "id" : "messageName",
-    "label" : "Message name",
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "feel" : "optional",
     "binding" : {
       "name" : "messageName",
       "type" : "zeebe:input"
     },
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "id" : "messageName",
+    "label" : "Message name",
     "type" : "String"
   }, {
-    "id" : "correlationKey",
-    "label" : "Correlation key",
-    "optional" : true,
-    "feel" : "optional",
     "binding" : {
       "name" : "correlationKey",
       "type" : "zeebe:input"
     },
+    "feel" : "optional",
+    "id" : "correlationKey",
+    "label" : "Correlation key",
+    "optional" : true,
     "type" : "String"
   }, {
-    "id" : "variables",
-    "label" : "Payload",
-    "optional" : true,
-    "feel" : "optional",
     "binding" : {
       "name" : "variables",
       "type" : "zeebe:input"
     },
+    "feel" : "optional",
+    "id" : "variables",
+    "label" : "Payload",
+    "optional" : true,
     "type" : "String"
   }, {
-    "id" : "tenantId",
-    "label" : "Tenant id",
-    "optional" : true,
-    "feel" : "optional",
     "binding" : {
       "name" : "tenantId",
       "type" : "zeebe:input"
     },
+    "feel" : "optional",
+    "id" : "tenantId",
+    "label" : "Tenant id",
+    "optional" : true,
     "type" : "String"
   }, {
-    "id" : "requestTimeout",
-    "label" : "Request timeout",
-    "optional" : true,
-    "feel" : "optional",
     "binding" : {
       "name" : "requestTimeout",
       "type" : "zeebe:input"
     },
+    "feel" : "optional",
+    "id" : "requestTimeout",
+    "label" : "Request timeout",
+    "optional" : true,
     "type" : "String"
   }, {
-    "id" : "correlationType.type",
-    "label" : "Correlation mode",
-    "description" : "Send message with <a href='https://docs.camunda.io/docs/components/concepts/messages/#message-buffering' target='_blank'>buffer (publish)</a> or with <a href='https://docs.camunda.io/docs/components/concepts/messages/#message-response' target='_blank'>result (correlate)</a>",
-    "value" : "publish",
-    "group" : "operation",
     "binding" : {
       "name" : "correlationType.type",
       "type" : "zeebe:input"
     },
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "Correlate message (with result)",
       "value" : "correlate"
     }, {
       "name" : "Publish message (with buffer)",
       "value" : "publish"
-    } ]
-  }, {
-    "id" : "correlationType.timeToLive",
-    "label" : "Time to live (as ISO 8601)",
-    "optional" : true,
-    "feel" : "optional",
+    } ],
+    "description" : "Send message with <a href='https://docs.camunda.io/docs/components/concepts/messages/#message-buffering' target='_blank'>buffer (publish)</a> or with <a href='https://docs.camunda.io/docs/components/concepts/messages/#message-response' target='_blank'>result (correlate)</a>",
     "group" : "operation",
+    "id" : "correlationType.type",
+    "label" : "Correlation mode",
+    "type" : "Dropdown",
+    "value" : "publish"
+  }, {
     "binding" : {
       "name" : "correlationType.timeToLive",
       "type" : "zeebe:input"
@@ -129,14 +124,14 @@
       "equals" : "publish",
       "type" : "simple"
     },
+    "feel" : "optional",
+    "group" : "operation",
+    "id" : "correlationType.timeToLive",
+    "label" : "Time to live (as ISO 8601)",
+    "optional" : true,
     "tooltip" : "Duration for which the message remains buffered",
     "type" : "String"
   }, {
-    "id" : "correlationType.messageId",
-    "label" : "Message id (optional)",
-    "optional" : true,
-    "feel" : "optional",
-    "group" : "operation",
     "binding" : {
       "name" : "correlationType.messageId",
       "type" : "zeebe:input"
@@ -146,94 +141,99 @@
       "equals" : "publish",
       "type" : "simple"
     },
+    "feel" : "optional",
+    "group" : "operation",
+    "id" : "correlationType.messageId",
+    "label" : "Message id (optional)",
+    "optional" : true,
     "type" : "String"
   }, {
-    "id" : "version",
-    "label" : "Version",
-    "description" : "Version of the element template",
-    "value" : "1",
-    "group" : "connector",
     "binding" : {
       "key" : "elementTemplateVersion",
       "type" : "zeebe:taskHeader"
     },
-    "type" : "Hidden"
-  }, {
-    "id" : "id",
-    "label" : "ID",
-    "description" : "ID of the element template",
-    "value" : "io.camunda.connectors.message.v1",
+    "description" : "Version of the element template",
     "group" : "connector",
+    "id" : "version",
+    "label" : "Version",
+    "type" : "Hidden",
+    "value" : "1"
+  }, {
     "binding" : {
       "key" : "elementTemplateId",
       "type" : "zeebe:taskHeader"
     },
-    "type" : "Hidden"
+    "description" : "ID of the element template",
+    "group" : "connector",
+    "id" : "id",
+    "label" : "ID",
+    "type" : "Hidden",
+    "value" : "io.camunda.connectors.message.v1"
   }, {
-    "id" : "resultVariable",
-    "label" : "Result variable",
-    "description" : "Name of variable to store the response in. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-variable\" target=\"_blank\">documentation</a>.",
-    "group" : "output",
     "binding" : {
       "key" : "resultVariable",
       "type" : "zeebe:taskHeader"
     },
+    "description" : "Name of variable to store the response in. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-variable\" target=\"_blank\">documentation</a>.",
+    "group" : "output",
+    "id" : "resultVariable",
+    "label" : "Result variable",
     "type" : "String"
   }, {
-    "id" : "resultExpression",
-    "label" : "Result expression",
-    "description" : "Expression to map the response into process variables. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-expression\" target=\"_blank\">documentation</a>.",
-    "feel" : "required",
-    "group" : "output",
     "binding" : {
       "key" : "resultExpression",
       "type" : "zeebe:taskHeader"
     },
+    "description" : "Expression to map the response into process variables. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-expression\" target=\"_blank\">documentation</a>.",
+    "feel" : "required",
+    "group" : "output",
+    "id" : "resultExpression",
+    "label" : "Result expression",
     "type" : "Text"
   }, {
-    "id" : "errorExpression",
-    "label" : "Error expression",
-    "description" : "Expression to handle errors. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/\" target=\"_blank\">documentation</a>.",
-    "feel" : "required",
-    "group" : "error",
     "binding" : {
       "key" : "errorExpression",
       "type" : "zeebe:taskHeader"
     },
+    "description" : "Expression to handle errors. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/\" target=\"_blank\">documentation</a>.",
+    "feel" : "required",
+    "group" : "error",
+    "id" : "errorExpression",
+    "label" : "Error expression",
     "type" : "Text"
   }, {
-    "id" : "retryCount",
-    "label" : "Retries",
-    "description" : "Number of retries",
-    "value" : "3",
-    "feel" : "optional",
-    "group" : "retries",
     "binding" : {
       "property" : "retries",
       "type" : "zeebe:taskDefinition"
     },
-    "type" : "String"
-  }, {
-    "id" : "retryBackoff",
-    "label" : "Retry backoff",
-    "description" : "ISO-8601 duration to wait between retries",
-    "value" : "PT30S",
+    "description" : "Number of retries",
+    "feel" : "optional",
     "group" : "retries",
+    "id" : "retryCount",
+    "label" : "Retries",
+    "type" : "String",
+    "value" : "3"
+  }, {
     "binding" : {
       "key" : "retryBackoff",
       "type" : "zeebe:taskHeader"
     },
-    "type" : "String"
-  }, {
-    "id" : "jobTimeout",
-    "label" : "Job timeout",
-    "description" : "ISO-8601 duration after which Zeebe considers this job timed out if not yet completed. Leave empty to use the default timeout",
-    "optional" : true,
+    "description" : "ISO-8601 duration to wait between retries",
     "group" : "retries",
+    "id" : "retryBackoff",
+    "label" : "Retry backoff",
+    "type" : "String",
+    "value" : "PT30S"
+  }, {
     "binding" : {
       "key" : "jobTimeout",
       "type" : "zeebe:taskHeader"
     },
+    "description" : "ISO-8601 duration after which Zeebe considers this job timed out if not yet completed. Leave empty to use the default timeout",
+    "group" : "retries",
+    "id" : "jobTimeout",
+    "label" : "Job timeout",
+    "optional" : true,
     "type" : "String"
   } ],
   "steps" : [ {

--- a/connectors/camunda-message/element-templates/hybrid/hybrid-send-message-connector-send-task-hybrid.json
+++ b/connectors/camunda-message/element-templates/hybrid/hybrid-send-message-connector-send-task-hybrid.json
@@ -35,90 +35,85 @@
     "label" : "Retries"
   } ],
   "properties" : [ {
-    "id" : "taskDefinitionType",
-    "value" : "io.camunda:sendMessage:1",
-    "group" : "taskDefinitionType",
     "binding" : {
       "property" : "type",
       "type" : "zeebe:taskDefinition"
     },
-    "type" : "String"
+    "group" : "taskDefinitionType",
+    "id" : "taskDefinitionType",
+    "type" : "String",
+    "value" : "io.camunda:sendMessage:1"
   }, {
-    "id" : "messageName",
-    "label" : "Message name",
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "feel" : "optional",
     "binding" : {
       "name" : "messageName",
       "type" : "zeebe:input"
     },
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "id" : "messageName",
+    "label" : "Message name",
     "type" : "String"
   }, {
-    "id" : "correlationKey",
-    "label" : "Correlation key",
-    "optional" : true,
-    "feel" : "optional",
     "binding" : {
       "name" : "correlationKey",
       "type" : "zeebe:input"
     },
+    "feel" : "optional",
+    "id" : "correlationKey",
+    "label" : "Correlation key",
+    "optional" : true,
     "type" : "String"
   }, {
-    "id" : "variables",
-    "label" : "Payload",
-    "optional" : true,
-    "feel" : "optional",
     "binding" : {
       "name" : "variables",
       "type" : "zeebe:input"
     },
+    "feel" : "optional",
+    "id" : "variables",
+    "label" : "Payload",
+    "optional" : true,
     "type" : "String"
   }, {
-    "id" : "tenantId",
-    "label" : "Tenant id",
-    "optional" : true,
-    "feel" : "optional",
     "binding" : {
       "name" : "tenantId",
       "type" : "zeebe:input"
     },
+    "feel" : "optional",
+    "id" : "tenantId",
+    "label" : "Tenant id",
+    "optional" : true,
     "type" : "String"
   }, {
-    "id" : "requestTimeout",
-    "label" : "Request timeout",
-    "optional" : true,
-    "feel" : "optional",
     "binding" : {
       "name" : "requestTimeout",
       "type" : "zeebe:input"
     },
+    "feel" : "optional",
+    "id" : "requestTimeout",
+    "label" : "Request timeout",
+    "optional" : true,
     "type" : "String"
   }, {
-    "id" : "correlationType.type",
-    "label" : "Correlation mode",
-    "description" : "Send message with <a href='https://docs.camunda.io/docs/components/concepts/messages/#message-buffering' target='_blank'>buffer (publish)</a> or with <a href='https://docs.camunda.io/docs/components/concepts/messages/#message-response' target='_blank'>result (correlate)</a>",
-    "value" : "publish",
-    "group" : "operation",
     "binding" : {
       "name" : "correlationType.type",
       "type" : "zeebe:input"
     },
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "Correlate message (with result)",
       "value" : "correlate"
     }, {
       "name" : "Publish message (with buffer)",
       "value" : "publish"
-    } ]
-  }, {
-    "id" : "correlationType.timeToLive",
-    "label" : "Time to live (as ISO 8601)",
-    "optional" : true,
-    "feel" : "optional",
+    } ],
+    "description" : "Send message with <a href='https://docs.camunda.io/docs/components/concepts/messages/#message-buffering' target='_blank'>buffer (publish)</a> or with <a href='https://docs.camunda.io/docs/components/concepts/messages/#message-response' target='_blank'>result (correlate)</a>",
     "group" : "operation",
+    "id" : "correlationType.type",
+    "label" : "Correlation mode",
+    "type" : "Dropdown",
+    "value" : "publish"
+  }, {
     "binding" : {
       "name" : "correlationType.timeToLive",
       "type" : "zeebe:input"
@@ -128,14 +123,14 @@
       "equals" : "publish",
       "type" : "simple"
     },
+    "feel" : "optional",
+    "group" : "operation",
+    "id" : "correlationType.timeToLive",
+    "label" : "Time to live (as ISO 8601)",
+    "optional" : true,
     "tooltip" : "Duration for which the message remains buffered",
     "type" : "String"
   }, {
-    "id" : "correlationType.messageId",
-    "label" : "Message id (optional)",
-    "optional" : true,
-    "feel" : "optional",
-    "group" : "operation",
     "binding" : {
       "name" : "correlationType.messageId",
       "type" : "zeebe:input"
@@ -145,94 +140,99 @@
       "equals" : "publish",
       "type" : "simple"
     },
+    "feel" : "optional",
+    "group" : "operation",
+    "id" : "correlationType.messageId",
+    "label" : "Message id (optional)",
+    "optional" : true,
     "type" : "String"
   }, {
-    "id" : "version",
-    "label" : "Version",
-    "description" : "Version of the element template",
-    "value" : "1",
-    "group" : "connector",
     "binding" : {
       "key" : "elementTemplateVersion",
       "type" : "zeebe:taskHeader"
     },
-    "type" : "Hidden"
-  }, {
-    "id" : "id",
-    "label" : "ID",
-    "description" : "ID of the element template",
-    "value" : "io.camunda.connectors.message.v1",
+    "description" : "Version of the element template",
     "group" : "connector",
+    "id" : "version",
+    "label" : "Version",
+    "type" : "Hidden",
+    "value" : "1"
+  }, {
     "binding" : {
       "key" : "elementTemplateId",
       "type" : "zeebe:taskHeader"
     },
-    "type" : "Hidden"
+    "description" : "ID of the element template",
+    "group" : "connector",
+    "id" : "id",
+    "label" : "ID",
+    "type" : "Hidden",
+    "value" : "io.camunda.connectors.message.v1"
   }, {
-    "id" : "resultVariable",
-    "label" : "Result variable",
-    "description" : "Name of variable to store the response in. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-variable\" target=\"_blank\">documentation</a>.",
-    "group" : "output",
     "binding" : {
       "key" : "resultVariable",
       "type" : "zeebe:taskHeader"
     },
+    "description" : "Name of variable to store the response in. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-variable\" target=\"_blank\">documentation</a>.",
+    "group" : "output",
+    "id" : "resultVariable",
+    "label" : "Result variable",
     "type" : "String"
   }, {
-    "id" : "resultExpression",
-    "label" : "Result expression",
-    "description" : "Expression to map the response into process variables. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-expression\" target=\"_blank\">documentation</a>.",
-    "feel" : "required",
-    "group" : "output",
     "binding" : {
       "key" : "resultExpression",
       "type" : "zeebe:taskHeader"
     },
+    "description" : "Expression to map the response into process variables. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-expression\" target=\"_blank\">documentation</a>.",
+    "feel" : "required",
+    "group" : "output",
+    "id" : "resultExpression",
+    "label" : "Result expression",
     "type" : "Text"
   }, {
-    "id" : "errorExpression",
-    "label" : "Error expression",
-    "description" : "Expression to handle errors. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/\" target=\"_blank\">documentation</a>.",
-    "feel" : "required",
-    "group" : "error",
     "binding" : {
       "key" : "errorExpression",
       "type" : "zeebe:taskHeader"
     },
+    "description" : "Expression to handle errors. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/\" target=\"_blank\">documentation</a>.",
+    "feel" : "required",
+    "group" : "error",
+    "id" : "errorExpression",
+    "label" : "Error expression",
     "type" : "Text"
   }, {
-    "id" : "retryCount",
-    "label" : "Retries",
-    "description" : "Number of retries",
-    "value" : "3",
-    "feel" : "optional",
-    "group" : "retries",
     "binding" : {
       "property" : "retries",
       "type" : "zeebe:taskDefinition"
     },
-    "type" : "String"
-  }, {
-    "id" : "retryBackoff",
-    "label" : "Retry backoff",
-    "description" : "ISO-8601 duration to wait between retries",
-    "value" : "PT30S",
+    "description" : "Number of retries",
+    "feel" : "optional",
     "group" : "retries",
+    "id" : "retryCount",
+    "label" : "Retries",
+    "type" : "String",
+    "value" : "3"
+  }, {
     "binding" : {
       "key" : "retryBackoff",
       "type" : "zeebe:taskHeader"
     },
-    "type" : "String"
-  }, {
-    "id" : "jobTimeout",
-    "label" : "Job timeout",
-    "description" : "ISO-8601 duration after which Zeebe considers this job timed out if not yet completed. Leave empty to use the default timeout",
-    "optional" : true,
+    "description" : "ISO-8601 duration to wait between retries",
     "group" : "retries",
+    "id" : "retryBackoff",
+    "label" : "Retry backoff",
+    "type" : "String",
+    "value" : "PT30S"
+  }, {
     "binding" : {
       "key" : "jobTimeout",
       "type" : "zeebe:taskHeader"
     },
+    "description" : "ISO-8601 duration after which Zeebe considers this job timed out if not yet completed. Leave empty to use the default timeout",
+    "group" : "retries",
+    "id" : "jobTimeout",
+    "label" : "Job timeout",
+    "optional" : true,
     "type" : "String"
   } ],
   "steps" : [ {

--- a/connectors/camunda-message/element-templates/send-message-connector-intermediate-throw-event.json
+++ b/connectors/camunda-message/element-templates/send-message-connector-intermediate-throw-event.json
@@ -33,88 +33,83 @@
     "label" : "Retries"
   } ],
   "properties" : [ {
-    "value" : "io.camunda:sendMessage:1",
     "binding" : {
       "property" : "type",
       "type" : "zeebe:taskDefinition"
     },
-    "type" : "Hidden"
+    "type" : "Hidden",
+    "value" : "io.camunda:sendMessage:1"
   }, {
-    "id" : "messageName",
-    "label" : "Message name",
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "feel" : "optional",
     "binding" : {
       "name" : "messageName",
       "type" : "zeebe:input"
     },
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "id" : "messageName",
+    "label" : "Message name",
     "type" : "String"
   }, {
-    "id" : "correlationKey",
-    "label" : "Correlation key",
-    "optional" : true,
-    "feel" : "optional",
     "binding" : {
       "name" : "correlationKey",
       "type" : "zeebe:input"
     },
+    "feel" : "optional",
+    "id" : "correlationKey",
+    "label" : "Correlation key",
+    "optional" : true,
     "type" : "String"
   }, {
-    "id" : "variables",
-    "label" : "Payload",
-    "optional" : true,
-    "feel" : "optional",
     "binding" : {
       "name" : "variables",
       "type" : "zeebe:input"
     },
+    "feel" : "optional",
+    "id" : "variables",
+    "label" : "Payload",
+    "optional" : true,
     "type" : "String"
   }, {
-    "id" : "tenantId",
-    "label" : "Tenant id",
-    "optional" : true,
-    "feel" : "optional",
     "binding" : {
       "name" : "tenantId",
       "type" : "zeebe:input"
     },
+    "feel" : "optional",
+    "id" : "tenantId",
+    "label" : "Tenant id",
+    "optional" : true,
     "type" : "String"
   }, {
-    "id" : "requestTimeout",
-    "label" : "Request timeout",
-    "optional" : true,
-    "feel" : "optional",
     "binding" : {
       "name" : "requestTimeout",
       "type" : "zeebe:input"
     },
+    "feel" : "optional",
+    "id" : "requestTimeout",
+    "label" : "Request timeout",
+    "optional" : true,
     "type" : "String"
   }, {
-    "id" : "correlationType.type",
-    "label" : "Correlation mode",
-    "description" : "Send message with <a href='https://docs.camunda.io/docs/components/concepts/messages/#message-buffering' target='_blank'>buffer (publish)</a> or with <a href='https://docs.camunda.io/docs/components/concepts/messages/#message-response' target='_blank'>result (correlate)</a>",
-    "value" : "publish",
-    "group" : "operation",
     "binding" : {
       "name" : "correlationType.type",
       "type" : "zeebe:input"
     },
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "Correlate message (with result)",
       "value" : "correlate"
     }, {
       "name" : "Publish message (with buffer)",
       "value" : "publish"
-    } ]
-  }, {
-    "id" : "correlationType.timeToLive",
-    "label" : "Time to live (as ISO 8601)",
-    "optional" : true,
-    "feel" : "optional",
+    } ],
+    "description" : "Send message with <a href='https://docs.camunda.io/docs/components/concepts/messages/#message-buffering' target='_blank'>buffer (publish)</a> or with <a href='https://docs.camunda.io/docs/components/concepts/messages/#message-response' target='_blank'>result (correlate)</a>",
     "group" : "operation",
+    "id" : "correlationType.type",
+    "label" : "Correlation mode",
+    "type" : "Dropdown",
+    "value" : "publish"
+  }, {
     "binding" : {
       "name" : "correlationType.timeToLive",
       "type" : "zeebe:input"
@@ -124,14 +119,14 @@
       "equals" : "publish",
       "type" : "simple"
     },
+    "feel" : "optional",
+    "group" : "operation",
+    "id" : "correlationType.timeToLive",
+    "label" : "Time to live (as ISO 8601)",
+    "optional" : true,
     "tooltip" : "Duration for which the message remains buffered",
     "type" : "String"
   }, {
-    "id" : "correlationType.messageId",
-    "label" : "Message id (optional)",
-    "optional" : true,
-    "feel" : "optional",
-    "group" : "operation",
     "binding" : {
       "name" : "correlationType.messageId",
       "type" : "zeebe:input"
@@ -141,94 +136,99 @@
       "equals" : "publish",
       "type" : "simple"
     },
+    "feel" : "optional",
+    "group" : "operation",
+    "id" : "correlationType.messageId",
+    "label" : "Message id (optional)",
+    "optional" : true,
     "type" : "String"
   }, {
-    "id" : "version",
-    "label" : "Version",
-    "description" : "Version of the element template",
-    "value" : "1",
-    "group" : "connector",
     "binding" : {
       "key" : "elementTemplateVersion",
       "type" : "zeebe:taskHeader"
     },
-    "type" : "Hidden"
-  }, {
-    "id" : "id",
-    "label" : "ID",
-    "description" : "ID of the element template",
-    "value" : "io.camunda.connectors.message.v1",
+    "description" : "Version of the element template",
     "group" : "connector",
+    "id" : "version",
+    "label" : "Version",
+    "type" : "Hidden",
+    "value" : "1"
+  }, {
     "binding" : {
       "key" : "elementTemplateId",
       "type" : "zeebe:taskHeader"
     },
-    "type" : "Hidden"
+    "description" : "ID of the element template",
+    "group" : "connector",
+    "id" : "id",
+    "label" : "ID",
+    "type" : "Hidden",
+    "value" : "io.camunda.connectors.message.v1"
   }, {
-    "id" : "resultVariable",
-    "label" : "Result variable",
-    "description" : "Name of variable to store the response in. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-variable\" target=\"_blank\">documentation</a>.",
-    "group" : "output",
     "binding" : {
       "key" : "resultVariable",
       "type" : "zeebe:taskHeader"
     },
+    "description" : "Name of variable to store the response in. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-variable\" target=\"_blank\">documentation</a>.",
+    "group" : "output",
+    "id" : "resultVariable",
+    "label" : "Result variable",
     "type" : "String"
   }, {
-    "id" : "resultExpression",
-    "label" : "Result expression",
-    "description" : "Expression to map the response into process variables. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-expression\" target=\"_blank\">documentation</a>.",
-    "feel" : "required",
-    "group" : "output",
     "binding" : {
       "key" : "resultExpression",
       "type" : "zeebe:taskHeader"
     },
+    "description" : "Expression to map the response into process variables. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-expression\" target=\"_blank\">documentation</a>.",
+    "feel" : "required",
+    "group" : "output",
+    "id" : "resultExpression",
+    "label" : "Result expression",
     "type" : "Text"
   }, {
-    "id" : "errorExpression",
-    "label" : "Error expression",
-    "description" : "Expression to handle errors. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/\" target=\"_blank\">documentation</a>.",
-    "feel" : "required",
-    "group" : "error",
     "binding" : {
       "key" : "errorExpression",
       "type" : "zeebe:taskHeader"
     },
+    "description" : "Expression to handle errors. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/\" target=\"_blank\">documentation</a>.",
+    "feel" : "required",
+    "group" : "error",
+    "id" : "errorExpression",
+    "label" : "Error expression",
     "type" : "Text"
   }, {
-    "id" : "retryCount",
-    "label" : "Retries",
-    "description" : "Number of retries",
-    "value" : "3",
-    "feel" : "optional",
-    "group" : "retries",
     "binding" : {
       "property" : "retries",
       "type" : "zeebe:taskDefinition"
     },
-    "type" : "String"
-  }, {
-    "id" : "retryBackoff",
-    "label" : "Retry backoff",
-    "description" : "ISO-8601 duration to wait between retries",
-    "value" : "PT30S",
+    "description" : "Number of retries",
+    "feel" : "optional",
     "group" : "retries",
+    "id" : "retryCount",
+    "label" : "Retries",
+    "type" : "String",
+    "value" : "3"
+  }, {
     "binding" : {
       "key" : "retryBackoff",
       "type" : "zeebe:taskHeader"
     },
-    "type" : "String"
-  }, {
-    "id" : "jobTimeout",
-    "label" : "Job timeout",
-    "description" : "ISO-8601 duration after which Zeebe considers this job timed out if not yet completed. Leave empty to use the default timeout",
-    "optional" : true,
+    "description" : "ISO-8601 duration to wait between retries",
     "group" : "retries",
+    "id" : "retryBackoff",
+    "label" : "Retry backoff",
+    "type" : "String",
+    "value" : "PT30S"
+  }, {
     "binding" : {
       "key" : "jobTimeout",
       "type" : "zeebe:taskHeader"
     },
+    "description" : "ISO-8601 duration after which Zeebe considers this job timed out if not yet completed. Leave empty to use the default timeout",
+    "group" : "retries",
+    "id" : "jobTimeout",
+    "label" : "Job timeout",
+    "optional" : true,
     "type" : "String"
   } ],
   "steps" : [ {

--- a/connectors/camunda-message/element-templates/send-message-connector-message-end-event.json
+++ b/connectors/camunda-message/element-templates/send-message-connector-message-end-event.json
@@ -33,88 +33,83 @@
     "label" : "Retries"
   } ],
   "properties" : [ {
-    "value" : "io.camunda:sendMessage:1",
     "binding" : {
       "property" : "type",
       "type" : "zeebe:taskDefinition"
     },
-    "type" : "Hidden"
+    "type" : "Hidden",
+    "value" : "io.camunda:sendMessage:1"
   }, {
-    "id" : "messageName",
-    "label" : "Message name",
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "feel" : "optional",
     "binding" : {
       "name" : "messageName",
       "type" : "zeebe:input"
     },
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "id" : "messageName",
+    "label" : "Message name",
     "type" : "String"
   }, {
-    "id" : "correlationKey",
-    "label" : "Correlation key",
-    "optional" : true,
-    "feel" : "optional",
     "binding" : {
       "name" : "correlationKey",
       "type" : "zeebe:input"
     },
+    "feel" : "optional",
+    "id" : "correlationKey",
+    "label" : "Correlation key",
+    "optional" : true,
     "type" : "String"
   }, {
-    "id" : "variables",
-    "label" : "Payload",
-    "optional" : true,
-    "feel" : "optional",
     "binding" : {
       "name" : "variables",
       "type" : "zeebe:input"
     },
+    "feel" : "optional",
+    "id" : "variables",
+    "label" : "Payload",
+    "optional" : true,
     "type" : "String"
   }, {
-    "id" : "tenantId",
-    "label" : "Tenant id",
-    "optional" : true,
-    "feel" : "optional",
     "binding" : {
       "name" : "tenantId",
       "type" : "zeebe:input"
     },
+    "feel" : "optional",
+    "id" : "tenantId",
+    "label" : "Tenant id",
+    "optional" : true,
     "type" : "String"
   }, {
-    "id" : "requestTimeout",
-    "label" : "Request timeout",
-    "optional" : true,
-    "feel" : "optional",
     "binding" : {
       "name" : "requestTimeout",
       "type" : "zeebe:input"
     },
+    "feel" : "optional",
+    "id" : "requestTimeout",
+    "label" : "Request timeout",
+    "optional" : true,
     "type" : "String"
   }, {
-    "id" : "correlationType.type",
-    "label" : "Correlation mode",
-    "description" : "Send message with <a href='https://docs.camunda.io/docs/components/concepts/messages/#message-buffering' target='_blank'>buffer (publish)</a> or with <a href='https://docs.camunda.io/docs/components/concepts/messages/#message-response' target='_blank'>result (correlate)</a>",
-    "value" : "publish",
-    "group" : "operation",
     "binding" : {
       "name" : "correlationType.type",
       "type" : "zeebe:input"
     },
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "Correlate message (with result)",
       "value" : "correlate"
     }, {
       "name" : "Publish message (with buffer)",
       "value" : "publish"
-    } ]
-  }, {
-    "id" : "correlationType.timeToLive",
-    "label" : "Time to live (as ISO 8601)",
-    "optional" : true,
-    "feel" : "optional",
+    } ],
+    "description" : "Send message with <a href='https://docs.camunda.io/docs/components/concepts/messages/#message-buffering' target='_blank'>buffer (publish)</a> or with <a href='https://docs.camunda.io/docs/components/concepts/messages/#message-response' target='_blank'>result (correlate)</a>",
     "group" : "operation",
+    "id" : "correlationType.type",
+    "label" : "Correlation mode",
+    "type" : "Dropdown",
+    "value" : "publish"
+  }, {
     "binding" : {
       "name" : "correlationType.timeToLive",
       "type" : "zeebe:input"
@@ -124,14 +119,14 @@
       "equals" : "publish",
       "type" : "simple"
     },
+    "feel" : "optional",
+    "group" : "operation",
+    "id" : "correlationType.timeToLive",
+    "label" : "Time to live (as ISO 8601)",
+    "optional" : true,
     "tooltip" : "Duration for which the message remains buffered",
     "type" : "String"
   }, {
-    "id" : "correlationType.messageId",
-    "label" : "Message id (optional)",
-    "optional" : true,
-    "feel" : "optional",
-    "group" : "operation",
     "binding" : {
       "name" : "correlationType.messageId",
       "type" : "zeebe:input"
@@ -141,94 +136,99 @@
       "equals" : "publish",
       "type" : "simple"
     },
+    "feel" : "optional",
+    "group" : "operation",
+    "id" : "correlationType.messageId",
+    "label" : "Message id (optional)",
+    "optional" : true,
     "type" : "String"
   }, {
-    "id" : "version",
-    "label" : "Version",
-    "description" : "Version of the element template",
-    "value" : "1",
-    "group" : "connector",
     "binding" : {
       "key" : "elementTemplateVersion",
       "type" : "zeebe:taskHeader"
     },
-    "type" : "Hidden"
-  }, {
-    "id" : "id",
-    "label" : "ID",
-    "description" : "ID of the element template",
-    "value" : "io.camunda.connectors.message.v1",
+    "description" : "Version of the element template",
     "group" : "connector",
+    "id" : "version",
+    "label" : "Version",
+    "type" : "Hidden",
+    "value" : "1"
+  }, {
     "binding" : {
       "key" : "elementTemplateId",
       "type" : "zeebe:taskHeader"
     },
-    "type" : "Hidden"
+    "description" : "ID of the element template",
+    "group" : "connector",
+    "id" : "id",
+    "label" : "ID",
+    "type" : "Hidden",
+    "value" : "io.camunda.connectors.message.v1"
   }, {
-    "id" : "resultVariable",
-    "label" : "Result variable",
-    "description" : "Name of variable to store the response in. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-variable\" target=\"_blank\">documentation</a>.",
-    "group" : "output",
     "binding" : {
       "key" : "resultVariable",
       "type" : "zeebe:taskHeader"
     },
+    "description" : "Name of variable to store the response in. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-variable\" target=\"_blank\">documentation</a>.",
+    "group" : "output",
+    "id" : "resultVariable",
+    "label" : "Result variable",
     "type" : "String"
   }, {
-    "id" : "resultExpression",
-    "label" : "Result expression",
-    "description" : "Expression to map the response into process variables. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-expression\" target=\"_blank\">documentation</a>.",
-    "feel" : "required",
-    "group" : "output",
     "binding" : {
       "key" : "resultExpression",
       "type" : "zeebe:taskHeader"
     },
+    "description" : "Expression to map the response into process variables. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-expression\" target=\"_blank\">documentation</a>.",
+    "feel" : "required",
+    "group" : "output",
+    "id" : "resultExpression",
+    "label" : "Result expression",
     "type" : "Text"
   }, {
-    "id" : "errorExpression",
-    "label" : "Error expression",
-    "description" : "Expression to handle errors. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/\" target=\"_blank\">documentation</a>.",
-    "feel" : "required",
-    "group" : "error",
     "binding" : {
       "key" : "errorExpression",
       "type" : "zeebe:taskHeader"
     },
+    "description" : "Expression to handle errors. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/\" target=\"_blank\">documentation</a>.",
+    "feel" : "required",
+    "group" : "error",
+    "id" : "errorExpression",
+    "label" : "Error expression",
     "type" : "Text"
   }, {
-    "id" : "retryCount",
-    "label" : "Retries",
-    "description" : "Number of retries",
-    "value" : "3",
-    "feel" : "optional",
-    "group" : "retries",
     "binding" : {
       "property" : "retries",
       "type" : "zeebe:taskDefinition"
     },
-    "type" : "String"
-  }, {
-    "id" : "retryBackoff",
-    "label" : "Retry backoff",
-    "description" : "ISO-8601 duration to wait between retries",
-    "value" : "PT30S",
+    "description" : "Number of retries",
+    "feel" : "optional",
     "group" : "retries",
+    "id" : "retryCount",
+    "label" : "Retries",
+    "type" : "String",
+    "value" : "3"
+  }, {
     "binding" : {
       "key" : "retryBackoff",
       "type" : "zeebe:taskHeader"
     },
-    "type" : "String"
-  }, {
-    "id" : "jobTimeout",
-    "label" : "Job timeout",
-    "description" : "ISO-8601 duration after which Zeebe considers this job timed out if not yet completed. Leave empty to use the default timeout",
-    "optional" : true,
+    "description" : "ISO-8601 duration to wait between retries",
     "group" : "retries",
+    "id" : "retryBackoff",
+    "label" : "Retry backoff",
+    "type" : "String",
+    "value" : "PT30S"
+  }, {
     "binding" : {
       "key" : "jobTimeout",
       "type" : "zeebe:taskHeader"
     },
+    "description" : "ISO-8601 duration after which Zeebe considers this job timed out if not yet completed. Leave empty to use the default timeout",
+    "group" : "retries",
+    "id" : "jobTimeout",
+    "label" : "Job timeout",
+    "optional" : true,
     "type" : "String"
   } ],
   "steps" : [ {

--- a/connectors/camunda-message/element-templates/send-message-connector-send-task.json
+++ b/connectors/camunda-message/element-templates/send-message-connector-send-task.json
@@ -32,88 +32,83 @@
     "label" : "Retries"
   } ],
   "properties" : [ {
-    "value" : "io.camunda:sendMessage:1",
     "binding" : {
       "property" : "type",
       "type" : "zeebe:taskDefinition"
     },
-    "type" : "Hidden"
+    "type" : "Hidden",
+    "value" : "io.camunda:sendMessage:1"
   }, {
-    "id" : "messageName",
-    "label" : "Message name",
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "feel" : "optional",
     "binding" : {
       "name" : "messageName",
       "type" : "zeebe:input"
     },
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "id" : "messageName",
+    "label" : "Message name",
     "type" : "String"
   }, {
-    "id" : "correlationKey",
-    "label" : "Correlation key",
-    "optional" : true,
-    "feel" : "optional",
     "binding" : {
       "name" : "correlationKey",
       "type" : "zeebe:input"
     },
+    "feel" : "optional",
+    "id" : "correlationKey",
+    "label" : "Correlation key",
+    "optional" : true,
     "type" : "String"
   }, {
-    "id" : "variables",
-    "label" : "Payload",
-    "optional" : true,
-    "feel" : "optional",
     "binding" : {
       "name" : "variables",
       "type" : "zeebe:input"
     },
+    "feel" : "optional",
+    "id" : "variables",
+    "label" : "Payload",
+    "optional" : true,
     "type" : "String"
   }, {
-    "id" : "tenantId",
-    "label" : "Tenant id",
-    "optional" : true,
-    "feel" : "optional",
     "binding" : {
       "name" : "tenantId",
       "type" : "zeebe:input"
     },
+    "feel" : "optional",
+    "id" : "tenantId",
+    "label" : "Tenant id",
+    "optional" : true,
     "type" : "String"
   }, {
-    "id" : "requestTimeout",
-    "label" : "Request timeout",
-    "optional" : true,
-    "feel" : "optional",
     "binding" : {
       "name" : "requestTimeout",
       "type" : "zeebe:input"
     },
+    "feel" : "optional",
+    "id" : "requestTimeout",
+    "label" : "Request timeout",
+    "optional" : true,
     "type" : "String"
   }, {
-    "id" : "correlationType.type",
-    "label" : "Correlation mode",
-    "description" : "Send message with <a href='https://docs.camunda.io/docs/components/concepts/messages/#message-buffering' target='_blank'>buffer (publish)</a> or with <a href='https://docs.camunda.io/docs/components/concepts/messages/#message-response' target='_blank'>result (correlate)</a>",
-    "value" : "publish",
-    "group" : "operation",
     "binding" : {
       "name" : "correlationType.type",
       "type" : "zeebe:input"
     },
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "Correlate message (with result)",
       "value" : "correlate"
     }, {
       "name" : "Publish message (with buffer)",
       "value" : "publish"
-    } ]
-  }, {
-    "id" : "correlationType.timeToLive",
-    "label" : "Time to live (as ISO 8601)",
-    "optional" : true,
-    "feel" : "optional",
+    } ],
+    "description" : "Send message with <a href='https://docs.camunda.io/docs/components/concepts/messages/#message-buffering' target='_blank'>buffer (publish)</a> or with <a href='https://docs.camunda.io/docs/components/concepts/messages/#message-response' target='_blank'>result (correlate)</a>",
     "group" : "operation",
+    "id" : "correlationType.type",
+    "label" : "Correlation mode",
+    "type" : "Dropdown",
+    "value" : "publish"
+  }, {
     "binding" : {
       "name" : "correlationType.timeToLive",
       "type" : "zeebe:input"
@@ -123,14 +118,14 @@
       "equals" : "publish",
       "type" : "simple"
     },
+    "feel" : "optional",
+    "group" : "operation",
+    "id" : "correlationType.timeToLive",
+    "label" : "Time to live (as ISO 8601)",
+    "optional" : true,
     "tooltip" : "Duration for which the message remains buffered",
     "type" : "String"
   }, {
-    "id" : "correlationType.messageId",
-    "label" : "Message id (optional)",
-    "optional" : true,
-    "feel" : "optional",
-    "group" : "operation",
     "binding" : {
       "name" : "correlationType.messageId",
       "type" : "zeebe:input"
@@ -140,94 +135,99 @@
       "equals" : "publish",
       "type" : "simple"
     },
+    "feel" : "optional",
+    "group" : "operation",
+    "id" : "correlationType.messageId",
+    "label" : "Message id (optional)",
+    "optional" : true,
     "type" : "String"
   }, {
-    "id" : "version",
-    "label" : "Version",
-    "description" : "Version of the element template",
-    "value" : "1",
-    "group" : "connector",
     "binding" : {
       "key" : "elementTemplateVersion",
       "type" : "zeebe:taskHeader"
     },
-    "type" : "Hidden"
-  }, {
-    "id" : "id",
-    "label" : "ID",
-    "description" : "ID of the element template",
-    "value" : "io.camunda.connectors.message.v1",
+    "description" : "Version of the element template",
     "group" : "connector",
+    "id" : "version",
+    "label" : "Version",
+    "type" : "Hidden",
+    "value" : "1"
+  }, {
     "binding" : {
       "key" : "elementTemplateId",
       "type" : "zeebe:taskHeader"
     },
-    "type" : "Hidden"
+    "description" : "ID of the element template",
+    "group" : "connector",
+    "id" : "id",
+    "label" : "ID",
+    "type" : "Hidden",
+    "value" : "io.camunda.connectors.message.v1"
   }, {
-    "id" : "resultVariable",
-    "label" : "Result variable",
-    "description" : "Name of variable to store the response in. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-variable\" target=\"_blank\">documentation</a>.",
-    "group" : "output",
     "binding" : {
       "key" : "resultVariable",
       "type" : "zeebe:taskHeader"
     },
+    "description" : "Name of variable to store the response in. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-variable\" target=\"_blank\">documentation</a>.",
+    "group" : "output",
+    "id" : "resultVariable",
+    "label" : "Result variable",
     "type" : "String"
   }, {
-    "id" : "resultExpression",
-    "label" : "Result expression",
-    "description" : "Expression to map the response into process variables. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-expression\" target=\"_blank\">documentation</a>.",
-    "feel" : "required",
-    "group" : "output",
     "binding" : {
       "key" : "resultExpression",
       "type" : "zeebe:taskHeader"
     },
+    "description" : "Expression to map the response into process variables. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-expression\" target=\"_blank\">documentation</a>.",
+    "feel" : "required",
+    "group" : "output",
+    "id" : "resultExpression",
+    "label" : "Result expression",
     "type" : "Text"
   }, {
-    "id" : "errorExpression",
-    "label" : "Error expression",
-    "description" : "Expression to handle errors. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/\" target=\"_blank\">documentation</a>.",
-    "feel" : "required",
-    "group" : "error",
     "binding" : {
       "key" : "errorExpression",
       "type" : "zeebe:taskHeader"
     },
+    "description" : "Expression to handle errors. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/\" target=\"_blank\">documentation</a>.",
+    "feel" : "required",
+    "group" : "error",
+    "id" : "errorExpression",
+    "label" : "Error expression",
     "type" : "Text"
   }, {
-    "id" : "retryCount",
-    "label" : "Retries",
-    "description" : "Number of retries",
-    "value" : "3",
-    "feel" : "optional",
-    "group" : "retries",
     "binding" : {
       "property" : "retries",
       "type" : "zeebe:taskDefinition"
     },
-    "type" : "String"
-  }, {
-    "id" : "retryBackoff",
-    "label" : "Retry backoff",
-    "description" : "ISO-8601 duration to wait between retries",
-    "value" : "PT30S",
+    "description" : "Number of retries",
+    "feel" : "optional",
     "group" : "retries",
+    "id" : "retryCount",
+    "label" : "Retries",
+    "type" : "String",
+    "value" : "3"
+  }, {
     "binding" : {
       "key" : "retryBackoff",
       "type" : "zeebe:taskHeader"
     },
-    "type" : "String"
-  }, {
-    "id" : "jobTimeout",
-    "label" : "Job timeout",
-    "description" : "ISO-8601 duration after which Zeebe considers this job timed out if not yet completed. Leave empty to use the default timeout",
-    "optional" : true,
+    "description" : "ISO-8601 duration to wait between retries",
     "group" : "retries",
+    "id" : "retryBackoff",
+    "label" : "Retry backoff",
+    "type" : "String",
+    "value" : "PT30S"
+  }, {
     "binding" : {
       "key" : "jobTimeout",
       "type" : "zeebe:taskHeader"
     },
+    "description" : "ISO-8601 duration after which Zeebe considers this job timed out if not yet completed. Leave empty to use the default timeout",
+    "group" : "retries",
+    "id" : "jobTimeout",
+    "label" : "Job timeout",
+    "optional" : true,
     "type" : "String"
   } ],
   "steps" : [ {

--- a/connectors/csv/element-templates/csv-outbound-connector.json
+++ b/connectors/csv/element-templates/csv-outbound-connector.json
@@ -33,48 +33,35 @@
     "label" : "Retries"
   } ],
   "properties" : [ {
-    "value" : "io.camunda:csv-connector",
     "binding" : {
       "property" : "type",
       "type" : "zeebe:taskDefinition"
     },
-    "type" : "Hidden"
+    "type" : "Hidden",
+    "value" : "io.camunda:csv-connector"
   }, {
-    "id" : "operation",
-    "label" : "Operation",
-    "description" : "The operation to execute",
-    "value" : "readCsv",
-    "group" : "operation",
     "binding" : {
       "key" : "operation",
       "type" : "zeebe:taskHeader"
     },
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "Read CSV",
       "value" : "readCsv"
     }, {
       "name" : "Write CSV",
       "value" : "writeCsv"
-    } ]
-  }, {
-    "id" : "readCsv:document_documentSource",
-    "label" : "Document source",
-    "value" : "camunda",
+    } ],
+    "description" : "The operation to execute",
     "group" : "operation",
+    "id" : "operation",
+    "label" : "Operation",
+    "type" : "Dropdown",
+    "value" : "readCsv"
+  }, {
     "binding" : {
       "name" : "document_documentSource",
       "type" : "zeebe:input"
     },
-    "condition" : {
-      "allMatch" : [ {
-        "property" : "operation",
-        "equals" : "readCsv",
-        "type" : "simple"
-      } ]
-    },
-    "tooltip" : "The CSV document to read.",
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "Camunda Document",
       "value" : "camunda"
@@ -84,15 +71,21 @@
     }, {
       "name" : "From URL",
       "value" : "external"
-    } ]
-  }, {
-    "id" : "readCsv:document_camundaReference",
-    "label" : "Camunda document",
-    "constraints" : {
-      "notEmpty" : true
+    } ],
+    "condition" : {
+      "allMatch" : [ {
+        "property" : "operation",
+        "equals" : "readCsv",
+        "type" : "simple"
+      } ]
     },
-    "feel" : "required",
     "group" : "operation",
+    "id" : "readCsv:document_documentSource",
+    "label" : "Document source",
+    "tooltip" : "The CSV document to read.",
+    "type" : "Dropdown",
+    "value" : "camunda"
+  }, {
     "binding" : {
       "name" : "document_camundaReference",
       "type" : "zeebe:input"
@@ -108,15 +101,15 @@
         "type" : "simple"
       } ]
     },
-    "type" : "String"
-  }, {
-    "id" : "readCsv:document_inline_content",
-    "label" : "Content",
     "constraints" : {
       "notEmpty" : true
     },
-    "feel" : "optional",
+    "feel" : "required",
     "group" : "operation",
+    "id" : "readCsv:document_camundaReference",
+    "label" : "Camunda document",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "document_inline_content",
       "type" : "zeebe:input"
@@ -132,12 +125,15 @@
         "type" : "simple"
       } ]
     },
-    "type" : "String"
-  }, {
-    "id" : "readCsv:document_inline_fileName",
-    "label" : "File name",
+    "constraints" : {
+      "notEmpty" : true
+    },
     "feel" : "optional",
     "group" : "operation",
+    "id" : "readCsv:document_inline_content",
+    "label" : "Content",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "document_inline_fileName",
       "type" : "zeebe:input"
@@ -153,12 +149,12 @@
         "type" : "simple"
       } ]
     },
-    "type" : "String"
-  }, {
-    "id" : "readCsv:document_inline_contentType",
-    "label" : "Content type",
     "feel" : "optional",
     "group" : "operation",
+    "id" : "readCsv:document_inline_fileName",
+    "label" : "File name",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "document_inline_contentType",
       "type" : "zeebe:input"
@@ -174,15 +170,12 @@
         "type" : "simple"
       } ]
     },
-    "type" : "String"
-  }, {
-    "id" : "readCsv:document_external_url",
-    "label" : "URL",
-    "constraints" : {
-      "notEmpty" : true
-    },
     "feel" : "optional",
     "group" : "operation",
+    "id" : "readCsv:document_inline_contentType",
+    "label" : "Content type",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "document_external_url",
       "type" : "zeebe:input"
@@ -198,12 +191,15 @@
         "type" : "simple"
       } ]
     },
-    "type" : "String"
-  }, {
-    "id" : "readCsv:document_external_fileName",
-    "label" : "File name",
+    "constraints" : {
+      "notEmpty" : true
+    },
     "feel" : "optional",
     "group" : "operation",
+    "id" : "readCsv:document_external_url",
+    "label" : "URL",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "document_external_fileName",
       "type" : "zeebe:input"
@@ -219,11 +215,12 @@
         "type" : "simple"
       } ]
     },
+    "feel" : "optional",
+    "group" : "operation",
+    "id" : "readCsv:document_external_fileName",
+    "label" : "File name",
     "type" : "String"
   }, {
-    "id" : "readCsv:document",
-    "value" : "=if document_documentSource = \"camunda\" then document_camundaReference else if document_documentSource = \"inline\" then { \"camunda.document.type\": \"inline\", content: document_inline_content, name: document_inline_fileName, contentType: document_inline_contentType } else if document_documentSource = \"external\" then { \"camunda.document.type\": \"external\", url: document_external_url, name: document_external_fileName } else null",
-    "group" : "operation",
     "binding" : {
       "name" : "document",
       "type" : "zeebe:input"
@@ -235,14 +232,11 @@
         "type" : "simple"
       } ]
     },
-    "type" : "Hidden"
-  }, {
-    "id" : "readCsv:format.delimiter",
-    "label" : "Delimiter",
-    "optional" : false,
-    "value" : ",",
-    "feel" : "optional",
     "group" : "operation",
+    "id" : "readCsv:document",
+    "type" : "Hidden",
+    "value" : "=if document_documentSource = \"camunda\" then document_camundaReference else if document_documentSource = \"inline\" then { \"camunda.document.type\": \"inline\", content: document_inline_content, name: document_inline_fileName, contentType: document_inline_contentType } else if document_documentSource = \"external\" then { \"camunda.document.type\": \"external\", url: document_external_url, name: document_external_fileName } else null"
+  }, {
     "binding" : {
       "name" : "format.delimiter",
       "type" : "zeebe:input"
@@ -254,15 +248,15 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "CSV column delimiter",
-    "type" : "String"
-  }, {
-    "id" : "readCsv:format.skipHeaderRecord",
-    "label" : "Skip Header Record",
-    "optional" : false,
-    "value" : true,
-    "feel" : "static",
+    "feel" : "optional",
     "group" : "operation",
+    "id" : "readCsv:format.delimiter",
+    "label" : "Delimiter",
+    "optional" : false,
+    "tooltip" : "CSV column delimiter",
+    "type" : "String",
+    "value" : ","
+  }, {
     "binding" : {
       "name" : "format.skipHeaderRecord",
       "type" : "zeebe:input"
@@ -274,14 +268,15 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "Skips the first row to be not included in the final records.",
-    "type" : "Boolean"
-  }, {
-    "id" : "readCsv:format.headers",
-    "label" : "Headers",
-    "optional" : false,
-    "feel" : "required",
+    "feel" : "static",
     "group" : "operation",
+    "id" : "readCsv:format.skipHeaderRecord",
+    "label" : "Skip Header Record",
+    "optional" : false,
+    "tooltip" : "Skips the first row to be not included in the final records.",
+    "type" : "Boolean",
+    "value" : true
+  }, {
     "binding" : {
       "name" : "format.headers",
       "type" : "zeebe:input"
@@ -293,18 +288,25 @@
         "type" : "simple"
       } ]
     },
+    "feel" : "required",
+    "group" : "operation",
+    "id" : "readCsv:format.headers",
+    "label" : "Headers",
+    "optional" : false,
     "tooltip" : "Mapping of the columns if not included in the CSV itself in the first row.",
     "type" : "String"
   }, {
-    "id" : "readCsv:rowType",
-    "label" : "Row Type",
-    "optional" : false,
-    "value" : "Object",
-    "group" : "operation",
     "binding" : {
       "name" : "rowType",
       "type" : "zeebe:input"
     },
+    "choices" : [ {
+      "name" : "Object",
+      "value" : "Object"
+    }, {
+      "name" : "Array",
+      "value" : "Array"
+    } ],
     "condition" : {
       "allMatch" : [ {
         "property" : "operation",
@@ -312,21 +314,14 @@
         "type" : "simple"
       } ]
     },
+    "group" : "operation",
+    "id" : "readCsv:rowType",
+    "label" : "Row Type",
+    "optional" : false,
     "tooltip" : "Type of the row in the CSV file, either Object or Array",
     "type" : "Dropdown",
-    "choices" : [ {
-      "name" : "Object",
-      "value" : "Object"
-    }, {
-      "name" : "Array",
-      "value" : "Array"
-    } ]
+    "value" : "Object"
   }, {
-    "id" : "readCsv:recordMapper",
-    "label" : "Record mapping",
-    "description" : "",
-    "feel" : "required",
-    "group" : "operation",
     "binding" : {
       "key" : "recordMapper",
       "type" : "zeebe:taskHeader"
@@ -338,14 +333,15 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "<a href=\"https://docs.camunda.io/docs/components/modeler/feel/what-is-feel/\">FEEL</a> function that allows to map each <code>record</code>. Returning <code>null</code> will exclude a record from the final results.",
-    "placeholder" : "",
-    "type" : "String"
-  }, {
-    "id" : "writeCsv:data",
-    "label" : "Data",
+    "description" : "",
     "feel" : "required",
     "group" : "operation",
+    "id" : "readCsv:recordMapper",
+    "label" : "Record mapping",
+    "placeholder" : "",
+    "tooltip" : "<a href=\"https://docs.camunda.io/docs/components/modeler/feel/what-is-feel/\">FEEL</a> function that allows to map each <code>record</code>. Returning <code>null</code> will exclude a record from the final results.",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "data",
       "type" : "zeebe:input"
@@ -357,14 +353,12 @@
         "type" : "simple"
       } ]
     },
+    "feel" : "required",
+    "group" : "operation",
+    "id" : "writeCsv:data",
+    "label" : "Data",
     "type" : "String"
   }, {
-    "id" : "writeCsv:format.delimiter",
-    "label" : "Delimiter",
-    "optional" : false,
-    "value" : ",",
-    "feel" : "optional",
-    "group" : "operation",
     "binding" : {
       "name" : "format.delimiter",
       "type" : "zeebe:input"
@@ -376,15 +370,15 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "CSV column delimiter",
-    "type" : "String"
-  }, {
-    "id" : "writeCsv:format.skipHeaderRecord",
-    "label" : "Skip Header Record",
-    "optional" : false,
-    "value" : true,
-    "feel" : "static",
+    "feel" : "optional",
     "group" : "operation",
+    "id" : "writeCsv:format.delimiter",
+    "label" : "Delimiter",
+    "optional" : false,
+    "tooltip" : "CSV column delimiter",
+    "type" : "String",
+    "value" : ","
+  }, {
     "binding" : {
       "name" : "format.skipHeaderRecord",
       "type" : "zeebe:input"
@@ -396,14 +390,15 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "Skips the first row to be not included in the final records.",
-    "type" : "Boolean"
-  }, {
-    "id" : "writeCsv:format.headers",
-    "label" : "Headers",
-    "optional" : false,
-    "feel" : "required",
+    "feel" : "static",
     "group" : "operation",
+    "id" : "writeCsv:format.skipHeaderRecord",
+    "label" : "Skip Header Record",
+    "optional" : false,
+    "tooltip" : "Skips the first row to be not included in the final records.",
+    "type" : "Boolean",
+    "value" : true
+  }, {
     "binding" : {
       "name" : "format.headers",
       "type" : "zeebe:input"
@@ -415,17 +410,25 @@
         "type" : "simple"
       } ]
     },
+    "feel" : "required",
+    "group" : "operation",
+    "id" : "writeCsv:format.headers",
+    "label" : "Headers",
+    "optional" : false,
     "tooltip" : "Mapping of the columns if not included in the CSV itself in the first row.",
     "type" : "String"
   }, {
-    "id" : "writeCsv:documentReturnFormat",
-    "label" : "Response format",
-    "value" : "TEXT",
-    "group" : "operation",
     "binding" : {
       "name" : "documentReturnFormat.choice",
       "type" : "zeebe:input"
     },
+    "choices" : [ {
+      "name" : "Document reference",
+      "value" : "DOCUMENT"
+    }, {
+      "name" : "as text",
+      "value" : "TEXT"
+    } ],
     "condition" : {
       "allMatch" : [ {
         "property" : "operation",
@@ -433,22 +436,13 @@
         "type" : "simple"
       } ]
     },
+    "group" : "operation",
+    "id" : "writeCsv:documentReturnFormat",
+    "label" : "Response format",
     "tooltip" : "How the rendered CSV should be returned. Document reference uploads it to the document store; as text returns the CSV inline as a String.",
     "type" : "Dropdown",
-    "choices" : [ {
-      "name" : "Document reference",
-      "value" : "DOCUMENT"
-    }, {
-      "name" : "as text",
-      "value" : "TEXT"
-    } ]
+    "value" : "TEXT"
   }, {
-    "id" : "writeCsv:documentReturnFormatEncoding",
-    "label" : "Encoding",
-    "description" : "Character set used to decode the response. Default UTF-8.",
-    "value" : "UTF-8",
-    "feel" : "optional",
-    "group" : "operation",
     "binding" : {
       "name" : "documentReturnFormat.encoding",
       "type" : "zeebe:input"
@@ -464,94 +458,100 @@
         "type" : "simple"
       } ]
     },
-    "type" : "String"
+    "description" : "Character set used to decode the response. Default UTF-8.",
+    "feel" : "optional",
+    "group" : "operation",
+    "id" : "writeCsv:documentReturnFormatEncoding",
+    "label" : "Encoding",
+    "type" : "String",
+    "value" : "UTF-8"
   }, {
-    "id" : "version",
-    "label" : "Version",
-    "description" : "Version of the element template",
-    "value" : "3",
-    "group" : "connector",
     "binding" : {
       "key" : "elementTemplateVersion",
       "type" : "zeebe:taskHeader"
     },
-    "type" : "Hidden"
-  }, {
-    "id" : "id",
-    "label" : "ID",
-    "description" : "ID of the element template",
-    "value" : "io.camunda.connectors.csv",
+    "description" : "Version of the element template",
     "group" : "connector",
+    "id" : "version",
+    "label" : "Version",
+    "type" : "Hidden",
+    "value" : "3"
+  }, {
     "binding" : {
       "key" : "elementTemplateId",
       "type" : "zeebe:taskHeader"
     },
-    "type" : "Hidden"
+    "description" : "ID of the element template",
+    "group" : "connector",
+    "id" : "id",
+    "label" : "ID",
+    "type" : "Hidden",
+    "value" : "io.camunda.connectors.csv"
   }, {
-    "id" : "resultVariable",
-    "label" : "Result variable",
-    "description" : "Name of variable to store the response in. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-variable\" target=\"_blank\">documentation</a>.",
-    "group" : "output",
     "binding" : {
       "key" : "resultVariable",
       "type" : "zeebe:taskHeader"
     },
+    "description" : "Name of variable to store the response in. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-variable\" target=\"_blank\">documentation</a>.",
+    "group" : "output",
+    "id" : "resultVariable",
+    "label" : "Result variable",
     "type" : "String"
   }, {
-    "id" : "resultExpression",
-    "label" : "Result expression",
-    "description" : "Expression to map the response into process variables. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-expression\" target=\"_blank\">documentation</a>.",
-    "feel" : "required",
-    "group" : "output",
     "binding" : {
       "key" : "resultExpression",
       "type" : "zeebe:taskHeader"
     },
+    "description" : "Expression to map the response into process variables. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-expression\" target=\"_blank\">documentation</a>.",
+    "feel" : "required",
+    "group" : "output",
+    "id" : "resultExpression",
+    "label" : "Result expression",
     "type" : "Text"
   }, {
-    "id" : "errorExpression",
-    "label" : "Error expression",
-    "description" : "Expression to handle errors. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/\" target=\"_blank\">documentation</a>.",
-    "feel" : "required",
-    "group" : "error",
     "binding" : {
       "key" : "errorExpression",
       "type" : "zeebe:taskHeader"
     },
+    "description" : "Expression to handle errors. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/\" target=\"_blank\">documentation</a>.",
+    "feel" : "required",
+    "group" : "error",
+    "id" : "errorExpression",
+    "label" : "Error expression",
     "type" : "Text"
   }, {
-    "id" : "retryCount",
-    "label" : "Retries",
-    "description" : "Number of retries",
-    "value" : "3",
-    "feel" : "optional",
-    "group" : "retries",
     "binding" : {
       "property" : "retries",
       "type" : "zeebe:taskDefinition"
     },
-    "type" : "String"
-  }, {
-    "id" : "retryBackoff",
-    "label" : "Retry backoff",
-    "description" : "ISO-8601 duration to wait between retries",
-    "value" : "PT30S",
+    "description" : "Number of retries",
+    "feel" : "optional",
     "group" : "retries",
+    "id" : "retryCount",
+    "label" : "Retries",
+    "type" : "String",
+    "value" : "3"
+  }, {
     "binding" : {
       "key" : "retryBackoff",
       "type" : "zeebe:taskHeader"
     },
-    "type" : "String"
-  }, {
-    "id" : "jobTimeout",
-    "label" : "Job timeout",
-    "description" : "ISO-8601 duration after which Zeebe considers this job timed out if not yet completed. Leave empty to use the default timeout",
-    "optional" : true,
+    "description" : "ISO-8601 duration to wait between retries",
     "group" : "retries",
+    "id" : "retryBackoff",
+    "label" : "Retry backoff",
+    "type" : "String",
+    "value" : "PT30S"
+  }, {
     "binding" : {
       "key" : "jobTimeout",
       "type" : "zeebe:taskHeader"
     },
+    "description" : "ISO-8601 duration after which Zeebe considers this job timed out if not yet completed. Leave empty to use the default timeout",
+    "group" : "retries",
+    "id" : "jobTimeout",
+    "label" : "Job timeout",
+    "optional" : true,
     "type" : "String"
   } ],
   "steps" : [ {

--- a/connectors/csv/element-templates/hybrid/csv-outbound-connector-hybrid.json
+++ b/connectors/csv/element-templates/hybrid/csv-outbound-connector-hybrid.json
@@ -36,50 +36,37 @@
     "label" : "Retries"
   } ],
   "properties" : [ {
-    "id" : "taskDefinitionType",
-    "value" : "io.camunda:csv-connector",
-    "group" : "taskDefinitionType",
     "binding" : {
       "property" : "type",
       "type" : "zeebe:taskDefinition"
     },
-    "type" : "String"
+    "group" : "taskDefinitionType",
+    "id" : "taskDefinitionType",
+    "type" : "String",
+    "value" : "io.camunda:csv-connector"
   }, {
-    "id" : "operation",
-    "label" : "Operation",
-    "description" : "The operation to execute",
-    "value" : "readCsv",
-    "group" : "operation",
     "binding" : {
       "key" : "operation",
       "type" : "zeebe:taskHeader"
     },
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "Read CSV",
       "value" : "readCsv"
     }, {
       "name" : "Write CSV",
       "value" : "writeCsv"
-    } ]
-  }, {
-    "id" : "readCsv:document_documentSource",
-    "label" : "Document source",
-    "value" : "camunda",
+    } ],
+    "description" : "The operation to execute",
     "group" : "operation",
+    "id" : "operation",
+    "label" : "Operation",
+    "type" : "Dropdown",
+    "value" : "readCsv"
+  }, {
     "binding" : {
       "name" : "document_documentSource",
       "type" : "zeebe:input"
     },
-    "condition" : {
-      "allMatch" : [ {
-        "property" : "operation",
-        "equals" : "readCsv",
-        "type" : "simple"
-      } ]
-    },
-    "tooltip" : "The CSV document to read.",
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "Camunda Document",
       "value" : "camunda"
@@ -89,15 +76,21 @@
     }, {
       "name" : "From URL",
       "value" : "external"
-    } ]
-  }, {
-    "id" : "readCsv:document_camundaReference",
-    "label" : "Camunda document",
-    "constraints" : {
-      "notEmpty" : true
+    } ],
+    "condition" : {
+      "allMatch" : [ {
+        "property" : "operation",
+        "equals" : "readCsv",
+        "type" : "simple"
+      } ]
     },
-    "feel" : "required",
     "group" : "operation",
+    "id" : "readCsv:document_documentSource",
+    "label" : "Document source",
+    "tooltip" : "The CSV document to read.",
+    "type" : "Dropdown",
+    "value" : "camunda"
+  }, {
     "binding" : {
       "name" : "document_camundaReference",
       "type" : "zeebe:input"
@@ -113,15 +106,15 @@
         "type" : "simple"
       } ]
     },
-    "type" : "String"
-  }, {
-    "id" : "readCsv:document_inline_content",
-    "label" : "Content",
     "constraints" : {
       "notEmpty" : true
     },
-    "feel" : "optional",
+    "feel" : "required",
     "group" : "operation",
+    "id" : "readCsv:document_camundaReference",
+    "label" : "Camunda document",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "document_inline_content",
       "type" : "zeebe:input"
@@ -137,12 +130,15 @@
         "type" : "simple"
       } ]
     },
-    "type" : "String"
-  }, {
-    "id" : "readCsv:document_inline_fileName",
-    "label" : "File name",
+    "constraints" : {
+      "notEmpty" : true
+    },
     "feel" : "optional",
     "group" : "operation",
+    "id" : "readCsv:document_inline_content",
+    "label" : "Content",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "document_inline_fileName",
       "type" : "zeebe:input"
@@ -158,12 +154,12 @@
         "type" : "simple"
       } ]
     },
-    "type" : "String"
-  }, {
-    "id" : "readCsv:document_inline_contentType",
-    "label" : "Content type",
     "feel" : "optional",
     "group" : "operation",
+    "id" : "readCsv:document_inline_fileName",
+    "label" : "File name",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "document_inline_contentType",
       "type" : "zeebe:input"
@@ -179,15 +175,12 @@
         "type" : "simple"
       } ]
     },
-    "type" : "String"
-  }, {
-    "id" : "readCsv:document_external_url",
-    "label" : "URL",
-    "constraints" : {
-      "notEmpty" : true
-    },
     "feel" : "optional",
     "group" : "operation",
+    "id" : "readCsv:document_inline_contentType",
+    "label" : "Content type",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "document_external_url",
       "type" : "zeebe:input"
@@ -203,12 +196,15 @@
         "type" : "simple"
       } ]
     },
-    "type" : "String"
-  }, {
-    "id" : "readCsv:document_external_fileName",
-    "label" : "File name",
+    "constraints" : {
+      "notEmpty" : true
+    },
     "feel" : "optional",
     "group" : "operation",
+    "id" : "readCsv:document_external_url",
+    "label" : "URL",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "document_external_fileName",
       "type" : "zeebe:input"
@@ -224,11 +220,12 @@
         "type" : "simple"
       } ]
     },
+    "feel" : "optional",
+    "group" : "operation",
+    "id" : "readCsv:document_external_fileName",
+    "label" : "File name",
     "type" : "String"
   }, {
-    "id" : "readCsv:document",
-    "value" : "=if document_documentSource = \"camunda\" then document_camundaReference else if document_documentSource = \"inline\" then { \"camunda.document.type\": \"inline\", content: document_inline_content, name: document_inline_fileName, contentType: document_inline_contentType } else if document_documentSource = \"external\" then { \"camunda.document.type\": \"external\", url: document_external_url, name: document_external_fileName } else null",
-    "group" : "operation",
     "binding" : {
       "name" : "document",
       "type" : "zeebe:input"
@@ -240,14 +237,11 @@
         "type" : "simple"
       } ]
     },
-    "type" : "Hidden"
-  }, {
-    "id" : "readCsv:format.delimiter",
-    "label" : "Delimiter",
-    "optional" : false,
-    "value" : ",",
-    "feel" : "optional",
     "group" : "operation",
+    "id" : "readCsv:document",
+    "type" : "Hidden",
+    "value" : "=if document_documentSource = \"camunda\" then document_camundaReference else if document_documentSource = \"inline\" then { \"camunda.document.type\": \"inline\", content: document_inline_content, name: document_inline_fileName, contentType: document_inline_contentType } else if document_documentSource = \"external\" then { \"camunda.document.type\": \"external\", url: document_external_url, name: document_external_fileName } else null"
+  }, {
     "binding" : {
       "name" : "format.delimiter",
       "type" : "zeebe:input"
@@ -259,15 +253,15 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "CSV column delimiter",
-    "type" : "String"
-  }, {
-    "id" : "readCsv:format.skipHeaderRecord",
-    "label" : "Skip Header Record",
-    "optional" : false,
-    "value" : true,
-    "feel" : "static",
+    "feel" : "optional",
     "group" : "operation",
+    "id" : "readCsv:format.delimiter",
+    "label" : "Delimiter",
+    "optional" : false,
+    "tooltip" : "CSV column delimiter",
+    "type" : "String",
+    "value" : ","
+  }, {
     "binding" : {
       "name" : "format.skipHeaderRecord",
       "type" : "zeebe:input"
@@ -279,14 +273,15 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "Skips the first row to be not included in the final records.",
-    "type" : "Boolean"
-  }, {
-    "id" : "readCsv:format.headers",
-    "label" : "Headers",
-    "optional" : false,
-    "feel" : "required",
+    "feel" : "static",
     "group" : "operation",
+    "id" : "readCsv:format.skipHeaderRecord",
+    "label" : "Skip Header Record",
+    "optional" : false,
+    "tooltip" : "Skips the first row to be not included in the final records.",
+    "type" : "Boolean",
+    "value" : true
+  }, {
     "binding" : {
       "name" : "format.headers",
       "type" : "zeebe:input"
@@ -298,18 +293,25 @@
         "type" : "simple"
       } ]
     },
+    "feel" : "required",
+    "group" : "operation",
+    "id" : "readCsv:format.headers",
+    "label" : "Headers",
+    "optional" : false,
     "tooltip" : "Mapping of the columns if not included in the CSV itself in the first row.",
     "type" : "String"
   }, {
-    "id" : "readCsv:rowType",
-    "label" : "Row Type",
-    "optional" : false,
-    "value" : "Object",
-    "group" : "operation",
     "binding" : {
       "name" : "rowType",
       "type" : "zeebe:input"
     },
+    "choices" : [ {
+      "name" : "Object",
+      "value" : "Object"
+    }, {
+      "name" : "Array",
+      "value" : "Array"
+    } ],
     "condition" : {
       "allMatch" : [ {
         "property" : "operation",
@@ -317,21 +319,14 @@
         "type" : "simple"
       } ]
     },
+    "group" : "operation",
+    "id" : "readCsv:rowType",
+    "label" : "Row Type",
+    "optional" : false,
     "tooltip" : "Type of the row in the CSV file, either Object or Array",
     "type" : "Dropdown",
-    "choices" : [ {
-      "name" : "Object",
-      "value" : "Object"
-    }, {
-      "name" : "Array",
-      "value" : "Array"
-    } ]
+    "value" : "Object"
   }, {
-    "id" : "readCsv:recordMapper",
-    "label" : "Record mapping",
-    "description" : "",
-    "feel" : "required",
-    "group" : "operation",
     "binding" : {
       "key" : "recordMapper",
       "type" : "zeebe:taskHeader"
@@ -343,14 +338,15 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "<a href=\"https://docs.camunda.io/docs/components/modeler/feel/what-is-feel/\">FEEL</a> function that allows to map each <code>record</code>. Returning <code>null</code> will exclude a record from the final results.",
-    "placeholder" : "",
-    "type" : "String"
-  }, {
-    "id" : "writeCsv:data",
-    "label" : "Data",
+    "description" : "",
     "feel" : "required",
     "group" : "operation",
+    "id" : "readCsv:recordMapper",
+    "label" : "Record mapping",
+    "placeholder" : "",
+    "tooltip" : "<a href=\"https://docs.camunda.io/docs/components/modeler/feel/what-is-feel/\">FEEL</a> function that allows to map each <code>record</code>. Returning <code>null</code> will exclude a record from the final results.",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "data",
       "type" : "zeebe:input"
@@ -362,14 +358,12 @@
         "type" : "simple"
       } ]
     },
+    "feel" : "required",
+    "group" : "operation",
+    "id" : "writeCsv:data",
+    "label" : "Data",
     "type" : "String"
   }, {
-    "id" : "writeCsv:format.delimiter",
-    "label" : "Delimiter",
-    "optional" : false,
-    "value" : ",",
-    "feel" : "optional",
-    "group" : "operation",
     "binding" : {
       "name" : "format.delimiter",
       "type" : "zeebe:input"
@@ -381,15 +375,15 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "CSV column delimiter",
-    "type" : "String"
-  }, {
-    "id" : "writeCsv:format.skipHeaderRecord",
-    "label" : "Skip Header Record",
-    "optional" : false,
-    "value" : true,
-    "feel" : "static",
+    "feel" : "optional",
     "group" : "operation",
+    "id" : "writeCsv:format.delimiter",
+    "label" : "Delimiter",
+    "optional" : false,
+    "tooltip" : "CSV column delimiter",
+    "type" : "String",
+    "value" : ","
+  }, {
     "binding" : {
       "name" : "format.skipHeaderRecord",
       "type" : "zeebe:input"
@@ -401,14 +395,15 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "Skips the first row to be not included in the final records.",
-    "type" : "Boolean"
-  }, {
-    "id" : "writeCsv:format.headers",
-    "label" : "Headers",
-    "optional" : false,
-    "feel" : "required",
+    "feel" : "static",
     "group" : "operation",
+    "id" : "writeCsv:format.skipHeaderRecord",
+    "label" : "Skip Header Record",
+    "optional" : false,
+    "tooltip" : "Skips the first row to be not included in the final records.",
+    "type" : "Boolean",
+    "value" : true
+  }, {
     "binding" : {
       "name" : "format.headers",
       "type" : "zeebe:input"
@@ -420,17 +415,25 @@
         "type" : "simple"
       } ]
     },
+    "feel" : "required",
+    "group" : "operation",
+    "id" : "writeCsv:format.headers",
+    "label" : "Headers",
+    "optional" : false,
     "tooltip" : "Mapping of the columns if not included in the CSV itself in the first row.",
     "type" : "String"
   }, {
-    "id" : "writeCsv:documentReturnFormat",
-    "label" : "Response format",
-    "value" : "TEXT",
-    "group" : "operation",
     "binding" : {
       "name" : "documentReturnFormat.choice",
       "type" : "zeebe:input"
     },
+    "choices" : [ {
+      "name" : "Document reference",
+      "value" : "DOCUMENT"
+    }, {
+      "name" : "as text",
+      "value" : "TEXT"
+    } ],
     "condition" : {
       "allMatch" : [ {
         "property" : "operation",
@@ -438,22 +441,13 @@
         "type" : "simple"
       } ]
     },
+    "group" : "operation",
+    "id" : "writeCsv:documentReturnFormat",
+    "label" : "Response format",
     "tooltip" : "How the rendered CSV should be returned. Document reference uploads it to the document store; as text returns the CSV inline as a String.",
     "type" : "Dropdown",
-    "choices" : [ {
-      "name" : "Document reference",
-      "value" : "DOCUMENT"
-    }, {
-      "name" : "as text",
-      "value" : "TEXT"
-    } ]
+    "value" : "TEXT"
   }, {
-    "id" : "writeCsv:documentReturnFormatEncoding",
-    "label" : "Encoding",
-    "description" : "Character set used to decode the response. Default UTF-8.",
-    "value" : "UTF-8",
-    "feel" : "optional",
-    "group" : "operation",
     "binding" : {
       "name" : "documentReturnFormat.encoding",
       "type" : "zeebe:input"
@@ -469,94 +463,100 @@
         "type" : "simple"
       } ]
     },
-    "type" : "String"
+    "description" : "Character set used to decode the response. Default UTF-8.",
+    "feel" : "optional",
+    "group" : "operation",
+    "id" : "writeCsv:documentReturnFormatEncoding",
+    "label" : "Encoding",
+    "type" : "String",
+    "value" : "UTF-8"
   }, {
-    "id" : "version",
-    "label" : "Version",
-    "description" : "Version of the element template",
-    "value" : "3",
-    "group" : "connector",
     "binding" : {
       "key" : "elementTemplateVersion",
       "type" : "zeebe:taskHeader"
     },
-    "type" : "Hidden"
-  }, {
-    "id" : "id",
-    "label" : "ID",
-    "description" : "ID of the element template",
-    "value" : "io.camunda.connectors.csv",
+    "description" : "Version of the element template",
     "group" : "connector",
+    "id" : "version",
+    "label" : "Version",
+    "type" : "Hidden",
+    "value" : "3"
+  }, {
     "binding" : {
       "key" : "elementTemplateId",
       "type" : "zeebe:taskHeader"
     },
-    "type" : "Hidden"
+    "description" : "ID of the element template",
+    "group" : "connector",
+    "id" : "id",
+    "label" : "ID",
+    "type" : "Hidden",
+    "value" : "io.camunda.connectors.csv"
   }, {
-    "id" : "resultVariable",
-    "label" : "Result variable",
-    "description" : "Name of variable to store the response in. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-variable\" target=\"_blank\">documentation</a>.",
-    "group" : "output",
     "binding" : {
       "key" : "resultVariable",
       "type" : "zeebe:taskHeader"
     },
+    "description" : "Name of variable to store the response in. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-variable\" target=\"_blank\">documentation</a>.",
+    "group" : "output",
+    "id" : "resultVariable",
+    "label" : "Result variable",
     "type" : "String"
   }, {
-    "id" : "resultExpression",
-    "label" : "Result expression",
-    "description" : "Expression to map the response into process variables. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-expression\" target=\"_blank\">documentation</a>.",
-    "feel" : "required",
-    "group" : "output",
     "binding" : {
       "key" : "resultExpression",
       "type" : "zeebe:taskHeader"
     },
+    "description" : "Expression to map the response into process variables. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-expression\" target=\"_blank\">documentation</a>.",
+    "feel" : "required",
+    "group" : "output",
+    "id" : "resultExpression",
+    "label" : "Result expression",
     "type" : "Text"
   }, {
-    "id" : "errorExpression",
-    "label" : "Error expression",
-    "description" : "Expression to handle errors. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/\" target=\"_blank\">documentation</a>.",
-    "feel" : "required",
-    "group" : "error",
     "binding" : {
       "key" : "errorExpression",
       "type" : "zeebe:taskHeader"
     },
+    "description" : "Expression to handle errors. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/\" target=\"_blank\">documentation</a>.",
+    "feel" : "required",
+    "group" : "error",
+    "id" : "errorExpression",
+    "label" : "Error expression",
     "type" : "Text"
   }, {
-    "id" : "retryCount",
-    "label" : "Retries",
-    "description" : "Number of retries",
-    "value" : "3",
-    "feel" : "optional",
-    "group" : "retries",
     "binding" : {
       "property" : "retries",
       "type" : "zeebe:taskDefinition"
     },
-    "type" : "String"
-  }, {
-    "id" : "retryBackoff",
-    "label" : "Retry backoff",
-    "description" : "ISO-8601 duration to wait between retries",
-    "value" : "PT30S",
+    "description" : "Number of retries",
+    "feel" : "optional",
     "group" : "retries",
+    "id" : "retryCount",
+    "label" : "Retries",
+    "type" : "String",
+    "value" : "3"
+  }, {
     "binding" : {
       "key" : "retryBackoff",
       "type" : "zeebe:taskHeader"
     },
-    "type" : "String"
-  }, {
-    "id" : "jobTimeout",
-    "label" : "Job timeout",
-    "description" : "ISO-8601 duration after which Zeebe considers this job timed out if not yet completed. Leave empty to use the default timeout",
-    "optional" : true,
+    "description" : "ISO-8601 duration to wait between retries",
     "group" : "retries",
+    "id" : "retryBackoff",
+    "label" : "Retry backoff",
+    "type" : "String",
+    "value" : "PT30S"
+  }, {
     "binding" : {
       "key" : "jobTimeout",
       "type" : "zeebe:taskHeader"
     },
+    "description" : "ISO-8601 duration after which Zeebe considers this job timed out if not yet completed. Leave empty to use the default timeout",
+    "group" : "retries",
+    "id" : "jobTimeout",
+    "label" : "Job timeout",
+    "optional" : true,
     "type" : "String"
   } ],
   "steps" : [ {

--- a/connectors/embeddings-vector-database/element-templates/embeddings-vector-database-outbound-connector.json
+++ b/connectors/embeddings-vector-database/element-templates/embeddings-vector-database-outbound-connector.json
@@ -45,40 +45,31 @@
     "label" : "Retries"
   } ],
   "properties" : [ {
-    "value" : "io.camunda:embeddings-vector-database:1",
     "binding" : {
       "property" : "type",
       "type" : "zeebe:taskDefinition"
     },
-    "type" : "Hidden"
+    "type" : "Hidden",
+    "value" : "io.camunda:embeddings-vector-database:1"
   }, {
-    "id" : "vectorDatabaseConnectorOperation.operationType",
-    "label" : "Operation",
-    "description" : "Select operation",
-    "value" : "retrieveDocumentOperation",
-    "group" : "operation",
     "binding" : {
       "name" : "vectorDatabaseConnectorOperation.operationType",
       "type" : "zeebe:input"
     },
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "Embed document",
       "value" : "embedDocumentOperation"
     }, {
       "name" : "Retrieve document",
       "value" : "retrieveDocumentOperation"
-    } ]
+    } ],
+    "description" : "Select operation",
+    "group" : "operation",
+    "id" : "vectorDatabaseConnectorOperation.operationType",
+    "label" : "Operation",
+    "type" : "Dropdown",
+    "value" : "retrieveDocumentOperation"
   }, {
-    "id" : "vectorDatabaseConnectorOperation.query.query",
-    "label" : "Search query",
-    "description" : "Document lookup query",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "feel" : "optional",
-    "group" : "query",
     "binding" : {
       "name" : "vectorDatabaseConnectorOperation.query",
       "type" : "zeebe:input"
@@ -88,15 +79,17 @@
       "equals" : "retrieveDocumentOperation",
       "type" : "simple"
     },
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "description" : "Document lookup query",
+    "feel" : "optional",
+    "group" : "query",
+    "id" : "vectorDatabaseConnectorOperation.query.query",
+    "label" : "Search query",
+    "optional" : false,
     "type" : "String"
   }, {
-    "id" : "vectorDatabaseConnectorOperation.query.maxResults",
-    "label" : "Max results",
-    "description" : "Limit number of returned results",
-    "optional" : false,
-    "value" : 5,
-    "feel" : "static",
-    "group" : "query",
     "binding" : {
       "name" : "vectorDatabaseConnectorOperation.documentLimit",
       "type" : "zeebe:input"
@@ -106,14 +99,15 @@
       "equals" : "retrieveDocumentOperation",
       "type" : "simple"
     },
-    "type" : "Number"
-  }, {
-    "id" : "vectorDatabaseConnectorOperation.query.minScore",
-    "label" : "Min score",
-    "description" : "Minimal vector similarity score for result to be included. Must be between 0 and 1 floating point value, e.g. 0.6. Incorrect and empty value resolves to 0.0",
-    "optional" : true,
+    "description" : "Limit number of returned results",
     "feel" : "static",
     "group" : "query",
+    "id" : "vectorDatabaseConnectorOperation.query.maxResults",
+    "label" : "Max results",
+    "optional" : false,
+    "type" : "Number",
+    "value" : 5
+  }, {
     "binding" : {
       "name" : "vectorDatabaseConnectorOperation.minScore",
       "type" : "zeebe:input"
@@ -123,18 +117,18 @@
       "equals" : "retrieveDocumentOperation",
       "type" : "simple"
     },
+    "description" : "Minimal vector similarity score for result to be included. Must be between 0 and 1 floating point value, e.g. 0.6. Incorrect and empty value resolves to 0.0",
+    "feel" : "static",
+    "group" : "query",
+    "id" : "vectorDatabaseConnectorOperation.query.minScore",
+    "label" : "Min score",
+    "optional" : true,
     "type" : "Number"
   }, {
-    "id" : "embeddingModelProvider.modelProvider",
-    "label" : "Model provider",
-    "description" : "Select embedding model provider",
-    "value" : "bedrockModelProvider",
-    "group" : "embeddingModel",
     "binding" : {
       "name" : "embeddingModelProvider.modelProvider",
       "type" : "zeebe:input"
     },
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "Azure OpenAI",
       "value" : "azureOpenAiModelProvider"
@@ -147,17 +141,14 @@
     }, {
       "name" : "OpenAI",
       "value" : "openAiModelProvider"
-    } ]
-  }, {
-    "id" : "embeddingModelProvider.azureOpenAi.endpoint",
-    "label" : "Endpoint",
-    "description" : "Specify Azure OpenAI endpoint. Details in the <a href=\"https://learn.microsoft.com/en-us/azure/ai-foundry/openai/reference\" target=\"_blank\">documentation</a>.",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "feel" : "optional",
+    } ],
+    "description" : "Select embedding model provider",
     "group" : "embeddingModel",
+    "id" : "embeddingModelProvider.modelProvider",
+    "label" : "Model provider",
+    "type" : "Dropdown",
+    "value" : "bedrockModelProvider"
+  }, {
     "binding" : {
       "name" : "embeddingModelProvider.azureOpenAi.endpoint",
       "type" : "zeebe:input"
@@ -167,39 +158,40 @@
       "equals" : "azureOpenAiModelProvider",
       "type" : "simple"
     },
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "description" : "Specify Azure OpenAI endpoint. Details in the <a href=\"https://learn.microsoft.com/en-us/azure/ai-foundry/openai/reference\" target=\"_blank\">documentation</a>.",
+    "feel" : "optional",
+    "group" : "embeddingModel",
+    "id" : "embeddingModelProvider.azureOpenAi.endpoint",
+    "label" : "Endpoint",
+    "optional" : false,
     "type" : "String"
   }, {
-    "id" : "embeddingModelProvider.azureOpenAi.authentication.type",
-    "label" : "Authentication",
-    "description" : "Specify the Azure OpenAI authentication strategy.",
-    "value" : "apiKey",
-    "group" : "embeddingModel",
     "binding" : {
       "name" : "embeddingModelProvider.azureOpenAi.authentication.type",
       "type" : "zeebe:input"
     },
-    "condition" : {
-      "property" : "embeddingModelProvider.modelProvider",
-      "equals" : "azureOpenAiModelProvider",
-      "type" : "simple"
-    },
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "API key",
       "value" : "apiKey"
     }, {
       "name" : "Client credentials",
       "value" : "clientCredentials"
-    } ]
-  }, {
-    "id" : "embeddingModelProvider.azureOpenAi.authentication.apiKey",
-    "label" : "API key",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
+    } ],
+    "condition" : {
+      "property" : "embeddingModelProvider.modelProvider",
+      "equals" : "azureOpenAiModelProvider",
+      "type" : "simple"
     },
-    "feel" : "optional",
+    "description" : "Specify the Azure OpenAI authentication strategy.",
     "group" : "embeddingModel",
+    "id" : "embeddingModelProvider.azureOpenAi.authentication.type",
+    "label" : "Authentication",
+    "type" : "Dropdown",
+    "value" : "apiKey"
+  }, {
     "binding" : {
       "name" : "embeddingModelProvider.azureOpenAi.authentication.apiKey",
       "type" : "zeebe:input"
@@ -215,17 +207,16 @@
         "type" : "simple"
       } ]
     },
-    "type" : "String"
-  }, {
-    "id" : "embeddingModelProvider.azureOpenAi.authentication.clientId",
-    "label" : "Client ID",
-    "description" : "ID of a Microsoft Entra application",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "embeddingModel",
+    "id" : "embeddingModelProvider.azureOpenAi.authentication.apiKey",
+    "label" : "API key",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "embeddingModelProvider.azureOpenAi.authentication.clientId",
       "type" : "zeebe:input"
@@ -241,17 +232,17 @@
         "type" : "simple"
       } ]
     },
-    "type" : "String"
-  }, {
-    "id" : "embeddingModelProvider.azureOpenAi.authentication.clientSecret",
-    "label" : "Client secret",
-    "description" : "Secret of a Microsoft Entra application",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
+    "description" : "ID of a Microsoft Entra application",
     "feel" : "optional",
     "group" : "embeddingModel",
+    "id" : "embeddingModelProvider.azureOpenAi.authentication.clientId",
+    "label" : "Client ID",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "embeddingModelProvider.azureOpenAi.authentication.clientSecret",
       "type" : "zeebe:input"
@@ -267,17 +258,17 @@
         "type" : "simple"
       } ]
     },
-    "type" : "String"
-  }, {
-    "id" : "embeddingModelProvider.azureOpenAi.authentication.tenantId",
-    "label" : "Tenant ID",
-    "description" : "ID of a Microsoft Entra tenant. Details in the <a href=\"https://learn.microsoft.com/en-us/entra/fundamentals/how-to-find-tenant\" target=\"_blank\">documentation</a>.",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
+    "description" : "Secret of a Microsoft Entra application",
     "feel" : "optional",
     "group" : "embeddingModel",
+    "id" : "embeddingModelProvider.azureOpenAi.authentication.clientSecret",
+    "label" : "Client secret",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "embeddingModelProvider.azureOpenAi.authentication.tenantId",
       "type" : "zeebe:input"
@@ -293,14 +284,17 @@
         "type" : "simple"
       } ]
     },
-    "type" : "String"
-  }, {
-    "id" : "embeddingModelProvider.azureOpenAi.authentication.authorityHost",
-    "label" : "Authority host",
-    "description" : "Authority host URL for the Microsoft Entra application. Defaults to <code>https://login.microsoftonline.com</code>. This can also contain an OAuth 2.0 token endpoint.",
-    "optional" : true,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "description" : "ID of a Microsoft Entra tenant. Details in the <a href=\"https://learn.microsoft.com/en-us/entra/fundamentals/how-to-find-tenant\" target=\"_blank\">documentation</a>.",
     "feel" : "optional",
     "group" : "embeddingModel",
+    "id" : "embeddingModelProvider.azureOpenAi.authentication.tenantId",
+    "label" : "Tenant ID",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "embeddingModelProvider.azureOpenAi.authentication.authorityHost",
       "type" : "zeebe:input"
@@ -316,17 +310,14 @@
         "type" : "simple"
       } ]
     },
-    "type" : "String"
-  }, {
-    "id" : "embeddingModelProvider.azureOpenAi.deploymentName",
-    "label" : "Model deployment name",
-    "description" : "Specify the model deployment name. Details in the <a href=\"https://learn.microsoft.com/en-us/azure/ai-foundry/openai/reference\" target=\"_blank\">documentation</a>.",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
+    "description" : "Authority host URL for the Microsoft Entra application. Defaults to <code>https://login.microsoftonline.com</code>. This can also contain an OAuth 2.0 token endpoint.",
     "feel" : "optional",
     "group" : "embeddingModel",
+    "id" : "embeddingModelProvider.azureOpenAi.authentication.authorityHost",
+    "label" : "Authority host",
+    "optional" : true,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "embeddingModelProvider.azureOpenAi.deploymentName",
       "type" : "zeebe:input"
@@ -336,14 +327,17 @@
       "equals" : "azureOpenAiModelProvider",
       "type" : "simple"
     },
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "description" : "Specify the model deployment name. Details in the <a href=\"https://learn.microsoft.com/en-us/azure/ai-foundry/openai/reference\" target=\"_blank\">documentation</a>.",
+    "feel" : "optional",
+    "group" : "embeddingModel",
+    "id" : "embeddingModelProvider.azureOpenAi.deploymentName",
+    "label" : "Model deployment name",
+    "optional" : false,
     "type" : "String"
   }, {
-    "id" : "embeddingModelProvider.azureOpenAi.dimensions",
-    "label" : "Embedding dimensions",
-    "description" : "The size of the vector used to represent data. If not specified, the default model dimensions are used. Details in the <a href=\"https://platform.openai.com/docs/guides/embeddings\" target=\"_blank\">documentation</a>.",
-    "optional" : true,
-    "feel" : "required",
-    "group" : "embeddingModel",
     "binding" : {
       "name" : "embeddingModelProvider.azureOpenAi.dimensions",
       "type" : "zeebe:input"
@@ -353,15 +347,14 @@
       "equals" : "azureOpenAiModelProvider",
       "type" : "simple"
     },
+    "description" : "The size of the vector used to represent data. If not specified, the default model dimensions are used. Details in the <a href=\"https://platform.openai.com/docs/guides/embeddings\" target=\"_blank\">documentation</a>.",
+    "feel" : "required",
+    "group" : "embeddingModel",
+    "id" : "embeddingModelProvider.azureOpenAi.dimensions",
+    "label" : "Embedding dimensions",
+    "optional" : true,
     "type" : "Number"
   }, {
-    "id" : "embeddingModelProvider.azureOpenAi.maxRetries",
-    "label" : "Max retries",
-    "description" : "Max retries",
-    "optional" : true,
-    "value" : 3,
-    "feel" : "static",
-    "group" : "embeddingModel",
     "binding" : {
       "name" : "embeddingModelProvider.azureOpenAi.maxRetries",
       "type" : "zeebe:input"
@@ -371,14 +364,15 @@
       "equals" : "azureOpenAiModelProvider",
       "type" : "simple"
     },
-    "type" : "Number"
-  }, {
-    "id" : "embeddingModelProvider.azureOpenAi.customHeaders",
-    "label" : "Custom headers",
-    "description" : "Map of custom HTTP headers to add to the request.",
-    "optional" : true,
-    "feel" : "required",
+    "description" : "Max retries",
+    "feel" : "static",
     "group" : "embeddingModel",
+    "id" : "embeddingModelProvider.azureOpenAi.maxRetries",
+    "label" : "Max retries",
+    "optional" : true,
+    "type" : "Number",
+    "value" : 3
+  }, {
     "binding" : {
       "name" : "embeddingModelProvider.azureOpenAi.customHeaders",
       "type" : "zeebe:input"
@@ -388,17 +382,14 @@
       "equals" : "azureOpenAiModelProvider",
       "type" : "simple"
     },
+    "description" : "Map of custom HTTP headers to add to the request.",
+    "feel" : "required",
+    "group" : "embeddingModel",
+    "id" : "embeddingModelProvider.azureOpenAi.customHeaders",
+    "label" : "Custom headers",
+    "optional" : true,
     "type" : "String"
   }, {
-    "id" : "embeddingModelProvider.bedrock.accessKey",
-    "label" : "Access key",
-    "description" : "Provide an IAM access key tailored to a user, equipped with the necessary permissions",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "feel" : "optional",
-    "group" : "embeddingModel",
     "binding" : {
       "name" : "embeddingModelProvider.bedrock.accessKey",
       "type" : "zeebe:input"
@@ -408,17 +399,17 @@
       "equals" : "bedrockModelProvider",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "embeddingModelProvider.bedrock.secretKey",
-    "label" : "Secret key",
-    "description" : "Provide a secret key associated with the access key",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
+    "description" : "Provide an IAM access key tailored to a user, equipped with the necessary permissions",
     "feel" : "optional",
     "group" : "embeddingModel",
+    "id" : "embeddingModelProvider.bedrock.accessKey",
+    "label" : "Access key",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "embeddingModelProvider.bedrock.secretKey",
       "type" : "zeebe:input"
@@ -428,17 +419,17 @@
       "equals" : "bedrockModelProvider",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "embeddingModelProvider.bedrock.region",
-    "label" : "Region",
-    "description" : "AWS Bedrock region",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
+    "description" : "Provide a secret key associated with the access key",
     "feel" : "optional",
     "group" : "embeddingModel",
+    "id" : "embeddingModelProvider.bedrock.secretKey",
+    "label" : "Secret key",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "embeddingModelProvider.bedrock.region",
       "type" : "zeebe:input"
@@ -448,27 +439,21 @@
       "equals" : "bedrockModelProvider",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "embeddingModelProvider.bedrock.modelName",
-    "label" : "Model name",
-    "description" : "Bedrock model name or identifier",
-    "optional" : false,
-    "value" : "TitanEmbedTextV2",
     "constraints" : {
       "notEmpty" : true
     },
+    "description" : "AWS Bedrock region",
+    "feel" : "optional",
     "group" : "embeddingModel",
+    "id" : "embeddingModelProvider.bedrock.region",
+    "label" : "Region",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "embeddingModelProvider.bedrock.modelName",
       "type" : "zeebe:input"
     },
-    "condition" : {
-      "property" : "embeddingModelProvider.modelProvider",
-      "equals" : "bedrockModelProvider",
-      "type" : "simple"
-    },
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "Custom",
       "value" : "Custom"
@@ -478,16 +463,23 @@
     }, {
       "name" : "amazon.titan-embed-text-v2:0",
       "value" : "TitanEmbedTextV2"
-    } ]
-  }, {
-    "id" : "embeddingModelProvider.bedrock.customModelName",
-    "label" : "Custom model name",
-    "optional" : false,
+    } ],
+    "condition" : {
+      "property" : "embeddingModelProvider.modelProvider",
+      "equals" : "bedrockModelProvider",
+      "type" : "simple"
+    },
     "constraints" : {
       "notEmpty" : true
     },
-    "feel" : "optional",
+    "description" : "Bedrock model name or identifier",
     "group" : "embeddingModel",
+    "id" : "embeddingModelProvider.bedrock.modelName",
+    "label" : "Model name",
+    "optional" : false,
+    "type" : "Dropdown",
+    "value" : "TitanEmbedTextV2"
+  }, {
     "binding" : {
       "name" : "embeddingModelProvider.bedrock.customModelName",
       "type" : "zeebe:input"
@@ -503,18 +495,30 @@
         "type" : "simple"
       } ]
     },
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "embeddingModel",
+    "id" : "embeddingModelProvider.bedrock.customModelName",
+    "label" : "Custom model name",
+    "optional" : false,
     "type" : "String"
   }, {
-    "id" : "embeddingModelProvider.bedrock.dimensions",
-    "label" : "Embedding dimensions",
-    "description" : "The size of the vector used to represent data",
-    "optional" : false,
-    "value" : "D1024",
-    "group" : "embeddingModel",
     "binding" : {
       "name" : "embeddingModelProvider.bedrock.dimensions",
       "type" : "zeebe:input"
     },
+    "choices" : [ {
+      "name" : "256",
+      "value" : "D256"
+    }, {
+      "name" : "512",
+      "value" : "D512"
+    }, {
+      "name" : "1024",
+      "value" : "D1024"
+    } ],
     "condition" : {
       "allMatch" : [ {
         "property" : "embeddingModelProvider.bedrock.modelName",
@@ -526,25 +530,14 @@
         "type" : "simple"
       } ]
     },
-    "type" : "Dropdown",
-    "choices" : [ {
-      "name" : "256",
-      "value" : "D256"
-    }, {
-      "name" : "512",
-      "value" : "D512"
-    }, {
-      "name" : "1024",
-      "value" : "D1024"
-    } ]
-  }, {
-    "id" : "embeddingModelProvider.bedrock.normalize",
-    "label" : "Normalize",
-    "description" : "Normalize vector",
-    "optional" : false,
-    "value" : false,
-    "feel" : "static",
+    "description" : "The size of the vector used to represent data",
     "group" : "embeddingModel",
+    "id" : "embeddingModelProvider.bedrock.dimensions",
+    "label" : "Embedding dimensions",
+    "optional" : false,
+    "type" : "Dropdown",
+    "value" : "D1024"
+  }, {
     "binding" : {
       "name" : "embeddingModelProvider.bedrock.normalize",
       "type" : "zeebe:input"
@@ -560,15 +553,15 @@
         "type" : "simple"
       } ]
     },
-    "type" : "Boolean"
-  }, {
-    "id" : "embeddingModelProvider.bedrock.maxRetries",
-    "label" : "Max retries",
-    "description" : "Max retries",
-    "optional" : false,
-    "value" : 3,
+    "description" : "Normalize vector",
     "feel" : "static",
     "group" : "embeddingModel",
+    "id" : "embeddingModelProvider.bedrock.normalize",
+    "label" : "Normalize",
+    "optional" : false,
+    "type" : "Boolean",
+    "value" : false
+  }, {
     "binding" : {
       "name" : "embeddingModelProvider.bedrock.maxRetries",
       "type" : "zeebe:input"
@@ -578,17 +571,15 @@
       "equals" : "bedrockModelProvider",
       "type" : "simple"
     },
-    "type" : "Number"
-  }, {
-    "id" : "embeddingModelProvider.googleVertexAi.projectId",
-    "label" : "Project ID",
-    "description" : "Google Cloud project ID",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "feel" : "optional",
+    "description" : "Max retries",
+    "feel" : "static",
     "group" : "embeddingModel",
+    "id" : "embeddingModelProvider.bedrock.maxRetries",
+    "label" : "Max retries",
+    "optional" : false,
+    "type" : "Number",
+    "value" : 3
+  }, {
     "binding" : {
       "name" : "embeddingModelProvider.googleVertexAi.projectId",
       "type" : "zeebe:input"
@@ -598,17 +589,17 @@
       "equals" : "vertexAiModelProvider",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "embeddingModelProvider.googleVertexAi.region",
-    "label" : "Region",
-    "description" : "Google Cloud region for Vertex AI",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
+    "description" : "Google Cloud project ID",
     "feel" : "optional",
     "group" : "embeddingModel",
+    "id" : "embeddingModelProvider.googleVertexAi.projectId",
+    "label" : "Project ID",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "embeddingModelProvider.googleVertexAi.region",
       "type" : "zeebe:input"
@@ -618,40 +609,40 @@
       "equals" : "vertexAiModelProvider",
       "type" : "simple"
     },
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "description" : "Google Cloud region for Vertex AI",
+    "feel" : "optional",
+    "group" : "embeddingModel",
+    "id" : "embeddingModelProvider.googleVertexAi.region",
+    "label" : "Region",
+    "optional" : false,
     "type" : "String"
   }, {
-    "id" : "embeddingModelProvider.googleVertexAi.authentication.type",
-    "label" : "Authentication",
-    "description" : "Specify the Google Vertex AI authentication strategy.",
-    "value" : "serviceAccountCredentials",
-    "group" : "embeddingModel",
     "binding" : {
       "name" : "embeddingModelProvider.googleVertexAi.authentication.type",
       "type" : "zeebe:input"
     },
-    "condition" : {
-      "property" : "embeddingModelProvider.modelProvider",
-      "equals" : "vertexAiModelProvider",
-      "type" : "simple"
-    },
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "Service account credentials",
       "value" : "serviceAccountCredentials"
     }, {
       "name" : "Application default credentials (Hybrid/Self-Managed only)",
       "value" : "applicationDefaultCredentials"
-    } ]
-  }, {
-    "id" : "embeddingModelProvider.googleVertexAi.authentication.jsonKey",
-    "label" : "JSON key of the service account",
-    "description" : "This is the key of the service account in JSON format.",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
+    } ],
+    "condition" : {
+      "property" : "embeddingModelProvider.modelProvider",
+      "equals" : "vertexAiModelProvider",
+      "type" : "simple"
     },
-    "feel" : "optional",
+    "description" : "Specify the Google Vertex AI authentication strategy.",
     "group" : "embeddingModel",
+    "id" : "embeddingModelProvider.googleVertexAi.authentication.type",
+    "label" : "Authentication",
+    "type" : "Dropdown",
+    "value" : "serviceAccountCredentials"
+  }, {
     "binding" : {
       "name" : "embeddingModelProvider.googleVertexAi.authentication.jsonKey",
       "type" : "zeebe:input"
@@ -667,17 +658,17 @@
         "type" : "simple"
       } ]
     },
-    "type" : "String"
-  }, {
-    "id" : "embeddingModelProvider.googleVertexAi.modelName",
-    "label" : "Model name",
-    "description" : "Vertex AI embedding model name",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
+    "description" : "This is the key of the service account in JSON format.",
     "feel" : "optional",
     "group" : "embeddingModel",
+    "id" : "embeddingModelProvider.googleVertexAi.authentication.jsonKey",
+    "label" : "JSON key of the service account",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "embeddingModelProvider.googleVertexAi.modelName",
       "type" : "zeebe:input"
@@ -687,17 +678,17 @@
       "equals" : "vertexAiModelProvider",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "embeddingModelProvider.googleVertexAi.dimensions",
-    "label" : "Embedding dimensions",
-    "description" : "The size of the vector used to represent data. Details in the <a href=\"https://cloud.google.com/vertex-ai/generative-ai/docs/embeddings/get-text-embeddings\" target=\"_blank\">documentation</a>.",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
-    "feel" : "required",
+    "description" : "Vertex AI embedding model name",
+    "feel" : "optional",
     "group" : "embeddingModel",
+    "id" : "embeddingModelProvider.googleVertexAi.modelName",
+    "label" : "Model name",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "embeddingModelProvider.googleVertexAi.dimensions",
       "type" : "zeebe:input"
@@ -707,15 +698,17 @@
       "equals" : "vertexAiModelProvider",
       "type" : "simple"
     },
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "description" : "The size of the vector used to represent data. Details in the <a href=\"https://cloud.google.com/vertex-ai/generative-ai/docs/embeddings/get-text-embeddings\" target=\"_blank\">documentation</a>.",
+    "feel" : "required",
+    "group" : "embeddingModel",
+    "id" : "embeddingModelProvider.googleVertexAi.dimensions",
+    "label" : "Embedding dimensions",
+    "optional" : false,
     "type" : "Number"
   }, {
-    "id" : "embeddingModelProvider.googleVertexAi.publisher",
-    "label" : "Publisher",
-    "description" : "The publisher of the Vertex AI model (e.g., 'google', 'third-party'). Optional.",
-    "optional" : true,
-    "value" : "google",
-    "feel" : "optional",
-    "group" : "embeddingModel",
     "binding" : {
       "name" : "embeddingModelProvider.googleVertexAi.publisher",
       "type" : "zeebe:input"
@@ -725,15 +718,15 @@
       "equals" : "vertexAiModelProvider",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "embeddingModelProvider.googleVertexAi.maxRetries",
-    "label" : "Max retries",
-    "description" : "Max retries",
-    "optional" : true,
-    "value" : 3,
-    "feel" : "static",
+    "description" : "The publisher of the Vertex AI model (e.g., 'google', 'third-party'). Optional.",
+    "feel" : "optional",
     "group" : "embeddingModel",
+    "id" : "embeddingModelProvider.googleVertexAi.publisher",
+    "label" : "Publisher",
+    "optional" : true,
+    "type" : "String",
+    "value" : "google"
+  }, {
     "binding" : {
       "name" : "embeddingModelProvider.googleVertexAi.maxRetries",
       "type" : "zeebe:input"
@@ -743,16 +736,15 @@
       "equals" : "vertexAiModelProvider",
       "type" : "simple"
     },
-    "type" : "Number"
-  }, {
-    "id" : "embeddingModelProvider.openAi.apiKey",
-    "label" : "OpenAI API key",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "feel" : "optional",
+    "description" : "Max retries",
+    "feel" : "static",
     "group" : "embeddingModel",
+    "id" : "embeddingModelProvider.googleVertexAi.maxRetries",
+    "label" : "Max retries",
+    "optional" : true,
+    "type" : "Number",
+    "value" : 3
+  }, {
     "binding" : {
       "name" : "embeddingModelProvider.openAi.apiKey",
       "type" : "zeebe:input"
@@ -762,17 +754,16 @@
       "equals" : "openAiModelProvider",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "embeddingModelProvider.openAi.modelName",
-    "label" : "Model name",
-    "description" : "Specify the model name. Details in the <a href=\"https://platform.openai.com/docs/guides/embeddings\" target=\"_blank\">documentation</a>.",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "embeddingModel",
+    "id" : "embeddingModelProvider.openAi.apiKey",
+    "label" : "OpenAI API key",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "embeddingModelProvider.openAi.modelName",
       "type" : "zeebe:input"
@@ -782,14 +773,17 @@
       "equals" : "openAiModelProvider",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "embeddingModelProvider.openAi.organizationId",
-    "label" : "Organization ID",
-    "description" : "For members of multiple organizations. Details in the <a href=\"https://platform.openai.com/docs/api-reference/authentication\" target=\"_blank\">documentation</a>.",
-    "optional" : true,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "description" : "Specify the model name. Details in the <a href=\"https://platform.openai.com/docs/guides/embeddings\" target=\"_blank\">documentation</a>.",
     "feel" : "optional",
     "group" : "embeddingModel",
+    "id" : "embeddingModelProvider.openAi.modelName",
+    "label" : "Model name",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "embeddingModelProvider.openAi.organizationId",
       "type" : "zeebe:input"
@@ -799,14 +793,14 @@
       "equals" : "openAiModelProvider",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "embeddingModelProvider.openAi.projectId",
-    "label" : "Project ID",
-    "description" : "For accounts with multiple projects. Details in the <a href=\"https://platform.openai.com/docs/api-reference/authentication\" target=\"_blank\">documentation</a>.",
-    "optional" : true,
+    "description" : "For members of multiple organizations. Details in the <a href=\"https://platform.openai.com/docs/api-reference/authentication\" target=\"_blank\">documentation</a>.",
     "feel" : "optional",
     "group" : "embeddingModel",
+    "id" : "embeddingModelProvider.openAi.organizationId",
+    "label" : "Organization ID",
+    "optional" : true,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "embeddingModelProvider.openAi.projectId",
       "type" : "zeebe:input"
@@ -816,14 +810,14 @@
       "equals" : "openAiModelProvider",
       "type" : "simple"
     },
+    "description" : "For accounts with multiple projects. Details in the <a href=\"https://platform.openai.com/docs/api-reference/authentication\" target=\"_blank\">documentation</a>.",
+    "feel" : "optional",
+    "group" : "embeddingModel",
+    "id" : "embeddingModelProvider.openAi.projectId",
+    "label" : "Project ID",
+    "optional" : true,
     "type" : "String"
   }, {
-    "id" : "embeddingModelProvider.openAi.dimensions",
-    "label" : "Embedding dimensions",
-    "description" : "The size of the vector used to represent data. If not specified, the default model dimensions are used. Details in the <a href=\"https://platform.openai.com/docs/guides/embeddings\" target=\"_blank\">documentation</a>.",
-    "optional" : true,
-    "feel" : "required",
-    "group" : "embeddingModel",
     "binding" : {
       "name" : "embeddingModelProvider.openAi.dimensions",
       "type" : "zeebe:input"
@@ -833,15 +827,14 @@
       "equals" : "openAiModelProvider",
       "type" : "simple"
     },
+    "description" : "The size of the vector used to represent data. If not specified, the default model dimensions are used. Details in the <a href=\"https://platform.openai.com/docs/guides/embeddings\" target=\"_blank\">documentation</a>.",
+    "feel" : "required",
+    "group" : "embeddingModel",
+    "id" : "embeddingModelProvider.openAi.dimensions",
+    "label" : "Embedding dimensions",
+    "optional" : true,
     "type" : "Number"
   }, {
-    "id" : "embeddingModelProvider.openAi.maxRetries",
-    "label" : "Max retries",
-    "description" : "Max retries",
-    "optional" : true,
-    "value" : 3,
-    "feel" : "static",
-    "group" : "embeddingModel",
     "binding" : {
       "name" : "embeddingModelProvider.openAi.maxRetries",
       "type" : "zeebe:input"
@@ -851,14 +844,15 @@
       "equals" : "openAiModelProvider",
       "type" : "simple"
     },
-    "type" : "Number"
-  }, {
-    "id" : "embeddingModelProvider.openAi.customHeaders",
-    "label" : "Custom headers",
-    "description" : "Map of custom HTTP headers to add to the request.",
-    "optional" : true,
-    "feel" : "required",
+    "description" : "Max retries",
+    "feel" : "static",
     "group" : "embeddingModel",
+    "id" : "embeddingModelProvider.openAi.maxRetries",
+    "label" : "Max retries",
+    "optional" : true,
+    "type" : "Number",
+    "value" : 3
+  }, {
     "binding" : {
       "name" : "embeddingModelProvider.openAi.customHeaders",
       "type" : "zeebe:input"
@@ -868,13 +862,14 @@
       "equals" : "openAiModelProvider",
       "type" : "simple"
     },
+    "description" : "Map of custom HTTP headers to add to the request.",
+    "feel" : "required",
+    "group" : "embeddingModel",
+    "id" : "embeddingModelProvider.openAi.customHeaders",
+    "label" : "Custom headers",
+    "optional" : true,
     "type" : "String"
   }, {
-    "id" : "embeddingModelProvider.openAi.baseUrl",
-    "label" : "Custom base URL",
-    "optional" : true,
-    "feel" : "optional",
-    "group" : "embeddingModel",
     "binding" : {
       "name" : "embeddingModelProvider.openAi.baseUrl",
       "type" : "zeebe:input"
@@ -884,19 +879,18 @@
       "equals" : "openAiModelProvider",
       "type" : "simple"
     },
+    "feel" : "optional",
+    "group" : "embeddingModel",
+    "id" : "embeddingModelProvider.openAi.baseUrl",
+    "label" : "Custom base URL",
+    "optional" : true,
     "tooltip" : "Base URL of OpenAI API. The default is 'https://api.openai.com/v1/'",
     "type" : "String"
   }, {
-    "id" : "vectorStore.vectorStore",
-    "label" : "Embeddings store",
-    "description" : "Select embedding store",
-    "value" : "elasticsearchStore",
-    "group" : "embeddingsStore",
     "binding" : {
       "name" : "vectorStore.storeType",
       "type" : "zeebe:input"
     },
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "Amazon Managed OpenSearch",
       "value" : "amazonManagedOpenSearchStore"
@@ -912,17 +906,14 @@
     }, {
       "name" : "OpenSearch",
       "value" : "openSearchStore"
-    } ]
-  }, {
-    "id" : "vectorStore.amazonManagedOpensearch.accessKey",
-    "label" : "Access key",
-    "description" : "Provide an IAM access key tailored to a user, equipped with the necessary permissions",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "feel" : "optional",
+    } ],
+    "description" : "Select embedding store",
     "group" : "embeddingsStore",
+    "id" : "vectorStore.vectorStore",
+    "label" : "Embeddings store",
+    "type" : "Dropdown",
+    "value" : "elasticsearchStore"
+  }, {
     "binding" : {
       "name" : "vectorStore.amazonManagedOpensearch.accessKey",
       "type" : "zeebe:input"
@@ -932,17 +923,17 @@
       "equals" : "amazonManagedOpenSearchStore",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "vectorStore.amazonManagedOpensearch.secretKey",
-    "label" : "Secret key",
-    "description" : "Provide a secret key associated with the access key",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
+    "description" : "Provide an IAM access key tailored to a user, equipped with the necessary permissions",
     "feel" : "optional",
     "group" : "embeddingsStore",
+    "id" : "vectorStore.amazonManagedOpensearch.accessKey",
+    "label" : "Access key",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "vectorStore.amazonManagedOpensearch.secretKey",
       "type" : "zeebe:input"
@@ -952,17 +943,17 @@
       "equals" : "amazonManagedOpenSearchStore",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "vectorStore.amazonManagedOpensearch.serverUrl",
-    "label" : "Server URL",
-    "description" : "Provide a fully qualified server URL",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
+    "description" : "Provide a secret key associated with the access key",
     "feel" : "optional",
     "group" : "embeddingsStore",
+    "id" : "vectorStore.amazonManagedOpensearch.secretKey",
+    "label" : "Secret key",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "vectorStore.amazonManagedOpensearch.serverUrl",
       "type" : "zeebe:input"
@@ -972,17 +963,17 @@
       "equals" : "amazonManagedOpenSearchStore",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "vectorStore.amazonManagedOpensearch.region",
-    "label" : "Region",
-    "description" : "Provide an instance region",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
+    "description" : "Provide a fully qualified server URL",
     "feel" : "optional",
     "group" : "embeddingsStore",
+    "id" : "vectorStore.amazonManagedOpensearch.serverUrl",
+    "label" : "Server URL",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "vectorStore.amazonManagedOpensearch.region",
       "type" : "zeebe:input"
@@ -992,17 +983,17 @@
       "equals" : "amazonManagedOpenSearchStore",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "vectorStore.amazonManagedOpensearch.indexName",
-    "label" : "Index name",
-    "description" : "Provide an index to store embeddings",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
+    "description" : "Provide an instance region",
     "feel" : "optional",
     "group" : "embeddingsStore",
+    "id" : "vectorStore.amazonManagedOpensearch.region",
+    "label" : "Region",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "vectorStore.amazonManagedOpensearch.indexName",
       "type" : "zeebe:input"
@@ -1012,17 +1003,17 @@
       "equals" : "amazonManagedOpenSearchStore",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "vectorStore.aiSearch.endpoint",
-    "label" : "Endpoint",
-    "description" : "Specify Azure AI Search endpoint. Details in the <a href=\"https://learn.microsoft.com/en-us/azure/search/\" target=\"_blank\">documentation</a>.",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
+    "description" : "Provide an index to store embeddings",
     "feel" : "optional",
     "group" : "embeddingsStore",
+    "id" : "vectorStore.amazonManagedOpensearch.indexName",
+    "label" : "Index name",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "vectorStore.aiSearch.endpoint",
       "type" : "zeebe:input"
@@ -1032,39 +1023,40 @@
       "equals" : "azureAiSearchStore",
       "type" : "simple"
     },
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "description" : "Specify Azure AI Search endpoint. Details in the <a href=\"https://learn.microsoft.com/en-us/azure/search/\" target=\"_blank\">documentation</a>.",
+    "feel" : "optional",
+    "group" : "embeddingsStore",
+    "id" : "vectorStore.aiSearch.endpoint",
+    "label" : "Endpoint",
+    "optional" : false,
     "type" : "String"
   }, {
-    "id" : "vectorStore.aiSearch.authentication.type",
-    "label" : "Authentication",
-    "description" : "Specify the Azure authentication strategy.",
-    "value" : "apiKey",
-    "group" : "embeddingsStore",
     "binding" : {
       "name" : "vectorStore.aiSearch.authentication.type",
       "type" : "zeebe:input"
     },
-    "condition" : {
-      "property" : "vectorStore.vectorStore",
-      "equals" : "azureAiSearchStore",
-      "type" : "simple"
-    },
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "API key",
       "value" : "apiKey"
     }, {
       "name" : "Client credentials",
       "value" : "clientCredentials"
-    } ]
-  }, {
-    "id" : "vectorStore.aiSearch.authentication.apiKey",
-    "label" : "API key",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
+    } ],
+    "condition" : {
+      "property" : "vectorStore.vectorStore",
+      "equals" : "azureAiSearchStore",
+      "type" : "simple"
     },
-    "feel" : "optional",
+    "description" : "Specify the Azure authentication strategy.",
     "group" : "embeddingsStore",
+    "id" : "vectorStore.aiSearch.authentication.type",
+    "label" : "Authentication",
+    "type" : "Dropdown",
+    "value" : "apiKey"
+  }, {
     "binding" : {
       "name" : "vectorStore.aiSearch.authentication.apiKey",
       "type" : "zeebe:input"
@@ -1080,17 +1072,16 @@
         "type" : "simple"
       } ]
     },
-    "type" : "String"
-  }, {
-    "id" : "vectorStore.aiSearch.authentication.clientId",
-    "label" : "Client ID",
-    "description" : "ID of a Microsoft Entra application",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "embeddingsStore",
+    "id" : "vectorStore.aiSearch.authentication.apiKey",
+    "label" : "API key",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "vectorStore.aiSearch.authentication.clientId",
       "type" : "zeebe:input"
@@ -1106,17 +1097,17 @@
         "type" : "simple"
       } ]
     },
-    "type" : "String"
-  }, {
-    "id" : "vectorStore.aiSearch.authentication.clientSecret",
-    "label" : "Client secret",
-    "description" : "Secret of a Microsoft Entra application",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
+    "description" : "ID of a Microsoft Entra application",
     "feel" : "optional",
     "group" : "embeddingsStore",
+    "id" : "vectorStore.aiSearch.authentication.clientId",
+    "label" : "Client ID",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "vectorStore.aiSearch.authentication.clientSecret",
       "type" : "zeebe:input"
@@ -1132,17 +1123,17 @@
         "type" : "simple"
       } ]
     },
-    "type" : "String"
-  }, {
-    "id" : "vectorStore.aiSearch.authentication.tenantId",
-    "label" : "Tenant ID",
-    "description" : "ID of a Microsoft Entra tenant. Details in the <a href=\"https://learn.microsoft.com/en-us/entra/fundamentals/how-to-find-tenant\" target=\"_blank\">documentation</a>.",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
+    "description" : "Secret of a Microsoft Entra application",
     "feel" : "optional",
     "group" : "embeddingsStore",
+    "id" : "vectorStore.aiSearch.authentication.clientSecret",
+    "label" : "Client secret",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "vectorStore.aiSearch.authentication.tenantId",
       "type" : "zeebe:input"
@@ -1158,14 +1149,17 @@
         "type" : "simple"
       } ]
     },
-    "type" : "String"
-  }, {
-    "id" : "vectorStore.aiSearch.authentication.authorityHost",
-    "label" : "Authority host",
-    "description" : "Authority host URL for the Microsoft Entra application. Defaults to <code>https://login.microsoftonline.com</code>. This can also contain an OAuth 2.0 token endpoint.",
-    "optional" : true,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "description" : "ID of a Microsoft Entra tenant. Details in the <a href=\"https://learn.microsoft.com/en-us/entra/fundamentals/how-to-find-tenant\" target=\"_blank\">documentation</a>.",
     "feel" : "optional",
     "group" : "embeddingsStore",
+    "id" : "vectorStore.aiSearch.authentication.tenantId",
+    "label" : "Tenant ID",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "vectorStore.aiSearch.authentication.authorityHost",
       "type" : "zeebe:input"
@@ -1181,17 +1175,14 @@
         "type" : "simple"
       } ]
     },
-    "type" : "String"
-  }, {
-    "id" : "vectorStore.aiSearch.indexName",
-    "label" : "Index name",
-    "description" : "The name of the search index. When storing embeddings this index is created or updated automatically.",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
+    "description" : "Authority host URL for the Microsoft Entra application. Defaults to <code>https://login.microsoftonline.com</code>. This can also contain an OAuth 2.0 token endpoint.",
     "feel" : "optional",
     "group" : "embeddingsStore",
+    "id" : "vectorStore.aiSearch.authentication.authorityHost",
+    "label" : "Authority host",
+    "optional" : true,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "vectorStore.aiSearch.indexName",
       "type" : "zeebe:input"
@@ -1201,17 +1192,17 @@
       "equals" : "azureAiSearchStore",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "vectorStore.azureCosmosDbNoSql.endpoint",
-    "label" : "Endpoint",
-    "description" : "Specify Azure Cosmos DB endpoint. Details in the <a href=\"https://learn.microsoft.com/en-us/azure/cosmos-db/\" target=\"_blank\">documentation</a>.",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
+    "description" : "The name of the search index. When storing embeddings this index is created or updated automatically.",
     "feel" : "optional",
     "group" : "embeddingsStore",
+    "id" : "vectorStore.aiSearch.indexName",
+    "label" : "Index name",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "vectorStore.azureCosmosDbNoSql.endpoint",
       "type" : "zeebe:input"
@@ -1221,39 +1212,40 @@
       "equals" : "azureCosmosDbNoSqlStore",
       "type" : "simple"
     },
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "description" : "Specify Azure Cosmos DB endpoint. Details in the <a href=\"https://learn.microsoft.com/en-us/azure/cosmos-db/\" target=\"_blank\">documentation</a>.",
+    "feel" : "optional",
+    "group" : "embeddingsStore",
+    "id" : "vectorStore.azureCosmosDbNoSql.endpoint",
+    "label" : "Endpoint",
+    "optional" : false,
     "type" : "String"
   }, {
-    "id" : "vectorStore.azureCosmosDbNoSql.authentication.type",
-    "label" : "Authentication",
-    "description" : "Specify the Azure authentication strategy.",
-    "value" : "apiKey",
-    "group" : "embeddingsStore",
     "binding" : {
       "name" : "vectorStore.azureCosmosDbNoSql.authentication.type",
       "type" : "zeebe:input"
     },
-    "condition" : {
-      "property" : "vectorStore.vectorStore",
-      "equals" : "azureCosmosDbNoSqlStore",
-      "type" : "simple"
-    },
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "API key",
       "value" : "apiKey"
     }, {
       "name" : "Client credentials",
       "value" : "clientCredentials"
-    } ]
-  }, {
-    "id" : "vectorStore.azureCosmosDbNoSql.authentication.apiKey",
-    "label" : "API key",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
+    } ],
+    "condition" : {
+      "property" : "vectorStore.vectorStore",
+      "equals" : "azureCosmosDbNoSqlStore",
+      "type" : "simple"
     },
-    "feel" : "optional",
+    "description" : "Specify the Azure authentication strategy.",
     "group" : "embeddingsStore",
+    "id" : "vectorStore.azureCosmosDbNoSql.authentication.type",
+    "label" : "Authentication",
+    "type" : "Dropdown",
+    "value" : "apiKey"
+  }, {
     "binding" : {
       "name" : "vectorStore.azureCosmosDbNoSql.authentication.apiKey",
       "type" : "zeebe:input"
@@ -1269,17 +1261,16 @@
         "type" : "simple"
       } ]
     },
-    "type" : "String"
-  }, {
-    "id" : "vectorStore.azureCosmosDbNoSql.authentication.clientId",
-    "label" : "Client ID",
-    "description" : "ID of a Microsoft Entra application",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "embeddingsStore",
+    "id" : "vectorStore.azureCosmosDbNoSql.authentication.apiKey",
+    "label" : "API key",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "vectorStore.azureCosmosDbNoSql.authentication.clientId",
       "type" : "zeebe:input"
@@ -1295,17 +1286,17 @@
         "type" : "simple"
       } ]
     },
-    "type" : "String"
-  }, {
-    "id" : "vectorStore.azureCosmosDbNoSql.authentication.clientSecret",
-    "label" : "Client secret",
-    "description" : "Secret of a Microsoft Entra application",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
+    "description" : "ID of a Microsoft Entra application",
     "feel" : "optional",
     "group" : "embeddingsStore",
+    "id" : "vectorStore.azureCosmosDbNoSql.authentication.clientId",
+    "label" : "Client ID",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "vectorStore.azureCosmosDbNoSql.authentication.clientSecret",
       "type" : "zeebe:input"
@@ -1321,17 +1312,17 @@
         "type" : "simple"
       } ]
     },
-    "type" : "String"
-  }, {
-    "id" : "vectorStore.azureCosmosDbNoSql.authentication.tenantId",
-    "label" : "Tenant ID",
-    "description" : "ID of a Microsoft Entra tenant. Details in the <a href=\"https://learn.microsoft.com/en-us/entra/fundamentals/how-to-find-tenant\" target=\"_blank\">documentation</a>.",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
+    "description" : "Secret of a Microsoft Entra application",
     "feel" : "optional",
     "group" : "embeddingsStore",
+    "id" : "vectorStore.azureCosmosDbNoSql.authentication.clientSecret",
+    "label" : "Client secret",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "vectorStore.azureCosmosDbNoSql.authentication.tenantId",
       "type" : "zeebe:input"
@@ -1347,14 +1338,17 @@
         "type" : "simple"
       } ]
     },
-    "type" : "String"
-  }, {
-    "id" : "vectorStore.azureCosmosDbNoSql.authentication.authorityHost",
-    "label" : "Authority host",
-    "description" : "Authority host URL for the Microsoft Entra application. Defaults to <code>https://login.microsoftonline.com</code>. This can also contain an OAuth 2.0 token endpoint.",
-    "optional" : true,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "description" : "ID of a Microsoft Entra tenant. Details in the <a href=\"https://learn.microsoft.com/en-us/entra/fundamentals/how-to-find-tenant\" target=\"_blank\">documentation</a>.",
     "feel" : "optional",
     "group" : "embeddingsStore",
+    "id" : "vectorStore.azureCosmosDbNoSql.authentication.tenantId",
+    "label" : "Tenant ID",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "vectorStore.azureCosmosDbNoSql.authentication.authorityHost",
       "type" : "zeebe:input"
@@ -1370,17 +1364,14 @@
         "type" : "simple"
       } ]
     },
-    "type" : "String"
-  }, {
-    "id" : "vectorStore.azureCosmosDbNoSql.databaseName",
-    "label" : "Database name",
-    "description" : "Specify the name of the Azure Cosmos DB NoSQL database.",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
+    "description" : "Authority host URL for the Microsoft Entra application. Defaults to <code>https://login.microsoftonline.com</code>. This can also contain an OAuth 2.0 token endpoint.",
     "feel" : "optional",
     "group" : "embeddingsStore",
+    "id" : "vectorStore.azureCosmosDbNoSql.authentication.authorityHost",
+    "label" : "Authority host",
+    "optional" : true,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "vectorStore.azureCosmosDbNoSql.databaseName",
       "type" : "zeebe:input"
@@ -1390,17 +1381,17 @@
       "equals" : "azureCosmosDbNoSqlStore",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "vectorStore.azureCosmosDbNoSql.containerName",
-    "label" : "Container name",
-    "description" : "Specify the name of the Azure Cosmos DB NoSQL container.",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
+    "description" : "Specify the name of the Azure Cosmos DB NoSQL database.",
     "feel" : "optional",
     "group" : "embeddingsStore",
+    "id" : "vectorStore.azureCosmosDbNoSql.databaseName",
+    "label" : "Database name",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "vectorStore.azureCosmosDbNoSql.containerName",
       "type" : "zeebe:input"
@@ -1410,27 +1401,21 @@
       "equals" : "azureCosmosDbNoSqlStore",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "vectorStore.azureCosmosDbNoSql.consistencyLevel",
-    "label" : "Consistency level",
-    "description" : "Specify the consistency level for the Azure Cosmos DB NoSQL store.",
-    "optional" : false,
-    "value" : "EVENTUAL",
     "constraints" : {
       "notEmpty" : true
     },
+    "description" : "Specify the name of the Azure Cosmos DB NoSQL container.",
+    "feel" : "optional",
     "group" : "embeddingsStore",
+    "id" : "vectorStore.azureCosmosDbNoSql.containerName",
+    "label" : "Container name",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "vectorStore.azureCosmosDbNoSql.consistencyLevel",
       "type" : "zeebe:input"
     },
-    "condition" : {
-      "property" : "vectorStore.vectorStore",
-      "equals" : "azureCosmosDbNoSqlStore",
-      "type" : "simple"
-    },
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "Strong",
       "value" : "STRONG"
@@ -1446,27 +1431,27 @@
     }, {
       "name" : "Eventual",
       "value" : "EVENTUAL"
-    } ]
-  }, {
-    "id" : "vectorStore.azureCosmosDbNoSql.distanceFunction",
-    "label" : "Distance function",
-    "description" : "The metric used to compute distance/similarity. Details in the <a href=\"https://learn.microsoft.com/en-us/azure/cosmos-db/nosql/vector-search\" target=\"_blank\">documentation</a>.",
-    "optional" : false,
-    "value" : "COSINE",
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "group" : "embeddingsStore",
-    "binding" : {
-      "name" : "vectorStore.azureCosmosDbNoSql.distanceFunction",
-      "type" : "zeebe:input"
-    },
+    } ],
     "condition" : {
       "property" : "vectorStore.vectorStore",
       "equals" : "azureCosmosDbNoSqlStore",
       "type" : "simple"
     },
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "description" : "Specify the consistency level for the Azure Cosmos DB NoSQL store.",
+    "group" : "embeddingsStore",
+    "id" : "vectorStore.azureCosmosDbNoSql.consistencyLevel",
+    "label" : "Consistency level",
+    "optional" : false,
     "type" : "Dropdown",
+    "value" : "EVENTUAL"
+  }, {
+    "binding" : {
+      "name" : "vectorStore.azureCosmosDbNoSql.distanceFunction",
+      "type" : "zeebe:input"
+    },
     "choices" : [ {
       "name" : "Euclidean",
       "value" : "EUCLIDEAN"
@@ -1476,27 +1461,27 @@
     }, {
       "name" : "Dot Product",
       "value" : "DOT_PRODUCT"
-    } ]
-  }, {
-    "id" : "vectorStore.azureCosmosDbNoSql.vectorIndexType",
-    "label" : "Vector index type",
-    "description" : "The type of vector index type to use. Details in the <a href=\"https://learn.microsoft.com/en-us/azure/cosmos-db/nosql/vector-search\" target=\"_blank\">documentation</a>.",
-    "optional" : false,
-    "value" : "FLAT",
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "group" : "embeddingsStore",
-    "binding" : {
-      "name" : "vectorStore.azureCosmosDbNoSql.vectorIndexType",
-      "type" : "zeebe:input"
-    },
+    } ],
     "condition" : {
       "property" : "vectorStore.vectorStore",
       "equals" : "azureCosmosDbNoSqlStore",
       "type" : "simple"
     },
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "description" : "The metric used to compute distance/similarity. Details in the <a href=\"https://learn.microsoft.com/en-us/azure/cosmos-db/nosql/vector-search\" target=\"_blank\">documentation</a>.",
+    "group" : "embeddingsStore",
+    "id" : "vectorStore.azureCosmosDbNoSql.distanceFunction",
+    "label" : "Distance function",
+    "optional" : false,
     "type" : "Dropdown",
+    "value" : "COSINE"
+  }, {
+    "binding" : {
+      "name" : "vectorStore.azureCosmosDbNoSql.vectorIndexType",
+      "type" : "zeebe:input"
+    },
     "choices" : [ {
       "name" : "Flat",
       "value" : "FLAT"
@@ -1506,17 +1491,23 @@
     }, {
       "name" : "DiskANN",
       "value" : "DISK_ANN"
-    } ]
-  }, {
-    "id" : "vectorStore.elasticsearch.baseUrl",
-    "label" : "Base URL",
-    "description" : "Elasticsearch base URL, i.e. http(s)://host:port",
-    "optional" : false,
+    } ],
+    "condition" : {
+      "property" : "vectorStore.vectorStore",
+      "equals" : "azureCosmosDbNoSqlStore",
+      "type" : "simple"
+    },
     "constraints" : {
       "notEmpty" : true
     },
-    "feel" : "optional",
+    "description" : "The type of vector index type to use. Details in the <a href=\"https://learn.microsoft.com/en-us/azure/cosmos-db/nosql/vector-search\" target=\"_blank\">documentation</a>.",
     "group" : "embeddingsStore",
+    "id" : "vectorStore.azureCosmosDbNoSql.vectorIndexType",
+    "label" : "Vector index type",
+    "optional" : false,
+    "type" : "Dropdown",
+    "value" : "FLAT"
+  }, {
     "binding" : {
       "name" : "vectorStore.elasticsearch.baseUrl",
       "type" : "zeebe:input"
@@ -1526,17 +1517,17 @@
       "equals" : "elasticsearchStore",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "vectorStore.elasticsearch.userName",
-    "label" : "Username",
-    "description" : "Elasticsearch username",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
+    "description" : "Elasticsearch base URL, i.e. http(s)://host:port",
     "feel" : "optional",
     "group" : "embeddingsStore",
+    "id" : "vectorStore.elasticsearch.baseUrl",
+    "label" : "Base URL",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "vectorStore.elasticsearch.userName",
       "type" : "zeebe:input"
@@ -1546,17 +1537,17 @@
       "equals" : "elasticsearchStore",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "vectorStore.elasticsearch.password",
-    "label" : "Password",
-    "description" : "Elasticsearch password",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
+    "description" : "Elasticsearch username",
     "feel" : "optional",
     "group" : "embeddingsStore",
+    "id" : "vectorStore.elasticsearch.userName",
+    "label" : "Username",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "vectorStore.elasticsearch.password",
       "type" : "zeebe:input"
@@ -1566,17 +1557,17 @@
       "equals" : "elasticsearchStore",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "vectorStore.elasticsearch.indexName",
-    "label" : "Index name",
-    "description" : "Elasticsearch index",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
+    "description" : "Elasticsearch password",
     "feel" : "optional",
     "group" : "embeddingsStore",
+    "id" : "vectorStore.elasticsearch.password",
+    "label" : "Password",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "vectorStore.elasticsearch.indexName",
       "type" : "zeebe:input"
@@ -1586,17 +1577,17 @@
       "equals" : "elasticsearchStore",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "vectorStore.openSearch.baseUrl",
-    "label" : "Base URL",
-    "description" : "OpenSearch base URL, i.e. http(s)://host:port",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
+    "description" : "Elasticsearch index",
     "feel" : "optional",
     "group" : "embeddingsStore",
+    "id" : "vectorStore.elasticsearch.indexName",
+    "label" : "Index name",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "vectorStore.openSearch.baseUrl",
       "type" : "zeebe:input"
@@ -1606,17 +1597,17 @@
       "equals" : "openSearchStore",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "vectorStore.openSearch.userName",
-    "label" : "Username",
-    "description" : "OpenSearch username",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
+    "description" : "OpenSearch base URL, i.e. http(s)://host:port",
     "feel" : "optional",
     "group" : "embeddingsStore",
+    "id" : "vectorStore.openSearch.baseUrl",
+    "label" : "Base URL",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "vectorStore.openSearch.userName",
       "type" : "zeebe:input"
@@ -1626,17 +1617,17 @@
       "equals" : "openSearchStore",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "vectorStore.openSearch.password",
-    "label" : "Password",
-    "description" : "OpenSearch password",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
+    "description" : "OpenSearch username",
     "feel" : "optional",
     "group" : "embeddingsStore",
+    "id" : "vectorStore.openSearch.userName",
+    "label" : "Username",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "vectorStore.openSearch.password",
       "type" : "zeebe:input"
@@ -1646,17 +1637,17 @@
       "equals" : "openSearchStore",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "vectorStore.openSearch.indexName",
-    "label" : "Index name",
-    "description" : "OpenSearch index",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
+    "description" : "OpenSearch password",
     "feel" : "optional",
     "group" : "embeddingsStore",
+    "id" : "vectorStore.openSearch.password",
+    "label" : "Password",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "vectorStore.openSearch.indexName",
       "type" : "zeebe:input"
@@ -1666,43 +1657,44 @@
       "equals" : "openSearchStore",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "vectorDatabaseConnectorOperation.documentSource",
-    "label" : "Document source",
-    "description" : "Whether you want to embed a Camunda document file or plain text",
-    "optional" : false,
-    "value" : "CamundaDocument",
     "constraints" : {
       "notEmpty" : true
     },
-    "group" : "document",
+    "description" : "OpenSearch index",
+    "feel" : "optional",
+    "group" : "embeddingsStore",
+    "id" : "vectorStore.openSearch.indexName",
+    "label" : "Index name",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "vectorDatabaseConnectorOperation.documentSource",
       "type" : "zeebe:input"
     },
-    "condition" : {
-      "property" : "vectorDatabaseConnectorOperation.operationType",
-      "equals" : "embedDocumentOperation",
-      "type" : "simple"
-    },
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "Camunda document",
       "value" : "CamundaDocument"
     }, {
       "name" : "Plain text",
       "value" : "PlainText"
-    } ]
-  }, {
-    "id" : "vectorDatabaseConnectorOperation.documentSourceFromProcessVariable",
-    "label" : "Plain text to embed",
-    "optional" : false,
+    } ],
+    "condition" : {
+      "property" : "vectorDatabaseConnectorOperation.operationType",
+      "equals" : "embedDocumentOperation",
+      "type" : "simple"
+    },
     "constraints" : {
       "notEmpty" : true
     },
-    "feel" : "optional",
+    "description" : "Whether you want to embed a Camunda document file or plain text",
     "group" : "document",
+    "id" : "vectorDatabaseConnectorOperation.documentSource",
+    "label" : "Document source",
+    "optional" : false,
+    "type" : "Dropdown",
+    "value" : "CamundaDocument"
+  }, {
     "binding" : {
       "name" : "vectorDatabaseConnectorOperation.documentSourceFromProcessVariable",
       "type" : "zeebe:input"
@@ -1718,16 +1710,16 @@
         "type" : "simple"
       } ]
     },
-    "type" : "String"
-  }, {
-    "id" : "vectorDatabaseConnectorOperation.newDocuments",
-    "label" : "Documents",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
-    "feel" : "required",
+    "feel" : "optional",
     "group" : "document",
+    "id" : "vectorDatabaseConnectorOperation.documentSourceFromProcessVariable",
+    "label" : "Plain text to embed",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "vectorDatabaseConnectorOperation.newDocuments",
       "type" : "zeebe:input"
@@ -1743,37 +1735,38 @@
         "type" : "simple"
       } ]
     },
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "required",
+    "group" : "document",
+    "id" : "vectorDatabaseConnectorOperation.newDocuments",
+    "label" : "Documents",
+    "optional" : false,
     "type" : "String"
   }, {
-    "id" : "vectorDatabaseConnectorOperation.documentSplitter.documentSplitter",
-    "label" : "Document splitting strategy",
-    "value" : "recursiveDocumentSplitter",
-    "group" : "document",
     "binding" : {
       "name" : "vectorDatabaseConnectorOperation.documentSplitter.splitterType",
       "type" : "zeebe:input"
     },
-    "condition" : {
-      "property" : "vectorDatabaseConnectorOperation.operationType",
-      "equals" : "embedDocumentOperation",
-      "type" : "simple"
-    },
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "Recursive",
       "value" : "recursiveDocumentSplitter"
     }, {
       "name" : "Do not split",
       "value" : "noopDocumentSplitter"
-    } ]
-  }, {
-    "id" : "vectorDatabaseConnectorOperation.documentSplitter.document.splitter.recursive.maxSegmentSizeInChars",
-    "label" : "Max chars",
-    "description" : "Max splitting segment size in chars",
-    "optional" : false,
-    "value" : 500,
-    "feel" : "static",
+    } ],
+    "condition" : {
+      "property" : "vectorDatabaseConnectorOperation.operationType",
+      "equals" : "embedDocumentOperation",
+      "type" : "simple"
+    },
     "group" : "document",
+    "id" : "vectorDatabaseConnectorOperation.documentSplitter.documentSplitter",
+    "label" : "Document splitting strategy",
+    "type" : "Dropdown",
+    "value" : "recursiveDocumentSplitter"
+  }, {
     "binding" : {
       "name" : "vectorDatabaseConnectorOperation.documentSplitter.maxSegmentSizeInChars",
       "type" : "zeebe:input"
@@ -1789,15 +1782,15 @@
         "type" : "simple"
       } ]
     },
-    "type" : "Number"
-  }, {
-    "id" : "vectorDatabaseConnectorOperation.documentSplitter.document.splitter.recursive.maxOverlapSizeInChars",
-    "label" : "Max overlap window",
-    "description" : "Max segment splitting overlap size in chars",
-    "optional" : false,
-    "value" : 80,
+    "description" : "Max splitting segment size in chars",
     "feel" : "static",
     "group" : "document",
+    "id" : "vectorDatabaseConnectorOperation.documentSplitter.document.splitter.recursive.maxSegmentSizeInChars",
+    "label" : "Max chars",
+    "optional" : false,
+    "type" : "Number",
+    "value" : 500
+  }, {
     "binding" : {
       "name" : "vectorDatabaseConnectorOperation.documentSplitter.maxOverlapSizeInChars",
       "type" : "zeebe:input"
@@ -1813,94 +1806,101 @@
         "type" : "simple"
       } ]
     },
-    "type" : "Number"
+    "description" : "Max segment splitting overlap size in chars",
+    "feel" : "static",
+    "group" : "document",
+    "id" : "vectorDatabaseConnectorOperation.documentSplitter.document.splitter.recursive.maxOverlapSizeInChars",
+    "label" : "Max overlap window",
+    "optional" : false,
+    "type" : "Number",
+    "value" : 80
   }, {
-    "id" : "version",
-    "label" : "Version",
-    "description" : "Version of the element template",
-    "value" : "3",
-    "group" : "connector",
     "binding" : {
       "key" : "elementTemplateVersion",
       "type" : "zeebe:taskHeader"
     },
-    "type" : "Hidden"
-  }, {
-    "id" : "id",
-    "label" : "ID",
-    "description" : "ID of the element template",
-    "value" : "io.camunda.connectors.EmbeddingsVectorDB.v1",
+    "description" : "Version of the element template",
     "group" : "connector",
+    "id" : "version",
+    "label" : "Version",
+    "type" : "Hidden",
+    "value" : "3"
+  }, {
     "binding" : {
       "key" : "elementTemplateId",
       "type" : "zeebe:taskHeader"
     },
-    "type" : "Hidden"
+    "description" : "ID of the element template",
+    "group" : "connector",
+    "id" : "id",
+    "label" : "ID",
+    "type" : "Hidden",
+    "value" : "io.camunda.connectors.EmbeddingsVectorDB.v1"
   }, {
-    "id" : "resultVariable",
-    "label" : "Result variable",
-    "description" : "Name of variable to store the response in. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-variable\" target=\"_blank\">documentation</a>.",
-    "group" : "output",
     "binding" : {
       "key" : "resultVariable",
       "type" : "zeebe:taskHeader"
     },
+    "description" : "Name of variable to store the response in. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-variable\" target=\"_blank\">documentation</a>.",
+    "group" : "output",
+    "id" : "resultVariable",
+    "label" : "Result variable",
     "type" : "String"
   }, {
-    "id" : "resultExpression",
-    "label" : "Result expression",
-    "description" : "Expression to map the response into process variables. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-expression\" target=\"_blank\">documentation</a>.",
-    "feel" : "required",
-    "group" : "output",
     "binding" : {
       "key" : "resultExpression",
       "type" : "zeebe:taskHeader"
     },
+    "description" : "Expression to map the response into process variables. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-expression\" target=\"_blank\">documentation</a>.",
+    "feel" : "required",
+    "group" : "output",
+    "id" : "resultExpression",
+    "label" : "Result expression",
     "type" : "Text"
   }, {
-    "id" : "errorExpression",
-    "label" : "Error expression",
-    "description" : "Expression to handle errors. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/\" target=\"_blank\">documentation</a>.",
-    "feel" : "required",
-    "group" : "error",
     "binding" : {
       "key" : "errorExpression",
       "type" : "zeebe:taskHeader"
     },
+    "description" : "Expression to handle errors. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/\" target=\"_blank\">documentation</a>.",
+    "feel" : "required",
+    "group" : "error",
+    "id" : "errorExpression",
+    "label" : "Error expression",
     "type" : "Text"
   }, {
-    "id" : "retryCount",
-    "label" : "Retries",
-    "description" : "Number of retries",
-    "value" : "3",
-    "feel" : "optional",
-    "group" : "retries",
     "binding" : {
       "property" : "retries",
       "type" : "zeebe:taskDefinition"
     },
-    "type" : "String"
-  }, {
-    "id" : "retryBackoff",
-    "label" : "Retry backoff",
-    "description" : "ISO-8601 duration to wait between retries",
-    "value" : "PT30S",
+    "description" : "Number of retries",
+    "feel" : "optional",
     "group" : "retries",
+    "id" : "retryCount",
+    "label" : "Retries",
+    "type" : "String",
+    "value" : "3"
+  }, {
     "binding" : {
       "key" : "retryBackoff",
       "type" : "zeebe:taskHeader"
     },
-    "type" : "String"
-  }, {
-    "id" : "jobTimeout",
-    "label" : "Job timeout",
-    "description" : "ISO-8601 duration after which Zeebe considers this job timed out if not yet completed. Leave empty to use the default timeout",
-    "optional" : true,
+    "description" : "ISO-8601 duration to wait between retries",
     "group" : "retries",
+    "id" : "retryBackoff",
+    "label" : "Retry backoff",
+    "type" : "String",
+    "value" : "PT30S"
+  }, {
     "binding" : {
       "key" : "jobTimeout",
       "type" : "zeebe:taskHeader"
     },
+    "description" : "ISO-8601 duration after which Zeebe considers this job timed out if not yet completed. Leave empty to use the default timeout",
+    "group" : "retries",
+    "id" : "jobTimeout",
+    "label" : "Job timeout",
+    "optional" : true,
     "type" : "String"
   } ],
   "steps" : [ {

--- a/connectors/embeddings-vector-database/element-templates/hybrid/embeddings-vector-database-outbound-connector-hybrid.json
+++ b/connectors/embeddings-vector-database/element-templates/hybrid/embeddings-vector-database-outbound-connector-hybrid.json
@@ -48,42 +48,33 @@
     "label" : "Retries"
   } ],
   "properties" : [ {
-    "id" : "taskDefinitionType",
-    "value" : "io.camunda:embeddings-vector-database:1",
-    "group" : "taskDefinitionType",
     "binding" : {
       "property" : "type",
       "type" : "zeebe:taskDefinition"
     },
-    "type" : "String"
+    "group" : "taskDefinitionType",
+    "id" : "taskDefinitionType",
+    "type" : "String",
+    "value" : "io.camunda:embeddings-vector-database:1"
   }, {
-    "id" : "vectorDatabaseConnectorOperation.operationType",
-    "label" : "Operation",
-    "description" : "Select operation",
-    "value" : "retrieveDocumentOperation",
-    "group" : "operation",
     "binding" : {
       "name" : "vectorDatabaseConnectorOperation.operationType",
       "type" : "zeebe:input"
     },
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "Embed document",
       "value" : "embedDocumentOperation"
     }, {
       "name" : "Retrieve document",
       "value" : "retrieveDocumentOperation"
-    } ]
+    } ],
+    "description" : "Select operation",
+    "group" : "operation",
+    "id" : "vectorDatabaseConnectorOperation.operationType",
+    "label" : "Operation",
+    "type" : "Dropdown",
+    "value" : "retrieveDocumentOperation"
   }, {
-    "id" : "vectorDatabaseConnectorOperation.query.query",
-    "label" : "Search query",
-    "description" : "Document lookup query",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "feel" : "optional",
-    "group" : "query",
     "binding" : {
       "name" : "vectorDatabaseConnectorOperation.query",
       "type" : "zeebe:input"
@@ -93,15 +84,17 @@
       "equals" : "retrieveDocumentOperation",
       "type" : "simple"
     },
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "description" : "Document lookup query",
+    "feel" : "optional",
+    "group" : "query",
+    "id" : "vectorDatabaseConnectorOperation.query.query",
+    "label" : "Search query",
+    "optional" : false,
     "type" : "String"
   }, {
-    "id" : "vectorDatabaseConnectorOperation.query.maxResults",
-    "label" : "Max results",
-    "description" : "Limit number of returned results",
-    "optional" : false,
-    "value" : 5,
-    "feel" : "static",
-    "group" : "query",
     "binding" : {
       "name" : "vectorDatabaseConnectorOperation.documentLimit",
       "type" : "zeebe:input"
@@ -111,14 +104,15 @@
       "equals" : "retrieveDocumentOperation",
       "type" : "simple"
     },
-    "type" : "Number"
-  }, {
-    "id" : "vectorDatabaseConnectorOperation.query.minScore",
-    "label" : "Min score",
-    "description" : "Minimal vector similarity score for result to be included. Must be between 0 and 1 floating point value, e.g. 0.6. Incorrect and empty value resolves to 0.0",
-    "optional" : true,
+    "description" : "Limit number of returned results",
     "feel" : "static",
     "group" : "query",
+    "id" : "vectorDatabaseConnectorOperation.query.maxResults",
+    "label" : "Max results",
+    "optional" : false,
+    "type" : "Number",
+    "value" : 5
+  }, {
     "binding" : {
       "name" : "vectorDatabaseConnectorOperation.minScore",
       "type" : "zeebe:input"
@@ -128,18 +122,18 @@
       "equals" : "retrieveDocumentOperation",
       "type" : "simple"
     },
+    "description" : "Minimal vector similarity score for result to be included. Must be between 0 and 1 floating point value, e.g. 0.6. Incorrect and empty value resolves to 0.0",
+    "feel" : "static",
+    "group" : "query",
+    "id" : "vectorDatabaseConnectorOperation.query.minScore",
+    "label" : "Min score",
+    "optional" : true,
     "type" : "Number"
   }, {
-    "id" : "embeddingModelProvider.modelProvider",
-    "label" : "Model provider",
-    "description" : "Select embedding model provider",
-    "value" : "bedrockModelProvider",
-    "group" : "embeddingModel",
     "binding" : {
       "name" : "embeddingModelProvider.modelProvider",
       "type" : "zeebe:input"
     },
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "Azure OpenAI",
       "value" : "azureOpenAiModelProvider"
@@ -152,17 +146,14 @@
     }, {
       "name" : "OpenAI",
       "value" : "openAiModelProvider"
-    } ]
-  }, {
-    "id" : "embeddingModelProvider.azureOpenAi.endpoint",
-    "label" : "Endpoint",
-    "description" : "Specify Azure OpenAI endpoint. Details in the <a href=\"https://learn.microsoft.com/en-us/azure/ai-foundry/openai/reference\" target=\"_blank\">documentation</a>.",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "feel" : "optional",
+    } ],
+    "description" : "Select embedding model provider",
     "group" : "embeddingModel",
+    "id" : "embeddingModelProvider.modelProvider",
+    "label" : "Model provider",
+    "type" : "Dropdown",
+    "value" : "bedrockModelProvider"
+  }, {
     "binding" : {
       "name" : "embeddingModelProvider.azureOpenAi.endpoint",
       "type" : "zeebe:input"
@@ -172,39 +163,40 @@
       "equals" : "azureOpenAiModelProvider",
       "type" : "simple"
     },
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "description" : "Specify Azure OpenAI endpoint. Details in the <a href=\"https://learn.microsoft.com/en-us/azure/ai-foundry/openai/reference\" target=\"_blank\">documentation</a>.",
+    "feel" : "optional",
+    "group" : "embeddingModel",
+    "id" : "embeddingModelProvider.azureOpenAi.endpoint",
+    "label" : "Endpoint",
+    "optional" : false,
     "type" : "String"
   }, {
-    "id" : "embeddingModelProvider.azureOpenAi.authentication.type",
-    "label" : "Authentication",
-    "description" : "Specify the Azure OpenAI authentication strategy.",
-    "value" : "apiKey",
-    "group" : "embeddingModel",
     "binding" : {
       "name" : "embeddingModelProvider.azureOpenAi.authentication.type",
       "type" : "zeebe:input"
     },
-    "condition" : {
-      "property" : "embeddingModelProvider.modelProvider",
-      "equals" : "azureOpenAiModelProvider",
-      "type" : "simple"
-    },
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "API key",
       "value" : "apiKey"
     }, {
       "name" : "Client credentials",
       "value" : "clientCredentials"
-    } ]
-  }, {
-    "id" : "embeddingModelProvider.azureOpenAi.authentication.apiKey",
-    "label" : "API key",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
+    } ],
+    "condition" : {
+      "property" : "embeddingModelProvider.modelProvider",
+      "equals" : "azureOpenAiModelProvider",
+      "type" : "simple"
     },
-    "feel" : "optional",
+    "description" : "Specify the Azure OpenAI authentication strategy.",
     "group" : "embeddingModel",
+    "id" : "embeddingModelProvider.azureOpenAi.authentication.type",
+    "label" : "Authentication",
+    "type" : "Dropdown",
+    "value" : "apiKey"
+  }, {
     "binding" : {
       "name" : "embeddingModelProvider.azureOpenAi.authentication.apiKey",
       "type" : "zeebe:input"
@@ -220,17 +212,16 @@
         "type" : "simple"
       } ]
     },
-    "type" : "String"
-  }, {
-    "id" : "embeddingModelProvider.azureOpenAi.authentication.clientId",
-    "label" : "Client ID",
-    "description" : "ID of a Microsoft Entra application",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "embeddingModel",
+    "id" : "embeddingModelProvider.azureOpenAi.authentication.apiKey",
+    "label" : "API key",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "embeddingModelProvider.azureOpenAi.authentication.clientId",
       "type" : "zeebe:input"
@@ -246,17 +237,17 @@
         "type" : "simple"
       } ]
     },
-    "type" : "String"
-  }, {
-    "id" : "embeddingModelProvider.azureOpenAi.authentication.clientSecret",
-    "label" : "Client secret",
-    "description" : "Secret of a Microsoft Entra application",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
+    "description" : "ID of a Microsoft Entra application",
     "feel" : "optional",
     "group" : "embeddingModel",
+    "id" : "embeddingModelProvider.azureOpenAi.authentication.clientId",
+    "label" : "Client ID",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "embeddingModelProvider.azureOpenAi.authentication.clientSecret",
       "type" : "zeebe:input"
@@ -272,17 +263,17 @@
         "type" : "simple"
       } ]
     },
-    "type" : "String"
-  }, {
-    "id" : "embeddingModelProvider.azureOpenAi.authentication.tenantId",
-    "label" : "Tenant ID",
-    "description" : "ID of a Microsoft Entra tenant. Details in the <a href=\"https://learn.microsoft.com/en-us/entra/fundamentals/how-to-find-tenant\" target=\"_blank\">documentation</a>.",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
+    "description" : "Secret of a Microsoft Entra application",
     "feel" : "optional",
     "group" : "embeddingModel",
+    "id" : "embeddingModelProvider.azureOpenAi.authentication.clientSecret",
+    "label" : "Client secret",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "embeddingModelProvider.azureOpenAi.authentication.tenantId",
       "type" : "zeebe:input"
@@ -298,14 +289,17 @@
         "type" : "simple"
       } ]
     },
-    "type" : "String"
-  }, {
-    "id" : "embeddingModelProvider.azureOpenAi.authentication.authorityHost",
-    "label" : "Authority host",
-    "description" : "Authority host URL for the Microsoft Entra application. Defaults to <code>https://login.microsoftonline.com</code>. This can also contain an OAuth 2.0 token endpoint.",
-    "optional" : true,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "description" : "ID of a Microsoft Entra tenant. Details in the <a href=\"https://learn.microsoft.com/en-us/entra/fundamentals/how-to-find-tenant\" target=\"_blank\">documentation</a>.",
     "feel" : "optional",
     "group" : "embeddingModel",
+    "id" : "embeddingModelProvider.azureOpenAi.authentication.tenantId",
+    "label" : "Tenant ID",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "embeddingModelProvider.azureOpenAi.authentication.authorityHost",
       "type" : "zeebe:input"
@@ -321,17 +315,14 @@
         "type" : "simple"
       } ]
     },
-    "type" : "String"
-  }, {
-    "id" : "embeddingModelProvider.azureOpenAi.deploymentName",
-    "label" : "Model deployment name",
-    "description" : "Specify the model deployment name. Details in the <a href=\"https://learn.microsoft.com/en-us/azure/ai-foundry/openai/reference\" target=\"_blank\">documentation</a>.",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
+    "description" : "Authority host URL for the Microsoft Entra application. Defaults to <code>https://login.microsoftonline.com</code>. This can also contain an OAuth 2.0 token endpoint.",
     "feel" : "optional",
     "group" : "embeddingModel",
+    "id" : "embeddingModelProvider.azureOpenAi.authentication.authorityHost",
+    "label" : "Authority host",
+    "optional" : true,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "embeddingModelProvider.azureOpenAi.deploymentName",
       "type" : "zeebe:input"
@@ -341,14 +332,17 @@
       "equals" : "azureOpenAiModelProvider",
       "type" : "simple"
     },
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "description" : "Specify the model deployment name. Details in the <a href=\"https://learn.microsoft.com/en-us/azure/ai-foundry/openai/reference\" target=\"_blank\">documentation</a>.",
+    "feel" : "optional",
+    "group" : "embeddingModel",
+    "id" : "embeddingModelProvider.azureOpenAi.deploymentName",
+    "label" : "Model deployment name",
+    "optional" : false,
     "type" : "String"
   }, {
-    "id" : "embeddingModelProvider.azureOpenAi.dimensions",
-    "label" : "Embedding dimensions",
-    "description" : "The size of the vector used to represent data. If not specified, the default model dimensions are used. Details in the <a href=\"https://platform.openai.com/docs/guides/embeddings\" target=\"_blank\">documentation</a>.",
-    "optional" : true,
-    "feel" : "required",
-    "group" : "embeddingModel",
     "binding" : {
       "name" : "embeddingModelProvider.azureOpenAi.dimensions",
       "type" : "zeebe:input"
@@ -358,15 +352,14 @@
       "equals" : "azureOpenAiModelProvider",
       "type" : "simple"
     },
+    "description" : "The size of the vector used to represent data. If not specified, the default model dimensions are used. Details in the <a href=\"https://platform.openai.com/docs/guides/embeddings\" target=\"_blank\">documentation</a>.",
+    "feel" : "required",
+    "group" : "embeddingModel",
+    "id" : "embeddingModelProvider.azureOpenAi.dimensions",
+    "label" : "Embedding dimensions",
+    "optional" : true,
     "type" : "Number"
   }, {
-    "id" : "embeddingModelProvider.azureOpenAi.maxRetries",
-    "label" : "Max retries",
-    "description" : "Max retries",
-    "optional" : true,
-    "value" : 3,
-    "feel" : "static",
-    "group" : "embeddingModel",
     "binding" : {
       "name" : "embeddingModelProvider.azureOpenAi.maxRetries",
       "type" : "zeebe:input"
@@ -376,14 +369,15 @@
       "equals" : "azureOpenAiModelProvider",
       "type" : "simple"
     },
-    "type" : "Number"
-  }, {
-    "id" : "embeddingModelProvider.azureOpenAi.customHeaders",
-    "label" : "Custom headers",
-    "description" : "Map of custom HTTP headers to add to the request.",
-    "optional" : true,
-    "feel" : "required",
+    "description" : "Max retries",
+    "feel" : "static",
     "group" : "embeddingModel",
+    "id" : "embeddingModelProvider.azureOpenAi.maxRetries",
+    "label" : "Max retries",
+    "optional" : true,
+    "type" : "Number",
+    "value" : 3
+  }, {
     "binding" : {
       "name" : "embeddingModelProvider.azureOpenAi.customHeaders",
       "type" : "zeebe:input"
@@ -393,17 +387,14 @@
       "equals" : "azureOpenAiModelProvider",
       "type" : "simple"
     },
+    "description" : "Map of custom HTTP headers to add to the request.",
+    "feel" : "required",
+    "group" : "embeddingModel",
+    "id" : "embeddingModelProvider.azureOpenAi.customHeaders",
+    "label" : "Custom headers",
+    "optional" : true,
     "type" : "String"
   }, {
-    "id" : "embeddingModelProvider.bedrock.accessKey",
-    "label" : "Access key",
-    "description" : "Provide an IAM access key tailored to a user, equipped with the necessary permissions",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "feel" : "optional",
-    "group" : "embeddingModel",
     "binding" : {
       "name" : "embeddingModelProvider.bedrock.accessKey",
       "type" : "zeebe:input"
@@ -413,17 +404,17 @@
       "equals" : "bedrockModelProvider",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "embeddingModelProvider.bedrock.secretKey",
-    "label" : "Secret key",
-    "description" : "Provide a secret key associated with the access key",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
+    "description" : "Provide an IAM access key tailored to a user, equipped with the necessary permissions",
     "feel" : "optional",
     "group" : "embeddingModel",
+    "id" : "embeddingModelProvider.bedrock.accessKey",
+    "label" : "Access key",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "embeddingModelProvider.bedrock.secretKey",
       "type" : "zeebe:input"
@@ -433,17 +424,17 @@
       "equals" : "bedrockModelProvider",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "embeddingModelProvider.bedrock.region",
-    "label" : "Region",
-    "description" : "AWS Bedrock region",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
+    "description" : "Provide a secret key associated with the access key",
     "feel" : "optional",
     "group" : "embeddingModel",
+    "id" : "embeddingModelProvider.bedrock.secretKey",
+    "label" : "Secret key",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "embeddingModelProvider.bedrock.region",
       "type" : "zeebe:input"
@@ -453,27 +444,21 @@
       "equals" : "bedrockModelProvider",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "embeddingModelProvider.bedrock.modelName",
-    "label" : "Model name",
-    "description" : "Bedrock model name or identifier",
-    "optional" : false,
-    "value" : "TitanEmbedTextV2",
     "constraints" : {
       "notEmpty" : true
     },
+    "description" : "AWS Bedrock region",
+    "feel" : "optional",
     "group" : "embeddingModel",
+    "id" : "embeddingModelProvider.bedrock.region",
+    "label" : "Region",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "embeddingModelProvider.bedrock.modelName",
       "type" : "zeebe:input"
     },
-    "condition" : {
-      "property" : "embeddingModelProvider.modelProvider",
-      "equals" : "bedrockModelProvider",
-      "type" : "simple"
-    },
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "Custom",
       "value" : "Custom"
@@ -483,16 +468,23 @@
     }, {
       "name" : "amazon.titan-embed-text-v2:0",
       "value" : "TitanEmbedTextV2"
-    } ]
-  }, {
-    "id" : "embeddingModelProvider.bedrock.customModelName",
-    "label" : "Custom model name",
-    "optional" : false,
+    } ],
+    "condition" : {
+      "property" : "embeddingModelProvider.modelProvider",
+      "equals" : "bedrockModelProvider",
+      "type" : "simple"
+    },
     "constraints" : {
       "notEmpty" : true
     },
-    "feel" : "optional",
+    "description" : "Bedrock model name or identifier",
     "group" : "embeddingModel",
+    "id" : "embeddingModelProvider.bedrock.modelName",
+    "label" : "Model name",
+    "optional" : false,
+    "type" : "Dropdown",
+    "value" : "TitanEmbedTextV2"
+  }, {
     "binding" : {
       "name" : "embeddingModelProvider.bedrock.customModelName",
       "type" : "zeebe:input"
@@ -508,18 +500,30 @@
         "type" : "simple"
       } ]
     },
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "embeddingModel",
+    "id" : "embeddingModelProvider.bedrock.customModelName",
+    "label" : "Custom model name",
+    "optional" : false,
     "type" : "String"
   }, {
-    "id" : "embeddingModelProvider.bedrock.dimensions",
-    "label" : "Embedding dimensions",
-    "description" : "The size of the vector used to represent data",
-    "optional" : false,
-    "value" : "D1024",
-    "group" : "embeddingModel",
     "binding" : {
       "name" : "embeddingModelProvider.bedrock.dimensions",
       "type" : "zeebe:input"
     },
+    "choices" : [ {
+      "name" : "256",
+      "value" : "D256"
+    }, {
+      "name" : "512",
+      "value" : "D512"
+    }, {
+      "name" : "1024",
+      "value" : "D1024"
+    } ],
     "condition" : {
       "allMatch" : [ {
         "property" : "embeddingModelProvider.bedrock.modelName",
@@ -531,25 +535,14 @@
         "type" : "simple"
       } ]
     },
-    "type" : "Dropdown",
-    "choices" : [ {
-      "name" : "256",
-      "value" : "D256"
-    }, {
-      "name" : "512",
-      "value" : "D512"
-    }, {
-      "name" : "1024",
-      "value" : "D1024"
-    } ]
-  }, {
-    "id" : "embeddingModelProvider.bedrock.normalize",
-    "label" : "Normalize",
-    "description" : "Normalize vector",
-    "optional" : false,
-    "value" : false,
-    "feel" : "static",
+    "description" : "The size of the vector used to represent data",
     "group" : "embeddingModel",
+    "id" : "embeddingModelProvider.bedrock.dimensions",
+    "label" : "Embedding dimensions",
+    "optional" : false,
+    "type" : "Dropdown",
+    "value" : "D1024"
+  }, {
     "binding" : {
       "name" : "embeddingModelProvider.bedrock.normalize",
       "type" : "zeebe:input"
@@ -565,15 +558,15 @@
         "type" : "simple"
       } ]
     },
-    "type" : "Boolean"
-  }, {
-    "id" : "embeddingModelProvider.bedrock.maxRetries",
-    "label" : "Max retries",
-    "description" : "Max retries",
-    "optional" : false,
-    "value" : 3,
+    "description" : "Normalize vector",
     "feel" : "static",
     "group" : "embeddingModel",
+    "id" : "embeddingModelProvider.bedrock.normalize",
+    "label" : "Normalize",
+    "optional" : false,
+    "type" : "Boolean",
+    "value" : false
+  }, {
     "binding" : {
       "name" : "embeddingModelProvider.bedrock.maxRetries",
       "type" : "zeebe:input"
@@ -583,17 +576,15 @@
       "equals" : "bedrockModelProvider",
       "type" : "simple"
     },
-    "type" : "Number"
-  }, {
-    "id" : "embeddingModelProvider.googleVertexAi.projectId",
-    "label" : "Project ID",
-    "description" : "Google Cloud project ID",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "feel" : "optional",
+    "description" : "Max retries",
+    "feel" : "static",
     "group" : "embeddingModel",
+    "id" : "embeddingModelProvider.bedrock.maxRetries",
+    "label" : "Max retries",
+    "optional" : false,
+    "type" : "Number",
+    "value" : 3
+  }, {
     "binding" : {
       "name" : "embeddingModelProvider.googleVertexAi.projectId",
       "type" : "zeebe:input"
@@ -603,17 +594,17 @@
       "equals" : "vertexAiModelProvider",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "embeddingModelProvider.googleVertexAi.region",
-    "label" : "Region",
-    "description" : "Google Cloud region for Vertex AI",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
+    "description" : "Google Cloud project ID",
     "feel" : "optional",
     "group" : "embeddingModel",
+    "id" : "embeddingModelProvider.googleVertexAi.projectId",
+    "label" : "Project ID",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "embeddingModelProvider.googleVertexAi.region",
       "type" : "zeebe:input"
@@ -623,40 +614,40 @@
       "equals" : "vertexAiModelProvider",
       "type" : "simple"
     },
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "description" : "Google Cloud region for Vertex AI",
+    "feel" : "optional",
+    "group" : "embeddingModel",
+    "id" : "embeddingModelProvider.googleVertexAi.region",
+    "label" : "Region",
+    "optional" : false,
     "type" : "String"
   }, {
-    "id" : "embeddingModelProvider.googleVertexAi.authentication.type",
-    "label" : "Authentication",
-    "description" : "Specify the Google Vertex AI authentication strategy.",
-    "value" : "serviceAccountCredentials",
-    "group" : "embeddingModel",
     "binding" : {
       "name" : "embeddingModelProvider.googleVertexAi.authentication.type",
       "type" : "zeebe:input"
     },
-    "condition" : {
-      "property" : "embeddingModelProvider.modelProvider",
-      "equals" : "vertexAiModelProvider",
-      "type" : "simple"
-    },
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "Service account credentials",
       "value" : "serviceAccountCredentials"
     }, {
       "name" : "Application default credentials (Hybrid/Self-Managed only)",
       "value" : "applicationDefaultCredentials"
-    } ]
-  }, {
-    "id" : "embeddingModelProvider.googleVertexAi.authentication.jsonKey",
-    "label" : "JSON key of the service account",
-    "description" : "This is the key of the service account in JSON format.",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
+    } ],
+    "condition" : {
+      "property" : "embeddingModelProvider.modelProvider",
+      "equals" : "vertexAiModelProvider",
+      "type" : "simple"
     },
-    "feel" : "optional",
+    "description" : "Specify the Google Vertex AI authentication strategy.",
     "group" : "embeddingModel",
+    "id" : "embeddingModelProvider.googleVertexAi.authentication.type",
+    "label" : "Authentication",
+    "type" : "Dropdown",
+    "value" : "serviceAccountCredentials"
+  }, {
     "binding" : {
       "name" : "embeddingModelProvider.googleVertexAi.authentication.jsonKey",
       "type" : "zeebe:input"
@@ -672,17 +663,17 @@
         "type" : "simple"
       } ]
     },
-    "type" : "String"
-  }, {
-    "id" : "embeddingModelProvider.googleVertexAi.modelName",
-    "label" : "Model name",
-    "description" : "Vertex AI embedding model name",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
+    "description" : "This is the key of the service account in JSON format.",
     "feel" : "optional",
     "group" : "embeddingModel",
+    "id" : "embeddingModelProvider.googleVertexAi.authentication.jsonKey",
+    "label" : "JSON key of the service account",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "embeddingModelProvider.googleVertexAi.modelName",
       "type" : "zeebe:input"
@@ -692,17 +683,17 @@
       "equals" : "vertexAiModelProvider",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "embeddingModelProvider.googleVertexAi.dimensions",
-    "label" : "Embedding dimensions",
-    "description" : "The size of the vector used to represent data. Details in the <a href=\"https://cloud.google.com/vertex-ai/generative-ai/docs/embeddings/get-text-embeddings\" target=\"_blank\">documentation</a>.",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
-    "feel" : "required",
+    "description" : "Vertex AI embedding model name",
+    "feel" : "optional",
     "group" : "embeddingModel",
+    "id" : "embeddingModelProvider.googleVertexAi.modelName",
+    "label" : "Model name",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "embeddingModelProvider.googleVertexAi.dimensions",
       "type" : "zeebe:input"
@@ -712,15 +703,17 @@
       "equals" : "vertexAiModelProvider",
       "type" : "simple"
     },
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "description" : "The size of the vector used to represent data. Details in the <a href=\"https://cloud.google.com/vertex-ai/generative-ai/docs/embeddings/get-text-embeddings\" target=\"_blank\">documentation</a>.",
+    "feel" : "required",
+    "group" : "embeddingModel",
+    "id" : "embeddingModelProvider.googleVertexAi.dimensions",
+    "label" : "Embedding dimensions",
+    "optional" : false,
     "type" : "Number"
   }, {
-    "id" : "embeddingModelProvider.googleVertexAi.publisher",
-    "label" : "Publisher",
-    "description" : "The publisher of the Vertex AI model (e.g., 'google', 'third-party'). Optional.",
-    "optional" : true,
-    "value" : "google",
-    "feel" : "optional",
-    "group" : "embeddingModel",
     "binding" : {
       "name" : "embeddingModelProvider.googleVertexAi.publisher",
       "type" : "zeebe:input"
@@ -730,15 +723,15 @@
       "equals" : "vertexAiModelProvider",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "embeddingModelProvider.googleVertexAi.maxRetries",
-    "label" : "Max retries",
-    "description" : "Max retries",
-    "optional" : true,
-    "value" : 3,
-    "feel" : "static",
+    "description" : "The publisher of the Vertex AI model (e.g., 'google', 'third-party'). Optional.",
+    "feel" : "optional",
     "group" : "embeddingModel",
+    "id" : "embeddingModelProvider.googleVertexAi.publisher",
+    "label" : "Publisher",
+    "optional" : true,
+    "type" : "String",
+    "value" : "google"
+  }, {
     "binding" : {
       "name" : "embeddingModelProvider.googleVertexAi.maxRetries",
       "type" : "zeebe:input"
@@ -748,16 +741,15 @@
       "equals" : "vertexAiModelProvider",
       "type" : "simple"
     },
-    "type" : "Number"
-  }, {
-    "id" : "embeddingModelProvider.openAi.apiKey",
-    "label" : "OpenAI API key",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "feel" : "optional",
+    "description" : "Max retries",
+    "feel" : "static",
     "group" : "embeddingModel",
+    "id" : "embeddingModelProvider.googleVertexAi.maxRetries",
+    "label" : "Max retries",
+    "optional" : true,
+    "type" : "Number",
+    "value" : 3
+  }, {
     "binding" : {
       "name" : "embeddingModelProvider.openAi.apiKey",
       "type" : "zeebe:input"
@@ -767,17 +759,16 @@
       "equals" : "openAiModelProvider",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "embeddingModelProvider.openAi.modelName",
-    "label" : "Model name",
-    "description" : "Specify the model name. Details in the <a href=\"https://platform.openai.com/docs/guides/embeddings\" target=\"_blank\">documentation</a>.",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "embeddingModel",
+    "id" : "embeddingModelProvider.openAi.apiKey",
+    "label" : "OpenAI API key",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "embeddingModelProvider.openAi.modelName",
       "type" : "zeebe:input"
@@ -787,14 +778,17 @@
       "equals" : "openAiModelProvider",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "embeddingModelProvider.openAi.organizationId",
-    "label" : "Organization ID",
-    "description" : "For members of multiple organizations. Details in the <a href=\"https://platform.openai.com/docs/api-reference/authentication\" target=\"_blank\">documentation</a>.",
-    "optional" : true,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "description" : "Specify the model name. Details in the <a href=\"https://platform.openai.com/docs/guides/embeddings\" target=\"_blank\">documentation</a>.",
     "feel" : "optional",
     "group" : "embeddingModel",
+    "id" : "embeddingModelProvider.openAi.modelName",
+    "label" : "Model name",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "embeddingModelProvider.openAi.organizationId",
       "type" : "zeebe:input"
@@ -804,14 +798,14 @@
       "equals" : "openAiModelProvider",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "embeddingModelProvider.openAi.projectId",
-    "label" : "Project ID",
-    "description" : "For accounts with multiple projects. Details in the <a href=\"https://platform.openai.com/docs/api-reference/authentication\" target=\"_blank\">documentation</a>.",
-    "optional" : true,
+    "description" : "For members of multiple organizations. Details in the <a href=\"https://platform.openai.com/docs/api-reference/authentication\" target=\"_blank\">documentation</a>.",
     "feel" : "optional",
     "group" : "embeddingModel",
+    "id" : "embeddingModelProvider.openAi.organizationId",
+    "label" : "Organization ID",
+    "optional" : true,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "embeddingModelProvider.openAi.projectId",
       "type" : "zeebe:input"
@@ -821,14 +815,14 @@
       "equals" : "openAiModelProvider",
       "type" : "simple"
     },
+    "description" : "For accounts with multiple projects. Details in the <a href=\"https://platform.openai.com/docs/api-reference/authentication\" target=\"_blank\">documentation</a>.",
+    "feel" : "optional",
+    "group" : "embeddingModel",
+    "id" : "embeddingModelProvider.openAi.projectId",
+    "label" : "Project ID",
+    "optional" : true,
     "type" : "String"
   }, {
-    "id" : "embeddingModelProvider.openAi.dimensions",
-    "label" : "Embedding dimensions",
-    "description" : "The size of the vector used to represent data. If not specified, the default model dimensions are used. Details in the <a href=\"https://platform.openai.com/docs/guides/embeddings\" target=\"_blank\">documentation</a>.",
-    "optional" : true,
-    "feel" : "required",
-    "group" : "embeddingModel",
     "binding" : {
       "name" : "embeddingModelProvider.openAi.dimensions",
       "type" : "zeebe:input"
@@ -838,15 +832,14 @@
       "equals" : "openAiModelProvider",
       "type" : "simple"
     },
+    "description" : "The size of the vector used to represent data. If not specified, the default model dimensions are used. Details in the <a href=\"https://platform.openai.com/docs/guides/embeddings\" target=\"_blank\">documentation</a>.",
+    "feel" : "required",
+    "group" : "embeddingModel",
+    "id" : "embeddingModelProvider.openAi.dimensions",
+    "label" : "Embedding dimensions",
+    "optional" : true,
     "type" : "Number"
   }, {
-    "id" : "embeddingModelProvider.openAi.maxRetries",
-    "label" : "Max retries",
-    "description" : "Max retries",
-    "optional" : true,
-    "value" : 3,
-    "feel" : "static",
-    "group" : "embeddingModel",
     "binding" : {
       "name" : "embeddingModelProvider.openAi.maxRetries",
       "type" : "zeebe:input"
@@ -856,14 +849,15 @@
       "equals" : "openAiModelProvider",
       "type" : "simple"
     },
-    "type" : "Number"
-  }, {
-    "id" : "embeddingModelProvider.openAi.customHeaders",
-    "label" : "Custom headers",
-    "description" : "Map of custom HTTP headers to add to the request.",
-    "optional" : true,
-    "feel" : "required",
+    "description" : "Max retries",
+    "feel" : "static",
     "group" : "embeddingModel",
+    "id" : "embeddingModelProvider.openAi.maxRetries",
+    "label" : "Max retries",
+    "optional" : true,
+    "type" : "Number",
+    "value" : 3
+  }, {
     "binding" : {
       "name" : "embeddingModelProvider.openAi.customHeaders",
       "type" : "zeebe:input"
@@ -873,13 +867,14 @@
       "equals" : "openAiModelProvider",
       "type" : "simple"
     },
+    "description" : "Map of custom HTTP headers to add to the request.",
+    "feel" : "required",
+    "group" : "embeddingModel",
+    "id" : "embeddingModelProvider.openAi.customHeaders",
+    "label" : "Custom headers",
+    "optional" : true,
     "type" : "String"
   }, {
-    "id" : "embeddingModelProvider.openAi.baseUrl",
-    "label" : "Custom base URL",
-    "optional" : true,
-    "feel" : "optional",
-    "group" : "embeddingModel",
     "binding" : {
       "name" : "embeddingModelProvider.openAi.baseUrl",
       "type" : "zeebe:input"
@@ -889,19 +884,18 @@
       "equals" : "openAiModelProvider",
       "type" : "simple"
     },
+    "feel" : "optional",
+    "group" : "embeddingModel",
+    "id" : "embeddingModelProvider.openAi.baseUrl",
+    "label" : "Custom base URL",
+    "optional" : true,
     "tooltip" : "Base URL of OpenAI API. The default is 'https://api.openai.com/v1/'",
     "type" : "String"
   }, {
-    "id" : "vectorStore.vectorStore",
-    "label" : "Embeddings store",
-    "description" : "Select embedding store",
-    "value" : "elasticsearchStore",
-    "group" : "embeddingsStore",
     "binding" : {
       "name" : "vectorStore.storeType",
       "type" : "zeebe:input"
     },
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "Amazon Managed OpenSearch",
       "value" : "amazonManagedOpenSearchStore"
@@ -917,17 +911,14 @@
     }, {
       "name" : "OpenSearch",
       "value" : "openSearchStore"
-    } ]
-  }, {
-    "id" : "vectorStore.amazonManagedOpensearch.accessKey",
-    "label" : "Access key",
-    "description" : "Provide an IAM access key tailored to a user, equipped with the necessary permissions",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "feel" : "optional",
+    } ],
+    "description" : "Select embedding store",
     "group" : "embeddingsStore",
+    "id" : "vectorStore.vectorStore",
+    "label" : "Embeddings store",
+    "type" : "Dropdown",
+    "value" : "elasticsearchStore"
+  }, {
     "binding" : {
       "name" : "vectorStore.amazonManagedOpensearch.accessKey",
       "type" : "zeebe:input"
@@ -937,17 +928,17 @@
       "equals" : "amazonManagedOpenSearchStore",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "vectorStore.amazonManagedOpensearch.secretKey",
-    "label" : "Secret key",
-    "description" : "Provide a secret key associated with the access key",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
+    "description" : "Provide an IAM access key tailored to a user, equipped with the necessary permissions",
     "feel" : "optional",
     "group" : "embeddingsStore",
+    "id" : "vectorStore.amazonManagedOpensearch.accessKey",
+    "label" : "Access key",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "vectorStore.amazonManagedOpensearch.secretKey",
       "type" : "zeebe:input"
@@ -957,17 +948,17 @@
       "equals" : "amazonManagedOpenSearchStore",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "vectorStore.amazonManagedOpensearch.serverUrl",
-    "label" : "Server URL",
-    "description" : "Provide a fully qualified server URL",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
+    "description" : "Provide a secret key associated with the access key",
     "feel" : "optional",
     "group" : "embeddingsStore",
+    "id" : "vectorStore.amazonManagedOpensearch.secretKey",
+    "label" : "Secret key",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "vectorStore.amazonManagedOpensearch.serverUrl",
       "type" : "zeebe:input"
@@ -977,17 +968,17 @@
       "equals" : "amazonManagedOpenSearchStore",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "vectorStore.amazonManagedOpensearch.region",
-    "label" : "Region",
-    "description" : "Provide an instance region",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
+    "description" : "Provide a fully qualified server URL",
     "feel" : "optional",
     "group" : "embeddingsStore",
+    "id" : "vectorStore.amazonManagedOpensearch.serverUrl",
+    "label" : "Server URL",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "vectorStore.amazonManagedOpensearch.region",
       "type" : "zeebe:input"
@@ -997,17 +988,17 @@
       "equals" : "amazonManagedOpenSearchStore",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "vectorStore.amazonManagedOpensearch.indexName",
-    "label" : "Index name",
-    "description" : "Provide an index to store embeddings",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
+    "description" : "Provide an instance region",
     "feel" : "optional",
     "group" : "embeddingsStore",
+    "id" : "vectorStore.amazonManagedOpensearch.region",
+    "label" : "Region",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "vectorStore.amazonManagedOpensearch.indexName",
       "type" : "zeebe:input"
@@ -1017,17 +1008,17 @@
       "equals" : "amazonManagedOpenSearchStore",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "vectorStore.aiSearch.endpoint",
-    "label" : "Endpoint",
-    "description" : "Specify Azure AI Search endpoint. Details in the <a href=\"https://learn.microsoft.com/en-us/azure/search/\" target=\"_blank\">documentation</a>.",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
+    "description" : "Provide an index to store embeddings",
     "feel" : "optional",
     "group" : "embeddingsStore",
+    "id" : "vectorStore.amazonManagedOpensearch.indexName",
+    "label" : "Index name",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "vectorStore.aiSearch.endpoint",
       "type" : "zeebe:input"
@@ -1037,39 +1028,40 @@
       "equals" : "azureAiSearchStore",
       "type" : "simple"
     },
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "description" : "Specify Azure AI Search endpoint. Details in the <a href=\"https://learn.microsoft.com/en-us/azure/search/\" target=\"_blank\">documentation</a>.",
+    "feel" : "optional",
+    "group" : "embeddingsStore",
+    "id" : "vectorStore.aiSearch.endpoint",
+    "label" : "Endpoint",
+    "optional" : false,
     "type" : "String"
   }, {
-    "id" : "vectorStore.aiSearch.authentication.type",
-    "label" : "Authentication",
-    "description" : "Specify the Azure authentication strategy.",
-    "value" : "apiKey",
-    "group" : "embeddingsStore",
     "binding" : {
       "name" : "vectorStore.aiSearch.authentication.type",
       "type" : "zeebe:input"
     },
-    "condition" : {
-      "property" : "vectorStore.vectorStore",
-      "equals" : "azureAiSearchStore",
-      "type" : "simple"
-    },
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "API key",
       "value" : "apiKey"
     }, {
       "name" : "Client credentials",
       "value" : "clientCredentials"
-    } ]
-  }, {
-    "id" : "vectorStore.aiSearch.authentication.apiKey",
-    "label" : "API key",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
+    } ],
+    "condition" : {
+      "property" : "vectorStore.vectorStore",
+      "equals" : "azureAiSearchStore",
+      "type" : "simple"
     },
-    "feel" : "optional",
+    "description" : "Specify the Azure authentication strategy.",
     "group" : "embeddingsStore",
+    "id" : "vectorStore.aiSearch.authentication.type",
+    "label" : "Authentication",
+    "type" : "Dropdown",
+    "value" : "apiKey"
+  }, {
     "binding" : {
       "name" : "vectorStore.aiSearch.authentication.apiKey",
       "type" : "zeebe:input"
@@ -1085,17 +1077,16 @@
         "type" : "simple"
       } ]
     },
-    "type" : "String"
-  }, {
-    "id" : "vectorStore.aiSearch.authentication.clientId",
-    "label" : "Client ID",
-    "description" : "ID of a Microsoft Entra application",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "embeddingsStore",
+    "id" : "vectorStore.aiSearch.authentication.apiKey",
+    "label" : "API key",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "vectorStore.aiSearch.authentication.clientId",
       "type" : "zeebe:input"
@@ -1111,17 +1102,17 @@
         "type" : "simple"
       } ]
     },
-    "type" : "String"
-  }, {
-    "id" : "vectorStore.aiSearch.authentication.clientSecret",
-    "label" : "Client secret",
-    "description" : "Secret of a Microsoft Entra application",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
+    "description" : "ID of a Microsoft Entra application",
     "feel" : "optional",
     "group" : "embeddingsStore",
+    "id" : "vectorStore.aiSearch.authentication.clientId",
+    "label" : "Client ID",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "vectorStore.aiSearch.authentication.clientSecret",
       "type" : "zeebe:input"
@@ -1137,17 +1128,17 @@
         "type" : "simple"
       } ]
     },
-    "type" : "String"
-  }, {
-    "id" : "vectorStore.aiSearch.authentication.tenantId",
-    "label" : "Tenant ID",
-    "description" : "ID of a Microsoft Entra tenant. Details in the <a href=\"https://learn.microsoft.com/en-us/entra/fundamentals/how-to-find-tenant\" target=\"_blank\">documentation</a>.",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
+    "description" : "Secret of a Microsoft Entra application",
     "feel" : "optional",
     "group" : "embeddingsStore",
+    "id" : "vectorStore.aiSearch.authentication.clientSecret",
+    "label" : "Client secret",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "vectorStore.aiSearch.authentication.tenantId",
       "type" : "zeebe:input"
@@ -1163,14 +1154,17 @@
         "type" : "simple"
       } ]
     },
-    "type" : "String"
-  }, {
-    "id" : "vectorStore.aiSearch.authentication.authorityHost",
-    "label" : "Authority host",
-    "description" : "Authority host URL for the Microsoft Entra application. Defaults to <code>https://login.microsoftonline.com</code>. This can also contain an OAuth 2.0 token endpoint.",
-    "optional" : true,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "description" : "ID of a Microsoft Entra tenant. Details in the <a href=\"https://learn.microsoft.com/en-us/entra/fundamentals/how-to-find-tenant\" target=\"_blank\">documentation</a>.",
     "feel" : "optional",
     "group" : "embeddingsStore",
+    "id" : "vectorStore.aiSearch.authentication.tenantId",
+    "label" : "Tenant ID",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "vectorStore.aiSearch.authentication.authorityHost",
       "type" : "zeebe:input"
@@ -1186,17 +1180,14 @@
         "type" : "simple"
       } ]
     },
-    "type" : "String"
-  }, {
-    "id" : "vectorStore.aiSearch.indexName",
-    "label" : "Index name",
-    "description" : "The name of the search index. When storing embeddings this index is created or updated automatically.",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
+    "description" : "Authority host URL for the Microsoft Entra application. Defaults to <code>https://login.microsoftonline.com</code>. This can also contain an OAuth 2.0 token endpoint.",
     "feel" : "optional",
     "group" : "embeddingsStore",
+    "id" : "vectorStore.aiSearch.authentication.authorityHost",
+    "label" : "Authority host",
+    "optional" : true,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "vectorStore.aiSearch.indexName",
       "type" : "zeebe:input"
@@ -1206,17 +1197,17 @@
       "equals" : "azureAiSearchStore",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "vectorStore.azureCosmosDbNoSql.endpoint",
-    "label" : "Endpoint",
-    "description" : "Specify Azure Cosmos DB endpoint. Details in the <a href=\"https://learn.microsoft.com/en-us/azure/cosmos-db/\" target=\"_blank\">documentation</a>.",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
+    "description" : "The name of the search index. When storing embeddings this index is created or updated automatically.",
     "feel" : "optional",
     "group" : "embeddingsStore",
+    "id" : "vectorStore.aiSearch.indexName",
+    "label" : "Index name",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "vectorStore.azureCosmosDbNoSql.endpoint",
       "type" : "zeebe:input"
@@ -1226,39 +1217,40 @@
       "equals" : "azureCosmosDbNoSqlStore",
       "type" : "simple"
     },
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "description" : "Specify Azure Cosmos DB endpoint. Details in the <a href=\"https://learn.microsoft.com/en-us/azure/cosmos-db/\" target=\"_blank\">documentation</a>.",
+    "feel" : "optional",
+    "group" : "embeddingsStore",
+    "id" : "vectorStore.azureCosmosDbNoSql.endpoint",
+    "label" : "Endpoint",
+    "optional" : false,
     "type" : "String"
   }, {
-    "id" : "vectorStore.azureCosmosDbNoSql.authentication.type",
-    "label" : "Authentication",
-    "description" : "Specify the Azure authentication strategy.",
-    "value" : "apiKey",
-    "group" : "embeddingsStore",
     "binding" : {
       "name" : "vectorStore.azureCosmosDbNoSql.authentication.type",
       "type" : "zeebe:input"
     },
-    "condition" : {
-      "property" : "vectorStore.vectorStore",
-      "equals" : "azureCosmosDbNoSqlStore",
-      "type" : "simple"
-    },
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "API key",
       "value" : "apiKey"
     }, {
       "name" : "Client credentials",
       "value" : "clientCredentials"
-    } ]
-  }, {
-    "id" : "vectorStore.azureCosmosDbNoSql.authentication.apiKey",
-    "label" : "API key",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
+    } ],
+    "condition" : {
+      "property" : "vectorStore.vectorStore",
+      "equals" : "azureCosmosDbNoSqlStore",
+      "type" : "simple"
     },
-    "feel" : "optional",
+    "description" : "Specify the Azure authentication strategy.",
     "group" : "embeddingsStore",
+    "id" : "vectorStore.azureCosmosDbNoSql.authentication.type",
+    "label" : "Authentication",
+    "type" : "Dropdown",
+    "value" : "apiKey"
+  }, {
     "binding" : {
       "name" : "vectorStore.azureCosmosDbNoSql.authentication.apiKey",
       "type" : "zeebe:input"
@@ -1274,17 +1266,16 @@
         "type" : "simple"
       } ]
     },
-    "type" : "String"
-  }, {
-    "id" : "vectorStore.azureCosmosDbNoSql.authentication.clientId",
-    "label" : "Client ID",
-    "description" : "ID of a Microsoft Entra application",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "embeddingsStore",
+    "id" : "vectorStore.azureCosmosDbNoSql.authentication.apiKey",
+    "label" : "API key",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "vectorStore.azureCosmosDbNoSql.authentication.clientId",
       "type" : "zeebe:input"
@@ -1300,17 +1291,17 @@
         "type" : "simple"
       } ]
     },
-    "type" : "String"
-  }, {
-    "id" : "vectorStore.azureCosmosDbNoSql.authentication.clientSecret",
-    "label" : "Client secret",
-    "description" : "Secret of a Microsoft Entra application",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
+    "description" : "ID of a Microsoft Entra application",
     "feel" : "optional",
     "group" : "embeddingsStore",
+    "id" : "vectorStore.azureCosmosDbNoSql.authentication.clientId",
+    "label" : "Client ID",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "vectorStore.azureCosmosDbNoSql.authentication.clientSecret",
       "type" : "zeebe:input"
@@ -1326,17 +1317,17 @@
         "type" : "simple"
       } ]
     },
-    "type" : "String"
-  }, {
-    "id" : "vectorStore.azureCosmosDbNoSql.authentication.tenantId",
-    "label" : "Tenant ID",
-    "description" : "ID of a Microsoft Entra tenant. Details in the <a href=\"https://learn.microsoft.com/en-us/entra/fundamentals/how-to-find-tenant\" target=\"_blank\">documentation</a>.",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
+    "description" : "Secret of a Microsoft Entra application",
     "feel" : "optional",
     "group" : "embeddingsStore",
+    "id" : "vectorStore.azureCosmosDbNoSql.authentication.clientSecret",
+    "label" : "Client secret",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "vectorStore.azureCosmosDbNoSql.authentication.tenantId",
       "type" : "zeebe:input"
@@ -1352,14 +1343,17 @@
         "type" : "simple"
       } ]
     },
-    "type" : "String"
-  }, {
-    "id" : "vectorStore.azureCosmosDbNoSql.authentication.authorityHost",
-    "label" : "Authority host",
-    "description" : "Authority host URL for the Microsoft Entra application. Defaults to <code>https://login.microsoftonline.com</code>. This can also contain an OAuth 2.0 token endpoint.",
-    "optional" : true,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "description" : "ID of a Microsoft Entra tenant. Details in the <a href=\"https://learn.microsoft.com/en-us/entra/fundamentals/how-to-find-tenant\" target=\"_blank\">documentation</a>.",
     "feel" : "optional",
     "group" : "embeddingsStore",
+    "id" : "vectorStore.azureCosmosDbNoSql.authentication.tenantId",
+    "label" : "Tenant ID",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "vectorStore.azureCosmosDbNoSql.authentication.authorityHost",
       "type" : "zeebe:input"
@@ -1375,17 +1369,14 @@
         "type" : "simple"
       } ]
     },
-    "type" : "String"
-  }, {
-    "id" : "vectorStore.azureCosmosDbNoSql.databaseName",
-    "label" : "Database name",
-    "description" : "Specify the name of the Azure Cosmos DB NoSQL database.",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
+    "description" : "Authority host URL for the Microsoft Entra application. Defaults to <code>https://login.microsoftonline.com</code>. This can also contain an OAuth 2.0 token endpoint.",
     "feel" : "optional",
     "group" : "embeddingsStore",
+    "id" : "vectorStore.azureCosmosDbNoSql.authentication.authorityHost",
+    "label" : "Authority host",
+    "optional" : true,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "vectorStore.azureCosmosDbNoSql.databaseName",
       "type" : "zeebe:input"
@@ -1395,17 +1386,17 @@
       "equals" : "azureCosmosDbNoSqlStore",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "vectorStore.azureCosmosDbNoSql.containerName",
-    "label" : "Container name",
-    "description" : "Specify the name of the Azure Cosmos DB NoSQL container.",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
+    "description" : "Specify the name of the Azure Cosmos DB NoSQL database.",
     "feel" : "optional",
     "group" : "embeddingsStore",
+    "id" : "vectorStore.azureCosmosDbNoSql.databaseName",
+    "label" : "Database name",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "vectorStore.azureCosmosDbNoSql.containerName",
       "type" : "zeebe:input"
@@ -1415,27 +1406,21 @@
       "equals" : "azureCosmosDbNoSqlStore",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "vectorStore.azureCosmosDbNoSql.consistencyLevel",
-    "label" : "Consistency level",
-    "description" : "Specify the consistency level for the Azure Cosmos DB NoSQL store.",
-    "optional" : false,
-    "value" : "EVENTUAL",
     "constraints" : {
       "notEmpty" : true
     },
+    "description" : "Specify the name of the Azure Cosmos DB NoSQL container.",
+    "feel" : "optional",
     "group" : "embeddingsStore",
+    "id" : "vectorStore.azureCosmosDbNoSql.containerName",
+    "label" : "Container name",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "vectorStore.azureCosmosDbNoSql.consistencyLevel",
       "type" : "zeebe:input"
     },
-    "condition" : {
-      "property" : "vectorStore.vectorStore",
-      "equals" : "azureCosmosDbNoSqlStore",
-      "type" : "simple"
-    },
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "Strong",
       "value" : "STRONG"
@@ -1451,27 +1436,27 @@
     }, {
       "name" : "Eventual",
       "value" : "EVENTUAL"
-    } ]
-  }, {
-    "id" : "vectorStore.azureCosmosDbNoSql.distanceFunction",
-    "label" : "Distance function",
-    "description" : "The metric used to compute distance/similarity. Details in the <a href=\"https://learn.microsoft.com/en-us/azure/cosmos-db/nosql/vector-search\" target=\"_blank\">documentation</a>.",
-    "optional" : false,
-    "value" : "COSINE",
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "group" : "embeddingsStore",
-    "binding" : {
-      "name" : "vectorStore.azureCosmosDbNoSql.distanceFunction",
-      "type" : "zeebe:input"
-    },
+    } ],
     "condition" : {
       "property" : "vectorStore.vectorStore",
       "equals" : "azureCosmosDbNoSqlStore",
       "type" : "simple"
     },
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "description" : "Specify the consistency level for the Azure Cosmos DB NoSQL store.",
+    "group" : "embeddingsStore",
+    "id" : "vectorStore.azureCosmosDbNoSql.consistencyLevel",
+    "label" : "Consistency level",
+    "optional" : false,
     "type" : "Dropdown",
+    "value" : "EVENTUAL"
+  }, {
+    "binding" : {
+      "name" : "vectorStore.azureCosmosDbNoSql.distanceFunction",
+      "type" : "zeebe:input"
+    },
     "choices" : [ {
       "name" : "Euclidean",
       "value" : "EUCLIDEAN"
@@ -1481,27 +1466,27 @@
     }, {
       "name" : "Dot Product",
       "value" : "DOT_PRODUCT"
-    } ]
-  }, {
-    "id" : "vectorStore.azureCosmosDbNoSql.vectorIndexType",
-    "label" : "Vector index type",
-    "description" : "The type of vector index type to use. Details in the <a href=\"https://learn.microsoft.com/en-us/azure/cosmos-db/nosql/vector-search\" target=\"_blank\">documentation</a>.",
-    "optional" : false,
-    "value" : "FLAT",
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "group" : "embeddingsStore",
-    "binding" : {
-      "name" : "vectorStore.azureCosmosDbNoSql.vectorIndexType",
-      "type" : "zeebe:input"
-    },
+    } ],
     "condition" : {
       "property" : "vectorStore.vectorStore",
       "equals" : "azureCosmosDbNoSqlStore",
       "type" : "simple"
     },
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "description" : "The metric used to compute distance/similarity. Details in the <a href=\"https://learn.microsoft.com/en-us/azure/cosmos-db/nosql/vector-search\" target=\"_blank\">documentation</a>.",
+    "group" : "embeddingsStore",
+    "id" : "vectorStore.azureCosmosDbNoSql.distanceFunction",
+    "label" : "Distance function",
+    "optional" : false,
     "type" : "Dropdown",
+    "value" : "COSINE"
+  }, {
+    "binding" : {
+      "name" : "vectorStore.azureCosmosDbNoSql.vectorIndexType",
+      "type" : "zeebe:input"
+    },
     "choices" : [ {
       "name" : "Flat",
       "value" : "FLAT"
@@ -1511,17 +1496,23 @@
     }, {
       "name" : "DiskANN",
       "value" : "DISK_ANN"
-    } ]
-  }, {
-    "id" : "vectorStore.elasticsearch.baseUrl",
-    "label" : "Base URL",
-    "description" : "Elasticsearch base URL, i.e. http(s)://host:port",
-    "optional" : false,
+    } ],
+    "condition" : {
+      "property" : "vectorStore.vectorStore",
+      "equals" : "azureCosmosDbNoSqlStore",
+      "type" : "simple"
+    },
     "constraints" : {
       "notEmpty" : true
     },
-    "feel" : "optional",
+    "description" : "The type of vector index type to use. Details in the <a href=\"https://learn.microsoft.com/en-us/azure/cosmos-db/nosql/vector-search\" target=\"_blank\">documentation</a>.",
     "group" : "embeddingsStore",
+    "id" : "vectorStore.azureCosmosDbNoSql.vectorIndexType",
+    "label" : "Vector index type",
+    "optional" : false,
+    "type" : "Dropdown",
+    "value" : "FLAT"
+  }, {
     "binding" : {
       "name" : "vectorStore.elasticsearch.baseUrl",
       "type" : "zeebe:input"
@@ -1531,17 +1522,17 @@
       "equals" : "elasticsearchStore",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "vectorStore.elasticsearch.userName",
-    "label" : "Username",
-    "description" : "Elasticsearch username",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
+    "description" : "Elasticsearch base URL, i.e. http(s)://host:port",
     "feel" : "optional",
     "group" : "embeddingsStore",
+    "id" : "vectorStore.elasticsearch.baseUrl",
+    "label" : "Base URL",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "vectorStore.elasticsearch.userName",
       "type" : "zeebe:input"
@@ -1551,17 +1542,17 @@
       "equals" : "elasticsearchStore",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "vectorStore.elasticsearch.password",
-    "label" : "Password",
-    "description" : "Elasticsearch password",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
+    "description" : "Elasticsearch username",
     "feel" : "optional",
     "group" : "embeddingsStore",
+    "id" : "vectorStore.elasticsearch.userName",
+    "label" : "Username",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "vectorStore.elasticsearch.password",
       "type" : "zeebe:input"
@@ -1571,17 +1562,17 @@
       "equals" : "elasticsearchStore",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "vectorStore.elasticsearch.indexName",
-    "label" : "Index name",
-    "description" : "Elasticsearch index",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
+    "description" : "Elasticsearch password",
     "feel" : "optional",
     "group" : "embeddingsStore",
+    "id" : "vectorStore.elasticsearch.password",
+    "label" : "Password",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "vectorStore.elasticsearch.indexName",
       "type" : "zeebe:input"
@@ -1591,17 +1582,17 @@
       "equals" : "elasticsearchStore",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "vectorStore.openSearch.baseUrl",
-    "label" : "Base URL",
-    "description" : "OpenSearch base URL, i.e. http(s)://host:port",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
+    "description" : "Elasticsearch index",
     "feel" : "optional",
     "group" : "embeddingsStore",
+    "id" : "vectorStore.elasticsearch.indexName",
+    "label" : "Index name",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "vectorStore.openSearch.baseUrl",
       "type" : "zeebe:input"
@@ -1611,17 +1602,17 @@
       "equals" : "openSearchStore",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "vectorStore.openSearch.userName",
-    "label" : "Username",
-    "description" : "OpenSearch username",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
+    "description" : "OpenSearch base URL, i.e. http(s)://host:port",
     "feel" : "optional",
     "group" : "embeddingsStore",
+    "id" : "vectorStore.openSearch.baseUrl",
+    "label" : "Base URL",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "vectorStore.openSearch.userName",
       "type" : "zeebe:input"
@@ -1631,17 +1622,17 @@
       "equals" : "openSearchStore",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "vectorStore.openSearch.password",
-    "label" : "Password",
-    "description" : "OpenSearch password",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
+    "description" : "OpenSearch username",
     "feel" : "optional",
     "group" : "embeddingsStore",
+    "id" : "vectorStore.openSearch.userName",
+    "label" : "Username",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "vectorStore.openSearch.password",
       "type" : "zeebe:input"
@@ -1651,17 +1642,17 @@
       "equals" : "openSearchStore",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "vectorStore.openSearch.indexName",
-    "label" : "Index name",
-    "description" : "OpenSearch index",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
+    "description" : "OpenSearch password",
     "feel" : "optional",
     "group" : "embeddingsStore",
+    "id" : "vectorStore.openSearch.password",
+    "label" : "Password",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "vectorStore.openSearch.indexName",
       "type" : "zeebe:input"
@@ -1671,43 +1662,44 @@
       "equals" : "openSearchStore",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "vectorDatabaseConnectorOperation.documentSource",
-    "label" : "Document source",
-    "description" : "Whether you want to embed a Camunda document file or plain text",
-    "optional" : false,
-    "value" : "CamundaDocument",
     "constraints" : {
       "notEmpty" : true
     },
-    "group" : "document",
+    "description" : "OpenSearch index",
+    "feel" : "optional",
+    "group" : "embeddingsStore",
+    "id" : "vectorStore.openSearch.indexName",
+    "label" : "Index name",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "vectorDatabaseConnectorOperation.documentSource",
       "type" : "zeebe:input"
     },
-    "condition" : {
-      "property" : "vectorDatabaseConnectorOperation.operationType",
-      "equals" : "embedDocumentOperation",
-      "type" : "simple"
-    },
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "Camunda document",
       "value" : "CamundaDocument"
     }, {
       "name" : "Plain text",
       "value" : "PlainText"
-    } ]
-  }, {
-    "id" : "vectorDatabaseConnectorOperation.documentSourceFromProcessVariable",
-    "label" : "Plain text to embed",
-    "optional" : false,
+    } ],
+    "condition" : {
+      "property" : "vectorDatabaseConnectorOperation.operationType",
+      "equals" : "embedDocumentOperation",
+      "type" : "simple"
+    },
     "constraints" : {
       "notEmpty" : true
     },
-    "feel" : "optional",
+    "description" : "Whether you want to embed a Camunda document file or plain text",
     "group" : "document",
+    "id" : "vectorDatabaseConnectorOperation.documentSource",
+    "label" : "Document source",
+    "optional" : false,
+    "type" : "Dropdown",
+    "value" : "CamundaDocument"
+  }, {
     "binding" : {
       "name" : "vectorDatabaseConnectorOperation.documentSourceFromProcessVariable",
       "type" : "zeebe:input"
@@ -1723,16 +1715,16 @@
         "type" : "simple"
       } ]
     },
-    "type" : "String"
-  }, {
-    "id" : "vectorDatabaseConnectorOperation.newDocuments",
-    "label" : "Documents",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
-    "feel" : "required",
+    "feel" : "optional",
     "group" : "document",
+    "id" : "vectorDatabaseConnectorOperation.documentSourceFromProcessVariable",
+    "label" : "Plain text to embed",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "vectorDatabaseConnectorOperation.newDocuments",
       "type" : "zeebe:input"
@@ -1748,37 +1740,38 @@
         "type" : "simple"
       } ]
     },
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "required",
+    "group" : "document",
+    "id" : "vectorDatabaseConnectorOperation.newDocuments",
+    "label" : "Documents",
+    "optional" : false,
     "type" : "String"
   }, {
-    "id" : "vectorDatabaseConnectorOperation.documentSplitter.documentSplitter",
-    "label" : "Document splitting strategy",
-    "value" : "recursiveDocumentSplitter",
-    "group" : "document",
     "binding" : {
       "name" : "vectorDatabaseConnectorOperation.documentSplitter.splitterType",
       "type" : "zeebe:input"
     },
-    "condition" : {
-      "property" : "vectorDatabaseConnectorOperation.operationType",
-      "equals" : "embedDocumentOperation",
-      "type" : "simple"
-    },
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "Recursive",
       "value" : "recursiveDocumentSplitter"
     }, {
       "name" : "Do not split",
       "value" : "noopDocumentSplitter"
-    } ]
-  }, {
-    "id" : "vectorDatabaseConnectorOperation.documentSplitter.document.splitter.recursive.maxSegmentSizeInChars",
-    "label" : "Max chars",
-    "description" : "Max splitting segment size in chars",
-    "optional" : false,
-    "value" : 500,
-    "feel" : "static",
+    } ],
+    "condition" : {
+      "property" : "vectorDatabaseConnectorOperation.operationType",
+      "equals" : "embedDocumentOperation",
+      "type" : "simple"
+    },
     "group" : "document",
+    "id" : "vectorDatabaseConnectorOperation.documentSplitter.documentSplitter",
+    "label" : "Document splitting strategy",
+    "type" : "Dropdown",
+    "value" : "recursiveDocumentSplitter"
+  }, {
     "binding" : {
       "name" : "vectorDatabaseConnectorOperation.documentSplitter.maxSegmentSizeInChars",
       "type" : "zeebe:input"
@@ -1794,15 +1787,15 @@
         "type" : "simple"
       } ]
     },
-    "type" : "Number"
-  }, {
-    "id" : "vectorDatabaseConnectorOperation.documentSplitter.document.splitter.recursive.maxOverlapSizeInChars",
-    "label" : "Max overlap window",
-    "description" : "Max segment splitting overlap size in chars",
-    "optional" : false,
-    "value" : 80,
+    "description" : "Max splitting segment size in chars",
     "feel" : "static",
     "group" : "document",
+    "id" : "vectorDatabaseConnectorOperation.documentSplitter.document.splitter.recursive.maxSegmentSizeInChars",
+    "label" : "Max chars",
+    "optional" : false,
+    "type" : "Number",
+    "value" : 500
+  }, {
     "binding" : {
       "name" : "vectorDatabaseConnectorOperation.documentSplitter.maxOverlapSizeInChars",
       "type" : "zeebe:input"
@@ -1818,94 +1811,101 @@
         "type" : "simple"
       } ]
     },
-    "type" : "Number"
+    "description" : "Max segment splitting overlap size in chars",
+    "feel" : "static",
+    "group" : "document",
+    "id" : "vectorDatabaseConnectorOperation.documentSplitter.document.splitter.recursive.maxOverlapSizeInChars",
+    "label" : "Max overlap window",
+    "optional" : false,
+    "type" : "Number",
+    "value" : 80
   }, {
-    "id" : "version",
-    "label" : "Version",
-    "description" : "Version of the element template",
-    "value" : "3",
-    "group" : "connector",
     "binding" : {
       "key" : "elementTemplateVersion",
       "type" : "zeebe:taskHeader"
     },
-    "type" : "Hidden"
-  }, {
-    "id" : "id",
-    "label" : "ID",
-    "description" : "ID of the element template",
-    "value" : "io.camunda.connectors.EmbeddingsVectorDB.v1",
+    "description" : "Version of the element template",
     "group" : "connector",
+    "id" : "version",
+    "label" : "Version",
+    "type" : "Hidden",
+    "value" : "3"
+  }, {
     "binding" : {
       "key" : "elementTemplateId",
       "type" : "zeebe:taskHeader"
     },
-    "type" : "Hidden"
+    "description" : "ID of the element template",
+    "group" : "connector",
+    "id" : "id",
+    "label" : "ID",
+    "type" : "Hidden",
+    "value" : "io.camunda.connectors.EmbeddingsVectorDB.v1"
   }, {
-    "id" : "resultVariable",
-    "label" : "Result variable",
-    "description" : "Name of variable to store the response in. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-variable\" target=\"_blank\">documentation</a>.",
-    "group" : "output",
     "binding" : {
       "key" : "resultVariable",
       "type" : "zeebe:taskHeader"
     },
+    "description" : "Name of variable to store the response in. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-variable\" target=\"_blank\">documentation</a>.",
+    "group" : "output",
+    "id" : "resultVariable",
+    "label" : "Result variable",
     "type" : "String"
   }, {
-    "id" : "resultExpression",
-    "label" : "Result expression",
-    "description" : "Expression to map the response into process variables. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-expression\" target=\"_blank\">documentation</a>.",
-    "feel" : "required",
-    "group" : "output",
     "binding" : {
       "key" : "resultExpression",
       "type" : "zeebe:taskHeader"
     },
+    "description" : "Expression to map the response into process variables. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-expression\" target=\"_blank\">documentation</a>.",
+    "feel" : "required",
+    "group" : "output",
+    "id" : "resultExpression",
+    "label" : "Result expression",
     "type" : "Text"
   }, {
-    "id" : "errorExpression",
-    "label" : "Error expression",
-    "description" : "Expression to handle errors. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/\" target=\"_blank\">documentation</a>.",
-    "feel" : "required",
-    "group" : "error",
     "binding" : {
       "key" : "errorExpression",
       "type" : "zeebe:taskHeader"
     },
+    "description" : "Expression to handle errors. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/\" target=\"_blank\">documentation</a>.",
+    "feel" : "required",
+    "group" : "error",
+    "id" : "errorExpression",
+    "label" : "Error expression",
     "type" : "Text"
   }, {
-    "id" : "retryCount",
-    "label" : "Retries",
-    "description" : "Number of retries",
-    "value" : "3",
-    "feel" : "optional",
-    "group" : "retries",
     "binding" : {
       "property" : "retries",
       "type" : "zeebe:taskDefinition"
     },
-    "type" : "String"
-  }, {
-    "id" : "retryBackoff",
-    "label" : "Retry backoff",
-    "description" : "ISO-8601 duration to wait between retries",
-    "value" : "PT30S",
+    "description" : "Number of retries",
+    "feel" : "optional",
     "group" : "retries",
+    "id" : "retryCount",
+    "label" : "Retries",
+    "type" : "String",
+    "value" : "3"
+  }, {
     "binding" : {
       "key" : "retryBackoff",
       "type" : "zeebe:taskHeader"
     },
-    "type" : "String"
-  }, {
-    "id" : "jobTimeout",
-    "label" : "Job timeout",
-    "description" : "ISO-8601 duration after which Zeebe considers this job timed out if not yet completed. Leave empty to use the default timeout",
-    "optional" : true,
+    "description" : "ISO-8601 duration to wait between retries",
     "group" : "retries",
+    "id" : "retryBackoff",
+    "label" : "Retry backoff",
+    "type" : "String",
+    "value" : "PT30S"
+  }, {
     "binding" : {
       "key" : "jobTimeout",
       "type" : "zeebe:taskHeader"
     },
+    "description" : "ISO-8601 duration after which Zeebe considers this job timed out if not yet completed. Leave empty to use the default timeout",
+    "group" : "retries",
+    "id" : "jobTimeout",
+    "label" : "Job timeout",
+    "optional" : true,
     "type" : "String"
   } ],
   "steps" : [ {

--- a/connectors/google/google-gcs/element-templates/google-cloud-storage-outbound-connector.json
+++ b/connectors/google/google-gcs/element-templates/google-cloud-storage-outbound-connector.json
@@ -40,38 +40,30 @@
     "label" : "Retries"
   } ],
   "properties" : [ {
-    "value" : "io.camunda:google-gcs:1",
     "binding" : {
       "property" : "type",
       "type" : "zeebe:taskDefinition"
     },
-    "type" : "Hidden"
+    "type" : "Hidden",
+    "value" : "io.camunda:google-gcs:1"
   }, {
-    "id" : "operationDiscriminator",
-    "label" : "Operation",
-    "value" : "uploadObject",
-    "group" : "operation",
     "binding" : {
       "name" : "operationDiscriminator",
       "type" : "zeebe:input"
     },
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "Download object",
       "value" : "downloadObject"
     }, {
       "name" : "Upload object",
       "value" : "uploadObject"
-    } ]
-  }, {
-    "id" : "downloadOperationProject",
-    "label" : "GCP project",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "feel" : "optional",
+    } ],
     "group" : "operation",
+    "id" : "operationDiscriminator",
+    "label" : "Operation",
+    "type" : "Dropdown",
+    "value" : "uploadObject"
+  }, {
     "binding" : {
       "name" : "operation.project",
       "type" : "zeebe:input"
@@ -81,17 +73,17 @@
       "equals" : "downloadObject",
       "type" : "simple"
     },
-    "tooltip" : "The project where the bucket is located.",
-    "type" : "String"
-  }, {
-    "id" : "downloadOperationBucket",
-    "label" : "Object Storage bucket",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "operation",
+    "id" : "downloadOperationProject",
+    "label" : "GCP project",
+    "optional" : false,
+    "tooltip" : "The project where the bucket is located.",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "operation.bucket",
       "type" : "zeebe:input"
@@ -101,17 +93,17 @@
       "equals" : "downloadObject",
       "type" : "simple"
     },
-    "tooltip" : "A bucket acts as a directory that organizes a set of objects.",
-    "type" : "String"
-  }, {
-    "id" : "downloadOperationFileName",
-    "label" : "File name",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "operation",
+    "id" : "downloadOperationBucket",
+    "label" : "Object Storage bucket",
+    "optional" : false,
+    "tooltip" : "A bucket acts as a directory that organizes a set of objects.",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "operation.fileName",
       "type" : "zeebe:input"
@@ -121,24 +113,21 @@
       "equals" : "downloadObject",
       "type" : "simple"
     },
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "operation",
+    "id" : "downloadOperationFileName",
+    "label" : "File name",
+    "optional" : false,
     "tooltip" : "Name of the object in the bucket to download.",
     "type" : "String"
   }, {
-    "id" : "documentReturnFormat",
-    "label" : "Response format",
-    "value" : "DOCUMENT",
-    "group" : "operation",
     "binding" : {
       "name" : "documentReturnFormat.choice",
       "type" : "zeebe:input"
     },
-    "condition" : {
-      "property" : "operationDiscriminator",
-      "equals" : "downloadObject",
-      "type" : "simple"
-    },
-    "tooltip" : "How the downloaded payload should be returned. Document reference uploads the payload to the document store; as text decodes it as a String; as JSON parses it into a structure you can access via dot notation.",
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "Document reference",
       "value" : "DOCUMENT"
@@ -148,14 +137,19 @@
     }, {
       "name" : "as JSON",
       "value" : "JSON"
-    } ]
-  }, {
-    "id" : "documentReturnFormatEncoding",
-    "label" : "Encoding",
-    "description" : "Character set used to decode the response. Default UTF-8.",
-    "value" : "UTF-8",
-    "feel" : "optional",
+    } ],
+    "condition" : {
+      "property" : "operationDiscriminator",
+      "equals" : "downloadObject",
+      "type" : "simple"
+    },
     "group" : "operation",
+    "id" : "documentReturnFormat",
+    "label" : "Response format",
+    "tooltip" : "How the downloaded payload should be returned. Document reference uploads the payload to the document store; as text decodes it as a String; as JSON parses it into a structure you can access via dot notation.",
+    "type" : "Dropdown",
+    "value" : "DOCUMENT"
+  }, {
     "binding" : {
       "name" : "documentReturnFormat.encoding",
       "type" : "zeebe:input"
@@ -171,16 +165,14 @@
         "type" : "simple"
       } ]
     },
-    "type" : "String"
-  }, {
-    "id" : "uploadOperationProject",
-    "label" : "GCP project",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
+    "description" : "Character set used to decode the response. Default UTF-8.",
     "feel" : "optional",
     "group" : "operation",
+    "id" : "documentReturnFormatEncoding",
+    "label" : "Encoding",
+    "type" : "String",
+    "value" : "UTF-8"
+  }, {
     "binding" : {
       "name" : "operation.project",
       "type" : "zeebe:input"
@@ -190,17 +182,17 @@
       "equals" : "uploadObject",
       "type" : "simple"
     },
-    "tooltip" : "The project where the bucket is located.",
-    "type" : "String"
-  }, {
-    "id" : "uploadOperationBucket",
-    "label" : "Object Storage bucket",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "operation",
+    "id" : "uploadOperationProject",
+    "label" : "GCP project",
+    "optional" : false,
+    "tooltip" : "The project where the bucket is located.",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "operation.bucket",
       "type" : "zeebe:input"
@@ -210,24 +202,21 @@
       "equals" : "uploadObject",
       "type" : "simple"
     },
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "operation",
+    "id" : "uploadOperationBucket",
+    "label" : "Object Storage bucket",
+    "optional" : false,
     "tooltip" : "A bucket acts as a directory that organizes a set of objects.",
     "type" : "String"
   }, {
-    "id" : "operation_document_documentSource",
-    "label" : "Document source",
-    "value" : "camunda",
-    "group" : "operation",
     "binding" : {
       "name" : "operation.operation_document_documentSource",
       "type" : "zeebe:input"
     },
-    "condition" : {
-      "property" : "operationDiscriminator",
-      "equals" : "uploadObject",
-      "type" : "simple"
-    },
-    "tooltip" : "Document to be uploaded to Google Cloud Storage.",
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "Camunda Document",
       "value" : "camunda"
@@ -237,15 +226,19 @@
     }, {
       "name" : "From URL",
       "value" : "external"
-    } ]
-  }, {
-    "id" : "operation_document_camundaReference",
-    "label" : "Camunda document",
-    "constraints" : {
-      "notEmpty" : true
+    } ],
+    "condition" : {
+      "property" : "operationDiscriminator",
+      "equals" : "uploadObject",
+      "type" : "simple"
     },
-    "feel" : "required",
     "group" : "operation",
+    "id" : "operation_document_documentSource",
+    "label" : "Document source",
+    "tooltip" : "Document to be uploaded to Google Cloud Storage.",
+    "type" : "Dropdown",
+    "value" : "camunda"
+  }, {
     "binding" : {
       "name" : "operation.operation_document_camundaReference",
       "type" : "zeebe:input"
@@ -261,15 +254,15 @@
         "type" : "simple"
       } ]
     },
-    "type" : "String"
-  }, {
-    "id" : "operation_document_inline_content",
-    "label" : "Content",
     "constraints" : {
       "notEmpty" : true
     },
-    "feel" : "optional",
+    "feel" : "required",
     "group" : "operation",
+    "id" : "operation_document_camundaReference",
+    "label" : "Camunda document",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "operation.operation_document_inline_content",
       "type" : "zeebe:input"
@@ -285,12 +278,15 @@
         "type" : "simple"
       } ]
     },
-    "type" : "String"
-  }, {
-    "id" : "operation_document_inline_fileName",
-    "label" : "File name",
+    "constraints" : {
+      "notEmpty" : true
+    },
     "feel" : "optional",
     "group" : "operation",
+    "id" : "operation_document_inline_content",
+    "label" : "Content",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "operation.operation_document_inline_fileName",
       "type" : "zeebe:input"
@@ -306,12 +302,12 @@
         "type" : "simple"
       } ]
     },
-    "type" : "String"
-  }, {
-    "id" : "operation_document_inline_contentType",
-    "label" : "Content type",
     "feel" : "optional",
     "group" : "operation",
+    "id" : "operation_document_inline_fileName",
+    "label" : "File name",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "operation.operation_document_inline_contentType",
       "type" : "zeebe:input"
@@ -327,15 +323,12 @@
         "type" : "simple"
       } ]
     },
-    "type" : "String"
-  }, {
-    "id" : "operation_document_external_url",
-    "label" : "URL",
-    "constraints" : {
-      "notEmpty" : true
-    },
     "feel" : "optional",
     "group" : "operation",
+    "id" : "operation_document_inline_contentType",
+    "label" : "Content type",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "operation.operation_document_external_url",
       "type" : "zeebe:input"
@@ -351,12 +344,15 @@
         "type" : "simple"
       } ]
     },
-    "type" : "String"
-  }, {
-    "id" : "operation_document_external_fileName",
-    "label" : "File name",
+    "constraints" : {
+      "notEmpty" : true
+    },
     "feel" : "optional",
     "group" : "operation",
+    "id" : "operation_document_external_url",
+    "label" : "URL",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "operation.operation_document_external_fileName",
       "type" : "zeebe:input"
@@ -372,11 +368,12 @@
         "type" : "simple"
       } ]
     },
+    "feel" : "optional",
+    "group" : "operation",
+    "id" : "operation_document_external_fileName",
+    "label" : "File name",
     "type" : "String"
   }, {
-    "id" : "uploadOperationDocument",
-    "value" : "=if operation_document_documentSource = \"camunda\" then operation_document_camundaReference else if operation_document_documentSource = \"inline\" then { \"camunda.document.type\": \"inline\", content: operation_document_inline_content, name: operation_document_inline_fileName, contentType: operation_document_inline_contentType } else if operation_document_documentSource = \"external\" then { \"camunda.document.type\": \"external\", url: operation_document_external_url, name: operation_document_external_fileName } else null",
-    "group" : "operation",
     "binding" : {
       "name" : "operation.document",
       "type" : "zeebe:input"
@@ -386,28 +383,26 @@
       "equals" : "uploadObject",
       "type" : "simple"
     },
-    "type" : "Hidden"
+    "group" : "operation",
+    "id" : "uploadOperationDocument",
+    "type" : "Hidden",
+    "value" : "=if operation_document_documentSource = \"camunda\" then operation_document_camundaReference else if operation_document_documentSource = \"inline\" then { \"camunda.document.type\": \"inline\", content: operation_document_inline_content, name: operation_document_inline_fileName, contentType: operation_document_inline_contentType } else if operation_document_documentSource = \"external\" then { \"camunda.document.type\": \"external\", url: operation_document_external_url, name: operation_document_external_fileName } else null"
   }, {
-    "id" : "authentication.jsonKey",
-    "label" : "JSON key of the service account",
-    "optional" : false,
+    "binding" : {
+      "name" : "authentication.jsonKey",
+      "type" : "zeebe:input"
+    },
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "authentication",
-    "binding" : {
-      "name" : "authentication.jsonKey",
-      "type" : "zeebe:input"
-    },
+    "id" : "authentication.jsonKey",
+    "label" : "JSON key of the service account",
+    "optional" : false,
     "tooltip" : "Service account key in JSON format. See the <a href=\"https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/google-cloud-storage/#authentication\" target=\"_blank\">Google Cloud Storage authentication guide</a> for details.",
     "type" : "String"
   }, {
-    "id" : "uploadOperationFileName",
-    "label" : "Document file name",
-    "optional" : true,
-    "feel" : "optional",
-    "group" : "additionalProperties",
     "binding" : {
       "name" : "operation.fileName",
       "type" : "zeebe:input"
@@ -417,95 +412,100 @@
       "equals" : "uploadObject",
       "type" : "simple"
     },
+    "feel" : "optional",
+    "group" : "additionalProperties",
+    "id" : "uploadOperationFileName",
+    "label" : "Document file name",
+    "optional" : true,
     "tooltip" : "By default, the file's metadata name is used unless a custom name is specified.",
     "type" : "String"
   }, {
-    "id" : "version",
-    "label" : "Version",
-    "description" : "Version of the element template",
-    "value" : "4",
-    "group" : "connector",
     "binding" : {
       "key" : "elementTemplateVersion",
       "type" : "zeebe:taskHeader"
     },
-    "type" : "Hidden"
-  }, {
-    "id" : "id",
-    "label" : "ID",
-    "description" : "ID of the element template",
-    "value" : "io.camunda.connectors.google.gcp.v1",
+    "description" : "Version of the element template",
     "group" : "connector",
+    "id" : "version",
+    "label" : "Version",
+    "type" : "Hidden",
+    "value" : "4"
+  }, {
     "binding" : {
       "key" : "elementTemplateId",
       "type" : "zeebe:taskHeader"
     },
-    "type" : "Hidden"
+    "description" : "ID of the element template",
+    "group" : "connector",
+    "id" : "id",
+    "label" : "ID",
+    "type" : "Hidden",
+    "value" : "io.camunda.connectors.google.gcp.v1"
   }, {
-    "id" : "resultVariable",
-    "label" : "Result variable",
-    "description" : "Name of variable to store the response in. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-variable\" target=\"_blank\">documentation</a>.",
-    "group" : "output",
     "binding" : {
       "key" : "resultVariable",
       "type" : "zeebe:taskHeader"
     },
+    "description" : "Name of variable to store the response in. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-variable\" target=\"_blank\">documentation</a>.",
+    "group" : "output",
+    "id" : "resultVariable",
+    "label" : "Result variable",
     "type" : "String"
   }, {
-    "id" : "resultExpression",
-    "label" : "Result expression",
-    "description" : "Expression to map the response into process variables. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-expression\" target=\"_blank\">documentation</a>.",
-    "feel" : "required",
-    "group" : "output",
     "binding" : {
       "key" : "resultExpression",
       "type" : "zeebe:taskHeader"
     },
+    "description" : "Expression to map the response into process variables. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-expression\" target=\"_blank\">documentation</a>.",
+    "feel" : "required",
+    "group" : "output",
+    "id" : "resultExpression",
+    "label" : "Result expression",
     "type" : "Text"
   }, {
-    "id" : "errorExpression",
-    "label" : "Error expression",
-    "description" : "Expression to handle errors. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/\" target=\"_blank\">documentation</a>.",
-    "feel" : "required",
-    "group" : "error",
     "binding" : {
       "key" : "errorExpression",
       "type" : "zeebe:taskHeader"
     },
+    "description" : "Expression to handle errors. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/\" target=\"_blank\">documentation</a>.",
+    "feel" : "required",
+    "group" : "error",
+    "id" : "errorExpression",
+    "label" : "Error expression",
     "type" : "Text"
   }, {
-    "id" : "retryCount",
-    "label" : "Retries",
-    "description" : "Number of retries",
-    "value" : "3",
-    "feel" : "optional",
-    "group" : "retries",
     "binding" : {
       "property" : "retries",
       "type" : "zeebe:taskDefinition"
     },
-    "type" : "String"
-  }, {
-    "id" : "retryBackoff",
-    "label" : "Retry backoff",
-    "description" : "ISO-8601 duration to wait between retries",
-    "value" : "PT30S",
+    "description" : "Number of retries",
+    "feel" : "optional",
     "group" : "retries",
+    "id" : "retryCount",
+    "label" : "Retries",
+    "type" : "String",
+    "value" : "3"
+  }, {
     "binding" : {
       "key" : "retryBackoff",
       "type" : "zeebe:taskHeader"
     },
-    "type" : "String"
-  }, {
-    "id" : "jobTimeout",
-    "label" : "Job timeout",
-    "description" : "ISO-8601 duration after which Zeebe considers this job timed out if not yet completed. Leave empty to use the default timeout",
-    "optional" : true,
+    "description" : "ISO-8601 duration to wait between retries",
     "group" : "retries",
+    "id" : "retryBackoff",
+    "label" : "Retry backoff",
+    "type" : "String",
+    "value" : "PT30S"
+  }, {
     "binding" : {
       "key" : "jobTimeout",
       "type" : "zeebe:taskHeader"
     },
+    "description" : "ISO-8601 duration after which Zeebe considers this job timed out if not yet completed. Leave empty to use the default timeout",
+    "group" : "retries",
+    "id" : "jobTimeout",
+    "label" : "Job timeout",
+    "optional" : true,
     "type" : "String"
   } ],
   "steps" : [ {

--- a/connectors/google/google-gcs/element-templates/hybrid/hybrid-google-cloud-storage-outbound-connector-hybrid.json
+++ b/connectors/google/google-gcs/element-templates/hybrid/hybrid-google-cloud-storage-outbound-connector-hybrid.json
@@ -43,40 +43,32 @@
     "label" : "Retries"
   } ],
   "properties" : [ {
-    "id" : "taskDefinitionType",
-    "value" : "io.camunda:google-gcs:1",
-    "group" : "taskDefinitionType",
     "binding" : {
       "property" : "type",
       "type" : "zeebe:taskDefinition"
     },
-    "type" : "String"
+    "group" : "taskDefinitionType",
+    "id" : "taskDefinitionType",
+    "type" : "String",
+    "value" : "io.camunda:google-gcs:1"
   }, {
-    "id" : "operationDiscriminator",
-    "label" : "Operation",
-    "value" : "uploadObject",
-    "group" : "operation",
     "binding" : {
       "name" : "operationDiscriminator",
       "type" : "zeebe:input"
     },
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "Download object",
       "value" : "downloadObject"
     }, {
       "name" : "Upload object",
       "value" : "uploadObject"
-    } ]
-  }, {
-    "id" : "downloadOperationProject",
-    "label" : "GCP project",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "feel" : "optional",
+    } ],
     "group" : "operation",
+    "id" : "operationDiscriminator",
+    "label" : "Operation",
+    "type" : "Dropdown",
+    "value" : "uploadObject"
+  }, {
     "binding" : {
       "name" : "operation.project",
       "type" : "zeebe:input"
@@ -86,17 +78,17 @@
       "equals" : "downloadObject",
       "type" : "simple"
     },
-    "tooltip" : "The project where the bucket is located.",
-    "type" : "String"
-  }, {
-    "id" : "downloadOperationBucket",
-    "label" : "Object Storage bucket",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "operation",
+    "id" : "downloadOperationProject",
+    "label" : "GCP project",
+    "optional" : false,
+    "tooltip" : "The project where the bucket is located.",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "operation.bucket",
       "type" : "zeebe:input"
@@ -106,17 +98,17 @@
       "equals" : "downloadObject",
       "type" : "simple"
     },
-    "tooltip" : "A bucket acts as a directory that organizes a set of objects.",
-    "type" : "String"
-  }, {
-    "id" : "downloadOperationFileName",
-    "label" : "File name",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "operation",
+    "id" : "downloadOperationBucket",
+    "label" : "Object Storage bucket",
+    "optional" : false,
+    "tooltip" : "A bucket acts as a directory that organizes a set of objects.",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "operation.fileName",
       "type" : "zeebe:input"
@@ -126,24 +118,21 @@
       "equals" : "downloadObject",
       "type" : "simple"
     },
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "operation",
+    "id" : "downloadOperationFileName",
+    "label" : "File name",
+    "optional" : false,
     "tooltip" : "Name of the object in the bucket to download.",
     "type" : "String"
   }, {
-    "id" : "documentReturnFormat",
-    "label" : "Response format",
-    "value" : "DOCUMENT",
-    "group" : "operation",
     "binding" : {
       "name" : "documentReturnFormat.choice",
       "type" : "zeebe:input"
     },
-    "condition" : {
-      "property" : "operationDiscriminator",
-      "equals" : "downloadObject",
-      "type" : "simple"
-    },
-    "tooltip" : "How the downloaded payload should be returned. Document reference uploads the payload to the document store; as text decodes it as a String; as JSON parses it into a structure you can access via dot notation.",
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "Document reference",
       "value" : "DOCUMENT"
@@ -153,14 +142,19 @@
     }, {
       "name" : "as JSON",
       "value" : "JSON"
-    } ]
-  }, {
-    "id" : "documentReturnFormatEncoding",
-    "label" : "Encoding",
-    "description" : "Character set used to decode the response. Default UTF-8.",
-    "value" : "UTF-8",
-    "feel" : "optional",
+    } ],
+    "condition" : {
+      "property" : "operationDiscriminator",
+      "equals" : "downloadObject",
+      "type" : "simple"
+    },
     "group" : "operation",
+    "id" : "documentReturnFormat",
+    "label" : "Response format",
+    "tooltip" : "How the downloaded payload should be returned. Document reference uploads the payload to the document store; as text decodes it as a String; as JSON parses it into a structure you can access via dot notation.",
+    "type" : "Dropdown",
+    "value" : "DOCUMENT"
+  }, {
     "binding" : {
       "name" : "documentReturnFormat.encoding",
       "type" : "zeebe:input"
@@ -176,16 +170,14 @@
         "type" : "simple"
       } ]
     },
-    "type" : "String"
-  }, {
-    "id" : "uploadOperationProject",
-    "label" : "GCP project",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
+    "description" : "Character set used to decode the response. Default UTF-8.",
     "feel" : "optional",
     "group" : "operation",
+    "id" : "documentReturnFormatEncoding",
+    "label" : "Encoding",
+    "type" : "String",
+    "value" : "UTF-8"
+  }, {
     "binding" : {
       "name" : "operation.project",
       "type" : "zeebe:input"
@@ -195,17 +187,17 @@
       "equals" : "uploadObject",
       "type" : "simple"
     },
-    "tooltip" : "The project where the bucket is located.",
-    "type" : "String"
-  }, {
-    "id" : "uploadOperationBucket",
-    "label" : "Object Storage bucket",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "operation",
+    "id" : "uploadOperationProject",
+    "label" : "GCP project",
+    "optional" : false,
+    "tooltip" : "The project where the bucket is located.",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "operation.bucket",
       "type" : "zeebe:input"
@@ -215,24 +207,21 @@
       "equals" : "uploadObject",
       "type" : "simple"
     },
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "operation",
+    "id" : "uploadOperationBucket",
+    "label" : "Object Storage bucket",
+    "optional" : false,
     "tooltip" : "A bucket acts as a directory that organizes a set of objects.",
     "type" : "String"
   }, {
-    "id" : "operation_document_documentSource",
-    "label" : "Document source",
-    "value" : "camunda",
-    "group" : "operation",
     "binding" : {
       "name" : "operation.operation_document_documentSource",
       "type" : "zeebe:input"
     },
-    "condition" : {
-      "property" : "operationDiscriminator",
-      "equals" : "uploadObject",
-      "type" : "simple"
-    },
-    "tooltip" : "Document to be uploaded to Google Cloud Storage.",
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "Camunda Document",
       "value" : "camunda"
@@ -242,15 +231,19 @@
     }, {
       "name" : "From URL",
       "value" : "external"
-    } ]
-  }, {
-    "id" : "operation_document_camundaReference",
-    "label" : "Camunda document",
-    "constraints" : {
-      "notEmpty" : true
+    } ],
+    "condition" : {
+      "property" : "operationDiscriminator",
+      "equals" : "uploadObject",
+      "type" : "simple"
     },
-    "feel" : "required",
     "group" : "operation",
+    "id" : "operation_document_documentSource",
+    "label" : "Document source",
+    "tooltip" : "Document to be uploaded to Google Cloud Storage.",
+    "type" : "Dropdown",
+    "value" : "camunda"
+  }, {
     "binding" : {
       "name" : "operation.operation_document_camundaReference",
       "type" : "zeebe:input"
@@ -266,15 +259,15 @@
         "type" : "simple"
       } ]
     },
-    "type" : "String"
-  }, {
-    "id" : "operation_document_inline_content",
-    "label" : "Content",
     "constraints" : {
       "notEmpty" : true
     },
-    "feel" : "optional",
+    "feel" : "required",
     "group" : "operation",
+    "id" : "operation_document_camundaReference",
+    "label" : "Camunda document",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "operation.operation_document_inline_content",
       "type" : "zeebe:input"
@@ -290,12 +283,15 @@
         "type" : "simple"
       } ]
     },
-    "type" : "String"
-  }, {
-    "id" : "operation_document_inline_fileName",
-    "label" : "File name",
+    "constraints" : {
+      "notEmpty" : true
+    },
     "feel" : "optional",
     "group" : "operation",
+    "id" : "operation_document_inline_content",
+    "label" : "Content",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "operation.operation_document_inline_fileName",
       "type" : "zeebe:input"
@@ -311,12 +307,12 @@
         "type" : "simple"
       } ]
     },
-    "type" : "String"
-  }, {
-    "id" : "operation_document_inline_contentType",
-    "label" : "Content type",
     "feel" : "optional",
     "group" : "operation",
+    "id" : "operation_document_inline_fileName",
+    "label" : "File name",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "operation.operation_document_inline_contentType",
       "type" : "zeebe:input"
@@ -332,15 +328,12 @@
         "type" : "simple"
       } ]
     },
-    "type" : "String"
-  }, {
-    "id" : "operation_document_external_url",
-    "label" : "URL",
-    "constraints" : {
-      "notEmpty" : true
-    },
     "feel" : "optional",
     "group" : "operation",
+    "id" : "operation_document_inline_contentType",
+    "label" : "Content type",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "operation.operation_document_external_url",
       "type" : "zeebe:input"
@@ -356,12 +349,15 @@
         "type" : "simple"
       } ]
     },
-    "type" : "String"
-  }, {
-    "id" : "operation_document_external_fileName",
-    "label" : "File name",
+    "constraints" : {
+      "notEmpty" : true
+    },
     "feel" : "optional",
     "group" : "operation",
+    "id" : "operation_document_external_url",
+    "label" : "URL",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "operation.operation_document_external_fileName",
       "type" : "zeebe:input"
@@ -377,11 +373,12 @@
         "type" : "simple"
       } ]
     },
+    "feel" : "optional",
+    "group" : "operation",
+    "id" : "operation_document_external_fileName",
+    "label" : "File name",
     "type" : "String"
   }, {
-    "id" : "uploadOperationDocument",
-    "value" : "=if operation_document_documentSource = \"camunda\" then operation_document_camundaReference else if operation_document_documentSource = \"inline\" then { \"camunda.document.type\": \"inline\", content: operation_document_inline_content, name: operation_document_inline_fileName, contentType: operation_document_inline_contentType } else if operation_document_documentSource = \"external\" then { \"camunda.document.type\": \"external\", url: operation_document_external_url, name: operation_document_external_fileName } else null",
-    "group" : "operation",
     "binding" : {
       "name" : "operation.document",
       "type" : "zeebe:input"
@@ -391,28 +388,26 @@
       "equals" : "uploadObject",
       "type" : "simple"
     },
-    "type" : "Hidden"
+    "group" : "operation",
+    "id" : "uploadOperationDocument",
+    "type" : "Hidden",
+    "value" : "=if operation_document_documentSource = \"camunda\" then operation_document_camundaReference else if operation_document_documentSource = \"inline\" then { \"camunda.document.type\": \"inline\", content: operation_document_inline_content, name: operation_document_inline_fileName, contentType: operation_document_inline_contentType } else if operation_document_documentSource = \"external\" then { \"camunda.document.type\": \"external\", url: operation_document_external_url, name: operation_document_external_fileName } else null"
   }, {
-    "id" : "authentication.jsonKey",
-    "label" : "JSON key of the service account",
-    "optional" : false,
+    "binding" : {
+      "name" : "authentication.jsonKey",
+      "type" : "zeebe:input"
+    },
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "authentication",
-    "binding" : {
-      "name" : "authentication.jsonKey",
-      "type" : "zeebe:input"
-    },
+    "id" : "authentication.jsonKey",
+    "label" : "JSON key of the service account",
+    "optional" : false,
     "tooltip" : "Service account key in JSON format. See the <a href=\"https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/google-cloud-storage/#authentication\" target=\"_blank\">Google Cloud Storage authentication guide</a> for details.",
     "type" : "String"
   }, {
-    "id" : "uploadOperationFileName",
-    "label" : "Document file name",
-    "optional" : true,
-    "feel" : "optional",
-    "group" : "additionalProperties",
     "binding" : {
       "name" : "operation.fileName",
       "type" : "zeebe:input"
@@ -422,95 +417,100 @@
       "equals" : "uploadObject",
       "type" : "simple"
     },
+    "feel" : "optional",
+    "group" : "additionalProperties",
+    "id" : "uploadOperationFileName",
+    "label" : "Document file name",
+    "optional" : true,
     "tooltip" : "By default, the file's metadata name is used unless a custom name is specified.",
     "type" : "String"
   }, {
-    "id" : "version",
-    "label" : "Version",
-    "description" : "Version of the element template",
-    "value" : "4",
-    "group" : "connector",
     "binding" : {
       "key" : "elementTemplateVersion",
       "type" : "zeebe:taskHeader"
     },
-    "type" : "Hidden"
-  }, {
-    "id" : "id",
-    "label" : "ID",
-    "description" : "ID of the element template",
-    "value" : "io.camunda.connectors.google.gcp.v1",
+    "description" : "Version of the element template",
     "group" : "connector",
+    "id" : "version",
+    "label" : "Version",
+    "type" : "Hidden",
+    "value" : "4"
+  }, {
     "binding" : {
       "key" : "elementTemplateId",
       "type" : "zeebe:taskHeader"
     },
-    "type" : "Hidden"
+    "description" : "ID of the element template",
+    "group" : "connector",
+    "id" : "id",
+    "label" : "ID",
+    "type" : "Hidden",
+    "value" : "io.camunda.connectors.google.gcp.v1"
   }, {
-    "id" : "resultVariable",
-    "label" : "Result variable",
-    "description" : "Name of variable to store the response in. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-variable\" target=\"_blank\">documentation</a>.",
-    "group" : "output",
     "binding" : {
       "key" : "resultVariable",
       "type" : "zeebe:taskHeader"
     },
+    "description" : "Name of variable to store the response in. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-variable\" target=\"_blank\">documentation</a>.",
+    "group" : "output",
+    "id" : "resultVariable",
+    "label" : "Result variable",
     "type" : "String"
   }, {
-    "id" : "resultExpression",
-    "label" : "Result expression",
-    "description" : "Expression to map the response into process variables. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-expression\" target=\"_blank\">documentation</a>.",
-    "feel" : "required",
-    "group" : "output",
     "binding" : {
       "key" : "resultExpression",
       "type" : "zeebe:taskHeader"
     },
+    "description" : "Expression to map the response into process variables. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-expression\" target=\"_blank\">documentation</a>.",
+    "feel" : "required",
+    "group" : "output",
+    "id" : "resultExpression",
+    "label" : "Result expression",
     "type" : "Text"
   }, {
-    "id" : "errorExpression",
-    "label" : "Error expression",
-    "description" : "Expression to handle errors. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/\" target=\"_blank\">documentation</a>.",
-    "feel" : "required",
-    "group" : "error",
     "binding" : {
       "key" : "errorExpression",
       "type" : "zeebe:taskHeader"
     },
+    "description" : "Expression to handle errors. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/\" target=\"_blank\">documentation</a>.",
+    "feel" : "required",
+    "group" : "error",
+    "id" : "errorExpression",
+    "label" : "Error expression",
     "type" : "Text"
   }, {
-    "id" : "retryCount",
-    "label" : "Retries",
-    "description" : "Number of retries",
-    "value" : "3",
-    "feel" : "optional",
-    "group" : "retries",
     "binding" : {
       "property" : "retries",
       "type" : "zeebe:taskDefinition"
     },
-    "type" : "String"
-  }, {
-    "id" : "retryBackoff",
-    "label" : "Retry backoff",
-    "description" : "ISO-8601 duration to wait between retries",
-    "value" : "PT30S",
+    "description" : "Number of retries",
+    "feel" : "optional",
     "group" : "retries",
+    "id" : "retryCount",
+    "label" : "Retries",
+    "type" : "String",
+    "value" : "3"
+  }, {
     "binding" : {
       "key" : "retryBackoff",
       "type" : "zeebe:taskHeader"
     },
-    "type" : "String"
-  }, {
-    "id" : "jobTimeout",
-    "label" : "Job timeout",
-    "description" : "ISO-8601 duration after which Zeebe considers this job timed out if not yet completed. Leave empty to use the default timeout",
-    "optional" : true,
+    "description" : "ISO-8601 duration to wait between retries",
     "group" : "retries",
+    "id" : "retryBackoff",
+    "label" : "Retry backoff",
+    "type" : "String",
+    "value" : "PT30S"
+  }, {
     "binding" : {
       "key" : "jobTimeout",
       "type" : "zeebe:taskHeader"
     },
+    "description" : "ISO-8601 duration after which Zeebe considers this job timed out if not yet completed. Leave empty to use the default timeout",
+    "group" : "retries",
+    "id" : "jobTimeout",
+    "label" : "Job timeout",
+    "optional" : true,
     "type" : "String"
   } ],
   "steps" : [ {

--- a/connectors/google/google-sheets/element-templates/google-sheets-outbound-connector.json
+++ b/connectors/google/google-sheets/element-templates/google-sheets-outbound-connector.json
@@ -40,22 +40,17 @@
     "label" : "Retries"
   } ],
   "properties" : [ {
-    "value" : "io.camunda:google-sheets:1",
     "binding" : {
       "property" : "type",
       "type" : "zeebe:taskDefinition"
     },
-    "type" : "Hidden"
+    "type" : "Hidden",
+    "value" : "io.camunda:google-sheets:1"
   }, {
-    "id" : "operation.type",
-    "label" : "Input",
-    "value" : "createSpreadsheet",
-    "group" : "operation",
     "binding" : {
       "name" : "operation.type",
       "type" : "zeebe:input"
     },
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "Create spreadsheet",
       "value" : "createSpreadsheet"
@@ -86,37 +81,34 @@
     }, {
       "name" : "Get worksheet data",
       "value" : "getWorksheetData"
-    } ]
+    } ],
+    "group" : "operation",
+    "id" : "operation.type",
+    "label" : "Input",
+    "type" : "Dropdown",
+    "value" : "createSpreadsheet"
   }, {
-    "id" : "authentication.authType",
-    "label" : "Type",
-    "optional" : false,
-    "value" : "refresh",
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "group" : "authentication",
     "binding" : {
       "name" : "authentication.authType",
       "type" : "zeebe:input"
     },
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "Bearer token",
       "value" : "bearer"
     }, {
       "name" : "Refresh token",
       "value" : "refresh"
-    } ]
-  }, {
-    "id" : "authentication.bearerToken",
-    "label" : "Bearer token",
-    "optional" : false,
+    } ],
     "constraints" : {
       "notEmpty" : true
     },
-    "feel" : "optional",
     "group" : "authentication",
+    "id" : "authentication.authType",
+    "label" : "Type",
+    "optional" : false,
+    "type" : "Dropdown",
+    "value" : "refresh"
+  }, {
     "binding" : {
       "name" : "authentication.bearerToken",
       "type" : "zeebe:input"
@@ -126,16 +118,16 @@
       "equals" : "bearer",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "authentication.oauthClientId",
-    "label" : "Client ID",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "authentication",
+    "id" : "authentication.bearerToken",
+    "label" : "Bearer token",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "authentication.oauthClientId",
       "type" : "zeebe:input"
@@ -145,16 +137,16 @@
       "equals" : "refresh",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "authentication.oauthClientSecret",
-    "label" : "Client secret",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "authentication",
+    "id" : "authentication.oauthClientId",
+    "label" : "Client ID",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "authentication.oauthClientSecret",
       "type" : "zeebe:input"
@@ -164,16 +156,16 @@
       "equals" : "refresh",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "authentication.oauthRefreshToken",
-    "label" : "Refresh token",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "authentication",
+    "id" : "authentication.oauthClientSecret",
+    "label" : "Client secret",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "authentication.oauthRefreshToken",
       "type" : "zeebe:input"
@@ -183,16 +175,16 @@
       "equals" : "refresh",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "createSpreadsheet.spreadsheetName",
-    "label" : "Spreadsheet name",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
-    "group" : "operationDetails",
+    "group" : "authentication",
+    "id" : "authentication.oauthRefreshToken",
+    "label" : "Refresh token",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "operation.spreadsheetName",
       "type" : "zeebe:input"
@@ -202,13 +194,16 @@
       "equals" : "createSpreadsheet",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "parent",
-    "label" : "Parent folder ID",
-    "optional" : true,
+    "constraints" : {
+      "notEmpty" : true
+    },
     "feel" : "optional",
     "group" : "operationDetails",
+    "id" : "createSpreadsheet.spreadsheetName",
+    "label" : "Spreadsheet name",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "operation.parent",
       "type" : "zeebe:input"
@@ -218,17 +213,14 @@
       "equals" : "createSpreadsheet",
       "type" : "simple"
     },
+    "feel" : "optional",
+    "group" : "operationDetails",
+    "id" : "parent",
+    "label" : "Parent folder ID",
+    "optional" : true,
     "tooltip" : "Folder in which the new spreadsheet is created. If left empty, it is created in the Google Drive root folder of the OAuth token owner.",
     "type" : "String"
   }, {
-    "id" : "addValues.spreadsheetId",
-    "label" : "Spreadsheet ID",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "feel" : "optional",
-    "group" : "operationDetails",
     "binding" : {
       "name" : "operation.spreadsheetId",
       "type" : "zeebe:input"
@@ -238,16 +230,16 @@
       "equals" : "addValues",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "addValues.worksheetName",
-    "label" : "Worksheet name",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "operationDetails",
+    "id" : "addValues.spreadsheetId",
+    "label" : "Spreadsheet ID",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "operation.worksheetName",
       "type" : "zeebe:input"
@@ -257,16 +249,16 @@
       "equals" : "addValues",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "cellId",
-    "label" : "Cell ID",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "operationDetails",
+    "id" : "addValues.worksheetName",
+    "label" : "Worksheet name",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "operation.cellId",
       "type" : "zeebe:input"
@@ -276,18 +268,18 @@
       "equals" : "addValues",
       "type" : "simple"
     },
-    "tooltip" : "Target cell in ColumnRow format. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-sheets/#add-values-to-spreadsheet\" target=\"_blank\">add values to spreadsheet</a> operation.",
-    "placeholder" : "A1",
-    "type" : "String"
-  }, {
-    "id" : "value",
-    "label" : "Value",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "operationDetails",
+    "id" : "cellId",
+    "label" : "Cell ID",
+    "optional" : false,
+    "placeholder" : "A1",
+    "tooltip" : "Target cell in ColumnRow format. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-sheets/#add-values-to-spreadsheet\" target=\"_blank\">add values to spreadsheet</a> operation.",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "operation.value",
       "type" : "zeebe:input"
@@ -297,16 +289,16 @@
       "equals" : "addValues",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "createEmptyColumnOrRow.spreadsheetId",
-    "label" : "Spreadsheet ID",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "operationDetails",
+    "id" : "value",
+    "label" : "Value",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "operation.spreadsheetId",
       "type" : "zeebe:input"
@@ -316,16 +308,16 @@
       "equals" : "createEmptyColumnOrRow",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "createEmptyColumnOrRow.worksheetId",
-    "label" : "Worksheet ID",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "operationDetails",
+    "id" : "createEmptyColumnOrRow.spreadsheetId",
+    "label" : "Spreadsheet ID",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "operation.worksheetId",
       "type" : "zeebe:input"
@@ -335,39 +327,42 @@
       "equals" : "createEmptyColumnOrRow",
       "type" : "simple"
     },
-    "type" : "Number"
-  }, {
-    "id" : "dimension",
-    "label" : "Dimension",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
+    "feel" : "optional",
     "group" : "operationDetails",
+    "id" : "createEmptyColumnOrRow.worksheetId",
+    "label" : "Worksheet ID",
+    "optional" : false,
+    "type" : "Number"
+  }, {
     "binding" : {
       "name" : "operation.dimension",
       "type" : "zeebe:input"
     },
-    "condition" : {
-      "property" : "operation.type",
-      "equals" : "createEmptyColumnOrRow",
-      "type" : "simple"
-    },
-    "tooltip" : "What to add: column or row",
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "ROWS",
       "value" : "ROWS"
     }, {
       "name" : "COLUMNS",
       "value" : "COLUMNS"
-    } ]
-  }, {
-    "id" : "startIndex",
-    "label" : "Start index",
-    "optional" : false,
-    "feel" : "optional",
+    } ],
+    "condition" : {
+      "property" : "operation.type",
+      "equals" : "createEmptyColumnOrRow",
+      "type" : "simple"
+    },
+    "constraints" : {
+      "notEmpty" : true
+    },
     "group" : "operationDetails",
+    "id" : "dimension",
+    "label" : "Dimension",
+    "optional" : false,
+    "tooltip" : "What to add: column or row",
+    "type" : "Dropdown"
+  }, {
     "binding" : {
       "name" : "operation.startIndex",
       "type" : "zeebe:input"
@@ -377,14 +372,14 @@
       "equals" : "createEmptyColumnOrRow",
       "type" : "simple"
     },
+    "feel" : "optional",
+    "group" : "operationDetails",
+    "id" : "startIndex",
+    "label" : "Start index",
+    "optional" : false,
     "tooltip" : "Leave empty to add to the end of the sheet. Count starts from 0. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-sheets/#create-empty-column-or-row\" target=\"_blank\">create empty column or row</a> operation.",
     "type" : "Number"
   }, {
-    "id" : "endIndex",
-    "label" : "End index",
-    "optional" : false,
-    "feel" : "optional",
-    "group" : "operationDetails",
     "binding" : {
       "name" : "operation.endIndex",
       "type" : "zeebe:input"
@@ -394,17 +389,14 @@
       "equals" : "createEmptyColumnOrRow",
       "type" : "simple"
     },
+    "feel" : "optional",
+    "group" : "operationDetails",
+    "id" : "endIndex",
+    "label" : "End index",
+    "optional" : false,
     "tooltip" : "Leave empty to add to the end of the sheet. Count starts from 0. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-sheets/#create-empty-column-or-row\" target=\"_blank\">create empty column or row</a> operation.",
     "type" : "Number"
   }, {
-    "id" : "createRow.spreadsheetId",
-    "label" : "Spreadsheet ID",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "feel" : "optional",
-    "group" : "operationDetails",
     "binding" : {
       "name" : "operation.spreadsheetId",
       "type" : "zeebe:input"
@@ -414,16 +406,16 @@
       "equals" : "createRow",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "createRow.worksheetName",
-    "label" : "Worksheet name",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "operationDetails",
+    "id" : "createRow.spreadsheetId",
+    "label" : "Spreadsheet ID",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "operation.worksheetName",
       "type" : "zeebe:input"
@@ -433,20 +425,16 @@
       "equals" : "createRow",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "createRow.rowIndex",
-    "label" : "Row index",
-    "optional" : true,
     "constraints" : {
-      "notEmpty" : false,
-      "pattern" : {
-        "value" : "^(=.*|[0-9]+|)$",
-        "message" : "Must be a number"
-      }
+      "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "operationDetails",
+    "id" : "createRow.worksheetName",
+    "label" : "Worksheet name",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "operation.rowIndex",
       "type" : "zeebe:input"
@@ -456,17 +444,21 @@
       "equals" : "createRow",
       "type" : "simple"
     },
+    "constraints" : {
+      "notEmpty" : false,
+      "pattern" : {
+        "value" : "^(=.*|[0-9]+|)$",
+        "message" : "Must be a number"
+      }
+    },
+    "feel" : "optional",
+    "group" : "operationDetails",
+    "id" : "createRow.rowIndex",
+    "label" : "Row index",
+    "optional" : true,
     "tooltip" : "Position of the row, shown to the left of each row. If left empty, a new row is appended to the end. See <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-sheets/#what-is-a-row-index\" target=\"_blank\">what is a row index</a>.",
     "type" : "Number"
   }, {
-    "id" : "values",
-    "label" : "Enter values",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "feel" : "required",
-    "group" : "operationDetails",
     "binding" : {
       "name" : "operation.values",
       "type" : "zeebe:input"
@@ -476,17 +468,17 @@
       "equals" : "createRow",
       "type" : "simple"
     },
-    "tooltip" : "List of cell values to add as a new row. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-sheets/#create-row\" target=\"_blank\">create row</a> operation.",
-    "type" : "String"
-  }, {
-    "id" : "createWorksheet.spreadsheetId",
-    "label" : "Spreadsheet ID",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
-    "feel" : "optional",
+    "feel" : "required",
     "group" : "operationDetails",
+    "id" : "values",
+    "label" : "Enter values",
+    "optional" : false,
+    "tooltip" : "List of cell values to add as a new row. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-sheets/#create-row\" target=\"_blank\">create row</a> operation.",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "operation.spreadsheetId",
       "type" : "zeebe:input"
@@ -496,16 +488,16 @@
       "equals" : "createWorksheet",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "createWorksheet.worksheetName",
-    "label" : "Worksheet name",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "operationDetails",
+    "id" : "createWorksheet.spreadsheetId",
+    "label" : "Spreadsheet ID",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "operation.worksheetName",
       "type" : "zeebe:input"
@@ -515,13 +507,16 @@
       "equals" : "createWorksheet",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "worksheetIndex",
-    "label" : "Worksheet index",
-    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
     "feel" : "optional",
     "group" : "operationDetails",
+    "id" : "createWorksheet.worksheetName",
+    "label" : "Worksheet name",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "operation.worksheetIndex",
       "type" : "zeebe:input"
@@ -531,17 +526,14 @@
       "equals" : "createWorksheet",
       "type" : "simple"
     },
+    "feel" : "optional",
+    "group" : "operationDetails",
+    "id" : "worksheetIndex",
+    "label" : "Worksheet index",
+    "optional" : false,
     "tooltip" : "Position of the new worksheet; count starts from 0. Leave empty to add it to the end of the sheet list. See <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-sheets/#what-is-a-worksheet-index\" target=\"_blank\">what is a worksheet index</a>.",
     "type" : "Number"
   }, {
-    "id" : "deleteColumn.spreadsheetId",
-    "label" : "Spreadsheet ID",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "feel" : "optional",
-    "group" : "operationDetails",
     "binding" : {
       "name" : "operation.spreadsheetId",
       "type" : "zeebe:input"
@@ -551,16 +543,16 @@
       "equals" : "deleteColumn",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "deleteColumn.worksheetId",
-    "label" : "Worksheet ID",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "operationDetails",
+    "id" : "deleteColumn.spreadsheetId",
+    "label" : "Spreadsheet ID",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "operation.worksheetId",
       "type" : "zeebe:input"
@@ -570,40 +562,43 @@
       "equals" : "deleteColumn",
       "type" : "simple"
     },
-    "type" : "Number"
-  }, {
-    "id" : "columnIndexType",
-    "label" : "Index format",
-    "optional" : false,
-    "value" : "NUMBERS",
     "constraints" : {
       "notEmpty" : true
     },
+    "feel" : "optional",
     "group" : "operationDetails",
+    "id" : "deleteColumn.worksheetId",
+    "label" : "Worksheet ID",
+    "optional" : false,
+    "type" : "Number"
+  }, {
     "binding" : {
       "name" : "operation.columnIndexType",
       "type" : "zeebe:input"
     },
-    "condition" : {
-      "property" : "operation.type",
-      "equals" : "deleteColumn",
-      "type" : "simple"
-    },
-    "tooltip" : "How the column to delete is identified: Numbers (numeric index at the top of the column, starting from 0) or Letters (the column letter). See <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-sheets/#how-can-i-define-which-column-will-be-deleted\" target=\"_blank\">defining which column will be deleted</a>.",
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "Numbers",
       "value" : "NUMBERS"
     }, {
       "name" : "Letters",
       "value" : "LETTERS"
-    } ]
-  }, {
-    "id" : "columnNumberIndex",
-    "label" : "Column numeric index",
-    "optional" : false,
-    "feel" : "optional",
+    } ],
+    "condition" : {
+      "property" : "operation.type",
+      "equals" : "deleteColumn",
+      "type" : "simple"
+    },
+    "constraints" : {
+      "notEmpty" : true
+    },
     "group" : "operationDetails",
+    "id" : "columnIndexType",
+    "label" : "Index format",
+    "optional" : false,
+    "tooltip" : "How the column to delete is identified: Numbers (numeric index at the top of the column, starting from 0) or Letters (the column letter). See <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-sheets/#how-can-i-define-which-column-will-be-deleted\" target=\"_blank\">defining which column will be deleted</a>.",
+    "type" : "Dropdown",
+    "value" : "NUMBERS"
+  }, {
     "binding" : {
       "name" : "operation.columnNumberIndex",
       "type" : "zeebe:input"
@@ -619,14 +614,14 @@
         "type" : "simple"
       } ]
     },
+    "feel" : "optional",
+    "group" : "operationDetails",
+    "id" : "columnNumberIndex",
+    "label" : "Column numeric index",
+    "optional" : false,
     "tooltip" : "Numeric position of the column to delete; count starts from 0 (column A is 0, B is 1). See <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-sheets/#how-can-i-define-which-column-will-be-deleted\" target=\"_blank\">defining which column will be deleted</a>.",
     "type" : "Number"
   }, {
-    "id" : "columnLetterIndex",
-    "label" : "Column letter index",
-    "optional" : false,
-    "feel" : "optional",
-    "group" : "operationDetails",
     "binding" : {
       "name" : "operation.columnLetterIndex",
       "type" : "zeebe:input"
@@ -642,18 +637,15 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "Letter of the column to delete, as shown at the top of the column. See <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-sheets/#how-can-i-define-which-column-will-be-deleted\" target=\"_blank\">defining which column will be deleted</a>.",
-    "placeholder" : "A",
-    "type" : "String"
-  }, {
-    "id" : "deleteWorksheet.spreadsheetId",
-    "label" : "Spreadsheet ID",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
     "feel" : "optional",
     "group" : "operationDetails",
+    "id" : "columnLetterIndex",
+    "label" : "Column letter index",
+    "optional" : false,
+    "placeholder" : "A",
+    "tooltip" : "Letter of the column to delete, as shown at the top of the column. See <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-sheets/#how-can-i-define-which-column-will-be-deleted\" target=\"_blank\">defining which column will be deleted</a>.",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "operation.spreadsheetId",
       "type" : "zeebe:input"
@@ -663,16 +655,16 @@
       "equals" : "deleteWorksheet",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "deleteWorksheet.worksheetId",
-    "label" : "Worksheet ID",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "operationDetails",
+    "id" : "deleteWorksheet.spreadsheetId",
+    "label" : "Spreadsheet ID",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "operation.worksheetId",
       "type" : "zeebe:input"
@@ -682,16 +674,16 @@
       "equals" : "deleteWorksheet",
       "type" : "simple"
     },
-    "type" : "Number"
-  }, {
-    "id" : "getRowByIndex.spreadsheetId",
-    "label" : "Spreadsheet ID",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "operationDetails",
+    "id" : "deleteWorksheet.worksheetId",
+    "label" : "Worksheet ID",
+    "optional" : false,
+    "type" : "Number"
+  }, {
     "binding" : {
       "name" : "operation.spreadsheetId",
       "type" : "zeebe:input"
@@ -701,13 +693,16 @@
       "equals" : "getRowByIndex",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "getRowByIndex.worksheetName",
-    "label" : "Worksheet name",
-    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
     "feel" : "optional",
     "group" : "operationDetails",
+    "id" : "getRowByIndex.spreadsheetId",
+    "label" : "Spreadsheet ID",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "operation.worksheetName",
       "type" : "zeebe:input"
@@ -717,16 +712,13 @@
       "equals" : "getRowByIndex",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "getRowByIndex.rowIndex",
-    "label" : "Row index",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
     "feel" : "optional",
     "group" : "operationDetails",
+    "id" : "getRowByIndex.worksheetName",
+    "label" : "Worksheet name",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "operation.rowIndex",
       "type" : "zeebe:input"
@@ -736,17 +728,17 @@
       "equals" : "getRowByIndex",
       "type" : "simple"
     },
-    "tooltip" : "Position of the row to retrieve, shown to the left of each row. See <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-sheets/#what-is-a-row-index\" target=\"_blank\">what is a row index</a>.",
-    "type" : "Number"
-  }, {
-    "id" : "spreadsheetsDetails.spreadsheetId",
-    "label" : "Spreadsheet ID",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "operationDetails",
+    "id" : "getRowByIndex.rowIndex",
+    "label" : "Row index",
+    "optional" : false,
+    "tooltip" : "Position of the row to retrieve, shown to the left of each row. See <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-sheets/#what-is-a-row-index\" target=\"_blank\">what is a row index</a>.",
+    "type" : "Number"
+  }, {
     "binding" : {
       "name" : "operation.spreadsheetId",
       "type" : "zeebe:input"
@@ -756,16 +748,16 @@
       "equals" : "spreadsheetsDetails",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "getWorksheetData.spreadsheetId",
-    "label" : "Spreadsheet ID",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "operationDetails",
+    "id" : "spreadsheetsDetails.spreadsheetId",
+    "label" : "Spreadsheet ID",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "operation.spreadsheetId",
       "type" : "zeebe:input"
@@ -775,16 +767,16 @@
       "equals" : "getWorksheetData",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "getWorksheetData.worksheetName",
-    "label" : "Worksheet name",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "operationDetails",
+    "id" : "getWorksheetData.spreadsheetId",
+    "label" : "Spreadsheet ID",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "operation.worksheetName",
       "type" : "zeebe:input"
@@ -794,94 +786,102 @@
       "equals" : "getWorksheetData",
       "type" : "simple"
     },
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "operationDetails",
+    "id" : "getWorksheetData.worksheetName",
+    "label" : "Worksheet name",
+    "optional" : false,
     "type" : "String"
   }, {
-    "id" : "version",
-    "label" : "Version",
-    "description" : "Version of the element template",
-    "value" : "7",
-    "group" : "connector",
     "binding" : {
       "key" : "elementTemplateVersion",
       "type" : "zeebe:taskHeader"
     },
-    "type" : "Hidden"
-  }, {
-    "id" : "id",
-    "label" : "ID",
-    "description" : "ID of the element template",
-    "value" : "io.camunda.connectors.GoogleSheets.v1",
+    "description" : "Version of the element template",
     "group" : "connector",
+    "id" : "version",
+    "label" : "Version",
+    "type" : "Hidden",
+    "value" : "7"
+  }, {
     "binding" : {
       "key" : "elementTemplateId",
       "type" : "zeebe:taskHeader"
     },
-    "type" : "Hidden"
+    "description" : "ID of the element template",
+    "group" : "connector",
+    "id" : "id",
+    "label" : "ID",
+    "type" : "Hidden",
+    "value" : "io.camunda.connectors.GoogleSheets.v1"
   }, {
-    "id" : "resultVariable",
-    "label" : "Result variable",
-    "description" : "Name of variable to store the response in. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-variable\" target=\"_blank\">documentation</a>.",
-    "group" : "output",
     "binding" : {
       "key" : "resultVariable",
       "type" : "zeebe:taskHeader"
     },
+    "description" : "Name of variable to store the response in. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-variable\" target=\"_blank\">documentation</a>.",
+    "group" : "output",
+    "id" : "resultVariable",
+    "label" : "Result variable",
     "type" : "String"
   }, {
-    "id" : "resultExpression",
-    "label" : "Result expression",
-    "description" : "Expression to map the response into process variables. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-expression\" target=\"_blank\">documentation</a>.",
-    "feel" : "required",
-    "group" : "output",
     "binding" : {
       "key" : "resultExpression",
       "type" : "zeebe:taskHeader"
     },
+    "description" : "Expression to map the response into process variables. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-expression\" target=\"_blank\">documentation</a>.",
+    "feel" : "required",
+    "group" : "output",
+    "id" : "resultExpression",
+    "label" : "Result expression",
     "type" : "Text"
   }, {
-    "id" : "errorExpression",
-    "label" : "Error expression",
-    "description" : "Expression to handle errors. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/\" target=\"_blank\">documentation</a>.",
-    "feel" : "required",
-    "group" : "error",
     "binding" : {
       "key" : "errorExpression",
       "type" : "zeebe:taskHeader"
     },
+    "description" : "Expression to handle errors. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/\" target=\"_blank\">documentation</a>.",
+    "feel" : "required",
+    "group" : "error",
+    "id" : "errorExpression",
+    "label" : "Error expression",
     "type" : "Text"
   }, {
-    "id" : "retryCount",
-    "label" : "Retries",
-    "description" : "Number of retries",
-    "value" : "3",
-    "feel" : "optional",
-    "group" : "retries",
     "binding" : {
       "property" : "retries",
       "type" : "zeebe:taskDefinition"
     },
-    "type" : "String"
-  }, {
-    "id" : "retryBackoff",
-    "label" : "Retry backoff",
-    "description" : "ISO-8601 duration to wait between retries",
-    "value" : "PT30S",
+    "description" : "Number of retries",
+    "feel" : "optional",
     "group" : "retries",
+    "id" : "retryCount",
+    "label" : "Retries",
+    "type" : "String",
+    "value" : "3"
+  }, {
     "binding" : {
       "key" : "retryBackoff",
       "type" : "zeebe:taskHeader"
     },
-    "type" : "String"
-  }, {
-    "id" : "jobTimeout",
-    "label" : "Job timeout",
-    "description" : "ISO-8601 duration after which Zeebe considers this job timed out if not yet completed. Leave empty to use the default timeout",
-    "optional" : true,
+    "description" : "ISO-8601 duration to wait between retries",
     "group" : "retries",
+    "id" : "retryBackoff",
+    "label" : "Retry backoff",
+    "type" : "String",
+    "value" : "PT30S"
+  }, {
     "binding" : {
       "key" : "jobTimeout",
       "type" : "zeebe:taskHeader"
     },
+    "description" : "ISO-8601 duration after which Zeebe considers this job timed out if not yet completed. Leave empty to use the default timeout",
+    "group" : "retries",
+    "id" : "jobTimeout",
+    "label" : "Job timeout",
+    "optional" : true,
     "type" : "String"
   } ],
   "steps" : [ {

--- a/connectors/google/google-sheets/element-templates/hybrid/google-sheets-outbound-connector-hybrid.json
+++ b/connectors/google/google-sheets/element-templates/hybrid/google-sheets-outbound-connector-hybrid.json
@@ -43,24 +43,19 @@
     "label" : "Retries"
   } ],
   "properties" : [ {
-    "id" : "taskDefinitionType",
-    "value" : "io.camunda:google-sheets:1",
-    "group" : "taskDefinitionType",
     "binding" : {
       "property" : "type",
       "type" : "zeebe:taskDefinition"
     },
-    "type" : "String"
+    "group" : "taskDefinitionType",
+    "id" : "taskDefinitionType",
+    "type" : "String",
+    "value" : "io.camunda:google-sheets:1"
   }, {
-    "id" : "operation.type",
-    "label" : "Input",
-    "value" : "createSpreadsheet",
-    "group" : "operation",
     "binding" : {
       "name" : "operation.type",
       "type" : "zeebe:input"
     },
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "Create spreadsheet",
       "value" : "createSpreadsheet"
@@ -91,37 +86,34 @@
     }, {
       "name" : "Get worksheet data",
       "value" : "getWorksheetData"
-    } ]
+    } ],
+    "group" : "operation",
+    "id" : "operation.type",
+    "label" : "Input",
+    "type" : "Dropdown",
+    "value" : "createSpreadsheet"
   }, {
-    "id" : "authentication.authType",
-    "label" : "Type",
-    "optional" : false,
-    "value" : "refresh",
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "group" : "authentication",
     "binding" : {
       "name" : "authentication.authType",
       "type" : "zeebe:input"
     },
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "Bearer token",
       "value" : "bearer"
     }, {
       "name" : "Refresh token",
       "value" : "refresh"
-    } ]
-  }, {
-    "id" : "authentication.bearerToken",
-    "label" : "Bearer token",
-    "optional" : false,
+    } ],
     "constraints" : {
       "notEmpty" : true
     },
-    "feel" : "optional",
     "group" : "authentication",
+    "id" : "authentication.authType",
+    "label" : "Type",
+    "optional" : false,
+    "type" : "Dropdown",
+    "value" : "refresh"
+  }, {
     "binding" : {
       "name" : "authentication.bearerToken",
       "type" : "zeebe:input"
@@ -131,16 +123,16 @@
       "equals" : "bearer",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "authentication.oauthClientId",
-    "label" : "Client ID",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "authentication",
+    "id" : "authentication.bearerToken",
+    "label" : "Bearer token",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "authentication.oauthClientId",
       "type" : "zeebe:input"
@@ -150,16 +142,16 @@
       "equals" : "refresh",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "authentication.oauthClientSecret",
-    "label" : "Client secret",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "authentication",
+    "id" : "authentication.oauthClientId",
+    "label" : "Client ID",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "authentication.oauthClientSecret",
       "type" : "zeebe:input"
@@ -169,16 +161,16 @@
       "equals" : "refresh",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "authentication.oauthRefreshToken",
-    "label" : "Refresh token",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "authentication",
+    "id" : "authentication.oauthClientSecret",
+    "label" : "Client secret",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "authentication.oauthRefreshToken",
       "type" : "zeebe:input"
@@ -188,16 +180,16 @@
       "equals" : "refresh",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "createSpreadsheet.spreadsheetName",
-    "label" : "Spreadsheet name",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
-    "group" : "operationDetails",
+    "group" : "authentication",
+    "id" : "authentication.oauthRefreshToken",
+    "label" : "Refresh token",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "operation.spreadsheetName",
       "type" : "zeebe:input"
@@ -207,13 +199,16 @@
       "equals" : "createSpreadsheet",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "parent",
-    "label" : "Parent folder ID",
-    "optional" : true,
+    "constraints" : {
+      "notEmpty" : true
+    },
     "feel" : "optional",
     "group" : "operationDetails",
+    "id" : "createSpreadsheet.spreadsheetName",
+    "label" : "Spreadsheet name",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "operation.parent",
       "type" : "zeebe:input"
@@ -223,17 +218,14 @@
       "equals" : "createSpreadsheet",
       "type" : "simple"
     },
+    "feel" : "optional",
+    "group" : "operationDetails",
+    "id" : "parent",
+    "label" : "Parent folder ID",
+    "optional" : true,
     "tooltip" : "Folder in which the new spreadsheet is created. If left empty, it is created in the Google Drive root folder of the OAuth token owner.",
     "type" : "String"
   }, {
-    "id" : "addValues.spreadsheetId",
-    "label" : "Spreadsheet ID",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "feel" : "optional",
-    "group" : "operationDetails",
     "binding" : {
       "name" : "operation.spreadsheetId",
       "type" : "zeebe:input"
@@ -243,16 +235,16 @@
       "equals" : "addValues",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "addValues.worksheetName",
-    "label" : "Worksheet name",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "operationDetails",
+    "id" : "addValues.spreadsheetId",
+    "label" : "Spreadsheet ID",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "operation.worksheetName",
       "type" : "zeebe:input"
@@ -262,16 +254,16 @@
       "equals" : "addValues",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "cellId",
-    "label" : "Cell ID",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "operationDetails",
+    "id" : "addValues.worksheetName",
+    "label" : "Worksheet name",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "operation.cellId",
       "type" : "zeebe:input"
@@ -281,18 +273,18 @@
       "equals" : "addValues",
       "type" : "simple"
     },
-    "tooltip" : "Target cell in ColumnRow format. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-sheets/#add-values-to-spreadsheet\" target=\"_blank\">add values to spreadsheet</a> operation.",
-    "placeholder" : "A1",
-    "type" : "String"
-  }, {
-    "id" : "value",
-    "label" : "Value",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "operationDetails",
+    "id" : "cellId",
+    "label" : "Cell ID",
+    "optional" : false,
+    "placeholder" : "A1",
+    "tooltip" : "Target cell in ColumnRow format. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-sheets/#add-values-to-spreadsheet\" target=\"_blank\">add values to spreadsheet</a> operation.",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "operation.value",
       "type" : "zeebe:input"
@@ -302,16 +294,16 @@
       "equals" : "addValues",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "createEmptyColumnOrRow.spreadsheetId",
-    "label" : "Spreadsheet ID",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "operationDetails",
+    "id" : "value",
+    "label" : "Value",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "operation.spreadsheetId",
       "type" : "zeebe:input"
@@ -321,16 +313,16 @@
       "equals" : "createEmptyColumnOrRow",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "createEmptyColumnOrRow.worksheetId",
-    "label" : "Worksheet ID",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "operationDetails",
+    "id" : "createEmptyColumnOrRow.spreadsheetId",
+    "label" : "Spreadsheet ID",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "operation.worksheetId",
       "type" : "zeebe:input"
@@ -340,39 +332,42 @@
       "equals" : "createEmptyColumnOrRow",
       "type" : "simple"
     },
-    "type" : "Number"
-  }, {
-    "id" : "dimension",
-    "label" : "Dimension",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
+    "feel" : "optional",
     "group" : "operationDetails",
+    "id" : "createEmptyColumnOrRow.worksheetId",
+    "label" : "Worksheet ID",
+    "optional" : false,
+    "type" : "Number"
+  }, {
     "binding" : {
       "name" : "operation.dimension",
       "type" : "zeebe:input"
     },
-    "condition" : {
-      "property" : "operation.type",
-      "equals" : "createEmptyColumnOrRow",
-      "type" : "simple"
-    },
-    "tooltip" : "What to add: column or row",
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "ROWS",
       "value" : "ROWS"
     }, {
       "name" : "COLUMNS",
       "value" : "COLUMNS"
-    } ]
-  }, {
-    "id" : "startIndex",
-    "label" : "Start index",
-    "optional" : false,
-    "feel" : "optional",
+    } ],
+    "condition" : {
+      "property" : "operation.type",
+      "equals" : "createEmptyColumnOrRow",
+      "type" : "simple"
+    },
+    "constraints" : {
+      "notEmpty" : true
+    },
     "group" : "operationDetails",
+    "id" : "dimension",
+    "label" : "Dimension",
+    "optional" : false,
+    "tooltip" : "What to add: column or row",
+    "type" : "Dropdown"
+  }, {
     "binding" : {
       "name" : "operation.startIndex",
       "type" : "zeebe:input"
@@ -382,14 +377,14 @@
       "equals" : "createEmptyColumnOrRow",
       "type" : "simple"
     },
+    "feel" : "optional",
+    "group" : "operationDetails",
+    "id" : "startIndex",
+    "label" : "Start index",
+    "optional" : false,
     "tooltip" : "Leave empty to add to the end of the sheet. Count starts from 0. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-sheets/#create-empty-column-or-row\" target=\"_blank\">create empty column or row</a> operation.",
     "type" : "Number"
   }, {
-    "id" : "endIndex",
-    "label" : "End index",
-    "optional" : false,
-    "feel" : "optional",
-    "group" : "operationDetails",
     "binding" : {
       "name" : "operation.endIndex",
       "type" : "zeebe:input"
@@ -399,17 +394,14 @@
       "equals" : "createEmptyColumnOrRow",
       "type" : "simple"
     },
+    "feel" : "optional",
+    "group" : "operationDetails",
+    "id" : "endIndex",
+    "label" : "End index",
+    "optional" : false,
     "tooltip" : "Leave empty to add to the end of the sheet. Count starts from 0. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-sheets/#create-empty-column-or-row\" target=\"_blank\">create empty column or row</a> operation.",
     "type" : "Number"
   }, {
-    "id" : "createRow.spreadsheetId",
-    "label" : "Spreadsheet ID",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "feel" : "optional",
-    "group" : "operationDetails",
     "binding" : {
       "name" : "operation.spreadsheetId",
       "type" : "zeebe:input"
@@ -419,16 +411,16 @@
       "equals" : "createRow",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "createRow.worksheetName",
-    "label" : "Worksheet name",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "operationDetails",
+    "id" : "createRow.spreadsheetId",
+    "label" : "Spreadsheet ID",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "operation.worksheetName",
       "type" : "zeebe:input"
@@ -438,20 +430,16 @@
       "equals" : "createRow",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "createRow.rowIndex",
-    "label" : "Row index",
-    "optional" : true,
     "constraints" : {
-      "notEmpty" : false,
-      "pattern" : {
-        "value" : "^(=.*|[0-9]+|)$",
-        "message" : "Must be a number"
-      }
+      "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "operationDetails",
+    "id" : "createRow.worksheetName",
+    "label" : "Worksheet name",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "operation.rowIndex",
       "type" : "zeebe:input"
@@ -461,17 +449,21 @@
       "equals" : "createRow",
       "type" : "simple"
     },
+    "constraints" : {
+      "notEmpty" : false,
+      "pattern" : {
+        "value" : "^(=.*|[0-9]+|)$",
+        "message" : "Must be a number"
+      }
+    },
+    "feel" : "optional",
+    "group" : "operationDetails",
+    "id" : "createRow.rowIndex",
+    "label" : "Row index",
+    "optional" : true,
     "tooltip" : "Position of the row, shown to the left of each row. If left empty, a new row is appended to the end. See <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-sheets/#what-is-a-row-index\" target=\"_blank\">what is a row index</a>.",
     "type" : "Number"
   }, {
-    "id" : "values",
-    "label" : "Enter values",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "feel" : "required",
-    "group" : "operationDetails",
     "binding" : {
       "name" : "operation.values",
       "type" : "zeebe:input"
@@ -481,17 +473,17 @@
       "equals" : "createRow",
       "type" : "simple"
     },
-    "tooltip" : "List of cell values to add as a new row. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-sheets/#create-row\" target=\"_blank\">create row</a> operation.",
-    "type" : "String"
-  }, {
-    "id" : "createWorksheet.spreadsheetId",
-    "label" : "Spreadsheet ID",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
-    "feel" : "optional",
+    "feel" : "required",
     "group" : "operationDetails",
+    "id" : "values",
+    "label" : "Enter values",
+    "optional" : false,
+    "tooltip" : "List of cell values to add as a new row. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-sheets/#create-row\" target=\"_blank\">create row</a> operation.",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "operation.spreadsheetId",
       "type" : "zeebe:input"
@@ -501,16 +493,16 @@
       "equals" : "createWorksheet",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "createWorksheet.worksheetName",
-    "label" : "Worksheet name",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "operationDetails",
+    "id" : "createWorksheet.spreadsheetId",
+    "label" : "Spreadsheet ID",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "operation.worksheetName",
       "type" : "zeebe:input"
@@ -520,13 +512,16 @@
       "equals" : "createWorksheet",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "worksheetIndex",
-    "label" : "Worksheet index",
-    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
     "feel" : "optional",
     "group" : "operationDetails",
+    "id" : "createWorksheet.worksheetName",
+    "label" : "Worksheet name",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "operation.worksheetIndex",
       "type" : "zeebe:input"
@@ -536,17 +531,14 @@
       "equals" : "createWorksheet",
       "type" : "simple"
     },
+    "feel" : "optional",
+    "group" : "operationDetails",
+    "id" : "worksheetIndex",
+    "label" : "Worksheet index",
+    "optional" : false,
     "tooltip" : "Position of the new worksheet; count starts from 0. Leave empty to add it to the end of the sheet list. See <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-sheets/#what-is-a-worksheet-index\" target=\"_blank\">what is a worksheet index</a>.",
     "type" : "Number"
   }, {
-    "id" : "deleteColumn.spreadsheetId",
-    "label" : "Spreadsheet ID",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "feel" : "optional",
-    "group" : "operationDetails",
     "binding" : {
       "name" : "operation.spreadsheetId",
       "type" : "zeebe:input"
@@ -556,16 +548,16 @@
       "equals" : "deleteColumn",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "deleteColumn.worksheetId",
-    "label" : "Worksheet ID",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "operationDetails",
+    "id" : "deleteColumn.spreadsheetId",
+    "label" : "Spreadsheet ID",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "operation.worksheetId",
       "type" : "zeebe:input"
@@ -575,40 +567,43 @@
       "equals" : "deleteColumn",
       "type" : "simple"
     },
-    "type" : "Number"
-  }, {
-    "id" : "columnIndexType",
-    "label" : "Index format",
-    "optional" : false,
-    "value" : "NUMBERS",
     "constraints" : {
       "notEmpty" : true
     },
+    "feel" : "optional",
     "group" : "operationDetails",
+    "id" : "deleteColumn.worksheetId",
+    "label" : "Worksheet ID",
+    "optional" : false,
+    "type" : "Number"
+  }, {
     "binding" : {
       "name" : "operation.columnIndexType",
       "type" : "zeebe:input"
     },
-    "condition" : {
-      "property" : "operation.type",
-      "equals" : "deleteColumn",
-      "type" : "simple"
-    },
-    "tooltip" : "How the column to delete is identified: Numbers (numeric index at the top of the column, starting from 0) or Letters (the column letter). See <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-sheets/#how-can-i-define-which-column-will-be-deleted\" target=\"_blank\">defining which column will be deleted</a>.",
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "Numbers",
       "value" : "NUMBERS"
     }, {
       "name" : "Letters",
       "value" : "LETTERS"
-    } ]
-  }, {
-    "id" : "columnNumberIndex",
-    "label" : "Column numeric index",
-    "optional" : false,
-    "feel" : "optional",
+    } ],
+    "condition" : {
+      "property" : "operation.type",
+      "equals" : "deleteColumn",
+      "type" : "simple"
+    },
+    "constraints" : {
+      "notEmpty" : true
+    },
     "group" : "operationDetails",
+    "id" : "columnIndexType",
+    "label" : "Index format",
+    "optional" : false,
+    "tooltip" : "How the column to delete is identified: Numbers (numeric index at the top of the column, starting from 0) or Letters (the column letter). See <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-sheets/#how-can-i-define-which-column-will-be-deleted\" target=\"_blank\">defining which column will be deleted</a>.",
+    "type" : "Dropdown",
+    "value" : "NUMBERS"
+  }, {
     "binding" : {
       "name" : "operation.columnNumberIndex",
       "type" : "zeebe:input"
@@ -624,14 +619,14 @@
         "type" : "simple"
       } ]
     },
+    "feel" : "optional",
+    "group" : "operationDetails",
+    "id" : "columnNumberIndex",
+    "label" : "Column numeric index",
+    "optional" : false,
     "tooltip" : "Numeric position of the column to delete; count starts from 0 (column A is 0, B is 1). See <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-sheets/#how-can-i-define-which-column-will-be-deleted\" target=\"_blank\">defining which column will be deleted</a>.",
     "type" : "Number"
   }, {
-    "id" : "columnLetterIndex",
-    "label" : "Column letter index",
-    "optional" : false,
-    "feel" : "optional",
-    "group" : "operationDetails",
     "binding" : {
       "name" : "operation.columnLetterIndex",
       "type" : "zeebe:input"
@@ -647,18 +642,15 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "Letter of the column to delete, as shown at the top of the column. See <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-sheets/#how-can-i-define-which-column-will-be-deleted\" target=\"_blank\">defining which column will be deleted</a>.",
-    "placeholder" : "A",
-    "type" : "String"
-  }, {
-    "id" : "deleteWorksheet.spreadsheetId",
-    "label" : "Spreadsheet ID",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
     "feel" : "optional",
     "group" : "operationDetails",
+    "id" : "columnLetterIndex",
+    "label" : "Column letter index",
+    "optional" : false,
+    "placeholder" : "A",
+    "tooltip" : "Letter of the column to delete, as shown at the top of the column. See <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-sheets/#how-can-i-define-which-column-will-be-deleted\" target=\"_blank\">defining which column will be deleted</a>.",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "operation.spreadsheetId",
       "type" : "zeebe:input"
@@ -668,16 +660,16 @@
       "equals" : "deleteWorksheet",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "deleteWorksheet.worksheetId",
-    "label" : "Worksheet ID",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "operationDetails",
+    "id" : "deleteWorksheet.spreadsheetId",
+    "label" : "Spreadsheet ID",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "operation.worksheetId",
       "type" : "zeebe:input"
@@ -687,16 +679,16 @@
       "equals" : "deleteWorksheet",
       "type" : "simple"
     },
-    "type" : "Number"
-  }, {
-    "id" : "getRowByIndex.spreadsheetId",
-    "label" : "Spreadsheet ID",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "operationDetails",
+    "id" : "deleteWorksheet.worksheetId",
+    "label" : "Worksheet ID",
+    "optional" : false,
+    "type" : "Number"
+  }, {
     "binding" : {
       "name" : "operation.spreadsheetId",
       "type" : "zeebe:input"
@@ -706,13 +698,16 @@
       "equals" : "getRowByIndex",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "getRowByIndex.worksheetName",
-    "label" : "Worksheet name",
-    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
     "feel" : "optional",
     "group" : "operationDetails",
+    "id" : "getRowByIndex.spreadsheetId",
+    "label" : "Spreadsheet ID",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "operation.worksheetName",
       "type" : "zeebe:input"
@@ -722,16 +717,13 @@
       "equals" : "getRowByIndex",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "getRowByIndex.rowIndex",
-    "label" : "Row index",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
     "feel" : "optional",
     "group" : "operationDetails",
+    "id" : "getRowByIndex.worksheetName",
+    "label" : "Worksheet name",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "operation.rowIndex",
       "type" : "zeebe:input"
@@ -741,17 +733,17 @@
       "equals" : "getRowByIndex",
       "type" : "simple"
     },
-    "tooltip" : "Position of the row to retrieve, shown to the left of each row. See <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-sheets/#what-is-a-row-index\" target=\"_blank\">what is a row index</a>.",
-    "type" : "Number"
-  }, {
-    "id" : "spreadsheetsDetails.spreadsheetId",
-    "label" : "Spreadsheet ID",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "operationDetails",
+    "id" : "getRowByIndex.rowIndex",
+    "label" : "Row index",
+    "optional" : false,
+    "tooltip" : "Position of the row to retrieve, shown to the left of each row. See <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-sheets/#what-is-a-row-index\" target=\"_blank\">what is a row index</a>.",
+    "type" : "Number"
+  }, {
     "binding" : {
       "name" : "operation.spreadsheetId",
       "type" : "zeebe:input"
@@ -761,16 +753,16 @@
       "equals" : "spreadsheetsDetails",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "getWorksheetData.spreadsheetId",
-    "label" : "Spreadsheet ID",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "operationDetails",
+    "id" : "spreadsheetsDetails.spreadsheetId",
+    "label" : "Spreadsheet ID",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "operation.spreadsheetId",
       "type" : "zeebe:input"
@@ -780,16 +772,16 @@
       "equals" : "getWorksheetData",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "getWorksheetData.worksheetName",
-    "label" : "Worksheet name",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "operationDetails",
+    "id" : "getWorksheetData.spreadsheetId",
+    "label" : "Spreadsheet ID",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "operation.worksheetName",
       "type" : "zeebe:input"
@@ -799,94 +791,102 @@
       "equals" : "getWorksheetData",
       "type" : "simple"
     },
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "operationDetails",
+    "id" : "getWorksheetData.worksheetName",
+    "label" : "Worksheet name",
+    "optional" : false,
     "type" : "String"
   }, {
-    "id" : "version",
-    "label" : "Version",
-    "description" : "Version of the element template",
-    "value" : "7",
-    "group" : "connector",
     "binding" : {
       "key" : "elementTemplateVersion",
       "type" : "zeebe:taskHeader"
     },
-    "type" : "Hidden"
-  }, {
-    "id" : "id",
-    "label" : "ID",
-    "description" : "ID of the element template",
-    "value" : "io.camunda.connectors.GoogleSheets.v1",
+    "description" : "Version of the element template",
     "group" : "connector",
+    "id" : "version",
+    "label" : "Version",
+    "type" : "Hidden",
+    "value" : "7"
+  }, {
     "binding" : {
       "key" : "elementTemplateId",
       "type" : "zeebe:taskHeader"
     },
-    "type" : "Hidden"
+    "description" : "ID of the element template",
+    "group" : "connector",
+    "id" : "id",
+    "label" : "ID",
+    "type" : "Hidden",
+    "value" : "io.camunda.connectors.GoogleSheets.v1"
   }, {
-    "id" : "resultVariable",
-    "label" : "Result variable",
-    "description" : "Name of variable to store the response in. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-variable\" target=\"_blank\">documentation</a>.",
-    "group" : "output",
     "binding" : {
       "key" : "resultVariable",
       "type" : "zeebe:taskHeader"
     },
+    "description" : "Name of variable to store the response in. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-variable\" target=\"_blank\">documentation</a>.",
+    "group" : "output",
+    "id" : "resultVariable",
+    "label" : "Result variable",
     "type" : "String"
   }, {
-    "id" : "resultExpression",
-    "label" : "Result expression",
-    "description" : "Expression to map the response into process variables. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-expression\" target=\"_blank\">documentation</a>.",
-    "feel" : "required",
-    "group" : "output",
     "binding" : {
       "key" : "resultExpression",
       "type" : "zeebe:taskHeader"
     },
+    "description" : "Expression to map the response into process variables. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-expression\" target=\"_blank\">documentation</a>.",
+    "feel" : "required",
+    "group" : "output",
+    "id" : "resultExpression",
+    "label" : "Result expression",
     "type" : "Text"
   }, {
-    "id" : "errorExpression",
-    "label" : "Error expression",
-    "description" : "Expression to handle errors. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/\" target=\"_blank\">documentation</a>.",
-    "feel" : "required",
-    "group" : "error",
     "binding" : {
       "key" : "errorExpression",
       "type" : "zeebe:taskHeader"
     },
+    "description" : "Expression to handle errors. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/\" target=\"_blank\">documentation</a>.",
+    "feel" : "required",
+    "group" : "error",
+    "id" : "errorExpression",
+    "label" : "Error expression",
     "type" : "Text"
   }, {
-    "id" : "retryCount",
-    "label" : "Retries",
-    "description" : "Number of retries",
-    "value" : "3",
-    "feel" : "optional",
-    "group" : "retries",
     "binding" : {
       "property" : "retries",
       "type" : "zeebe:taskDefinition"
     },
-    "type" : "String"
-  }, {
-    "id" : "retryBackoff",
-    "label" : "Retry backoff",
-    "description" : "ISO-8601 duration to wait between retries",
-    "value" : "PT30S",
+    "description" : "Number of retries",
+    "feel" : "optional",
     "group" : "retries",
+    "id" : "retryCount",
+    "label" : "Retries",
+    "type" : "String",
+    "value" : "3"
+  }, {
     "binding" : {
       "key" : "retryBackoff",
       "type" : "zeebe:taskHeader"
     },
-    "type" : "String"
-  }, {
-    "id" : "jobTimeout",
-    "label" : "Job timeout",
-    "description" : "ISO-8601 duration after which Zeebe considers this job timed out if not yet completed. Leave empty to use the default timeout",
-    "optional" : true,
+    "description" : "ISO-8601 duration to wait between retries",
     "group" : "retries",
+    "id" : "retryBackoff",
+    "label" : "Retry backoff",
+    "type" : "String",
+    "value" : "PT30S"
+  }, {
     "binding" : {
       "key" : "jobTimeout",
       "type" : "zeebe:taskHeader"
     },
+    "description" : "ISO-8601 duration after which Zeebe considers this job timed out if not yet completed. Leave empty to use the default timeout",
+    "group" : "retries",
+    "id" : "jobTimeout",
+    "label" : "Job timeout",
+    "optional" : true,
     "type" : "String"
   } ],
   "steps" : [ {

--- a/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/HttpCommonResultMapper.java
+++ b/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/HttpCommonResultMapper.java
@@ -8,7 +8,6 @@ package io.camunda.connector.http.base;
 
 import static io.camunda.connector.http.client.utils.JsonHelper.isJsonStringValid;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.connector.api.document.DocumentCreationRequest;
 import io.camunda.connector.api.document.DocumentFactory;
 import io.camunda.connector.http.base.model.HttpCommonResult;
@@ -24,6 +23,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.hc.core5.http.HttpHeaders;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import tools.jackson.databind.ObjectMapper;
 
 /**
  * Maps a {@link StreamingHttpResponse} to a {@link HttpCommonResult}. If the option to store the

--- a/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/HttpService.java
+++ b/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/HttpService.java
@@ -6,7 +6,6 @@
  */
 package io.camunda.connector.http.base;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.connector.api.document.Document;
 import io.camunda.connector.api.document.DocumentFactory;
 import io.camunda.connector.api.document.DocumentReturn;
@@ -24,6 +23,7 @@ import io.camunda.connector.http.client.utils.HttpStatusHelper;
 import io.camunda.connector.jackson.ConnectorsObjectMapperSupplier;
 import java.util.Optional;
 import org.apache.hc.core5.http.HttpHeaders;
+import tools.jackson.databind.ObjectMapper;
 
 public class HttpService {
 

--- a/connectors/http/http-base/src/test/java/io/camunda/connector/http/base/HttpServiceTest.java
+++ b/connectors/http/http-base/src/test/java/io/camunda/connector/http/base/HttpServiceTest.java
@@ -8,7 +8,6 @@ package io.camunda.connector.http.base;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
 import com.github.tomakehurst.wiremock.junit5.WireMockTest;
@@ -35,6 +34,7 @@ import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
 import org.skyscreamer.jsonassert.JSONCompareMode;
+import tools.jackson.databind.ObjectMapper;
 import wiremock.com.fasterxml.jackson.databind.node.JsonNodeFactory;
 
 @WireMockTest(extensionScanningEnabled = true)

--- a/connectors/http/rest/README.md
+++ b/connectors/http/rest/README.md
@@ -209,16 +209,16 @@ used in the result expression.
 
 ```json
 {
+  "status" : 200,
+  "headers" : {
+    "Content-Type" : "application/json"
+  },
   "body" : {
     "order" : {
       "id" : "123",
       "total" : "100.00€"
     }
-  },
-  "headers" : {
-    "Content-Type" : "application/json"
-  },
-  "status" : 200
+  }
 }
 ```
 

--- a/connectors/http/rest/element-templates/http-json-connector.json
+++ b/connectors/http/rest/element-templates/http-json-connector.json
@@ -46,35 +46,29 @@
     "label" : "Retries"
   } ],
   "properties" : [ {
-    "value" : "io.camunda:http-json:1",
     "binding" : {
       "property" : "type",
       "type" : "zeebe:taskDefinition"
     },
-    "type" : "Hidden"
+    "type" : "Hidden",
+    "value" : "io.camunda:http-json:1"
   }, {
-    "id" : "authenticationConfiguration",
-    "label" : "Authentication credential",
-    "description" : "Choose a reusable REST authentication credential. When set, it is bound as a whole to the connector's 'authenticationConfiguration' input.",
-    "optional" : true,
-    "group" : "authentication",
     "binding" : {
       "name" : "authenticationConfiguration",
       "type" : "zeebe:input"
     },
-    "type" : "Configuration",
-    "configurationTemplate" : "io.camunda.connectors:rest-authentication:1"
-  }, {
-    "id" : "authentication.type",
-    "label" : "Type",
-    "description" : "Choose the authentication type. Select 'None' if no authentication is necessary",
-    "value" : "noAuth",
+    "configurationTemplate" : "io.camunda.connectors:rest-authentication:1",
+    "description" : "Choose a reusable REST authentication credential. When set, it is bound as a whole to the connector's 'authenticationConfiguration' input.",
     "group" : "authentication",
+    "id" : "authenticationConfiguration",
+    "label" : "Authentication credential",
+    "optional" : true,
+    "type" : "Configuration"
+  }, {
     "binding" : {
       "name" : "authentication.type",
       "type" : "zeebe:input"
     },
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "API key",
       "value" : "apiKey"
@@ -93,43 +87,41 @@
     }, {
       "name" : "OAuth 2.0 Refresh Token",
       "value" : "oauth-refresh-token"
-    } ]
-  }, {
-    "id" : "authentication.apiKeyLocation",
-    "label" : "Api key location",
-    "optional" : false,
-    "value" : "headers",
-    "constraints" : {
-      "notEmpty" : true
-    },
+    } ],
+    "description" : "Choose the authentication type. Select 'None' if no authentication is necessary",
     "group" : "authentication",
+    "id" : "authentication.type",
+    "label" : "Type",
+    "type" : "Dropdown",
+    "value" : "noAuth"
+  }, {
     "binding" : {
       "name" : "authentication.apiKeyLocation",
       "type" : "zeebe:input"
     },
-    "condition" : {
-      "property" : "authentication.type",
-      "equals" : "apiKey",
-      "type" : "simple"
-    },
-    "tooltip" : "Send API key in header or as query parameter.",
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "Headers",
       "value" : "headers"
     }, {
       "name" : "Query parameters",
       "value" : "query"
-    } ]
-  }, {
-    "id" : "authentication.name",
-    "label" : "API key name",
-    "optional" : false,
+    } ],
+    "condition" : {
+      "property" : "authentication.type",
+      "equals" : "apiKey",
+      "type" : "simple"
+    },
     "constraints" : {
       "notEmpty" : true
     },
-    "feel" : "optional",
     "group" : "authentication",
+    "id" : "authentication.apiKeyLocation",
+    "label" : "Api key location",
+    "optional" : false,
+    "tooltip" : "Send API key in header or as query parameter.",
+    "type" : "Dropdown",
+    "value" : "headers"
+  }, {
     "binding" : {
       "name" : "authentication.name",
       "type" : "zeebe:input"
@@ -139,16 +131,16 @@
       "equals" : "apiKey",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "authentication.value",
-    "label" : "API key value",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "authentication",
+    "id" : "authentication.name",
+    "label" : "API key name",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "authentication.value",
       "type" : "zeebe:input"
@@ -158,17 +150,17 @@
       "equals" : "apiKey",
       "type" : "simple"
     },
-    "type" : "String",
-    "secret" : true
-  }, {
-    "id" : "authentication.username",
-    "label" : "Username",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "authentication",
+    "id" : "authentication.value",
+    "label" : "API key value",
+    "optional" : false,
+    "secret" : true,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "authentication.username",
       "type" : "zeebe:input"
@@ -178,16 +170,16 @@
       "equals" : "basic",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "authentication.password",
-    "label" : "Password",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "authentication",
+    "id" : "authentication.username",
+    "label" : "Username",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "authentication.password",
       "type" : "zeebe:input"
@@ -197,17 +189,17 @@
       "equals" : "basic",
       "type" : "simple"
     },
-    "type" : "String",
-    "secret" : true
-  }, {
-    "id" : "authentication.token",
-    "label" : "Bearer token",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "authentication",
+    "id" : "authentication.password",
+    "label" : "Password",
+    "optional" : false,
+    "secret" : true,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "authentication.token",
       "type" : "zeebe:input"
@@ -217,21 +209,17 @@
       "equals" : "bearer",
       "type" : "simple"
     },
-    "type" : "String",
-    "secret" : true
-  }, {
-    "id" : "authentication.oauthTokenEndpoint",
-    "label" : "OAuth 2.0 token endpoint",
-    "optional" : false,
     "constraints" : {
-      "notEmpty" : true,
-      "pattern" : {
-        "value" : "^(=|(http://|https://|secrets|\\{\\{).*$)",
-        "message" : "Must be a http(s) URL"
-      }
+      "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "authentication",
+    "id" : "authentication.token",
+    "label" : "Bearer token",
+    "optional" : false,
+    "secret" : true,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "authentication.oauthTokenEndpoint",
       "type" : "zeebe:input"
@@ -241,16 +229,20 @@
       "equals" : "oauth-client-credentials-flow",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "authentication.clientId",
-    "label" : "Client ID",
-    "optional" : false,
     "constraints" : {
-      "notEmpty" : true
+      "notEmpty" : true,
+      "pattern" : {
+        "value" : "^(=|(http://|https://|secrets|\\{\\{).*$)",
+        "message" : "Must be a http(s) URL"
+      }
     },
     "feel" : "optional",
     "group" : "authentication",
+    "id" : "authentication.oauthTokenEndpoint",
+    "label" : "OAuth 2.0 token endpoint",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "authentication.clientId",
       "type" : "zeebe:input"
@@ -260,17 +252,17 @@
       "equals" : "oauth-client-credentials-flow",
       "type" : "simple"
     },
-    "tooltip" : "Your application's client ID from the OAuth client",
-    "type" : "String"
-  }, {
-    "id" : "authentication.clientSecret",
-    "label" : "Client secret",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "authentication",
+    "id" : "authentication.clientId",
+    "label" : "Client ID",
+    "optional" : false,
+    "tooltip" : "Your application's client ID from the OAuth client",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "authentication.clientSecret",
       "type" : "zeebe:input"
@@ -280,15 +272,18 @@
       "equals" : "oauth-client-credentials-flow",
       "type" : "simple"
     },
-    "tooltip" : "Your application's client secret from the OAuth client",
-    "type" : "String",
-    "secret" : true
-  }, {
-    "id" : "authentication.audience",
-    "label" : "Audience",
-    "optional" : true,
+    "constraints" : {
+      "notEmpty" : true
+    },
     "feel" : "optional",
     "group" : "authentication",
+    "id" : "authentication.clientSecret",
+    "label" : "Client secret",
+    "optional" : false,
+    "secret" : true,
+    "tooltip" : "Your application's client secret from the OAuth client",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "authentication.audience",
       "type" : "zeebe:input"
@@ -298,40 +293,40 @@
       "equals" : "oauth-client-credentials-flow",
       "type" : "simple"
     },
+    "feel" : "optional",
+    "group" : "authentication",
+    "id" : "authentication.audience",
+    "label" : "Audience",
+    "optional" : true,
     "tooltip" : "The unique identifier of the target API you want to access",
     "type" : "String"
   }, {
-    "id" : "authentication.clientAuthentication",
-    "label" : "Client authentication",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "group" : "authentication",
     "binding" : {
       "name" : "authentication.clientAuthentication",
       "type" : "zeebe:input"
     },
-    "condition" : {
-      "property" : "authentication.type",
-      "equals" : "oauth-client-credentials-flow",
-      "type" : "simple"
-    },
-    "tooltip" : "Send client ID and client secret as a Basic Auth header, or as client credentials in the request body",
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "Send client credentials in body",
       "value" : "credentialsBody"
     }, {
       "name" : "Send as Basic Auth header",
       "value" : "basicAuthHeader"
-    } ]
-  }, {
-    "id" : "authentication.scopes",
-    "label" : "Scopes",
-    "optional" : true,
-    "feel" : "optional",
+    } ],
+    "condition" : {
+      "property" : "authentication.type",
+      "equals" : "oauth-client-credentials-flow",
+      "type" : "simple"
+    },
+    "constraints" : {
+      "notEmpty" : true
+    },
     "group" : "authentication",
+    "id" : "authentication.clientAuthentication",
+    "label" : "Client authentication",
+    "optional" : false,
+    "tooltip" : "Send client ID and client secret as a Basic Auth header, or as client credentials in the request body",
+    "type" : "Dropdown"
+  }, {
     "binding" : {
       "name" : "authentication.scopes",
       "type" : "zeebe:input"
@@ -341,22 +336,15 @@
       "equals" : "oauth-client-credentials-flow",
       "type" : "simple"
     },
-    "tooltip" : "The scopes which you want to request authorization for",
-    "placeholder" : "read:contacts",
-    "type" : "String"
-  }, {
-    "id" : "authentication.oauthRefreshToken.oauthTokenEndpoint",
-    "label" : "OAuth 2.0 token endpoint",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true,
-      "pattern" : {
-        "value" : "^(=|(http://|https://|secrets|\\{\\{).*$)",
-        "message" : "Must be a http(s) URL"
-      }
-    },
     "feel" : "optional",
     "group" : "authentication",
+    "id" : "authentication.scopes",
+    "label" : "Scopes",
+    "optional" : true,
+    "placeholder" : "read:contacts",
+    "tooltip" : "The scopes which you want to request authorization for",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "authentication.oauthTokenEndpoint",
       "type" : "zeebe:input"
@@ -366,16 +354,20 @@
       "equals" : "oauth-refresh-token",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "authentication.oauthRefreshToken.clientId",
-    "label" : "Client ID",
-    "optional" : false,
     "constraints" : {
-      "notEmpty" : true
+      "notEmpty" : true,
+      "pattern" : {
+        "value" : "^(=|(http://|https://|secrets|\\{\\{).*$)",
+        "message" : "Must be a http(s) URL"
+      }
     },
     "feel" : "optional",
     "group" : "authentication",
+    "id" : "authentication.oauthRefreshToken.oauthTokenEndpoint",
+    "label" : "OAuth 2.0 token endpoint",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "authentication.clientId",
       "type" : "zeebe:input"
@@ -385,14 +377,17 @@
       "equals" : "oauth-refresh-token",
       "type" : "simple"
     },
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "authentication",
+    "id" : "authentication.oauthRefreshToken.clientId",
+    "label" : "Client ID",
+    "optional" : false,
     "tooltip" : "Your application's client ID from the OAuth client",
     "type" : "String"
   }, {
-    "id" : "authentication.oauthRefreshToken.clientSecret",
-    "label" : "Client secret",
-    "optional" : true,
-    "feel" : "optional",
-    "group" : "authentication",
     "binding" : {
       "name" : "authentication.clientSecret",
       "type" : "zeebe:input"
@@ -402,18 +397,15 @@
       "equals" : "oauth-refresh-token",
       "type" : "simple"
     },
-    "tooltip" : "Your application's client secret from the OAuth client",
-    "type" : "String",
-    "secret" : true
-  }, {
-    "id" : "authentication.oauthRefreshToken.refreshToken",
-    "label" : "Refresh token",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
     "feel" : "optional",
     "group" : "authentication",
+    "id" : "authentication.oauthRefreshToken.clientSecret",
+    "label" : "Client secret",
+    "optional" : true,
+    "secret" : true,
+    "tooltip" : "Your application's client secret from the OAuth client",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "authentication.refreshToken",
       "type" : "zeebe:input"
@@ -423,15 +415,18 @@
       "equals" : "oauth-refresh-token",
       "type" : "simple"
     },
-    "tooltip" : "The refresh token used to obtain a new access token",
-    "type" : "String",
-    "secret" : true
-  }, {
-    "id" : "authentication.oauthRefreshToken.scopes",
-    "label" : "Scopes",
-    "optional" : true,
+    "constraints" : {
+      "notEmpty" : true
+    },
     "feel" : "optional",
     "group" : "authentication",
+    "id" : "authentication.oauthRefreshToken.refreshToken",
+    "label" : "Refresh token",
+    "optional" : false,
+    "secret" : true,
+    "tooltip" : "The refresh token used to obtain a new access token",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "authentication.scopes",
       "type" : "zeebe:input"
@@ -441,70 +436,66 @@
       "equals" : "oauth-refresh-token",
       "type" : "simple"
     },
+    "feel" : "optional",
+    "group" : "authentication",
+    "id" : "authentication.oauthRefreshToken.scopes",
+    "label" : "Scopes",
+    "optional" : true,
     "tooltip" : "The scopes to request authorization for (space-separated)",
     "type" : "String"
   }, {
-    "id" : "clientTls.clientCertificate",
-    "label" : "Client certificate (PEM)",
-    "optional" : true,
-    "feel" : "optional",
-    "group" : "tls",
     "binding" : {
       "name" : "clientTls.clientCertificate",
       "type" : "zeebe:input"
     },
+    "feel" : "optional",
+    "group" : "tls",
+    "id" : "clientTls.clientCertificate",
+    "label" : "Client certificate (PEM)",
+    "optional" : true,
     "tooltip" : "PEM-encoded client certificate chain presented to the server for mTLS. Provide together with the private key.",
     "type" : "Text"
   }, {
-    "id" : "clientTls.clientPrivateKey",
-    "label" : "Client private key (PEM)",
-    "optional" : true,
-    "feel" : "optional",
-    "group" : "tls",
     "binding" : {
       "name" : "clientTls.clientPrivateKey",
       "type" : "zeebe:input"
     },
+    "feel" : "optional",
+    "group" : "tls",
+    "id" : "clientTls.clientPrivateKey",
+    "label" : "Client private key (PEM)",
+    "optional" : true,
     "tooltip" : "PEM-encoded private key (PKCS#1, PKCS#8 or EC), optionally encrypted.",
     "type" : "Text"
   }, {
-    "id" : "clientTls.privateKeyPassword",
-    "label" : "Private key password",
-    "optional" : true,
-    "feel" : "optional",
-    "group" : "tls",
     "binding" : {
       "name" : "clientTls.privateKeyPassword",
       "type" : "zeebe:input"
     },
+    "feel" : "optional",
+    "group" : "tls",
+    "id" : "clientTls.privateKeyPassword",
+    "label" : "Private key password",
+    "optional" : true,
     "tooltip" : "Password protecting the private key. Leave empty if it is not encrypted.",
     "type" : "String"
   }, {
-    "id" : "clientTls.trustedCertificate",
-    "label" : "Trusted CA certificate (PEM)",
-    "optional" : true,
-    "feel" : "optional",
-    "group" : "tls",
     "binding" : {
       "name" : "clientTls.trustedCertificate",
       "type" : "zeebe:input"
     },
+    "feel" : "optional",
+    "group" : "tls",
+    "id" : "clientTls.trustedCertificate",
+    "label" : "Trusted CA certificate (PEM)",
+    "optional" : true,
     "tooltip" : "Optional PEM-encoded CA certificate(s) used to validate the server. If empty, the JVM's default trust store is used.",
     "type" : "Text"
   }, {
-    "id" : "method",
-    "label" : "Method",
-    "optional" : false,
-    "value" : "GET",
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "group" : "endpoint",
     "binding" : {
       "name" : "method",
       "type" : "zeebe:input"
     },
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "POST",
       "value" : "POST"
@@ -520,11 +511,21 @@
     }, {
       "name" : "PUT",
       "value" : "PUT"
-    } ]
-  }, {
-    "id" : "url",
-    "label" : "URL",
+    } ],
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "group" : "endpoint",
+    "id" : "method",
+    "label" : "Method",
     "optional" : false,
+    "type" : "Dropdown",
+    "value" : "GET"
+  }, {
+    "binding" : {
+      "name" : "url",
+      "type" : "zeebe:input"
+    },
     "constraints" : {
       "notEmpty" : true,
       "pattern" : {
@@ -534,69 +535,62 @@
     },
     "feel" : "optional",
     "group" : "endpoint",
-    "binding" : {
-      "name" : "url",
-      "type" : "zeebe:input"
-    },
+    "id" : "url",
+    "label" : "URL",
+    "optional" : false,
     "type" : "String"
   }, {
-    "id" : "headers",
-    "label" : "Headers",
-    "optional" : true,
-    "feel" : "required",
-    "group" : "endpoint",
     "binding" : {
       "name" : "headers",
       "type" : "zeebe:input"
     },
+    "feel" : "required",
+    "group" : "endpoint",
+    "id" : "headers",
+    "label" : "Headers",
+    "optional" : true,
     "tooltip" : "Map of HTTP headers to add to the request",
     "type" : "String"
   }, {
-    "id" : "queryParameters",
-    "label" : "Query parameters",
-    "optional" : true,
-    "feel" : "required",
-    "group" : "endpoint",
     "binding" : {
       "name" : "queryParameters",
       "type" : "zeebe:input"
     },
+    "feel" : "required",
+    "group" : "endpoint",
+    "id" : "queryParameters",
+    "label" : "Query parameters",
+    "optional" : true,
     "tooltip" : "Map of query parameters to add to the request URL",
     "type" : "String"
   }, {
-    "id" : "skipEncoding",
-    "label" : "Skip URL encoding",
-    "optional" : true,
-    "group" : "endpoint",
     "binding" : {
       "name" : "skipEncoding",
       "type" : "zeebe:input"
     },
+    "group" : "endpoint",
+    "id" : "skipEncoding",
+    "label" : "Skip URL encoding",
+    "optional" : true,
     "type" : "Hidden"
   }, {
-    "id" : "followRedirects",
-    "label" : "Follow redirects",
-    "optional" : false,
-    "value" : false,
-    "feel" : "static",
-    "group" : "endpoint",
     "binding" : {
       "name" : "followRedirects",
       "type" : "zeebe:input"
     },
-    "tooltip" : "If enabled, HTTP 3xx redirects will be followed automatically. Disabled by default.",
-    "type" : "Boolean"
-  }, {
-    "id" : "documentReturnFormat",
-    "label" : "Response format",
-    "value" : "JSON",
+    "feel" : "static",
     "group" : "endpoint",
+    "id" : "followRedirects",
+    "label" : "Follow redirects",
+    "optional" : false,
+    "tooltip" : "If enabled, HTTP 3xx redirects will be followed automatically. Disabled by default.",
+    "type" : "Boolean",
+    "value" : false
+  }, {
     "binding" : {
       "name" : "documentReturnFormat.choice",
       "type" : "zeebe:input"
     },
-    "tooltip" : "How the response body should be returned. Document reference uploads the body to the document store; as text decodes it as a String; as JSON parses it into a structure you can access via dot notation.",
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "Document reference",
       "value" : "DOCUMENT"
@@ -606,14 +600,14 @@
     }, {
       "name" : "as JSON",
       "value" : "JSON"
-    } ]
-  }, {
-    "id" : "documentReturnFormatEncoding",
-    "label" : "Encoding",
-    "description" : "Character set used to decode the response. Default UTF-8.",
-    "value" : "UTF-8",
-    "feel" : "optional",
+    } ],
     "group" : "endpoint",
+    "id" : "documentReturnFormat",
+    "label" : "Response format",
+    "tooltip" : "How the response body should be returned. Document reference uploads the body to the document store; as text decodes it as a String; as JSON parses it into a structure you can access via dot notation.",
+    "type" : "Dropdown",
+    "value" : "JSON"
+  }, {
     "binding" : {
       "name" : "documentReturnFormat.encoding",
       "type" : "zeebe:input"
@@ -623,32 +617,18 @@
       "equals" : "TEXT",
       "type" : "simple"
     },
-    "type" : "String"
+    "description" : "Character set used to decode the response. Default UTF-8.",
+    "feel" : "optional",
+    "group" : "endpoint",
+    "id" : "documentReturnFormatEncoding",
+    "label" : "Encoding",
+    "type" : "String",
+    "value" : "UTF-8"
   }, {
-    "id" : "connectionTimeoutInSeconds",
-    "label" : "Connection timeout in seconds",
-    "optional" : false,
-    "value" : 20,
-    "constraints" : {
-      "notEmpty" : true,
-      "pattern" : {
-        "value" : "^\\d+$",
-        "message" : "Must be a number"
-      }
-    },
-    "feel" : "static",
-    "group" : "timeout",
     "binding" : {
       "name" : "connectionTimeoutInSeconds",
       "type" : "zeebe:input"
     },
-    "tooltip" : "Use 0 for an infinite timeout",
-    "type" : "Number"
-  }, {
-    "id" : "readTimeoutInSeconds",
-    "label" : "Read timeout in seconds",
-    "optional" : false,
-    "value" : 20,
     "constraints" : {
       "notEmpty" : true,
       "pattern" : {
@@ -658,18 +638,33 @@
     },
     "feel" : "static",
     "group" : "timeout",
+    "id" : "connectionTimeoutInSeconds",
+    "label" : "Connection timeout in seconds",
+    "optional" : false,
+    "tooltip" : "Use 0 for an infinite timeout",
+    "type" : "Number",
+    "value" : 20
+  }, {
     "binding" : {
       "name" : "readTimeoutInSeconds",
       "type" : "zeebe:input"
     },
+    "constraints" : {
+      "notEmpty" : true,
+      "pattern" : {
+        "value" : "^\\d+$",
+        "message" : "Must be a number"
+      }
+    },
+    "feel" : "static",
+    "group" : "timeout",
+    "id" : "readTimeoutInSeconds",
+    "label" : "Read timeout in seconds",
+    "optional" : false,
     "tooltip" : "Use 0 for an infinite timeout",
-    "type" : "Number"
+    "type" : "Number",
+    "value" : 20
   }, {
-    "id" : "body",
-    "label" : "Request body",
-    "optional" : true,
-    "feel" : "optional",
-    "group" : "payload",
     "binding" : {
       "name" : "body",
       "type" : "zeebe:input"
@@ -679,15 +674,14 @@
       "oneOf" : [ "POST", "PUT", "PATCH" ],
       "type" : "simple"
     },
+    "feel" : "optional",
+    "group" : "payload",
+    "id" : "body",
+    "label" : "Request body",
+    "optional" : true,
     "tooltip" : "Payload to send with the request",
     "type" : "Text"
   }, {
-    "id" : "ignoreNullValues",
-    "label" : "Ignore null values",
-    "optional" : false,
-    "value" : false,
-    "feel" : "static",
-    "group" : "payload",
     "binding" : {
       "name" : "ignoreNullValues",
       "type" : "zeebe:input"
@@ -697,97 +691,103 @@
       "oneOf" : [ "POST", "PUT", "PATCH" ],
       "type" : "simple"
     },
+    "feel" : "static",
+    "group" : "payload",
+    "id" : "ignoreNullValues",
+    "label" : "Ignore null values",
+    "optional" : false,
     "tooltip" : "Null values will not be sent",
-    "type" : "Boolean"
+    "type" : "Boolean",
+    "value" : false
   }, {
-    "id" : "version",
-    "label" : "Version",
-    "description" : "Version of the element template",
-    "value" : "17",
-    "group" : "connector",
     "binding" : {
       "key" : "elementTemplateVersion",
       "type" : "zeebe:taskHeader"
     },
-    "type" : "Hidden"
-  }, {
-    "id" : "id",
-    "label" : "ID",
-    "description" : "ID of the element template",
-    "value" : "io.camunda.connectors.HttpJson.v2",
+    "description" : "Version of the element template",
     "group" : "connector",
+    "id" : "version",
+    "label" : "Version",
+    "type" : "Hidden",
+    "value" : "17"
+  }, {
     "binding" : {
       "key" : "elementTemplateId",
       "type" : "zeebe:taskHeader"
     },
-    "type" : "Hidden"
+    "description" : "ID of the element template",
+    "group" : "connector",
+    "id" : "id",
+    "label" : "ID",
+    "type" : "Hidden",
+    "value" : "io.camunda.connectors.HttpJson.v2"
   }, {
-    "id" : "resultVariable",
-    "label" : "Result variable",
-    "description" : "Name of variable to store the response in. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-variable\" target=\"_blank\">documentation</a>.",
-    "group" : "output",
     "binding" : {
       "key" : "resultVariable",
       "type" : "zeebe:taskHeader"
     },
+    "description" : "Name of variable to store the response in. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-variable\" target=\"_blank\">documentation</a>.",
+    "group" : "output",
+    "id" : "resultVariable",
+    "label" : "Result variable",
     "type" : "String"
   }, {
-    "id" : "resultExpression",
-    "label" : "Result expression",
-    "description" : "Expression to map the response into process variables. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-expression\" target=\"_blank\">documentation</a>.",
-    "value" : "{\n  myResponseBody: response.body\n  // Use FEEL to extract values, e.g.,:\n  // myUserId: response.body.post.userId\n}",
-    "feel" : "required",
-    "group" : "output",
     "binding" : {
       "key" : "resultExpression",
       "type" : "zeebe:taskHeader"
     },
-    "tooltip" : "<div><p>Example response:</p><code>{\"body\":{\"order\":{\"id\":\"123\",\"total\":\"100.00€\"}},\"headers\":{\"Content-Type\":\"application/json\"},\"status\":200}</code><p>Example FEEL expression: <code>= { orderId: body.order.id }</code> -&gt; <code>{\"orderId\":\"123\"}</code></p></div>",
-    "type" : "Text"
-  }, {
-    "id" : "errorExpression",
-    "label" : "Error expression",
-    "description" : "Expression to handle errors. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/\" target=\"_blank\">documentation</a>.",
+    "description" : "Expression to map the response into process variables. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-expression\" target=\"_blank\">documentation</a>.",
     "feel" : "required",
-    "group" : "error",
+    "group" : "output",
+    "id" : "resultExpression",
+    "label" : "Result expression",
+    "tooltip" : "<div><p>Example response:</p><code>{\"status\":200,\"headers\":{\"Content-Type\":\"application/json\"},\"body\":{\"order\":{\"id\":\"123\",\"total\":\"100.00€\"}}}</code><p>Example FEEL expression: <code>= { orderId: body.order.id }</code> -&gt; <code>{\"orderId\":\"123\"}</code></p></div>",
+    "type" : "Text",
+    "value" : "{\n  myResponseBody: response.body\n  // Use FEEL to extract values, e.g.,:\n  // myUserId: response.body.post.userId\n}"
+  }, {
     "binding" : {
       "key" : "errorExpression",
       "type" : "zeebe:taskHeader"
     },
+    "description" : "Expression to handle errors. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/\" target=\"_blank\">documentation</a>.",
+    "feel" : "required",
+    "group" : "error",
+    "id" : "errorExpression",
+    "label" : "Error expression",
     "type" : "Text"
   }, {
-    "id" : "retryCount",
-    "label" : "Retries",
-    "description" : "Number of retries",
-    "value" : "3",
-    "feel" : "optional",
-    "group" : "retries",
     "binding" : {
       "property" : "retries",
       "type" : "zeebe:taskDefinition"
     },
-    "type" : "String"
-  }, {
-    "id" : "retryBackoff",
-    "label" : "Retry backoff",
-    "description" : "ISO-8601 duration to wait between retries",
-    "value" : "PT30S",
+    "description" : "Number of retries",
+    "feel" : "optional",
     "group" : "retries",
+    "id" : "retryCount",
+    "label" : "Retries",
+    "type" : "String",
+    "value" : "3"
+  }, {
     "binding" : {
       "key" : "retryBackoff",
       "type" : "zeebe:taskHeader"
     },
-    "type" : "String"
-  }, {
-    "id" : "jobTimeout",
-    "label" : "Job timeout",
-    "description" : "ISO-8601 duration after which Zeebe considers this job timed out if not yet completed. Leave empty to use the default timeout",
-    "optional" : true,
+    "description" : "ISO-8601 duration to wait between retries",
     "group" : "retries",
+    "id" : "retryBackoff",
+    "label" : "Retry backoff",
+    "type" : "String",
+    "value" : "PT30S"
+  }, {
     "binding" : {
       "key" : "jobTimeout",
       "type" : "zeebe:taskHeader"
     },
+    "description" : "ISO-8601 duration after which Zeebe considers this job timed out if not yet completed. Leave empty to use the default timeout",
+    "group" : "retries",
+    "id" : "jobTimeout",
+    "label" : "Job timeout",
+    "optional" : true,
     "type" : "String"
   } ],
   "configurationTemplates" : [ {
@@ -796,16 +796,10 @@
     "version" : 1,
     "name" : "REST Authentication",
     "properties" : [ {
-      "id" : "authentication.type",
-      "label" : "Type",
-      "description" : "Choose the authentication type. Select 'None' if no authentication is necessary",
-      "value" : "noAuth",
-      "group" : "authentication",
       "binding" : {
         "name" : "authentication.type",
         "type" : "property"
       },
-      "type" : "Dropdown",
       "choices" : [ {
         "name" : "API key",
         "value" : "apiKey"
@@ -824,40 +818,40 @@
       }, {
         "name" : "OAuth 2.0 Refresh Token",
         "value" : "oauth-refresh-token"
-      } ]
-    }, {
-      "id" : "authentication.apiKeyLocation",
-      "label" : "Api key location",
-      "value" : "headers",
-      "constraints" : {
-        "notEmpty" : true
-      },
+      } ],
+      "description" : "Choose the authentication type. Select 'None' if no authentication is necessary",
       "group" : "authentication",
+      "id" : "authentication.type",
+      "label" : "Type",
+      "type" : "Dropdown",
+      "value" : "noAuth"
+    }, {
       "binding" : {
         "name" : "authentication.apiKeyLocation",
         "type" : "property"
       },
-      "condition" : {
-        "property" : "authentication.type",
-        "equals" : "apiKey",
-        "type" : "simple"
-      },
-      "tooltip" : "Send API key in header or as query parameter.",
-      "type" : "Dropdown",
       "choices" : [ {
         "name" : "Headers",
         "value" : "headers"
       }, {
         "name" : "Query parameters",
         "value" : "query"
-      } ]
-    }, {
-      "id" : "authentication.name",
-      "label" : "API key name",
+      } ],
+      "condition" : {
+        "property" : "authentication.type",
+        "equals" : "apiKey",
+        "type" : "simple"
+      },
       "constraints" : {
         "notEmpty" : true
       },
       "group" : "authentication",
+      "id" : "authentication.apiKeyLocation",
+      "label" : "Api key location",
+      "tooltip" : "Send API key in header or as query parameter.",
+      "type" : "Dropdown",
+      "value" : "headers"
+    }, {
       "binding" : {
         "name" : "authentication.name",
         "type" : "property"
@@ -867,14 +861,14 @@
         "equals" : "apiKey",
         "type" : "simple"
       },
-      "type" : "String"
-    }, {
-      "id" : "authentication.value",
-      "label" : "API key value",
       "constraints" : {
         "notEmpty" : true
       },
       "group" : "authentication",
+      "id" : "authentication.name",
+      "label" : "API key name",
+      "type" : "String"
+    }, {
       "binding" : {
         "name" : "authentication.value",
         "type" : "property"
@@ -884,15 +878,15 @@
         "equals" : "apiKey",
         "type" : "simple"
       },
-      "type" : "String",
-      "secret" : true
-    }, {
-      "id" : "authentication.username",
-      "label" : "Username",
       "constraints" : {
         "notEmpty" : true
       },
       "group" : "authentication",
+      "id" : "authentication.value",
+      "label" : "API key value",
+      "secret" : true,
+      "type" : "String"
+    }, {
       "binding" : {
         "name" : "authentication.username",
         "type" : "property"
@@ -902,14 +896,14 @@
         "equals" : "basic",
         "type" : "simple"
       },
-      "type" : "String"
-    }, {
-      "id" : "authentication.password",
-      "label" : "Password",
       "constraints" : {
         "notEmpty" : true
       },
       "group" : "authentication",
+      "id" : "authentication.username",
+      "label" : "Username",
+      "type" : "String"
+    }, {
       "binding" : {
         "name" : "authentication.password",
         "type" : "property"
@@ -919,15 +913,15 @@
         "equals" : "basic",
         "type" : "simple"
       },
-      "type" : "String",
-      "secret" : true
-    }, {
-      "id" : "authentication.token",
-      "label" : "Bearer token",
       "constraints" : {
         "notEmpty" : true
       },
       "group" : "authentication",
+      "id" : "authentication.password",
+      "label" : "Password",
+      "secret" : true,
+      "type" : "String"
+    }, {
       "binding" : {
         "name" : "authentication.token",
         "type" : "property"
@@ -937,19 +931,15 @@
         "equals" : "bearer",
         "type" : "simple"
       },
-      "type" : "String",
-      "secret" : true
-    }, {
-      "id" : "authentication.oauthTokenEndpoint",
-      "label" : "OAuth 2.0 token endpoint",
       "constraints" : {
-        "notEmpty" : true,
-        "pattern" : {
-          "value" : "^(=|(http://|https://|secrets|\\{\\{).*$)",
-          "message" : "Must be a http(s) URL"
-        }
+        "notEmpty" : true
       },
       "group" : "authentication",
+      "id" : "authentication.token",
+      "label" : "Bearer token",
+      "secret" : true,
+      "type" : "String"
+    }, {
       "binding" : {
         "name" : "authentication.oauthTokenEndpoint",
         "type" : "property"
@@ -959,14 +949,18 @@
         "equals" : "oauth-client-credentials-flow",
         "type" : "simple"
       },
-      "type" : "String"
-    }, {
-      "id" : "authentication.clientId",
-      "label" : "Client ID",
       "constraints" : {
-        "notEmpty" : true
+        "notEmpty" : true,
+        "pattern" : {
+          "value" : "^(=|(http://|https://|secrets|\\{\\{).*$)",
+          "message" : "Must be a http(s) URL"
+        }
       },
       "group" : "authentication",
+      "id" : "authentication.oauthTokenEndpoint",
+      "label" : "OAuth 2.0 token endpoint",
+      "type" : "String"
+    }, {
       "binding" : {
         "name" : "authentication.clientId",
         "type" : "property"
@@ -976,15 +970,15 @@
         "equals" : "oauth-client-credentials-flow",
         "type" : "simple"
       },
-      "tooltip" : "Your application's client ID from the OAuth client",
-      "type" : "String"
-    }, {
-      "id" : "authentication.clientSecret",
-      "label" : "Client secret",
       "constraints" : {
         "notEmpty" : true
       },
       "group" : "authentication",
+      "id" : "authentication.clientId",
+      "label" : "Client ID",
+      "tooltip" : "Your application's client ID from the OAuth client",
+      "type" : "String"
+    }, {
       "binding" : {
         "name" : "authentication.clientSecret",
         "type" : "property"
@@ -994,13 +988,16 @@
         "equals" : "oauth-client-credentials-flow",
         "type" : "simple"
       },
-      "tooltip" : "Your application's client secret from the OAuth client",
-      "type" : "String",
-      "secret" : true
-    }, {
-      "id" : "authentication.audience",
-      "label" : "Audience",
+      "constraints" : {
+        "notEmpty" : true
+      },
       "group" : "authentication",
+      "id" : "authentication.clientSecret",
+      "label" : "Client secret",
+      "secret" : true,
+      "tooltip" : "Your application's client secret from the OAuth client",
+      "type" : "String"
+    }, {
       "binding" : {
         "name" : "authentication.audience",
         "type" : "property"
@@ -1010,37 +1007,37 @@
         "equals" : "oauth-client-credentials-flow",
         "type" : "simple"
       },
+      "group" : "authentication",
+      "id" : "authentication.audience",
+      "label" : "Audience",
       "tooltip" : "The unique identifier of the target API you want to access",
       "type" : "String"
     }, {
-      "id" : "authentication.clientAuthentication",
-      "label" : "Client authentication",
-      "constraints" : {
-        "notEmpty" : true
-      },
-      "group" : "authentication",
       "binding" : {
         "name" : "authentication.clientAuthentication",
         "type" : "property"
       },
-      "condition" : {
-        "property" : "authentication.type",
-        "equals" : "oauth-client-credentials-flow",
-        "type" : "simple"
-      },
-      "tooltip" : "Send client ID and client secret as a Basic Auth header, or as client credentials in the request body",
-      "type" : "Dropdown",
       "choices" : [ {
         "name" : "Send client credentials in body",
         "value" : "credentialsBody"
       }, {
         "name" : "Send as Basic Auth header",
         "value" : "basicAuthHeader"
-      } ]
-    }, {
-      "id" : "authentication.scopes",
-      "label" : "Scopes",
+      } ],
+      "condition" : {
+        "property" : "authentication.type",
+        "equals" : "oauth-client-credentials-flow",
+        "type" : "simple"
+      },
+      "constraints" : {
+        "notEmpty" : true
+      },
       "group" : "authentication",
+      "id" : "authentication.clientAuthentication",
+      "label" : "Client authentication",
+      "tooltip" : "Send client ID and client secret as a Basic Auth header, or as client credentials in the request body",
+      "type" : "Dropdown"
+    }, {
       "binding" : {
         "name" : "authentication.scopes",
         "type" : "property"
@@ -1050,20 +1047,13 @@
         "equals" : "oauth-client-credentials-flow",
         "type" : "simple"
       },
-      "tooltip" : "The scopes which you want to request authorization for",
+      "group" : "authentication",
+      "id" : "authentication.scopes",
+      "label" : "Scopes",
       "placeholder" : "read:contacts",
+      "tooltip" : "The scopes which you want to request authorization for",
       "type" : "String"
     }, {
-      "id" : "authentication.oauthRefreshToken.oauthTokenEndpoint",
-      "label" : "OAuth 2.0 token endpoint",
-      "constraints" : {
-        "notEmpty" : true,
-        "pattern" : {
-          "value" : "^(=|(http://|https://|secrets|\\{\\{).*$)",
-          "message" : "Must be a http(s) URL"
-        }
-      },
-      "group" : "authentication",
       "binding" : {
         "name" : "authentication.oauthRefreshToken.oauthTokenEndpoint",
         "type" : "property"
@@ -1073,14 +1063,18 @@
         "equals" : "oauth-refresh-token",
         "type" : "simple"
       },
-      "type" : "String"
-    }, {
-      "id" : "authentication.oauthRefreshToken.clientId",
-      "label" : "Client ID",
       "constraints" : {
-        "notEmpty" : true
+        "notEmpty" : true,
+        "pattern" : {
+          "value" : "^(=|(http://|https://|secrets|\\{\\{).*$)",
+          "message" : "Must be a http(s) URL"
+        }
       },
       "group" : "authentication",
+      "id" : "authentication.oauthRefreshToken.oauthTokenEndpoint",
+      "label" : "OAuth 2.0 token endpoint",
+      "type" : "String"
+    }, {
       "binding" : {
         "name" : "authentication.oauthRefreshToken.clientId",
         "type" : "property"
@@ -1090,12 +1084,15 @@
         "equals" : "oauth-refresh-token",
         "type" : "simple"
       },
+      "constraints" : {
+        "notEmpty" : true
+      },
+      "group" : "authentication",
+      "id" : "authentication.oauthRefreshToken.clientId",
+      "label" : "Client ID",
       "tooltip" : "Your application's client ID from the OAuth client",
       "type" : "String"
     }, {
-      "id" : "authentication.oauthRefreshToken.clientSecret",
-      "label" : "Client secret",
-      "group" : "authentication",
       "binding" : {
         "name" : "authentication.oauthRefreshToken.clientSecret",
         "type" : "property"
@@ -1105,16 +1102,13 @@
         "equals" : "oauth-refresh-token",
         "type" : "simple"
       },
-      "tooltip" : "Your application's client secret from the OAuth client",
-      "type" : "String",
-      "secret" : true
-    }, {
-      "id" : "authentication.oauthRefreshToken.refreshToken",
-      "label" : "Refresh token",
-      "constraints" : {
-        "notEmpty" : true
-      },
       "group" : "authentication",
+      "id" : "authentication.oauthRefreshToken.clientSecret",
+      "label" : "Client secret",
+      "secret" : true,
+      "tooltip" : "Your application's client secret from the OAuth client",
+      "type" : "String"
+    }, {
       "binding" : {
         "name" : "authentication.oauthRefreshToken.refreshToken",
         "type" : "property"
@@ -1124,13 +1118,16 @@
         "equals" : "oauth-refresh-token",
         "type" : "simple"
       },
-      "tooltip" : "The refresh token used to obtain a new access token",
-      "type" : "String",
-      "secret" : true
-    }, {
-      "id" : "authentication.oauthRefreshToken.scopes",
-      "label" : "Scopes",
+      "constraints" : {
+        "notEmpty" : true
+      },
       "group" : "authentication",
+      "id" : "authentication.oauthRefreshToken.refreshToken",
+      "label" : "Refresh token",
+      "secret" : true,
+      "tooltip" : "The refresh token used to obtain a new access token",
+      "type" : "String"
+    }, {
       "binding" : {
         "name" : "authentication.oauthRefreshToken.scopes",
         "type" : "property"
@@ -1140,6 +1137,9 @@
         "equals" : "oauth-refresh-token",
         "type" : "simple"
       },
+      "group" : "authentication",
+      "id" : "authentication.oauthRefreshToken.scopes",
+      "label" : "Scopes",
       "tooltip" : "The scopes to request authorization for (space-separated)",
       "type" : "String"
     } ]

--- a/connectors/http/rest/element-templates/hybrid/http-json-connector-hybrid.json
+++ b/connectors/http/rest/element-templates/hybrid/http-json-connector-hybrid.json
@@ -49,37 +49,31 @@
     "label" : "Retries"
   } ],
   "properties" : [ {
-    "id" : "taskDefinitionType",
-    "value" : "io.camunda:http-json:1",
-    "group" : "taskDefinitionType",
     "binding" : {
       "property" : "type",
       "type" : "zeebe:taskDefinition"
     },
-    "type" : "String"
+    "group" : "taskDefinitionType",
+    "id" : "taskDefinitionType",
+    "type" : "String",
+    "value" : "io.camunda:http-json:1"
   }, {
-    "id" : "authenticationConfiguration",
-    "label" : "Authentication credential",
-    "description" : "Choose a reusable REST authentication credential. When set, it is bound as a whole to the connector's 'authenticationConfiguration' input.",
-    "optional" : true,
-    "group" : "authentication",
     "binding" : {
       "name" : "authenticationConfiguration",
       "type" : "zeebe:input"
     },
-    "type" : "Configuration",
-    "configurationTemplate" : "io.camunda.connectors:rest-authentication:1"
-  }, {
-    "id" : "authentication.type",
-    "label" : "Type",
-    "description" : "Choose the authentication type. Select 'None' if no authentication is necessary",
-    "value" : "noAuth",
+    "configurationTemplate" : "io.camunda.connectors:rest-authentication:1",
+    "description" : "Choose a reusable REST authentication credential. When set, it is bound as a whole to the connector's 'authenticationConfiguration' input.",
     "group" : "authentication",
+    "id" : "authenticationConfiguration",
+    "label" : "Authentication credential",
+    "optional" : true,
+    "type" : "Configuration"
+  }, {
     "binding" : {
       "name" : "authentication.type",
       "type" : "zeebe:input"
     },
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "API key",
       "value" : "apiKey"
@@ -98,43 +92,41 @@
     }, {
       "name" : "OAuth 2.0 Refresh Token",
       "value" : "oauth-refresh-token"
-    } ]
-  }, {
-    "id" : "authentication.apiKeyLocation",
-    "label" : "Api key location",
-    "optional" : false,
-    "value" : "headers",
-    "constraints" : {
-      "notEmpty" : true
-    },
+    } ],
+    "description" : "Choose the authentication type. Select 'None' if no authentication is necessary",
     "group" : "authentication",
+    "id" : "authentication.type",
+    "label" : "Type",
+    "type" : "Dropdown",
+    "value" : "noAuth"
+  }, {
     "binding" : {
       "name" : "authentication.apiKeyLocation",
       "type" : "zeebe:input"
     },
-    "condition" : {
-      "property" : "authentication.type",
-      "equals" : "apiKey",
-      "type" : "simple"
-    },
-    "tooltip" : "Send API key in header or as query parameter.",
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "Headers",
       "value" : "headers"
     }, {
       "name" : "Query parameters",
       "value" : "query"
-    } ]
-  }, {
-    "id" : "authentication.name",
-    "label" : "API key name",
-    "optional" : false,
+    } ],
+    "condition" : {
+      "property" : "authentication.type",
+      "equals" : "apiKey",
+      "type" : "simple"
+    },
     "constraints" : {
       "notEmpty" : true
     },
-    "feel" : "optional",
     "group" : "authentication",
+    "id" : "authentication.apiKeyLocation",
+    "label" : "Api key location",
+    "optional" : false,
+    "tooltip" : "Send API key in header or as query parameter.",
+    "type" : "Dropdown",
+    "value" : "headers"
+  }, {
     "binding" : {
       "name" : "authentication.name",
       "type" : "zeebe:input"
@@ -144,16 +136,16 @@
       "equals" : "apiKey",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "authentication.value",
-    "label" : "API key value",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "authentication",
+    "id" : "authentication.name",
+    "label" : "API key name",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "authentication.value",
       "type" : "zeebe:input"
@@ -163,17 +155,17 @@
       "equals" : "apiKey",
       "type" : "simple"
     },
-    "type" : "String",
-    "secret" : true
-  }, {
-    "id" : "authentication.username",
-    "label" : "Username",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "authentication",
+    "id" : "authentication.value",
+    "label" : "API key value",
+    "optional" : false,
+    "secret" : true,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "authentication.username",
       "type" : "zeebe:input"
@@ -183,16 +175,16 @@
       "equals" : "basic",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "authentication.password",
-    "label" : "Password",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "authentication",
+    "id" : "authentication.username",
+    "label" : "Username",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "authentication.password",
       "type" : "zeebe:input"
@@ -202,17 +194,17 @@
       "equals" : "basic",
       "type" : "simple"
     },
-    "type" : "String",
-    "secret" : true
-  }, {
-    "id" : "authentication.token",
-    "label" : "Bearer token",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "authentication",
+    "id" : "authentication.password",
+    "label" : "Password",
+    "optional" : false,
+    "secret" : true,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "authentication.token",
       "type" : "zeebe:input"
@@ -222,21 +214,17 @@
       "equals" : "bearer",
       "type" : "simple"
     },
-    "type" : "String",
-    "secret" : true
-  }, {
-    "id" : "authentication.oauthTokenEndpoint",
-    "label" : "OAuth 2.0 token endpoint",
-    "optional" : false,
     "constraints" : {
-      "notEmpty" : true,
-      "pattern" : {
-        "value" : "^(=|(http://|https://|secrets|\\{\\{).*$)",
-        "message" : "Must be a http(s) URL"
-      }
+      "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "authentication",
+    "id" : "authentication.token",
+    "label" : "Bearer token",
+    "optional" : false,
+    "secret" : true,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "authentication.oauthTokenEndpoint",
       "type" : "zeebe:input"
@@ -246,16 +234,20 @@
       "equals" : "oauth-client-credentials-flow",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "authentication.clientId",
-    "label" : "Client ID",
-    "optional" : false,
     "constraints" : {
-      "notEmpty" : true
+      "notEmpty" : true,
+      "pattern" : {
+        "value" : "^(=|(http://|https://|secrets|\\{\\{).*$)",
+        "message" : "Must be a http(s) URL"
+      }
     },
     "feel" : "optional",
     "group" : "authentication",
+    "id" : "authentication.oauthTokenEndpoint",
+    "label" : "OAuth 2.0 token endpoint",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "authentication.clientId",
       "type" : "zeebe:input"
@@ -265,17 +257,17 @@
       "equals" : "oauth-client-credentials-flow",
       "type" : "simple"
     },
-    "tooltip" : "Your application's client ID from the OAuth client",
-    "type" : "String"
-  }, {
-    "id" : "authentication.clientSecret",
-    "label" : "Client secret",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "authentication",
+    "id" : "authentication.clientId",
+    "label" : "Client ID",
+    "optional" : false,
+    "tooltip" : "Your application's client ID from the OAuth client",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "authentication.clientSecret",
       "type" : "zeebe:input"
@@ -285,15 +277,18 @@
       "equals" : "oauth-client-credentials-flow",
       "type" : "simple"
     },
-    "tooltip" : "Your application's client secret from the OAuth client",
-    "type" : "String",
-    "secret" : true
-  }, {
-    "id" : "authentication.audience",
-    "label" : "Audience",
-    "optional" : true,
+    "constraints" : {
+      "notEmpty" : true
+    },
     "feel" : "optional",
     "group" : "authentication",
+    "id" : "authentication.clientSecret",
+    "label" : "Client secret",
+    "optional" : false,
+    "secret" : true,
+    "tooltip" : "Your application's client secret from the OAuth client",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "authentication.audience",
       "type" : "zeebe:input"
@@ -303,40 +298,40 @@
       "equals" : "oauth-client-credentials-flow",
       "type" : "simple"
     },
+    "feel" : "optional",
+    "group" : "authentication",
+    "id" : "authentication.audience",
+    "label" : "Audience",
+    "optional" : true,
     "tooltip" : "The unique identifier of the target API you want to access",
     "type" : "String"
   }, {
-    "id" : "authentication.clientAuthentication",
-    "label" : "Client authentication",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "group" : "authentication",
     "binding" : {
       "name" : "authentication.clientAuthentication",
       "type" : "zeebe:input"
     },
-    "condition" : {
-      "property" : "authentication.type",
-      "equals" : "oauth-client-credentials-flow",
-      "type" : "simple"
-    },
-    "tooltip" : "Send client ID and client secret as a Basic Auth header, or as client credentials in the request body",
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "Send client credentials in body",
       "value" : "credentialsBody"
     }, {
       "name" : "Send as Basic Auth header",
       "value" : "basicAuthHeader"
-    } ]
-  }, {
-    "id" : "authentication.scopes",
-    "label" : "Scopes",
-    "optional" : true,
-    "feel" : "optional",
+    } ],
+    "condition" : {
+      "property" : "authentication.type",
+      "equals" : "oauth-client-credentials-flow",
+      "type" : "simple"
+    },
+    "constraints" : {
+      "notEmpty" : true
+    },
     "group" : "authentication",
+    "id" : "authentication.clientAuthentication",
+    "label" : "Client authentication",
+    "optional" : false,
+    "tooltip" : "Send client ID and client secret as a Basic Auth header, or as client credentials in the request body",
+    "type" : "Dropdown"
+  }, {
     "binding" : {
       "name" : "authentication.scopes",
       "type" : "zeebe:input"
@@ -346,22 +341,15 @@
       "equals" : "oauth-client-credentials-flow",
       "type" : "simple"
     },
-    "tooltip" : "The scopes which you want to request authorization for",
-    "placeholder" : "read:contacts",
-    "type" : "String"
-  }, {
-    "id" : "authentication.oauthRefreshToken.oauthTokenEndpoint",
-    "label" : "OAuth 2.0 token endpoint",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true,
-      "pattern" : {
-        "value" : "^(=|(http://|https://|secrets|\\{\\{).*$)",
-        "message" : "Must be a http(s) URL"
-      }
-    },
     "feel" : "optional",
     "group" : "authentication",
+    "id" : "authentication.scopes",
+    "label" : "Scopes",
+    "optional" : true,
+    "placeholder" : "read:contacts",
+    "tooltip" : "The scopes which you want to request authorization for",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "authentication.oauthTokenEndpoint",
       "type" : "zeebe:input"
@@ -371,16 +359,20 @@
       "equals" : "oauth-refresh-token",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "authentication.oauthRefreshToken.clientId",
-    "label" : "Client ID",
-    "optional" : false,
     "constraints" : {
-      "notEmpty" : true
+      "notEmpty" : true,
+      "pattern" : {
+        "value" : "^(=|(http://|https://|secrets|\\{\\{).*$)",
+        "message" : "Must be a http(s) URL"
+      }
     },
     "feel" : "optional",
     "group" : "authentication",
+    "id" : "authentication.oauthRefreshToken.oauthTokenEndpoint",
+    "label" : "OAuth 2.0 token endpoint",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "authentication.clientId",
       "type" : "zeebe:input"
@@ -390,14 +382,17 @@
       "equals" : "oauth-refresh-token",
       "type" : "simple"
     },
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "authentication",
+    "id" : "authentication.oauthRefreshToken.clientId",
+    "label" : "Client ID",
+    "optional" : false,
     "tooltip" : "Your application's client ID from the OAuth client",
     "type" : "String"
   }, {
-    "id" : "authentication.oauthRefreshToken.clientSecret",
-    "label" : "Client secret",
-    "optional" : true,
-    "feel" : "optional",
-    "group" : "authentication",
     "binding" : {
       "name" : "authentication.clientSecret",
       "type" : "zeebe:input"
@@ -407,18 +402,15 @@
       "equals" : "oauth-refresh-token",
       "type" : "simple"
     },
-    "tooltip" : "Your application's client secret from the OAuth client",
-    "type" : "String",
-    "secret" : true
-  }, {
-    "id" : "authentication.oauthRefreshToken.refreshToken",
-    "label" : "Refresh token",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
     "feel" : "optional",
     "group" : "authentication",
+    "id" : "authentication.oauthRefreshToken.clientSecret",
+    "label" : "Client secret",
+    "optional" : true,
+    "secret" : true,
+    "tooltip" : "Your application's client secret from the OAuth client",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "authentication.refreshToken",
       "type" : "zeebe:input"
@@ -428,15 +420,18 @@
       "equals" : "oauth-refresh-token",
       "type" : "simple"
     },
-    "tooltip" : "The refresh token used to obtain a new access token",
-    "type" : "String",
-    "secret" : true
-  }, {
-    "id" : "authentication.oauthRefreshToken.scopes",
-    "label" : "Scopes",
-    "optional" : true,
+    "constraints" : {
+      "notEmpty" : true
+    },
     "feel" : "optional",
     "group" : "authentication",
+    "id" : "authentication.oauthRefreshToken.refreshToken",
+    "label" : "Refresh token",
+    "optional" : false,
+    "secret" : true,
+    "tooltip" : "The refresh token used to obtain a new access token",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "authentication.scopes",
       "type" : "zeebe:input"
@@ -446,70 +441,66 @@
       "equals" : "oauth-refresh-token",
       "type" : "simple"
     },
+    "feel" : "optional",
+    "group" : "authentication",
+    "id" : "authentication.oauthRefreshToken.scopes",
+    "label" : "Scopes",
+    "optional" : true,
     "tooltip" : "The scopes to request authorization for (space-separated)",
     "type" : "String"
   }, {
-    "id" : "clientTls.clientCertificate",
-    "label" : "Client certificate (PEM)",
-    "optional" : true,
-    "feel" : "optional",
-    "group" : "tls",
     "binding" : {
       "name" : "clientTls.clientCertificate",
       "type" : "zeebe:input"
     },
+    "feel" : "optional",
+    "group" : "tls",
+    "id" : "clientTls.clientCertificate",
+    "label" : "Client certificate (PEM)",
+    "optional" : true,
     "tooltip" : "PEM-encoded client certificate chain presented to the server for mTLS. Provide together with the private key.",
     "type" : "Text"
   }, {
-    "id" : "clientTls.clientPrivateKey",
-    "label" : "Client private key (PEM)",
-    "optional" : true,
-    "feel" : "optional",
-    "group" : "tls",
     "binding" : {
       "name" : "clientTls.clientPrivateKey",
       "type" : "zeebe:input"
     },
+    "feel" : "optional",
+    "group" : "tls",
+    "id" : "clientTls.clientPrivateKey",
+    "label" : "Client private key (PEM)",
+    "optional" : true,
     "tooltip" : "PEM-encoded private key (PKCS#1, PKCS#8 or EC), optionally encrypted.",
     "type" : "Text"
   }, {
-    "id" : "clientTls.privateKeyPassword",
-    "label" : "Private key password",
-    "optional" : true,
-    "feel" : "optional",
-    "group" : "tls",
     "binding" : {
       "name" : "clientTls.privateKeyPassword",
       "type" : "zeebe:input"
     },
+    "feel" : "optional",
+    "group" : "tls",
+    "id" : "clientTls.privateKeyPassword",
+    "label" : "Private key password",
+    "optional" : true,
     "tooltip" : "Password protecting the private key. Leave empty if it is not encrypted.",
     "type" : "String"
   }, {
-    "id" : "clientTls.trustedCertificate",
-    "label" : "Trusted CA certificate (PEM)",
-    "optional" : true,
-    "feel" : "optional",
-    "group" : "tls",
     "binding" : {
       "name" : "clientTls.trustedCertificate",
       "type" : "zeebe:input"
     },
+    "feel" : "optional",
+    "group" : "tls",
+    "id" : "clientTls.trustedCertificate",
+    "label" : "Trusted CA certificate (PEM)",
+    "optional" : true,
     "tooltip" : "Optional PEM-encoded CA certificate(s) used to validate the server. If empty, the JVM's default trust store is used.",
     "type" : "Text"
   }, {
-    "id" : "method",
-    "label" : "Method",
-    "optional" : false,
-    "value" : "GET",
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "group" : "endpoint",
     "binding" : {
       "name" : "method",
       "type" : "zeebe:input"
     },
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "POST",
       "value" : "POST"
@@ -525,11 +516,21 @@
     }, {
       "name" : "PUT",
       "value" : "PUT"
-    } ]
-  }, {
-    "id" : "url",
-    "label" : "URL",
+    } ],
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "group" : "endpoint",
+    "id" : "method",
+    "label" : "Method",
     "optional" : false,
+    "type" : "Dropdown",
+    "value" : "GET"
+  }, {
+    "binding" : {
+      "name" : "url",
+      "type" : "zeebe:input"
+    },
     "constraints" : {
       "notEmpty" : true,
       "pattern" : {
@@ -539,69 +540,62 @@
     },
     "feel" : "optional",
     "group" : "endpoint",
-    "binding" : {
-      "name" : "url",
-      "type" : "zeebe:input"
-    },
+    "id" : "url",
+    "label" : "URL",
+    "optional" : false,
     "type" : "String"
   }, {
-    "id" : "headers",
-    "label" : "Headers",
-    "optional" : true,
-    "feel" : "required",
-    "group" : "endpoint",
     "binding" : {
       "name" : "headers",
       "type" : "zeebe:input"
     },
+    "feel" : "required",
+    "group" : "endpoint",
+    "id" : "headers",
+    "label" : "Headers",
+    "optional" : true,
     "tooltip" : "Map of HTTP headers to add to the request",
     "type" : "String"
   }, {
-    "id" : "queryParameters",
-    "label" : "Query parameters",
-    "optional" : true,
-    "feel" : "required",
-    "group" : "endpoint",
     "binding" : {
       "name" : "queryParameters",
       "type" : "zeebe:input"
     },
+    "feel" : "required",
+    "group" : "endpoint",
+    "id" : "queryParameters",
+    "label" : "Query parameters",
+    "optional" : true,
     "tooltip" : "Map of query parameters to add to the request URL",
     "type" : "String"
   }, {
-    "id" : "skipEncoding",
-    "label" : "Skip URL encoding",
-    "optional" : true,
-    "group" : "endpoint",
     "binding" : {
       "name" : "skipEncoding",
       "type" : "zeebe:input"
     },
+    "group" : "endpoint",
+    "id" : "skipEncoding",
+    "label" : "Skip URL encoding",
+    "optional" : true,
     "type" : "Hidden"
   }, {
-    "id" : "followRedirects",
-    "label" : "Follow redirects",
-    "optional" : false,
-    "value" : false,
-    "feel" : "static",
-    "group" : "endpoint",
     "binding" : {
       "name" : "followRedirects",
       "type" : "zeebe:input"
     },
-    "tooltip" : "If enabled, HTTP 3xx redirects will be followed automatically. Disabled by default.",
-    "type" : "Boolean"
-  }, {
-    "id" : "documentReturnFormat",
-    "label" : "Response format",
-    "value" : "JSON",
+    "feel" : "static",
     "group" : "endpoint",
+    "id" : "followRedirects",
+    "label" : "Follow redirects",
+    "optional" : false,
+    "tooltip" : "If enabled, HTTP 3xx redirects will be followed automatically. Disabled by default.",
+    "type" : "Boolean",
+    "value" : false
+  }, {
     "binding" : {
       "name" : "documentReturnFormat.choice",
       "type" : "zeebe:input"
     },
-    "tooltip" : "How the response body should be returned. Document reference uploads the body to the document store; as text decodes it as a String; as JSON parses it into a structure you can access via dot notation.",
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "Document reference",
       "value" : "DOCUMENT"
@@ -611,14 +605,14 @@
     }, {
       "name" : "as JSON",
       "value" : "JSON"
-    } ]
-  }, {
-    "id" : "documentReturnFormatEncoding",
-    "label" : "Encoding",
-    "description" : "Character set used to decode the response. Default UTF-8.",
-    "value" : "UTF-8",
-    "feel" : "optional",
+    } ],
     "group" : "endpoint",
+    "id" : "documentReturnFormat",
+    "label" : "Response format",
+    "tooltip" : "How the response body should be returned. Document reference uploads the body to the document store; as text decodes it as a String; as JSON parses it into a structure you can access via dot notation.",
+    "type" : "Dropdown",
+    "value" : "JSON"
+  }, {
     "binding" : {
       "name" : "documentReturnFormat.encoding",
       "type" : "zeebe:input"
@@ -628,32 +622,18 @@
       "equals" : "TEXT",
       "type" : "simple"
     },
-    "type" : "String"
+    "description" : "Character set used to decode the response. Default UTF-8.",
+    "feel" : "optional",
+    "group" : "endpoint",
+    "id" : "documentReturnFormatEncoding",
+    "label" : "Encoding",
+    "type" : "String",
+    "value" : "UTF-8"
   }, {
-    "id" : "connectionTimeoutInSeconds",
-    "label" : "Connection timeout in seconds",
-    "optional" : false,
-    "value" : 20,
-    "constraints" : {
-      "notEmpty" : true,
-      "pattern" : {
-        "value" : "^\\d+$",
-        "message" : "Must be a number"
-      }
-    },
-    "feel" : "static",
-    "group" : "timeout",
     "binding" : {
       "name" : "connectionTimeoutInSeconds",
       "type" : "zeebe:input"
     },
-    "tooltip" : "Use 0 for an infinite timeout",
-    "type" : "Number"
-  }, {
-    "id" : "readTimeoutInSeconds",
-    "label" : "Read timeout in seconds",
-    "optional" : false,
-    "value" : 20,
     "constraints" : {
       "notEmpty" : true,
       "pattern" : {
@@ -663,18 +643,33 @@
     },
     "feel" : "static",
     "group" : "timeout",
+    "id" : "connectionTimeoutInSeconds",
+    "label" : "Connection timeout in seconds",
+    "optional" : false,
+    "tooltip" : "Use 0 for an infinite timeout",
+    "type" : "Number",
+    "value" : 20
+  }, {
     "binding" : {
       "name" : "readTimeoutInSeconds",
       "type" : "zeebe:input"
     },
+    "constraints" : {
+      "notEmpty" : true,
+      "pattern" : {
+        "value" : "^\\d+$",
+        "message" : "Must be a number"
+      }
+    },
+    "feel" : "static",
+    "group" : "timeout",
+    "id" : "readTimeoutInSeconds",
+    "label" : "Read timeout in seconds",
+    "optional" : false,
     "tooltip" : "Use 0 for an infinite timeout",
-    "type" : "Number"
+    "type" : "Number",
+    "value" : 20
   }, {
-    "id" : "body",
-    "label" : "Request body",
-    "optional" : true,
-    "feel" : "optional",
-    "group" : "payload",
     "binding" : {
       "name" : "body",
       "type" : "zeebe:input"
@@ -684,15 +679,14 @@
       "oneOf" : [ "POST", "PUT", "PATCH" ],
       "type" : "simple"
     },
+    "feel" : "optional",
+    "group" : "payload",
+    "id" : "body",
+    "label" : "Request body",
+    "optional" : true,
     "tooltip" : "Payload to send with the request",
     "type" : "Text"
   }, {
-    "id" : "ignoreNullValues",
-    "label" : "Ignore null values",
-    "optional" : false,
-    "value" : false,
-    "feel" : "static",
-    "group" : "payload",
     "binding" : {
       "name" : "ignoreNullValues",
       "type" : "zeebe:input"
@@ -702,97 +696,103 @@
       "oneOf" : [ "POST", "PUT", "PATCH" ],
       "type" : "simple"
     },
+    "feel" : "static",
+    "group" : "payload",
+    "id" : "ignoreNullValues",
+    "label" : "Ignore null values",
+    "optional" : false,
     "tooltip" : "Null values will not be sent",
-    "type" : "Boolean"
+    "type" : "Boolean",
+    "value" : false
   }, {
-    "id" : "version",
-    "label" : "Version",
-    "description" : "Version of the element template",
-    "value" : "17",
-    "group" : "connector",
     "binding" : {
       "key" : "elementTemplateVersion",
       "type" : "zeebe:taskHeader"
     },
-    "type" : "Hidden"
-  }, {
-    "id" : "id",
-    "label" : "ID",
-    "description" : "ID of the element template",
-    "value" : "io.camunda.connectors.HttpJson.v2",
+    "description" : "Version of the element template",
     "group" : "connector",
+    "id" : "version",
+    "label" : "Version",
+    "type" : "Hidden",
+    "value" : "17"
+  }, {
     "binding" : {
       "key" : "elementTemplateId",
       "type" : "zeebe:taskHeader"
     },
-    "type" : "Hidden"
+    "description" : "ID of the element template",
+    "group" : "connector",
+    "id" : "id",
+    "label" : "ID",
+    "type" : "Hidden",
+    "value" : "io.camunda.connectors.HttpJson.v2"
   }, {
-    "id" : "resultVariable",
-    "label" : "Result variable",
-    "description" : "Name of variable to store the response in. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-variable\" target=\"_blank\">documentation</a>.",
-    "group" : "output",
     "binding" : {
       "key" : "resultVariable",
       "type" : "zeebe:taskHeader"
     },
+    "description" : "Name of variable to store the response in. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-variable\" target=\"_blank\">documentation</a>.",
+    "group" : "output",
+    "id" : "resultVariable",
+    "label" : "Result variable",
     "type" : "String"
   }, {
-    "id" : "resultExpression",
-    "label" : "Result expression",
-    "description" : "Expression to map the response into process variables. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-expression\" target=\"_blank\">documentation</a>.",
-    "value" : "{\n  myResponseBody: response.body\n  // Use FEEL to extract values, e.g.,:\n  // myUserId: response.body.post.userId\n}",
-    "feel" : "required",
-    "group" : "output",
     "binding" : {
       "key" : "resultExpression",
       "type" : "zeebe:taskHeader"
     },
-    "tooltip" : "<div><p>Example response:</p><code>{\"body\":{\"order\":{\"id\":\"123\",\"total\":\"100.00€\"}},\"headers\":{\"Content-Type\":\"application/json\"},\"status\":200}</code><p>Example FEEL expression: <code>= { orderId: body.order.id }</code> -&gt; <code>{\"orderId\":\"123\"}</code></p></div>",
-    "type" : "Text"
-  }, {
-    "id" : "errorExpression",
-    "label" : "Error expression",
-    "description" : "Expression to handle errors. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/\" target=\"_blank\">documentation</a>.",
+    "description" : "Expression to map the response into process variables. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-expression\" target=\"_blank\">documentation</a>.",
     "feel" : "required",
-    "group" : "error",
+    "group" : "output",
+    "id" : "resultExpression",
+    "label" : "Result expression",
+    "tooltip" : "<div><p>Example response:</p><code>{\"status\":200,\"headers\":{\"Content-Type\":\"application/json\"},\"body\":{\"order\":{\"id\":\"123\",\"total\":\"100.00€\"}}}</code><p>Example FEEL expression: <code>= { orderId: body.order.id }</code> -&gt; <code>{\"orderId\":\"123\"}</code></p></div>",
+    "type" : "Text",
+    "value" : "{\n  myResponseBody: response.body\n  // Use FEEL to extract values, e.g.,:\n  // myUserId: response.body.post.userId\n}"
+  }, {
     "binding" : {
       "key" : "errorExpression",
       "type" : "zeebe:taskHeader"
     },
+    "description" : "Expression to handle errors. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/\" target=\"_blank\">documentation</a>.",
+    "feel" : "required",
+    "group" : "error",
+    "id" : "errorExpression",
+    "label" : "Error expression",
     "type" : "Text"
   }, {
-    "id" : "retryCount",
-    "label" : "Retries",
-    "description" : "Number of retries",
-    "value" : "3",
-    "feel" : "optional",
-    "group" : "retries",
     "binding" : {
       "property" : "retries",
       "type" : "zeebe:taskDefinition"
     },
-    "type" : "String"
-  }, {
-    "id" : "retryBackoff",
-    "label" : "Retry backoff",
-    "description" : "ISO-8601 duration to wait between retries",
-    "value" : "PT30S",
+    "description" : "Number of retries",
+    "feel" : "optional",
     "group" : "retries",
+    "id" : "retryCount",
+    "label" : "Retries",
+    "type" : "String",
+    "value" : "3"
+  }, {
     "binding" : {
       "key" : "retryBackoff",
       "type" : "zeebe:taskHeader"
     },
-    "type" : "String"
-  }, {
-    "id" : "jobTimeout",
-    "label" : "Job timeout",
-    "description" : "ISO-8601 duration after which Zeebe considers this job timed out if not yet completed. Leave empty to use the default timeout",
-    "optional" : true,
+    "description" : "ISO-8601 duration to wait between retries",
     "group" : "retries",
+    "id" : "retryBackoff",
+    "label" : "Retry backoff",
+    "type" : "String",
+    "value" : "PT30S"
+  }, {
     "binding" : {
       "key" : "jobTimeout",
       "type" : "zeebe:taskHeader"
     },
+    "description" : "ISO-8601 duration after which Zeebe considers this job timed out if not yet completed. Leave empty to use the default timeout",
+    "group" : "retries",
+    "id" : "jobTimeout",
+    "label" : "Job timeout",
+    "optional" : true,
     "type" : "String"
   } ],
   "configurationTemplates" : [ {
@@ -801,16 +801,10 @@
     "version" : 1,
     "name" : "REST Authentication",
     "properties" : [ {
-      "id" : "authentication.type",
-      "label" : "Type",
-      "description" : "Choose the authentication type. Select 'None' if no authentication is necessary",
-      "value" : "noAuth",
-      "group" : "authentication",
       "binding" : {
         "name" : "authentication.type",
         "type" : "property"
       },
-      "type" : "Dropdown",
       "choices" : [ {
         "name" : "API key",
         "value" : "apiKey"
@@ -829,40 +823,40 @@
       }, {
         "name" : "OAuth 2.0 Refresh Token",
         "value" : "oauth-refresh-token"
-      } ]
-    }, {
-      "id" : "authentication.apiKeyLocation",
-      "label" : "Api key location",
-      "value" : "headers",
-      "constraints" : {
-        "notEmpty" : true
-      },
+      } ],
+      "description" : "Choose the authentication type. Select 'None' if no authentication is necessary",
       "group" : "authentication",
+      "id" : "authentication.type",
+      "label" : "Type",
+      "type" : "Dropdown",
+      "value" : "noAuth"
+    }, {
       "binding" : {
         "name" : "authentication.apiKeyLocation",
         "type" : "property"
       },
-      "condition" : {
-        "property" : "authentication.type",
-        "equals" : "apiKey",
-        "type" : "simple"
-      },
-      "tooltip" : "Send API key in header or as query parameter.",
-      "type" : "Dropdown",
       "choices" : [ {
         "name" : "Headers",
         "value" : "headers"
       }, {
         "name" : "Query parameters",
         "value" : "query"
-      } ]
-    }, {
-      "id" : "authentication.name",
-      "label" : "API key name",
+      } ],
+      "condition" : {
+        "property" : "authentication.type",
+        "equals" : "apiKey",
+        "type" : "simple"
+      },
       "constraints" : {
         "notEmpty" : true
       },
       "group" : "authentication",
+      "id" : "authentication.apiKeyLocation",
+      "label" : "Api key location",
+      "tooltip" : "Send API key in header or as query parameter.",
+      "type" : "Dropdown",
+      "value" : "headers"
+    }, {
       "binding" : {
         "name" : "authentication.name",
         "type" : "property"
@@ -872,14 +866,14 @@
         "equals" : "apiKey",
         "type" : "simple"
       },
-      "type" : "String"
-    }, {
-      "id" : "authentication.value",
-      "label" : "API key value",
       "constraints" : {
         "notEmpty" : true
       },
       "group" : "authentication",
+      "id" : "authentication.name",
+      "label" : "API key name",
+      "type" : "String"
+    }, {
       "binding" : {
         "name" : "authentication.value",
         "type" : "property"
@@ -889,15 +883,15 @@
         "equals" : "apiKey",
         "type" : "simple"
       },
-      "type" : "String",
-      "secret" : true
-    }, {
-      "id" : "authentication.username",
-      "label" : "Username",
       "constraints" : {
         "notEmpty" : true
       },
       "group" : "authentication",
+      "id" : "authentication.value",
+      "label" : "API key value",
+      "secret" : true,
+      "type" : "String"
+    }, {
       "binding" : {
         "name" : "authentication.username",
         "type" : "property"
@@ -907,14 +901,14 @@
         "equals" : "basic",
         "type" : "simple"
       },
-      "type" : "String"
-    }, {
-      "id" : "authentication.password",
-      "label" : "Password",
       "constraints" : {
         "notEmpty" : true
       },
       "group" : "authentication",
+      "id" : "authentication.username",
+      "label" : "Username",
+      "type" : "String"
+    }, {
       "binding" : {
         "name" : "authentication.password",
         "type" : "property"
@@ -924,15 +918,15 @@
         "equals" : "basic",
         "type" : "simple"
       },
-      "type" : "String",
-      "secret" : true
-    }, {
-      "id" : "authentication.token",
-      "label" : "Bearer token",
       "constraints" : {
         "notEmpty" : true
       },
       "group" : "authentication",
+      "id" : "authentication.password",
+      "label" : "Password",
+      "secret" : true,
+      "type" : "String"
+    }, {
       "binding" : {
         "name" : "authentication.token",
         "type" : "property"
@@ -942,19 +936,15 @@
         "equals" : "bearer",
         "type" : "simple"
       },
-      "type" : "String",
-      "secret" : true
-    }, {
-      "id" : "authentication.oauthTokenEndpoint",
-      "label" : "OAuth 2.0 token endpoint",
       "constraints" : {
-        "notEmpty" : true,
-        "pattern" : {
-          "value" : "^(=|(http://|https://|secrets|\\{\\{).*$)",
-          "message" : "Must be a http(s) URL"
-        }
+        "notEmpty" : true
       },
       "group" : "authentication",
+      "id" : "authentication.token",
+      "label" : "Bearer token",
+      "secret" : true,
+      "type" : "String"
+    }, {
       "binding" : {
         "name" : "authentication.oauthTokenEndpoint",
         "type" : "property"
@@ -964,14 +954,18 @@
         "equals" : "oauth-client-credentials-flow",
         "type" : "simple"
       },
-      "type" : "String"
-    }, {
-      "id" : "authentication.clientId",
-      "label" : "Client ID",
       "constraints" : {
-        "notEmpty" : true
+        "notEmpty" : true,
+        "pattern" : {
+          "value" : "^(=|(http://|https://|secrets|\\{\\{).*$)",
+          "message" : "Must be a http(s) URL"
+        }
       },
       "group" : "authentication",
+      "id" : "authentication.oauthTokenEndpoint",
+      "label" : "OAuth 2.0 token endpoint",
+      "type" : "String"
+    }, {
       "binding" : {
         "name" : "authentication.clientId",
         "type" : "property"
@@ -981,15 +975,15 @@
         "equals" : "oauth-client-credentials-flow",
         "type" : "simple"
       },
-      "tooltip" : "Your application's client ID from the OAuth client",
-      "type" : "String"
-    }, {
-      "id" : "authentication.clientSecret",
-      "label" : "Client secret",
       "constraints" : {
         "notEmpty" : true
       },
       "group" : "authentication",
+      "id" : "authentication.clientId",
+      "label" : "Client ID",
+      "tooltip" : "Your application's client ID from the OAuth client",
+      "type" : "String"
+    }, {
       "binding" : {
         "name" : "authentication.clientSecret",
         "type" : "property"
@@ -999,13 +993,16 @@
         "equals" : "oauth-client-credentials-flow",
         "type" : "simple"
       },
-      "tooltip" : "Your application's client secret from the OAuth client",
-      "type" : "String",
-      "secret" : true
-    }, {
-      "id" : "authentication.audience",
-      "label" : "Audience",
+      "constraints" : {
+        "notEmpty" : true
+      },
       "group" : "authentication",
+      "id" : "authentication.clientSecret",
+      "label" : "Client secret",
+      "secret" : true,
+      "tooltip" : "Your application's client secret from the OAuth client",
+      "type" : "String"
+    }, {
       "binding" : {
         "name" : "authentication.audience",
         "type" : "property"
@@ -1015,37 +1012,37 @@
         "equals" : "oauth-client-credentials-flow",
         "type" : "simple"
       },
+      "group" : "authentication",
+      "id" : "authentication.audience",
+      "label" : "Audience",
       "tooltip" : "The unique identifier of the target API you want to access",
       "type" : "String"
     }, {
-      "id" : "authentication.clientAuthentication",
-      "label" : "Client authentication",
-      "constraints" : {
-        "notEmpty" : true
-      },
-      "group" : "authentication",
       "binding" : {
         "name" : "authentication.clientAuthentication",
         "type" : "property"
       },
-      "condition" : {
-        "property" : "authentication.type",
-        "equals" : "oauth-client-credentials-flow",
-        "type" : "simple"
-      },
-      "tooltip" : "Send client ID and client secret as a Basic Auth header, or as client credentials in the request body",
-      "type" : "Dropdown",
       "choices" : [ {
         "name" : "Send client credentials in body",
         "value" : "credentialsBody"
       }, {
         "name" : "Send as Basic Auth header",
         "value" : "basicAuthHeader"
-      } ]
-    }, {
-      "id" : "authentication.scopes",
-      "label" : "Scopes",
+      } ],
+      "condition" : {
+        "property" : "authentication.type",
+        "equals" : "oauth-client-credentials-flow",
+        "type" : "simple"
+      },
+      "constraints" : {
+        "notEmpty" : true
+      },
       "group" : "authentication",
+      "id" : "authentication.clientAuthentication",
+      "label" : "Client authentication",
+      "tooltip" : "Send client ID and client secret as a Basic Auth header, or as client credentials in the request body",
+      "type" : "Dropdown"
+    }, {
       "binding" : {
         "name" : "authentication.scopes",
         "type" : "property"
@@ -1055,20 +1052,13 @@
         "equals" : "oauth-client-credentials-flow",
         "type" : "simple"
       },
-      "tooltip" : "The scopes which you want to request authorization for",
+      "group" : "authentication",
+      "id" : "authentication.scopes",
+      "label" : "Scopes",
       "placeholder" : "read:contacts",
+      "tooltip" : "The scopes which you want to request authorization for",
       "type" : "String"
     }, {
-      "id" : "authentication.oauthRefreshToken.oauthTokenEndpoint",
-      "label" : "OAuth 2.0 token endpoint",
-      "constraints" : {
-        "notEmpty" : true,
-        "pattern" : {
-          "value" : "^(=|(http://|https://|secrets|\\{\\{).*$)",
-          "message" : "Must be a http(s) URL"
-        }
-      },
-      "group" : "authentication",
       "binding" : {
         "name" : "authentication.oauthRefreshToken.oauthTokenEndpoint",
         "type" : "property"
@@ -1078,14 +1068,18 @@
         "equals" : "oauth-refresh-token",
         "type" : "simple"
       },
-      "type" : "String"
-    }, {
-      "id" : "authentication.oauthRefreshToken.clientId",
-      "label" : "Client ID",
       "constraints" : {
-        "notEmpty" : true
+        "notEmpty" : true,
+        "pattern" : {
+          "value" : "^(=|(http://|https://|secrets|\\{\\{).*$)",
+          "message" : "Must be a http(s) URL"
+        }
       },
       "group" : "authentication",
+      "id" : "authentication.oauthRefreshToken.oauthTokenEndpoint",
+      "label" : "OAuth 2.0 token endpoint",
+      "type" : "String"
+    }, {
       "binding" : {
         "name" : "authentication.oauthRefreshToken.clientId",
         "type" : "property"
@@ -1095,12 +1089,15 @@
         "equals" : "oauth-refresh-token",
         "type" : "simple"
       },
+      "constraints" : {
+        "notEmpty" : true
+      },
+      "group" : "authentication",
+      "id" : "authentication.oauthRefreshToken.clientId",
+      "label" : "Client ID",
       "tooltip" : "Your application's client ID from the OAuth client",
       "type" : "String"
     }, {
-      "id" : "authentication.oauthRefreshToken.clientSecret",
-      "label" : "Client secret",
-      "group" : "authentication",
       "binding" : {
         "name" : "authentication.oauthRefreshToken.clientSecret",
         "type" : "property"
@@ -1110,16 +1107,13 @@
         "equals" : "oauth-refresh-token",
         "type" : "simple"
       },
-      "tooltip" : "Your application's client secret from the OAuth client",
-      "type" : "String",
-      "secret" : true
-    }, {
-      "id" : "authentication.oauthRefreshToken.refreshToken",
-      "label" : "Refresh token",
-      "constraints" : {
-        "notEmpty" : true
-      },
       "group" : "authentication",
+      "id" : "authentication.oauthRefreshToken.clientSecret",
+      "label" : "Client secret",
+      "secret" : true,
+      "tooltip" : "Your application's client secret from the OAuth client",
+      "type" : "String"
+    }, {
       "binding" : {
         "name" : "authentication.oauthRefreshToken.refreshToken",
         "type" : "property"
@@ -1129,13 +1123,16 @@
         "equals" : "oauth-refresh-token",
         "type" : "simple"
       },
-      "tooltip" : "The refresh token used to obtain a new access token",
-      "type" : "String",
-      "secret" : true
-    }, {
-      "id" : "authentication.oauthRefreshToken.scopes",
-      "label" : "Scopes",
+      "constraints" : {
+        "notEmpty" : true
+      },
       "group" : "authentication",
+      "id" : "authentication.oauthRefreshToken.refreshToken",
+      "label" : "Refresh token",
+      "secret" : true,
+      "tooltip" : "The refresh token used to obtain a new access token",
+      "type" : "String"
+    }, {
       "binding" : {
         "name" : "authentication.oauthRefreshToken.scopes",
         "type" : "property"
@@ -1145,6 +1142,9 @@
         "equals" : "oauth-refresh-token",
         "type" : "simple"
       },
+      "group" : "authentication",
+      "id" : "authentication.oauthRefreshToken.scopes",
+      "label" : "Scopes",
       "tooltip" : "The scopes to request authorization for (space-separated)",
       "type" : "String"
     } ]

--- a/connectors/http/rest/pom.xml
+++ b/connectors/http/rest/pom.xml
@@ -63,7 +63,7 @@ limitations under the License.</license.inlineheader>
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
+      <groupId>tools.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
       <scope>test</scope>
     </dependency>

--- a/connectors/jdbc/element-templates/hybrid/jdbc-outbound-connector-hybrid.json
+++ b/connectors/jdbc/element-templates/hybrid/jdbc-outbound-connector-hybrid.json
@@ -43,28 +43,19 @@
     "label" : "Retries"
   } ],
   "properties" : [ {
-    "id" : "taskDefinitionType",
-    "value" : "io.camunda:connector-jdbc:1",
-    "group" : "taskDefinitionType",
     "binding" : {
       "property" : "type",
       "type" : "zeebe:taskDefinition"
     },
-    "type" : "String"
+    "group" : "taskDefinitionType",
+    "id" : "taskDefinitionType",
+    "type" : "String",
+    "value" : "io.camunda:connector-jdbc:1"
   }, {
-    "id" : "database",
-    "label" : "Select a database",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "group" : "database",
     "binding" : {
       "name" : "database",
       "type" : "zeebe:input"
     },
-    "tooltip" : "If you choose Oracle, make sure the Oracle JDBC driver is included. <a href=\"https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/sql/#database\">Oracle JDBC driver setup</a>.",
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "MariaDB",
       "value" : "MARIADB"
@@ -80,37 +71,34 @@
     }, {
       "name" : "Oracle",
       "value" : "ORACLE"
-    } ]
+    } ],
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "group" : "database",
+    "id" : "database",
+    "label" : "Select a database",
+    "optional" : false,
+    "tooltip" : "If you choose Oracle, make sure the Oracle JDBC driver is included. <a href=\"https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/sql/#database\">Oracle JDBC driver setup</a>.",
+    "type" : "Dropdown"
   }, {
-    "id" : "connection.authType",
-    "label" : "Connection type",
-    "value" : "uri",
-    "group" : "connection",
     "binding" : {
       "name" : "connection.authType",
       "type" : "zeebe:input"
     },
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "URI",
       "value" : "uri"
     }, {
       "name" : "Detailed",
       "value" : "detailed"
-    } ]
-  }, {
-    "id" : "connection.uri",
-    "label" : "URI",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true,
-      "pattern" : {
-        "value" : "^(=|(jdbc:|secrets|\\{\\{).*$)",
-        "message" : "Must start with 'jdbc:' or contain a secret reference"
-      }
-    },
-    "feel" : "optional",
+    } ],
     "group" : "connection",
+    "id" : "connection.authType",
+    "label" : "Connection type",
+    "type" : "Dropdown",
+    "value" : "uri"
+  }, {
     "binding" : {
       "name" : "connection.uri",
       "type" : "zeebe:input"
@@ -120,14 +108,21 @@
       "equals" : "uri",
       "type" : "simple"
     },
+    "constraints" : {
+      "notEmpty" : true,
+      "pattern" : {
+        "value" : "^(=|(jdbc:|secrets|\\{\\{).*$)",
+        "message" : "Must start with 'jdbc:' or contain a secret reference"
+      }
+    },
+    "feel" : "optional",
+    "group" : "connection",
+    "id" : "connection.uri",
+    "label" : "URI",
+    "optional" : false,
     "tooltip" : "URI should contain JDBC driver, host name, and port number. See the <a href=\"https://docs.camunda.io/docs/8.6/components/connectors/out-of-the-box-connectors/sql/#uri-connection\" target=\"_blank\">URI connection</a> reference.",
     "type" : "String"
   }, {
-    "id" : "connection.uriProperties",
-    "label" : "Properties",
-    "optional" : true,
-    "feel" : "required",
-    "group" : "connection",
     "binding" : {
       "name" : "connection.uriProperties",
       "type" : "zeebe:input"
@@ -137,17 +132,14 @@
       "equals" : "uri",
       "type" : "simple"
     },
+    "feel" : "required",
+    "group" : "connection",
+    "id" : "connection.uriProperties",
+    "label" : "Properties",
+    "optional" : true,
     "tooltip" : "Additional properties for the connection ('user' and 'password' for instance). See the <a href=\"https://docs.camunda.io/docs/8.6/components/connectors/out-of-the-box-connectors/sql/#connection\" target=\"_blank\">SQL connection properties</a> reference.",
     "type" : "String"
   }, {
-    "id" : "connection.host",
-    "label" : "Host",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "feel" : "optional",
-    "group" : "connection",
     "binding" : {
       "name" : "connection.host",
       "type" : "zeebe:input"
@@ -157,16 +149,16 @@
       "equals" : "detailed",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "connection.port",
-    "label" : "Port",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "connection",
+    "id" : "connection.host",
+    "label" : "Host",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "connection.port",
       "type" : "zeebe:input"
@@ -176,13 +168,16 @@
       "equals" : "detailed",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "connection.username",
-    "label" : "Username",
-    "optional" : true,
+    "constraints" : {
+      "notEmpty" : true
+    },
     "feel" : "optional",
     "group" : "connection",
+    "id" : "connection.port",
+    "label" : "Port",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "connection.username",
       "type" : "zeebe:input"
@@ -192,13 +187,13 @@
       "equals" : "detailed",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "connection.password",
-    "label" : "Password",
-    "optional" : true,
     "feel" : "optional",
     "group" : "connection",
+    "id" : "connection.username",
+    "label" : "Username",
+    "optional" : true,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "connection.password",
       "type" : "zeebe:input"
@@ -208,13 +203,13 @@
       "equals" : "detailed",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "connection.databaseName",
-    "label" : "Database name",
-    "optional" : true,
     "feel" : "optional",
     "group" : "connection",
+    "id" : "connection.password",
+    "label" : "Password",
+    "optional" : true,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "connection.databaseName",
       "type" : "zeebe:input"
@@ -224,13 +219,13 @@
       "equals" : "detailed",
       "type" : "simple"
     },
+    "feel" : "optional",
+    "group" : "connection",
+    "id" : "connection.databaseName",
+    "label" : "Database name",
+    "optional" : true,
     "type" : "String"
   }, {
-    "id" : "connection.properties",
-    "label" : "Properties",
-    "optional" : true,
-    "feel" : "required",
-    "group" : "connection",
     "binding" : {
       "name" : "connection.properties",
       "type" : "zeebe:input"
@@ -240,147 +235,152 @@
       "equals" : "detailed",
       "type" : "simple"
     },
+    "feel" : "required",
+    "group" : "connection",
+    "id" : "connection.properties",
+    "label" : "Properties",
+    "optional" : true,
     "tooltip" : "Additional properties for the connection. See the <a href=\"https://docs.camunda.io/docs/8.6/components/connectors/out-of-the-box-connectors/sql/#connection\" target=\"_blank\">SQL connection properties</a> reference.",
     "type" : "String"
   }, {
-    "id" : "connectionConfiguration",
-    "label" : "Connection credential",
-    "description" : "Choose a reusable JDBC connection credential. When set, it is bound as a whole to the connector's 'configuration' input.",
-    "optional" : true,
-    "group" : "connection",
     "binding" : {
       "name" : "configuration",
       "type" : "zeebe:input"
     },
-    "type" : "Configuration",
-    "configurationTemplate" : "io.camunda.connectors:jdbc-connection:1"
+    "configurationTemplate" : "io.camunda.connectors:jdbc-connection:1",
+    "description" : "Choose a reusable JDBC connection credential. When set, it is bound as a whole to the connector's 'configuration' input.",
+    "group" : "connection",
+    "id" : "connectionConfiguration",
+    "label" : "Connection credential",
+    "optional" : true,
+    "type" : "Configuration"
   }, {
-    "id" : "data.returnResults",
-    "label" : "Return results",
-    "optional" : false,
-    "value" : false,
-    "feel" : "static",
-    "group" : "query",
     "binding" : {
       "name" : "data.returnResults",
       "type" : "zeebe:input"
     },
-    "tooltip" : "Check this box if the SQL statement returns results, e.g. a SELECT or any statement with a RETURNING clause",
-    "type" : "Boolean"
-  }, {
-    "id" : "data.query",
-    "label" : "SQL Query to execute",
+    "feel" : "static",
+    "group" : "query",
+    "id" : "data.returnResults",
+    "label" : "Return results",
     "optional" : false,
+    "tooltip" : "Check this box if the SQL statement returns results, e.g. a SELECT or any statement with a RETURNING clause",
+    "type" : "Boolean",
+    "value" : false
+  }, {
+    "binding" : {
+      "name" : "data.query",
+      "type" : "zeebe:input"
+    },
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "query",
-    "binding" : {
-      "name" : "data.query",
-      "type" : "zeebe:input"
-    },
+    "id" : "data.query",
+    "label" : "SQL Query to execute",
+    "optional" : false,
     "tooltip" : "You can use named, positional or binding <a href=\"https://docs.camunda.io/docs/8.6/components/connectors/out-of-the-box-connectors/sql/#variables\" target=\"_blank\">parameters</a>",
     "type" : "String"
   }, {
-    "id" : "data.variables",
-    "label" : "SQL Query variables",
-    "optional" : true,
-    "feel" : "required",
-    "group" : "query",
     "binding" : {
       "name" : "data.variables",
       "type" : "zeebe:input"
     },
+    "feel" : "required",
+    "group" : "query",
+    "id" : "data.variables",
+    "label" : "SQL Query variables",
+    "optional" : true,
     "tooltip" : "The <a href=\"https://docs.camunda.io/docs/8.6/components/connectors/out-of-the-box-connectors/sql/#variables\" target=\"_blank\">variables</a> to use in the SQL query.",
     "type" : "String"
   }, {
-    "id" : "version",
-    "label" : "Version",
-    "description" : "Version of the element template",
-    "value" : "5",
-    "group" : "connector",
     "binding" : {
       "key" : "elementTemplateVersion",
       "type" : "zeebe:taskHeader"
     },
-    "type" : "Hidden"
-  }, {
-    "id" : "id",
-    "label" : "ID",
-    "description" : "ID of the element template",
-    "value" : "io.camunda.connectors.Jdbc.v1",
+    "description" : "Version of the element template",
     "group" : "connector",
+    "id" : "version",
+    "label" : "Version",
+    "type" : "Hidden",
+    "value" : "5"
+  }, {
     "binding" : {
       "key" : "elementTemplateId",
       "type" : "zeebe:taskHeader"
     },
-    "type" : "Hidden"
+    "description" : "ID of the element template",
+    "group" : "connector",
+    "id" : "id",
+    "label" : "ID",
+    "type" : "Hidden",
+    "value" : "io.camunda.connectors.Jdbc.v1"
   }, {
-    "id" : "resultVariable",
-    "label" : "Result variable",
-    "description" : "Name of variable to store the response in. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-variable\" target=\"_blank\">documentation</a>.",
-    "group" : "output",
     "binding" : {
       "key" : "resultVariable",
       "type" : "zeebe:taskHeader"
     },
+    "description" : "Name of variable to store the response in. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-variable\" target=\"_blank\">documentation</a>.",
+    "group" : "output",
+    "id" : "resultVariable",
+    "label" : "Result variable",
     "type" : "String"
   }, {
-    "id" : "resultExpression",
-    "label" : "Result expression",
-    "description" : "Expression to map the response into process variables. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-expression\" target=\"_blank\">documentation</a>.",
-    "feel" : "required",
-    "group" : "output",
     "binding" : {
       "key" : "resultExpression",
       "type" : "zeebe:taskHeader"
     },
+    "description" : "Expression to map the response into process variables. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-expression\" target=\"_blank\">documentation</a>.",
+    "feel" : "required",
+    "group" : "output",
+    "id" : "resultExpression",
+    "label" : "Result expression",
     "type" : "Text"
   }, {
-    "id" : "errorExpression",
-    "label" : "Error expression",
-    "description" : "Expression to handle errors. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/\" target=\"_blank\">documentation</a>.",
-    "feel" : "required",
-    "group" : "error",
     "binding" : {
       "key" : "errorExpression",
       "type" : "zeebe:taskHeader"
     },
+    "description" : "Expression to handle errors. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/\" target=\"_blank\">documentation</a>.",
+    "feel" : "required",
+    "group" : "error",
+    "id" : "errorExpression",
+    "label" : "Error expression",
     "type" : "Text"
   }, {
-    "id" : "retryCount",
-    "label" : "Retries",
-    "description" : "Number of retries",
-    "value" : "3",
-    "feel" : "optional",
-    "group" : "retries",
     "binding" : {
       "property" : "retries",
       "type" : "zeebe:taskDefinition"
     },
-    "type" : "String"
-  }, {
-    "id" : "retryBackoff",
-    "label" : "Retry backoff",
-    "description" : "ISO-8601 duration to wait between retries",
-    "value" : "PT30S",
+    "description" : "Number of retries",
+    "feel" : "optional",
     "group" : "retries",
+    "id" : "retryCount",
+    "label" : "Retries",
+    "type" : "String",
+    "value" : "3"
+  }, {
     "binding" : {
       "key" : "retryBackoff",
       "type" : "zeebe:taskHeader"
     },
-    "type" : "String"
-  }, {
-    "id" : "jobTimeout",
-    "label" : "Job timeout",
-    "description" : "ISO-8601 duration after which Zeebe considers this job timed out if not yet completed. Leave empty to use the default timeout",
-    "optional" : true,
+    "description" : "ISO-8601 duration to wait between retries",
     "group" : "retries",
+    "id" : "retryBackoff",
+    "label" : "Retry backoff",
+    "type" : "String",
+    "value" : "PT30S"
+  }, {
     "binding" : {
       "key" : "jobTimeout",
       "type" : "zeebe:taskHeader"
     },
+    "description" : "ISO-8601 duration after which Zeebe considers this job timed out if not yet completed. Leave empty to use the default timeout",
+    "group" : "retries",
+    "id" : "jobTimeout",
+    "label" : "Job timeout",
+    "optional" : true,
     "type" : "String"
   } ],
   "configurationTemplates" : [ {
@@ -389,58 +389,58 @@
     "version" : 1,
     "name" : "JDBC Connection",
     "properties" : [ {
-      "id" : "host",
-      "label" : "Host",
-      "constraints" : {
-        "notEmpty" : true
-      },
-      "group" : "connection",
       "binding" : {
         "name" : "host",
         "type" : "property"
       },
-      "type" : "String"
-    }, {
-      "id" : "port",
-      "label" : "Port",
       "constraints" : {
         "notEmpty" : true
       },
       "group" : "connection",
+      "id" : "host",
+      "label" : "Host",
+      "type" : "String"
+    }, {
       "binding" : {
         "name" : "port",
         "type" : "property"
       },
+      "constraints" : {
+        "notEmpty" : true
+      },
+      "group" : "connection",
+      "id" : "port",
+      "label" : "Port",
       "type" : "String"
     }, {
-      "id" : "databaseName",
-      "label" : "Database name",
-      "group" : "connection",
       "binding" : {
         "name" : "databaseName",
         "type" : "property"
       },
+      "group" : "connection",
+      "id" : "databaseName",
+      "label" : "Database name",
       "type" : "String"
     }, {
-      "id" : "username",
-      "label" : "Username",
-      "group" : "authentication",
       "binding" : {
         "name" : "username",
         "type" : "property"
       },
-      "type" : "String",
-      "secret" : true
-    }, {
-      "id" : "password",
-      "label" : "Password",
       "group" : "authentication",
+      "id" : "username",
+      "label" : "Username",
+      "secret" : true,
+      "type" : "String"
+    }, {
       "binding" : {
         "name" : "password",
         "type" : "property"
       },
-      "type" : "String",
-      "secret" : true
+      "group" : "authentication",
+      "id" : "password",
+      "label" : "Password",
+      "secret" : true,
+      "type" : "String"
     } ]
   } ],
   "icon" : {

--- a/connectors/jdbc/element-templates/jdbc-outbound-connector.json
+++ b/connectors/jdbc/element-templates/jdbc-outbound-connector.json
@@ -40,26 +40,17 @@
     "label" : "Retries"
   } ],
   "properties" : [ {
-    "value" : "io.camunda:connector-jdbc:1",
     "binding" : {
       "property" : "type",
       "type" : "zeebe:taskDefinition"
     },
-    "type" : "Hidden"
+    "type" : "Hidden",
+    "value" : "io.camunda:connector-jdbc:1"
   }, {
-    "id" : "database",
-    "label" : "Select a database",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "group" : "database",
     "binding" : {
       "name" : "database",
       "type" : "zeebe:input"
     },
-    "tooltip" : "If you choose Oracle, make sure the Oracle JDBC driver is included. <a href=\"https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/sql/#database\">Oracle JDBC driver setup</a>.",
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "MariaDB",
       "value" : "MARIADB"
@@ -75,37 +66,34 @@
     }, {
       "name" : "Oracle",
       "value" : "ORACLE"
-    } ]
+    } ],
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "group" : "database",
+    "id" : "database",
+    "label" : "Select a database",
+    "optional" : false,
+    "tooltip" : "If you choose Oracle, make sure the Oracle JDBC driver is included. <a href=\"https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/sql/#database\">Oracle JDBC driver setup</a>.",
+    "type" : "Dropdown"
   }, {
-    "id" : "connection.authType",
-    "label" : "Connection type",
-    "value" : "uri",
-    "group" : "connection",
     "binding" : {
       "name" : "connection.authType",
       "type" : "zeebe:input"
     },
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "URI",
       "value" : "uri"
     }, {
       "name" : "Detailed",
       "value" : "detailed"
-    } ]
-  }, {
-    "id" : "connection.uri",
-    "label" : "URI",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true,
-      "pattern" : {
-        "value" : "^(=|(jdbc:|secrets|\\{\\{).*$)",
-        "message" : "Must start with 'jdbc:' or contain a secret reference"
-      }
-    },
-    "feel" : "optional",
+    } ],
     "group" : "connection",
+    "id" : "connection.authType",
+    "label" : "Connection type",
+    "type" : "Dropdown",
+    "value" : "uri"
+  }, {
     "binding" : {
       "name" : "connection.uri",
       "type" : "zeebe:input"
@@ -115,14 +103,21 @@
       "equals" : "uri",
       "type" : "simple"
     },
+    "constraints" : {
+      "notEmpty" : true,
+      "pattern" : {
+        "value" : "^(=|(jdbc:|secrets|\\{\\{).*$)",
+        "message" : "Must start with 'jdbc:' or contain a secret reference"
+      }
+    },
+    "feel" : "optional",
+    "group" : "connection",
+    "id" : "connection.uri",
+    "label" : "URI",
+    "optional" : false,
     "tooltip" : "URI should contain JDBC driver, host name, and port number. See the <a href=\"https://docs.camunda.io/docs/8.6/components/connectors/out-of-the-box-connectors/sql/#uri-connection\" target=\"_blank\">URI connection</a> reference.",
     "type" : "String"
   }, {
-    "id" : "connection.uriProperties",
-    "label" : "Properties",
-    "optional" : true,
-    "feel" : "required",
-    "group" : "connection",
     "binding" : {
       "name" : "connection.uriProperties",
       "type" : "zeebe:input"
@@ -132,17 +127,14 @@
       "equals" : "uri",
       "type" : "simple"
     },
+    "feel" : "required",
+    "group" : "connection",
+    "id" : "connection.uriProperties",
+    "label" : "Properties",
+    "optional" : true,
     "tooltip" : "Additional properties for the connection ('user' and 'password' for instance). See the <a href=\"https://docs.camunda.io/docs/8.6/components/connectors/out-of-the-box-connectors/sql/#connection\" target=\"_blank\">SQL connection properties</a> reference.",
     "type" : "String"
   }, {
-    "id" : "connection.host",
-    "label" : "Host",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "feel" : "optional",
-    "group" : "connection",
     "binding" : {
       "name" : "connection.host",
       "type" : "zeebe:input"
@@ -152,16 +144,16 @@
       "equals" : "detailed",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "connection.port",
-    "label" : "Port",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "connection",
+    "id" : "connection.host",
+    "label" : "Host",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "connection.port",
       "type" : "zeebe:input"
@@ -171,13 +163,16 @@
       "equals" : "detailed",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "connection.username",
-    "label" : "Username",
-    "optional" : true,
+    "constraints" : {
+      "notEmpty" : true
+    },
     "feel" : "optional",
     "group" : "connection",
+    "id" : "connection.port",
+    "label" : "Port",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "connection.username",
       "type" : "zeebe:input"
@@ -187,13 +182,13 @@
       "equals" : "detailed",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "connection.password",
-    "label" : "Password",
-    "optional" : true,
     "feel" : "optional",
     "group" : "connection",
+    "id" : "connection.username",
+    "label" : "Username",
+    "optional" : true,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "connection.password",
       "type" : "zeebe:input"
@@ -203,13 +198,13 @@
       "equals" : "detailed",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "connection.databaseName",
-    "label" : "Database name",
-    "optional" : true,
     "feel" : "optional",
     "group" : "connection",
+    "id" : "connection.password",
+    "label" : "Password",
+    "optional" : true,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "connection.databaseName",
       "type" : "zeebe:input"
@@ -219,13 +214,13 @@
       "equals" : "detailed",
       "type" : "simple"
     },
+    "feel" : "optional",
+    "group" : "connection",
+    "id" : "connection.databaseName",
+    "label" : "Database name",
+    "optional" : true,
     "type" : "String"
   }, {
-    "id" : "connection.properties",
-    "label" : "Properties",
-    "optional" : true,
-    "feel" : "required",
-    "group" : "connection",
     "binding" : {
       "name" : "connection.properties",
       "type" : "zeebe:input"
@@ -235,147 +230,152 @@
       "equals" : "detailed",
       "type" : "simple"
     },
+    "feel" : "required",
+    "group" : "connection",
+    "id" : "connection.properties",
+    "label" : "Properties",
+    "optional" : true,
     "tooltip" : "Additional properties for the connection. See the <a href=\"https://docs.camunda.io/docs/8.6/components/connectors/out-of-the-box-connectors/sql/#connection\" target=\"_blank\">SQL connection properties</a> reference.",
     "type" : "String"
   }, {
-    "id" : "connectionConfiguration",
-    "label" : "Connection credential",
-    "description" : "Choose a reusable JDBC connection credential. When set, it is bound as a whole to the connector's 'configuration' input.",
-    "optional" : true,
-    "group" : "connection",
     "binding" : {
       "name" : "configuration",
       "type" : "zeebe:input"
     },
-    "type" : "Configuration",
-    "configurationTemplate" : "io.camunda.connectors:jdbc-connection:1"
+    "configurationTemplate" : "io.camunda.connectors:jdbc-connection:1",
+    "description" : "Choose a reusable JDBC connection credential. When set, it is bound as a whole to the connector's 'configuration' input.",
+    "group" : "connection",
+    "id" : "connectionConfiguration",
+    "label" : "Connection credential",
+    "optional" : true,
+    "type" : "Configuration"
   }, {
-    "id" : "data.returnResults",
-    "label" : "Return results",
-    "optional" : false,
-    "value" : false,
-    "feel" : "static",
-    "group" : "query",
     "binding" : {
       "name" : "data.returnResults",
       "type" : "zeebe:input"
     },
-    "tooltip" : "Check this box if the SQL statement returns results, e.g. a SELECT or any statement with a RETURNING clause",
-    "type" : "Boolean"
-  }, {
-    "id" : "data.query",
-    "label" : "SQL Query to execute",
+    "feel" : "static",
+    "group" : "query",
+    "id" : "data.returnResults",
+    "label" : "Return results",
     "optional" : false,
+    "tooltip" : "Check this box if the SQL statement returns results, e.g. a SELECT or any statement with a RETURNING clause",
+    "type" : "Boolean",
+    "value" : false
+  }, {
+    "binding" : {
+      "name" : "data.query",
+      "type" : "zeebe:input"
+    },
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "query",
-    "binding" : {
-      "name" : "data.query",
-      "type" : "zeebe:input"
-    },
+    "id" : "data.query",
+    "label" : "SQL Query to execute",
+    "optional" : false,
     "tooltip" : "You can use named, positional or binding <a href=\"https://docs.camunda.io/docs/8.6/components/connectors/out-of-the-box-connectors/sql/#variables\" target=\"_blank\">parameters</a>",
     "type" : "String"
   }, {
-    "id" : "data.variables",
-    "label" : "SQL Query variables",
-    "optional" : true,
-    "feel" : "required",
-    "group" : "query",
     "binding" : {
       "name" : "data.variables",
       "type" : "zeebe:input"
     },
+    "feel" : "required",
+    "group" : "query",
+    "id" : "data.variables",
+    "label" : "SQL Query variables",
+    "optional" : true,
     "tooltip" : "The <a href=\"https://docs.camunda.io/docs/8.6/components/connectors/out-of-the-box-connectors/sql/#variables\" target=\"_blank\">variables</a> to use in the SQL query.",
     "type" : "String"
   }, {
-    "id" : "version",
-    "label" : "Version",
-    "description" : "Version of the element template",
-    "value" : "5",
-    "group" : "connector",
     "binding" : {
       "key" : "elementTemplateVersion",
       "type" : "zeebe:taskHeader"
     },
-    "type" : "Hidden"
-  }, {
-    "id" : "id",
-    "label" : "ID",
-    "description" : "ID of the element template",
-    "value" : "io.camunda.connectors.Jdbc.v1",
+    "description" : "Version of the element template",
     "group" : "connector",
+    "id" : "version",
+    "label" : "Version",
+    "type" : "Hidden",
+    "value" : "5"
+  }, {
     "binding" : {
       "key" : "elementTemplateId",
       "type" : "zeebe:taskHeader"
     },
-    "type" : "Hidden"
+    "description" : "ID of the element template",
+    "group" : "connector",
+    "id" : "id",
+    "label" : "ID",
+    "type" : "Hidden",
+    "value" : "io.camunda.connectors.Jdbc.v1"
   }, {
-    "id" : "resultVariable",
-    "label" : "Result variable",
-    "description" : "Name of variable to store the response in. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-variable\" target=\"_blank\">documentation</a>.",
-    "group" : "output",
     "binding" : {
       "key" : "resultVariable",
       "type" : "zeebe:taskHeader"
     },
+    "description" : "Name of variable to store the response in. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-variable\" target=\"_blank\">documentation</a>.",
+    "group" : "output",
+    "id" : "resultVariable",
+    "label" : "Result variable",
     "type" : "String"
   }, {
-    "id" : "resultExpression",
-    "label" : "Result expression",
-    "description" : "Expression to map the response into process variables. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-expression\" target=\"_blank\">documentation</a>.",
-    "feel" : "required",
-    "group" : "output",
     "binding" : {
       "key" : "resultExpression",
       "type" : "zeebe:taskHeader"
     },
+    "description" : "Expression to map the response into process variables. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-expression\" target=\"_blank\">documentation</a>.",
+    "feel" : "required",
+    "group" : "output",
+    "id" : "resultExpression",
+    "label" : "Result expression",
     "type" : "Text"
   }, {
-    "id" : "errorExpression",
-    "label" : "Error expression",
-    "description" : "Expression to handle errors. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/\" target=\"_blank\">documentation</a>.",
-    "feel" : "required",
-    "group" : "error",
     "binding" : {
       "key" : "errorExpression",
       "type" : "zeebe:taskHeader"
     },
+    "description" : "Expression to handle errors. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/\" target=\"_blank\">documentation</a>.",
+    "feel" : "required",
+    "group" : "error",
+    "id" : "errorExpression",
+    "label" : "Error expression",
     "type" : "Text"
   }, {
-    "id" : "retryCount",
-    "label" : "Retries",
-    "description" : "Number of retries",
-    "value" : "3",
-    "feel" : "optional",
-    "group" : "retries",
     "binding" : {
       "property" : "retries",
       "type" : "zeebe:taskDefinition"
     },
-    "type" : "String"
-  }, {
-    "id" : "retryBackoff",
-    "label" : "Retry backoff",
-    "description" : "ISO-8601 duration to wait between retries",
-    "value" : "PT30S",
+    "description" : "Number of retries",
+    "feel" : "optional",
     "group" : "retries",
+    "id" : "retryCount",
+    "label" : "Retries",
+    "type" : "String",
+    "value" : "3"
+  }, {
     "binding" : {
       "key" : "retryBackoff",
       "type" : "zeebe:taskHeader"
     },
-    "type" : "String"
-  }, {
-    "id" : "jobTimeout",
-    "label" : "Job timeout",
-    "description" : "ISO-8601 duration after which Zeebe considers this job timed out if not yet completed. Leave empty to use the default timeout",
-    "optional" : true,
+    "description" : "ISO-8601 duration to wait between retries",
     "group" : "retries",
+    "id" : "retryBackoff",
+    "label" : "Retry backoff",
+    "type" : "String",
+    "value" : "PT30S"
+  }, {
     "binding" : {
       "key" : "jobTimeout",
       "type" : "zeebe:taskHeader"
     },
+    "description" : "ISO-8601 duration after which Zeebe considers this job timed out if not yet completed. Leave empty to use the default timeout",
+    "group" : "retries",
+    "id" : "jobTimeout",
+    "label" : "Job timeout",
+    "optional" : true,
     "type" : "String"
   } ],
   "configurationTemplates" : [ {
@@ -384,58 +384,58 @@
     "version" : 1,
     "name" : "JDBC Connection",
     "properties" : [ {
-      "id" : "host",
-      "label" : "Host",
-      "constraints" : {
-        "notEmpty" : true
-      },
-      "group" : "connection",
       "binding" : {
         "name" : "host",
         "type" : "property"
       },
-      "type" : "String"
-    }, {
-      "id" : "port",
-      "label" : "Port",
       "constraints" : {
         "notEmpty" : true
       },
       "group" : "connection",
+      "id" : "host",
+      "label" : "Host",
+      "type" : "String"
+    }, {
       "binding" : {
         "name" : "port",
         "type" : "property"
       },
+      "constraints" : {
+        "notEmpty" : true
+      },
+      "group" : "connection",
+      "id" : "port",
+      "label" : "Port",
       "type" : "String"
     }, {
-      "id" : "databaseName",
-      "label" : "Database name",
-      "group" : "connection",
       "binding" : {
         "name" : "databaseName",
         "type" : "property"
       },
+      "group" : "connection",
+      "id" : "databaseName",
+      "label" : "Database name",
       "type" : "String"
     }, {
-      "id" : "username",
-      "label" : "Username",
-      "group" : "authentication",
       "binding" : {
         "name" : "username",
         "type" : "property"
       },
-      "type" : "String",
-      "secret" : true
-    }, {
-      "id" : "password",
-      "label" : "Password",
       "group" : "authentication",
+      "id" : "username",
+      "label" : "Username",
+      "secret" : true,
+      "type" : "String"
+    }, {
       "binding" : {
         "name" : "password",
         "type" : "property"
       },
-      "type" : "String",
-      "secret" : true
+      "group" : "authentication",
+      "id" : "password",
+      "label" : "Password",
+      "secret" : true,
+      "type" : "String"
     } ]
   } ],
   "icon" : {

--- a/connectors/jdbc/pom.xml
+++ b/connectors/jdbc/pom.xml
@@ -28,7 +28,7 @@
   </licenses>
   <dependencies>
     <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
+      <groupId>tools.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
       <version>${version.jackson-bom}</version>
     </dependency>

--- a/connectors/kafka/pom.xml
+++ b/connectors/kafka/pom.xml
@@ -86,16 +86,6 @@ except in compliance with the proprietary license.</license.inlineheader>
     </dependency>
 
     <dependency>
-      <groupId>com.fasterxml.jackson.datatype</groupId>
-      <artifactId>jackson-datatype-jdk8</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>com.fasterxml.jackson.datatype</groupId>
-      <artifactId>jackson-datatype-jsr310</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>com.fasterxml.jackson.module</groupId>
       <artifactId>jackson-module-scala_2.13</artifactId>
     </dependency>

--- a/connectors/microsoft/azure-blobstorage/element-templates/azure-blobstorage-outbound-connector.json
+++ b/connectors/microsoft/azure-blobstorage/element-templates/azure-blobstorage-outbound-connector.json
@@ -40,38 +40,30 @@
     "label" : "Retries"
   } ],
   "properties" : [ {
-    "value" : "io.camunda:azure-blobstorage:1",
     "binding" : {
       "property" : "type",
       "type" : "zeebe:taskDefinition"
     },
-    "type" : "Hidden"
+    "type" : "Hidden",
+    "value" : "io.camunda:azure-blobstorage:1"
   }, {
-    "id" : "operationDiscriminator",
-    "label" : "Operation",
-    "value" : "uploadBlob",
-    "group" : "operation",
     "binding" : {
       "name" : "operationDiscriminator",
       "type" : "zeebe:input"
     },
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "Download blob",
       "value" : "downloadBlob"
     }, {
       "name" : "Upload blob",
       "value" : "uploadBlob"
-    } ]
-  }, {
-    "id" : "downloadOperationContainer",
-    "label" : "Blob Storage container",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "feel" : "optional",
+    } ],
     "group" : "operation",
+    "id" : "operationDiscriminator",
+    "label" : "Operation",
+    "type" : "Dropdown",
+    "value" : "uploadBlob"
+  }, {
     "binding" : {
       "name" : "operation.container",
       "type" : "zeebe:input"
@@ -81,17 +73,17 @@
       "equals" : "downloadBlob",
       "type" : "simple"
     },
-    "tooltip" : "A container acts as a directory that organizes a set of blobs.",
-    "type" : "String"
-  }, {
-    "id" : "downloadOperationFileName",
-    "label" : "File name",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "operation",
+    "id" : "downloadOperationContainer",
+    "label" : "Blob Storage container",
+    "optional" : false,
+    "tooltip" : "A container acts as a directory that organizes a set of blobs.",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "operation.fileName",
       "type" : "zeebe:input"
@@ -101,24 +93,21 @@
       "equals" : "downloadBlob",
       "type" : "simple"
     },
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "operation",
+    "id" : "downloadOperationFileName",
+    "label" : "File name",
+    "optional" : false,
     "tooltip" : "Specify the name of the document to be downloaded.",
     "type" : "String"
   }, {
-    "id" : "documentReturnFormat",
-    "label" : "Response format",
-    "value" : "DOCUMENT",
-    "group" : "operation",
     "binding" : {
       "name" : "documentReturnFormat.choice",
       "type" : "zeebe:input"
     },
-    "condition" : {
-      "property" : "operationDiscriminator",
-      "equals" : "downloadBlob",
-      "type" : "simple"
-    },
-    "tooltip" : "How the downloaded payload should be returned. Document reference uploads the payload to the document store; as text decodes it as a String; as JSON parses it into a structure you can access via dot notation.",
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "Document reference",
       "value" : "DOCUMENT"
@@ -128,14 +117,19 @@
     }, {
       "name" : "as JSON",
       "value" : "JSON"
-    } ]
-  }, {
-    "id" : "documentReturnFormatEncoding",
-    "label" : "Encoding",
-    "description" : "Character set used to decode the response. Default UTF-8.",
-    "value" : "UTF-8",
-    "feel" : "optional",
+    } ],
+    "condition" : {
+      "property" : "operationDiscriminator",
+      "equals" : "downloadBlob",
+      "type" : "simple"
+    },
     "group" : "operation",
+    "id" : "documentReturnFormat",
+    "label" : "Response format",
+    "tooltip" : "How the downloaded payload should be returned. Document reference uploads the payload to the document store; as text decodes it as a String; as JSON parses it into a structure you can access via dot notation.",
+    "type" : "Dropdown",
+    "value" : "DOCUMENT"
+  }, {
     "binding" : {
       "name" : "documentReturnFormat.encoding",
       "type" : "zeebe:input"
@@ -151,16 +145,14 @@
         "type" : "simple"
       } ]
     },
-    "type" : "String"
-  }, {
-    "id" : "container",
-    "label" : "Blob Storage container",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
+    "description" : "Character set used to decode the response. Default UTF-8.",
     "feel" : "optional",
     "group" : "operation",
+    "id" : "documentReturnFormatEncoding",
+    "label" : "Encoding",
+    "type" : "String",
+    "value" : "UTF-8"
+  }, {
     "binding" : {
       "name" : "operation.container",
       "type" : "zeebe:input"
@@ -170,24 +162,21 @@
       "equals" : "uploadBlob",
       "type" : "simple"
     },
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "operation",
+    "id" : "container",
+    "label" : "Blob Storage container",
+    "optional" : false,
     "tooltip" : "A container acts as a directory that organizes a set of blobs.",
     "type" : "String"
   }, {
-    "id" : "operation_document_documentSource",
-    "label" : "Document source",
-    "value" : "camunda",
-    "group" : "operation",
     "binding" : {
       "name" : "operation.operation_document_documentSource",
       "type" : "zeebe:input"
     },
-    "condition" : {
-      "property" : "operationDiscriminator",
-      "equals" : "uploadBlob",
-      "type" : "simple"
-    },
-    "tooltip" : "Document to be uploaded to Azure Blob Storage.",
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "Camunda Document",
       "value" : "camunda"
@@ -197,15 +186,19 @@
     }, {
       "name" : "From URL",
       "value" : "external"
-    } ]
-  }, {
-    "id" : "operation_document_camundaReference",
-    "label" : "Camunda document",
-    "constraints" : {
-      "notEmpty" : true
+    } ],
+    "condition" : {
+      "property" : "operationDiscriminator",
+      "equals" : "uploadBlob",
+      "type" : "simple"
     },
-    "feel" : "required",
     "group" : "operation",
+    "id" : "operation_document_documentSource",
+    "label" : "Document source",
+    "tooltip" : "Document to be uploaded to Azure Blob Storage.",
+    "type" : "Dropdown",
+    "value" : "camunda"
+  }, {
     "binding" : {
       "name" : "operation.operation_document_camundaReference",
       "type" : "zeebe:input"
@@ -221,15 +214,15 @@
         "type" : "simple"
       } ]
     },
-    "type" : "String"
-  }, {
-    "id" : "operation_document_inline_content",
-    "label" : "Content",
     "constraints" : {
       "notEmpty" : true
     },
-    "feel" : "optional",
+    "feel" : "required",
     "group" : "operation",
+    "id" : "operation_document_camundaReference",
+    "label" : "Camunda document",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "operation.operation_document_inline_content",
       "type" : "zeebe:input"
@@ -245,12 +238,15 @@
         "type" : "simple"
       } ]
     },
-    "type" : "String"
-  }, {
-    "id" : "operation_document_inline_fileName",
-    "label" : "File name",
+    "constraints" : {
+      "notEmpty" : true
+    },
     "feel" : "optional",
     "group" : "operation",
+    "id" : "operation_document_inline_content",
+    "label" : "Content",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "operation.operation_document_inline_fileName",
       "type" : "zeebe:input"
@@ -266,12 +262,12 @@
         "type" : "simple"
       } ]
     },
-    "type" : "String"
-  }, {
-    "id" : "operation_document_inline_contentType",
-    "label" : "Content type",
     "feel" : "optional",
     "group" : "operation",
+    "id" : "operation_document_inline_fileName",
+    "label" : "File name",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "operation.operation_document_inline_contentType",
       "type" : "zeebe:input"
@@ -287,15 +283,12 @@
         "type" : "simple"
       } ]
     },
-    "type" : "String"
-  }, {
-    "id" : "operation_document_external_url",
-    "label" : "URL",
-    "constraints" : {
-      "notEmpty" : true
-    },
     "feel" : "optional",
     "group" : "operation",
+    "id" : "operation_document_inline_contentType",
+    "label" : "Content type",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "operation.operation_document_external_url",
       "type" : "zeebe:input"
@@ -311,12 +304,15 @@
         "type" : "simple"
       } ]
     },
-    "type" : "String"
-  }, {
-    "id" : "operation_document_external_fileName",
-    "label" : "File name",
+    "constraints" : {
+      "notEmpty" : true
+    },
     "feel" : "optional",
     "group" : "operation",
+    "id" : "operation_document_external_url",
+    "label" : "URL",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "operation.operation_document_external_fileName",
       "type" : "zeebe:input"
@@ -332,11 +328,12 @@
         "type" : "simple"
       } ]
     },
+    "feel" : "optional",
+    "group" : "operation",
+    "id" : "operation_document_external_fileName",
+    "label" : "File name",
     "type" : "String"
   }, {
-    "id" : "uploadOperationDocument",
-    "value" : "=if operation_document_documentSource = \"camunda\" then operation_document_camundaReference else if operation_document_documentSource = \"inline\" then { \"camunda.document.type\": \"inline\", content: operation_document_inline_content, name: operation_document_inline_fileName, contentType: operation_document_inline_contentType } else if operation_document_documentSource = \"external\" then { \"camunda.document.type\": \"external\", url: operation_document_external_url, name: operation_document_external_fileName } else null",
-    "group" : "operation",
     "binding" : {
       "name" : "operation.document",
       "type" : "zeebe:input"
@@ -346,34 +343,29 @@
       "equals" : "uploadBlob",
       "type" : "simple"
     },
-    "type" : "Hidden"
+    "group" : "operation",
+    "id" : "uploadOperationDocument",
+    "type" : "Hidden",
+    "value" : "=if operation_document_documentSource = \"camunda\" then operation_document_camundaReference else if operation_document_documentSource = \"inline\" then { \"camunda.document.type\": \"inline\", content: operation_document_inline_content, name: operation_document_inline_fileName, contentType: operation_document_inline_contentType } else if operation_document_documentSource = \"external\" then { \"camunda.document.type\": \"external\", url: operation_document_external_url, name: operation_document_external_fileName } else null"
   }, {
-    "id" : "authentication.type",
-    "label" : "Type",
-    "description" : "Choose the authentication type.",
-    "value" : "SAS",
-    "group" : "authentication",
     "binding" : {
       "name" : "authentication.type",
       "type" : "zeebe:input"
     },
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "SAS token",
       "value" : "SAS"
     }, {
       "name" : "OAuth 2.0 (Microsoft Entra ID)",
       "value" : "oAuth-client-credentials-flow"
-    } ]
-  }, {
-    "id" : "authentication.SASToken",
-    "label" : "SAS token",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "feel" : "optional",
+    } ],
+    "description" : "Choose the authentication type.",
     "group" : "authentication",
+    "id" : "authentication.type",
+    "label" : "Type",
+    "type" : "Dropdown",
+    "value" : "SAS"
+  }, {
     "binding" : {
       "name" : "authentication.SASToken",
       "type" : "zeebe:input"
@@ -383,17 +375,17 @@
       "equals" : "SAS",
       "type" : "simple"
     },
-    "tooltip" : "Shared access signature (SAS) token of the container. Learn more in our <a href=\"https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/azure-blob-storage/#prerequisites\">Azure Blob Storage SAS token documentation</a>.",
-    "type" : "String"
-  }, {
-    "id" : "authentication.SASUrl",
-    "label" : "SAS URL",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "authentication",
+    "id" : "authentication.SASToken",
+    "label" : "SAS token",
+    "optional" : false,
+    "tooltip" : "Shared access signature (SAS) token of the container. Learn more in our <a href=\"https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/azure-blob-storage/#prerequisites\">Azure Blob Storage SAS token documentation</a>.",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "authentication.SASUrl",
       "type" : "zeebe:input"
@@ -403,17 +395,17 @@
       "equals" : "SAS",
       "type" : "simple"
     },
-    "tooltip" : "Shared access signature (SAS) URL of the container. Learn more in our <a href=\"https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/azure-blob-storage/#prerequisites\">Azure Blob Storage SAS token documentation</a>.",
-    "type" : "String"
-  }, {
-    "id" : "authentication.tenantId",
-    "label" : "Tenant id",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "authentication",
+    "id" : "authentication.SASUrl",
+    "label" : "SAS URL",
+    "optional" : false,
+    "tooltip" : "Shared access signature (SAS) URL of the container. Learn more in our <a href=\"https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/azure-blob-storage/#prerequisites\">Azure Blob Storage SAS token documentation</a>.",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "authentication.tenantId",
       "type" : "zeebe:input"
@@ -423,17 +415,17 @@
       "equals" : "oAuth-client-credentials-flow",
       "type" : "simple"
     },
-    "tooltip" : "ID of the Microsoft Entra ID tenant that owns the application. Learn more in our <a href=\"https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/azure-blob-storage/#oauth-20\">Azure Blob Storage OAuth 2.0 documentation</a>.",
-    "type" : "String"
-  }, {
-    "id" : "authentication.clientId",
-    "label" : "Client id",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "authentication",
+    "id" : "authentication.tenantId",
+    "label" : "Tenant id",
+    "optional" : false,
+    "tooltip" : "ID of the Microsoft Entra ID tenant that owns the application. Learn more in our <a href=\"https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/azure-blob-storage/#oauth-20\">Azure Blob Storage OAuth 2.0 documentation</a>.",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "authentication.clientId",
       "type" : "zeebe:input"
@@ -443,17 +435,17 @@
       "equals" : "oAuth-client-credentials-flow",
       "type" : "simple"
     },
-    "tooltip" : "Application (client) ID of the registered Microsoft Entra ID application. Learn more in our <a href=\"https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/azure-blob-storage/#oauth-20\">Azure Blob Storage OAuth 2.0 documentation</a>.",
-    "type" : "String"
-  }, {
-    "id" : "authentication.clientSecret",
-    "label" : "Client secret",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "authentication",
+    "id" : "authentication.clientId",
+    "label" : "Client id",
+    "optional" : false,
+    "tooltip" : "Application (client) ID of the registered Microsoft Entra ID application. Learn more in our <a href=\"https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/azure-blob-storage/#oauth-20\">Azure Blob Storage OAuth 2.0 documentation</a>.",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "authentication.clientSecret",
       "type" : "zeebe:input"
@@ -463,17 +455,17 @@
       "equals" : "oAuth-client-credentials-flow",
       "type" : "simple"
     },
-    "tooltip" : "Client secret generated for the registered Microsoft Entra ID application. Learn more in our <a href=\"https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/azure-blob-storage/#oauth-20\">Azure Blob Storage OAuth 2.0 documentation</a>.",
-    "type" : "String"
-  }, {
-    "id" : "authentication.accountUrl",
-    "label" : "Account url",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "authentication",
+    "id" : "authentication.clientSecret",
+    "label" : "Client secret",
+    "optional" : false,
+    "tooltip" : "Client secret generated for the registered Microsoft Entra ID application. Learn more in our <a href=\"https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/azure-blob-storage/#oauth-20\">Azure Blob Storage OAuth 2.0 documentation</a>.",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "authentication.accountUrl",
       "type" : "zeebe:input"
@@ -483,14 +475,17 @@
       "equals" : "oAuth-client-credentials-flow",
       "type" : "simple"
     },
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "authentication",
+    "id" : "authentication.accountUrl",
+    "label" : "Account url",
+    "optional" : false,
     "tooltip" : "URL of the Azure Blob Storage account to connect to. Learn more in our <a href=\"https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/azure-blob-storage/#oauth-20\">Azure Blob Storage OAuth 2.0 documentation</a>.",
     "type" : "String"
   }, {
-    "id" : "uploadOperationFileName",
-    "label" : "Document file name",
-    "optional" : true,
-    "feel" : "optional",
-    "group" : "additionalProperties",
     "binding" : {
       "name" : "operation.fileName",
       "type" : "zeebe:input"
@@ -500,18 +495,14 @@
       "equals" : "uploadBlob",
       "type" : "simple"
     },
+    "feel" : "optional",
+    "group" : "additionalProperties",
+    "id" : "uploadOperationFileName",
+    "label" : "Document file name",
+    "optional" : true,
     "tooltip" : "By default, the file's metadata name is used unless a custom name is specified.",
     "type" : "String"
   }, {
-    "id" : "timeout",
-    "label" : "Timeout (in seconds)",
-    "optional" : false,
-    "value" : 30,
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "feel" : "static",
-    "group" : "additionalProperties",
     "binding" : {
       "name" : "operation.timeout",
       "type" : "zeebe:input"
@@ -521,94 +512,103 @@
       "equals" : "uploadBlob",
       "type" : "simple"
     },
-    "type" : "Number"
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "static",
+    "group" : "additionalProperties",
+    "id" : "timeout",
+    "label" : "Timeout (in seconds)",
+    "optional" : false,
+    "type" : "Number",
+    "value" : 30
   }, {
-    "id" : "version",
-    "label" : "Version",
-    "description" : "Version of the element template",
-    "value" : "5",
-    "group" : "connector",
     "binding" : {
       "key" : "elementTemplateVersion",
       "type" : "zeebe:taskHeader"
     },
-    "type" : "Hidden"
-  }, {
-    "id" : "id",
-    "label" : "ID",
-    "description" : "ID of the element template",
-    "value" : "io.camunda.connectors.azure.blobstorage.v1",
+    "description" : "Version of the element template",
     "group" : "connector",
+    "id" : "version",
+    "label" : "Version",
+    "type" : "Hidden",
+    "value" : "5"
+  }, {
     "binding" : {
       "key" : "elementTemplateId",
       "type" : "zeebe:taskHeader"
     },
-    "type" : "Hidden"
+    "description" : "ID of the element template",
+    "group" : "connector",
+    "id" : "id",
+    "label" : "ID",
+    "type" : "Hidden",
+    "value" : "io.camunda.connectors.azure.blobstorage.v1"
   }, {
-    "id" : "resultVariable",
-    "label" : "Result variable",
-    "description" : "Name of variable to store the response in. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-variable\" target=\"_blank\">documentation</a>.",
-    "group" : "output",
     "binding" : {
       "key" : "resultVariable",
       "type" : "zeebe:taskHeader"
     },
+    "description" : "Name of variable to store the response in. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-variable\" target=\"_blank\">documentation</a>.",
+    "group" : "output",
+    "id" : "resultVariable",
+    "label" : "Result variable",
     "type" : "String"
   }, {
-    "id" : "resultExpression",
-    "label" : "Result expression",
-    "description" : "Expression to map the response into process variables. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-expression\" target=\"_blank\">documentation</a>.",
-    "feel" : "required",
-    "group" : "output",
     "binding" : {
       "key" : "resultExpression",
       "type" : "zeebe:taskHeader"
     },
+    "description" : "Expression to map the response into process variables. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-expression\" target=\"_blank\">documentation</a>.",
+    "feel" : "required",
+    "group" : "output",
+    "id" : "resultExpression",
+    "label" : "Result expression",
     "type" : "Text"
   }, {
-    "id" : "errorExpression",
-    "label" : "Error expression",
-    "description" : "Expression to handle errors. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/\" target=\"_blank\">documentation</a>.",
-    "feel" : "required",
-    "group" : "error",
     "binding" : {
       "key" : "errorExpression",
       "type" : "zeebe:taskHeader"
     },
+    "description" : "Expression to handle errors. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/\" target=\"_blank\">documentation</a>.",
+    "feel" : "required",
+    "group" : "error",
+    "id" : "errorExpression",
+    "label" : "Error expression",
     "type" : "Text"
   }, {
-    "id" : "retryCount",
-    "label" : "Retries",
-    "description" : "Number of retries",
-    "value" : "3",
-    "feel" : "optional",
-    "group" : "retries",
     "binding" : {
       "property" : "retries",
       "type" : "zeebe:taskDefinition"
     },
-    "type" : "String"
-  }, {
-    "id" : "retryBackoff",
-    "label" : "Retry backoff",
-    "description" : "ISO-8601 duration to wait between retries",
-    "value" : "PT30S",
+    "description" : "Number of retries",
+    "feel" : "optional",
     "group" : "retries",
+    "id" : "retryCount",
+    "label" : "Retries",
+    "type" : "String",
+    "value" : "3"
+  }, {
     "binding" : {
       "key" : "retryBackoff",
       "type" : "zeebe:taskHeader"
     },
-    "type" : "String"
-  }, {
-    "id" : "jobTimeout",
-    "label" : "Job timeout",
-    "description" : "ISO-8601 duration after which Zeebe considers this job timed out if not yet completed. Leave empty to use the default timeout",
-    "optional" : true,
+    "description" : "ISO-8601 duration to wait between retries",
     "group" : "retries",
+    "id" : "retryBackoff",
+    "label" : "Retry backoff",
+    "type" : "String",
+    "value" : "PT30S"
+  }, {
     "binding" : {
       "key" : "jobTimeout",
       "type" : "zeebe:taskHeader"
     },
+    "description" : "ISO-8601 duration after which Zeebe considers this job timed out if not yet completed. Leave empty to use the default timeout",
+    "group" : "retries",
+    "id" : "jobTimeout",
+    "label" : "Job timeout",
+    "optional" : true,
     "type" : "String"
   } ],
   "steps" : [ {

--- a/connectors/microsoft/azure-blobstorage/element-templates/hybrid/azure-blobstorage-outbound-connector-hybrid.json
+++ b/connectors/microsoft/azure-blobstorage/element-templates/hybrid/azure-blobstorage-outbound-connector-hybrid.json
@@ -43,40 +43,32 @@
     "label" : "Retries"
   } ],
   "properties" : [ {
-    "id" : "taskDefinitionType",
-    "value" : "io.camunda:azure-blobstorage:1",
-    "group" : "taskDefinitionType",
     "binding" : {
       "property" : "type",
       "type" : "zeebe:taskDefinition"
     },
-    "type" : "String"
+    "group" : "taskDefinitionType",
+    "id" : "taskDefinitionType",
+    "type" : "String",
+    "value" : "io.camunda:azure-blobstorage:1"
   }, {
-    "id" : "operationDiscriminator",
-    "label" : "Operation",
-    "value" : "uploadBlob",
-    "group" : "operation",
     "binding" : {
       "name" : "operationDiscriminator",
       "type" : "zeebe:input"
     },
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "Download blob",
       "value" : "downloadBlob"
     }, {
       "name" : "Upload blob",
       "value" : "uploadBlob"
-    } ]
-  }, {
-    "id" : "downloadOperationContainer",
-    "label" : "Blob Storage container",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "feel" : "optional",
+    } ],
     "group" : "operation",
+    "id" : "operationDiscriminator",
+    "label" : "Operation",
+    "type" : "Dropdown",
+    "value" : "uploadBlob"
+  }, {
     "binding" : {
       "name" : "operation.container",
       "type" : "zeebe:input"
@@ -86,17 +78,17 @@
       "equals" : "downloadBlob",
       "type" : "simple"
     },
-    "tooltip" : "A container acts as a directory that organizes a set of blobs.",
-    "type" : "String"
-  }, {
-    "id" : "downloadOperationFileName",
-    "label" : "File name",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "operation",
+    "id" : "downloadOperationContainer",
+    "label" : "Blob Storage container",
+    "optional" : false,
+    "tooltip" : "A container acts as a directory that organizes a set of blobs.",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "operation.fileName",
       "type" : "zeebe:input"
@@ -106,24 +98,21 @@
       "equals" : "downloadBlob",
       "type" : "simple"
     },
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "operation",
+    "id" : "downloadOperationFileName",
+    "label" : "File name",
+    "optional" : false,
     "tooltip" : "Specify the name of the document to be downloaded.",
     "type" : "String"
   }, {
-    "id" : "documentReturnFormat",
-    "label" : "Response format",
-    "value" : "DOCUMENT",
-    "group" : "operation",
     "binding" : {
       "name" : "documentReturnFormat.choice",
       "type" : "zeebe:input"
     },
-    "condition" : {
-      "property" : "operationDiscriminator",
-      "equals" : "downloadBlob",
-      "type" : "simple"
-    },
-    "tooltip" : "How the downloaded payload should be returned. Document reference uploads the payload to the document store; as text decodes it as a String; as JSON parses it into a structure you can access via dot notation.",
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "Document reference",
       "value" : "DOCUMENT"
@@ -133,14 +122,19 @@
     }, {
       "name" : "as JSON",
       "value" : "JSON"
-    } ]
-  }, {
-    "id" : "documentReturnFormatEncoding",
-    "label" : "Encoding",
-    "description" : "Character set used to decode the response. Default UTF-8.",
-    "value" : "UTF-8",
-    "feel" : "optional",
+    } ],
+    "condition" : {
+      "property" : "operationDiscriminator",
+      "equals" : "downloadBlob",
+      "type" : "simple"
+    },
     "group" : "operation",
+    "id" : "documentReturnFormat",
+    "label" : "Response format",
+    "tooltip" : "How the downloaded payload should be returned. Document reference uploads the payload to the document store; as text decodes it as a String; as JSON parses it into a structure you can access via dot notation.",
+    "type" : "Dropdown",
+    "value" : "DOCUMENT"
+  }, {
     "binding" : {
       "name" : "documentReturnFormat.encoding",
       "type" : "zeebe:input"
@@ -156,16 +150,14 @@
         "type" : "simple"
       } ]
     },
-    "type" : "String"
-  }, {
-    "id" : "container",
-    "label" : "Blob Storage container",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
+    "description" : "Character set used to decode the response. Default UTF-8.",
     "feel" : "optional",
     "group" : "operation",
+    "id" : "documentReturnFormatEncoding",
+    "label" : "Encoding",
+    "type" : "String",
+    "value" : "UTF-8"
+  }, {
     "binding" : {
       "name" : "operation.container",
       "type" : "zeebe:input"
@@ -175,24 +167,21 @@
       "equals" : "uploadBlob",
       "type" : "simple"
     },
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "operation",
+    "id" : "container",
+    "label" : "Blob Storage container",
+    "optional" : false,
     "tooltip" : "A container acts as a directory that organizes a set of blobs.",
     "type" : "String"
   }, {
-    "id" : "operation_document_documentSource",
-    "label" : "Document source",
-    "value" : "camunda",
-    "group" : "operation",
     "binding" : {
       "name" : "operation.operation_document_documentSource",
       "type" : "zeebe:input"
     },
-    "condition" : {
-      "property" : "operationDiscriminator",
-      "equals" : "uploadBlob",
-      "type" : "simple"
-    },
-    "tooltip" : "Document to be uploaded to Azure Blob Storage.",
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "Camunda Document",
       "value" : "camunda"
@@ -202,15 +191,19 @@
     }, {
       "name" : "From URL",
       "value" : "external"
-    } ]
-  }, {
-    "id" : "operation_document_camundaReference",
-    "label" : "Camunda document",
-    "constraints" : {
-      "notEmpty" : true
+    } ],
+    "condition" : {
+      "property" : "operationDiscriminator",
+      "equals" : "uploadBlob",
+      "type" : "simple"
     },
-    "feel" : "required",
     "group" : "operation",
+    "id" : "operation_document_documentSource",
+    "label" : "Document source",
+    "tooltip" : "Document to be uploaded to Azure Blob Storage.",
+    "type" : "Dropdown",
+    "value" : "camunda"
+  }, {
     "binding" : {
       "name" : "operation.operation_document_camundaReference",
       "type" : "zeebe:input"
@@ -226,15 +219,15 @@
         "type" : "simple"
       } ]
     },
-    "type" : "String"
-  }, {
-    "id" : "operation_document_inline_content",
-    "label" : "Content",
     "constraints" : {
       "notEmpty" : true
     },
-    "feel" : "optional",
+    "feel" : "required",
     "group" : "operation",
+    "id" : "operation_document_camundaReference",
+    "label" : "Camunda document",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "operation.operation_document_inline_content",
       "type" : "zeebe:input"
@@ -250,12 +243,15 @@
         "type" : "simple"
       } ]
     },
-    "type" : "String"
-  }, {
-    "id" : "operation_document_inline_fileName",
-    "label" : "File name",
+    "constraints" : {
+      "notEmpty" : true
+    },
     "feel" : "optional",
     "group" : "operation",
+    "id" : "operation_document_inline_content",
+    "label" : "Content",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "operation.operation_document_inline_fileName",
       "type" : "zeebe:input"
@@ -271,12 +267,12 @@
         "type" : "simple"
       } ]
     },
-    "type" : "String"
-  }, {
-    "id" : "operation_document_inline_contentType",
-    "label" : "Content type",
     "feel" : "optional",
     "group" : "operation",
+    "id" : "operation_document_inline_fileName",
+    "label" : "File name",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "operation.operation_document_inline_contentType",
       "type" : "zeebe:input"
@@ -292,15 +288,12 @@
         "type" : "simple"
       } ]
     },
-    "type" : "String"
-  }, {
-    "id" : "operation_document_external_url",
-    "label" : "URL",
-    "constraints" : {
-      "notEmpty" : true
-    },
     "feel" : "optional",
     "group" : "operation",
+    "id" : "operation_document_inline_contentType",
+    "label" : "Content type",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "operation.operation_document_external_url",
       "type" : "zeebe:input"
@@ -316,12 +309,15 @@
         "type" : "simple"
       } ]
     },
-    "type" : "String"
-  }, {
-    "id" : "operation_document_external_fileName",
-    "label" : "File name",
+    "constraints" : {
+      "notEmpty" : true
+    },
     "feel" : "optional",
     "group" : "operation",
+    "id" : "operation_document_external_url",
+    "label" : "URL",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "operation.operation_document_external_fileName",
       "type" : "zeebe:input"
@@ -337,11 +333,12 @@
         "type" : "simple"
       } ]
     },
+    "feel" : "optional",
+    "group" : "operation",
+    "id" : "operation_document_external_fileName",
+    "label" : "File name",
     "type" : "String"
   }, {
-    "id" : "uploadOperationDocument",
-    "value" : "=if operation_document_documentSource = \"camunda\" then operation_document_camundaReference else if operation_document_documentSource = \"inline\" then { \"camunda.document.type\": \"inline\", content: operation_document_inline_content, name: operation_document_inline_fileName, contentType: operation_document_inline_contentType } else if operation_document_documentSource = \"external\" then { \"camunda.document.type\": \"external\", url: operation_document_external_url, name: operation_document_external_fileName } else null",
-    "group" : "operation",
     "binding" : {
       "name" : "operation.document",
       "type" : "zeebe:input"
@@ -351,34 +348,29 @@
       "equals" : "uploadBlob",
       "type" : "simple"
     },
-    "type" : "Hidden"
+    "group" : "operation",
+    "id" : "uploadOperationDocument",
+    "type" : "Hidden",
+    "value" : "=if operation_document_documentSource = \"camunda\" then operation_document_camundaReference else if operation_document_documentSource = \"inline\" then { \"camunda.document.type\": \"inline\", content: operation_document_inline_content, name: operation_document_inline_fileName, contentType: operation_document_inline_contentType } else if operation_document_documentSource = \"external\" then { \"camunda.document.type\": \"external\", url: operation_document_external_url, name: operation_document_external_fileName } else null"
   }, {
-    "id" : "authentication.type",
-    "label" : "Type",
-    "description" : "Choose the authentication type.",
-    "value" : "SAS",
-    "group" : "authentication",
     "binding" : {
       "name" : "authentication.type",
       "type" : "zeebe:input"
     },
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "SAS token",
       "value" : "SAS"
     }, {
       "name" : "OAuth 2.0 (Microsoft Entra ID)",
       "value" : "oAuth-client-credentials-flow"
-    } ]
-  }, {
-    "id" : "authentication.SASToken",
-    "label" : "SAS token",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "feel" : "optional",
+    } ],
+    "description" : "Choose the authentication type.",
     "group" : "authentication",
+    "id" : "authentication.type",
+    "label" : "Type",
+    "type" : "Dropdown",
+    "value" : "SAS"
+  }, {
     "binding" : {
       "name" : "authentication.SASToken",
       "type" : "zeebe:input"
@@ -388,17 +380,17 @@
       "equals" : "SAS",
       "type" : "simple"
     },
-    "tooltip" : "Shared access signature (SAS) token of the container. Learn more in our <a href=\"https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/azure-blob-storage/#prerequisites\">Azure Blob Storage SAS token documentation</a>.",
-    "type" : "String"
-  }, {
-    "id" : "authentication.SASUrl",
-    "label" : "SAS URL",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "authentication",
+    "id" : "authentication.SASToken",
+    "label" : "SAS token",
+    "optional" : false,
+    "tooltip" : "Shared access signature (SAS) token of the container. Learn more in our <a href=\"https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/azure-blob-storage/#prerequisites\">Azure Blob Storage SAS token documentation</a>.",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "authentication.SASUrl",
       "type" : "zeebe:input"
@@ -408,17 +400,17 @@
       "equals" : "SAS",
       "type" : "simple"
     },
-    "tooltip" : "Shared access signature (SAS) URL of the container. Learn more in our <a href=\"https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/azure-blob-storage/#prerequisites\">Azure Blob Storage SAS token documentation</a>.",
-    "type" : "String"
-  }, {
-    "id" : "authentication.tenantId",
-    "label" : "Tenant id",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "authentication",
+    "id" : "authentication.SASUrl",
+    "label" : "SAS URL",
+    "optional" : false,
+    "tooltip" : "Shared access signature (SAS) URL of the container. Learn more in our <a href=\"https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/azure-blob-storage/#prerequisites\">Azure Blob Storage SAS token documentation</a>.",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "authentication.tenantId",
       "type" : "zeebe:input"
@@ -428,17 +420,17 @@
       "equals" : "oAuth-client-credentials-flow",
       "type" : "simple"
     },
-    "tooltip" : "ID of the Microsoft Entra ID tenant that owns the application. Learn more in our <a href=\"https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/azure-blob-storage/#oauth-20\">Azure Blob Storage OAuth 2.0 documentation</a>.",
-    "type" : "String"
-  }, {
-    "id" : "authentication.clientId",
-    "label" : "Client id",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "authentication",
+    "id" : "authentication.tenantId",
+    "label" : "Tenant id",
+    "optional" : false,
+    "tooltip" : "ID of the Microsoft Entra ID tenant that owns the application. Learn more in our <a href=\"https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/azure-blob-storage/#oauth-20\">Azure Blob Storage OAuth 2.0 documentation</a>.",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "authentication.clientId",
       "type" : "zeebe:input"
@@ -448,17 +440,17 @@
       "equals" : "oAuth-client-credentials-flow",
       "type" : "simple"
     },
-    "tooltip" : "Application (client) ID of the registered Microsoft Entra ID application. Learn more in our <a href=\"https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/azure-blob-storage/#oauth-20\">Azure Blob Storage OAuth 2.0 documentation</a>.",
-    "type" : "String"
-  }, {
-    "id" : "authentication.clientSecret",
-    "label" : "Client secret",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "authentication",
+    "id" : "authentication.clientId",
+    "label" : "Client id",
+    "optional" : false,
+    "tooltip" : "Application (client) ID of the registered Microsoft Entra ID application. Learn more in our <a href=\"https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/azure-blob-storage/#oauth-20\">Azure Blob Storage OAuth 2.0 documentation</a>.",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "authentication.clientSecret",
       "type" : "zeebe:input"
@@ -468,17 +460,17 @@
       "equals" : "oAuth-client-credentials-flow",
       "type" : "simple"
     },
-    "tooltip" : "Client secret generated for the registered Microsoft Entra ID application. Learn more in our <a href=\"https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/azure-blob-storage/#oauth-20\">Azure Blob Storage OAuth 2.0 documentation</a>.",
-    "type" : "String"
-  }, {
-    "id" : "authentication.accountUrl",
-    "label" : "Account url",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "authentication",
+    "id" : "authentication.clientSecret",
+    "label" : "Client secret",
+    "optional" : false,
+    "tooltip" : "Client secret generated for the registered Microsoft Entra ID application. Learn more in our <a href=\"https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/azure-blob-storage/#oauth-20\">Azure Blob Storage OAuth 2.0 documentation</a>.",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "authentication.accountUrl",
       "type" : "zeebe:input"
@@ -488,14 +480,17 @@
       "equals" : "oAuth-client-credentials-flow",
       "type" : "simple"
     },
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "authentication",
+    "id" : "authentication.accountUrl",
+    "label" : "Account url",
+    "optional" : false,
     "tooltip" : "URL of the Azure Blob Storage account to connect to. Learn more in our <a href=\"https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/azure-blob-storage/#oauth-20\">Azure Blob Storage OAuth 2.0 documentation</a>.",
     "type" : "String"
   }, {
-    "id" : "uploadOperationFileName",
-    "label" : "Document file name",
-    "optional" : true,
-    "feel" : "optional",
-    "group" : "additionalProperties",
     "binding" : {
       "name" : "operation.fileName",
       "type" : "zeebe:input"
@@ -505,18 +500,14 @@
       "equals" : "uploadBlob",
       "type" : "simple"
     },
+    "feel" : "optional",
+    "group" : "additionalProperties",
+    "id" : "uploadOperationFileName",
+    "label" : "Document file name",
+    "optional" : true,
     "tooltip" : "By default, the file's metadata name is used unless a custom name is specified.",
     "type" : "String"
   }, {
-    "id" : "timeout",
-    "label" : "Timeout (in seconds)",
-    "optional" : false,
-    "value" : 30,
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "feel" : "static",
-    "group" : "additionalProperties",
     "binding" : {
       "name" : "operation.timeout",
       "type" : "zeebe:input"
@@ -526,94 +517,103 @@
       "equals" : "uploadBlob",
       "type" : "simple"
     },
-    "type" : "Number"
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "static",
+    "group" : "additionalProperties",
+    "id" : "timeout",
+    "label" : "Timeout (in seconds)",
+    "optional" : false,
+    "type" : "Number",
+    "value" : 30
   }, {
-    "id" : "version",
-    "label" : "Version",
-    "description" : "Version of the element template",
-    "value" : "5",
-    "group" : "connector",
     "binding" : {
       "key" : "elementTemplateVersion",
       "type" : "zeebe:taskHeader"
     },
-    "type" : "Hidden"
-  }, {
-    "id" : "id",
-    "label" : "ID",
-    "description" : "ID of the element template",
-    "value" : "io.camunda.connectors.azure.blobstorage.v1",
+    "description" : "Version of the element template",
     "group" : "connector",
+    "id" : "version",
+    "label" : "Version",
+    "type" : "Hidden",
+    "value" : "5"
+  }, {
     "binding" : {
       "key" : "elementTemplateId",
       "type" : "zeebe:taskHeader"
     },
-    "type" : "Hidden"
+    "description" : "ID of the element template",
+    "group" : "connector",
+    "id" : "id",
+    "label" : "ID",
+    "type" : "Hidden",
+    "value" : "io.camunda.connectors.azure.blobstorage.v1"
   }, {
-    "id" : "resultVariable",
-    "label" : "Result variable",
-    "description" : "Name of variable to store the response in. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-variable\" target=\"_blank\">documentation</a>.",
-    "group" : "output",
     "binding" : {
       "key" : "resultVariable",
       "type" : "zeebe:taskHeader"
     },
+    "description" : "Name of variable to store the response in. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-variable\" target=\"_blank\">documentation</a>.",
+    "group" : "output",
+    "id" : "resultVariable",
+    "label" : "Result variable",
     "type" : "String"
   }, {
-    "id" : "resultExpression",
-    "label" : "Result expression",
-    "description" : "Expression to map the response into process variables. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-expression\" target=\"_blank\">documentation</a>.",
-    "feel" : "required",
-    "group" : "output",
     "binding" : {
       "key" : "resultExpression",
       "type" : "zeebe:taskHeader"
     },
+    "description" : "Expression to map the response into process variables. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-expression\" target=\"_blank\">documentation</a>.",
+    "feel" : "required",
+    "group" : "output",
+    "id" : "resultExpression",
+    "label" : "Result expression",
     "type" : "Text"
   }, {
-    "id" : "errorExpression",
-    "label" : "Error expression",
-    "description" : "Expression to handle errors. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/\" target=\"_blank\">documentation</a>.",
-    "feel" : "required",
-    "group" : "error",
     "binding" : {
       "key" : "errorExpression",
       "type" : "zeebe:taskHeader"
     },
+    "description" : "Expression to handle errors. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/\" target=\"_blank\">documentation</a>.",
+    "feel" : "required",
+    "group" : "error",
+    "id" : "errorExpression",
+    "label" : "Error expression",
     "type" : "Text"
   }, {
-    "id" : "retryCount",
-    "label" : "Retries",
-    "description" : "Number of retries",
-    "value" : "3",
-    "feel" : "optional",
-    "group" : "retries",
     "binding" : {
       "property" : "retries",
       "type" : "zeebe:taskDefinition"
     },
-    "type" : "String"
-  }, {
-    "id" : "retryBackoff",
-    "label" : "Retry backoff",
-    "description" : "ISO-8601 duration to wait between retries",
-    "value" : "PT30S",
+    "description" : "Number of retries",
+    "feel" : "optional",
     "group" : "retries",
+    "id" : "retryCount",
+    "label" : "Retries",
+    "type" : "String",
+    "value" : "3"
+  }, {
     "binding" : {
       "key" : "retryBackoff",
       "type" : "zeebe:taskHeader"
     },
-    "type" : "String"
-  }, {
-    "id" : "jobTimeout",
-    "label" : "Job timeout",
-    "description" : "ISO-8601 duration after which Zeebe considers this job timed out if not yet completed. Leave empty to use the default timeout",
-    "optional" : true,
+    "description" : "ISO-8601 duration to wait between retries",
     "group" : "retries",
+    "id" : "retryBackoff",
+    "label" : "Retry backoff",
+    "type" : "String",
+    "value" : "PT30S"
+  }, {
     "binding" : {
       "key" : "jobTimeout",
       "type" : "zeebe:taskHeader"
     },
+    "description" : "ISO-8601 duration after which Zeebe considers this job timed out if not yet completed. Leave empty to use the default timeout",
+    "group" : "retries",
+    "id" : "jobTimeout",
+    "label" : "Job timeout",
+    "optional" : true,
     "type" : "String"
   } ],
   "steps" : [ {

--- a/connectors/microsoft/common/src/main/java/io/camunda/connector/microsoft/common/auth/GraphServiceClientSupplier.java
+++ b/connectors/microsoft/common/src/main/java/io/camunda/connector/microsoft/common/auth/GraphServiceClientSupplier.java
@@ -11,9 +11,6 @@ import com.azure.core.credential.TokenCredential;
 import com.azure.core.credential.TokenRequestContext;
 import com.azure.identity.ClientSecretCredential;
 import com.azure.identity.ClientSecretCredentialBuilder;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.microsoft.graph.serviceclient.GraphServiceClient;
 import io.camunda.connector.jackson.ConnectorsObjectMapperSupplier;
 import java.io.IOException;
@@ -24,6 +21,9 @@ import okhttp3.Request;
 import okhttp3.Response;
 import org.apache.commons.lang3.StringUtils;
 import reactor.core.publisher.Mono;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
 
 /**
  * Builds {@link GraphServiceClient} instances for different Microsoft authentication types. This
@@ -113,7 +113,7 @@ public class GraphServiceClientSupplier {
                 + ", response: "
                 + responseBody);
       }
-    } catch (JsonProcessingException e) {
+    } catch (JacksonException e) {
       throw new RuntimeException("Error while parsing refresh token response", e);
     } catch (IOException e) {
       throw new RuntimeException("Network error occurred", e);

--- a/connectors/microsoft/email-inbound/element-templates/hybrid/hybrid-microsoft-o365-email-boundary-event-connector-hybrid.json
+++ b/connectors/microsoft/email-inbound/element-templates/hybrid/hybrid-microsoft-o365-email-boundary-event-connector-hybrid.json
@@ -42,25 +42,19 @@
     "label" : "Output mapping"
   } ],
   "properties" : [ {
-    "id" : "connectorType",
-    "value" : "io.camunda:connector-o365-email-inbound:1",
-    "group" : "connectorType",
     "binding" : {
       "name" : "inbound.type",
       "type" : "zeebe:property"
     },
-    "type" : "String"
+    "group" : "connectorType",
+    "id" : "connectorType",
+    "type" : "String",
+    "value" : "io.camunda:connector-o365-email-inbound:1"
   }, {
-    "id" : "authentication.type",
-    "label" : "Type",
-    "description" : "Authentication type depends on your Microsoft Entra (Azure AD) configuration. See <a href='https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/microsoft-teams/'>connector documentation</a>",
-    "value" : "clientCredentials",
-    "group" : "authentication",
     "binding" : {
       "name" : "authentication.type",
       "type" : "zeebe:property"
     },
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "Bearer token",
       "value" : "token"
@@ -70,15 +64,14 @@
     }, {
       "name" : "Refresh token",
       "value" : "refresh"
-    } ]
-  }, {
-    "id" : "authentication.bearer.token",
-    "label" : "Bearer token",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
+    } ],
+    "description" : "Authentication type depends on your Microsoft Entra (Azure AD) configuration. See <a href='https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/microsoft-teams/'>connector documentation</a>",
     "group" : "authentication",
+    "id" : "authentication.type",
+    "label" : "Type",
+    "type" : "Dropdown",
+    "value" : "clientCredentials"
+  }, {
     "binding" : {
       "name" : "authentication.token",
       "type" : "zeebe:property"
@@ -88,16 +81,15 @@
       "equals" : "token",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "authentication.credentials.clientId",
-    "label" : "Client ID",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
-    "feel" : "optional",
     "group" : "authentication",
+    "id" : "authentication.bearer.token",
+    "label" : "Bearer token",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "authentication.clientId",
       "type" : "zeebe:property"
@@ -107,16 +99,16 @@
       "equals" : "clientCredentials",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "authentication.credentials.tenantId",
-    "label" : "Tenant ID",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "authentication",
+    "id" : "authentication.credentials.clientId",
+    "label" : "Client ID",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "authentication.tenantId",
       "type" : "zeebe:property"
@@ -126,16 +118,16 @@
       "equals" : "clientCredentials",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "authentication.credentials.clientSecret",
-    "label" : "Client secret",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "authentication",
+    "id" : "authentication.credentials.tenantId",
+    "label" : "Tenant ID",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "authentication.clientSecret",
       "type" : "zeebe:property"
@@ -145,17 +137,17 @@
       "equals" : "clientCredentials",
       "type" : "simple"
     },
-    "tooltip" : "The secret value of the Microsoft Entra ID (formerly Azure AD) application",
-    "type" : "String"
-  }, {
-    "id" : "authentication.refresh.token",
-    "label" : "Refresh token",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "authentication",
+    "id" : "authentication.credentials.clientSecret",
+    "label" : "Client secret",
+    "optional" : false,
+    "tooltip" : "The secret value of the Microsoft Entra ID (formerly Azure AD) application",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "authentication.token",
       "type" : "zeebe:property"
@@ -165,16 +157,16 @@
       "equals" : "refresh",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "authentication.refresh.clientId",
-    "label" : "Client ID",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "authentication",
+    "id" : "authentication.refresh.token",
+    "label" : "Refresh token",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "authentication.clientId",
       "type" : "zeebe:property"
@@ -184,16 +176,16 @@
       "equals" : "refresh",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "authentication.refresh.tenantId",
-    "label" : "Tenant ID",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "authentication",
+    "id" : "authentication.refresh.clientId",
+    "label" : "Client ID",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "authentication.tenantId",
       "type" : "zeebe:property"
@@ -203,13 +195,16 @@
       "equals" : "refresh",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "authentication.refresh.clientSecret",
-    "label" : "Client secret",
-    "optional" : true,
+    "constraints" : {
+      "notEmpty" : true
+    },
     "feel" : "optional",
     "group" : "authentication",
+    "id" : "authentication.refresh.tenantId",
+    "label" : "Tenant ID",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "authentication.clientSecret",
       "type" : "zeebe:property"
@@ -219,52 +214,48 @@
       "equals" : "refresh",
       "type" : "simple"
     },
+    "feel" : "optional",
+    "group" : "authentication",
+    "id" : "authentication.refresh.clientSecret",
+    "label" : "Client secret",
+    "optional" : true,
     "tooltip" : "The secret value of the Microsoft Entra ID (formerly Azure AD) application; optional, depends on whether the client is public or private",
     "type" : "String"
   }, {
-    "id" : "pollingConfig.userId",
-    "label" : "Mailbox Owner",
-    "optional" : false,
+    "binding" : {
+      "name" : "pollingConfig.userId",
+      "type" : "zeebe:property"
+    },
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "pollingConfig",
-    "binding" : {
-      "name" : "pollingConfig.userId",
-      "type" : "zeebe:property"
-    },
-    "tooltip" : "The email address or user ID of the mailbox to monitor. <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/microsoft-o365-mail-inbound/#configuration\" target=\"_blank\">Microsoft O365 Mail connector configuration</a>",
+    "id" : "pollingConfig.userId",
+    "label" : "Mailbox Owner",
+    "optional" : false,
     "placeholder" : "user@example.com",
+    "tooltip" : "The email address or user ID of the mailbox to monitor. <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/microsoft-o365-mail-inbound/#configuration\" target=\"_blank\">Microsoft O365 Mail connector configuration</a>",
     "type" : "String"
   }, {
-    "id" : "pollingConfig.folder.folderSpecification",
-    "label" : "Folder Identifier Type",
-    "description" : "Prefer using a folder ID if you are using a well-known folder; otherwise, use the folder name.",
-    "value" : "byId",
-    "group" : "pollingConfig",
     "binding" : {
       "name" : "pollingConfig.folder.folderSpecification",
       "type" : "zeebe:property"
     },
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "Folder ID",
       "value" : "byId"
     }, {
       "name" : "Folder Name",
       "value" : "byName"
-    } ]
-  }, {
-    "id" : "pollingConfig.folder.folderId",
-    "label" : "Folder ID",
-    "optional" : false,
-    "value" : "inbox",
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "feel" : "optional",
+    } ],
+    "description" : "Prefer using a folder ID if you are using a well-known folder; otherwise, use the folder name.",
     "group" : "pollingConfig",
+    "id" : "pollingConfig.folder.folderSpecification",
+    "label" : "Folder Identifier Type",
+    "type" : "Dropdown",
+    "value" : "byId"
+  }, {
     "binding" : {
       "name" : "pollingConfig.folder.folderId",
       "type" : "zeebe:property"
@@ -274,17 +265,18 @@
       "equals" : "byId",
       "type" : "simple"
     },
-    "tooltip" : "The well-known folder ID or custom folder ID. <a href='https://learn.microsoft.com/en-us/graph/api/resources/mailfolder?view=graph-rest-1.0#properties' target='_blank'>See folder properties in the API</a>",
-    "type" : "String"
-  }, {
-    "id" : "pollingConfig.folder.folderName",
-    "label" : "Folder Name",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "pollingConfig",
+    "id" : "pollingConfig.folder.folderId",
+    "label" : "Folder ID",
+    "optional" : false,
+    "tooltip" : "The well-known folder ID or custom folder ID. <a href='https://learn.microsoft.com/en-us/graph/api/resources/mailfolder?view=graph-rest-1.0#properties' target='_blank'>See folder properties in the API</a>",
+    "type" : "String",
+    "value" : "inbox"
+  }, {
     "binding" : {
       "name" : "pollingConfig.folder.folderName",
       "type" : "zeebe:property"
@@ -294,46 +286,48 @@
       "equals" : "byName",
       "type" : "simple"
     },
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "pollingConfig",
+    "id" : "pollingConfig.folder.folderName",
+    "label" : "Folder Name",
+    "optional" : false,
     "tooltip" : "The display name of the folder. Must be unique within the mailbox.",
     "type" : "String"
   }, {
-    "id" : "pollingConfig.pollingInterval",
-    "label" : "Polling interval",
-    "optional" : false,
-    "value" : "PT30S",
-    "feel" : "optional",
-    "group" : "pollingConfig",
     "binding" : {
       "name" : "pollingConfig.pollingInterval",
       "type" : "zeebe:property"
     },
-    "tooltip" : "The interval between email polling requests, in ISO 8601 duration format. <a href='https://docs.camunda.io/docs/components/modeler/bpmn/timer-events/#time-duration' target='_blank'>How to configure a time duration</a>",
-    "type" : "String"
-  }, {
-    "id" : "pollingConfig.filterCriteria.filterSpecification",
-    "label" : "Filter Specification",
-    "description" : "Use predefined filter conditions or provide your own OData filter string",
-    "value" : "simple",
+    "feel" : "optional",
     "group" : "pollingConfig",
+    "id" : "pollingConfig.pollingInterval",
+    "label" : "Polling interval",
+    "optional" : false,
+    "tooltip" : "The interval between email polling requests, in ISO 8601 duration format. <a href='https://docs.camunda.io/docs/components/modeler/bpmn/timer-events/#time-duration' target='_blank'>How to configure a time duration</a>",
+    "type" : "String",
+    "value" : "PT30S"
+  }, {
     "binding" : {
       "name" : "pollingConfig.filterCriteria.filterSpecification",
       "type" : "zeebe:property"
     },
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "Simple",
       "value" : "simple"
     }, {
       "name" : "Advanced",
       "value" : "advanced"
-    } ]
-  }, {
-    "id" : "pollingConfig.filterCriteria.onlyUnread",
-    "label" : "Only Unread",
-    "optional" : false,
-    "value" : true,
-    "feel" : "static",
+    } ],
+    "description" : "Use predefined filter conditions or provide your own OData filter string",
     "group" : "pollingConfig",
+    "id" : "pollingConfig.filterCriteria.filterSpecification",
+    "label" : "Filter Specification",
+    "type" : "Dropdown",
+    "value" : "simple"
+  }, {
     "binding" : {
       "name" : "pollingConfig.filterCriteria.onlyUnread",
       "type" : "zeebe:property"
@@ -343,14 +337,15 @@
       "equals" : "simple",
       "type" : "simple"
     },
-    "tooltip" : "Only fetch unread emails",
-    "type" : "Boolean"
-  }, {
-    "id" : "pollingConfig.filterCriteria.subjectContains",
-    "label" : "Subject Contains",
-    "optional" : true,
-    "feel" : "optional",
+    "feel" : "static",
     "group" : "pollingConfig",
+    "id" : "pollingConfig.filterCriteria.onlyUnread",
+    "label" : "Only Unread",
+    "optional" : false,
+    "tooltip" : "Only fetch unread emails",
+    "type" : "Boolean",
+    "value" : true
+  }, {
     "binding" : {
       "name" : "pollingConfig.filterCriteria.subjectContains",
       "type" : "zeebe:property"
@@ -360,14 +355,14 @@
       "equals" : "simple",
       "type" : "simple"
     },
+    "feel" : "optional",
+    "group" : "pollingConfig",
+    "id" : "pollingConfig.filterCriteria.subjectContains",
+    "label" : "Subject Contains",
+    "optional" : true,
     "tooltip" : "Only fetch emails where subject contains this text (case-sensitive)",
     "type" : "String"
   }, {
-    "id" : "pollingConfig.filterCriteria.fromAddress",
-    "label" : "From Email Address",
-    "optional" : true,
-    "feel" : "optional",
-    "group" : "pollingConfig",
     "binding" : {
       "name" : "pollingConfig.filterCriteria.fromAddress",
       "type" : "zeebe:property"
@@ -377,16 +372,14 @@
       "equals" : "simple",
       "type" : "simple"
     },
+    "feel" : "optional",
+    "group" : "pollingConfig",
+    "id" : "pollingConfig.filterCriteria.fromAddress",
+    "label" : "From Email Address",
+    "optional" : true,
     "tooltip" : "Only fetch emails from this sender address (exact match, e.g. 'invoice@vendor.com')",
     "type" : "String"
   }, {
-    "id" : "pollingConfig.filterCriteria.filterString",
-    "label" : "OData Filter String",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "group" : "pollingConfig",
     "binding" : {
       "name" : "pollingConfig.filterCriteria.filterString",
       "type" : "zeebe:property"
@@ -396,18 +389,20 @@
       "equals" : "advanced",
       "type" : "simple"
     },
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "group" : "pollingConfig",
+    "id" : "pollingConfig.filterCriteria.filterString",
+    "label" : "OData Filter String",
+    "optional" : false,
     "tooltip" : "A custom OData filter expression. <a href='https://learn.microsoft.com/en-us/graph/filter-query-parameter' target='_blank'>See OData filter documentation</a>",
     "type" : "String"
   }, {
-    "id" : "operation.processingOperationDiscriminator",
-    "label" : "Postprocessing configuration",
-    "value" : "mark-read",
-    "group" : "postprocessing",
     "binding" : {
       "name" : "operation.processingOperationDiscriminator",
       "type" : "zeebe:property"
     },
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "Delete",
       "value" : "delete"
@@ -417,14 +412,13 @@
     }, {
       "name" : "Move to other folder",
       "value" : "move"
-    } ]
-  }, {
-    "id" : "operation.force",
-    "label" : "Force delete (email is permanently deleted)",
-    "optional" : false,
-    "value" : false,
-    "feel" : "static",
+    } ],
     "group" : "postprocessing",
+    "id" : "operation.processingOperationDiscriminator",
+    "label" : "Postprocessing configuration",
+    "type" : "Dropdown",
+    "value" : "mark-read"
+  }, {
     "binding" : {
       "name" : "operation.force",
       "type" : "zeebe:property"
@@ -434,40 +428,37 @@
       "equals" : "delete",
       "type" : "simple"
     },
-    "type" : "Boolean"
-  }, {
-    "id" : "operation.targetFolder.folderSpecification",
-    "label" : "Folder Identifier Type",
-    "description" : "Prefer using a folder ID if you are using a well-known folder; otherwise, use the folder name.",
-    "value" : "byId",
+    "feel" : "static",
     "group" : "postprocessing",
+    "id" : "operation.force",
+    "label" : "Force delete (email is permanently deleted)",
+    "optional" : false,
+    "type" : "Boolean",
+    "value" : false
+  }, {
     "binding" : {
       "name" : "operation.targetFolder.folderSpecification",
       "type" : "zeebe:property"
     },
-    "condition" : {
-      "property" : "operation.processingOperationDiscriminator",
-      "equals" : "move",
-      "type" : "simple"
-    },
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "Folder ID",
       "value" : "byId"
     }, {
       "name" : "Folder Name",
       "value" : "byName"
-    } ]
-  }, {
-    "id" : "operation.targetFolder.folderId",
-    "label" : "Folder ID",
-    "optional" : false,
-    "value" : "inbox",
-    "constraints" : {
-      "notEmpty" : true
+    } ],
+    "condition" : {
+      "property" : "operation.processingOperationDiscriminator",
+      "equals" : "move",
+      "type" : "simple"
     },
-    "feel" : "optional",
+    "description" : "Prefer using a folder ID if you are using a well-known folder; otherwise, use the folder name.",
     "group" : "postprocessing",
+    "id" : "operation.targetFolder.folderSpecification",
+    "label" : "Folder Identifier Type",
+    "type" : "Dropdown",
+    "value" : "byId"
+  }, {
     "binding" : {
       "name" : "operation.targetFolder.folderId",
       "type" : "zeebe:property"
@@ -483,17 +474,18 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "The well-known folder ID or custom folder ID. <a href='https://learn.microsoft.com/en-us/graph/api/resources/mailfolder?view=graph-rest-1.0#properties' target='_blank'>See folder properties in the API</a>",
-    "type" : "String"
-  }, {
-    "id" : "operation.targetFolder.folderName",
-    "label" : "Folder Name",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "postprocessing",
+    "id" : "operation.targetFolder.folderId",
+    "label" : "Folder ID",
+    "optional" : false,
+    "tooltip" : "The well-known folder ID or custom folder ID. <a href='https://learn.microsoft.com/en-us/graph/api/resources/mailfolder?view=graph-rest-1.0#properties' target='_blank'>See folder properties in the API</a>",
+    "type" : "String",
+    "value" : "inbox"
+  }, {
     "binding" : {
       "name" : "operation.targetFolder.folderName",
       "type" : "zeebe:property"
@@ -509,65 +501,73 @@
         "type" : "simple"
       } ]
     },
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "postprocessing",
+    "id" : "operation.targetFolder.folderName",
+    "label" : "Folder Name",
+    "optional" : false,
     "tooltip" : "The display name of the folder. Must be unique within the mailbox.",
     "type" : "String"
   }, {
-    "id" : "activationCondition",
-    "label" : "Activation condition",
-    "description" : "Condition under which the Connector triggers. Leave empty to catch all events",
-    "optional" : true,
-    "feel" : "required",
-    "group" : "activation",
     "binding" : {
       "name" : "activationCondition",
       "type" : "zeebe:property"
     },
+    "description" : "Condition under which the Connector triggers. Leave empty to catch all events",
+    "feel" : "required",
+    "group" : "activation",
+    "id" : "activationCondition",
+    "label" : "Activation condition",
+    "optional" : true,
     "type" : "String"
   }, {
-    "id" : "correlationKeyProcess",
-    "label" : "Correlation key (process)",
-    "description" : "Sets up the correlation key from process variables",
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "feel" : "required",
-    "group" : "correlation",
     "binding" : {
       "name" : "correlationKey",
       "type" : "bpmn:Message#zeebe:subscription#property"
     },
-    "type" : "String"
-  }, {
-    "id" : "correlationKeyPayload",
-    "label" : "Correlation key (payload)",
-    "description" : "Extracts the correlation key from the incoming message payload",
     "constraints" : {
       "notEmpty" : true
     },
+    "description" : "Sets up the correlation key from process variables",
     "feel" : "required",
     "group" : "correlation",
+    "id" : "correlationKeyProcess",
+    "label" : "Correlation key (process)",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "correlationKeyExpression",
       "type" : "zeebe:property"
     },
-    "type" : "String"
-  }, {
-    "id" : "messageIdExpression",
-    "label" : "Message ID expression",
-    "description" : "Expression to extract unique identifier of a message",
-    "optional" : true,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "description" : "Extracts the correlation key from the incoming message payload",
     "feel" : "required",
     "group" : "correlation",
+    "id" : "correlationKeyPayload",
+    "label" : "Correlation key (payload)",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "messageIdExpression",
       "type" : "zeebe:property"
     },
+    "description" : "Expression to extract unique identifier of a message",
+    "feel" : "required",
+    "group" : "correlation",
+    "id" : "messageIdExpression",
+    "label" : "Message ID expression",
+    "optional" : true,
     "type" : "String"
   }, {
-    "id" : "messageTtl",
-    "label" : "Message TTL",
-    "description" : "Time-to-live for the message in the broker (ISO-8601 duration)",
-    "optional" : true,
+    "binding" : {
+      "name" : "messageTtl",
+      "type" : "zeebe:property"
+    },
     "constraints" : {
       "notEmpty" : false,
       "pattern" : {
@@ -575,47 +575,47 @@
         "message" : "must be an ISO-8601 duration"
       }
     },
+    "description" : "Time-to-live for the message in the broker (ISO-8601 duration)",
     "feel" : "optional",
     "group" : "correlation",
-    "binding" : {
-      "name" : "messageTtl",
-      "type" : "zeebe:property"
-    },
+    "id" : "messageTtl",
+    "label" : "Message TTL",
+    "optional" : true,
     "type" : "String"
   }, {
-    "id" : "messageNameUuid",
-    "label" : "Message name",
-    "generatedValue" : {
-      "type" : "uuid"
-    },
-    "feel" : "optional",
-    "group" : "correlation",
     "binding" : {
       "name" : "name",
       "type" : "bpmn:Message#property"
     },
+    "feel" : "optional",
+    "generatedValue" : {
+      "type" : "uuid"
+    },
+    "group" : "correlation",
+    "id" : "messageNameUuid",
+    "label" : "Message name",
     "tooltip" : "By default, this is an auto-generated random UUID. We recommend using a unique message name for each connector element in the diagram. Override to set a custom message name. Learn more about <a href=\"https://docs.camunda.io/docs/components/concepts/messages/#message-subscriptions\">message subscriptions</a> that power inbound connectors.",
     "type" : "String"
   }, {
-    "id" : "resultVariable",
-    "label" : "Result variable",
-    "description" : "Name of variable to store the response in. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-variable\" target=\"_blank\">documentation</a>.",
-    "group" : "output",
     "binding" : {
       "name" : "resultVariable",
       "type" : "zeebe:property"
     },
+    "description" : "Name of variable to store the response in. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-variable\" target=\"_blank\">documentation</a>.",
+    "group" : "output",
+    "id" : "resultVariable",
+    "label" : "Result variable",
     "type" : "String"
   }, {
-    "id" : "resultExpression",
-    "label" : "Result expression",
-    "description" : "Expression to map the response into process variables. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-expression\" target=\"_blank\">documentation</a>.",
-    "feel" : "required",
-    "group" : "output",
     "binding" : {
       "name" : "resultExpression",
       "type" : "zeebe:property"
     },
+    "description" : "Expression to map the response into process variables. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-expression\" target=\"_blank\">documentation</a>.",
+    "feel" : "required",
+    "group" : "output",
+    "id" : "resultExpression",
+    "label" : "Result expression",
     "type" : "Text"
   } ],
   "icon" : {

--- a/connectors/microsoft/email-inbound/element-templates/hybrid/hybrid-microsoft-o365-email-intermediate-catch-event-connector-hybrid.json
+++ b/connectors/microsoft/email-inbound/element-templates/hybrid/hybrid-microsoft-o365-email-intermediate-catch-event-connector-hybrid.json
@@ -42,25 +42,19 @@
     "label" : "Output mapping"
   } ],
   "properties" : [ {
-    "id" : "connectorType",
-    "value" : "io.camunda:connector-o365-email-inbound:1",
-    "group" : "connectorType",
     "binding" : {
       "name" : "inbound.type",
       "type" : "zeebe:property"
     },
-    "type" : "String"
+    "group" : "connectorType",
+    "id" : "connectorType",
+    "type" : "String",
+    "value" : "io.camunda:connector-o365-email-inbound:1"
   }, {
-    "id" : "authentication.type",
-    "label" : "Type",
-    "description" : "Authentication type depends on your Microsoft Entra (Azure AD) configuration. See <a href='https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/microsoft-teams/'>connector documentation</a>",
-    "value" : "clientCredentials",
-    "group" : "authentication",
     "binding" : {
       "name" : "authentication.type",
       "type" : "zeebe:property"
     },
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "Bearer token",
       "value" : "token"
@@ -70,15 +64,14 @@
     }, {
       "name" : "Refresh token",
       "value" : "refresh"
-    } ]
-  }, {
-    "id" : "authentication.bearer.token",
-    "label" : "Bearer token",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
+    } ],
+    "description" : "Authentication type depends on your Microsoft Entra (Azure AD) configuration. See <a href='https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/microsoft-teams/'>connector documentation</a>",
     "group" : "authentication",
+    "id" : "authentication.type",
+    "label" : "Type",
+    "type" : "Dropdown",
+    "value" : "clientCredentials"
+  }, {
     "binding" : {
       "name" : "authentication.token",
       "type" : "zeebe:property"
@@ -88,16 +81,15 @@
       "equals" : "token",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "authentication.credentials.clientId",
-    "label" : "Client ID",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
-    "feel" : "optional",
     "group" : "authentication",
+    "id" : "authentication.bearer.token",
+    "label" : "Bearer token",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "authentication.clientId",
       "type" : "zeebe:property"
@@ -107,16 +99,16 @@
       "equals" : "clientCredentials",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "authentication.credentials.tenantId",
-    "label" : "Tenant ID",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "authentication",
+    "id" : "authentication.credentials.clientId",
+    "label" : "Client ID",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "authentication.tenantId",
       "type" : "zeebe:property"
@@ -126,16 +118,16 @@
       "equals" : "clientCredentials",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "authentication.credentials.clientSecret",
-    "label" : "Client secret",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "authentication",
+    "id" : "authentication.credentials.tenantId",
+    "label" : "Tenant ID",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "authentication.clientSecret",
       "type" : "zeebe:property"
@@ -145,17 +137,17 @@
       "equals" : "clientCredentials",
       "type" : "simple"
     },
-    "tooltip" : "The secret value of the Microsoft Entra ID (formerly Azure AD) application",
-    "type" : "String"
-  }, {
-    "id" : "authentication.refresh.token",
-    "label" : "Refresh token",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "authentication",
+    "id" : "authentication.credentials.clientSecret",
+    "label" : "Client secret",
+    "optional" : false,
+    "tooltip" : "The secret value of the Microsoft Entra ID (formerly Azure AD) application",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "authentication.token",
       "type" : "zeebe:property"
@@ -165,16 +157,16 @@
       "equals" : "refresh",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "authentication.refresh.clientId",
-    "label" : "Client ID",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "authentication",
+    "id" : "authentication.refresh.token",
+    "label" : "Refresh token",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "authentication.clientId",
       "type" : "zeebe:property"
@@ -184,16 +176,16 @@
       "equals" : "refresh",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "authentication.refresh.tenantId",
-    "label" : "Tenant ID",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "authentication",
+    "id" : "authentication.refresh.clientId",
+    "label" : "Client ID",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "authentication.tenantId",
       "type" : "zeebe:property"
@@ -203,13 +195,16 @@
       "equals" : "refresh",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "authentication.refresh.clientSecret",
-    "label" : "Client secret",
-    "optional" : true,
+    "constraints" : {
+      "notEmpty" : true
+    },
     "feel" : "optional",
     "group" : "authentication",
+    "id" : "authentication.refresh.tenantId",
+    "label" : "Tenant ID",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "authentication.clientSecret",
       "type" : "zeebe:property"
@@ -219,52 +214,48 @@
       "equals" : "refresh",
       "type" : "simple"
     },
+    "feel" : "optional",
+    "group" : "authentication",
+    "id" : "authentication.refresh.clientSecret",
+    "label" : "Client secret",
+    "optional" : true,
     "tooltip" : "The secret value of the Microsoft Entra ID (formerly Azure AD) application; optional, depends on whether the client is public or private",
     "type" : "String"
   }, {
-    "id" : "pollingConfig.userId",
-    "label" : "Mailbox Owner",
-    "optional" : false,
+    "binding" : {
+      "name" : "pollingConfig.userId",
+      "type" : "zeebe:property"
+    },
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "pollingConfig",
-    "binding" : {
-      "name" : "pollingConfig.userId",
-      "type" : "zeebe:property"
-    },
-    "tooltip" : "The email address or user ID of the mailbox to monitor. <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/microsoft-o365-mail-inbound/#configuration\" target=\"_blank\">Microsoft O365 Mail connector configuration</a>",
+    "id" : "pollingConfig.userId",
+    "label" : "Mailbox Owner",
+    "optional" : false,
     "placeholder" : "user@example.com",
+    "tooltip" : "The email address or user ID of the mailbox to monitor. <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/microsoft-o365-mail-inbound/#configuration\" target=\"_blank\">Microsoft O365 Mail connector configuration</a>",
     "type" : "String"
   }, {
-    "id" : "pollingConfig.folder.folderSpecification",
-    "label" : "Folder Identifier Type",
-    "description" : "Prefer using a folder ID if you are using a well-known folder; otherwise, use the folder name.",
-    "value" : "byId",
-    "group" : "pollingConfig",
     "binding" : {
       "name" : "pollingConfig.folder.folderSpecification",
       "type" : "zeebe:property"
     },
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "Folder ID",
       "value" : "byId"
     }, {
       "name" : "Folder Name",
       "value" : "byName"
-    } ]
-  }, {
-    "id" : "pollingConfig.folder.folderId",
-    "label" : "Folder ID",
-    "optional" : false,
-    "value" : "inbox",
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "feel" : "optional",
+    } ],
+    "description" : "Prefer using a folder ID if you are using a well-known folder; otherwise, use the folder name.",
     "group" : "pollingConfig",
+    "id" : "pollingConfig.folder.folderSpecification",
+    "label" : "Folder Identifier Type",
+    "type" : "Dropdown",
+    "value" : "byId"
+  }, {
     "binding" : {
       "name" : "pollingConfig.folder.folderId",
       "type" : "zeebe:property"
@@ -274,17 +265,18 @@
       "equals" : "byId",
       "type" : "simple"
     },
-    "tooltip" : "The well-known folder ID or custom folder ID. <a href='https://learn.microsoft.com/en-us/graph/api/resources/mailfolder?view=graph-rest-1.0#properties' target='_blank'>See folder properties in the API</a>",
-    "type" : "String"
-  }, {
-    "id" : "pollingConfig.folder.folderName",
-    "label" : "Folder Name",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "pollingConfig",
+    "id" : "pollingConfig.folder.folderId",
+    "label" : "Folder ID",
+    "optional" : false,
+    "tooltip" : "The well-known folder ID or custom folder ID. <a href='https://learn.microsoft.com/en-us/graph/api/resources/mailfolder?view=graph-rest-1.0#properties' target='_blank'>See folder properties in the API</a>",
+    "type" : "String",
+    "value" : "inbox"
+  }, {
     "binding" : {
       "name" : "pollingConfig.folder.folderName",
       "type" : "zeebe:property"
@@ -294,46 +286,48 @@
       "equals" : "byName",
       "type" : "simple"
     },
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "pollingConfig",
+    "id" : "pollingConfig.folder.folderName",
+    "label" : "Folder Name",
+    "optional" : false,
     "tooltip" : "The display name of the folder. Must be unique within the mailbox.",
     "type" : "String"
   }, {
-    "id" : "pollingConfig.pollingInterval",
-    "label" : "Polling interval",
-    "optional" : false,
-    "value" : "PT30S",
-    "feel" : "optional",
-    "group" : "pollingConfig",
     "binding" : {
       "name" : "pollingConfig.pollingInterval",
       "type" : "zeebe:property"
     },
-    "tooltip" : "The interval between email polling requests, in ISO 8601 duration format. <a href='https://docs.camunda.io/docs/components/modeler/bpmn/timer-events/#time-duration' target='_blank'>How to configure a time duration</a>",
-    "type" : "String"
-  }, {
-    "id" : "pollingConfig.filterCriteria.filterSpecification",
-    "label" : "Filter Specification",
-    "description" : "Use predefined filter conditions or provide your own OData filter string",
-    "value" : "simple",
+    "feel" : "optional",
     "group" : "pollingConfig",
+    "id" : "pollingConfig.pollingInterval",
+    "label" : "Polling interval",
+    "optional" : false,
+    "tooltip" : "The interval between email polling requests, in ISO 8601 duration format. <a href='https://docs.camunda.io/docs/components/modeler/bpmn/timer-events/#time-duration' target='_blank'>How to configure a time duration</a>",
+    "type" : "String",
+    "value" : "PT30S"
+  }, {
     "binding" : {
       "name" : "pollingConfig.filterCriteria.filterSpecification",
       "type" : "zeebe:property"
     },
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "Simple",
       "value" : "simple"
     }, {
       "name" : "Advanced",
       "value" : "advanced"
-    } ]
-  }, {
-    "id" : "pollingConfig.filterCriteria.onlyUnread",
-    "label" : "Only Unread",
-    "optional" : false,
-    "value" : true,
-    "feel" : "static",
+    } ],
+    "description" : "Use predefined filter conditions or provide your own OData filter string",
     "group" : "pollingConfig",
+    "id" : "pollingConfig.filterCriteria.filterSpecification",
+    "label" : "Filter Specification",
+    "type" : "Dropdown",
+    "value" : "simple"
+  }, {
     "binding" : {
       "name" : "pollingConfig.filterCriteria.onlyUnread",
       "type" : "zeebe:property"
@@ -343,14 +337,15 @@
       "equals" : "simple",
       "type" : "simple"
     },
-    "tooltip" : "Only fetch unread emails",
-    "type" : "Boolean"
-  }, {
-    "id" : "pollingConfig.filterCriteria.subjectContains",
-    "label" : "Subject Contains",
-    "optional" : true,
-    "feel" : "optional",
+    "feel" : "static",
     "group" : "pollingConfig",
+    "id" : "pollingConfig.filterCriteria.onlyUnread",
+    "label" : "Only Unread",
+    "optional" : false,
+    "tooltip" : "Only fetch unread emails",
+    "type" : "Boolean",
+    "value" : true
+  }, {
     "binding" : {
       "name" : "pollingConfig.filterCriteria.subjectContains",
       "type" : "zeebe:property"
@@ -360,14 +355,14 @@
       "equals" : "simple",
       "type" : "simple"
     },
+    "feel" : "optional",
+    "group" : "pollingConfig",
+    "id" : "pollingConfig.filterCriteria.subjectContains",
+    "label" : "Subject Contains",
+    "optional" : true,
     "tooltip" : "Only fetch emails where subject contains this text (case-sensitive)",
     "type" : "String"
   }, {
-    "id" : "pollingConfig.filterCriteria.fromAddress",
-    "label" : "From Email Address",
-    "optional" : true,
-    "feel" : "optional",
-    "group" : "pollingConfig",
     "binding" : {
       "name" : "pollingConfig.filterCriteria.fromAddress",
       "type" : "zeebe:property"
@@ -377,16 +372,14 @@
       "equals" : "simple",
       "type" : "simple"
     },
+    "feel" : "optional",
+    "group" : "pollingConfig",
+    "id" : "pollingConfig.filterCriteria.fromAddress",
+    "label" : "From Email Address",
+    "optional" : true,
     "tooltip" : "Only fetch emails from this sender address (exact match, e.g. 'invoice@vendor.com')",
     "type" : "String"
   }, {
-    "id" : "pollingConfig.filterCriteria.filterString",
-    "label" : "OData Filter String",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "group" : "pollingConfig",
     "binding" : {
       "name" : "pollingConfig.filterCriteria.filterString",
       "type" : "zeebe:property"
@@ -396,18 +389,20 @@
       "equals" : "advanced",
       "type" : "simple"
     },
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "group" : "pollingConfig",
+    "id" : "pollingConfig.filterCriteria.filterString",
+    "label" : "OData Filter String",
+    "optional" : false,
     "tooltip" : "A custom OData filter expression. <a href='https://learn.microsoft.com/en-us/graph/filter-query-parameter' target='_blank'>See OData filter documentation</a>",
     "type" : "String"
   }, {
-    "id" : "operation.processingOperationDiscriminator",
-    "label" : "Postprocessing configuration",
-    "value" : "mark-read",
-    "group" : "postprocessing",
     "binding" : {
       "name" : "operation.processingOperationDiscriminator",
       "type" : "zeebe:property"
     },
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "Delete",
       "value" : "delete"
@@ -417,14 +412,13 @@
     }, {
       "name" : "Move to other folder",
       "value" : "move"
-    } ]
-  }, {
-    "id" : "operation.force",
-    "label" : "Force delete (email is permanently deleted)",
-    "optional" : false,
-    "value" : false,
-    "feel" : "static",
+    } ],
     "group" : "postprocessing",
+    "id" : "operation.processingOperationDiscriminator",
+    "label" : "Postprocessing configuration",
+    "type" : "Dropdown",
+    "value" : "mark-read"
+  }, {
     "binding" : {
       "name" : "operation.force",
       "type" : "zeebe:property"
@@ -434,40 +428,37 @@
       "equals" : "delete",
       "type" : "simple"
     },
-    "type" : "Boolean"
-  }, {
-    "id" : "operation.targetFolder.folderSpecification",
-    "label" : "Folder Identifier Type",
-    "description" : "Prefer using a folder ID if you are using a well-known folder; otherwise, use the folder name.",
-    "value" : "byId",
+    "feel" : "static",
     "group" : "postprocessing",
+    "id" : "operation.force",
+    "label" : "Force delete (email is permanently deleted)",
+    "optional" : false,
+    "type" : "Boolean",
+    "value" : false
+  }, {
     "binding" : {
       "name" : "operation.targetFolder.folderSpecification",
       "type" : "zeebe:property"
     },
-    "condition" : {
-      "property" : "operation.processingOperationDiscriminator",
-      "equals" : "move",
-      "type" : "simple"
-    },
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "Folder ID",
       "value" : "byId"
     }, {
       "name" : "Folder Name",
       "value" : "byName"
-    } ]
-  }, {
-    "id" : "operation.targetFolder.folderId",
-    "label" : "Folder ID",
-    "optional" : false,
-    "value" : "inbox",
-    "constraints" : {
-      "notEmpty" : true
+    } ],
+    "condition" : {
+      "property" : "operation.processingOperationDiscriminator",
+      "equals" : "move",
+      "type" : "simple"
     },
-    "feel" : "optional",
+    "description" : "Prefer using a folder ID if you are using a well-known folder; otherwise, use the folder name.",
     "group" : "postprocessing",
+    "id" : "operation.targetFolder.folderSpecification",
+    "label" : "Folder Identifier Type",
+    "type" : "Dropdown",
+    "value" : "byId"
+  }, {
     "binding" : {
       "name" : "operation.targetFolder.folderId",
       "type" : "zeebe:property"
@@ -483,17 +474,18 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "The well-known folder ID or custom folder ID. <a href='https://learn.microsoft.com/en-us/graph/api/resources/mailfolder?view=graph-rest-1.0#properties' target='_blank'>See folder properties in the API</a>",
-    "type" : "String"
-  }, {
-    "id" : "operation.targetFolder.folderName",
-    "label" : "Folder Name",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "postprocessing",
+    "id" : "operation.targetFolder.folderId",
+    "label" : "Folder ID",
+    "optional" : false,
+    "tooltip" : "The well-known folder ID or custom folder ID. <a href='https://learn.microsoft.com/en-us/graph/api/resources/mailfolder?view=graph-rest-1.0#properties' target='_blank'>See folder properties in the API</a>",
+    "type" : "String",
+    "value" : "inbox"
+  }, {
     "binding" : {
       "name" : "operation.targetFolder.folderName",
       "type" : "zeebe:property"
@@ -509,65 +501,73 @@
         "type" : "simple"
       } ]
     },
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "postprocessing",
+    "id" : "operation.targetFolder.folderName",
+    "label" : "Folder Name",
+    "optional" : false,
     "tooltip" : "The display name of the folder. Must be unique within the mailbox.",
     "type" : "String"
   }, {
-    "id" : "activationCondition",
-    "label" : "Activation condition",
-    "description" : "Condition under which the Connector triggers. Leave empty to catch all events",
-    "optional" : true,
-    "feel" : "required",
-    "group" : "activation",
     "binding" : {
       "name" : "activationCondition",
       "type" : "zeebe:property"
     },
+    "description" : "Condition under which the Connector triggers. Leave empty to catch all events",
+    "feel" : "required",
+    "group" : "activation",
+    "id" : "activationCondition",
+    "label" : "Activation condition",
+    "optional" : true,
     "type" : "String"
   }, {
-    "id" : "correlationKeyProcess",
-    "label" : "Correlation key (process)",
-    "description" : "Sets up the correlation key from process variables",
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "feel" : "required",
-    "group" : "correlation",
     "binding" : {
       "name" : "correlationKey",
       "type" : "bpmn:Message#zeebe:subscription#property"
     },
-    "type" : "String"
-  }, {
-    "id" : "correlationKeyPayload",
-    "label" : "Correlation key (payload)",
-    "description" : "Extracts the correlation key from the incoming message payload",
     "constraints" : {
       "notEmpty" : true
     },
+    "description" : "Sets up the correlation key from process variables",
     "feel" : "required",
     "group" : "correlation",
+    "id" : "correlationKeyProcess",
+    "label" : "Correlation key (process)",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "correlationKeyExpression",
       "type" : "zeebe:property"
     },
-    "type" : "String"
-  }, {
-    "id" : "messageIdExpression",
-    "label" : "Message ID expression",
-    "description" : "Expression to extract unique identifier of a message",
-    "optional" : true,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "description" : "Extracts the correlation key from the incoming message payload",
     "feel" : "required",
     "group" : "correlation",
+    "id" : "correlationKeyPayload",
+    "label" : "Correlation key (payload)",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "messageIdExpression",
       "type" : "zeebe:property"
     },
+    "description" : "Expression to extract unique identifier of a message",
+    "feel" : "required",
+    "group" : "correlation",
+    "id" : "messageIdExpression",
+    "label" : "Message ID expression",
+    "optional" : true,
     "type" : "String"
   }, {
-    "id" : "messageTtl",
-    "label" : "Message TTL",
-    "description" : "Time-to-live for the message in the broker (ISO-8601 duration)",
-    "optional" : true,
+    "binding" : {
+      "name" : "messageTtl",
+      "type" : "zeebe:property"
+    },
     "constraints" : {
       "notEmpty" : false,
       "pattern" : {
@@ -575,47 +575,47 @@
         "message" : "must be an ISO-8601 duration"
       }
     },
+    "description" : "Time-to-live for the message in the broker (ISO-8601 duration)",
     "feel" : "optional",
     "group" : "correlation",
-    "binding" : {
-      "name" : "messageTtl",
-      "type" : "zeebe:property"
-    },
+    "id" : "messageTtl",
+    "label" : "Message TTL",
+    "optional" : true,
     "type" : "String"
   }, {
-    "id" : "messageNameUuid",
-    "label" : "Message name",
-    "generatedValue" : {
-      "type" : "uuid"
-    },
-    "feel" : "optional",
-    "group" : "correlation",
     "binding" : {
       "name" : "name",
       "type" : "bpmn:Message#property"
     },
+    "feel" : "optional",
+    "generatedValue" : {
+      "type" : "uuid"
+    },
+    "group" : "correlation",
+    "id" : "messageNameUuid",
+    "label" : "Message name",
     "tooltip" : "By default, this is an auto-generated random UUID. We recommend using a unique message name for each connector element in the diagram. Override to set a custom message name. Learn more about <a href=\"https://docs.camunda.io/docs/components/concepts/messages/#message-subscriptions\">message subscriptions</a> that power inbound connectors.",
     "type" : "String"
   }, {
-    "id" : "resultVariable",
-    "label" : "Result variable",
-    "description" : "Name of variable to store the response in. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-variable\" target=\"_blank\">documentation</a>.",
-    "group" : "output",
     "binding" : {
       "name" : "resultVariable",
       "type" : "zeebe:property"
     },
+    "description" : "Name of variable to store the response in. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-variable\" target=\"_blank\">documentation</a>.",
+    "group" : "output",
+    "id" : "resultVariable",
+    "label" : "Result variable",
     "type" : "String"
   }, {
-    "id" : "resultExpression",
-    "label" : "Result expression",
-    "description" : "Expression to map the response into process variables. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-expression\" target=\"_blank\">documentation</a>.",
-    "feel" : "required",
-    "group" : "output",
     "binding" : {
       "name" : "resultExpression",
       "type" : "zeebe:property"
     },
+    "description" : "Expression to map the response into process variables. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-expression\" target=\"_blank\">documentation</a>.",
+    "feel" : "required",
+    "group" : "output",
+    "id" : "resultExpression",
+    "label" : "Result expression",
     "type" : "Text"
   } ],
   "icon" : {

--- a/connectors/microsoft/email-inbound/element-templates/hybrid/hybrid-microsoft-o365-email-message-start-event-connector-hybrid.json
+++ b/connectors/microsoft/email-inbound/element-templates/hybrid/hybrid-microsoft-o365-email-message-start-event-connector-hybrid.json
@@ -42,25 +42,19 @@
     "label" : "Output mapping"
   } ],
   "properties" : [ {
-    "id" : "connectorType",
-    "value" : "io.camunda:connector-o365-email-inbound:1",
-    "group" : "connectorType",
     "binding" : {
       "name" : "inbound.type",
       "type" : "zeebe:property"
     },
-    "type" : "String"
+    "group" : "connectorType",
+    "id" : "connectorType",
+    "type" : "String",
+    "value" : "io.camunda:connector-o365-email-inbound:1"
   }, {
-    "id" : "authentication.type",
-    "label" : "Type",
-    "description" : "Authentication type depends on your Microsoft Entra (Azure AD) configuration. See <a href='https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/microsoft-teams/'>connector documentation</a>",
-    "value" : "clientCredentials",
-    "group" : "authentication",
     "binding" : {
       "name" : "authentication.type",
       "type" : "zeebe:property"
     },
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "Bearer token",
       "value" : "token"
@@ -70,15 +64,14 @@
     }, {
       "name" : "Refresh token",
       "value" : "refresh"
-    } ]
-  }, {
-    "id" : "authentication.bearer.token",
-    "label" : "Bearer token",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
+    } ],
+    "description" : "Authentication type depends on your Microsoft Entra (Azure AD) configuration. See <a href='https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/microsoft-teams/'>connector documentation</a>",
     "group" : "authentication",
+    "id" : "authentication.type",
+    "label" : "Type",
+    "type" : "Dropdown",
+    "value" : "clientCredentials"
+  }, {
     "binding" : {
       "name" : "authentication.token",
       "type" : "zeebe:property"
@@ -88,16 +81,15 @@
       "equals" : "token",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "authentication.credentials.clientId",
-    "label" : "Client ID",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
-    "feel" : "optional",
     "group" : "authentication",
+    "id" : "authentication.bearer.token",
+    "label" : "Bearer token",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "authentication.clientId",
       "type" : "zeebe:property"
@@ -107,16 +99,16 @@
       "equals" : "clientCredentials",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "authentication.credentials.tenantId",
-    "label" : "Tenant ID",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "authentication",
+    "id" : "authentication.credentials.clientId",
+    "label" : "Client ID",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "authentication.tenantId",
       "type" : "zeebe:property"
@@ -126,16 +118,16 @@
       "equals" : "clientCredentials",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "authentication.credentials.clientSecret",
-    "label" : "Client secret",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "authentication",
+    "id" : "authentication.credentials.tenantId",
+    "label" : "Tenant ID",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "authentication.clientSecret",
       "type" : "zeebe:property"
@@ -145,17 +137,17 @@
       "equals" : "clientCredentials",
       "type" : "simple"
     },
-    "tooltip" : "The secret value of the Microsoft Entra ID (formerly Azure AD) application",
-    "type" : "String"
-  }, {
-    "id" : "authentication.refresh.token",
-    "label" : "Refresh token",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "authentication",
+    "id" : "authentication.credentials.clientSecret",
+    "label" : "Client secret",
+    "optional" : false,
+    "tooltip" : "The secret value of the Microsoft Entra ID (formerly Azure AD) application",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "authentication.token",
       "type" : "zeebe:property"
@@ -165,16 +157,16 @@
       "equals" : "refresh",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "authentication.refresh.clientId",
-    "label" : "Client ID",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "authentication",
+    "id" : "authentication.refresh.token",
+    "label" : "Refresh token",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "authentication.clientId",
       "type" : "zeebe:property"
@@ -184,16 +176,16 @@
       "equals" : "refresh",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "authentication.refresh.tenantId",
-    "label" : "Tenant ID",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "authentication",
+    "id" : "authentication.refresh.clientId",
+    "label" : "Client ID",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "authentication.tenantId",
       "type" : "zeebe:property"
@@ -203,13 +195,16 @@
       "equals" : "refresh",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "authentication.refresh.clientSecret",
-    "label" : "Client secret",
-    "optional" : true,
+    "constraints" : {
+      "notEmpty" : true
+    },
     "feel" : "optional",
     "group" : "authentication",
+    "id" : "authentication.refresh.tenantId",
+    "label" : "Tenant ID",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "authentication.clientSecret",
       "type" : "zeebe:property"
@@ -219,52 +214,48 @@
       "equals" : "refresh",
       "type" : "simple"
     },
+    "feel" : "optional",
+    "group" : "authentication",
+    "id" : "authentication.refresh.clientSecret",
+    "label" : "Client secret",
+    "optional" : true,
     "tooltip" : "The secret value of the Microsoft Entra ID (formerly Azure AD) application; optional, depends on whether the client is public or private",
     "type" : "String"
   }, {
-    "id" : "pollingConfig.userId",
-    "label" : "Mailbox Owner",
-    "optional" : false,
+    "binding" : {
+      "name" : "pollingConfig.userId",
+      "type" : "zeebe:property"
+    },
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "pollingConfig",
-    "binding" : {
-      "name" : "pollingConfig.userId",
-      "type" : "zeebe:property"
-    },
-    "tooltip" : "The email address or user ID of the mailbox to monitor. <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/microsoft-o365-mail-inbound/#configuration\" target=\"_blank\">Microsoft O365 Mail connector configuration</a>",
+    "id" : "pollingConfig.userId",
+    "label" : "Mailbox Owner",
+    "optional" : false,
     "placeholder" : "user@example.com",
+    "tooltip" : "The email address or user ID of the mailbox to monitor. <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/microsoft-o365-mail-inbound/#configuration\" target=\"_blank\">Microsoft O365 Mail connector configuration</a>",
     "type" : "String"
   }, {
-    "id" : "pollingConfig.folder.folderSpecification",
-    "label" : "Folder Identifier Type",
-    "description" : "Prefer using a folder ID if you are using a well-known folder; otherwise, use the folder name.",
-    "value" : "byId",
-    "group" : "pollingConfig",
     "binding" : {
       "name" : "pollingConfig.folder.folderSpecification",
       "type" : "zeebe:property"
     },
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "Folder ID",
       "value" : "byId"
     }, {
       "name" : "Folder Name",
       "value" : "byName"
-    } ]
-  }, {
-    "id" : "pollingConfig.folder.folderId",
-    "label" : "Folder ID",
-    "optional" : false,
-    "value" : "inbox",
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "feel" : "optional",
+    } ],
+    "description" : "Prefer using a folder ID if you are using a well-known folder; otherwise, use the folder name.",
     "group" : "pollingConfig",
+    "id" : "pollingConfig.folder.folderSpecification",
+    "label" : "Folder Identifier Type",
+    "type" : "Dropdown",
+    "value" : "byId"
+  }, {
     "binding" : {
       "name" : "pollingConfig.folder.folderId",
       "type" : "zeebe:property"
@@ -274,17 +265,18 @@
       "equals" : "byId",
       "type" : "simple"
     },
-    "tooltip" : "The well-known folder ID or custom folder ID. <a href='https://learn.microsoft.com/en-us/graph/api/resources/mailfolder?view=graph-rest-1.0#properties' target='_blank'>See folder properties in the API</a>",
-    "type" : "String"
-  }, {
-    "id" : "pollingConfig.folder.folderName",
-    "label" : "Folder Name",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "pollingConfig",
+    "id" : "pollingConfig.folder.folderId",
+    "label" : "Folder ID",
+    "optional" : false,
+    "tooltip" : "The well-known folder ID or custom folder ID. <a href='https://learn.microsoft.com/en-us/graph/api/resources/mailfolder?view=graph-rest-1.0#properties' target='_blank'>See folder properties in the API</a>",
+    "type" : "String",
+    "value" : "inbox"
+  }, {
     "binding" : {
       "name" : "pollingConfig.folder.folderName",
       "type" : "zeebe:property"
@@ -294,46 +286,48 @@
       "equals" : "byName",
       "type" : "simple"
     },
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "pollingConfig",
+    "id" : "pollingConfig.folder.folderName",
+    "label" : "Folder Name",
+    "optional" : false,
     "tooltip" : "The display name of the folder. Must be unique within the mailbox.",
     "type" : "String"
   }, {
-    "id" : "pollingConfig.pollingInterval",
-    "label" : "Polling interval",
-    "optional" : false,
-    "value" : "PT30S",
-    "feel" : "optional",
-    "group" : "pollingConfig",
     "binding" : {
       "name" : "pollingConfig.pollingInterval",
       "type" : "zeebe:property"
     },
-    "tooltip" : "The interval between email polling requests, in ISO 8601 duration format. <a href='https://docs.camunda.io/docs/components/modeler/bpmn/timer-events/#time-duration' target='_blank'>How to configure a time duration</a>",
-    "type" : "String"
-  }, {
-    "id" : "pollingConfig.filterCriteria.filterSpecification",
-    "label" : "Filter Specification",
-    "description" : "Use predefined filter conditions or provide your own OData filter string",
-    "value" : "simple",
+    "feel" : "optional",
     "group" : "pollingConfig",
+    "id" : "pollingConfig.pollingInterval",
+    "label" : "Polling interval",
+    "optional" : false,
+    "tooltip" : "The interval between email polling requests, in ISO 8601 duration format. <a href='https://docs.camunda.io/docs/components/modeler/bpmn/timer-events/#time-duration' target='_blank'>How to configure a time duration</a>",
+    "type" : "String",
+    "value" : "PT30S"
+  }, {
     "binding" : {
       "name" : "pollingConfig.filterCriteria.filterSpecification",
       "type" : "zeebe:property"
     },
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "Simple",
       "value" : "simple"
     }, {
       "name" : "Advanced",
       "value" : "advanced"
-    } ]
-  }, {
-    "id" : "pollingConfig.filterCriteria.onlyUnread",
-    "label" : "Only Unread",
-    "optional" : false,
-    "value" : true,
-    "feel" : "static",
+    } ],
+    "description" : "Use predefined filter conditions or provide your own OData filter string",
     "group" : "pollingConfig",
+    "id" : "pollingConfig.filterCriteria.filterSpecification",
+    "label" : "Filter Specification",
+    "type" : "Dropdown",
+    "value" : "simple"
+  }, {
     "binding" : {
       "name" : "pollingConfig.filterCriteria.onlyUnread",
       "type" : "zeebe:property"
@@ -343,14 +337,15 @@
       "equals" : "simple",
       "type" : "simple"
     },
-    "tooltip" : "Only fetch unread emails",
-    "type" : "Boolean"
-  }, {
-    "id" : "pollingConfig.filterCriteria.subjectContains",
-    "label" : "Subject Contains",
-    "optional" : true,
-    "feel" : "optional",
+    "feel" : "static",
     "group" : "pollingConfig",
+    "id" : "pollingConfig.filterCriteria.onlyUnread",
+    "label" : "Only Unread",
+    "optional" : false,
+    "tooltip" : "Only fetch unread emails",
+    "type" : "Boolean",
+    "value" : true
+  }, {
     "binding" : {
       "name" : "pollingConfig.filterCriteria.subjectContains",
       "type" : "zeebe:property"
@@ -360,14 +355,14 @@
       "equals" : "simple",
       "type" : "simple"
     },
+    "feel" : "optional",
+    "group" : "pollingConfig",
+    "id" : "pollingConfig.filterCriteria.subjectContains",
+    "label" : "Subject Contains",
+    "optional" : true,
     "tooltip" : "Only fetch emails where subject contains this text (case-sensitive)",
     "type" : "String"
   }, {
-    "id" : "pollingConfig.filterCriteria.fromAddress",
-    "label" : "From Email Address",
-    "optional" : true,
-    "feel" : "optional",
-    "group" : "pollingConfig",
     "binding" : {
       "name" : "pollingConfig.filterCriteria.fromAddress",
       "type" : "zeebe:property"
@@ -377,16 +372,14 @@
       "equals" : "simple",
       "type" : "simple"
     },
+    "feel" : "optional",
+    "group" : "pollingConfig",
+    "id" : "pollingConfig.filterCriteria.fromAddress",
+    "label" : "From Email Address",
+    "optional" : true,
     "tooltip" : "Only fetch emails from this sender address (exact match, e.g. 'invoice@vendor.com')",
     "type" : "String"
   }, {
-    "id" : "pollingConfig.filterCriteria.filterString",
-    "label" : "OData Filter String",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "group" : "pollingConfig",
     "binding" : {
       "name" : "pollingConfig.filterCriteria.filterString",
       "type" : "zeebe:property"
@@ -396,18 +389,20 @@
       "equals" : "advanced",
       "type" : "simple"
     },
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "group" : "pollingConfig",
+    "id" : "pollingConfig.filterCriteria.filterString",
+    "label" : "OData Filter String",
+    "optional" : false,
     "tooltip" : "A custom OData filter expression. <a href='https://learn.microsoft.com/en-us/graph/filter-query-parameter' target='_blank'>See OData filter documentation</a>",
     "type" : "String"
   }, {
-    "id" : "operation.processingOperationDiscriminator",
-    "label" : "Postprocessing configuration",
-    "value" : "mark-read",
-    "group" : "postprocessing",
     "binding" : {
       "name" : "operation.processingOperationDiscriminator",
       "type" : "zeebe:property"
     },
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "Delete",
       "value" : "delete"
@@ -417,14 +412,13 @@
     }, {
       "name" : "Move to other folder",
       "value" : "move"
-    } ]
-  }, {
-    "id" : "operation.force",
-    "label" : "Force delete (email is permanently deleted)",
-    "optional" : false,
-    "value" : false,
-    "feel" : "static",
+    } ],
     "group" : "postprocessing",
+    "id" : "operation.processingOperationDiscriminator",
+    "label" : "Postprocessing configuration",
+    "type" : "Dropdown",
+    "value" : "mark-read"
+  }, {
     "binding" : {
       "name" : "operation.force",
       "type" : "zeebe:property"
@@ -434,40 +428,37 @@
       "equals" : "delete",
       "type" : "simple"
     },
-    "type" : "Boolean"
-  }, {
-    "id" : "operation.targetFolder.folderSpecification",
-    "label" : "Folder Identifier Type",
-    "description" : "Prefer using a folder ID if you are using a well-known folder; otherwise, use the folder name.",
-    "value" : "byId",
+    "feel" : "static",
     "group" : "postprocessing",
+    "id" : "operation.force",
+    "label" : "Force delete (email is permanently deleted)",
+    "optional" : false,
+    "type" : "Boolean",
+    "value" : false
+  }, {
     "binding" : {
       "name" : "operation.targetFolder.folderSpecification",
       "type" : "zeebe:property"
     },
-    "condition" : {
-      "property" : "operation.processingOperationDiscriminator",
-      "equals" : "move",
-      "type" : "simple"
-    },
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "Folder ID",
       "value" : "byId"
     }, {
       "name" : "Folder Name",
       "value" : "byName"
-    } ]
-  }, {
-    "id" : "operation.targetFolder.folderId",
-    "label" : "Folder ID",
-    "optional" : false,
-    "value" : "inbox",
-    "constraints" : {
-      "notEmpty" : true
+    } ],
+    "condition" : {
+      "property" : "operation.processingOperationDiscriminator",
+      "equals" : "move",
+      "type" : "simple"
     },
-    "feel" : "optional",
+    "description" : "Prefer using a folder ID if you are using a well-known folder; otherwise, use the folder name.",
     "group" : "postprocessing",
+    "id" : "operation.targetFolder.folderSpecification",
+    "label" : "Folder Identifier Type",
+    "type" : "Dropdown",
+    "value" : "byId"
+  }, {
     "binding" : {
       "name" : "operation.targetFolder.folderId",
       "type" : "zeebe:property"
@@ -483,17 +474,18 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "The well-known folder ID or custom folder ID. <a href='https://learn.microsoft.com/en-us/graph/api/resources/mailfolder?view=graph-rest-1.0#properties' target='_blank'>See folder properties in the API</a>",
-    "type" : "String"
-  }, {
-    "id" : "operation.targetFolder.folderName",
-    "label" : "Folder Name",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "postprocessing",
+    "id" : "operation.targetFolder.folderId",
+    "label" : "Folder ID",
+    "optional" : false,
+    "tooltip" : "The well-known folder ID or custom folder ID. <a href='https://learn.microsoft.com/en-us/graph/api/resources/mailfolder?view=graph-rest-1.0#properties' target='_blank'>See folder properties in the API</a>",
+    "type" : "String",
+    "value" : "inbox"
+  }, {
     "binding" : {
       "name" : "operation.targetFolder.folderName",
       "type" : "zeebe:property"
@@ -509,47 +501,47 @@
         "type" : "simple"
       } ]
     },
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "postprocessing",
+    "id" : "operation.targetFolder.folderName",
+    "label" : "Folder Name",
+    "optional" : false,
     "tooltip" : "The display name of the folder. Must be unique within the mailbox.",
     "type" : "String"
   }, {
-    "id" : "activationCondition",
-    "label" : "Activation condition",
-    "description" : "Condition under which the Connector triggers. Leave empty to catch all events",
-    "optional" : true,
-    "feel" : "required",
-    "group" : "activation",
     "binding" : {
       "name" : "activationCondition",
       "type" : "zeebe:property"
     },
+    "description" : "Condition under which the Connector triggers. Leave empty to catch all events",
+    "feel" : "required",
+    "group" : "activation",
+    "id" : "activationCondition",
+    "label" : "Activation condition",
+    "optional" : true,
     "type" : "String"
   }, {
-    "id" : "correlationRequired",
-    "label" : "Subprocess correlation required",
-    "description" : "Indicates whether correlation is required. This is needed for event-based subprocess message start events",
-    "value" : "notRequired",
-    "group" : "correlation",
     "binding" : {
       "name" : "correlationRequired",
       "type" : "zeebe:property"
     },
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "Correlation not required",
       "value" : "notRequired"
     }, {
       "name" : "Correlation required",
       "value" : "required"
-    } ]
-  }, {
-    "id" : "correlationKeyProcess",
-    "label" : "Correlation key (process)",
-    "description" : "Sets up the correlation key from process variables",
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "feel" : "required",
+    } ],
+    "description" : "Indicates whether correlation is required. This is needed for event-based subprocess message start events",
     "group" : "correlation",
+    "id" : "correlationRequired",
+    "label" : "Subprocess correlation required",
+    "type" : "Dropdown",
+    "value" : "notRequired"
+  }, {
     "binding" : {
       "name" : "correlationKey",
       "type" : "bpmn:Message#zeebe:subscription#property"
@@ -559,16 +551,16 @@
       "equals" : "required",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "correlationKeyPayload",
-    "label" : "Correlation key (payload)",
-    "description" : "Extracts the correlation key from the incoming message payload",
     "constraints" : {
       "notEmpty" : true
     },
+    "description" : "Sets up the correlation key from process variables",
     "feel" : "required",
     "group" : "correlation",
+    "id" : "correlationKeyProcess",
+    "label" : "Correlation key (process)",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "correlationKeyExpression",
       "type" : "zeebe:property"
@@ -578,24 +570,32 @@
       "equals" : "required",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "messageIdExpression",
-    "label" : "Message ID expression",
-    "description" : "Expression to extract unique identifier of a message",
-    "optional" : true,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "description" : "Extracts the correlation key from the incoming message payload",
     "feel" : "required",
     "group" : "correlation",
+    "id" : "correlationKeyPayload",
+    "label" : "Correlation key (payload)",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "messageIdExpression",
       "type" : "zeebe:property"
     },
+    "description" : "Expression to extract unique identifier of a message",
+    "feel" : "required",
+    "group" : "correlation",
+    "id" : "messageIdExpression",
+    "label" : "Message ID expression",
+    "optional" : true,
     "type" : "String"
   }, {
-    "id" : "messageTtl",
-    "label" : "Message TTL",
-    "description" : "Time-to-live for the message in the broker (ISO-8601 duration)",
-    "optional" : true,
+    "binding" : {
+      "name" : "messageTtl",
+      "type" : "zeebe:property"
+    },
     "constraints" : {
       "notEmpty" : false,
       "pattern" : {
@@ -603,47 +603,47 @@
         "message" : "must be an ISO-8601 duration"
       }
     },
+    "description" : "Time-to-live for the message in the broker (ISO-8601 duration)",
     "feel" : "optional",
     "group" : "correlation",
-    "binding" : {
-      "name" : "messageTtl",
-      "type" : "zeebe:property"
-    },
+    "id" : "messageTtl",
+    "label" : "Message TTL",
+    "optional" : true,
     "type" : "String"
   }, {
-    "id" : "messageNameUuid",
-    "label" : "Message name",
-    "generatedValue" : {
-      "type" : "uuid"
-    },
-    "feel" : "optional",
-    "group" : "correlation",
     "binding" : {
       "name" : "name",
       "type" : "bpmn:Message#property"
     },
+    "feel" : "optional",
+    "generatedValue" : {
+      "type" : "uuid"
+    },
+    "group" : "correlation",
+    "id" : "messageNameUuid",
+    "label" : "Message name",
     "tooltip" : "By default, this is an auto-generated random UUID. We recommend using a unique message name for each connector element in the diagram. Override to set a custom message name. Learn more about <a href=\"https://docs.camunda.io/docs/components/concepts/messages/#message-subscriptions\">message subscriptions</a> that power inbound connectors.",
     "type" : "String"
   }, {
-    "id" : "resultVariable",
-    "label" : "Result variable",
-    "description" : "Name of variable to store the response in. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-variable\" target=\"_blank\">documentation</a>.",
-    "group" : "output",
     "binding" : {
       "name" : "resultVariable",
       "type" : "zeebe:property"
     },
+    "description" : "Name of variable to store the response in. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-variable\" target=\"_blank\">documentation</a>.",
+    "group" : "output",
+    "id" : "resultVariable",
+    "label" : "Result variable",
     "type" : "String"
   }, {
-    "id" : "resultExpression",
-    "label" : "Result expression",
-    "description" : "Expression to map the response into process variables. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-expression\" target=\"_blank\">documentation</a>.",
-    "feel" : "required",
-    "group" : "output",
     "binding" : {
       "name" : "resultExpression",
       "type" : "zeebe:property"
     },
+    "description" : "Expression to map the response into process variables. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-expression\" target=\"_blank\">documentation</a>.",
+    "feel" : "required",
+    "group" : "output",
+    "id" : "resultExpression",
+    "label" : "Result expression",
     "type" : "Text"
   } ],
   "icon" : {

--- a/connectors/microsoft/email-inbound/element-templates/microsoft-o365-email-boundary-event-connector.json
+++ b/connectors/microsoft/email-inbound/element-templates/microsoft-o365-email-boundary-event-connector.json
@@ -39,23 +39,17 @@
     "label" : "Output mapping"
   } ],
   "properties" : [ {
-    "value" : "io.camunda:connector-o365-email-inbound:1",
     "binding" : {
       "name" : "inbound.type",
       "type" : "zeebe:property"
     },
-    "type" : "Hidden"
+    "type" : "Hidden",
+    "value" : "io.camunda:connector-o365-email-inbound:1"
   }, {
-    "id" : "authentication.type",
-    "label" : "Type",
-    "description" : "Authentication type depends on your Microsoft Entra (Azure AD) configuration. See <a href='https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/microsoft-teams/'>connector documentation</a>",
-    "value" : "clientCredentials",
-    "group" : "authentication",
     "binding" : {
       "name" : "authentication.type",
       "type" : "zeebe:property"
     },
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "Bearer token",
       "value" : "token"
@@ -65,15 +59,14 @@
     }, {
       "name" : "Refresh token",
       "value" : "refresh"
-    } ]
-  }, {
-    "id" : "authentication.bearer.token",
-    "label" : "Bearer token",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
+    } ],
+    "description" : "Authentication type depends on your Microsoft Entra (Azure AD) configuration. See <a href='https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/microsoft-teams/'>connector documentation</a>",
     "group" : "authentication",
+    "id" : "authentication.type",
+    "label" : "Type",
+    "type" : "Dropdown",
+    "value" : "clientCredentials"
+  }, {
     "binding" : {
       "name" : "authentication.token",
       "type" : "zeebe:property"
@@ -83,16 +76,15 @@
       "equals" : "token",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "authentication.credentials.clientId",
-    "label" : "Client ID",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
-    "feel" : "optional",
     "group" : "authentication",
+    "id" : "authentication.bearer.token",
+    "label" : "Bearer token",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "authentication.clientId",
       "type" : "zeebe:property"
@@ -102,16 +94,16 @@
       "equals" : "clientCredentials",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "authentication.credentials.tenantId",
-    "label" : "Tenant ID",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "authentication",
+    "id" : "authentication.credentials.clientId",
+    "label" : "Client ID",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "authentication.tenantId",
       "type" : "zeebe:property"
@@ -121,16 +113,16 @@
       "equals" : "clientCredentials",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "authentication.credentials.clientSecret",
-    "label" : "Client secret",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "authentication",
+    "id" : "authentication.credentials.tenantId",
+    "label" : "Tenant ID",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "authentication.clientSecret",
       "type" : "zeebe:property"
@@ -140,17 +132,17 @@
       "equals" : "clientCredentials",
       "type" : "simple"
     },
-    "tooltip" : "The secret value of the Microsoft Entra ID (formerly Azure AD) application",
-    "type" : "String"
-  }, {
-    "id" : "authentication.refresh.token",
-    "label" : "Refresh token",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "authentication",
+    "id" : "authentication.credentials.clientSecret",
+    "label" : "Client secret",
+    "optional" : false,
+    "tooltip" : "The secret value of the Microsoft Entra ID (formerly Azure AD) application",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "authentication.token",
       "type" : "zeebe:property"
@@ -160,16 +152,16 @@
       "equals" : "refresh",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "authentication.refresh.clientId",
-    "label" : "Client ID",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "authentication",
+    "id" : "authentication.refresh.token",
+    "label" : "Refresh token",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "authentication.clientId",
       "type" : "zeebe:property"
@@ -179,16 +171,16 @@
       "equals" : "refresh",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "authentication.refresh.tenantId",
-    "label" : "Tenant ID",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "authentication",
+    "id" : "authentication.refresh.clientId",
+    "label" : "Client ID",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "authentication.tenantId",
       "type" : "zeebe:property"
@@ -198,13 +190,16 @@
       "equals" : "refresh",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "authentication.refresh.clientSecret",
-    "label" : "Client secret",
-    "optional" : true,
+    "constraints" : {
+      "notEmpty" : true
+    },
     "feel" : "optional",
     "group" : "authentication",
+    "id" : "authentication.refresh.tenantId",
+    "label" : "Tenant ID",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "authentication.clientSecret",
       "type" : "zeebe:property"
@@ -214,52 +209,48 @@
       "equals" : "refresh",
       "type" : "simple"
     },
+    "feel" : "optional",
+    "group" : "authentication",
+    "id" : "authentication.refresh.clientSecret",
+    "label" : "Client secret",
+    "optional" : true,
     "tooltip" : "The secret value of the Microsoft Entra ID (formerly Azure AD) application; optional, depends on whether the client is public or private",
     "type" : "String"
   }, {
-    "id" : "pollingConfig.userId",
-    "label" : "Mailbox Owner",
-    "optional" : false,
+    "binding" : {
+      "name" : "pollingConfig.userId",
+      "type" : "zeebe:property"
+    },
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "pollingConfig",
-    "binding" : {
-      "name" : "pollingConfig.userId",
-      "type" : "zeebe:property"
-    },
-    "tooltip" : "The email address or user ID of the mailbox to monitor. <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/microsoft-o365-mail-inbound/#configuration\" target=\"_blank\">Microsoft O365 Mail connector configuration</a>",
+    "id" : "pollingConfig.userId",
+    "label" : "Mailbox Owner",
+    "optional" : false,
     "placeholder" : "user@example.com",
+    "tooltip" : "The email address or user ID of the mailbox to monitor. <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/microsoft-o365-mail-inbound/#configuration\" target=\"_blank\">Microsoft O365 Mail connector configuration</a>",
     "type" : "String"
   }, {
-    "id" : "pollingConfig.folder.folderSpecification",
-    "label" : "Folder Identifier Type",
-    "description" : "Prefer using a folder ID if you are using a well-known folder; otherwise, use the folder name.",
-    "value" : "byId",
-    "group" : "pollingConfig",
     "binding" : {
       "name" : "pollingConfig.folder.folderSpecification",
       "type" : "zeebe:property"
     },
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "Folder ID",
       "value" : "byId"
     }, {
       "name" : "Folder Name",
       "value" : "byName"
-    } ]
-  }, {
-    "id" : "pollingConfig.folder.folderId",
-    "label" : "Folder ID",
-    "optional" : false,
-    "value" : "inbox",
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "feel" : "optional",
+    } ],
+    "description" : "Prefer using a folder ID if you are using a well-known folder; otherwise, use the folder name.",
     "group" : "pollingConfig",
+    "id" : "pollingConfig.folder.folderSpecification",
+    "label" : "Folder Identifier Type",
+    "type" : "Dropdown",
+    "value" : "byId"
+  }, {
     "binding" : {
       "name" : "pollingConfig.folder.folderId",
       "type" : "zeebe:property"
@@ -269,17 +260,18 @@
       "equals" : "byId",
       "type" : "simple"
     },
-    "tooltip" : "The well-known folder ID or custom folder ID. <a href='https://learn.microsoft.com/en-us/graph/api/resources/mailfolder?view=graph-rest-1.0#properties' target='_blank'>See folder properties in the API</a>",
-    "type" : "String"
-  }, {
-    "id" : "pollingConfig.folder.folderName",
-    "label" : "Folder Name",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "pollingConfig",
+    "id" : "pollingConfig.folder.folderId",
+    "label" : "Folder ID",
+    "optional" : false,
+    "tooltip" : "The well-known folder ID or custom folder ID. <a href='https://learn.microsoft.com/en-us/graph/api/resources/mailfolder?view=graph-rest-1.0#properties' target='_blank'>See folder properties in the API</a>",
+    "type" : "String",
+    "value" : "inbox"
+  }, {
     "binding" : {
       "name" : "pollingConfig.folder.folderName",
       "type" : "zeebe:property"
@@ -289,46 +281,48 @@
       "equals" : "byName",
       "type" : "simple"
     },
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "pollingConfig",
+    "id" : "pollingConfig.folder.folderName",
+    "label" : "Folder Name",
+    "optional" : false,
     "tooltip" : "The display name of the folder. Must be unique within the mailbox.",
     "type" : "String"
   }, {
-    "id" : "pollingConfig.pollingInterval",
-    "label" : "Polling interval",
-    "optional" : false,
-    "value" : "PT30S",
-    "feel" : "optional",
-    "group" : "pollingConfig",
     "binding" : {
       "name" : "pollingConfig.pollingInterval",
       "type" : "zeebe:property"
     },
-    "tooltip" : "The interval between email polling requests, in ISO 8601 duration format. <a href='https://docs.camunda.io/docs/components/modeler/bpmn/timer-events/#time-duration' target='_blank'>How to configure a time duration</a>",
-    "type" : "String"
-  }, {
-    "id" : "pollingConfig.filterCriteria.filterSpecification",
-    "label" : "Filter Specification",
-    "description" : "Use predefined filter conditions or provide your own OData filter string",
-    "value" : "simple",
+    "feel" : "optional",
     "group" : "pollingConfig",
+    "id" : "pollingConfig.pollingInterval",
+    "label" : "Polling interval",
+    "optional" : false,
+    "tooltip" : "The interval between email polling requests, in ISO 8601 duration format. <a href='https://docs.camunda.io/docs/components/modeler/bpmn/timer-events/#time-duration' target='_blank'>How to configure a time duration</a>",
+    "type" : "String",
+    "value" : "PT30S"
+  }, {
     "binding" : {
       "name" : "pollingConfig.filterCriteria.filterSpecification",
       "type" : "zeebe:property"
     },
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "Simple",
       "value" : "simple"
     }, {
       "name" : "Advanced",
       "value" : "advanced"
-    } ]
-  }, {
-    "id" : "pollingConfig.filterCriteria.onlyUnread",
-    "label" : "Only Unread",
-    "optional" : false,
-    "value" : true,
-    "feel" : "static",
+    } ],
+    "description" : "Use predefined filter conditions or provide your own OData filter string",
     "group" : "pollingConfig",
+    "id" : "pollingConfig.filterCriteria.filterSpecification",
+    "label" : "Filter Specification",
+    "type" : "Dropdown",
+    "value" : "simple"
+  }, {
     "binding" : {
       "name" : "pollingConfig.filterCriteria.onlyUnread",
       "type" : "zeebe:property"
@@ -338,14 +332,15 @@
       "equals" : "simple",
       "type" : "simple"
     },
-    "tooltip" : "Only fetch unread emails",
-    "type" : "Boolean"
-  }, {
-    "id" : "pollingConfig.filterCriteria.subjectContains",
-    "label" : "Subject Contains",
-    "optional" : true,
-    "feel" : "optional",
+    "feel" : "static",
     "group" : "pollingConfig",
+    "id" : "pollingConfig.filterCriteria.onlyUnread",
+    "label" : "Only Unread",
+    "optional" : false,
+    "tooltip" : "Only fetch unread emails",
+    "type" : "Boolean",
+    "value" : true
+  }, {
     "binding" : {
       "name" : "pollingConfig.filterCriteria.subjectContains",
       "type" : "zeebe:property"
@@ -355,14 +350,14 @@
       "equals" : "simple",
       "type" : "simple"
     },
+    "feel" : "optional",
+    "group" : "pollingConfig",
+    "id" : "pollingConfig.filterCriteria.subjectContains",
+    "label" : "Subject Contains",
+    "optional" : true,
     "tooltip" : "Only fetch emails where subject contains this text (case-sensitive)",
     "type" : "String"
   }, {
-    "id" : "pollingConfig.filterCriteria.fromAddress",
-    "label" : "From Email Address",
-    "optional" : true,
-    "feel" : "optional",
-    "group" : "pollingConfig",
     "binding" : {
       "name" : "pollingConfig.filterCriteria.fromAddress",
       "type" : "zeebe:property"
@@ -372,16 +367,14 @@
       "equals" : "simple",
       "type" : "simple"
     },
+    "feel" : "optional",
+    "group" : "pollingConfig",
+    "id" : "pollingConfig.filterCriteria.fromAddress",
+    "label" : "From Email Address",
+    "optional" : true,
     "tooltip" : "Only fetch emails from this sender address (exact match, e.g. 'invoice@vendor.com')",
     "type" : "String"
   }, {
-    "id" : "pollingConfig.filterCriteria.filterString",
-    "label" : "OData Filter String",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "group" : "pollingConfig",
     "binding" : {
       "name" : "pollingConfig.filterCriteria.filterString",
       "type" : "zeebe:property"
@@ -391,18 +384,20 @@
       "equals" : "advanced",
       "type" : "simple"
     },
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "group" : "pollingConfig",
+    "id" : "pollingConfig.filterCriteria.filterString",
+    "label" : "OData Filter String",
+    "optional" : false,
     "tooltip" : "A custom OData filter expression. <a href='https://learn.microsoft.com/en-us/graph/filter-query-parameter' target='_blank'>See OData filter documentation</a>",
     "type" : "String"
   }, {
-    "id" : "operation.processingOperationDiscriminator",
-    "label" : "Postprocessing configuration",
-    "value" : "mark-read",
-    "group" : "postprocessing",
     "binding" : {
       "name" : "operation.processingOperationDiscriminator",
       "type" : "zeebe:property"
     },
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "Delete",
       "value" : "delete"
@@ -412,14 +407,13 @@
     }, {
       "name" : "Move to other folder",
       "value" : "move"
-    } ]
-  }, {
-    "id" : "operation.force",
-    "label" : "Force delete (email is permanently deleted)",
-    "optional" : false,
-    "value" : false,
-    "feel" : "static",
+    } ],
     "group" : "postprocessing",
+    "id" : "operation.processingOperationDiscriminator",
+    "label" : "Postprocessing configuration",
+    "type" : "Dropdown",
+    "value" : "mark-read"
+  }, {
     "binding" : {
       "name" : "operation.force",
       "type" : "zeebe:property"
@@ -429,40 +423,37 @@
       "equals" : "delete",
       "type" : "simple"
     },
-    "type" : "Boolean"
-  }, {
-    "id" : "operation.targetFolder.folderSpecification",
-    "label" : "Folder Identifier Type",
-    "description" : "Prefer using a folder ID if you are using a well-known folder; otherwise, use the folder name.",
-    "value" : "byId",
+    "feel" : "static",
     "group" : "postprocessing",
+    "id" : "operation.force",
+    "label" : "Force delete (email is permanently deleted)",
+    "optional" : false,
+    "type" : "Boolean",
+    "value" : false
+  }, {
     "binding" : {
       "name" : "operation.targetFolder.folderSpecification",
       "type" : "zeebe:property"
     },
-    "condition" : {
-      "property" : "operation.processingOperationDiscriminator",
-      "equals" : "move",
-      "type" : "simple"
-    },
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "Folder ID",
       "value" : "byId"
     }, {
       "name" : "Folder Name",
       "value" : "byName"
-    } ]
-  }, {
-    "id" : "operation.targetFolder.folderId",
-    "label" : "Folder ID",
-    "optional" : false,
-    "value" : "inbox",
-    "constraints" : {
-      "notEmpty" : true
+    } ],
+    "condition" : {
+      "property" : "operation.processingOperationDiscriminator",
+      "equals" : "move",
+      "type" : "simple"
     },
-    "feel" : "optional",
+    "description" : "Prefer using a folder ID if you are using a well-known folder; otherwise, use the folder name.",
     "group" : "postprocessing",
+    "id" : "operation.targetFolder.folderSpecification",
+    "label" : "Folder Identifier Type",
+    "type" : "Dropdown",
+    "value" : "byId"
+  }, {
     "binding" : {
       "name" : "operation.targetFolder.folderId",
       "type" : "zeebe:property"
@@ -478,17 +469,18 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "The well-known folder ID or custom folder ID. <a href='https://learn.microsoft.com/en-us/graph/api/resources/mailfolder?view=graph-rest-1.0#properties' target='_blank'>See folder properties in the API</a>",
-    "type" : "String"
-  }, {
-    "id" : "operation.targetFolder.folderName",
-    "label" : "Folder Name",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "postprocessing",
+    "id" : "operation.targetFolder.folderId",
+    "label" : "Folder ID",
+    "optional" : false,
+    "tooltip" : "The well-known folder ID or custom folder ID. <a href='https://learn.microsoft.com/en-us/graph/api/resources/mailfolder?view=graph-rest-1.0#properties' target='_blank'>See folder properties in the API</a>",
+    "type" : "String",
+    "value" : "inbox"
+  }, {
     "binding" : {
       "name" : "operation.targetFolder.folderName",
       "type" : "zeebe:property"
@@ -504,65 +496,73 @@
         "type" : "simple"
       } ]
     },
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "postprocessing",
+    "id" : "operation.targetFolder.folderName",
+    "label" : "Folder Name",
+    "optional" : false,
     "tooltip" : "The display name of the folder. Must be unique within the mailbox.",
     "type" : "String"
   }, {
-    "id" : "activationCondition",
-    "label" : "Activation condition",
-    "description" : "Condition under which the Connector triggers. Leave empty to catch all events",
-    "optional" : true,
-    "feel" : "required",
-    "group" : "activation",
     "binding" : {
       "name" : "activationCondition",
       "type" : "zeebe:property"
     },
+    "description" : "Condition under which the Connector triggers. Leave empty to catch all events",
+    "feel" : "required",
+    "group" : "activation",
+    "id" : "activationCondition",
+    "label" : "Activation condition",
+    "optional" : true,
     "type" : "String"
   }, {
-    "id" : "correlationKeyProcess",
-    "label" : "Correlation key (process)",
-    "description" : "Sets up the correlation key from process variables",
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "feel" : "required",
-    "group" : "correlation",
     "binding" : {
       "name" : "correlationKey",
       "type" : "bpmn:Message#zeebe:subscription#property"
     },
-    "type" : "String"
-  }, {
-    "id" : "correlationKeyPayload",
-    "label" : "Correlation key (payload)",
-    "description" : "Extracts the correlation key from the incoming message payload",
     "constraints" : {
       "notEmpty" : true
     },
+    "description" : "Sets up the correlation key from process variables",
     "feel" : "required",
     "group" : "correlation",
+    "id" : "correlationKeyProcess",
+    "label" : "Correlation key (process)",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "correlationKeyExpression",
       "type" : "zeebe:property"
     },
-    "type" : "String"
-  }, {
-    "id" : "messageIdExpression",
-    "label" : "Message ID expression",
-    "description" : "Expression to extract unique identifier of a message",
-    "optional" : true,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "description" : "Extracts the correlation key from the incoming message payload",
     "feel" : "required",
     "group" : "correlation",
+    "id" : "correlationKeyPayload",
+    "label" : "Correlation key (payload)",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "messageIdExpression",
       "type" : "zeebe:property"
     },
+    "description" : "Expression to extract unique identifier of a message",
+    "feel" : "required",
+    "group" : "correlation",
+    "id" : "messageIdExpression",
+    "label" : "Message ID expression",
+    "optional" : true,
     "type" : "String"
   }, {
-    "id" : "messageTtl",
-    "label" : "Message TTL",
-    "description" : "Time-to-live for the message in the broker (ISO-8601 duration)",
-    "optional" : true,
+    "binding" : {
+      "name" : "messageTtl",
+      "type" : "zeebe:property"
+    },
     "constraints" : {
       "notEmpty" : false,
       "pattern" : {
@@ -570,47 +570,47 @@
         "message" : "must be an ISO-8601 duration"
       }
     },
+    "description" : "Time-to-live for the message in the broker (ISO-8601 duration)",
     "feel" : "optional",
     "group" : "correlation",
-    "binding" : {
-      "name" : "messageTtl",
-      "type" : "zeebe:property"
-    },
+    "id" : "messageTtl",
+    "label" : "Message TTL",
+    "optional" : true,
     "type" : "String"
   }, {
-    "id" : "messageNameUuid",
-    "label" : "Message name",
-    "generatedValue" : {
-      "type" : "uuid"
-    },
-    "feel" : "optional",
-    "group" : "correlation",
     "binding" : {
       "name" : "name",
       "type" : "bpmn:Message#property"
     },
+    "feel" : "optional",
+    "generatedValue" : {
+      "type" : "uuid"
+    },
+    "group" : "correlation",
+    "id" : "messageNameUuid",
+    "label" : "Message name",
     "tooltip" : "By default, this is an auto-generated random UUID. We recommend using a unique message name for each connector element in the diagram. Override to set a custom message name. Learn more about <a href=\"https://docs.camunda.io/docs/components/concepts/messages/#message-subscriptions\">message subscriptions</a> that power inbound connectors.",
     "type" : "String"
   }, {
-    "id" : "resultVariable",
-    "label" : "Result variable",
-    "description" : "Name of variable to store the response in. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-variable\" target=\"_blank\">documentation</a>.",
-    "group" : "output",
     "binding" : {
       "name" : "resultVariable",
       "type" : "zeebe:property"
     },
+    "description" : "Name of variable to store the response in. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-variable\" target=\"_blank\">documentation</a>.",
+    "group" : "output",
+    "id" : "resultVariable",
+    "label" : "Result variable",
     "type" : "String"
   }, {
-    "id" : "resultExpression",
-    "label" : "Result expression",
-    "description" : "Expression to map the response into process variables. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-expression\" target=\"_blank\">documentation</a>.",
-    "feel" : "required",
-    "group" : "output",
     "binding" : {
       "name" : "resultExpression",
       "type" : "zeebe:property"
     },
+    "description" : "Expression to map the response into process variables. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-expression\" target=\"_blank\">documentation</a>.",
+    "feel" : "required",
+    "group" : "output",
+    "id" : "resultExpression",
+    "label" : "Result expression",
     "type" : "Text"
   } ],
   "icon" : {

--- a/connectors/microsoft/email-inbound/element-templates/microsoft-o365-email-intermediate-catch-event-connector.json
+++ b/connectors/microsoft/email-inbound/element-templates/microsoft-o365-email-intermediate-catch-event-connector.json
@@ -39,23 +39,17 @@
     "label" : "Output mapping"
   } ],
   "properties" : [ {
-    "value" : "io.camunda:connector-o365-email-inbound:1",
     "binding" : {
       "name" : "inbound.type",
       "type" : "zeebe:property"
     },
-    "type" : "Hidden"
+    "type" : "Hidden",
+    "value" : "io.camunda:connector-o365-email-inbound:1"
   }, {
-    "id" : "authentication.type",
-    "label" : "Type",
-    "description" : "Authentication type depends on your Microsoft Entra (Azure AD) configuration. See <a href='https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/microsoft-teams/'>connector documentation</a>",
-    "value" : "clientCredentials",
-    "group" : "authentication",
     "binding" : {
       "name" : "authentication.type",
       "type" : "zeebe:property"
     },
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "Bearer token",
       "value" : "token"
@@ -65,15 +59,14 @@
     }, {
       "name" : "Refresh token",
       "value" : "refresh"
-    } ]
-  }, {
-    "id" : "authentication.bearer.token",
-    "label" : "Bearer token",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
+    } ],
+    "description" : "Authentication type depends on your Microsoft Entra (Azure AD) configuration. See <a href='https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/microsoft-teams/'>connector documentation</a>",
     "group" : "authentication",
+    "id" : "authentication.type",
+    "label" : "Type",
+    "type" : "Dropdown",
+    "value" : "clientCredentials"
+  }, {
     "binding" : {
       "name" : "authentication.token",
       "type" : "zeebe:property"
@@ -83,16 +76,15 @@
       "equals" : "token",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "authentication.credentials.clientId",
-    "label" : "Client ID",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
-    "feel" : "optional",
     "group" : "authentication",
+    "id" : "authentication.bearer.token",
+    "label" : "Bearer token",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "authentication.clientId",
       "type" : "zeebe:property"
@@ -102,16 +94,16 @@
       "equals" : "clientCredentials",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "authentication.credentials.tenantId",
-    "label" : "Tenant ID",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "authentication",
+    "id" : "authentication.credentials.clientId",
+    "label" : "Client ID",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "authentication.tenantId",
       "type" : "zeebe:property"
@@ -121,16 +113,16 @@
       "equals" : "clientCredentials",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "authentication.credentials.clientSecret",
-    "label" : "Client secret",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "authentication",
+    "id" : "authentication.credentials.tenantId",
+    "label" : "Tenant ID",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "authentication.clientSecret",
       "type" : "zeebe:property"
@@ -140,17 +132,17 @@
       "equals" : "clientCredentials",
       "type" : "simple"
     },
-    "tooltip" : "The secret value of the Microsoft Entra ID (formerly Azure AD) application",
-    "type" : "String"
-  }, {
-    "id" : "authentication.refresh.token",
-    "label" : "Refresh token",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "authentication",
+    "id" : "authentication.credentials.clientSecret",
+    "label" : "Client secret",
+    "optional" : false,
+    "tooltip" : "The secret value of the Microsoft Entra ID (formerly Azure AD) application",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "authentication.token",
       "type" : "zeebe:property"
@@ -160,16 +152,16 @@
       "equals" : "refresh",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "authentication.refresh.clientId",
-    "label" : "Client ID",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "authentication",
+    "id" : "authentication.refresh.token",
+    "label" : "Refresh token",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "authentication.clientId",
       "type" : "zeebe:property"
@@ -179,16 +171,16 @@
       "equals" : "refresh",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "authentication.refresh.tenantId",
-    "label" : "Tenant ID",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "authentication",
+    "id" : "authentication.refresh.clientId",
+    "label" : "Client ID",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "authentication.tenantId",
       "type" : "zeebe:property"
@@ -198,13 +190,16 @@
       "equals" : "refresh",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "authentication.refresh.clientSecret",
-    "label" : "Client secret",
-    "optional" : true,
+    "constraints" : {
+      "notEmpty" : true
+    },
     "feel" : "optional",
     "group" : "authentication",
+    "id" : "authentication.refresh.tenantId",
+    "label" : "Tenant ID",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "authentication.clientSecret",
       "type" : "zeebe:property"
@@ -214,52 +209,48 @@
       "equals" : "refresh",
       "type" : "simple"
     },
+    "feel" : "optional",
+    "group" : "authentication",
+    "id" : "authentication.refresh.clientSecret",
+    "label" : "Client secret",
+    "optional" : true,
     "tooltip" : "The secret value of the Microsoft Entra ID (formerly Azure AD) application; optional, depends on whether the client is public or private",
     "type" : "String"
   }, {
-    "id" : "pollingConfig.userId",
-    "label" : "Mailbox Owner",
-    "optional" : false,
+    "binding" : {
+      "name" : "pollingConfig.userId",
+      "type" : "zeebe:property"
+    },
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "pollingConfig",
-    "binding" : {
-      "name" : "pollingConfig.userId",
-      "type" : "zeebe:property"
-    },
-    "tooltip" : "The email address or user ID of the mailbox to monitor. <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/microsoft-o365-mail-inbound/#configuration\" target=\"_blank\">Microsoft O365 Mail connector configuration</a>",
+    "id" : "pollingConfig.userId",
+    "label" : "Mailbox Owner",
+    "optional" : false,
     "placeholder" : "user@example.com",
+    "tooltip" : "The email address or user ID of the mailbox to monitor. <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/microsoft-o365-mail-inbound/#configuration\" target=\"_blank\">Microsoft O365 Mail connector configuration</a>",
     "type" : "String"
   }, {
-    "id" : "pollingConfig.folder.folderSpecification",
-    "label" : "Folder Identifier Type",
-    "description" : "Prefer using a folder ID if you are using a well-known folder; otherwise, use the folder name.",
-    "value" : "byId",
-    "group" : "pollingConfig",
     "binding" : {
       "name" : "pollingConfig.folder.folderSpecification",
       "type" : "zeebe:property"
     },
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "Folder ID",
       "value" : "byId"
     }, {
       "name" : "Folder Name",
       "value" : "byName"
-    } ]
-  }, {
-    "id" : "pollingConfig.folder.folderId",
-    "label" : "Folder ID",
-    "optional" : false,
-    "value" : "inbox",
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "feel" : "optional",
+    } ],
+    "description" : "Prefer using a folder ID if you are using a well-known folder; otherwise, use the folder name.",
     "group" : "pollingConfig",
+    "id" : "pollingConfig.folder.folderSpecification",
+    "label" : "Folder Identifier Type",
+    "type" : "Dropdown",
+    "value" : "byId"
+  }, {
     "binding" : {
       "name" : "pollingConfig.folder.folderId",
       "type" : "zeebe:property"
@@ -269,17 +260,18 @@
       "equals" : "byId",
       "type" : "simple"
     },
-    "tooltip" : "The well-known folder ID or custom folder ID. <a href='https://learn.microsoft.com/en-us/graph/api/resources/mailfolder?view=graph-rest-1.0#properties' target='_blank'>See folder properties in the API</a>",
-    "type" : "String"
-  }, {
-    "id" : "pollingConfig.folder.folderName",
-    "label" : "Folder Name",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "pollingConfig",
+    "id" : "pollingConfig.folder.folderId",
+    "label" : "Folder ID",
+    "optional" : false,
+    "tooltip" : "The well-known folder ID or custom folder ID. <a href='https://learn.microsoft.com/en-us/graph/api/resources/mailfolder?view=graph-rest-1.0#properties' target='_blank'>See folder properties in the API</a>",
+    "type" : "String",
+    "value" : "inbox"
+  }, {
     "binding" : {
       "name" : "pollingConfig.folder.folderName",
       "type" : "zeebe:property"
@@ -289,46 +281,48 @@
       "equals" : "byName",
       "type" : "simple"
     },
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "pollingConfig",
+    "id" : "pollingConfig.folder.folderName",
+    "label" : "Folder Name",
+    "optional" : false,
     "tooltip" : "The display name of the folder. Must be unique within the mailbox.",
     "type" : "String"
   }, {
-    "id" : "pollingConfig.pollingInterval",
-    "label" : "Polling interval",
-    "optional" : false,
-    "value" : "PT30S",
-    "feel" : "optional",
-    "group" : "pollingConfig",
     "binding" : {
       "name" : "pollingConfig.pollingInterval",
       "type" : "zeebe:property"
     },
-    "tooltip" : "The interval between email polling requests, in ISO 8601 duration format. <a href='https://docs.camunda.io/docs/components/modeler/bpmn/timer-events/#time-duration' target='_blank'>How to configure a time duration</a>",
-    "type" : "String"
-  }, {
-    "id" : "pollingConfig.filterCriteria.filterSpecification",
-    "label" : "Filter Specification",
-    "description" : "Use predefined filter conditions or provide your own OData filter string",
-    "value" : "simple",
+    "feel" : "optional",
     "group" : "pollingConfig",
+    "id" : "pollingConfig.pollingInterval",
+    "label" : "Polling interval",
+    "optional" : false,
+    "tooltip" : "The interval between email polling requests, in ISO 8601 duration format. <a href='https://docs.camunda.io/docs/components/modeler/bpmn/timer-events/#time-duration' target='_blank'>How to configure a time duration</a>",
+    "type" : "String",
+    "value" : "PT30S"
+  }, {
     "binding" : {
       "name" : "pollingConfig.filterCriteria.filterSpecification",
       "type" : "zeebe:property"
     },
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "Simple",
       "value" : "simple"
     }, {
       "name" : "Advanced",
       "value" : "advanced"
-    } ]
-  }, {
-    "id" : "pollingConfig.filterCriteria.onlyUnread",
-    "label" : "Only Unread",
-    "optional" : false,
-    "value" : true,
-    "feel" : "static",
+    } ],
+    "description" : "Use predefined filter conditions or provide your own OData filter string",
     "group" : "pollingConfig",
+    "id" : "pollingConfig.filterCriteria.filterSpecification",
+    "label" : "Filter Specification",
+    "type" : "Dropdown",
+    "value" : "simple"
+  }, {
     "binding" : {
       "name" : "pollingConfig.filterCriteria.onlyUnread",
       "type" : "zeebe:property"
@@ -338,14 +332,15 @@
       "equals" : "simple",
       "type" : "simple"
     },
-    "tooltip" : "Only fetch unread emails",
-    "type" : "Boolean"
-  }, {
-    "id" : "pollingConfig.filterCriteria.subjectContains",
-    "label" : "Subject Contains",
-    "optional" : true,
-    "feel" : "optional",
+    "feel" : "static",
     "group" : "pollingConfig",
+    "id" : "pollingConfig.filterCriteria.onlyUnread",
+    "label" : "Only Unread",
+    "optional" : false,
+    "tooltip" : "Only fetch unread emails",
+    "type" : "Boolean",
+    "value" : true
+  }, {
     "binding" : {
       "name" : "pollingConfig.filterCriteria.subjectContains",
       "type" : "zeebe:property"
@@ -355,14 +350,14 @@
       "equals" : "simple",
       "type" : "simple"
     },
+    "feel" : "optional",
+    "group" : "pollingConfig",
+    "id" : "pollingConfig.filterCriteria.subjectContains",
+    "label" : "Subject Contains",
+    "optional" : true,
     "tooltip" : "Only fetch emails where subject contains this text (case-sensitive)",
     "type" : "String"
   }, {
-    "id" : "pollingConfig.filterCriteria.fromAddress",
-    "label" : "From Email Address",
-    "optional" : true,
-    "feel" : "optional",
-    "group" : "pollingConfig",
     "binding" : {
       "name" : "pollingConfig.filterCriteria.fromAddress",
       "type" : "zeebe:property"
@@ -372,16 +367,14 @@
       "equals" : "simple",
       "type" : "simple"
     },
+    "feel" : "optional",
+    "group" : "pollingConfig",
+    "id" : "pollingConfig.filterCriteria.fromAddress",
+    "label" : "From Email Address",
+    "optional" : true,
     "tooltip" : "Only fetch emails from this sender address (exact match, e.g. 'invoice@vendor.com')",
     "type" : "String"
   }, {
-    "id" : "pollingConfig.filterCriteria.filterString",
-    "label" : "OData Filter String",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "group" : "pollingConfig",
     "binding" : {
       "name" : "pollingConfig.filterCriteria.filterString",
       "type" : "zeebe:property"
@@ -391,18 +384,20 @@
       "equals" : "advanced",
       "type" : "simple"
     },
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "group" : "pollingConfig",
+    "id" : "pollingConfig.filterCriteria.filterString",
+    "label" : "OData Filter String",
+    "optional" : false,
     "tooltip" : "A custom OData filter expression. <a href='https://learn.microsoft.com/en-us/graph/filter-query-parameter' target='_blank'>See OData filter documentation</a>",
     "type" : "String"
   }, {
-    "id" : "operation.processingOperationDiscriminator",
-    "label" : "Postprocessing configuration",
-    "value" : "mark-read",
-    "group" : "postprocessing",
     "binding" : {
       "name" : "operation.processingOperationDiscriminator",
       "type" : "zeebe:property"
     },
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "Delete",
       "value" : "delete"
@@ -412,14 +407,13 @@
     }, {
       "name" : "Move to other folder",
       "value" : "move"
-    } ]
-  }, {
-    "id" : "operation.force",
-    "label" : "Force delete (email is permanently deleted)",
-    "optional" : false,
-    "value" : false,
-    "feel" : "static",
+    } ],
     "group" : "postprocessing",
+    "id" : "operation.processingOperationDiscriminator",
+    "label" : "Postprocessing configuration",
+    "type" : "Dropdown",
+    "value" : "mark-read"
+  }, {
     "binding" : {
       "name" : "operation.force",
       "type" : "zeebe:property"
@@ -429,40 +423,37 @@
       "equals" : "delete",
       "type" : "simple"
     },
-    "type" : "Boolean"
-  }, {
-    "id" : "operation.targetFolder.folderSpecification",
-    "label" : "Folder Identifier Type",
-    "description" : "Prefer using a folder ID if you are using a well-known folder; otherwise, use the folder name.",
-    "value" : "byId",
+    "feel" : "static",
     "group" : "postprocessing",
+    "id" : "operation.force",
+    "label" : "Force delete (email is permanently deleted)",
+    "optional" : false,
+    "type" : "Boolean",
+    "value" : false
+  }, {
     "binding" : {
       "name" : "operation.targetFolder.folderSpecification",
       "type" : "zeebe:property"
     },
-    "condition" : {
-      "property" : "operation.processingOperationDiscriminator",
-      "equals" : "move",
-      "type" : "simple"
-    },
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "Folder ID",
       "value" : "byId"
     }, {
       "name" : "Folder Name",
       "value" : "byName"
-    } ]
-  }, {
-    "id" : "operation.targetFolder.folderId",
-    "label" : "Folder ID",
-    "optional" : false,
-    "value" : "inbox",
-    "constraints" : {
-      "notEmpty" : true
+    } ],
+    "condition" : {
+      "property" : "operation.processingOperationDiscriminator",
+      "equals" : "move",
+      "type" : "simple"
     },
-    "feel" : "optional",
+    "description" : "Prefer using a folder ID if you are using a well-known folder; otherwise, use the folder name.",
     "group" : "postprocessing",
+    "id" : "operation.targetFolder.folderSpecification",
+    "label" : "Folder Identifier Type",
+    "type" : "Dropdown",
+    "value" : "byId"
+  }, {
     "binding" : {
       "name" : "operation.targetFolder.folderId",
       "type" : "zeebe:property"
@@ -478,17 +469,18 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "The well-known folder ID or custom folder ID. <a href='https://learn.microsoft.com/en-us/graph/api/resources/mailfolder?view=graph-rest-1.0#properties' target='_blank'>See folder properties in the API</a>",
-    "type" : "String"
-  }, {
-    "id" : "operation.targetFolder.folderName",
-    "label" : "Folder Name",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "postprocessing",
+    "id" : "operation.targetFolder.folderId",
+    "label" : "Folder ID",
+    "optional" : false,
+    "tooltip" : "The well-known folder ID or custom folder ID. <a href='https://learn.microsoft.com/en-us/graph/api/resources/mailfolder?view=graph-rest-1.0#properties' target='_blank'>See folder properties in the API</a>",
+    "type" : "String",
+    "value" : "inbox"
+  }, {
     "binding" : {
       "name" : "operation.targetFolder.folderName",
       "type" : "zeebe:property"
@@ -504,65 +496,73 @@
         "type" : "simple"
       } ]
     },
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "postprocessing",
+    "id" : "operation.targetFolder.folderName",
+    "label" : "Folder Name",
+    "optional" : false,
     "tooltip" : "The display name of the folder. Must be unique within the mailbox.",
     "type" : "String"
   }, {
-    "id" : "activationCondition",
-    "label" : "Activation condition",
-    "description" : "Condition under which the Connector triggers. Leave empty to catch all events",
-    "optional" : true,
-    "feel" : "required",
-    "group" : "activation",
     "binding" : {
       "name" : "activationCondition",
       "type" : "zeebe:property"
     },
+    "description" : "Condition under which the Connector triggers. Leave empty to catch all events",
+    "feel" : "required",
+    "group" : "activation",
+    "id" : "activationCondition",
+    "label" : "Activation condition",
+    "optional" : true,
     "type" : "String"
   }, {
-    "id" : "correlationKeyProcess",
-    "label" : "Correlation key (process)",
-    "description" : "Sets up the correlation key from process variables",
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "feel" : "required",
-    "group" : "correlation",
     "binding" : {
       "name" : "correlationKey",
       "type" : "bpmn:Message#zeebe:subscription#property"
     },
-    "type" : "String"
-  }, {
-    "id" : "correlationKeyPayload",
-    "label" : "Correlation key (payload)",
-    "description" : "Extracts the correlation key from the incoming message payload",
     "constraints" : {
       "notEmpty" : true
     },
+    "description" : "Sets up the correlation key from process variables",
     "feel" : "required",
     "group" : "correlation",
+    "id" : "correlationKeyProcess",
+    "label" : "Correlation key (process)",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "correlationKeyExpression",
       "type" : "zeebe:property"
     },
-    "type" : "String"
-  }, {
-    "id" : "messageIdExpression",
-    "label" : "Message ID expression",
-    "description" : "Expression to extract unique identifier of a message",
-    "optional" : true,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "description" : "Extracts the correlation key from the incoming message payload",
     "feel" : "required",
     "group" : "correlation",
+    "id" : "correlationKeyPayload",
+    "label" : "Correlation key (payload)",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "messageIdExpression",
       "type" : "zeebe:property"
     },
+    "description" : "Expression to extract unique identifier of a message",
+    "feel" : "required",
+    "group" : "correlation",
+    "id" : "messageIdExpression",
+    "label" : "Message ID expression",
+    "optional" : true,
     "type" : "String"
   }, {
-    "id" : "messageTtl",
-    "label" : "Message TTL",
-    "description" : "Time-to-live for the message in the broker (ISO-8601 duration)",
-    "optional" : true,
+    "binding" : {
+      "name" : "messageTtl",
+      "type" : "zeebe:property"
+    },
     "constraints" : {
       "notEmpty" : false,
       "pattern" : {
@@ -570,47 +570,47 @@
         "message" : "must be an ISO-8601 duration"
       }
     },
+    "description" : "Time-to-live for the message in the broker (ISO-8601 duration)",
     "feel" : "optional",
     "group" : "correlation",
-    "binding" : {
-      "name" : "messageTtl",
-      "type" : "zeebe:property"
-    },
+    "id" : "messageTtl",
+    "label" : "Message TTL",
+    "optional" : true,
     "type" : "String"
   }, {
-    "id" : "messageNameUuid",
-    "label" : "Message name",
-    "generatedValue" : {
-      "type" : "uuid"
-    },
-    "feel" : "optional",
-    "group" : "correlation",
     "binding" : {
       "name" : "name",
       "type" : "bpmn:Message#property"
     },
+    "feel" : "optional",
+    "generatedValue" : {
+      "type" : "uuid"
+    },
+    "group" : "correlation",
+    "id" : "messageNameUuid",
+    "label" : "Message name",
     "tooltip" : "By default, this is an auto-generated random UUID. We recommend using a unique message name for each connector element in the diagram. Override to set a custom message name. Learn more about <a href=\"https://docs.camunda.io/docs/components/concepts/messages/#message-subscriptions\">message subscriptions</a> that power inbound connectors.",
     "type" : "String"
   }, {
-    "id" : "resultVariable",
-    "label" : "Result variable",
-    "description" : "Name of variable to store the response in. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-variable\" target=\"_blank\">documentation</a>.",
-    "group" : "output",
     "binding" : {
       "name" : "resultVariable",
       "type" : "zeebe:property"
     },
+    "description" : "Name of variable to store the response in. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-variable\" target=\"_blank\">documentation</a>.",
+    "group" : "output",
+    "id" : "resultVariable",
+    "label" : "Result variable",
     "type" : "String"
   }, {
-    "id" : "resultExpression",
-    "label" : "Result expression",
-    "description" : "Expression to map the response into process variables. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-expression\" target=\"_blank\">documentation</a>.",
-    "feel" : "required",
-    "group" : "output",
     "binding" : {
       "name" : "resultExpression",
       "type" : "zeebe:property"
     },
+    "description" : "Expression to map the response into process variables. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-expression\" target=\"_blank\">documentation</a>.",
+    "feel" : "required",
+    "group" : "output",
+    "id" : "resultExpression",
+    "label" : "Result expression",
     "type" : "Text"
   } ],
   "icon" : {

--- a/connectors/microsoft/email-inbound/element-templates/microsoft-o365-email-message-start-event-connector.json
+++ b/connectors/microsoft/email-inbound/element-templates/microsoft-o365-email-message-start-event-connector.json
@@ -39,23 +39,17 @@
     "label" : "Output mapping"
   } ],
   "properties" : [ {
-    "value" : "io.camunda:connector-o365-email-inbound:1",
     "binding" : {
       "name" : "inbound.type",
       "type" : "zeebe:property"
     },
-    "type" : "Hidden"
+    "type" : "Hidden",
+    "value" : "io.camunda:connector-o365-email-inbound:1"
   }, {
-    "id" : "authentication.type",
-    "label" : "Type",
-    "description" : "Authentication type depends on your Microsoft Entra (Azure AD) configuration. See <a href='https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/microsoft-teams/'>connector documentation</a>",
-    "value" : "clientCredentials",
-    "group" : "authentication",
     "binding" : {
       "name" : "authentication.type",
       "type" : "zeebe:property"
     },
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "Bearer token",
       "value" : "token"
@@ -65,15 +59,14 @@
     }, {
       "name" : "Refresh token",
       "value" : "refresh"
-    } ]
-  }, {
-    "id" : "authentication.bearer.token",
-    "label" : "Bearer token",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
+    } ],
+    "description" : "Authentication type depends on your Microsoft Entra (Azure AD) configuration. See <a href='https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/microsoft-teams/'>connector documentation</a>",
     "group" : "authentication",
+    "id" : "authentication.type",
+    "label" : "Type",
+    "type" : "Dropdown",
+    "value" : "clientCredentials"
+  }, {
     "binding" : {
       "name" : "authentication.token",
       "type" : "zeebe:property"
@@ -83,16 +76,15 @@
       "equals" : "token",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "authentication.credentials.clientId",
-    "label" : "Client ID",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
-    "feel" : "optional",
     "group" : "authentication",
+    "id" : "authentication.bearer.token",
+    "label" : "Bearer token",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "authentication.clientId",
       "type" : "zeebe:property"
@@ -102,16 +94,16 @@
       "equals" : "clientCredentials",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "authentication.credentials.tenantId",
-    "label" : "Tenant ID",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "authentication",
+    "id" : "authentication.credentials.clientId",
+    "label" : "Client ID",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "authentication.tenantId",
       "type" : "zeebe:property"
@@ -121,16 +113,16 @@
       "equals" : "clientCredentials",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "authentication.credentials.clientSecret",
-    "label" : "Client secret",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "authentication",
+    "id" : "authentication.credentials.tenantId",
+    "label" : "Tenant ID",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "authentication.clientSecret",
       "type" : "zeebe:property"
@@ -140,17 +132,17 @@
       "equals" : "clientCredentials",
       "type" : "simple"
     },
-    "tooltip" : "The secret value of the Microsoft Entra ID (formerly Azure AD) application",
-    "type" : "String"
-  }, {
-    "id" : "authentication.refresh.token",
-    "label" : "Refresh token",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "authentication",
+    "id" : "authentication.credentials.clientSecret",
+    "label" : "Client secret",
+    "optional" : false,
+    "tooltip" : "The secret value of the Microsoft Entra ID (formerly Azure AD) application",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "authentication.token",
       "type" : "zeebe:property"
@@ -160,16 +152,16 @@
       "equals" : "refresh",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "authentication.refresh.clientId",
-    "label" : "Client ID",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "authentication",
+    "id" : "authentication.refresh.token",
+    "label" : "Refresh token",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "authentication.clientId",
       "type" : "zeebe:property"
@@ -179,16 +171,16 @@
       "equals" : "refresh",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "authentication.refresh.tenantId",
-    "label" : "Tenant ID",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "authentication",
+    "id" : "authentication.refresh.clientId",
+    "label" : "Client ID",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "authentication.tenantId",
       "type" : "zeebe:property"
@@ -198,13 +190,16 @@
       "equals" : "refresh",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "authentication.refresh.clientSecret",
-    "label" : "Client secret",
-    "optional" : true,
+    "constraints" : {
+      "notEmpty" : true
+    },
     "feel" : "optional",
     "group" : "authentication",
+    "id" : "authentication.refresh.tenantId",
+    "label" : "Tenant ID",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "authentication.clientSecret",
       "type" : "zeebe:property"
@@ -214,52 +209,48 @@
       "equals" : "refresh",
       "type" : "simple"
     },
+    "feel" : "optional",
+    "group" : "authentication",
+    "id" : "authentication.refresh.clientSecret",
+    "label" : "Client secret",
+    "optional" : true,
     "tooltip" : "The secret value of the Microsoft Entra ID (formerly Azure AD) application; optional, depends on whether the client is public or private",
     "type" : "String"
   }, {
-    "id" : "pollingConfig.userId",
-    "label" : "Mailbox Owner",
-    "optional" : false,
+    "binding" : {
+      "name" : "pollingConfig.userId",
+      "type" : "zeebe:property"
+    },
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "pollingConfig",
-    "binding" : {
-      "name" : "pollingConfig.userId",
-      "type" : "zeebe:property"
-    },
-    "tooltip" : "The email address or user ID of the mailbox to monitor. <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/microsoft-o365-mail-inbound/#configuration\" target=\"_blank\">Microsoft O365 Mail connector configuration</a>",
+    "id" : "pollingConfig.userId",
+    "label" : "Mailbox Owner",
+    "optional" : false,
     "placeholder" : "user@example.com",
+    "tooltip" : "The email address or user ID of the mailbox to monitor. <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/microsoft-o365-mail-inbound/#configuration\" target=\"_blank\">Microsoft O365 Mail connector configuration</a>",
     "type" : "String"
   }, {
-    "id" : "pollingConfig.folder.folderSpecification",
-    "label" : "Folder Identifier Type",
-    "description" : "Prefer using a folder ID if you are using a well-known folder; otherwise, use the folder name.",
-    "value" : "byId",
-    "group" : "pollingConfig",
     "binding" : {
       "name" : "pollingConfig.folder.folderSpecification",
       "type" : "zeebe:property"
     },
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "Folder ID",
       "value" : "byId"
     }, {
       "name" : "Folder Name",
       "value" : "byName"
-    } ]
-  }, {
-    "id" : "pollingConfig.folder.folderId",
-    "label" : "Folder ID",
-    "optional" : false,
-    "value" : "inbox",
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "feel" : "optional",
+    } ],
+    "description" : "Prefer using a folder ID if you are using a well-known folder; otherwise, use the folder name.",
     "group" : "pollingConfig",
+    "id" : "pollingConfig.folder.folderSpecification",
+    "label" : "Folder Identifier Type",
+    "type" : "Dropdown",
+    "value" : "byId"
+  }, {
     "binding" : {
       "name" : "pollingConfig.folder.folderId",
       "type" : "zeebe:property"
@@ -269,17 +260,18 @@
       "equals" : "byId",
       "type" : "simple"
     },
-    "tooltip" : "The well-known folder ID or custom folder ID. <a href='https://learn.microsoft.com/en-us/graph/api/resources/mailfolder?view=graph-rest-1.0#properties' target='_blank'>See folder properties in the API</a>",
-    "type" : "String"
-  }, {
-    "id" : "pollingConfig.folder.folderName",
-    "label" : "Folder Name",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "pollingConfig",
+    "id" : "pollingConfig.folder.folderId",
+    "label" : "Folder ID",
+    "optional" : false,
+    "tooltip" : "The well-known folder ID or custom folder ID. <a href='https://learn.microsoft.com/en-us/graph/api/resources/mailfolder?view=graph-rest-1.0#properties' target='_blank'>See folder properties in the API</a>",
+    "type" : "String",
+    "value" : "inbox"
+  }, {
     "binding" : {
       "name" : "pollingConfig.folder.folderName",
       "type" : "zeebe:property"
@@ -289,46 +281,48 @@
       "equals" : "byName",
       "type" : "simple"
     },
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "pollingConfig",
+    "id" : "pollingConfig.folder.folderName",
+    "label" : "Folder Name",
+    "optional" : false,
     "tooltip" : "The display name of the folder. Must be unique within the mailbox.",
     "type" : "String"
   }, {
-    "id" : "pollingConfig.pollingInterval",
-    "label" : "Polling interval",
-    "optional" : false,
-    "value" : "PT30S",
-    "feel" : "optional",
-    "group" : "pollingConfig",
     "binding" : {
       "name" : "pollingConfig.pollingInterval",
       "type" : "zeebe:property"
     },
-    "tooltip" : "The interval between email polling requests, in ISO 8601 duration format. <a href='https://docs.camunda.io/docs/components/modeler/bpmn/timer-events/#time-duration' target='_blank'>How to configure a time duration</a>",
-    "type" : "String"
-  }, {
-    "id" : "pollingConfig.filterCriteria.filterSpecification",
-    "label" : "Filter Specification",
-    "description" : "Use predefined filter conditions or provide your own OData filter string",
-    "value" : "simple",
+    "feel" : "optional",
     "group" : "pollingConfig",
+    "id" : "pollingConfig.pollingInterval",
+    "label" : "Polling interval",
+    "optional" : false,
+    "tooltip" : "The interval between email polling requests, in ISO 8601 duration format. <a href='https://docs.camunda.io/docs/components/modeler/bpmn/timer-events/#time-duration' target='_blank'>How to configure a time duration</a>",
+    "type" : "String",
+    "value" : "PT30S"
+  }, {
     "binding" : {
       "name" : "pollingConfig.filterCriteria.filterSpecification",
       "type" : "zeebe:property"
     },
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "Simple",
       "value" : "simple"
     }, {
       "name" : "Advanced",
       "value" : "advanced"
-    } ]
-  }, {
-    "id" : "pollingConfig.filterCriteria.onlyUnread",
-    "label" : "Only Unread",
-    "optional" : false,
-    "value" : true,
-    "feel" : "static",
+    } ],
+    "description" : "Use predefined filter conditions or provide your own OData filter string",
     "group" : "pollingConfig",
+    "id" : "pollingConfig.filterCriteria.filterSpecification",
+    "label" : "Filter Specification",
+    "type" : "Dropdown",
+    "value" : "simple"
+  }, {
     "binding" : {
       "name" : "pollingConfig.filterCriteria.onlyUnread",
       "type" : "zeebe:property"
@@ -338,14 +332,15 @@
       "equals" : "simple",
       "type" : "simple"
     },
-    "tooltip" : "Only fetch unread emails",
-    "type" : "Boolean"
-  }, {
-    "id" : "pollingConfig.filterCriteria.subjectContains",
-    "label" : "Subject Contains",
-    "optional" : true,
-    "feel" : "optional",
+    "feel" : "static",
     "group" : "pollingConfig",
+    "id" : "pollingConfig.filterCriteria.onlyUnread",
+    "label" : "Only Unread",
+    "optional" : false,
+    "tooltip" : "Only fetch unread emails",
+    "type" : "Boolean",
+    "value" : true
+  }, {
     "binding" : {
       "name" : "pollingConfig.filterCriteria.subjectContains",
       "type" : "zeebe:property"
@@ -355,14 +350,14 @@
       "equals" : "simple",
       "type" : "simple"
     },
+    "feel" : "optional",
+    "group" : "pollingConfig",
+    "id" : "pollingConfig.filterCriteria.subjectContains",
+    "label" : "Subject Contains",
+    "optional" : true,
     "tooltip" : "Only fetch emails where subject contains this text (case-sensitive)",
     "type" : "String"
   }, {
-    "id" : "pollingConfig.filterCriteria.fromAddress",
-    "label" : "From Email Address",
-    "optional" : true,
-    "feel" : "optional",
-    "group" : "pollingConfig",
     "binding" : {
       "name" : "pollingConfig.filterCriteria.fromAddress",
       "type" : "zeebe:property"
@@ -372,16 +367,14 @@
       "equals" : "simple",
       "type" : "simple"
     },
+    "feel" : "optional",
+    "group" : "pollingConfig",
+    "id" : "pollingConfig.filterCriteria.fromAddress",
+    "label" : "From Email Address",
+    "optional" : true,
     "tooltip" : "Only fetch emails from this sender address (exact match, e.g. 'invoice@vendor.com')",
     "type" : "String"
   }, {
-    "id" : "pollingConfig.filterCriteria.filterString",
-    "label" : "OData Filter String",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "group" : "pollingConfig",
     "binding" : {
       "name" : "pollingConfig.filterCriteria.filterString",
       "type" : "zeebe:property"
@@ -391,18 +384,20 @@
       "equals" : "advanced",
       "type" : "simple"
     },
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "group" : "pollingConfig",
+    "id" : "pollingConfig.filterCriteria.filterString",
+    "label" : "OData Filter String",
+    "optional" : false,
     "tooltip" : "A custom OData filter expression. <a href='https://learn.microsoft.com/en-us/graph/filter-query-parameter' target='_blank'>See OData filter documentation</a>",
     "type" : "String"
   }, {
-    "id" : "operation.processingOperationDiscriminator",
-    "label" : "Postprocessing configuration",
-    "value" : "mark-read",
-    "group" : "postprocessing",
     "binding" : {
       "name" : "operation.processingOperationDiscriminator",
       "type" : "zeebe:property"
     },
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "Delete",
       "value" : "delete"
@@ -412,14 +407,13 @@
     }, {
       "name" : "Move to other folder",
       "value" : "move"
-    } ]
-  }, {
-    "id" : "operation.force",
-    "label" : "Force delete (email is permanently deleted)",
-    "optional" : false,
-    "value" : false,
-    "feel" : "static",
+    } ],
     "group" : "postprocessing",
+    "id" : "operation.processingOperationDiscriminator",
+    "label" : "Postprocessing configuration",
+    "type" : "Dropdown",
+    "value" : "mark-read"
+  }, {
     "binding" : {
       "name" : "operation.force",
       "type" : "zeebe:property"
@@ -429,40 +423,37 @@
       "equals" : "delete",
       "type" : "simple"
     },
-    "type" : "Boolean"
-  }, {
-    "id" : "operation.targetFolder.folderSpecification",
-    "label" : "Folder Identifier Type",
-    "description" : "Prefer using a folder ID if you are using a well-known folder; otherwise, use the folder name.",
-    "value" : "byId",
+    "feel" : "static",
     "group" : "postprocessing",
+    "id" : "operation.force",
+    "label" : "Force delete (email is permanently deleted)",
+    "optional" : false,
+    "type" : "Boolean",
+    "value" : false
+  }, {
     "binding" : {
       "name" : "operation.targetFolder.folderSpecification",
       "type" : "zeebe:property"
     },
-    "condition" : {
-      "property" : "operation.processingOperationDiscriminator",
-      "equals" : "move",
-      "type" : "simple"
-    },
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "Folder ID",
       "value" : "byId"
     }, {
       "name" : "Folder Name",
       "value" : "byName"
-    } ]
-  }, {
-    "id" : "operation.targetFolder.folderId",
-    "label" : "Folder ID",
-    "optional" : false,
-    "value" : "inbox",
-    "constraints" : {
-      "notEmpty" : true
+    } ],
+    "condition" : {
+      "property" : "operation.processingOperationDiscriminator",
+      "equals" : "move",
+      "type" : "simple"
     },
-    "feel" : "optional",
+    "description" : "Prefer using a folder ID if you are using a well-known folder; otherwise, use the folder name.",
     "group" : "postprocessing",
+    "id" : "operation.targetFolder.folderSpecification",
+    "label" : "Folder Identifier Type",
+    "type" : "Dropdown",
+    "value" : "byId"
+  }, {
     "binding" : {
       "name" : "operation.targetFolder.folderId",
       "type" : "zeebe:property"
@@ -478,17 +469,18 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "The well-known folder ID or custom folder ID. <a href='https://learn.microsoft.com/en-us/graph/api/resources/mailfolder?view=graph-rest-1.0#properties' target='_blank'>See folder properties in the API</a>",
-    "type" : "String"
-  }, {
-    "id" : "operation.targetFolder.folderName",
-    "label" : "Folder Name",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "postprocessing",
+    "id" : "operation.targetFolder.folderId",
+    "label" : "Folder ID",
+    "optional" : false,
+    "tooltip" : "The well-known folder ID or custom folder ID. <a href='https://learn.microsoft.com/en-us/graph/api/resources/mailfolder?view=graph-rest-1.0#properties' target='_blank'>See folder properties in the API</a>",
+    "type" : "String",
+    "value" : "inbox"
+  }, {
     "binding" : {
       "name" : "operation.targetFolder.folderName",
       "type" : "zeebe:property"
@@ -504,47 +496,47 @@
         "type" : "simple"
       } ]
     },
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "postprocessing",
+    "id" : "operation.targetFolder.folderName",
+    "label" : "Folder Name",
+    "optional" : false,
     "tooltip" : "The display name of the folder. Must be unique within the mailbox.",
     "type" : "String"
   }, {
-    "id" : "activationCondition",
-    "label" : "Activation condition",
-    "description" : "Condition under which the Connector triggers. Leave empty to catch all events",
-    "optional" : true,
-    "feel" : "required",
-    "group" : "activation",
     "binding" : {
       "name" : "activationCondition",
       "type" : "zeebe:property"
     },
+    "description" : "Condition under which the Connector triggers. Leave empty to catch all events",
+    "feel" : "required",
+    "group" : "activation",
+    "id" : "activationCondition",
+    "label" : "Activation condition",
+    "optional" : true,
     "type" : "String"
   }, {
-    "id" : "correlationRequired",
-    "label" : "Subprocess correlation required",
-    "description" : "Indicates whether correlation is required. This is needed for event-based subprocess message start events",
-    "value" : "notRequired",
-    "group" : "correlation",
     "binding" : {
       "name" : "correlationRequired",
       "type" : "zeebe:property"
     },
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "Correlation not required",
       "value" : "notRequired"
     }, {
       "name" : "Correlation required",
       "value" : "required"
-    } ]
-  }, {
-    "id" : "correlationKeyProcess",
-    "label" : "Correlation key (process)",
-    "description" : "Sets up the correlation key from process variables",
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "feel" : "required",
+    } ],
+    "description" : "Indicates whether correlation is required. This is needed for event-based subprocess message start events",
     "group" : "correlation",
+    "id" : "correlationRequired",
+    "label" : "Subprocess correlation required",
+    "type" : "Dropdown",
+    "value" : "notRequired"
+  }, {
     "binding" : {
       "name" : "correlationKey",
       "type" : "bpmn:Message#zeebe:subscription#property"
@@ -554,16 +546,16 @@
       "equals" : "required",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "correlationKeyPayload",
-    "label" : "Correlation key (payload)",
-    "description" : "Extracts the correlation key from the incoming message payload",
     "constraints" : {
       "notEmpty" : true
     },
+    "description" : "Sets up the correlation key from process variables",
     "feel" : "required",
     "group" : "correlation",
+    "id" : "correlationKeyProcess",
+    "label" : "Correlation key (process)",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "correlationKeyExpression",
       "type" : "zeebe:property"
@@ -573,24 +565,32 @@
       "equals" : "required",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "messageIdExpression",
-    "label" : "Message ID expression",
-    "description" : "Expression to extract unique identifier of a message",
-    "optional" : true,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "description" : "Extracts the correlation key from the incoming message payload",
     "feel" : "required",
     "group" : "correlation",
+    "id" : "correlationKeyPayload",
+    "label" : "Correlation key (payload)",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "messageIdExpression",
       "type" : "zeebe:property"
     },
+    "description" : "Expression to extract unique identifier of a message",
+    "feel" : "required",
+    "group" : "correlation",
+    "id" : "messageIdExpression",
+    "label" : "Message ID expression",
+    "optional" : true,
     "type" : "String"
   }, {
-    "id" : "messageTtl",
-    "label" : "Message TTL",
-    "description" : "Time-to-live for the message in the broker (ISO-8601 duration)",
-    "optional" : true,
+    "binding" : {
+      "name" : "messageTtl",
+      "type" : "zeebe:property"
+    },
     "constraints" : {
       "notEmpty" : false,
       "pattern" : {
@@ -598,47 +598,47 @@
         "message" : "must be an ISO-8601 duration"
       }
     },
+    "description" : "Time-to-live for the message in the broker (ISO-8601 duration)",
     "feel" : "optional",
     "group" : "correlation",
-    "binding" : {
-      "name" : "messageTtl",
-      "type" : "zeebe:property"
-    },
+    "id" : "messageTtl",
+    "label" : "Message TTL",
+    "optional" : true,
     "type" : "String"
   }, {
-    "id" : "messageNameUuid",
-    "label" : "Message name",
-    "generatedValue" : {
-      "type" : "uuid"
-    },
-    "feel" : "optional",
-    "group" : "correlation",
     "binding" : {
       "name" : "name",
       "type" : "bpmn:Message#property"
     },
+    "feel" : "optional",
+    "generatedValue" : {
+      "type" : "uuid"
+    },
+    "group" : "correlation",
+    "id" : "messageNameUuid",
+    "label" : "Message name",
     "tooltip" : "By default, this is an auto-generated random UUID. We recommend using a unique message name for each connector element in the diagram. Override to set a custom message name. Learn more about <a href=\"https://docs.camunda.io/docs/components/concepts/messages/#message-subscriptions\">message subscriptions</a> that power inbound connectors.",
     "type" : "String"
   }, {
-    "id" : "resultVariable",
-    "label" : "Result variable",
-    "description" : "Name of variable to store the response in. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-variable\" target=\"_blank\">documentation</a>.",
-    "group" : "output",
     "binding" : {
       "name" : "resultVariable",
       "type" : "zeebe:property"
     },
+    "description" : "Name of variable to store the response in. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-variable\" target=\"_blank\">documentation</a>.",
+    "group" : "output",
+    "id" : "resultVariable",
+    "label" : "Result variable",
     "type" : "String"
   }, {
-    "id" : "resultExpression",
-    "label" : "Result expression",
-    "description" : "Expression to map the response into process variables. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-expression\" target=\"_blank\">documentation</a>.",
-    "feel" : "required",
-    "group" : "output",
     "binding" : {
       "name" : "resultExpression",
       "type" : "zeebe:property"
     },
+    "description" : "Expression to map the response into process variables. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-expression\" target=\"_blank\">documentation</a>.",
+    "feel" : "required",
+    "group" : "output",
+    "id" : "resultExpression",
+    "label" : "Result expression",
     "type" : "Text"
   } ],
   "icon" : {

--- a/connectors/microsoft/teams/src/main/java/io/camunda/connector/suppliers/ObjectMapperSupplier.java
+++ b/connectors/microsoft/teams/src/main/java/io/camunda/connector/suppliers/ObjectMapperSupplier.java
@@ -7,14 +7,17 @@
 package io.camunda.connector.suppliers;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.connector.jackson.ConnectorsObjectMapperSupplier;
+import tools.jackson.databind.ObjectMapper;
 
 public final class ObjectMapperSupplier {
 
   private static final ObjectMapper OBJECT_MAPPER =
       ConnectorsObjectMapperSupplier.getCopy()
-          .setSerializationInclusion(JsonInclude.Include.NON_NULL);
+          .rebuild()
+          .changeDefaultPropertyInclusion(
+              incl -> incl.withValueInclusion(JsonInclude.Include.NON_NULL))
+          .build();
 
   private ObjectMapperSupplier() {}
 

--- a/connectors/pom.xml
+++ b/connectors/pom.xml
@@ -74,7 +74,7 @@ except in compliance with the proprietary license.</license.inlineheader>
       <artifactId>slf4j-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
+      <groupId>tools.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
     </dependency>
 
@@ -128,7 +128,6 @@ except in compliance with the proprietary license.</license.inlineheader>
     </dependencies>
   </dependencyManagement>
 
-
   <build>
     <pluginManagement>
       <plugins>
@@ -162,14 +161,14 @@ except in compliance with the proprietary license.</license.inlineheader>
                 <dependency>io.camunda.connector:connector-runtime-test</dependency>
                 <dependency>io.camunda.connector:connector-object-mapper</dependency>
                 <dependency>io.camunda.connector:connector-validation</dependency>
-                <dependency>com.fasterxml.jackson.core:jackson-databind</dependency>
+                <dependency>tools.jackson.core:jackson-databind</dependency>
                 <dependency>org.mockito:mockito-core</dependency>
                 <dependency>org.springframework.boot:spring-boot-test</dependency>
                 <dependency>org.apache.tika:tika-parsers-standard-package</dependency>
               </ignoredUnusedDeclaredDependencies>
               <ignoredNonTestScopedDependencies combine.children="append">
                 <dependency>io.camunda.connector:connector-validation</dependency>
-                <dependency>com.fasterxml.jackson.core:jackson-core</dependency>
+                <dependency>tools.jackson.core:jackson-core</dependency>
                 <dependency>io.camunda.connector:jackson-datatype-document</dependency>
                 <dependency>io.camunda.connector:connector-object-mapper</dependency>
                 <dependency>org.junit.jupiter:junit-jupiter-api</dependency>

--- a/connectors/rabbitmq/src/main/java/io/camunda/connector/rabbitmq/supplier/ObjectMapperSupplier.java
+++ b/connectors/rabbitmq/src/main/java/io/camunda/connector/rabbitmq/supplier/ObjectMapperSupplier.java
@@ -6,8 +6,8 @@
  */
 package io.camunda.connector.rabbitmq.supplier;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.connector.jackson.ConnectorsObjectMapperSupplier;
+import tools.jackson.databind.ObjectMapper;
 
 public final class ObjectMapperSupplier {
 

--- a/connectors/salesforce/pom.xml
+++ b/connectors/salesforce/pom.xml
@@ -48,7 +48,7 @@ except in compliance with the proprietary license.</license.inlineheader>
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
+      <groupId>tools.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
       <scope>test</scope>
     </dependency>

--- a/connectors/sendgrid/element-templates/hybrid/sendgrid-outbound-connector-hybrid.json
+++ b/connectors/sendgrid/element-templates/hybrid/sendgrid-outbound-connector-hybrid.json
@@ -46,110 +46,102 @@
     "label" : "Retries"
   } ],
   "properties" : [ {
-    "id" : "taskDefinitionType",
-    "value" : "io.camunda:sendgrid:1",
-    "group" : "taskDefinitionType",
     "binding" : {
       "property" : "type",
       "type" : "zeebe:taskDefinition"
     },
-    "type" : "String"
+    "group" : "taskDefinitionType",
+    "id" : "taskDefinitionType",
+    "type" : "String",
+    "value" : "io.camunda:sendgrid:1"
   }, {
-    "id" : "apiKey",
-    "label" : "SendGrid API key",
-    "optional" : false,
+    "binding" : {
+      "name" : "apiKey",
+      "type" : "zeebe:input"
+    },
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "authentication",
-    "binding" : {
-      "name" : "apiKey",
-      "type" : "zeebe:input"
-    },
+    "id" : "apiKey",
+    "label" : "SendGrid API key",
+    "optional" : false,
     "type" : "String"
   }, {
-    "id" : "from.name",
-    "label" : "Name",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "feel" : "optional",
-    "group" : "sender",
     "binding" : {
       "name" : "from.name",
       "type" : "zeebe:input"
     },
-    "type" : "String"
-  }, {
-    "id" : "from.email",
-    "label" : "Email address",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "sender",
+    "id" : "from.name",
+    "label" : "Name",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "from.email",
       "type" : "zeebe:input"
     },
-    "type" : "String"
-  }, {
-    "id" : "to.name",
-    "label" : "Name",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
-    "group" : "receiver",
+    "group" : "sender",
+    "id" : "from.email",
+    "label" : "Email address",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "to.name",
       "type" : "zeebe:input"
     },
-    "type" : "String"
-  }, {
-    "id" : "to.email",
-    "label" : "Email address",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "receiver",
+    "id" : "to.name",
+    "label" : "Name",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "to.email",
       "type" : "zeebe:input"
     },
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "receiver",
+    "id" : "to.email",
+    "label" : "Email address",
+    "optional" : false,
     "type" : "String"
   }, {
-    "id" : "unMappedFieldNotUseInModel.mailType",
-    "label" : "Mail contents",
-    "optional" : false,
-    "group" : "content",
     "binding" : {
       "name" : "unMappedFieldNotUseInModel.mailType",
       "type" : "zeebe:input"
     },
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "Simple (no dynamic template)",
       "value" : "mail"
     }, {
       "name" : "Using dynamic template",
       "value" : "byTemplate"
-    } ]
-  }, {
-    "id" : "template.id",
-    "label" : "Template ID",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "feel" : "optional",
+    } ],
     "group" : "content",
+    "id" : "unMappedFieldNotUseInModel.mailType",
+    "label" : "Mail contents",
+    "optional" : false,
+    "type" : "Dropdown"
+  }, {
     "binding" : {
       "name" : "template.id",
       "type" : "zeebe:input"
@@ -159,16 +151,16 @@
       "equals" : "byTemplate",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "template.data",
-    "label" : "Template data",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
-    "feel" : "required",
+    "feel" : "optional",
     "group" : "content",
+    "id" : "template.id",
+    "label" : "Template ID",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "template.data",
       "type" : "zeebe:input"
@@ -178,16 +170,16 @@
       "equals" : "byTemplate",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "content.subject",
-    "label" : "Subject",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
-    "feel" : "optional",
+    "feel" : "required",
     "group" : "content",
+    "id" : "template.data",
+    "label" : "Template data",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "content.subject",
       "type" : "zeebe:input"
@@ -197,17 +189,16 @@
       "equals" : "mail",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "content.type",
-    "label" : "Content type",
-    "optional" : false,
-    "value" : "text/plain",
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "content",
+    "id" : "content.subject",
+    "label" : "Subject",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "content.type",
       "type" : "zeebe:input"
@@ -217,16 +208,17 @@
       "equals" : "mail",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "content.value",
-    "label" : "Body",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "content",
+    "id" : "content.type",
+    "label" : "Content type",
+    "optional" : false,
+    "type" : "String",
+    "value" : "text/plain"
+  }, {
     "binding" : {
       "name" : "content.value",
       "type" : "zeebe:input"
@@ -236,18 +228,20 @@
       "equals" : "mail",
       "type" : "simple"
     },
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "content",
+    "id" : "content.value",
+    "label" : "Body",
+    "optional" : false,
     "type" : "Text"
   }, {
-    "id" : "attachments_documentMode",
-    "label" : "Number of documents",
-    "value" : "none",
-    "group" : "content",
     "binding" : {
       "name" : "attachments_documentMode",
       "type" : "zeebe:input"
     },
-    "tooltip" : "Files to attach to the email, referenced as <a href=\"https://docs.camunda.io/docs/apis-tools/camunda-api-rest/specifications/upload-document-alpha/\">Camunda documents</a>.",
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "None",
       "value" : "none"
@@ -257,22 +251,18 @@
     }, {
       "name" : "Multiple documents",
       "value" : "multiple"
-    } ]
-  }, {
-    "id" : "attachments_single_documentSource",
-    "label" : "Document source",
-    "value" : "camunda",
+    } ],
     "group" : "content",
+    "id" : "attachments_documentMode",
+    "label" : "Number of documents",
+    "tooltip" : "Files to attach to the email, referenced as <a href=\"https://docs.camunda.io/docs/apis-tools/camunda-api-rest/specifications/upload-document-alpha/\">Camunda documents</a>.",
+    "type" : "Dropdown",
+    "value" : "none"
+  }, {
     "binding" : {
       "name" : "attachments_single_documentSource",
       "type" : "zeebe:input"
     },
-    "condition" : {
-      "property" : "attachments_documentMode",
-      "equals" : "single",
-      "type" : "simple"
-    },
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "Camunda Document",
       "value" : "camunda"
@@ -282,15 +272,18 @@
     }, {
       "name" : "From URL",
       "value" : "external"
-    } ]
-  }, {
-    "id" : "attachments_single_camundaReference",
-    "label" : "Camunda document",
-    "constraints" : {
-      "notEmpty" : true
+    } ],
+    "condition" : {
+      "property" : "attachments_documentMode",
+      "equals" : "single",
+      "type" : "simple"
     },
-    "feel" : "required",
     "group" : "content",
+    "id" : "attachments_single_documentSource",
+    "label" : "Document source",
+    "type" : "Dropdown",
+    "value" : "camunda"
+  }, {
     "binding" : {
       "name" : "attachments_single_camundaReference",
       "type" : "zeebe:input"
@@ -306,15 +299,15 @@
         "type" : "simple"
       } ]
     },
-    "type" : "String"
-  }, {
-    "id" : "attachments_single_inline_content",
-    "label" : "Content",
     "constraints" : {
       "notEmpty" : true
     },
-    "feel" : "optional",
+    "feel" : "required",
     "group" : "content",
+    "id" : "attachments_single_camundaReference",
+    "label" : "Camunda document",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "attachments_single_inline_content",
       "type" : "zeebe:input"
@@ -330,12 +323,15 @@
         "type" : "simple"
       } ]
     },
-    "type" : "String"
-  }, {
-    "id" : "attachments_single_inline_fileName",
-    "label" : "File name",
+    "constraints" : {
+      "notEmpty" : true
+    },
     "feel" : "optional",
     "group" : "content",
+    "id" : "attachments_single_inline_content",
+    "label" : "Content",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "attachments_single_inline_fileName",
       "type" : "zeebe:input"
@@ -351,12 +347,12 @@
         "type" : "simple"
       } ]
     },
-    "type" : "String"
-  }, {
-    "id" : "attachments_single_inline_contentType",
-    "label" : "Content type",
     "feel" : "optional",
     "group" : "content",
+    "id" : "attachments_single_inline_fileName",
+    "label" : "File name",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "attachments_single_inline_contentType",
       "type" : "zeebe:input"
@@ -372,15 +368,12 @@
         "type" : "simple"
       } ]
     },
-    "type" : "String"
-  }, {
-    "id" : "attachments_single_external_url",
-    "label" : "URL",
-    "constraints" : {
-      "notEmpty" : true
-    },
     "feel" : "optional",
     "group" : "content",
+    "id" : "attachments_single_inline_contentType",
+    "label" : "Content type",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "attachments_single_external_url",
       "type" : "zeebe:input"
@@ -396,12 +389,15 @@
         "type" : "simple"
       } ]
     },
-    "type" : "String"
-  }, {
-    "id" : "attachments_single_external_fileName",
-    "label" : "File name",
+    "constraints" : {
+      "notEmpty" : true
+    },
     "feel" : "optional",
     "group" : "content",
+    "id" : "attachments_single_external_url",
+    "label" : "URL",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "attachments_single_external_fileName",
       "type" : "zeebe:input"
@@ -417,15 +413,12 @@
         "type" : "simple"
       } ]
     },
+    "feel" : "optional",
+    "group" : "content",
+    "id" : "attachments_single_external_fileName",
+    "label" : "File name",
     "type" : "String"
   }, {
-    "id" : "attachments_multiple_expression",
-    "label" : "Documents",
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "feel" : "required",
-    "group" : "content",
     "binding" : {
       "name" : "attachments_multiple_expression",
       "type" : "zeebe:input"
@@ -435,103 +428,110 @@
       "equals" : "multiple",
       "type" : "simple"
     },
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "required",
+    "group" : "content",
+    "id" : "attachments_multiple_expression",
+    "label" : "Documents",
     "type" : "String"
   }, {
-    "id" : "attachments",
-    "value" : "=if attachments_documentMode = \"multiple\" then attachments_multiple_expression else if attachments_documentMode = \"single\" then (if attachments_single_documentSource = \"camunda\" then [attachments_single_camundaReference] else if attachments_single_documentSource = \"inline\" then [{ \"camunda.document.type\": \"inline\", content: attachments_single_inline_content, name: attachments_single_inline_fileName, contentType: attachments_single_inline_contentType }] else if attachments_single_documentSource = \"external\" then [{ \"camunda.document.type\": \"external\", url: attachments_single_external_url, name: attachments_single_external_fileName }] else null) else null",
-    "group" : "content",
     "binding" : {
       "name" : "attachments",
       "type" : "zeebe:input"
     },
-    "type" : "Hidden"
+    "group" : "content",
+    "id" : "attachments",
+    "type" : "Hidden",
+    "value" : "=if attachments_documentMode = \"multiple\" then attachments_multiple_expression else if attachments_documentMode = \"single\" then (if attachments_single_documentSource = \"camunda\" then [attachments_single_camundaReference] else if attachments_single_documentSource = \"inline\" then [{ \"camunda.document.type\": \"inline\", content: attachments_single_inline_content, name: attachments_single_inline_fileName, contentType: attachments_single_inline_contentType }] else if attachments_single_documentSource = \"external\" then [{ \"camunda.document.type\": \"external\", url: attachments_single_external_url, name: attachments_single_external_fileName }] else null) else null"
   }, {
-    "id" : "version",
-    "label" : "Version",
-    "description" : "Version of the element template",
-    "value" : "6",
-    "group" : "connector",
     "binding" : {
       "key" : "elementTemplateVersion",
       "type" : "zeebe:taskHeader"
     },
-    "type" : "Hidden"
-  }, {
-    "id" : "id",
-    "label" : "ID",
-    "description" : "ID of the element template",
-    "value" : "io.camunda.connectors.SendGrid.v2",
+    "description" : "Version of the element template",
     "group" : "connector",
+    "id" : "version",
+    "label" : "Version",
+    "type" : "Hidden",
+    "value" : "6"
+  }, {
     "binding" : {
       "key" : "elementTemplateId",
       "type" : "zeebe:taskHeader"
     },
-    "type" : "Hidden"
+    "description" : "ID of the element template",
+    "group" : "connector",
+    "id" : "id",
+    "label" : "ID",
+    "type" : "Hidden",
+    "value" : "io.camunda.connectors.SendGrid.v2"
   }, {
-    "id" : "resultVariable",
-    "label" : "Result variable",
-    "description" : "Name of variable to store the response in. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-variable\" target=\"_blank\">documentation</a>.",
-    "group" : "output",
     "binding" : {
       "key" : "resultVariable",
       "type" : "zeebe:taskHeader"
     },
+    "description" : "Name of variable to store the response in. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-variable\" target=\"_blank\">documentation</a>.",
+    "group" : "output",
+    "id" : "resultVariable",
+    "label" : "Result variable",
     "type" : "String"
   }, {
-    "id" : "resultExpression",
-    "label" : "Result expression",
-    "description" : "Expression to map the response into process variables. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-expression\" target=\"_blank\">documentation</a>.",
-    "feel" : "required",
-    "group" : "output",
     "binding" : {
       "key" : "resultExpression",
       "type" : "zeebe:taskHeader"
     },
+    "description" : "Expression to map the response into process variables. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-expression\" target=\"_blank\">documentation</a>.",
+    "feel" : "required",
+    "group" : "output",
+    "id" : "resultExpression",
+    "label" : "Result expression",
     "type" : "Text"
   }, {
-    "id" : "errorExpression",
-    "label" : "Error expression",
-    "description" : "Expression to handle errors. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/\" target=\"_blank\">documentation</a>.",
-    "feel" : "required",
-    "group" : "error",
     "binding" : {
       "key" : "errorExpression",
       "type" : "zeebe:taskHeader"
     },
+    "description" : "Expression to handle errors. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/\" target=\"_blank\">documentation</a>.",
+    "feel" : "required",
+    "group" : "error",
+    "id" : "errorExpression",
+    "label" : "Error expression",
     "type" : "Text"
   }, {
-    "id" : "retryCount",
-    "label" : "Retries",
-    "description" : "Number of retries",
-    "value" : "3",
-    "feel" : "optional",
-    "group" : "retries",
     "binding" : {
       "property" : "retries",
       "type" : "zeebe:taskDefinition"
     },
-    "type" : "String"
-  }, {
-    "id" : "retryBackoff",
-    "label" : "Retry backoff",
-    "description" : "ISO-8601 duration to wait between retries",
-    "value" : "PT30S",
+    "description" : "Number of retries",
+    "feel" : "optional",
     "group" : "retries",
+    "id" : "retryCount",
+    "label" : "Retries",
+    "type" : "String",
+    "value" : "3"
+  }, {
     "binding" : {
       "key" : "retryBackoff",
       "type" : "zeebe:taskHeader"
     },
-    "type" : "String"
-  }, {
-    "id" : "jobTimeout",
-    "label" : "Job timeout",
-    "description" : "ISO-8601 duration after which Zeebe considers this job timed out if not yet completed. Leave empty to use the default timeout",
-    "optional" : true,
+    "description" : "ISO-8601 duration to wait between retries",
     "group" : "retries",
+    "id" : "retryBackoff",
+    "label" : "Retry backoff",
+    "type" : "String",
+    "value" : "PT30S"
+  }, {
     "binding" : {
       "key" : "jobTimeout",
       "type" : "zeebe:taskHeader"
     },
+    "description" : "ISO-8601 duration after which Zeebe considers this job timed out if not yet completed. Leave empty to use the default timeout",
+    "group" : "retries",
+    "id" : "jobTimeout",
+    "label" : "Job timeout",
+    "optional" : true,
     "type" : "String"
   } ],
   "icon" : {

--- a/connectors/sendgrid/element-templates/sendgrid-outbound-connector.json
+++ b/connectors/sendgrid/element-templates/sendgrid-outbound-connector.json
@@ -43,108 +43,100 @@
     "label" : "Retries"
   } ],
   "properties" : [ {
-    "value" : "io.camunda:sendgrid:1",
     "binding" : {
       "property" : "type",
       "type" : "zeebe:taskDefinition"
     },
-    "type" : "Hidden"
+    "type" : "Hidden",
+    "value" : "io.camunda:sendgrid:1"
   }, {
-    "id" : "apiKey",
-    "label" : "SendGrid API key",
-    "optional" : false,
+    "binding" : {
+      "name" : "apiKey",
+      "type" : "zeebe:input"
+    },
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "authentication",
-    "binding" : {
-      "name" : "apiKey",
-      "type" : "zeebe:input"
-    },
+    "id" : "apiKey",
+    "label" : "SendGrid API key",
+    "optional" : false,
     "type" : "String"
   }, {
-    "id" : "from.name",
-    "label" : "Name",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "feel" : "optional",
-    "group" : "sender",
     "binding" : {
       "name" : "from.name",
       "type" : "zeebe:input"
     },
-    "type" : "String"
-  }, {
-    "id" : "from.email",
-    "label" : "Email address",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "sender",
+    "id" : "from.name",
+    "label" : "Name",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "from.email",
       "type" : "zeebe:input"
     },
-    "type" : "String"
-  }, {
-    "id" : "to.name",
-    "label" : "Name",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
-    "group" : "receiver",
+    "group" : "sender",
+    "id" : "from.email",
+    "label" : "Email address",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "to.name",
       "type" : "zeebe:input"
     },
-    "type" : "String"
-  }, {
-    "id" : "to.email",
-    "label" : "Email address",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "receiver",
+    "id" : "to.name",
+    "label" : "Name",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "to.email",
       "type" : "zeebe:input"
     },
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "receiver",
+    "id" : "to.email",
+    "label" : "Email address",
+    "optional" : false,
     "type" : "String"
   }, {
-    "id" : "unMappedFieldNotUseInModel.mailType",
-    "label" : "Mail contents",
-    "optional" : false,
-    "group" : "content",
     "binding" : {
       "name" : "unMappedFieldNotUseInModel.mailType",
       "type" : "zeebe:input"
     },
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "Simple (no dynamic template)",
       "value" : "mail"
     }, {
       "name" : "Using dynamic template",
       "value" : "byTemplate"
-    } ]
-  }, {
-    "id" : "template.id",
-    "label" : "Template ID",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "feel" : "optional",
+    } ],
     "group" : "content",
+    "id" : "unMappedFieldNotUseInModel.mailType",
+    "label" : "Mail contents",
+    "optional" : false,
+    "type" : "Dropdown"
+  }, {
     "binding" : {
       "name" : "template.id",
       "type" : "zeebe:input"
@@ -154,16 +146,16 @@
       "equals" : "byTemplate",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "template.data",
-    "label" : "Template data",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
-    "feel" : "required",
+    "feel" : "optional",
     "group" : "content",
+    "id" : "template.id",
+    "label" : "Template ID",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "template.data",
       "type" : "zeebe:input"
@@ -173,16 +165,16 @@
       "equals" : "byTemplate",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "content.subject",
-    "label" : "Subject",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
-    "feel" : "optional",
+    "feel" : "required",
     "group" : "content",
+    "id" : "template.data",
+    "label" : "Template data",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "content.subject",
       "type" : "zeebe:input"
@@ -192,17 +184,16 @@
       "equals" : "mail",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "content.type",
-    "label" : "Content type",
-    "optional" : false,
-    "value" : "text/plain",
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "content",
+    "id" : "content.subject",
+    "label" : "Subject",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "content.type",
       "type" : "zeebe:input"
@@ -212,16 +203,17 @@
       "equals" : "mail",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "content.value",
-    "label" : "Body",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "content",
+    "id" : "content.type",
+    "label" : "Content type",
+    "optional" : false,
+    "type" : "String",
+    "value" : "text/plain"
+  }, {
     "binding" : {
       "name" : "content.value",
       "type" : "zeebe:input"
@@ -231,18 +223,20 @@
       "equals" : "mail",
       "type" : "simple"
     },
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "content",
+    "id" : "content.value",
+    "label" : "Body",
+    "optional" : false,
     "type" : "Text"
   }, {
-    "id" : "attachments_documentMode",
-    "label" : "Number of documents",
-    "value" : "none",
-    "group" : "content",
     "binding" : {
       "name" : "attachments_documentMode",
       "type" : "zeebe:input"
     },
-    "tooltip" : "Files to attach to the email, referenced as <a href=\"https://docs.camunda.io/docs/apis-tools/camunda-api-rest/specifications/upload-document-alpha/\">Camunda documents</a>.",
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "None",
       "value" : "none"
@@ -252,22 +246,18 @@
     }, {
       "name" : "Multiple documents",
       "value" : "multiple"
-    } ]
-  }, {
-    "id" : "attachments_single_documentSource",
-    "label" : "Document source",
-    "value" : "camunda",
+    } ],
     "group" : "content",
+    "id" : "attachments_documentMode",
+    "label" : "Number of documents",
+    "tooltip" : "Files to attach to the email, referenced as <a href=\"https://docs.camunda.io/docs/apis-tools/camunda-api-rest/specifications/upload-document-alpha/\">Camunda documents</a>.",
+    "type" : "Dropdown",
+    "value" : "none"
+  }, {
     "binding" : {
       "name" : "attachments_single_documentSource",
       "type" : "zeebe:input"
     },
-    "condition" : {
-      "property" : "attachments_documentMode",
-      "equals" : "single",
-      "type" : "simple"
-    },
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "Camunda Document",
       "value" : "camunda"
@@ -277,15 +267,18 @@
     }, {
       "name" : "From URL",
       "value" : "external"
-    } ]
-  }, {
-    "id" : "attachments_single_camundaReference",
-    "label" : "Camunda document",
-    "constraints" : {
-      "notEmpty" : true
+    } ],
+    "condition" : {
+      "property" : "attachments_documentMode",
+      "equals" : "single",
+      "type" : "simple"
     },
-    "feel" : "required",
     "group" : "content",
+    "id" : "attachments_single_documentSource",
+    "label" : "Document source",
+    "type" : "Dropdown",
+    "value" : "camunda"
+  }, {
     "binding" : {
       "name" : "attachments_single_camundaReference",
       "type" : "zeebe:input"
@@ -301,15 +294,15 @@
         "type" : "simple"
       } ]
     },
-    "type" : "String"
-  }, {
-    "id" : "attachments_single_inline_content",
-    "label" : "Content",
     "constraints" : {
       "notEmpty" : true
     },
-    "feel" : "optional",
+    "feel" : "required",
     "group" : "content",
+    "id" : "attachments_single_camundaReference",
+    "label" : "Camunda document",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "attachments_single_inline_content",
       "type" : "zeebe:input"
@@ -325,12 +318,15 @@
         "type" : "simple"
       } ]
     },
-    "type" : "String"
-  }, {
-    "id" : "attachments_single_inline_fileName",
-    "label" : "File name",
+    "constraints" : {
+      "notEmpty" : true
+    },
     "feel" : "optional",
     "group" : "content",
+    "id" : "attachments_single_inline_content",
+    "label" : "Content",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "attachments_single_inline_fileName",
       "type" : "zeebe:input"
@@ -346,12 +342,12 @@
         "type" : "simple"
       } ]
     },
-    "type" : "String"
-  }, {
-    "id" : "attachments_single_inline_contentType",
-    "label" : "Content type",
     "feel" : "optional",
     "group" : "content",
+    "id" : "attachments_single_inline_fileName",
+    "label" : "File name",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "attachments_single_inline_contentType",
       "type" : "zeebe:input"
@@ -367,15 +363,12 @@
         "type" : "simple"
       } ]
     },
-    "type" : "String"
-  }, {
-    "id" : "attachments_single_external_url",
-    "label" : "URL",
-    "constraints" : {
-      "notEmpty" : true
-    },
     "feel" : "optional",
     "group" : "content",
+    "id" : "attachments_single_inline_contentType",
+    "label" : "Content type",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "attachments_single_external_url",
       "type" : "zeebe:input"
@@ -391,12 +384,15 @@
         "type" : "simple"
       } ]
     },
-    "type" : "String"
-  }, {
-    "id" : "attachments_single_external_fileName",
-    "label" : "File name",
+    "constraints" : {
+      "notEmpty" : true
+    },
     "feel" : "optional",
     "group" : "content",
+    "id" : "attachments_single_external_url",
+    "label" : "URL",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "attachments_single_external_fileName",
       "type" : "zeebe:input"
@@ -412,15 +408,12 @@
         "type" : "simple"
       } ]
     },
+    "feel" : "optional",
+    "group" : "content",
+    "id" : "attachments_single_external_fileName",
+    "label" : "File name",
     "type" : "String"
   }, {
-    "id" : "attachments_multiple_expression",
-    "label" : "Documents",
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "feel" : "required",
-    "group" : "content",
     "binding" : {
       "name" : "attachments_multiple_expression",
       "type" : "zeebe:input"
@@ -430,103 +423,110 @@
       "equals" : "multiple",
       "type" : "simple"
     },
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "required",
+    "group" : "content",
+    "id" : "attachments_multiple_expression",
+    "label" : "Documents",
     "type" : "String"
   }, {
-    "id" : "attachments",
-    "value" : "=if attachments_documentMode = \"multiple\" then attachments_multiple_expression else if attachments_documentMode = \"single\" then (if attachments_single_documentSource = \"camunda\" then [attachments_single_camundaReference] else if attachments_single_documentSource = \"inline\" then [{ \"camunda.document.type\": \"inline\", content: attachments_single_inline_content, name: attachments_single_inline_fileName, contentType: attachments_single_inline_contentType }] else if attachments_single_documentSource = \"external\" then [{ \"camunda.document.type\": \"external\", url: attachments_single_external_url, name: attachments_single_external_fileName }] else null) else null",
-    "group" : "content",
     "binding" : {
       "name" : "attachments",
       "type" : "zeebe:input"
     },
-    "type" : "Hidden"
+    "group" : "content",
+    "id" : "attachments",
+    "type" : "Hidden",
+    "value" : "=if attachments_documentMode = \"multiple\" then attachments_multiple_expression else if attachments_documentMode = \"single\" then (if attachments_single_documentSource = \"camunda\" then [attachments_single_camundaReference] else if attachments_single_documentSource = \"inline\" then [{ \"camunda.document.type\": \"inline\", content: attachments_single_inline_content, name: attachments_single_inline_fileName, contentType: attachments_single_inline_contentType }] else if attachments_single_documentSource = \"external\" then [{ \"camunda.document.type\": \"external\", url: attachments_single_external_url, name: attachments_single_external_fileName }] else null) else null"
   }, {
-    "id" : "version",
-    "label" : "Version",
-    "description" : "Version of the element template",
-    "value" : "6",
-    "group" : "connector",
     "binding" : {
       "key" : "elementTemplateVersion",
       "type" : "zeebe:taskHeader"
     },
-    "type" : "Hidden"
-  }, {
-    "id" : "id",
-    "label" : "ID",
-    "description" : "ID of the element template",
-    "value" : "io.camunda.connectors.SendGrid.v2",
+    "description" : "Version of the element template",
     "group" : "connector",
+    "id" : "version",
+    "label" : "Version",
+    "type" : "Hidden",
+    "value" : "6"
+  }, {
     "binding" : {
       "key" : "elementTemplateId",
       "type" : "zeebe:taskHeader"
     },
-    "type" : "Hidden"
+    "description" : "ID of the element template",
+    "group" : "connector",
+    "id" : "id",
+    "label" : "ID",
+    "type" : "Hidden",
+    "value" : "io.camunda.connectors.SendGrid.v2"
   }, {
-    "id" : "resultVariable",
-    "label" : "Result variable",
-    "description" : "Name of variable to store the response in. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-variable\" target=\"_blank\">documentation</a>.",
-    "group" : "output",
     "binding" : {
       "key" : "resultVariable",
       "type" : "zeebe:taskHeader"
     },
+    "description" : "Name of variable to store the response in. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-variable\" target=\"_blank\">documentation</a>.",
+    "group" : "output",
+    "id" : "resultVariable",
+    "label" : "Result variable",
     "type" : "String"
   }, {
-    "id" : "resultExpression",
-    "label" : "Result expression",
-    "description" : "Expression to map the response into process variables. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-expression\" target=\"_blank\">documentation</a>.",
-    "feel" : "required",
-    "group" : "output",
     "binding" : {
       "key" : "resultExpression",
       "type" : "zeebe:taskHeader"
     },
+    "description" : "Expression to map the response into process variables. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-expression\" target=\"_blank\">documentation</a>.",
+    "feel" : "required",
+    "group" : "output",
+    "id" : "resultExpression",
+    "label" : "Result expression",
     "type" : "Text"
   }, {
-    "id" : "errorExpression",
-    "label" : "Error expression",
-    "description" : "Expression to handle errors. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/\" target=\"_blank\">documentation</a>.",
-    "feel" : "required",
-    "group" : "error",
     "binding" : {
       "key" : "errorExpression",
       "type" : "zeebe:taskHeader"
     },
+    "description" : "Expression to handle errors. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/\" target=\"_blank\">documentation</a>.",
+    "feel" : "required",
+    "group" : "error",
+    "id" : "errorExpression",
+    "label" : "Error expression",
     "type" : "Text"
   }, {
-    "id" : "retryCount",
-    "label" : "Retries",
-    "description" : "Number of retries",
-    "value" : "3",
-    "feel" : "optional",
-    "group" : "retries",
     "binding" : {
       "property" : "retries",
       "type" : "zeebe:taskDefinition"
     },
-    "type" : "String"
-  }, {
-    "id" : "retryBackoff",
-    "label" : "Retry backoff",
-    "description" : "ISO-8601 duration to wait between retries",
-    "value" : "PT30S",
+    "description" : "Number of retries",
+    "feel" : "optional",
     "group" : "retries",
+    "id" : "retryCount",
+    "label" : "Retries",
+    "type" : "String",
+    "value" : "3"
+  }, {
     "binding" : {
       "key" : "retryBackoff",
       "type" : "zeebe:taskHeader"
     },
-    "type" : "String"
-  }, {
-    "id" : "jobTimeout",
-    "label" : "Job timeout",
-    "description" : "ISO-8601 duration after which Zeebe considers this job timed out if not yet completed. Leave empty to use the default timeout",
-    "optional" : true,
+    "description" : "ISO-8601 duration to wait between retries",
     "group" : "retries",
+    "id" : "retryBackoff",
+    "label" : "Retry backoff",
+    "type" : "String",
+    "value" : "PT30S"
+  }, {
     "binding" : {
       "key" : "jobTimeout",
       "type" : "zeebe:taskHeader"
     },
+    "description" : "ISO-8601 duration after which Zeebe considers this job timed out if not yet completed. Leave empty to use the default timeout",
+    "group" : "retries",
+    "id" : "jobTimeout",
+    "label" : "Job timeout",
+    "optional" : true,
     "type" : "String"
   } ],
   "icon" : {

--- a/connectors/slack/pom.xml
+++ b/connectors/slack/pom.xml
@@ -25,7 +25,7 @@
 
   <dependencies>
     <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
+      <groupId>tools.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
       <version>${version.jackson-bom}</version>
     </dependency>

--- a/connectors/soap/element-templates/hybrid/soap-outbound-connector-hybrid.json
+++ b/connectors/soap/element-templates/hybrid/soap-outbound-connector-hybrid.json
@@ -46,40 +46,34 @@
     "label" : "Retries"
   } ],
   "properties" : [ {
-    "id" : "taskDefinitionType",
-    "value" : "io.camunda:soap:1",
-    "group" : "taskDefinitionType",
     "binding" : {
       "property" : "type",
       "type" : "zeebe:taskDefinition"
     },
-    "type" : "String"
+    "group" : "taskDefinitionType",
+    "id" : "taskDefinitionType",
+    "type" : "String",
+    "value" : "io.camunda:soap:1"
   }, {
-    "id" : "serviceUrl",
-    "label" : "Service URL",
-    "optional" : false,
+    "binding" : {
+      "name" : "serviceUrl",
+      "type" : "zeebe:input"
+    },
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "connection",
-    "binding" : {
-      "name" : "serviceUrl",
-      "type" : "zeebe:input"
-    },
+    "id" : "serviceUrl",
+    "label" : "Service URL",
+    "optional" : false,
     "tooltip" : "The URL where the service runs",
     "type" : "String"
   }, {
-    "id" : "authentication.authentication",
-    "label" : "Authentication",
-    "description" : "Authentication mechanism to use",
-    "value" : "none",
-    "group" : "authentication",
     "binding" : {
       "name" : "authentication.authentication",
       "type" : "zeebe:input"
     },
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "None",
       "value" : "none"
@@ -89,16 +83,14 @@
     }, {
       "name" : "WSS signature",
       "value" : "signature"
-    } ]
-  }, {
-    "id" : "authentication.username",
-    "label" : "Username",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "feel" : "optional",
+    } ],
+    "description" : "Authentication mechanism to use",
     "group" : "authentication",
+    "id" : "authentication.authentication",
+    "label" : "Authentication",
+    "type" : "Dropdown",
+    "value" : "none"
+  }, {
     "binding" : {
       "name" : "authentication.username",
       "type" : "zeebe:input"
@@ -108,13 +100,16 @@
       "equals" : "usernameToken",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "authentication.password",
-    "label" : "Password",
-    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
     "feel" : "optional",
     "group" : "authentication",
+    "id" : "authentication.username",
+    "label" : "Username",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "authentication.password",
       "type" : "zeebe:input"
@@ -124,63 +119,60 @@
       "equals" : "usernameToken",
       "type" : "simple"
     },
+    "feel" : "optional",
+    "group" : "authentication",
+    "id" : "authentication.password",
+    "label" : "Password",
+    "optional" : false,
     "type" : "String"
   }, {
-    "id" : "authentication.encoded",
-    "label" : "Encoded",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "group" : "authentication",
     "binding" : {
       "name" : "authentication.encoded",
       "type" : "zeebe:input"
     },
-    "condition" : {
-      "property" : "authentication.authentication",
-      "equals" : "usernameToken",
-      "type" : "simple"
-    },
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "Yes",
       "value" : "Yes"
     }, {
       "name" : "No",
       "value" : "No"
-    } ]
-  }, {
-    "id" : "authentication.certificate.certificateType",
-    "label" : "Certificate type",
-    "description" : "From where the certificate is obtained",
+    } ],
+    "condition" : {
+      "property" : "authentication.authentication",
+      "equals" : "usernameToken",
+      "type" : "simple"
+    },
+    "constraints" : {
+      "notEmpty" : true
+    },
     "group" : "authentication",
+    "id" : "authentication.encoded",
+    "label" : "Encoded",
+    "optional" : false,
+    "type" : "Dropdown"
+  }, {
     "binding" : {
       "name" : "authentication.certificate.certificateType",
       "type" : "zeebe:input"
     },
-    "condition" : {
-      "property" : "authentication.authentication",
-      "equals" : "signature",
-      "type" : "simple"
-    },
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "Single certificate",
       "value" : "single"
     }, {
       "name" : "Keystore certificate",
       "value" : "keystore"
-    } ]
-  }, {
-    "id" : "authentication.certificate.certificate",
-    "label" : "Certificate",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
+    } ],
+    "condition" : {
+      "property" : "authentication.authentication",
+      "equals" : "signature",
+      "type" : "simple"
     },
-    "feel" : "optional",
+    "description" : "From where the certificate is obtained",
     "group" : "authentication",
+    "id" : "authentication.certificate.certificateType",
+    "label" : "Certificate type",
+    "type" : "Dropdown"
+  }, {
     "binding" : {
       "name" : "authentication.certificate.certificate",
       "type" : "zeebe:input"
@@ -196,17 +188,17 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "The X.509 certificate to use to sign the request",
-    "type" : "String"
-  }, {
-    "id" : "authentication.certificate.privateKey",
-    "label" : "Private key",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "authentication",
+    "id" : "authentication.certificate.certificate",
+    "label" : "Certificate",
+    "optional" : false,
+    "tooltip" : "The X.509 certificate to use to sign the request",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "authentication.certificate.privateKey",
       "type" : "zeebe:input"
@@ -222,17 +214,17 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "The private key for the certificate",
-    "type" : "String"
-  }, {
-    "id" : "authentication.certificate.keystoreLocation",
-    "label" : "Keystore location",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "authentication",
+    "id" : "authentication.certificate.privateKey",
+    "label" : "Private key",
+    "optional" : false,
+    "tooltip" : "The private key for the certificate",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "authentication.certificate.keystoreLocation",
       "type" : "zeebe:input"
@@ -248,16 +240,16 @@
         "type" : "simple"
       } ]
     },
-    "type" : "String"
-  }, {
-    "id" : "authentication.certificate.keystorePassword",
-    "label" : "Keystore password",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "authentication",
+    "id" : "authentication.certificate.keystoreLocation",
+    "label" : "Keystore location",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "authentication.certificate.keystorePassword",
       "type" : "zeebe:input"
@@ -273,16 +265,16 @@
         "type" : "simple"
       } ]
     },
-    "type" : "String"
-  }, {
-    "id" : "authentication.certificate.alias",
-    "label" : "Certificate alias",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "authentication",
+    "id" : "authentication.certificate.keystorePassword",
+    "label" : "Keystore password",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "authentication.certificate.alias",
       "type" : "zeebe:input"
@@ -298,17 +290,17 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "The alias for the certificate in the keystore",
-    "type" : "String"
-  }, {
-    "id" : "authentication.certificate.password",
-    "label" : "Certificate password",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "authentication",
+    "id" : "authentication.certificate.alias",
+    "label" : "Certificate alias",
+    "optional" : false,
+    "tooltip" : "The alias for the certificate in the keystore",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "authentication.certificate.password",
       "type" : "zeebe:input"
@@ -324,13 +316,16 @@
         "type" : "simple"
       } ]
     },
-    "type" : "String"
-  }, {
-    "id" : "authentication.signatureAlgorithm",
-    "label" : "Signature algorithm",
-    "optional" : true,
+    "constraints" : {
+      "notEmpty" : true
+    },
     "feel" : "optional",
     "group" : "authentication",
+    "id" : "authentication.certificate.password",
+    "label" : "Certificate password",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "authentication.signatureAlgorithm",
       "type" : "zeebe:input"
@@ -340,14 +335,14 @@
       "equals" : "signature",
       "type" : "simple"
     },
+    "feel" : "optional",
+    "group" : "authentication",
+    "id" : "authentication.signatureAlgorithm",
+    "label" : "Signature algorithm",
+    "optional" : true,
     "tooltip" : "Fully qualified name of an alternative signature algorithm",
     "type" : "String"
   }, {
-    "id" : "authentication.digestAlgorithm",
-    "label" : "Digest algorithm",
-    "optional" : true,
-    "feel" : "optional",
-    "group" : "authentication",
     "binding" : {
       "name" : "authentication.digestAlgorithm",
       "type" : "zeebe:input"
@@ -357,14 +352,14 @@
       "equals" : "signature",
       "type" : "simple"
     },
+    "feel" : "optional",
+    "group" : "authentication",
+    "id" : "authentication.digestAlgorithm",
+    "label" : "Digest algorithm",
+    "optional" : true,
     "tooltip" : "Fully qualified name of an alternative digest algorithm",
     "type" : "String"
   }, {
-    "id" : "authentication.timestamp",
-    "label" : "Timestamp timeout in seconds",
-    "optional" : true,
-    "feel" : "static",
-    "group" : "authentication",
     "binding" : {
       "name" : "authentication.timestamp",
       "type" : "zeebe:input"
@@ -374,14 +369,14 @@
       "equals" : "signature",
       "type" : "simple"
     },
+    "feel" : "static",
+    "group" : "authentication",
+    "id" : "authentication.timestamp",
+    "label" : "Timestamp timeout in seconds",
+    "optional" : true,
     "tooltip" : "If set, adds a timestamp header with the given timeout",
     "type" : "Number"
   }, {
-    "id" : "authentication.encryptionParts",
-    "label" : "Signature parts",
-    "optional" : true,
-    "feel" : "required",
-    "group" : "authentication",
     "binding" : {
       "name" : "authentication.encryptionParts",
       "type" : "zeebe:input"
@@ -391,32 +386,32 @@
       "equals" : "signature",
       "type" : "simple"
     },
+    "feel" : "required",
+    "group" : "authentication",
+    "id" : "authentication.encryptionParts",
+    "label" : "Signature parts",
+    "optional" : true,
     "tooltip" : "Array of signature parts with namespace and localName",
     "type" : "String"
   }, {
-    "id" : "soapVersion.version",
-    "label" : "SOAP version",
-    "description" : "The SOAP version the service uses",
-    "value" : "1.1",
-    "group" : "soap-message",
     "binding" : {
       "name" : "soapVersion.version",
       "type" : "zeebe:input"
     },
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "1.1",
       "value" : "1.1"
     }, {
       "name" : "1.2",
       "value" : "1.2"
-    } ]
-  }, {
-    "id" : "soapVersion.soapAction",
-    "label" : "SOAPAction HTTP header",
-    "optional" : true,
-    "feel" : "optional",
+    } ],
+    "description" : "The SOAP version the service uses",
     "group" : "soap-message",
+    "id" : "soapVersion.version",
+    "label" : "SOAP version",
+    "type" : "Dropdown",
+    "value" : "1.1"
+  }, {
     "binding" : {
       "name" : "soapVersion.soapAction",
       "type" : "zeebe:input"
@@ -426,18 +421,17 @@
       "equals" : "1.1",
       "type" : "simple"
     },
+    "feel" : "optional",
+    "group" : "soap-message",
+    "id" : "soapVersion.soapAction",
+    "label" : "SOAPAction HTTP header",
+    "optional" : true,
     "type" : "String"
   }, {
-    "id" : "header.type",
-    "label" : "SOAP header",
-    "description" : "The definition of the SOAP header",
-    "value" : "none",
-    "group" : "soap-message",
     "binding" : {
       "name" : "header.type",
       "type" : "zeebe:input"
     },
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "Template",
       "value" : "template"
@@ -447,13 +441,14 @@
     }, {
       "name" : "No SOAP header required",
       "value" : "none"
-    } ]
-  }, {
-    "id" : "header.template",
-    "label" : "XML template",
-    "optional" : false,
-    "feel" : "optional",
+    } ],
+    "description" : "The definition of the SOAP header",
     "group" : "soap-message",
+    "id" : "header.type",
+    "label" : "SOAP header",
+    "type" : "Dropdown",
+    "value" : "none"
+  }, {
     "binding" : {
       "name" : "header.template",
       "type" : "zeebe:input"
@@ -463,14 +458,14 @@
       "equals" : "template",
       "type" : "simple"
     },
+    "feel" : "optional",
+    "group" : "soap-message",
+    "id" : "header.template",
+    "label" : "XML template",
+    "optional" : false,
     "tooltip" : "The template for the header in XML format",
     "type" : "Text"
   }, {
-    "id" : "header.context",
-    "label" : "XML template context",
-    "optional" : false,
-    "feel" : "required",
-    "group" : "soap-message",
     "binding" : {
       "name" : "header.context",
       "type" : "zeebe:input"
@@ -480,14 +475,14 @@
       "equals" : "template",
       "type" : "simple"
     },
+    "feel" : "required",
+    "group" : "soap-message",
+    "id" : "header.context",
+    "label" : "XML template context",
+    "optional" : false,
     "tooltip" : "The context that is used to fill the template",
     "type" : "String"
   }, {
-    "id" : "header.json",
-    "label" : "JSON definition",
-    "optional" : false,
-    "feel" : "required",
-    "group" : "soap-message",
     "binding" : {
       "name" : "header.json",
       "type" : "zeebe:input"
@@ -497,32 +492,32 @@
       "equals" : "json",
       "type" : "simple"
     },
+    "feel" : "required",
+    "group" : "soap-message",
+    "id" : "header.json",
+    "label" : "JSON definition",
+    "optional" : false,
     "tooltip" : "Definition of the SOAP header as JSON object",
     "type" : "String"
   }, {
-    "id" : "body.type",
-    "label" : "SOAP body",
-    "description" : "The XML definition of the SOAP body",
-    "value" : "json",
-    "group" : "soap-message",
     "binding" : {
       "name" : "body.type",
       "type" : "zeebe:input"
     },
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "Template",
       "value" : "template"
     }, {
       "name" : "XML compatible JSON",
       "value" : "json"
-    } ]
-  }, {
-    "id" : "body.template",
-    "label" : "XML template",
-    "optional" : false,
-    "feel" : "optional",
+    } ],
+    "description" : "The XML definition of the SOAP body",
     "group" : "soap-message",
+    "id" : "body.type",
+    "label" : "SOAP body",
+    "type" : "Dropdown",
+    "value" : "json"
+  }, {
     "binding" : {
       "name" : "body.template",
       "type" : "zeebe:input"
@@ -532,14 +527,14 @@
       "equals" : "template",
       "type" : "simple"
     },
+    "feel" : "optional",
+    "group" : "soap-message",
+    "id" : "body.template",
+    "label" : "XML template",
+    "optional" : false,
     "tooltip" : "The template for the body in XML format",
     "type" : "Text"
   }, {
-    "id" : "body.context",
-    "label" : "XML template context",
-    "optional" : false,
-    "feel" : "required",
-    "group" : "soap-message",
     "binding" : {
       "name" : "body.context",
       "type" : "zeebe:input"
@@ -549,14 +544,14 @@
       "equals" : "template",
       "type" : "simple"
     },
+    "feel" : "required",
+    "group" : "soap-message",
+    "id" : "body.context",
+    "label" : "XML template context",
+    "optional" : false,
     "tooltip" : "The context that is used to fill the template",
     "type" : "String"
   }, {
-    "id" : "body.json",
-    "label" : "JSON definition",
-    "optional" : false,
-    "feel" : "required",
-    "group" : "soap-message",
     "binding" : {
       "name" : "body.json",
       "type" : "zeebe:input"
@@ -566,120 +561,125 @@
       "equals" : "json",
       "type" : "simple"
     },
+    "feel" : "required",
+    "group" : "soap-message",
+    "id" : "body.json",
+    "label" : "JSON definition",
+    "optional" : false,
     "tooltip" : "Definition of the SOAP body as JSON object",
     "type" : "String"
   }, {
-    "id" : "namespaces",
-    "label" : "Namespaces",
-    "optional" : true,
-    "feel" : "required",
-    "group" : "soap-message",
     "binding" : {
       "name" : "namespaces",
       "type" : "zeebe:input"
     },
+    "feel" : "required",
+    "group" : "soap-message",
+    "id" : "namespaces",
+    "label" : "Namespaces",
+    "optional" : true,
     "tooltip" : "The namespaces that should be declared on the SOAP Envelope",
     "type" : "String"
   }, {
-    "id" : "connectionTimeoutInSeconds",
-    "label" : "Connection timeout in seconds",
-    "optional" : true,
-    "value" : 20,
-    "feel" : "static",
-    "group" : "timeout",
     "binding" : {
       "name" : "connectionTimeoutInSeconds",
       "type" : "zeebe:input"
     },
+    "feel" : "static",
+    "group" : "timeout",
+    "id" : "connectionTimeoutInSeconds",
+    "label" : "Connection timeout in seconds",
+    "optional" : true,
     "tooltip" : "Time in seconds to wait when establishing a connection, or 0 to wait indefinitely",
-    "type" : "Number"
+    "type" : "Number",
+    "value" : 20
   }, {
-    "id" : "version",
-    "label" : "Version",
-    "description" : "Version of the element template",
-    "value" : "2",
-    "group" : "connector",
     "binding" : {
       "key" : "elementTemplateVersion",
       "type" : "zeebe:taskHeader"
     },
-    "type" : "Hidden"
-  }, {
-    "id" : "id",
-    "label" : "ID",
-    "description" : "ID of the element template",
-    "value" : "io.camunda:soap",
+    "description" : "Version of the element template",
     "group" : "connector",
+    "id" : "version",
+    "label" : "Version",
+    "type" : "Hidden",
+    "value" : "2"
+  }, {
     "binding" : {
       "key" : "elementTemplateId",
       "type" : "zeebe:taskHeader"
     },
-    "type" : "Hidden"
+    "description" : "ID of the element template",
+    "group" : "connector",
+    "id" : "id",
+    "label" : "ID",
+    "type" : "Hidden",
+    "value" : "io.camunda:soap"
   }, {
-    "id" : "resultVariable",
-    "label" : "Result variable",
-    "description" : "Name of variable to store the response in. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-variable\" target=\"_blank\">documentation</a>.",
-    "group" : "output",
     "binding" : {
       "key" : "resultVariable",
       "type" : "zeebe:taskHeader"
     },
+    "description" : "Name of variable to store the response in. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-variable\" target=\"_blank\">documentation</a>.",
+    "group" : "output",
+    "id" : "resultVariable",
+    "label" : "Result variable",
     "type" : "String"
   }, {
-    "id" : "resultExpression",
-    "label" : "Result expression",
-    "description" : "Expression to map the response into process variables. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-expression\" target=\"_blank\">documentation</a>.",
-    "feel" : "required",
-    "group" : "output",
     "binding" : {
       "key" : "resultExpression",
       "type" : "zeebe:taskHeader"
     },
+    "description" : "Expression to map the response into process variables. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-expression\" target=\"_blank\">documentation</a>.",
+    "feel" : "required",
+    "group" : "output",
+    "id" : "resultExpression",
+    "label" : "Result expression",
     "type" : "Text"
   }, {
-    "id" : "errorExpression",
-    "label" : "Error expression",
-    "description" : "Expression to handle errors. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/\" target=\"_blank\">documentation</a>.",
-    "feel" : "required",
-    "group" : "error",
     "binding" : {
       "key" : "errorExpression",
       "type" : "zeebe:taskHeader"
     },
+    "description" : "Expression to handle errors. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/\" target=\"_blank\">documentation</a>.",
+    "feel" : "required",
+    "group" : "error",
+    "id" : "errorExpression",
+    "label" : "Error expression",
     "type" : "Text"
   }, {
-    "id" : "retryCount",
-    "label" : "Retries",
-    "description" : "Number of retries",
-    "value" : "3",
-    "feel" : "optional",
-    "group" : "retries",
     "binding" : {
       "property" : "retries",
       "type" : "zeebe:taskDefinition"
     },
-    "type" : "String"
-  }, {
-    "id" : "retryBackoff",
-    "label" : "Retry backoff",
-    "description" : "ISO-8601 duration to wait between retries",
-    "value" : "PT30S",
+    "description" : "Number of retries",
+    "feel" : "optional",
     "group" : "retries",
+    "id" : "retryCount",
+    "label" : "Retries",
+    "type" : "String",
+    "value" : "3"
+  }, {
     "binding" : {
       "key" : "retryBackoff",
       "type" : "zeebe:taskHeader"
     },
-    "type" : "String"
-  }, {
-    "id" : "jobTimeout",
-    "label" : "Job timeout",
-    "description" : "ISO-8601 duration after which Zeebe considers this job timed out if not yet completed. Leave empty to use the default timeout",
-    "optional" : true,
+    "description" : "ISO-8601 duration to wait between retries",
     "group" : "retries",
+    "id" : "retryBackoff",
+    "label" : "Retry backoff",
+    "type" : "String",
+    "value" : "PT30S"
+  }, {
     "binding" : {
       "key" : "jobTimeout",
       "type" : "zeebe:taskHeader"
     },
+    "description" : "ISO-8601 duration after which Zeebe considers this job timed out if not yet completed. Leave empty to use the default timeout",
+    "group" : "retries",
+    "id" : "jobTimeout",
+    "label" : "Job timeout",
+    "optional" : true,
     "type" : "String"
   } ],
   "icon" : {

--- a/connectors/soap/element-templates/soap-outbound-connector.json
+++ b/connectors/soap/element-templates/soap-outbound-connector.json
@@ -43,38 +43,32 @@
     "label" : "Retries"
   } ],
   "properties" : [ {
-    "value" : "io.camunda:soap:1",
     "binding" : {
       "property" : "type",
       "type" : "zeebe:taskDefinition"
     },
-    "type" : "Hidden"
+    "type" : "Hidden",
+    "value" : "io.camunda:soap:1"
   }, {
-    "id" : "serviceUrl",
-    "label" : "Service URL",
-    "optional" : false,
+    "binding" : {
+      "name" : "serviceUrl",
+      "type" : "zeebe:input"
+    },
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "connection",
-    "binding" : {
-      "name" : "serviceUrl",
-      "type" : "zeebe:input"
-    },
+    "id" : "serviceUrl",
+    "label" : "Service URL",
+    "optional" : false,
     "tooltip" : "The URL where the service runs",
     "type" : "String"
   }, {
-    "id" : "authentication.authentication",
-    "label" : "Authentication",
-    "description" : "Authentication mechanism to use",
-    "value" : "none",
-    "group" : "authentication",
     "binding" : {
       "name" : "authentication.authentication",
       "type" : "zeebe:input"
     },
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "None",
       "value" : "none"
@@ -84,16 +78,14 @@
     }, {
       "name" : "WSS signature",
       "value" : "signature"
-    } ]
-  }, {
-    "id" : "authentication.username",
-    "label" : "Username",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "feel" : "optional",
+    } ],
+    "description" : "Authentication mechanism to use",
     "group" : "authentication",
+    "id" : "authentication.authentication",
+    "label" : "Authentication",
+    "type" : "Dropdown",
+    "value" : "none"
+  }, {
     "binding" : {
       "name" : "authentication.username",
       "type" : "zeebe:input"
@@ -103,13 +95,16 @@
       "equals" : "usernameToken",
       "type" : "simple"
     },
-    "type" : "String"
-  }, {
-    "id" : "authentication.password",
-    "label" : "Password",
-    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
     "feel" : "optional",
     "group" : "authentication",
+    "id" : "authentication.username",
+    "label" : "Username",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "authentication.password",
       "type" : "zeebe:input"
@@ -119,63 +114,60 @@
       "equals" : "usernameToken",
       "type" : "simple"
     },
+    "feel" : "optional",
+    "group" : "authentication",
+    "id" : "authentication.password",
+    "label" : "Password",
+    "optional" : false,
     "type" : "String"
   }, {
-    "id" : "authentication.encoded",
-    "label" : "Encoded",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "group" : "authentication",
     "binding" : {
       "name" : "authentication.encoded",
       "type" : "zeebe:input"
     },
-    "condition" : {
-      "property" : "authentication.authentication",
-      "equals" : "usernameToken",
-      "type" : "simple"
-    },
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "Yes",
       "value" : "Yes"
     }, {
       "name" : "No",
       "value" : "No"
-    } ]
-  }, {
-    "id" : "authentication.certificate.certificateType",
-    "label" : "Certificate type",
-    "description" : "From where the certificate is obtained",
+    } ],
+    "condition" : {
+      "property" : "authentication.authentication",
+      "equals" : "usernameToken",
+      "type" : "simple"
+    },
+    "constraints" : {
+      "notEmpty" : true
+    },
     "group" : "authentication",
+    "id" : "authentication.encoded",
+    "label" : "Encoded",
+    "optional" : false,
+    "type" : "Dropdown"
+  }, {
     "binding" : {
       "name" : "authentication.certificate.certificateType",
       "type" : "zeebe:input"
     },
-    "condition" : {
-      "property" : "authentication.authentication",
-      "equals" : "signature",
-      "type" : "simple"
-    },
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "Single certificate",
       "value" : "single"
     }, {
       "name" : "Keystore certificate",
       "value" : "keystore"
-    } ]
-  }, {
-    "id" : "authentication.certificate.certificate",
-    "label" : "Certificate",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
+    } ],
+    "condition" : {
+      "property" : "authentication.authentication",
+      "equals" : "signature",
+      "type" : "simple"
     },
-    "feel" : "optional",
+    "description" : "From where the certificate is obtained",
     "group" : "authentication",
+    "id" : "authentication.certificate.certificateType",
+    "label" : "Certificate type",
+    "type" : "Dropdown"
+  }, {
     "binding" : {
       "name" : "authentication.certificate.certificate",
       "type" : "zeebe:input"
@@ -191,17 +183,17 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "The X.509 certificate to use to sign the request",
-    "type" : "String"
-  }, {
-    "id" : "authentication.certificate.privateKey",
-    "label" : "Private key",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "authentication",
+    "id" : "authentication.certificate.certificate",
+    "label" : "Certificate",
+    "optional" : false,
+    "tooltip" : "The X.509 certificate to use to sign the request",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "authentication.certificate.privateKey",
       "type" : "zeebe:input"
@@ -217,17 +209,17 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "The private key for the certificate",
-    "type" : "String"
-  }, {
-    "id" : "authentication.certificate.keystoreLocation",
-    "label" : "Keystore location",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "authentication",
+    "id" : "authentication.certificate.privateKey",
+    "label" : "Private key",
+    "optional" : false,
+    "tooltip" : "The private key for the certificate",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "authentication.certificate.keystoreLocation",
       "type" : "zeebe:input"
@@ -243,16 +235,16 @@
         "type" : "simple"
       } ]
     },
-    "type" : "String"
-  }, {
-    "id" : "authentication.certificate.keystorePassword",
-    "label" : "Keystore password",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "authentication",
+    "id" : "authentication.certificate.keystoreLocation",
+    "label" : "Keystore location",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "authentication.certificate.keystorePassword",
       "type" : "zeebe:input"
@@ -268,16 +260,16 @@
         "type" : "simple"
       } ]
     },
-    "type" : "String"
-  }, {
-    "id" : "authentication.certificate.alias",
-    "label" : "Certificate alias",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "authentication",
+    "id" : "authentication.certificate.keystorePassword",
+    "label" : "Keystore password",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "authentication.certificate.alias",
       "type" : "zeebe:input"
@@ -293,17 +285,17 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "The alias for the certificate in the keystore",
-    "type" : "String"
-  }, {
-    "id" : "authentication.certificate.password",
-    "label" : "Certificate password",
-    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "authentication",
+    "id" : "authentication.certificate.alias",
+    "label" : "Certificate alias",
+    "optional" : false,
+    "tooltip" : "The alias for the certificate in the keystore",
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "authentication.certificate.password",
       "type" : "zeebe:input"
@@ -319,13 +311,16 @@
         "type" : "simple"
       } ]
     },
-    "type" : "String"
-  }, {
-    "id" : "authentication.signatureAlgorithm",
-    "label" : "Signature algorithm",
-    "optional" : true,
+    "constraints" : {
+      "notEmpty" : true
+    },
     "feel" : "optional",
     "group" : "authentication",
+    "id" : "authentication.certificate.password",
+    "label" : "Certificate password",
+    "optional" : false,
+    "type" : "String"
+  }, {
     "binding" : {
       "name" : "authentication.signatureAlgorithm",
       "type" : "zeebe:input"
@@ -335,14 +330,14 @@
       "equals" : "signature",
       "type" : "simple"
     },
+    "feel" : "optional",
+    "group" : "authentication",
+    "id" : "authentication.signatureAlgorithm",
+    "label" : "Signature algorithm",
+    "optional" : true,
     "tooltip" : "Fully qualified name of an alternative signature algorithm",
     "type" : "String"
   }, {
-    "id" : "authentication.digestAlgorithm",
-    "label" : "Digest algorithm",
-    "optional" : true,
-    "feel" : "optional",
-    "group" : "authentication",
     "binding" : {
       "name" : "authentication.digestAlgorithm",
       "type" : "zeebe:input"
@@ -352,14 +347,14 @@
       "equals" : "signature",
       "type" : "simple"
     },
+    "feel" : "optional",
+    "group" : "authentication",
+    "id" : "authentication.digestAlgorithm",
+    "label" : "Digest algorithm",
+    "optional" : true,
     "tooltip" : "Fully qualified name of an alternative digest algorithm",
     "type" : "String"
   }, {
-    "id" : "authentication.timestamp",
-    "label" : "Timestamp timeout in seconds",
-    "optional" : true,
-    "feel" : "static",
-    "group" : "authentication",
     "binding" : {
       "name" : "authentication.timestamp",
       "type" : "zeebe:input"
@@ -369,14 +364,14 @@
       "equals" : "signature",
       "type" : "simple"
     },
+    "feel" : "static",
+    "group" : "authentication",
+    "id" : "authentication.timestamp",
+    "label" : "Timestamp timeout in seconds",
+    "optional" : true,
     "tooltip" : "If set, adds a timestamp header with the given timeout",
     "type" : "Number"
   }, {
-    "id" : "authentication.encryptionParts",
-    "label" : "Signature parts",
-    "optional" : true,
-    "feel" : "required",
-    "group" : "authentication",
     "binding" : {
       "name" : "authentication.encryptionParts",
       "type" : "zeebe:input"
@@ -386,32 +381,32 @@
       "equals" : "signature",
       "type" : "simple"
     },
+    "feel" : "required",
+    "group" : "authentication",
+    "id" : "authentication.encryptionParts",
+    "label" : "Signature parts",
+    "optional" : true,
     "tooltip" : "Array of signature parts with namespace and localName",
     "type" : "String"
   }, {
-    "id" : "soapVersion.version",
-    "label" : "SOAP version",
-    "description" : "The SOAP version the service uses",
-    "value" : "1.1",
-    "group" : "soap-message",
     "binding" : {
       "name" : "soapVersion.version",
       "type" : "zeebe:input"
     },
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "1.1",
       "value" : "1.1"
     }, {
       "name" : "1.2",
       "value" : "1.2"
-    } ]
-  }, {
-    "id" : "soapVersion.soapAction",
-    "label" : "SOAPAction HTTP header",
-    "optional" : true,
-    "feel" : "optional",
+    } ],
+    "description" : "The SOAP version the service uses",
     "group" : "soap-message",
+    "id" : "soapVersion.version",
+    "label" : "SOAP version",
+    "type" : "Dropdown",
+    "value" : "1.1"
+  }, {
     "binding" : {
       "name" : "soapVersion.soapAction",
       "type" : "zeebe:input"
@@ -421,18 +416,17 @@
       "equals" : "1.1",
       "type" : "simple"
     },
+    "feel" : "optional",
+    "group" : "soap-message",
+    "id" : "soapVersion.soapAction",
+    "label" : "SOAPAction HTTP header",
+    "optional" : true,
     "type" : "String"
   }, {
-    "id" : "header.type",
-    "label" : "SOAP header",
-    "description" : "The definition of the SOAP header",
-    "value" : "none",
-    "group" : "soap-message",
     "binding" : {
       "name" : "header.type",
       "type" : "zeebe:input"
     },
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "Template",
       "value" : "template"
@@ -442,13 +436,14 @@
     }, {
       "name" : "No SOAP header required",
       "value" : "none"
-    } ]
-  }, {
-    "id" : "header.template",
-    "label" : "XML template",
-    "optional" : false,
-    "feel" : "optional",
+    } ],
+    "description" : "The definition of the SOAP header",
     "group" : "soap-message",
+    "id" : "header.type",
+    "label" : "SOAP header",
+    "type" : "Dropdown",
+    "value" : "none"
+  }, {
     "binding" : {
       "name" : "header.template",
       "type" : "zeebe:input"
@@ -458,14 +453,14 @@
       "equals" : "template",
       "type" : "simple"
     },
+    "feel" : "optional",
+    "group" : "soap-message",
+    "id" : "header.template",
+    "label" : "XML template",
+    "optional" : false,
     "tooltip" : "The template for the header in XML format",
     "type" : "Text"
   }, {
-    "id" : "header.context",
-    "label" : "XML template context",
-    "optional" : false,
-    "feel" : "required",
-    "group" : "soap-message",
     "binding" : {
       "name" : "header.context",
       "type" : "zeebe:input"
@@ -475,14 +470,14 @@
       "equals" : "template",
       "type" : "simple"
     },
+    "feel" : "required",
+    "group" : "soap-message",
+    "id" : "header.context",
+    "label" : "XML template context",
+    "optional" : false,
     "tooltip" : "The context that is used to fill the template",
     "type" : "String"
   }, {
-    "id" : "header.json",
-    "label" : "JSON definition",
-    "optional" : false,
-    "feel" : "required",
-    "group" : "soap-message",
     "binding" : {
       "name" : "header.json",
       "type" : "zeebe:input"
@@ -492,32 +487,32 @@
       "equals" : "json",
       "type" : "simple"
     },
+    "feel" : "required",
+    "group" : "soap-message",
+    "id" : "header.json",
+    "label" : "JSON definition",
+    "optional" : false,
     "tooltip" : "Definition of the SOAP header as JSON object",
     "type" : "String"
   }, {
-    "id" : "body.type",
-    "label" : "SOAP body",
-    "description" : "The XML definition of the SOAP body",
-    "value" : "json",
-    "group" : "soap-message",
     "binding" : {
       "name" : "body.type",
       "type" : "zeebe:input"
     },
-    "type" : "Dropdown",
     "choices" : [ {
       "name" : "Template",
       "value" : "template"
     }, {
       "name" : "XML compatible JSON",
       "value" : "json"
-    } ]
-  }, {
-    "id" : "body.template",
-    "label" : "XML template",
-    "optional" : false,
-    "feel" : "optional",
+    } ],
+    "description" : "The XML definition of the SOAP body",
     "group" : "soap-message",
+    "id" : "body.type",
+    "label" : "SOAP body",
+    "type" : "Dropdown",
+    "value" : "json"
+  }, {
     "binding" : {
       "name" : "body.template",
       "type" : "zeebe:input"
@@ -527,14 +522,14 @@
       "equals" : "template",
       "type" : "simple"
     },
+    "feel" : "optional",
+    "group" : "soap-message",
+    "id" : "body.template",
+    "label" : "XML template",
+    "optional" : false,
     "tooltip" : "The template for the body in XML format",
     "type" : "Text"
   }, {
-    "id" : "body.context",
-    "label" : "XML template context",
-    "optional" : false,
-    "feel" : "required",
-    "group" : "soap-message",
     "binding" : {
       "name" : "body.context",
       "type" : "zeebe:input"
@@ -544,14 +539,14 @@
       "equals" : "template",
       "type" : "simple"
     },
+    "feel" : "required",
+    "group" : "soap-message",
+    "id" : "body.context",
+    "label" : "XML template context",
+    "optional" : false,
     "tooltip" : "The context that is used to fill the template",
     "type" : "String"
   }, {
-    "id" : "body.json",
-    "label" : "JSON definition",
-    "optional" : false,
-    "feel" : "required",
-    "group" : "soap-message",
     "binding" : {
       "name" : "body.json",
       "type" : "zeebe:input"
@@ -561,120 +556,125 @@
       "equals" : "json",
       "type" : "simple"
     },
+    "feel" : "required",
+    "group" : "soap-message",
+    "id" : "body.json",
+    "label" : "JSON definition",
+    "optional" : false,
     "tooltip" : "Definition of the SOAP body as JSON object",
     "type" : "String"
   }, {
-    "id" : "namespaces",
-    "label" : "Namespaces",
-    "optional" : true,
-    "feel" : "required",
-    "group" : "soap-message",
     "binding" : {
       "name" : "namespaces",
       "type" : "zeebe:input"
     },
+    "feel" : "required",
+    "group" : "soap-message",
+    "id" : "namespaces",
+    "label" : "Namespaces",
+    "optional" : true,
     "tooltip" : "The namespaces that should be declared on the SOAP Envelope",
     "type" : "String"
   }, {
-    "id" : "connectionTimeoutInSeconds",
-    "label" : "Connection timeout in seconds",
-    "optional" : true,
-    "value" : 20,
-    "feel" : "static",
-    "group" : "timeout",
     "binding" : {
       "name" : "connectionTimeoutInSeconds",
       "type" : "zeebe:input"
     },
+    "feel" : "static",
+    "group" : "timeout",
+    "id" : "connectionTimeoutInSeconds",
+    "label" : "Connection timeout in seconds",
+    "optional" : true,
     "tooltip" : "Time in seconds to wait when establishing a connection, or 0 to wait indefinitely",
-    "type" : "Number"
+    "type" : "Number",
+    "value" : 20
   }, {
-    "id" : "version",
-    "label" : "Version",
-    "description" : "Version of the element template",
-    "value" : "2",
-    "group" : "connector",
     "binding" : {
       "key" : "elementTemplateVersion",
       "type" : "zeebe:taskHeader"
     },
-    "type" : "Hidden"
-  }, {
-    "id" : "id",
-    "label" : "ID",
-    "description" : "ID of the element template",
-    "value" : "io.camunda:soap",
+    "description" : "Version of the element template",
     "group" : "connector",
+    "id" : "version",
+    "label" : "Version",
+    "type" : "Hidden",
+    "value" : "2"
+  }, {
     "binding" : {
       "key" : "elementTemplateId",
       "type" : "zeebe:taskHeader"
     },
-    "type" : "Hidden"
+    "description" : "ID of the element template",
+    "group" : "connector",
+    "id" : "id",
+    "label" : "ID",
+    "type" : "Hidden",
+    "value" : "io.camunda:soap"
   }, {
-    "id" : "resultVariable",
-    "label" : "Result variable",
-    "description" : "Name of variable to store the response in. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-variable\" target=\"_blank\">documentation</a>.",
-    "group" : "output",
     "binding" : {
       "key" : "resultVariable",
       "type" : "zeebe:taskHeader"
     },
+    "description" : "Name of variable to store the response in. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-variable\" target=\"_blank\">documentation</a>.",
+    "group" : "output",
+    "id" : "resultVariable",
+    "label" : "Result variable",
     "type" : "String"
   }, {
-    "id" : "resultExpression",
-    "label" : "Result expression",
-    "description" : "Expression to map the response into process variables. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-expression\" target=\"_blank\">documentation</a>.",
-    "feel" : "required",
-    "group" : "output",
     "binding" : {
       "key" : "resultExpression",
       "type" : "zeebe:taskHeader"
     },
+    "description" : "Expression to map the response into process variables. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-expression\" target=\"_blank\">documentation</a>.",
+    "feel" : "required",
+    "group" : "output",
+    "id" : "resultExpression",
+    "label" : "Result expression",
     "type" : "Text"
   }, {
-    "id" : "errorExpression",
-    "label" : "Error expression",
-    "description" : "Expression to handle errors. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/\" target=\"_blank\">documentation</a>.",
-    "feel" : "required",
-    "group" : "error",
     "binding" : {
       "key" : "errorExpression",
       "type" : "zeebe:taskHeader"
     },
+    "description" : "Expression to handle errors. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/\" target=\"_blank\">documentation</a>.",
+    "feel" : "required",
+    "group" : "error",
+    "id" : "errorExpression",
+    "label" : "Error expression",
     "type" : "Text"
   }, {
-    "id" : "retryCount",
-    "label" : "Retries",
-    "description" : "Number of retries",
-    "value" : "3",
-    "feel" : "optional",
-    "group" : "retries",
     "binding" : {
       "property" : "retries",
       "type" : "zeebe:taskDefinition"
     },
-    "type" : "String"
-  }, {
-    "id" : "retryBackoff",
-    "label" : "Retry backoff",
-    "description" : "ISO-8601 duration to wait between retries",
-    "value" : "PT30S",
+    "description" : "Number of retries",
+    "feel" : "optional",
     "group" : "retries",
+    "id" : "retryCount",
+    "label" : "Retries",
+    "type" : "String",
+    "value" : "3"
+  }, {
     "binding" : {
       "key" : "retryBackoff",
       "type" : "zeebe:taskHeader"
     },
-    "type" : "String"
-  }, {
-    "id" : "jobTimeout",
-    "label" : "Job timeout",
-    "description" : "ISO-8601 duration after which Zeebe considers this job timed out if not yet completed. Leave empty to use the default timeout",
-    "optional" : true,
+    "description" : "ISO-8601 duration to wait between retries",
     "group" : "retries",
+    "id" : "retryBackoff",
+    "label" : "Retry backoff",
+    "type" : "String",
+    "value" : "PT30S"
+  }, {
     "binding" : {
       "key" : "jobTimeout",
       "type" : "zeebe:taskHeader"
     },
+    "description" : "ISO-8601 duration after which Zeebe considers this job timed out if not yet completed. Leave empty to use the default timeout",
+    "group" : "retries",
+    "id" : "jobTimeout",
+    "label" : "Job timeout",
+    "optional" : true,
     "type" : "String"
   } ],
   "icon" : {

--- a/connectors/soap/pom.xml
+++ b/connectors/soap/pom.xml
@@ -104,7 +104,7 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
+      <groupId>tools.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
       <scope>provided</scope>
     </dependency>
@@ -113,7 +113,7 @@
       <artifactId>jmustache</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
+      <groupId>tools.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
       <scope>provided</scope>
     </dependency>

--- a/element-template-generator/congen-cli/pom.xml
+++ b/element-template-generator/congen-cli/pom.xml
@@ -33,7 +33,7 @@
     </dependency>
 
     <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
+      <groupId>tools.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
     </dependency>
 

--- a/element-template-generator/core/pom.xml
+++ b/element-template-generator/core/pom.xml
@@ -36,8 +36,24 @@
       <artifactId>connector-feel</artifactId>
     </dependency>
     <dependency>
+      <groupId>tools.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
+    <!-- Jackson 2: TemplatePropertiesUtil recognizes both Jackson major versions' JsonNode (most
+         connectors haven't migrated yet), and ClassBasedDocsGenerator needs it resolvable for
+         connector-feel's FeelExpressionEvaluator overloads. Declared at compile scope rather than
+         test scope: a closer (test-scoped) declaration here would otherwise shadow the transitive
+         compile-scope dependency from connector-feel that main src relies on. -->
+    <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
+    </dependency>
+    <!-- Jackson 2: only ConfigurationTemplateSchemaTest references this directly (for
+         JsonGenerator), so test scope is correct here. -->
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>jakarta.validation</groupId>

--- a/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/ClassBasedDocsGenerator.java
+++ b/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/ClassBasedDocsGenerator.java
@@ -16,14 +16,11 @@
  */
 package io.camunda.connector.generator.java;
 
-import static com.fasterxml.jackson.databind.MapperFeature.SORT_PROPERTIES_ALPHABETICALLY;
 import static io.camunda.connector.util.reflection.ReflectionUtil.getRequiredAnnotation;
 import static java.lang.Boolean.TRUE;
+import static tools.jackson.databind.MapperFeature.SORT_PROPERTIES_ALPHABETICALLY;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectWriter;
-import com.fasterxml.jackson.databind.SerializationFeature;
 import io.camunda.connector.feel.LocalFeelExpressionEvaluator;
 import io.camunda.connector.generator.api.DocsGenerator;
 import io.camunda.connector.generator.api.DocsGeneratorConfiguration;
@@ -64,6 +61,8 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
+import tools.jackson.databind.ObjectWriter;
+import tools.jackson.databind.SerializationFeature;
 import uk.co.jemos.podam.api.DataProviderStrategy;
 import uk.co.jemos.podam.api.PodamFactory;
 import uk.co.jemos.podam.api.PodamFactoryImpl;
@@ -72,10 +71,12 @@ public class ClassBasedDocsGenerator implements DocsGenerator<Class<?>> {
 
   private static final ObjectWriter OBJECT_WRITER =
       ConnectorsObjectMapperSupplier.getCopy()
+          .rebuild()
           .enable(SORT_PROPERTIES_ALPHABETICALLY)
           .enable(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS)
-          .setSerializationInclusion(JsonInclude.Include.NON_NULL)
-          .registerModule(new ElementTemplateModule())
+          .changeDefaultPropertyInclusion(v -> v.withValueInclusion(JsonInclude.Include.NON_NULL))
+          .addModule(new ElementTemplateModule())
+          .build()
           .writerWithDefaultPrettyPrinter();
   private static final LocalFeelExpressionEvaluator feelEngine = new LocalFeelExpressionEvaluator();
   private final ClassLoader classLoader;
@@ -150,13 +151,7 @@ public class ClassBasedDocsGenerator implements DocsGenerator<Class<?>> {
     DataProviderStrategy strategy = new DocsDataProviderStrategy();
     PodamFactory factory = new PodamFactoryImpl(strategy);
     var exampleOutput = factory.manufacturePojo(type);
-    String exampleOutputJson;
-    try {
-      exampleOutputJson = OBJECT_WRITER.writeValueAsString(exampleOutput);
-    } catch (JsonProcessingException e) {
-      throw new RuntimeException(e);
-    }
-    return exampleOutputJson;
+    return OBJECT_WRITER.writeValueAsString(exampleOutput);
   }
 
   @Override

--- a/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/ClassBasedTemplateGenerator.java
+++ b/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/ClassBasedTemplateGenerator.java
@@ -19,8 +19,6 @@ package io.camunda.connector.generator.java;
 import static io.camunda.connector.generator.java.util.OperationBasedConnectorUtil.*;
 import static io.camunda.connector.generator.java.util.TemplateGenerationStringUtil.camelCaseToSpaces;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.connector.api.annotation.Operation;
 import io.camunda.connector.api.inbound.InboundConnectorExecutable;
 import io.camunda.connector.api.outbound.OutboundConnectorFunction;
@@ -41,6 +39,7 @@ import io.camunda.connector.util.reflection.ReflectionUtil.MethodWithAnnotation;
 import java.util.*;
 import java.util.regex.Pattern;
 import org.apache.commons.lang3.StringUtils;
+import tools.jackson.databind.ObjectMapper;
 
 public class ClassBasedTemplateGenerator implements ElementTemplateGenerator<Class<?>> {
 
@@ -389,11 +388,7 @@ public class ClassBasedTemplateGenerator implements ElementTemplateGenerator<Cla
     if (json == null) {
       return "";
     }
-    try {
-      return TOOLTIP_JSON_MAPPER.readTree(json).toString();
-    } catch (JsonProcessingException e) {
-      throw new IllegalStateException("Failed to compact JSON for tooltip: " + json, e);
-    }
+    return TOOLTIP_JSON_MAPPER.readTree(json).toString();
   }
 
   private static String escapeHtml(String value) {

--- a/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/json/ElementTemplateModule.java
+++ b/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/json/ElementTemplateModule.java
@@ -16,7 +16,7 @@
  */
 package io.camunda.connector.generator.java.json;
 
-import com.fasterxml.jackson.databind.module.SimpleModule;
+import tools.jackson.databind.module.SimpleModule;
 
 public class ElementTemplateModule extends SimpleModule {
 

--- a/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/json/FeelModelSerializer.java
+++ b/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/json/FeelModelSerializer.java
@@ -16,17 +16,15 @@
  */
 package io.camunda.connector.generator.java.json;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.JsonSerializer;
-import com.fasterxml.jackson.databind.SerializerProvider;
 import io.camunda.connector.generator.java.annotation.FeelMode;
-import java.io.IOException;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.databind.SerializationContext;
+import tools.jackson.databind.ValueSerializer;
 
-public class FeelModelSerializer extends JsonSerializer<FeelMode> {
+public class FeelModelSerializer extends ValueSerializer<FeelMode> {
   @Override
   public void serialize(
-      FeelMode feelMode, JsonGenerator jsonGenerator, SerializerProvider serializerProvider)
-      throws IOException {
+      FeelMode feelMode, JsonGenerator jsonGenerator, SerializationContext serializationContext) {
     if (feelMode == FeelMode.staticFeel) {
       // The Element Template specification expects "static" instead of "staticFeel" for the static
       // FEEL mode.

--- a/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/util/TemplatePropertiesUtil.java
+++ b/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/util/TemplatePropertiesUtil.java
@@ -18,7 +18,6 @@ package io.camunda.connector.generator.java.util;
 
 import static io.camunda.connector.util.reflection.ReflectionUtil.getAllFields;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import io.camunda.connector.api.annotation.Header;
 import io.camunda.connector.api.annotation.Variable;
 import io.camunda.connector.api.document.Document;
@@ -50,6 +49,7 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.ClassUtils;
 import org.apache.commons.lang3.StringUtils;
+import tools.jackson.databind.JsonNode;
 
 /** Utility class for transforming data classes into {@link PropertyBuilder} instances. */
 public class TemplatePropertiesUtil {
@@ -493,6 +493,9 @@ public class TemplatePropertiesUtil {
         };
     if (Object.class.equals(parameterType)
         || JsonNode.class.equals(parameterType)
+        // Most connectors haven't migrated to Jackson 3 yet, so a field may still be typed as the
+        // Jackson 2 JsonNode.
+        || com.fasterxml.jackson.databind.JsonNode.class.equals(parameterType)
         || Collection.class.isAssignableFrom(parameterType)
         || Map.class.isAssignableFrom(parameterType)) {
       builder.feel(FeelMode.required);
@@ -711,6 +714,9 @@ public class TemplatePropertiesUtil {
         && type != String.class
         && type != Object.class
         && type != JsonNode.class
+        // Most connectors haven't migrated to Jackson 3 yet, so a field may still be typed as the
+        // Jackson 2 JsonNode.
+        && type != com.fasterxml.jackson.databind.JsonNode.class
         && !Document.class.isAssignableFrom(type)
         && !type.isEnum()
         && !type.isArray()

--- a/element-template-generator/core/src/test/java/io/camunda/connector/generator/dsl/ElementTemplateSerializationTest.java
+++ b/element-template-generator/core/src/test/java/io/camunda/connector/generator/dsl/ElementTemplateSerializationTest.java
@@ -19,7 +19,6 @@ package io.camunda.connector.generator.dsl;
 import static io.camunda.connector.generator.java.annotation.BpmnType.*;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.connector.generator.dsl.DropdownProperty.DropdownChoice;
 import io.camunda.connector.generator.dsl.PropertyBinding.ZeebeInput;
 import io.camunda.connector.generator.dsl.PropertyBinding.ZeebeTaskHeader;
@@ -34,11 +33,13 @@ import java.util.Set;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 
 public class ElementTemplateSerializationTest {
 
   private final ObjectMapper objectMapper =
-      new ObjectMapper().registerModule(new ElementTemplateModule());
+      JsonMapper.builder().addModule(new ElementTemplateModule()).build();
 
   @Test
   void serializationTest() throws Exception {

--- a/element-template-generator/core/src/test/java/io/camunda/connector/generator/java/ConfigurationTemplateSchemaTest.java
+++ b/element-template-generator/core/src/test/java/io/camunda/connector/generator/java/ConfigurationTemplateSchemaTest.java
@@ -18,8 +18,12 @@ package io.camunda.connector.generator.java;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.networknt.schema.JsonSchema;
 import com.networknt.schema.JsonSchemaFactory;
 import com.networknt.schema.SpecVersion.VersionFlag;
@@ -29,8 +33,9 @@ import io.camunda.connector.api.annotation.OutboundConnector;
 import io.camunda.connector.api.outbound.OutboundConnectorContext;
 import io.camunda.connector.api.outbound.OutboundConnectorFunction;
 import io.camunda.connector.generator.java.annotation.ElementTemplate;
+import io.camunda.connector.generator.java.annotation.FeelMode;
 import io.camunda.connector.generator.java.annotation.TemplateProperty;
-import io.camunda.connector.generator.java.json.ElementTemplateModule;
+import java.io.IOException;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
@@ -58,8 +63,24 @@ public class ConfigurationTemplateSchemaTest {
           + SCHEMA_VERSION
           + "/resources/schema.json";
 
+  // The generator's own ElementTemplateModule is Jackson 3 (see ClassBasedDocsGenerator), but
+  // com.networknt:json-schema-validator here is still Jackson 2-only, so this test needs its own
+  // Jackson 2 FeelMode serializer to keep enum rendering ("static" instead of "staticFeel")
+  // consistent with what the generator actually produces.
   private static final ObjectMapper MAPPER =
-      new ObjectMapper().registerModule(new ElementTemplateModule());
+      new ObjectMapper()
+          .registerModule(
+              new SimpleModule()
+                  .addSerializer(
+                      FeelMode.class,
+                      new JsonSerializer<>() {
+                        @Override
+                        public void serialize(
+                            FeelMode value, JsonGenerator gen, SerializerProvider serializers)
+                            throws IOException {
+                          gen.writeString(value == FeelMode.staticFeel ? "static" : value.name());
+                        }
+                      }));
 
   private final ClassBasedTemplateGenerator generator = new ClassBasedTemplateGenerator();
 

--- a/element-template-generator/maven-plugin/pom.xml
+++ b/element-template-generator/maven-plugin/pom.xml
@@ -33,7 +33,7 @@
     </dependency>
 
     <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
+      <groupId>tools.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
     </dependency>
 

--- a/element-template-generator/maven-plugin/src/main/java/io/camunda/connector/generator/ElementTemplateGeneratorMojo.java
+++ b/element-template-generator/maven-plugin/src/main/java/io/camunda/connector/generator/ElementTemplateGeneratorMojo.java
@@ -16,11 +16,6 @@
  */
 package io.camunda.connector.generator;
 
-import com.fasterxml.jackson.core.util.DefaultIndenter;
-import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.ObjectWriter;
 import io.camunda.connector.api.inbound.InboundConnectorExecutable;
 import io.camunda.connector.api.outbound.OutboundConnectorFunction;
 import io.camunda.connector.api.outbound.OutboundConnectorProvider;
@@ -58,6 +53,13 @@ import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
 import org.apache.maven.project.MavenProject;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.util.DefaultIndenter;
+import tools.jackson.core.util.DefaultPrettyPrinter;
+import tools.jackson.databind.DeserializationFeature;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectWriter;
+import tools.jackson.databind.json.JsonMapper;
 
 @Mojo(
     name = "generate-templates",
@@ -66,11 +68,13 @@ import org.apache.maven.project.MavenProject;
 public class ElementTemplateGeneratorMojo extends AbstractMojo {
 
   private static final ObjectMapper objectMapper =
-      new ObjectMapper().disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+      JsonMapper.builder().disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES).build();
   private static final ObjectWriter objectWriter =
-      new ObjectMapper()
-          .registerModule(new ElementTemplateModule())
-          .writer(
+      JsonMapper.builder()
+          .addModule(new ElementTemplateModule())
+          .build()
+          .writer()
+          .with(
               new DefaultPrettyPrinter()
                   .withObjectIndenter(new DefaultIndenter().withLinefeed("\n")));
   private static final String COMPILED_CLASSES_DIR = "target" + File.separator + "classes";
@@ -99,7 +103,7 @@ public class ElementTemplateGeneratorMojo extends AbstractMojo {
   private Optional<VersionedElementTemplate> getBasicElementTemplate(File file) {
     try {
       return Optional.of(objectMapper.readValue(file, VersionedElementTemplate.class));
-    } catch (IOException e) {
+    } catch (JacksonException e) {
       // Skip templates that cannot be parsed (e.g., templates from other tools with incompatible
       // formats)
       getLog()

--- a/element-template-generator/openapi-parser/pom.xml
+++ b/element-template-generator/openapi-parser/pom.xml
@@ -32,6 +32,11 @@
     </dependency>
 
     <dependency>
+      <groupId>tools.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
+    <!-- Jackson 2: OpenApiGenerationSource uses jackson-dataformat-yaml (Jackson 2-only) directly. -->
+    <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
     </dependency>

--- a/element-template-generator/openapi-parser/src/main/java/io/camunda/connector/generator/openapi/util/ParameterUtil.java
+++ b/element-template-generator/openapi-parser/src/main/java/io/camunda/connector/generator/openapi/util/ParameterUtil.java
@@ -16,7 +16,6 @@
  */
 package io.camunda.connector.generator.openapi.util;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import io.camunda.connector.generator.dsl.http.HttpOperationProperty;
 import io.camunda.connector.generator.dsl.http.HttpOperationProperty.Target;
 import io.camunda.connector.jackson.ConnectorsObjectMapperSupplier;
@@ -182,13 +181,9 @@ public class ParameterUtil {
     } else if (data instanceof Boolean || data instanceof Number) {
       return data.toString();
     }
-    try {
-      return ConnectorsObjectMapperSupplier.getCopy()
-          .writerWithDefaultPrettyPrinter()
-          .writeValueAsString(data);
-    } catch (JsonProcessingException e) {
-      throw new RuntimeException(e);
-    }
+    return ConnectorsObjectMapperSupplier.getCopy()
+        .writerWithDefaultPrettyPrinter()
+        .writeValueAsString(data);
   }
 
   private static Object generateFakeDataFromSchema(Schema<?> schema, Components components) {

--- a/element-template-generator/postman-collections-parser/pom.xml
+++ b/element-template-generator/postman-collections-parser/pom.xml
@@ -29,6 +29,10 @@
       <artifactId>jackson-databind</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
     </dependency>

--- a/element-template-generator/uniquet/pom.xml
+++ b/element-template-generator/uniquet/pom.xml
@@ -30,7 +30,7 @@
     </dependency>
 
     <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
+      <groupId>tools.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
     </dependency>
 

--- a/element-template-generator/uniquet/src/main/java/io/camunda/connector/uniquet/core/ConnectorsFinder.java
+++ b/element-template-generator/uniquet/src/main/java/io/camunda/connector/uniquet/core/ConnectorsFinder.java
@@ -18,8 +18,6 @@ package io.camunda.connector.uniquet.core;
 
 import static io.camunda.connector.uniquet.core.FileHelper.getBaseName;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.connector.uniquet.dto.Connector;
 import java.io.File;
 import java.io.IOException;
@@ -30,6 +28,8 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Stream;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
 
 public class ConnectorsFinder {
 
@@ -128,13 +128,9 @@ public class ConnectorsFinder {
   }
 
   private boolean isIgnoredTemplate(File file) {
-    try {
-      JsonNode root = objectMapper.readTree(file);
-      JsonNode idNode = root.get("id");
-      var a = idNode != null && IGNORED_TEMPLATE_IDS.contains(idNode.asText());
-      return !a;
-    } catch (IOException e) {
-      throw new RuntimeException(e);
-    }
+    JsonNode root = objectMapper.readTree(file);
+    JsonNode idNode = root.get("id");
+    var a = idNode != null && IGNORED_TEMPLATE_IDS.contains(idNode.asText());
+    return !a;
   }
 }

--- a/element-template-generator/uniquet/src/main/java/io/camunda/connector/uniquet/core/FileHelper.java
+++ b/element-template-generator/uniquet/src/main/java/io/camunda/connector/uniquet/core/FileHelper.java
@@ -16,12 +16,8 @@
  */
 package io.camunda.connector.uniquet.core;
 
-import static com.fasterxml.jackson.core.util.DefaultIndenter.SYSTEM_LINEFEED_INSTANCE;
+import static tools.jackson.core.util.DefaultIndenter.SYSTEM_LINEFEED_INSTANCE;
 
-import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.ObjectWriter;
 import java.io.File;
 import java.io.IOException;
 import java.util.Map;
@@ -31,12 +27,17 @@ import org.eclipse.jgit.lib.ObjectId;
 import org.eclipse.jgit.lib.Repository;
 import org.eclipse.jgit.revwalk.RevCommit;
 import org.eclipse.jgit.revwalk.RevWalk;
+import tools.jackson.core.util.DefaultPrettyPrinter;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectWriter;
 
 public class FileHelper {
   private static final ObjectMapper mapper = new ObjectMapper();
   private static final ObjectWriter objectWriter =
       new ObjectMapper()
-          .writer(new DefaultPrettyPrinter().withObjectIndenter(SYSTEM_LINEFEED_INSTANCE));
+          .writer()
+          .with(new DefaultPrettyPrinter().withObjectIndenter(SYSTEM_LINEFEED_INSTANCE));
 
   public static String getBaseName(File file) {
     String filename = file.getName();
@@ -48,11 +49,7 @@ public class FileHelper {
   }
 
   public static JsonNode toJsonNode(File jsonFile) {
-    try {
-      return mapper.readTree(jsonFile);
-    } catch (IOException e) {
-      throw new RuntimeException(e);
-    }
+    return mapper.readTree(jsonFile);
   }
 
   public static void writeToFile(File file, JsonNode jsonNode) {

--- a/element-template-generator/uniquet/src/main/java/io/camunda/connector/uniquet/core/IndexWriter.java
+++ b/element-template-generator/uniquet/src/main/java/io/camunda/connector/uniquet/core/IndexWriter.java
@@ -18,7 +18,6 @@ package io.camunda.connector.uniquet.core;
 
 import static io.camunda.connector.uniquet.core.FileHelper.*;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import io.camunda.connector.uniquet.dto.Connector;
 import io.camunda.connector.uniquet.dto.Engine;
 import io.camunda.connector.uniquet.dto.OutputElementTemplate;
@@ -27,6 +26,7 @@ import java.nio.file.Path;
 import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import tools.jackson.databind.JsonNode;
 
 public class IndexWriter {
 

--- a/element-template-generator/uniquet/src/test/java/io/camunda/connector/uniquet/core/IndexWriterTest.java
+++ b/element-template-generator/uniquet/src/test/java/io/camunda/connector/uniquet/core/IndexWriterTest.java
@@ -21,9 +21,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ArrayNode;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -31,6 +28,9 @@ import java.nio.file.Path;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
 import org.mockito.MockedStatic;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.node.ArrayNode;
 
 class IndexWriterTest {
 

--- a/element-template-generator/validator/pom.xml
+++ b/element-template-generator/validator/pom.xml
@@ -34,6 +34,10 @@
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
     </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>info.picocli</groupId>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -86,8 +86,10 @@ limitations under the License.</license.inlineheader>
     <version.mockito>5.23.0</version.mockito>
     <version.junit-jupiter>6.1.2</version.junit-jupiter>
     <version.assertj>3.27.7</version.assertj>
-    <version.jackson-bom>2.22.1</version.jackson-bom>
-    <version.jackson-datatype-jsr310>2.22.1</version.jackson-datatype-jsr310>
+    <version.jackson-bom>3.2.1</version.jackson-bom>
+    <!-- Jackson 2, kept only for the handful of modules that cannot move to Jackson 3 yet
+         because a transitive dependency (jackson-module-scala) has no Jackson 3 release. -->
+    <version.jackson2-legacy>2.22.1</version.jackson2-legacy>
     <version.hibernate-validator>9.1.3.Final</version.hibernate-validator>
     <version.jsonassert>1.5.3</version.jsonassert>
     <version.json>20250517</version.json>
@@ -209,18 +211,36 @@ limitations under the License.</license.inlineheader>
 
   <dependencyManagement>
     <dependencies>
-      <!-- Jackson BOM -->
+      <!-- Jackson BOM (Jackson 3; jackson-annotations stays on the com.fasterxml.jackson.core
+           groupId, it did not move to tools.jackson. Jdk8Module/JavaTimeModule are built into
+           jackson-databind in Jackson 3, so no separate jsr310 datatype dependency is needed. -->
       <dependency>
-        <groupId>com.fasterxml.jackson</groupId>
+        <groupId>tools.jackson</groupId>
         <artifactId>jackson-bom</artifactId>
         <version>${version.jackson-bom}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
+
+      <!-- Jackson 2, for modules still blocked on jackson-module-scala (see comment on
+           version.jackson2-legacy above). Remove once that dependency ships a Jackson 3 release
+           and connector-feel/jackson-datatype-document's legacy serializer are dropped. -->
       <dependency>
-        <groupId>com.fasterxml.jackson.datatype</groupId>
-        <artifactId>jackson-datatype-jsr310</artifactId>
-        <version>${version.jackson-datatype-jsr310}</version>
+        <groupId>com.fasterxml.jackson.core</groupId>
+        <artifactId>jackson-databind</artifactId>
+        <version>${version.jackson2-legacy}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.fasterxml.jackson.core</groupId>
+        <artifactId>jackson-core</artifactId>
+        <version>${version.jackson2-legacy}</version>
+      </dependency>
+      <!-- jackson-module-scala pins a strict jackson-databind compatibility range per release;
+           keep it in lockstep with version.jackson2-legacy above. -->
+      <dependency>
+        <groupId>com.fasterxml.jackson.module</groupId>
+        <artifactId>jackson-module-scala_2.13</artifactId>
+        <version>${version.jackson2-legacy}</version>
       </dependency>
 
       <!--
@@ -1194,13 +1214,16 @@ See: https://nvd.nist.gov/vuln/detail/CVE-2026-59949
                   <!-- included in junit-jupiter, ignore for cleaner pom -->
                   <dependency>org.junit.jupiter:junit-jupiter-api</dependency>
                   <dependency>org.junit.jupiter:junit-jupiter-params</dependency>
-                  <!-- jackson core and jackson-annotations are transitive from jackson-databind -->
+                  <!-- jackson core and jackson-annotations are transitive from jackson-databind
+                       (both Jackson 3, and Jackson 2 for modules still on it) -->
+                  <dependency>tools.jackson.core:jackson-core</dependency>
                   <dependency>com.fasterxml.jackson.core:jackson-core</dependency>
                   <dependency>com.fasterxml.jackson.core:jackson-annotations</dependency>
                   <!-- false-positive, transitive from jsonassert -->
                   <dependency>com.vaadin.external.google:android-json</dependency>
                 </ignoredUsedUndeclaredDependencies>
                 <ignoredNonTestScopedDependencies>
+                  <dependency>tools.jackson.core:jackson-core</dependency>
                   <dependency>com.fasterxml.jackson.core:jackson-core</dependency>
                 </ignoredNonTestScopedDependencies>
               </configuration>

--- a/secret-providers/aws/pom.xml
+++ b/secret-providers/aws/pom.xml
@@ -45,7 +45,7 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
+      <groupId>tools.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
     </dependency>
     <dependency>

--- a/secret-providers/aws/src/main/java/io/camunda/connector/secret/providers/AwsSecretProvider.java
+++ b/secret-providers/aws/src/main/java/io/camunda/connector/secret/providers/AwsSecretProvider.java
@@ -16,7 +16,6 @@
  */
 package io.camunda.connector.secret.providers;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.connector.api.error.ConnectorException;
 import java.util.Objects;
 import org.slf4j.Logger;
@@ -25,6 +24,7 @@ import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
 import software.amazon.awssdk.services.secretsmanager.model.GetSecretValueRequest;
 import software.amazon.awssdk.services.secretsmanager.model.GetSecretValueResponse;
 import software.amazon.awssdk.services.secretsmanager.model.SecretsManagerException;
+import tools.jackson.databind.ObjectMapper;
 
 public class AwsSecretProvider extends AbstractSecretProvider implements AutoCloseable {
 

--- a/secret-providers/gcp/pom.xml
+++ b/secret-providers/gcp/pom.xml
@@ -53,7 +53,7 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
+      <groupId>tools.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
     </dependency>
     <dependency>

--- a/secret-providers/gcp/src/main/java/io/camunda/connector/secret/providers/GcpSecretProvider.java
+++ b/secret-providers/gcp/src/main/java/io/camunda/connector/secret/providers/GcpSecretProvider.java
@@ -16,12 +16,12 @@
  */
 package io.camunda.connector.secret.providers;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.cloud.secretmanager.v1.AccessSecretVersionResponse;
 import com.google.cloud.secretmanager.v1.SecretManagerServiceClient;
 import com.google.cloud.secretmanager.v1.SecretVersionName;
 import java.util.Objects;
 import org.slf4j.Logger;
+import tools.jackson.databind.ObjectMapper;
 
 public class GcpSecretProvider extends AbstractSecretProvider {
 

--- a/secret-providers/secret-providers-base/pom.xml
+++ b/secret-providers/secret-providers-base/pom.xml
@@ -31,16 +31,8 @@
     </dependency>
     <!-- Jackson -->
     <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
+      <groupId>tools.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>com.fasterxml.jackson.datatype</groupId>
-      <artifactId>jackson-datatype-jdk8</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>com.fasterxml.jackson.datatype</groupId>
-      <artifactId>jackson-datatype-jsr310</artifactId>
     </dependency>
 
     <dependency>

--- a/secret-providers/secret-providers-base/src/main/java/io/camunda/connector/secret/providers/AbstractSecretProvider.java
+++ b/secret-providers/secret-providers-base/src/main/java/io/camunda/connector/secret/providers/AbstractSecretProvider.java
@@ -16,15 +16,10 @@
  */
 package io.camunda.connector.secret.providers;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
+import com.google.common.util.concurrent.UncheckedExecutionException;
 import io.camunda.connector.api.error.ConnectorException;
 import io.camunda.connector.api.secret.SecretContext;
 import io.camunda.connector.api.secret.SecretProvider;
@@ -35,6 +30,10 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import tools.jackson.databind.DeserializationFeature;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.SerializationFeature;
+import tools.jackson.databind.json.JsonMapper;
 
 public abstract class AbstractSecretProvider implements SecretProvider, AutoCloseable {
 
@@ -48,11 +47,10 @@ public abstract class AbstractSecretProvider implements SecretProvider, AutoClos
 
   private static final Logger logger = LoggerFactory.getLogger(AbstractSecretProvider.class);
   private static final ObjectMapper DEFAULT_MAPPER =
-      new ObjectMapper()
-          .registerModule(new Jdk8Module())
-          .registerModule(new JavaTimeModule())
+      JsonMapper.builder()
           .disable(SerializationFeature.FAIL_ON_EMPTY_BEANS)
-          .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+          .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+          .build();
   private static final String CACHE_KEY = "SECRETS";
   private final String clusterId;
   private final String secretsProjectId;
@@ -90,7 +88,7 @@ public abstract class AbstractSecretProvider implements SecretProvider, AutoClos
     CacheLoader<String, Map<String, String>> loader =
         new CacheLoader<>() {
           @Override
-          public Map<String, String> load(String key) throws JsonProcessingException {
+          public Map<String, String> load(String key) {
             return unwrapSecrets(
                 loadSecrets(clusterId, secretsProjectId, secretsNamePrefix, logger));
           }
@@ -103,8 +101,7 @@ public abstract class AbstractSecretProvider implements SecretProvider, AutoClos
         CacheBuilder.newBuilder().refreshAfterWrite(millis, TimeUnit.MILLISECONDS).build(loader);
   }
 
-  protected Map<String, String> unwrapSecrets(final String secretsAsJson)
-      throws JsonProcessingException {
+  protected Map<String, String> unwrapSecrets(final String secretsAsJson) {
     return mapper.readValue(secretsAsJson, Map.class);
   }
 
@@ -115,7 +112,9 @@ public abstract class AbstractSecretProvider implements SecretProvider, AutoClos
   public String getSecret(String name, SecretContext context) {
     try {
       return secretsCache.get(CACHE_KEY).get(name);
-    } catch (ExecutionException e) {
+    } catch (ExecutionException | UncheckedExecutionException e) {
+      // Jackson 3 exceptions are unchecked, so Guava wraps them as UncheckedExecutionException
+      // rather than ExecutionException when they escape the CacheLoader.
       throw new ConnectorException("Could not resolve secrets: " + e.getMessage(), e);
     }
   }


### PR DESCRIPTION
This pull request updates the project to use Jackson 3 (now under the `tools.jackson` namespace) and removes legacy Jackson 2 modules and features. The changes ensure compatibility with Jackson 3, update dependency management, and adapt code to new APIs and feature flags. The most important changes are grouped below.

**Migration to Jackson 3:**

* All imports and dependencies on `com.fasterxml.jackson.*` have been replaced with `tools.jackson.*` throughout the codebase, including in `pom.xml` files, Java source files, and test files. [[1]](diffhunk://#diff-c79243acc94df642a87911dd85705076fb1840a3071ace5afe20db67d4acf389L20-L34) [[2]](diffhunk://#diff-ede706c7678221f382d2a30f02f0980ab39e4c493e297deef8256df99ba17c9bL19-R48) [[3]](diffhunk://#diff-dee5a29d86f10440d919930673701ba5ca8143b5de3f9970aa56c7ed27f7a6c6L19-R25) [[4]](diffhunk://#diff-866507a5194cea5c19755c78048f6643aba0e5a9ec7cdda28fad0e0eb5431a6eR32-R33) [[5]](diffhunk://#diff-dd805748ba9960526a14c8ab98cddfddad0de17014f51bb65742143736cf4d21R40-R41) F2cbe851L20R20, [[6]](diffhunk://#diff-fb3623d04fadfbe015c3cf69517bba24b0e4986a9b9a4e372968f051e3436c52L19-R22) [[7]](diffhunk://#diff-32a8d4d2960855102beb90b874b1436204695b394f638aaf6bb1a5f0bab79276R31)

**Dependency and Module Cleanup:**

* Removed Jackson 2-specific modules such as `jackson-datatype-jdk8` and `jackson-datatype-jsr310` from dependencies, as they are no longer needed with Jackson 3. [[1]](diffhunk://#diff-c79243acc94df642a87911dd85705076fb1840a3071ace5afe20db67d4acf389L20-L34) [[2]](diffhunk://#diff-e7e1e673cfbb667296f5ccf44f373942f659898c791f9448bca8a780524a3244L42-L52)
* Updated ignored dependencies in Maven plugin configurations to reference the new `tools.jackson.core` group.

**ObjectMapper Configuration Updates:**

* Updated `ObjectMapper` builder configurations in both `ConnectorsObjectMapperSupplier` and `HttpClientObjectMapperSupplier` to use new Jackson 3 feature flags (e.g., `DateTimeFeature`, `EnumFeature`) and removed deprecated or obsolete methods. [[1]](diffhunk://#diff-ede706c7678221f382d2a30f02f0980ab39e4c493e297deef8256df99ba17c9bL19-R48) [[2]](diffhunk://#diff-dee5a29d86f10440d919930673701ba5ca8143b5de3f9970aa56c7ed27f7a6c6L37-R53)
* Changed how custom property inclusion is handled for null values in serialization, using the new Jackson 3 builder API.

**Exception Handling Adjustments:**

* Updated all exception handling from `JsonProcessingException`/`IOException` to the new `JacksonException` in all relevant places. [[1]](diffhunk://#diff-dd805748ba9960526a14c8ab98cddfddad0de17014f51bb65742143736cf4d21L116-R119) [[2]](diffhunk://#diff-b218b567e5d3a81e8753382254039e49e658fb877026485ff456b552b55df304L56-R56) [[3]](diffhunk://#diff-b218b567e5d3a81e8753382254039e49e658fb877026485ff456b552b55df304L117-R117) [[4]](diffhunk://#diff-fb3623d04fadfbe015c3cf69517bba24b0e4986a9b9a4e372968f051e3436c52L35-R35)

**Test Code Updates:**

* Updated test imports and removed unnecessary exception declarations from test methods, reflecting the new Jackson 3 APIs. [[1]](diffhunk://#diff-dc399383ef9c31b501710105fd98ff8f871c2342f648eb34af06c5324bf884eaL22-R33) [[2]](diffhunk://#diff-dc399383ef9c31b501710105fd98ff8f871c2342f648eb34af06c5324bf884eaL44-R59) [[3]](diffhunk://#diff-dc399383ef9c31b501710105fd98ff8f871c2342f648eb34af06c5324bf884eaL70-R69) [[4]](diffhunk://#diff-32a8d4d2960855102beb90b874b1436204695b394f638aaf6bb1a5f0bab79276L22-L23)

These changes modernize the codebase for Jackson 3 compatibility and remove legacy dependencies and patterns.