### PR TITLE
ci: report AlwaysGreen SaaS failures and unblock the silent Slack path

### DIFF
--- a/.github/actions/post-failure-feedback/action.yml
+++ b/.github/actions/post-failure-feedback/action.yml
@@ -41,9 +41,11 @@ inputs:
   pr_is_draft:
     description: >
       Draft state of `pr` when the caller already knows it — on a pull_request
-      trigger pass ${{ github.event.pull_request.draft }}, on merge_group pass
+      trigger pass the event's pull_request.draft value, on merge_group pass
       "false" (a draft cannot enter a merge queue). Empty means resolve it via
-      the API, which needs github_token.
+      the API, which needs github_token. Do not write an expression here: the
+      template engine evaluates it and the github context is unavailable in an
+      action's input metadata, which makes the whole action fail to load.
     required: false
     default: ""
   skip_on_draft:
@@ -70,10 +72,22 @@ inputs:
     required: false
     default: ""
 
+outputs:
+  slack_ts:
+    description: >
+      Timestamp of the Slack message that was posted, so a later job can reply in its
+      thread instead of starting a second top-level message. Empty when Slack was
+      skipped or the post failed.
+    value: ${{ steps.feedback.outputs.slack_ts }}
+  slack_channel:
+    description: "Channel id the message was posted to. Empty when nothing was posted."
+    value: ${{ steps.feedback.outputs.slack_channel }}
+
 runs:
   using: composite
   steps:
     - name: Render & post failure feedback
+      id: feedback
       shell: bash
       continue-on-error: true
       env:

--- a/.github/actions/post-failure-feedback/feedback.mjs
+++ b/.github/actions/post-failure-feedback/feedback.mjs
@@ -174,7 +174,17 @@ async function postSummary(md) {
 // Upsert: one bot comment per PR, updated on re-runs (find by MARKER).
 async function upsertPrComment(m, md) {
   if (!m.pr || !m.repo || !env('GH_TOKEN')) {
-    console.log('[feedback] PR comment skipped (no pr/repo/token)');
+    // Name the missing input: "no pr/repo/token" cannot distinguish a push run
+    // (no PR at all, expected) from a merge_group run whose head_ref did not
+    // parse or whose token was empty (a wiring bug worth fixing).
+    const missing = [
+      !m.pr && `pr (FB_PR=${JSON.stringify(env('FB_PR'))})`,
+      !m.repo && 'repo',
+      !env('GH_TOKEN') && 'github_token',
+    ]
+      .filter(Boolean)
+      .join(', ');
+    console.log(`[feedback] PR comment skipped — missing ${missing}`);
     return;
   }
   try {
@@ -209,6 +219,18 @@ async function upsertPrComment(m, md) {
     }
   } catch (e) {
     console.error(`[feedback] PR comment failed: ${e.message || e}`);
+  }
+}
+
+// Publishes the posted message's identity so a later job in the same run can reply in
+// its thread instead of opening a second top-level message for the same failure.
+async function setStepOutput(name, value) {
+  const file = process.env.GITHUB_OUTPUT;
+  if (!file || !value) return;
+  try {
+    await appendFile(file, `${name}=${value}\n`);
+  } catch (e) {
+    console.error(`[feedback] could not write output ${name}: ${e.message || e}`);
   }
 }
 
@@ -269,7 +291,9 @@ async function postSlack(m) {
     });
     const j = await res.json();
     if (!j.ok) throw new Error(j.error || 'unknown');
-    console.log(`[feedback] posted to Slack ${channel}`);
+    console.log(`[feedback] posted to Slack ${channel} (ts=${j.ts})`);
+    await setStepOutput('slack_ts', j.ts);
+    await setStepOutput('slack_channel', j.channel || channel);
   } catch (e) {
     console.error(`[feedback] Slack post failed: ${e.message || e}`);
   }

--- a/.github/workflows/MERGE_QUEUE_HELM_TEST.yaml
+++ b/.github/workflows/MERGE_QUEUE_HELM_TEST.yaml
@@ -179,11 +179,36 @@ jobs:
     permissions:
       pull-requests: write
       contents: read
+    # Surfaced so a later job can reply in this message's thread instead of
+    # opening a second top-level message for the same failure.
+    outputs:
+      slack_ts: ${{ steps.feedback.outputs.slack_ts }}
+      slack_channel: ${{ steps.feedback.outputs.slack_channel }}
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v7.0.0
         with:
           node-version: "24"
+      # Post as the shared QA bot, like every other AlwaysGreen repo, so one
+      # failure reads as one thread from one sender. The connectors bot is not a
+      # member of the channel and its posts come back not_in_channel.
+      #
+      # This read is currently denied (403): connectors' approle has no policy for
+      # secret/data/products/qa/ci/common. continue-on-error keeps the job summary
+      # and the PR comment working meanwhile — the action skips Slack when the
+      # token is empty — and Slack starts working by itself once the grant lands.
+      - name: Import Slack token
+        id: slack-secrets
+        continue-on-error: true
+        uses: hashicorp/vault-action@v4.0.0
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          exportEnv: false
+          secrets: |
+            secret/data/products/qa/ci/common SLACK_BOT_USER_OAUTH_TOKEN ;
       - name: Generate GitHub App Token
         id: app-token
         uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@main
@@ -198,9 +223,10 @@ jobs:
           vault-url: ${{ secrets.VAULT_ADDR }}
           owner: camunda
           repositories: connectors
-      # Standardised AlwaysGreen feedback → job summary + PR comment (+ Slack once
-      # the channel is set below and the bot is invited to it). Best-effort.
+      # Standardised AlwaysGreen feedback → job summary, PR comment, and Slack.
+      # Best-effort.
       - name: Post AlwaysGreen failure feedback
+        id: feedback
         continue-on-error: true
         uses: ./.github/actions/post-failure-feedback
         with:
@@ -216,9 +242,9 @@ jobs:
           # paying for a lookup that would also need pull-requests: read.
           pr_is_draft: "false"
           # Shared AlwaysGreen channel (#alwaysgreen-reliability) — consistent
-          # across all AlwaysGreen repos. The connectors bot must be a member.
+          # across all AlwaysGreen repos.
           slack_channel: "C0AK0AVKRL0"
-          slack_bot_token: ${{ secrets.CONNECTORS_SLACK_BOT_TOKEN }}
+          slack_bot_token: ${{ steps.slack-secrets.outputs.SLACK_BOT_USER_OAUTH_TOKEN }}
           github_token: ${{ steps.app-token.outputs.token }}
 
   trigger-saas-e2e:
@@ -229,6 +255,12 @@ jobs:
     timeout-minutes: 25
     continue-on-error: ${{ github.event_name == 'merge_group' }}
     permissions: { }
+    # The downstream run is where a SaaS failure is actually diagnosed, so the
+    # feedback job needs its URL to put in the alert.
+    outputs:
+      downstream_run_url: ${{ steps.wait-downstream.outputs.downstream_run_url }}
+      downstream_conclusion: ${{ steps.wait-downstream.outputs.downstream_conclusion }}
+      outcome: ${{ steps.outcome.outputs.status }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
@@ -277,17 +309,6 @@ jobs:
                       "optimizeVersion": "SNAPSHOT"
                   }
                 }'
-
-      - name: Observe build status
-        if: always()
-        continue-on-error: true
-        uses: ./.github/actions/observe-build-status
-        with:
-          build_status: ${{ job.status }}
-          job_name: trigger-saas-e2e
-          secret_vault_address: ${{ secrets.VAULT_ADDR }}
-          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
 
       - name: Wait for downstream workflow to finish
         id: wait-downstream
@@ -365,6 +386,7 @@ jobs:
             echo "Workflow run $RUN_ID status: $STATUS ($CONCLUSION)"
 
             if [[ "$STATUS" == "completed" ]]; then
+              echo "downstream_conclusion=${CONCLUSION}" >> "$GITHUB_OUTPUT"
               if [[ "$CONCLUSION" == "success" ]]; then
                 echo "Downstream workflow succeeded!"
                 exit 0
@@ -377,6 +399,7 @@ jobs:
             sleep 30
           done
 
+          echo "downstream_conclusion=timed-out" >> "$GITHUB_OUTPUT"
           echo "Timed out waiting for downstream workflow to complete."
           exit 1
 
@@ -410,6 +433,121 @@ jobs:
             fi
             echo "**Full guide:** [CI Debugging Cookbook — SaaS E2E section](${COOKBOOK_URL}#failure-type-5--saas-e2e-tests)"
           } >> "$GITHUB_STEP_SUMMARY"
+
+      # The downstream run holds the only per-spec evidence for a SaaS failure, and
+      # its id lives nowhere but this job's log — which another workflow cannot read.
+      # Publish it as an artifact instead. The name and the field names are the ones
+      # the AlwaysGreen classifier looks for; changing either breaks SaaS triage.
+      - name: Record downstream SaaS run for triage
+        if: ${{ always() && steps.wait-downstream.outcome != 'success' }}
+        env:
+          DOWNSTREAM_RUN_URL: ${{ steps.wait-downstream.outputs.downstream_run_url }}
+          DOWNSTREAM_CONCLUSION: ${{ steps.wait-downstream.outputs.downstream_conclusion }}
+          CORRELATION_ID: ${{ github.repository }}:${{ github.run_id }}:${{ github.run_attempt }}:${{ github.sha }}
+        run: |
+          set -euo pipefail
+          jq -nc \
+            --arg url "${DOWNSTREAM_RUN_URL}" \
+            --arg conclusion "${DOWNSTREAM_CONCLUSION}" \
+            --arg correlation "${CORRELATION_ID}" \
+            '{downstream_run_url: $url,
+              downstream_conclusion: $conclusion,
+              correlation_id: $correlation}' \
+            > "${RUNNER_TEMP}/alwaysgreen-saas-category.json"
+          cat "${RUNNER_TEMP}/alwaysgreen-saas-category.json"
+
+      - name: Upload downstream SaaS run record
+        if: ${{ always() && steps.wait-downstream.outcome != 'success' }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: alwaysgreen-saas-category
+          path: ${{ runner.temp }}/alwaysgreen-saas-category.json
+          retention-days: 5
+          if-no-files-found: warn
+
+      # On merge_group this job runs with continue-on-error, and a job that failed
+      # that way reports `success` in a dependent job's needs.<job>.result — so a
+      # gate on the result cannot see the failure at all. Measured, not assumed:
+      # a probe with two failed continue-on-error jobs read back result=success
+      # for both and contains(needs.*.result, 'failure') = false. Publish the real
+      # outcome so the feedback job below fires on both push and merge_group.
+      - name: Publish job outcome
+        id: outcome
+        if: always()
+        run: echo "status=${{ job.status }}" >> "$GITHUB_OUTPUT"
+
+  saas-e2e-debug-summary:
+    name: AlwaysGreen failure feedback (SaaS E2E)
+    needs: trigger-saas-e2e
+    # `outputs.outcome` first: on merge_group the result reads `success` even when
+    # the job failed (see "Publish job outcome" above). The result check is the
+    # fallback for a job that died before publishing its outcome, e.g. cancelled.
+    if: >-
+      always() && (needs.trigger-saas-e2e.outputs.outcome == 'failure'
+      || needs.trigger-saas-e2e.result == 'failure')
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    continue-on-error: ${{ github.event_name == 'merge_group' }}
+    permissions:
+      pull-requests: write
+      contents: read
+    outputs:
+      slack_ts: ${{ steps.feedback.outputs.slack_ts }}
+      slack_channel: ${{ steps.feedback.outputs.slack_channel }}
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7.0.0
+        with:
+          node-version: "24"
+      # Same shared QA bot, same pending Vault grant, as the SM job above.
+      - name: Import Slack token
+        id: slack-secrets
+        continue-on-error: true
+        uses: hashicorp/vault-action@v4.0.0
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          exportEnv: false
+          secrets: |
+            secret/data/products/qa/ci/common SLACK_BOT_USER_OAUTH_TOKEN ;
+      - name: Generate GitHub App Token
+        id: app-token
+        uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@main
+        with:
+          github-app-id-vault-key: GITHUB_APP_ID
+          github-app-id-vault-path: secret/data/products/qa/ci/github.com/apps/camunda/quality-assurance-ci
+          github-app-private-key-vault-key: GITHUB_APP_SECRET
+          github-app-private-key-vault-path: secret/data/products/qa/ci/github.com/apps/camunda/quality-assurance-ci
+          vault-auth-method: approle
+          vault-auth-role-id: ${{ secrets.VAULT_ROLE_ID }}
+          vault-auth-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+          vault-url: ${{ secrets.VAULT_ADDR }}
+          owner: camunda
+          repositories: connectors
+      # SaaS failures were previously reported nowhere: this stage had no feedback
+      # step, so 18 of the 41 failing runs in a recent 400-run window were silent
+      # apart from the job log.
+      - name: Post AlwaysGreen failure feedback
+        id: feedback
+        continue-on-error: true
+        uses: ./.github/actions/post-failure-feedback
+        with:
+          failure_category: unknown
+          stage: saas-e2e
+          owner_team: "@camunda/connectors"
+          run_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          status: failure
+          evidence: >-
+            SaaS E2E tests failed (downstream conclusion:
+            ${{ needs.trigger-saas-e2e.outputs.downstream_conclusion || 'unknown' }})
+            ${{ needs.trigger-saas-e2e.outputs.downstream_run_url }}
+          pr: ${{ github.event.merge_group.head_ref }}
+          pr_is_draft: "false"
+          slack_channel: "C0AK0AVKRL0"
+          slack_bot_token: ${{ steps.slack-secrets.outputs.SLACK_BOT_USER_OAUTH_TOKEN }}
+          github_token: ${{ steps.app-token.outputs.token }}
 
   run-ai-agent-cpt:
     name: AI Agent E2E Tests (CPT)
@@ -502,14 +640,3 @@ jobs:
             -am \
             -Pit-real-llm \
             --batch-mode
-
-      - name: Observe build status
-        if: always()
-        continue-on-error: true
-        uses: ./.github/actions/observe-build-status
-        with:
-          build_status: ${{ job.status }}
-          job_name: run-ai-agent-cpt
-          secret_vault_address: ${{ secrets.VAULT_ADDR }}
-          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}

--- a/.github/workflows/connectors-streak-detector.yml
+++ b/.github/workflows/connectors-streak-detector.yml
@@ -1,7 +1,7 @@
 # description: Streak detector for the "Merge queue Helm test" pipeline. Reacts
 # to completion of that pipeline on a protected branch (main / stable/*) and
-# maintains ONE live Slack message per base branch in the connectors support
-# channel — same find-and-update pattern as camunda/camunda's
+# maintains ONE live Slack message per base branch in #alwaysgreen-reliability —
+# same find-and-update pattern as camunda/camunda's
 # alwaysgreen-streak-detector.yml.
 #
 # Behaviour:
@@ -138,12 +138,34 @@ jobs:
           echo "pings=${pings}" >> "$GITHUB_OUTPUT"
           echo "Will ping: ${pings}"
 
+      # No streak alert from this repo has ever arrived: the connectors bot is not a
+      # member of #alwaysgreen-reliability, so conversations.history and
+      # chat.postMessage both come back not_in_channel. Post as the shared QA bot
+      # instead, like the other AlwaysGreen repos.
+      #
+      # The read is denied (403) until connectors' approle is granted
+      # secret/data/products/qa/ci/common; the steps below then no-op on an empty
+      # token, exactly as they do today, and start working once it lands.
+      - name: Import Slack token
+        id: slack-secrets
+        if: steps.streak.outputs.is_streak == 'true' || steps.streak.outputs.latest_success == 'true'
+        continue-on-error: true
+        uses: hashicorp/vault-action@v4.0.0
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          exportEnv: false
+          secrets: |
+            secret/data/products/qa/ci/common SLACK_BOT_USER_OAUTH_TOKEN ;
+
       - name: Find existing Slack streak message for this base
         id: find-message
         if: steps.streak.outputs.is_streak == 'true' || steps.streak.outputs.latest_success == 'true'
         continue-on-error: true
         env:
-          SLACK_TOKEN: ${{ secrets.CONNECTORS_SLACK_BOT_TOKEN }}
+          SLACK_TOKEN: ${{ steps.slack-secrets.outputs.SLACK_BOT_USER_OAUTH_TOKEN }}
           CHANNEL_ID: C0AK0AVKRL0
           BASE_REF: ${{ steps.streak.outputs.base_ref }}
         run: |
@@ -173,7 +195,7 @@ jobs:
         uses: slackapi/slack-github-action@v4.0.0
         with:
           method: chat.postMessage
-          token: ${{ secrets.CONNECTORS_SLACK_BOT_TOKEN }}
+          token: ${{ steps.slack-secrets.outputs.SLACK_BOT_USER_OAUTH_TOKEN }}
           payload: |
             {
               "channel": "C0AK0AVKRL0",
@@ -185,7 +207,7 @@ jobs:
         uses: slackapi/slack-github-action@v4.0.0
         with:
           method: chat.update
-          token: ${{ secrets.CONNECTORS_SLACK_BOT_TOKEN }}
+          token: ${{ steps.slack-secrets.outputs.SLACK_BOT_USER_OAUTH_TOKEN }}
           payload: |
             {
               "channel": "C0AK0AVKRL0",
@@ -198,7 +220,7 @@ jobs:
         uses: slackapi/slack-github-action@v4.0.0
         with:
           method: chat.update
-          token: ${{ secrets.CONNECTORS_SLACK_BOT_TOKEN }}
+          token: ${{ steps.slack-secrets.outputs.SLACK_BOT_USER_OAUTH_TOKEN }}
           payload: |
             {
               "channel": "C0AK0AVKRL0",


### PR DESCRIPTION
## Description

The merge-queue Helm/E2E pipeline is this repo's AlwaysGreen check, but almost nothing it
learns reaches a human. This fixes the reporting path; no test or product behaviour changes.

Found while sampling the last 400 runs of `MERGE_QUEUE_HELM_TEST.yaml` (41 failures):

- **Slack has never worked from this repo.** Alerts are posted with the connectors bot, which
  is not a member of #alwaysgreen-reliability, so every message came back `not_in_channel` —
  in the run logs, and confirmed by the channel history containing no post from this repo. The
  streak detector uses the same token, so it is silent too. Both now post as the shared QA bot,
  like the other AlwaysGreen repos, so one failure reads as one thread from one sender.
  **This part is inert until a pending Vault grant lands:** this repo's approle is denied (403)
  on `secret/data/products/qa/ci/common`, where that token lives. Access has been requested
  from infra. Until then the import step yields an empty token and posting is skipped with a log
  line — exactly today's behaviour — and Slack starts working by itself once the grant lands, with
  no follow-up PR.
- **The SaaS stage reported nothing at all.** It had no feedback step, so 18 of those 41
  failures produced only a job log. It now gets the same standardised feedback as the SM stage,
  with the downstream conclusion and run URL in the message.
- **A merge-queue failure could not be seen by a dependent job.** Every job here carries
  `continue-on-error` on `merge_group`, and a job that fails that way reports `success` in
  `needs.<job>.result` — measured on a throwaway probe, not assumed. The new feedback job
  therefore gates on the stage's real `job.status`, published as a job output. (Run
  `31096803880` is an example of a merge-queue run that concluded green with a failed job in it.)

Also included, because they block the AlwaysGreen triage work that follows:

- `post-failure-feedback` now emits `slack_ts` / `slack_channel`, so a later job can reply in the
  same thread instead of opening a second top-level message for one failure. The action is
  otherwise identical to `camunda/camunda`'s copy, including the removal of a `${{ }}` expression
  from an input description (it is evaluated even there, and the github context is unavailable in
  input metadata).
- The SaaS stage publishes the downstream run URL as an `alwaysgreen-saas-category` artifact. It
  previously existed only in a step log, which another workflow cannot read, and that downstream
  run holds the only per-spec evidence for a SaaS failure.
- The two `observe-build-status` steps are **removed**: the action does not exist in this repo and
  errored on every run (masked by `continue-on-error`). It is monorepo build-status telemetry owned
  by another team — opting connectors in is their call, not this PR's.
- The PR-comment skip message now names the missing input, so the next occurrence says whether the
  PR number failed to parse or the token was empty instead of leaving all three possibilities open.

Scoped to `main`. The `stable/8.x` copies of this workflow still carry the dead
`observe-build-status` steps and will be updated when the triage rollout reaches them.

Validation: `actionlint` clean (one pre-existing shellcheck warning on an untouched line), YAML
parses, `node --check` on the feedback script, and the feedback script exercised locally against
both the push-shaped and merge_group-shaped inputs.

## Related issues

No issue — part of the AlwaysGreen rollout for connectors; the triage/fix-agent port follows in
separate PRs.

closes #

## Checklist

- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest
  release, as this branch will be rebased onto main before the next release. Example backport labels:
    - `backport stable/8.8`: for changes that should be included in the next 8.8.x release.
    - **or** `backport release-8.8.7`: for changes that should be included in the specific release 8.8.7, and this
      *release has already been created*. The release branch will be merged back into stable/8.8 later, so the change
      will be included in future 8.8.x releases as well.
- [ ] Tests/Integration tests for the changes have been added if applicable.
- [ ] If the change requires a documentation update, it has been added to the appropriate section in the documentation.
