### PR TITLE
[Backport stable/8.8] refactor(agentic-ai): migrate Google Vertex AI provider to google-genai SDK

### DIFF
--- a/connectors/agentic-ai/pom.xml
+++ b/connectors/agentic-ai/pom.xml
@@ -113,9 +113,21 @@
       <groupId>dev.langchain4j</groupId>
       <artifactId>langchain4j-open-ai</artifactId>
     </dependency>
+    <!--
+      Brings in com.fasterxml.jackson.module:jackson-module-kotlin at runtime scope, which is
+      REQUIRED: google-genai shades KotlinModule into com.google.genai.shaded.* but ships a
+      META-INF/services entry pointing at the unshaded class, so
+      ObjectMapper.findAndRegisterModules() (called by langchain4j-core) throws
+      ServiceConfigurationError without it. Do not exclude it.
+    -->
     <dependency>
       <groupId>dev.langchain4j</groupId>
-      <artifactId>langchain4j-vertex-ai-gemini</artifactId>
+      <artifactId>langchain4j-google-genai</artifactId>
+    </dependency>
+    <!-- main code imports com.google.genai.* directly (we build the Client ourselves) -->
+    <dependency>
+      <groupId>com.google.genai</groupId>
+      <artifactId>google-genai</artifactId>
     </dependency>
 
     <dependency>

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/ChatMessageConverter.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/ChatMessageConverter.java
@@ -8,6 +8,7 @@ package io.camunda.connector.agenticai.aiagent.framework.langchain4j;
 
 import dev.langchain4j.data.message.ChatMessage;
 import dev.langchain4j.model.chat.response.ChatResponse;
+import io.camunda.connector.agenticai.aiagent.model.request.provider.ProviderConfiguration;
 import io.camunda.connector.agenticai.model.message.AssistantMessage;
 import io.camunda.connector.agenticai.model.message.Message;
 import io.camunda.connector.agenticai.model.message.SystemMessage;
@@ -17,11 +18,12 @@ import java.util.List;
 
 public interface ChatMessageConverter {
 
-  default List<ChatMessage> map(Message message) {
+  default List<ChatMessage> map(Message message, ProviderConfiguration providerConfiguration) {
     return switch (message) {
       case SystemMessage systemMessage -> List.of(fromSystemMessage(systemMessage));
       case UserMessage userMessage -> List.of(fromUserMessage(userMessage));
-      case AssistantMessage assistantMessage -> List.of(fromAssistantMessage(assistantMessage));
+      case AssistantMessage assistantMessage ->
+          List.of(fromAssistantMessage(assistantMessage, providerConfiguration));
       case ToolCallResultMessage toolCallResultMessage ->
           fromToolCallResultMessage(toolCallResultMessage).stream()
               .map(ChatMessage.class::cast)
@@ -30,17 +32,23 @@ public interface ChatMessageConverter {
     };
   }
 
-  default List<ChatMessage> map(List<Message> messages) {
-    return messages.stream().map(this::map).flatMap(List::stream).toList();
+  default List<ChatMessage> map(
+      List<Message> messages, ProviderConfiguration providerConfiguration) {
+    return messages.stream()
+        .map(message -> map(message, providerConfiguration))
+        .flatMap(List::stream)
+        .toList();
   }
 
   dev.langchain4j.data.message.SystemMessage fromSystemMessage(SystemMessage systemMessage);
 
   dev.langchain4j.data.message.UserMessage fromUserMessage(UserMessage userMessage);
 
-  dev.langchain4j.data.message.AiMessage fromAssistantMessage(AssistantMessage assistantMessage);
+  dev.langchain4j.data.message.AiMessage fromAssistantMessage(
+      AssistantMessage assistantMessage, ProviderConfiguration providerConfiguration);
 
-  AssistantMessage toAssistantMessage(ChatResponse chatResponse);
+  AssistantMessage toAssistantMessage(
+      ChatResponse chatResponse, ProviderConfiguration providerConfiguration);
 
   List<dev.langchain4j.data.message.ToolExecutionResultMessage> fromToolCallResultMessage(
       ToolCallResultMessage toolCallResultMessage);

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/ChatMessageConverterImpl.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/ChatMessageConverterImpl.java
@@ -17,6 +17,7 @@ import dev.langchain4j.model.chat.response.ChatResponse;
 import dev.langchain4j.model.chat.response.ChatResponseMetadata;
 import dev.langchain4j.model.output.TokenUsage;
 import io.camunda.connector.agenticai.aiagent.framework.langchain4j.tool.ToolCallConverter;
+import io.camunda.connector.agenticai.aiagent.model.request.provider.ProviderConfiguration;
 import io.camunda.connector.agenticai.model.message.AssistantMessage;
 import io.camunda.connector.agenticai.model.message.AssistantMessageBuilder;
 import io.camunda.connector.agenticai.model.message.SystemMessage;
@@ -24,6 +25,7 @@ import io.camunda.connector.agenticai.model.message.ToolCallResultMessage;
 import io.camunda.connector.agenticai.model.message.UserMessage;
 import io.camunda.connector.agenticai.model.message.content.Content;
 import io.camunda.connector.agenticai.model.message.content.TextContent;
+import io.camunda.connector.agenticai.model.tool.ToolCall;
 import io.camunda.connector.agenticai.util.ObjectMapperConstants;
 import io.camunda.connector.api.error.ConnectorException;
 import java.time.ZonedDateTime;
@@ -39,6 +41,8 @@ import org.springframework.util.CollectionUtils;
 public class ChatMessageConverterImpl implements ChatMessageConverter {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(ChatMessageConverterImpl.class);
+
+  private static final String FRAMEWORK_METADATA_KEY = "framework";
 
   private final ContentConverter contentConverter;
   private final ToolCallConverter toolCallConverter;
@@ -93,12 +97,12 @@ public class ChatMessageConverterImpl implements ChatMessageConverter {
 
   @Override
   public dev.langchain4j.data.message.AiMessage fromAssistantMessage(
-      AssistantMessage assistantMessage) {
-    return fromAssistantMessageBuilder(assistantMessage).build();
+      AssistantMessage assistantMessage, ProviderConfiguration providerConfiguration) {
+    return fromAssistantMessageBuilder(assistantMessage, providerConfiguration).build();
   }
 
   protected dev.langchain4j.data.message.AiMessage.Builder fromAssistantMessageBuilder(
-      AssistantMessage assistantMessage) {
+      AssistantMessage assistantMessage, ProviderConfiguration providerConfiguration) {
     final var builder = AiMessage.builder();
 
     if (!CollectionUtils.isEmpty(assistantMessage.content())) {
@@ -121,35 +125,85 @@ public class ChatMessageConverterImpl implements ChatMessageConverter {
       builder.toolExecutionRequests(toolExecutionRequests);
     }
 
+    final var attributes = toolCallAttributes(assistantMessage, providerConfiguration);
+    if (!attributes.isEmpty()) {
+      builder.attributes(attributes);
+    }
+
     return builder;
   }
 
-  @Override
-  public AssistantMessage toAssistantMessage(ChatResponse chatResponse) {
-    return toAssistantMessageBuilder(chatResponse).build();
-  }
-
-  protected AssistantMessageBuilder toAssistantMessageBuilder(ChatResponse chatResponse) {
-    final var builder = AssistantMessage.builder();
-
-    if (chatResponse.metadata() != null) {
-      builder.metadata(
-          Map.of(
-              "timestamp", ZonedDateTime.now(),
-              "framework", serializedChatResponseMetadata(chatResponse.metadata())));
+  /**
+   * Provider tool call metadata carries data the provider requires us to echo back verbatim on the
+   * next request, e.g. Gemini 3 thought signatures. This is provider-specific data, kept separate
+   * from {@link #serializedChatResponseMetadata}. What is safe to restore is provider-specific -
+   * see {@link ToolCallMetadataDecorator}.
+   */
+  protected Map<String, Object> toolCallAttributes(
+      AssistantMessage assistantMessage, ProviderConfiguration providerConfiguration) {
+    if (CollectionUtils.isEmpty(assistantMessage.toolCalls())) {
+      return Map.of();
     }
 
+    final var attributes = new LinkedHashMap<String, Object>();
+    for (final var toolCall : assistantMessage.toolCalls()) {
+      if (CollectionUtils.isEmpty(toolCall.metadata())) {
+        continue;
+      }
+
+      attributes.putAll(
+          ToolCallMetadataDecorator.decorateOnRead(
+              providerConfiguration, toolCall.id(), toolCall.metadata()));
+    }
+
+    return attributes;
+  }
+
+  @Override
+  public AssistantMessage toAssistantMessage(
+      ChatResponse chatResponse, ProviderConfiguration providerConfiguration) {
+    return toAssistantMessageBuilder(chatResponse, providerConfiguration).build();
+  }
+
+  protected AssistantMessageBuilder toAssistantMessageBuilder(
+      ChatResponse chatResponse, ProviderConfiguration providerConfiguration) {
+    final var builder = AssistantMessage.builder();
     final var aiMessage = chatResponse.aiMessage();
+
+    if (chatResponse.metadata() != null) {
+      final var metadata = new LinkedHashMap<String, Object>();
+      metadata.put("timestamp", ZonedDateTime.now());
+      metadata.put(FRAMEWORK_METADATA_KEY, serializedChatResponseMetadata(chatResponse.metadata()));
+
+      builder.metadata(metadata);
+    }
+
     if (StringUtils.isNotBlank(aiMessage.text())) {
       builder.content(List.of(TextContent.textContent(aiMessage.text())));
     }
 
     final var toolCalls =
-        aiMessage.toolExecutionRequests().stream().map(toolCallConverter::asToolCall).toList();
+        aiMessage.toolExecutionRequests().stream()
+            .map(toolCallConverter::asToolCall)
+            .map(toolCall -> decorateToolCallMetadata(toolCall, aiMessage, providerConfiguration))
+            .toList();
 
     builder.toolCalls(toolCalls);
 
     return builder;
+  }
+
+  private ToolCall decorateToolCallMetadata(
+      ToolCall toolCall, AiMessage aiMessage, ProviderConfiguration providerConfiguration) {
+    if (CollectionUtils.isEmpty(aiMessage.attributes())) {
+      return toolCall;
+    }
+
+    final var metadata =
+        ToolCallMetadataDecorator.decorateOnWrite(
+            providerConfiguration, toolCall.id(), aiMessage.attributes());
+
+    return metadata.isEmpty() ? toolCall : toolCall.withMetadata(metadata);
   }
 
   protected Map<String, Object> serializedChatResponseMetadata(

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/ChatModelFactoryImpl.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/ChatModelFactoryImpl.java
@@ -206,9 +206,7 @@ public class ChatModelFactoryImpl implements ChatModelFactory {
       Optional.ofNullable(modelParameters.temperature())
           .map(Float::doubleValue)
           .ifPresent(builder::temperature);
-      Optional.ofNullable(modelParameters.topP())
-          .map(Float::doubleValue)
-          .ifPresent(builder::topP);
+      Optional.ofNullable(modelParameters.topP()).map(Float::doubleValue).ifPresent(builder::topP);
       Optional.ofNullable(modelParameters.topK()).ifPresent(builder::topK);
     }
 

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/ChatModelFactoryImpl.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/ChatModelFactoryImpl.java
@@ -7,15 +7,20 @@
 package io.camunda.connector.agenticai.aiagent.framework.langchain4j;
 
 import com.azure.identity.ClientSecretCredentialBuilder;
+import com.google.auth.oauth2.GoogleCredentials;
 import com.google.auth.oauth2.ServiceAccountCredentials;
+import com.google.genai.Client;
+import com.google.genai.errors.GenAiIOException;
+import com.google.genai.types.HttpOptions;
+import com.google.genai.types.HttpRetryOptions;
 import dev.langchain4j.model.anthropic.AnthropicChatModel;
 import dev.langchain4j.model.azure.AzureOpenAiChatModel;
 import dev.langchain4j.model.bedrock.BedrockChatModel;
 import dev.langchain4j.model.bedrock.BedrockChatRequestParameters;
 import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.google.genai.GoogleGenAiChatModel;
 import dev.langchain4j.model.openai.OpenAiChatModel;
 import dev.langchain4j.model.openai.OpenAiChatRequestParameters;
-import dev.langchain4j.model.vertexai.gemini.VertexAiGeminiChatModel;
 import io.camunda.connector.agenticai.aiagent.model.request.provider.AnthropicProviderConfiguration;
 import io.camunda.connector.agenticai.aiagent.model.request.provider.AzureOpenAiProviderConfiguration;
 import io.camunda.connector.agenticai.aiagent.model.request.provider.AzureOpenAiProviderConfiguration.AzureAuthentication.AzureApiKeyAuthentication;
@@ -25,6 +30,7 @@ import io.camunda.connector.agenticai.aiagent.model.request.provider.BedrockProv
 import io.camunda.connector.agenticai.aiagent.model.request.provider.BedrockProviderConfiguration.AwsAuthentication.AwsStaticCredentialsAuthentication;
 import io.camunda.connector.agenticai.aiagent.model.request.provider.GoogleVertexAiProviderConfiguration;
 import io.camunda.connector.agenticai.aiagent.model.request.provider.GoogleVertexAiProviderConfiguration.GoogleVertexAiAuthentication.ServiceAccountCredentialsAuthentication;
+import io.camunda.connector.agenticai.aiagent.model.request.provider.GoogleVertexAiProviderConfiguration.GoogleVertexAiConnection;
 import io.camunda.connector.agenticai.aiagent.model.request.provider.OpenAiCompatibleProviderConfiguration;
 import io.camunda.connector.agenticai.aiagent.model.request.provider.OpenAiCompatibleProviderConfiguration.OpenAiCompatibleAuthentication;
 import io.camunda.connector.agenticai.aiagent.model.request.provider.OpenAiProviderConfiguration;
@@ -56,6 +62,9 @@ public class ChatModelFactoryImpl implements ChatModelFactory {
   // it was not easily backportable, thus a simple backport of the actual functionality for version
   // 8.8
   private static final Duration DEFAULT_MODEL_CALL_TIMEOUT = Duration.ofMinutes(3);
+
+  private static final String GOOGLE_CLOUD_PLATFORM_SCOPE =
+      "https://www.googleapis.com/auth/cloud-platform";
 
   @Override
   public ChatModel createChatModel(ProviderConfiguration providerConfiguration) {
@@ -182,35 +191,66 @@ public class ChatModelFactoryImpl implements ChatModelFactory {
     return builder;
   }
 
-  protected VertexAiGeminiChatModel.VertexAiGeminiChatModelBuilder
-      createGoogleVertexAiChatModelBuilder(GoogleVertexAiProviderConfiguration vertexAi) {
+  protected GoogleGenAiChatModel.Builder createGoogleVertexAiChatModelBuilder(
+      GoogleVertexAiProviderConfiguration vertexAi) {
     final var connection = vertexAi.googleVertexAi();
     final var builder =
-        VertexAiGeminiChatModel.builder()
-            .project(connection.projectId())
-            .location(connection.region())
-            .modelName(connection.model().model());
-
-    if (connection.authentication() instanceof ServiceAccountCredentialsAuthentication sac) {
-      builder.credentials(createGoogleServiceAccountCredentials(sac));
-    }
+        GoogleGenAiChatModel.builder()
+            .client(createGoogleGenAiClient(connection))
+            .modelName(connection.model().model())
+            .maxRetries(0);
 
     final var modelParameters = connection.model().parameters();
     if (modelParameters != null) {
       Optional.ofNullable(modelParameters.maxOutputTokens()).ifPresent(builder::maxOutputTokens);
-      Optional.ofNullable(modelParameters.temperature()).ifPresent(builder::temperature);
-      Optional.ofNullable(modelParameters.topP()).ifPresent(builder::topP);
+      Optional.ofNullable(modelParameters.temperature())
+          .map(Float::doubleValue)
+          .ifPresent(builder::temperature);
+      Optional.ofNullable(modelParameters.topP())
+          .map(Float::doubleValue)
+          .ifPresent(builder::topP);
       Optional.ofNullable(modelParameters.topK()).ifPresent(builder::topK);
     }
 
     return builder;
   }
 
-  private ServiceAccountCredentials createGoogleServiceAccountCredentials(
+  private Client createGoogleGenAiClient(GoogleVertexAiConnection connection) {
+    final var httpOptions =
+        HttpOptions.builder()
+            .retryOptions(HttpRetryOptions.builder().attempts(1).build())
+            .timeout((int) DEFAULT_MODEL_CALL_TIMEOUT.toMillis())
+            .build();
+
+    final var clientBuilder =
+        Client.builder()
+            .vertexAI(true)
+            .project(connection.projectId())
+            .location(connection.region())
+            .httpOptions(httpOptions);
+
+    if (connection.authentication() instanceof ServiceAccountCredentialsAuthentication sac) {
+      clientBuilder.credentials(createGoogleServiceAccountCredentials(sac));
+    }
+
+    try {
+      // application default credentials are resolved eagerly here
+      return clientBuilder.build();
+    } catch (GenAiIOException | IllegalArgumentException e) {
+      LOGGER.error("Failed to create Google Vertex AI client", e);
+      throw new ConnectorInputException("Failed to create Google Vertex AI client", e);
+    }
+  }
+
+  private GoogleCredentials createGoogleServiceAccountCredentials(
       ServiceAccountCredentialsAuthentication sac) {
     try {
+      // Credentials read from a key file carry no scopes. google-genai only scopes the
+      // application default credentials it resolves itself and passes these through verbatim,
+      // so without this the token request fails with invalid_scope.
       return ServiceAccountCredentials.fromStream(
-          new ByteArrayInputStream(sac.jsonKey().getBytes(StandardCharsets.UTF_8)));
+              new ByteArrayInputStream(sac.jsonKey().getBytes(StandardCharsets.UTF_8)))
+          .createScoped(GOOGLE_CLOUD_PLATFORM_SCOPE);
     } catch (IOException e) {
       LOGGER.error("Failed to parse service account credentials", e);
       throw new ConnectorInputException(

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/Langchain4JAiFrameworkAdapter.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/Langchain4JAiFrameworkAdapter.java
@@ -49,7 +49,8 @@ public class Langchain4JAiFrameworkAdapter
       AgentExecutionContext executionContext,
       AgentContext agentContext,
       RuntimeMemory runtimeMemory) {
-    final var messages = chatMessageConverter.map(runtimeMemory.filteredMessages());
+    final var messages =
+        chatMessageConverter.map(runtimeMemory.filteredMessages(), executionContext.provider());
     final var toolSpecifications =
         toolSpecificationConverter.asToolSpecifications(agentContext.toolDefinitions());
 
@@ -59,7 +60,8 @@ public class Langchain4JAiFrameworkAdapter
 
     final ChatModel chatModel = chatModelFactory.createChatModel(executionContext.provider());
     final ChatResponse chatResponse = chatModel.chat(chatRequestBuilder.build());
-    final AssistantMessage assistantMessage = chatMessageConverter.toAssistantMessage(chatResponse);
+    final AssistantMessage assistantMessage =
+        chatMessageConverter.toAssistantMessage(chatResponse, executionContext.provider());
 
     final var updatedAgentContext =
         agentContext.withMetrics(

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/ToolCallMetadataDecorator.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/ToolCallMetadataDecorator.java
@@ -73,7 +73,8 @@ final class ToolCallMetadataDecorator {
       case GoogleVertexAiProviderConfiguration ignored -> {
         if (toolCallMetadata.get(GoogleVertexAiProviderConfiguration.GOOGLE_VERTEX_AI_ID)
                 instanceof Map<?, ?> googleMetadata
-            && googleMetadata.get(GOOGLE_THOUGHT_SIGNATURE_METADATA_KEY) instanceof String signature) {
+            && googleMetadata.get(GOOGLE_THOUGHT_SIGNATURE_METADATA_KEY)
+                instanceof String signature) {
           yield Map.of(GOOGLE_THOUGHT_SIGNATURE_ATTRIBUTE_KEY_PREFIX + toolCallId, signature);
         }
         yield Map.of();

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/ToolCallMetadataDecorator.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/ToolCallMetadataDecorator.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.agenticai.aiagent.framework.langchain4j;
+
+import io.camunda.connector.agenticai.aiagent.model.request.provider.GoogleVertexAiProviderConfiguration;
+import io.camunda.connector.agenticai.aiagent.model.request.provider.ProviderConfiguration;
+import java.util.Map;
+
+/**
+ * Decorates the {@code AiMessage.attributes()} / {@code ToolCall.metadata()} round trip with
+ * provider-specific knowledge of what is safe to persist into a Camunda process variable.
+ *
+ * <p>{@code AiMessage.attributes()} is a generic map, populated only by langchain4j's own
+ * provider-specific integration code, and is documented as "typically provider-specific". Since the
+ * persisted {@code ToolCall} lives in an untyped process variable, it must never be dumped verbatim
+ * - every provider drops attributes entirely unless explicitly handled below.
+ *
+ * <p>Google's Gemini API attaches a thought signature to the specific function-call part it belongs
+ * to, not to the message as a whole - langchain4j only exposes it via the flat, message- level
+ * {@code AiMessage.attributes()} map keyed by tool call ID, since {@code ToolExecutionRequest} has
+ * no field for it. This decorator un-flattens that back onto the individual {@link
+ * io.camunda.connector.agenticai.model.tool.ToolCall} it actually belongs to.
+ *
+ * <p>Persisted entries are namespaced by the provider's {@code TemplateSubType} ID (currently only
+ * {@link GoogleVertexAiProviderConfiguration#GOOGLE_VERTEX_AI_ID}), so that switching a process
+ * instance's provider - e.g. via a config update or a process instance migration - cannot leak a
+ * previous provider's persisted metadata into an unrelated one.
+ */
+final class ToolCallMetadataDecorator {
+
+  private static final String GOOGLE_THOUGHT_SIGNATURE_ATTRIBUTE_KEY_PREFIX = "thought_signature_";
+  private static final String GOOGLE_THOUGHT_SIGNATURE_METADATA_KEY = "thoughtSignature";
+
+  private ToolCallMetadataDecorator() {}
+
+  /**
+   * Called on the write path with the full, flat {@code aiMessage.attributes()} (never null, may be
+   * empty) and the ID of the specific tool call being converted.
+   *
+   * @return the namespaced metadata to persist on that tool call.
+   */
+  static Map<String, Object> decorateOnWrite(
+      ProviderConfiguration providerConfiguration,
+      String toolCallId,
+      Map<String, Object> aiMessageAttributes) {
+    return switch (providerConfiguration) {
+      case GoogleVertexAiProviderConfiguration ignored -> {
+        if (aiMessageAttributes.get(GOOGLE_THOUGHT_SIGNATURE_ATTRIBUTE_KEY_PREFIX + toolCallId)
+            instanceof String signature) {
+          yield namespaced(
+              GoogleVertexAiProviderConfiguration.GOOGLE_VERTEX_AI_ID,
+              Map.of(GOOGLE_THOUGHT_SIGNATURE_METADATA_KEY, signature));
+        }
+        yield Map.of();
+      }
+      default -> Map.of();
+    };
+  }
+
+  /**
+   * Called on the read path with the already-unwrapped {@code toolCall.metadata()} (never null, may
+   * be empty, untyped since it round-tripped through a process variable) of a single tool call.
+   * Returns the entry to restore onto the outgoing {@code AiMessage.attributes()}, keyed the way
+   * langchain4j expects.
+   */
+  static Map<String, Object> decorateOnRead(
+      ProviderConfiguration providerConfiguration, String toolCallId, Map<?, ?> toolCallMetadata) {
+    return switch (providerConfiguration) {
+      case GoogleVertexAiProviderConfiguration ignored -> {
+        if (toolCallMetadata.get(GoogleVertexAiProviderConfiguration.GOOGLE_VERTEX_AI_ID)
+                instanceof Map<?, ?> googleMetadata
+            && googleMetadata.get(GOOGLE_THOUGHT_SIGNATURE_METADATA_KEY) instanceof String signature) {
+          yield Map.of(GOOGLE_THOUGHT_SIGNATURE_ATTRIBUTE_KEY_PREFIX + toolCallId, signature);
+        }
+        yield Map.of();
+      }
+      default -> Map.of();
+    };
+  }
+
+  private static Map<String, Object> namespaced(String providerId, Map<String, Object> metadata) {
+    return Map.of(providerId, metadata);
+  }
+}

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/model/tool/ToolCall.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/model/tool/ToolCall.java
@@ -6,6 +6,7 @@
  */
 package io.camunda.connector.agenticai.model.tool;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import io.camunda.connector.agenticai.model.AgenticAiRecord;
@@ -13,8 +14,16 @@ import java.util.Map;
 
 @AgenticAiRecord
 @JsonDeserialize(builder = ToolCall.ToolCallJacksonProxyBuilder.class)
-public record ToolCall(String id, String name, Map<String, Object> arguments)
+public record ToolCall(
+    String id,
+    String name,
+    Map<String, Object> arguments,
+    @JsonInclude(JsonInclude.Include.NON_EMPTY) Map<String, Object> metadata)
     implements ToolCallBuilder.With {
+
+  public ToolCall(String id, String name, Map<String, Object> arguments) {
+    this(id, name, arguments, Map.of());
+  }
 
   public static ToolCallBuilder builder() {
     return ToolCallBuilder.builder();

--- a/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/ChatMessageConverterTest.java
+++ b/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/ChatMessageConverterTest.java
@@ -30,6 +30,13 @@ import dev.langchain4j.model.openai.OpenAiTokenUsage;
 import dev.langchain4j.model.output.FinishReason;
 import dev.langchain4j.model.output.TokenUsage;
 import io.camunda.connector.agenticai.aiagent.framework.langchain4j.tool.ToolCallConverter;
+import io.camunda.connector.agenticai.aiagent.model.request.provider.AnthropicProviderConfiguration;
+import io.camunda.connector.agenticai.aiagent.model.request.provider.AzureOpenAiProviderConfiguration;
+import io.camunda.connector.agenticai.aiagent.model.request.provider.BedrockProviderConfiguration;
+import io.camunda.connector.agenticai.aiagent.model.request.provider.GoogleVertexAiProviderConfiguration;
+import io.camunda.connector.agenticai.aiagent.model.request.provider.OpenAiCompatibleProviderConfiguration;
+import io.camunda.connector.agenticai.aiagent.model.request.provider.OpenAiProviderConfiguration;
+import io.camunda.connector.agenticai.aiagent.model.request.provider.ProviderConfiguration;
 import io.camunda.connector.agenticai.model.message.AssistantMessage;
 import io.camunda.connector.agenticai.model.message.Message;
 import io.camunda.connector.agenticai.model.message.SystemMessage;
@@ -46,9 +53,13 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.NullSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
@@ -56,6 +67,19 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class ChatMessageConverterTest {
+
+  private static final ProviderConfiguration ANTHROPIC = new AnthropicProviderConfiguration(null);
+  private static final ProviderConfiguration VERTEX_AI =
+      new GoogleVertexAiProviderConfiguration(null);
+
+  static Stream<ProviderConfiguration> nonVertexAiProviders() {
+    return Stream.of(
+        new AnthropicProviderConfiguration(null),
+        new BedrockProviderConfiguration(null),
+        new AzureOpenAiProviderConfiguration(null),
+        new OpenAiProviderConfiguration(null),
+        new OpenAiCompatibleProviderConfiguration(null));
+  }
 
   @Mock private ToolCallConverter toolCallConverter;
   @Mock private ContentConverter contentConverter;
@@ -106,7 +130,7 @@ class ChatMessageConverterTest {
   @Test
   void fromUserMessage_withDocumentContent_convertsDocument() throws JsonProcessingException {
     Document document = mock(Document.class);
-    DocumentContent documentContent = new DocumentContent(document);
+    DocumentContent documentContent = DocumentContent.documentContent(document);
 
     UserMessage userMessage =
         UserMessage.builder()
@@ -145,7 +169,7 @@ class ChatMessageConverterTest {
     AssistantMessage assistantMessage =
         AssistantMessage.builder().content(List.of(textContent("Test assistant message"))).build();
 
-    AiMessage result = chatMessageConverter.fromAssistantMessage(assistantMessage);
+    AiMessage result = chatMessageConverter.fromAssistantMessage(assistantMessage, ANTHROPIC);
 
     assertThat(result.text()).isEqualTo("Test assistant message");
     assertThat(result.toolExecutionRequests()).isEmpty();
@@ -155,7 +179,7 @@ class ChatMessageConverterTest {
   void fromAssistantMessage_withoutAnyContent_returnsAiMessage() {
     AssistantMessage assistantMessage = AssistantMessage.builder().build();
 
-    AiMessage result = chatMessageConverter.fromAssistantMessage(assistantMessage);
+    AiMessage result = chatMessageConverter.fromAssistantMessage(assistantMessage, ANTHROPIC);
 
     assertThat(result.text()).isNull();
     assertThat(result.toolExecutionRequests()).isEmpty();
@@ -173,7 +197,7 @@ class ChatMessageConverterTest {
     ToolExecutionRequest toolExecutionRequest = mock(ToolExecutionRequest.class);
     when(toolCallConverter.asToolExecutionRequest(toolCall)).thenReturn(toolExecutionRequest);
 
-    AiMessage result = chatMessageConverter.fromAssistantMessage(assistantMessage);
+    AiMessage result = chatMessageConverter.fromAssistantMessage(assistantMessage, ANTHROPIC);
 
     assertThat(result.text()).isEqualTo("Test message");
     assertThat(result.toolExecutionRequests()).hasSize(1);
@@ -188,13 +212,220 @@ class ChatMessageConverterTest {
                 List.of(
                     textContent("Content 1"),
                     textContent("Content 2"),
-                    new DocumentContent(mock(Document.class))))
+                    DocumentContent.documentContent(mock(Document.class))))
             .build();
 
-    assertThatThrownBy(() -> chatMessageConverter.fromAssistantMessage(assistantMessage))
+    assertThatThrownBy(() -> chatMessageConverter.fromAssistantMessage(assistantMessage, ANTHROPIC))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining(
             "AiMessage currently only supports a single TextContent block, 3 content blocks found instead.");
+  }
+
+  /**
+   * Provider tool call metadata carries data the provider requires us to echo back verbatim on the
+   * next request - most notably Gemini 3 thought signatures, without which a follow-up request
+   * containing function calls is rejected with a 400. It must survive the round trip through the
+   * conversation history, attached to the specific tool call it belongs to. Only the {@code
+   * thought_signature_*} entry for this tool call survives - a decoy key and an unrelated tool
+   * call's signature prove the Google Vertex AI decorator narrows the dump to this one tool call,
+   * it does not pass everything through unfiltered.
+   */
+  @Test
+  void assistantMessageRoundTrip_preservesToolCallThoughtSignature() {
+    final var toolExecutionRequest =
+        ToolExecutionRequest.builder().id("toolCallId").name("toolName").build();
+    final var attributes =
+        Map.<String, Object>of(
+            "thought_signature_toolCallId",
+            "c2lnbmF0dXJl",
+            "thought_signature_someOtherToolCallId",
+            "unrelated-signature",
+            "raw_http_response",
+            "should-be-dropped");
+    final var aiMessage =
+        AiMessage.builder()
+            .text("AI response")
+            .toolExecutionRequests(List.of(toolExecutionRequest))
+            .attributes(attributes)
+            .build();
+    final var chatResponse =
+        new ChatResponse.Builder()
+            .aiMessage(aiMessage)
+            .metadata(ChatResponseMetadata.builder().finishReason(FinishReason.STOP).build())
+            .build();
+
+    final var toolCall = ToolCall.builder().id("toolCallId").name("toolName").build();
+    when(toolCallConverter.asToolCall(toolExecutionRequest)).thenReturn(toolCall);
+
+    final var assistantMessage = chatMessageConverter.toAssistantMessage(chatResponse, VERTEX_AI);
+
+    assertThat(assistantMessage.toolCalls()).hasSize(1);
+
+    final var decoratedToolCall = assistantMessage.toolCalls().getFirst();
+    assertThat(decoratedToolCall.id()).isEqualTo("toolCallId");
+    assertThat(decoratedToolCall.metadata())
+        .containsExactly(
+            entry(
+                GoogleVertexAiProviderConfiguration.GOOGLE_VERTEX_AI_ID,
+                Map.of("thoughtSignature", "c2lnbmF0dXJl")));
+
+    when(toolCallConverter.asToolExecutionRequest(decoratedToolCall))
+        .thenReturn(toolExecutionRequest);
+
+    assertThat(chatMessageConverter.fromAssistantMessage(assistantMessage, VERTEX_AI).attributes())
+        .isEqualTo(Map.of("thought_signature_toolCallId", "c2lnbmF0dXJl"));
+  }
+
+  @Test
+  void toAssistantMessage_toolCallWithoutMatchingThoughtSignature_hasNoMetadata() {
+    final var toolExecutionRequest =
+        ToolExecutionRequest.builder().id("toolCallId").name("toolName").build();
+    final var aiMessage =
+        AiMessage.builder()
+            .text("AI response")
+            .toolExecutionRequests(List.of(toolExecutionRequest))
+            .build();
+    final var chatResponse =
+        new ChatResponse.Builder()
+            .aiMessage(aiMessage)
+            .metadata(ChatResponseMetadata.builder().finishReason(FinishReason.STOP).build())
+            .build();
+
+    final var toolCall = ToolCall.builder().id("toolCallId").name("toolName").build();
+    when(toolCallConverter.asToolCall(toolExecutionRequest)).thenReturn(toolCall);
+
+    final var result = chatMessageConverter.toAssistantMessage(chatResponse, VERTEX_AI);
+
+    assertThat(result.toolCalls()).hasSize(1);
+    assertThat(result.toolCalls().getFirst().metadata()).isEmpty();
+  }
+
+  @ParameterizedTest
+  @MethodSource("nonVertexAiProviders")
+  void toAssistantMessage_forNonVertexAiProvider_neverAddsToolCallMetadata(
+      ProviderConfiguration providerConfiguration) {
+    final var toolExecutionRequest =
+        ToolExecutionRequest.builder().id("toolCallId").name("toolName").build();
+    final var attributes =
+        Map.<String, Object>of(
+            "thought_signature_toolCallId", "c2lnbmF0dXJl", "raw_http_response", "leak-risk");
+    final var aiMessage =
+        AiMessage.builder()
+            .text("AI response")
+            .toolExecutionRequests(List.of(toolExecutionRequest))
+            .attributes(attributes)
+            .build();
+    final var chatResponse =
+        new ChatResponse.Builder()
+            .aiMessage(aiMessage)
+            .metadata(ChatResponseMetadata.builder().finishReason(FinishReason.STOP).build())
+            .build();
+
+    final var toolCall = ToolCall.builder().id("toolCallId").name("toolName").build();
+    when(toolCallConverter.asToolCall(toolExecutionRequest)).thenReturn(toolCall);
+
+    final var assistantMessage =
+        chatMessageConverter.toAssistantMessage(chatResponse, providerConfiguration);
+
+    assertThat(assistantMessage.toolCalls()).hasSize(1);
+    assertThat(assistantMessage.toolCalls().getFirst().metadata()).isEmpty();
+  }
+
+  @ParameterizedTest
+  @MethodSource("nonVertexAiProviders")
+  void fromAssistantMessage_forNonVertexAiProvider_neverRestoresAttributes(
+      ProviderConfiguration providerConfiguration) {
+    final var toolCall =
+        ToolCall.builder()
+            .id("toolCallId")
+            .name("toolName")
+            .metadata(
+                Map.of(
+                    GoogleVertexAiProviderConfiguration.GOOGLE_VERTEX_AI_ID,
+                    Map.of("thoughtSignature", "c2lnbmF0dXJl")))
+            .build();
+    final var assistantMessage =
+        AssistantMessage.builder()
+            .content(List.of(textContent("Test message")))
+            .toolCalls(List.of(toolCall))
+            .build();
+
+    when(toolCallConverter.asToolExecutionRequest(toolCall))
+        .thenReturn(mock(ToolExecutionRequest.class));
+
+    assertThat(
+            chatMessageConverter
+                .fromAssistantMessage(assistantMessage, providerConfiguration)
+                .attributes())
+        .isEmpty();
+  }
+
+  /**
+   * The persisted tool call metadata lives in a process variable, so its shape is neither type-safe
+   * nor beyond tampering.
+   */
+  @ParameterizedTest
+  @NullSource
+  @MethodSource("toolCallMetadataWithoutUsableThoughtSignature")
+  void fromAssistantMessage_withoutUsableToolCallMetadata_returnsEmptyAttributes(
+      Map<String, Object> toolCallMetadata) {
+    final var toolCall =
+        ToolCall.builder().id("toolCallId").name("toolName").metadata(toolCallMetadata).build();
+    final var assistantMessage =
+        AssistantMessage.builder()
+            .content(List.of(textContent("Test message")))
+            .toolCalls(List.of(toolCall))
+            .build();
+
+    when(toolCallConverter.asToolExecutionRequest(toolCall))
+        .thenReturn(mock(ToolExecutionRequest.class));
+
+    assertThat(chatMessageConverter.fromAssistantMessage(assistantMessage, VERTEX_AI).attributes())
+        .isEmpty();
+  }
+
+  static Stream<Map<String, Object>> toolCallMetadataWithoutUsableThoughtSignature() {
+    return Stream.of(
+        Map.of(),
+        // no matching provider key
+        Map.of("some-other-provider", Map.of("thoughtSignature", "c2ln")),
+        // provider key present but not a map
+        Map.of(GoogleVertexAiProviderConfiguration.GOOGLE_VERTEX_AI_ID, "not-a-map"));
+  }
+
+  @Test
+  void fromAssistantMessage_withMultipleToolCalls_reconstructsFlatAttributesPerToolCallId() {
+    final var validToolCall =
+        ToolCall.builder()
+            .id("toolCallA")
+            .name("toolName")
+            .metadata(
+                Map.of(
+                    GoogleVertexAiProviderConfiguration.GOOGLE_VERTEX_AI_ID,
+                    Map.of("thoughtSignature", "c2ln")))
+            .build();
+    final var invalidToolCall =
+        ToolCall.builder()
+            .id("toolCallB")
+            .name("toolName")
+            .metadata(
+                Map.of(
+                    GoogleVertexAiProviderConfiguration.GOOGLE_VERTEX_AI_ID,
+                    Map.of("thoughtSignature", 42)))
+            .build();
+    final var assistantMessage =
+        AssistantMessage.builder()
+            .content(List.of(textContent("Test message")))
+            .toolCalls(List.of(validToolCall, invalidToolCall))
+            .build();
+
+    when(toolCallConverter.asToolExecutionRequest(validToolCall))
+        .thenReturn(mock(ToolExecutionRequest.class));
+    when(toolCallConverter.asToolExecutionRequest(invalidToolCall))
+        .thenReturn(mock(ToolExecutionRequest.class));
+
+    assertThat(chatMessageConverter.fromAssistantMessage(assistantMessage, VERTEX_AI).attributes())
+        .containsExactly(entry("thought_signature_toolCallA", "c2ln"));
   }
 
   @Test
@@ -211,7 +442,7 @@ class ChatMessageConverterTest {
     final var chatResponse =
         new ChatResponse.Builder().aiMessage(aiMessage).metadata(chatResponseMetadata).build();
 
-    final var result = chatMessageConverter.toAssistantMessage(chatResponse);
+    final var result = chatMessageConverter.toAssistantMessage(chatResponse, ANTHROPIC);
 
     assertThat(result.content())
         .hasSize(1)
@@ -268,7 +499,7 @@ class ChatMessageConverterTest {
     final var chatResponse =
         new ChatResponse.Builder().aiMessage(aiMessage).metadata(chatResponseMetadata).build();
 
-    final var result = chatMessageConverter.toAssistantMessage(chatResponse);
+    final var result = chatMessageConverter.toAssistantMessage(chatResponse, ANTHROPIC);
 
     final var expectedTokenUsage = new LinkedHashMap<String, Object>();
     expectedTokenUsage.put("inputTokenCount", 10);
@@ -300,7 +531,7 @@ class ChatMessageConverterTest {
     final var chatResponse =
         new ChatResponse.Builder().aiMessage(aiMessage).metadata(chatResponseMetadata).build();
 
-    final var result = chatMessageConverter.toAssistantMessage(chatResponse);
+    final var result = chatMessageConverter.toAssistantMessage(chatResponse, ANTHROPIC);
 
     assertThat(result.content()).isEmpty();
 
@@ -321,7 +552,7 @@ class ChatMessageConverterTest {
 
     final var chatResponse = new ChatResponse.Builder().aiMessage(aiMessage).build();
 
-    final var result = chatMessageConverter.toAssistantMessage(chatResponse);
+    final var result = chatMessageConverter.toAssistantMessage(chatResponse, ANTHROPIC);
 
     assertThat(result.content()).isEmpty();
   }
@@ -331,7 +562,7 @@ class ChatMessageConverterTest {
     final var chatResponse =
         new ChatResponse.Builder().aiMessage(AiMessage.builder().build()).build();
 
-    final var result = chatMessageConverter.toAssistantMessage(chatResponse);
+    final var result = chatMessageConverter.toAssistantMessage(chatResponse, ANTHROPIC);
 
     assertThat(result.metadata()).containsKey("framework");
     assertThat(result.metadata().get("framework"))
@@ -356,7 +587,7 @@ class ChatMessageConverterTest {
     ToolCall toolCall = ToolCall.builder().id("toolCallId").name("toolName").build();
     when(toolCallConverter.asToolCall(toolExecutionRequest)).thenReturn(toolCall);
 
-    AssistantMessage result = chatMessageConverter.toAssistantMessage(chatResponse);
+    AssistantMessage result = chatMessageConverter.toAssistantMessage(chatResponse, ANTHROPIC);
 
     assertThat(result.toolCalls()).hasSize(1).containsExactly(toolCall);
   }
@@ -384,7 +615,7 @@ class ChatMessageConverterTest {
     SystemMessage systemMessage =
         SystemMessage.builder().content(List.of(textContent("Test system message"))).build();
 
-    List<ChatMessage> result = chatMessageConverter.map(systemMessage);
+    List<ChatMessage> result = chatMessageConverter.map(systemMessage, ANTHROPIC);
 
     assertThat(result)
         .hasSize(1)
@@ -405,7 +636,8 @@ class ChatMessageConverterTest {
     UserMessage userMessage =
         UserMessage.builder().content(List.of(textContent("User message"))).build();
 
-    List<ChatMessage> result = chatMessageConverter.map(List.of(systemMessage, userMessage));
+    List<ChatMessage> result =
+        chatMessageConverter.map(List.of(systemMessage, userMessage), ANTHROPIC);
 
     assertThat(result).hasSize(2);
     assertThat(result.get(0)).isInstanceOf(dev.langchain4j.data.message.SystemMessage.class);
@@ -422,7 +654,7 @@ class ChatMessageConverterTest {
           }
         };
 
-    assertThatThrownBy(() -> chatMessageConverter.map(unknownMessage))
+    assertThatThrownBy(() -> chatMessageConverter.map(unknownMessage, ANTHROPIC))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("Unknown message type");
   }

--- a/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/ChatModelFactoryTest.java
+++ b/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/ChatModelFactoryTest.java
@@ -11,7 +11,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyDouble;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyMap;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;

--- a/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/ChatModelFactoryTest.java
+++ b/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/ChatModelFactoryTest.java
@@ -9,12 +9,12 @@ package io.camunda.connector.agenticai.aiagent.framework.langchain4j;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyDouble;
-import static org.mockito.ArgumentMatchers.anyFloat;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
@@ -25,18 +25,20 @@ import static org.mockito.Mockito.when;
 
 import com.azure.core.credential.TokenCredential;
 import com.azure.identity.ClientSecretCredential;
+import com.google.auth.oauth2.GoogleCredentials;
 import com.google.auth.oauth2.ServiceAccountCredentials;
+import com.google.genai.Client;
+import com.google.genai.types.HttpOptions;
 import dev.langchain4j.model.anthropic.AnthropicChatModel;
 import dev.langchain4j.model.anthropic.AnthropicChatModel.AnthropicChatModelBuilder;
 import dev.langchain4j.model.azure.AzureOpenAiChatModel;
 import dev.langchain4j.model.bedrock.BedrockChatModel;
 import dev.langchain4j.model.bedrock.BedrockChatRequestParameters;
 import dev.langchain4j.model.chat.request.ChatRequestParameters;
+import dev.langchain4j.model.google.genai.GoogleGenAiChatModel;
 import dev.langchain4j.model.openai.OpenAiChatModel;
 import dev.langchain4j.model.openai.OpenAiChatModel.OpenAiChatModelBuilder;
 import dev.langchain4j.model.openai.OpenAiChatRequestParameters;
-import dev.langchain4j.model.vertexai.gemini.VertexAiGeminiChatModel;
-import dev.langchain4j.model.vertexai.gemini.VertexAiGeminiChatModel.VertexAiGeminiChatModelBuilder;
 import io.camunda.connector.agenticai.aiagent.model.request.provider.AnthropicProviderConfiguration;
 import io.camunda.connector.agenticai.aiagent.model.request.provider.AnthropicProviderConfiguration.AnthropicAuthentication;
 import io.camunda.connector.agenticai.aiagent.model.request.provider.AnthropicProviderConfiguration.AnthropicConnection;
@@ -497,6 +499,8 @@ class ChatModelFactoryTest {
     private static final GoogleVertexAiModelParameters DEFAULT_MODEL_PARAMETERS =
         new GoogleVertexAiModelParameters(10, 1.0F, 0.8F, 100);
 
+    @Captor private ArgumentCaptor<HttpOptions> httpOptionsArgumentCaptor;
+
     @Test
     void createsGoogleVertexAiChatModel() {
       final var providerConfig =
@@ -509,14 +513,21 @@ class ChatModelFactoryTest {
 
       testGoogleVertexAiChatModelBuilder(
           providerConfig,
-          (builder) -> {
-            verify(builder).location(REGION);
-            verify(builder).project(PROJECT_ID);
-            verify(builder).modelName(MODEL);
-            verify(builder).maxOutputTokens(DEFAULT_MODEL_PARAMETERS.maxOutputTokens());
-            verify(builder).temperature(DEFAULT_MODEL_PARAMETERS.temperature());
-            verify(builder).topP(DEFAULT_MODEL_PARAMETERS.topP());
-            verify(builder).topK(DEFAULT_MODEL_PARAMETERS.topK());
+          (builders) -> {
+            verify(builders.clientBuilder).vertexAI(true);
+            verify(builders.clientBuilder).project(PROJECT_ID);
+            verify(builders.clientBuilder).location(REGION);
+            verify(builders.clientBuilder, never()).credentials(any());
+
+            verify(builders.chatModelBuilder).client(builders.client);
+            verify(builders.chatModelBuilder).modelName(MODEL);
+            verify(builders.chatModelBuilder).maxRetries(0);
+            verify(builders.chatModelBuilder)
+                .maxOutputTokens(DEFAULT_MODEL_PARAMETERS.maxOutputTokens());
+            verify(builders.chatModelBuilder)
+                .temperature(DEFAULT_MODEL_PARAMETERS.temperature().doubleValue());
+            verify(builders.chatModelBuilder).topP(DEFAULT_MODEL_PARAMETERS.topP().doubleValue());
+            verify(builders.chatModelBuilder).topK(DEFAULT_MODEL_PARAMETERS.topK());
           });
     }
 
@@ -535,14 +546,20 @@ class ChatModelFactoryTest {
 
       testGoogleVertexAiChatModelBuilder(
           providerConfig,
-          (builder) -> {
-            verify(builder, never()).maxOutputTokens(anyInt());
-            verify(builder, never()).temperature(anyFloat());
-            verify(builder, never()).topP(anyFloat());
-            verify(builder, never()).topK(anyInt());
+          (builders) -> {
+            verify(builders.chatModelBuilder, never()).maxOutputTokens(anyInt());
+            verify(builders.chatModelBuilder, never()).temperature(anyDouble());
+            verify(builders.chatModelBuilder, never()).topP(anyDouble());
+            verify(builders.chatModelBuilder, never()).topK(anyInt());
           });
     }
 
+    /**
+     * Service account credentials must be scoped explicitly. google-genai only scopes the
+     * application default credentials it resolves itself and passes user-supplied credentials
+     * through verbatim, so an unscoped credential makes the token request fail with {@code
+     * invalid_scope}.
+     */
     @Test
     void createsGoogleVertexAiChatModelWithServiceAccountCredential() {
       final var providerConfig =
@@ -555,50 +572,117 @@ class ChatModelFactoryTest {
 
       try (final var staticMockedSac = mockStatic(ServiceAccountCredentials.class)) {
         final var mockedSac = mock(ServiceAccountCredentials.class);
-        when(mockedSac.createScoped(anyString())).thenReturn(mockedSac);
+        final var scopedSac = mock(GoogleCredentials.class);
+        when(mockedSac.createScoped("https://www.googleapis.com/auth/cloud-platform"))
+            .thenReturn(scopedSac);
         staticMockedSac
             .when(() -> ServiceAccountCredentials.fromStream(any()))
             .thenReturn(mockedSac);
 
         testGoogleVertexAiChatModelBuilder(
-            providerConfig,
-            (builder) -> {
-              verify(builder).location(REGION);
-              verify(builder).project(PROJECT_ID);
-              verify(builder).credentials(mockedSac);
-              verify(builder).modelName(MODEL);
-              verify(builder).maxOutputTokens(DEFAULT_MODEL_PARAMETERS.maxOutputTokens());
-              verify(builder).temperature(DEFAULT_MODEL_PARAMETERS.temperature());
-              verify(builder).topP(DEFAULT_MODEL_PARAMETERS.topP());
-              verify(builder).topK(DEFAULT_MODEL_PARAMETERS.topK());
-            });
+            providerConfig, (builders) -> verify(builders.clientBuilder).credentials(scopedSac));
 
         staticMockedSac.verify(() -> ServiceAccountCredentials.fromStream(any()));
       }
     }
 
+    @ParameterizedTest
+    @ValueSource(strings = {"global", "us", "us-central1", "europe-west1"})
+    void passesRegionThroughUnchanged(String region) {
+      final var providerConfig =
+          new GoogleVertexAiProviderConfiguration(
+              new GoogleVertexAiConnection(
+                  PROJECT_ID,
+                  region,
+                  new ApplicationDefaultCredentialsAuthentication(),
+                  new GoogleVertexAiModel(MODEL, null)));
+
+      testGoogleVertexAiChatModelBuilder(
+          providerConfig, (builders) -> verify(builders.clientBuilder).location(region));
+    }
+
+    @Test
+    void disablesGenAiRetries() {
+      final var providerConfig =
+          new GoogleVertexAiProviderConfiguration(
+              new GoogleVertexAiConnection(
+                  PROJECT_ID,
+                  REGION,
+                  new ApplicationDefaultCredentialsAuthentication(),
+                  new GoogleVertexAiModel(MODEL, null)));
+
+      testGoogleVertexAiChatModelBuilder(
+          providerConfig,
+          (builders) ->
+              assertThat(captureHttpOptions(builders).retryOptions())
+                  .isPresent()
+                  .get()
+                  .extracting(retryOptions -> retryOptions.attempts().orElseThrow())
+                  .isEqualTo(1));
+    }
+
+    /**
+     * The timeout is not configurable on this version - unlike 8.9, it always applies the same
+     * default used by every other provider here.
+     */
+    @Test
+    void appliesDefaultTimeout() {
+      final var providerConfig =
+          new GoogleVertexAiProviderConfiguration(
+              new GoogleVertexAiConnection(
+                  PROJECT_ID,
+                  REGION,
+                  new ApplicationDefaultCredentialsAuthentication(),
+                  new GoogleVertexAiModel(MODEL, null)));
+
+      testGoogleVertexAiChatModelBuilder(
+          providerConfig,
+          (builders) ->
+              assertThat(captureHttpOptions(builders).timeout())
+                  .isPresent()
+                  .contains((int) EXPECTED_DEFAULT_TIMEOUT.toMillis()));
+    }
+
+    private HttpOptions captureHttpOptions(GoogleVertexAiBuilderContext builders) {
+      verify(builders.clientBuilder).httpOptions(httpOptionsArgumentCaptor.capture());
+      return httpOptionsArgumentCaptor.getValue();
+    }
+
     private void testGoogleVertexAiChatModelBuilder(
         GoogleVertexAiProviderConfiguration providerConfig,
-        ThrowingConsumer<VertexAiGeminiChatModelBuilder> builderAssertions) {
-      final var chatModelBuilder = spy(VertexAiGeminiChatModel.builder());
-      final var chatModelResultCaptor = new ResultCaptor<VertexAiGeminiChatModel>();
+        ThrowingConsumer<GoogleVertexAiBuilderContext> builderAssertions) {
+      // the client must not really be built - it would resolve application default credentials
+      final var client = mock(Client.class);
+      final var clientBuilder = spy(Client.builder());
+      doReturn(client).when(clientBuilder).build();
+
+      final var chatModelBuilder = spy(GoogleGenAiChatModel.builder());
+      final var chatModelResultCaptor = new ResultCaptor<GoogleGenAiChatModel>();
       doAnswer(chatModelResultCaptor).when(chatModelBuilder).build();
 
-      try (MockedStatic<VertexAiGeminiChatModel> chatModelMock =
-          mockStatic(VertexAiGeminiChatModel.class, Answers.CALLS_REAL_METHODS)) {
-        chatModelMock.when(VertexAiGeminiChatModel::builder).thenReturn(chatModelBuilder);
+      try (MockedStatic<Client> clientMock = mockStatic(Client.class, Answers.CALLS_REAL_METHODS);
+          MockedStatic<GoogleGenAiChatModel> chatModelMock =
+              mockStatic(GoogleGenAiChatModel.class, Answers.CALLS_REAL_METHODS)) {
+        clientMock.when(Client::builder).thenReturn(clientBuilder);
+        chatModelMock.when(GoogleGenAiChatModel::builder).thenReturn(chatModelBuilder);
 
         final var chatModel = chatModelFactory.createChatModel(providerConfig);
-        assertThat(chatModel).isNotNull().isInstanceOf(VertexAiGeminiChatModel.class);
+        assertThat(chatModel).isNotNull().isInstanceOf(GoogleGenAiChatModel.class);
         assertThat(chatModel).isSameAs(chatModelResultCaptor.getResult());
 
-        builderAssertions.accept(chatModelBuilder);
+        builderAssertions.accept(
+            new GoogleVertexAiBuilderContext(clientBuilder, client, chatModelBuilder));
       }
     }
 
     static Stream<GoogleVertexAiModelParameters> nullModelParameters() {
       return Stream.of(new GoogleVertexAiModelParameters(null, null, null, null));
     }
+
+    private record GoogleVertexAiBuilderContext(
+        Client.Builder clientBuilder,
+        Client client,
+        GoogleGenAiChatModel.Builder chatModelBuilder) {}
   }
 
   @Nested

--- a/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/Langchain4JAiFrameworkAdapterTest.java
+++ b/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/Langchain4JAiFrameworkAdapterTest.java
@@ -34,6 +34,8 @@ import io.camunda.connector.agenticai.aiagent.model.request.OutboundConnectorRes
 import io.camunda.connector.agenticai.aiagent.model.request.ResponseConfiguration;
 import io.camunda.connector.agenticai.aiagent.model.request.ResponseFormatConfiguration.JsonResponseFormatConfiguration;
 import io.camunda.connector.agenticai.aiagent.model.request.ResponseFormatConfiguration.TextResponseFormatConfiguration;
+import io.camunda.connector.agenticai.aiagent.model.request.provider.AnthropicProviderConfiguration;
+import io.camunda.connector.agenticai.aiagent.model.request.provider.ProviderConfiguration;
 import io.camunda.connector.agenticai.model.message.AssistantMessage;
 import io.camunda.connector.agenticai.model.message.Message;
 import io.camunda.connector.agenticai.model.tool.ToolDefinition;
@@ -67,6 +69,9 @@ class Langchain4JAiFrameworkAdapterTest {
           dev.langchain4j.data.message.UserMessage.userMessage(USER_PROMPT));
 
   private static final AssistantMessage ASSISTANT_MESSAGE = assistantMessage(RESPONSE_TEXT);
+
+  private static final ProviderConfiguration PROVIDER_CONFIGURATION =
+      new AnthropicProviderConfiguration(null);
 
   private static final List<ToolDefinition> TOOL_DEFINITIONS =
       List.of(
@@ -108,7 +113,8 @@ class Langchain4JAiFrameworkAdapterTest {
   void setUp() {
     runtimeMemory = new DefaultRuntimeMemory();
     runtimeMemory.addMessages(INPUT_MESSAGES);
-    when(chatMessageConverter.map(runtimeMemory.filteredMessages())).thenReturn(L4J_MESSAGES);
+    when(chatMessageConverter.map(runtimeMemory.filteredMessages(), PROVIDER_CONFIGURATION))
+        .thenReturn(L4J_MESSAGES);
 
     when(toolSpecificationConverter.asToolSpecifications(TOOL_DEFINITIONS))
         .thenReturn(L4J_TOOL_SPECIFICATIONS);
@@ -116,7 +122,8 @@ class Langchain4JAiFrameworkAdapterTest {
     when(chatModelFactory.createChatModel(any())).thenReturn(chatModel);
     when(chatModel.chat(chatRequestCaptor.capture())).thenReturn(chatResponse);
     when(chatResponse.tokenUsage()).thenReturn(new TokenUsage(5, 6));
-    when(chatMessageConverter.toAssistantMessage(chatResponse)).thenReturn(ASSISTANT_MESSAGE);
+    when(chatMessageConverter.toAssistantMessage(chatResponse, PROVIDER_CONFIGURATION))
+        .thenReturn(ASSISTANT_MESSAGE);
 
     adapter =
         new Langchain4JAiFrameworkAdapter(
@@ -261,6 +268,7 @@ class Langchain4JAiFrameworkAdapterTest {
       ResponseConfiguration responseConfiguration) {
     final var executionContext = mock(AgentExecutionContext.class);
     when(executionContext.response()).thenReturn(responseConfiguration);
+    when(executionContext.provider()).thenReturn(PROVIDER_CONFIGURATION);
 
     return executionContext;
   }

--- a/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/ToolCallMetadataDecoratorTest.java
+++ b/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/ToolCallMetadataDecoratorTest.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.agenticai.aiagent.framework.langchain4j;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+
+import io.camunda.connector.agenticai.aiagent.model.request.provider.AnthropicProviderConfiguration;
+import io.camunda.connector.agenticai.aiagent.model.request.provider.AzureOpenAiProviderConfiguration;
+import io.camunda.connector.agenticai.aiagent.model.request.provider.BedrockProviderConfiguration;
+import io.camunda.connector.agenticai.aiagent.model.request.provider.GoogleVertexAiProviderConfiguration;
+import io.camunda.connector.agenticai.aiagent.model.request.provider.OpenAiCompatibleProviderConfiguration;
+import io.camunda.connector.agenticai.aiagent.model.request.provider.OpenAiProviderConfiguration;
+import io.camunda.connector.agenticai.aiagent.model.request.provider.ProviderConfiguration;
+import java.util.Map;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class ToolCallMetadataDecoratorTest {
+
+  private static final GoogleVertexAiProviderConfiguration GOOGLE_VERTEX_AI =
+      new GoogleVertexAiProviderConfiguration(null);
+
+  private static final String TOOL_CALL_ID = "toolCallId";
+
+  static Stream<ProviderConfiguration> nonVertexAiProviders() {
+    return Stream.of(
+        new AnthropicProviderConfiguration(null),
+        new BedrockProviderConfiguration(null),
+        new AzureOpenAiProviderConfiguration(null),
+        new OpenAiProviderConfiguration(null),
+        new OpenAiCompatibleProviderConfiguration(null));
+  }
+
+  @ParameterizedTest
+  @MethodSource("nonVertexAiProviders")
+  void decorateOnWrite_dropsAttributesForNonVertexAiProviders(
+      ProviderConfiguration providerConfiguration) {
+    assertThat(
+            ToolCallMetadataDecorator.decorateOnWrite(
+                providerConfiguration,
+                TOOL_CALL_ID,
+                Map.of("thought_signature_" + TOOL_CALL_ID, "c2lnbmF0dXJl")))
+        .isEmpty();
+  }
+
+  @ParameterizedTest
+  @MethodSource("nonVertexAiProviders")
+  void decorateOnRead_dropsAttributesForNonVertexAiProviders(
+      ProviderConfiguration providerConfiguration) {
+    assertThat(
+            ToolCallMetadataDecorator.decorateOnRead(
+                providerConfiguration,
+                TOOL_CALL_ID,
+                Map.of(
+                    GoogleVertexAiProviderConfiguration.GOOGLE_VERTEX_AI_ID,
+                    Map.of("thoughtSignature", "c2lnbmF0dXJl"))))
+        .isEmpty();
+  }
+
+  @Test
+  void decorateOnWrite_keepsThoughtSignatureMatchingThisToolCallId_namespacedByProviderId() {
+    final var aiMessageAttributes =
+        Map.<String, Object>of(
+            "thought_signature_" + TOOL_CALL_ID,
+            "c2lnbmF0dXJl",
+            "thought_signature_someOtherToolCallId",
+            "unrelated-signature",
+            "raw_http_response",
+            "leak-risk");
+
+    assertThat(
+            ToolCallMetadataDecorator.decorateOnWrite(
+                GOOGLE_VERTEX_AI, TOOL_CALL_ID, aiMessageAttributes))
+        .containsExactly(
+            entry(
+                GoogleVertexAiProviderConfiguration.GOOGLE_VERTEX_AI_ID,
+                Map.of("thoughtSignature", "c2lnbmF0dXJl")));
+  }
+
+  @Test
+  void decorateOnWrite_dropsResultForGoogleVertexAiWhenNoMatchingThoughtSignature() {
+    assertThat(
+            ToolCallMetadataDecorator.decorateOnWrite(
+                GOOGLE_VERTEX_AI, TOOL_CALL_ID, Map.of("raw_http_response", "leak-risk")))
+        .isEmpty();
+  }
+
+  @Test
+  void decorateOnWrite_dropsResultForGoogleVertexAiWhenSignatureValueIsNotAString() {
+    assertThat(
+            ToolCallMetadataDecorator.decorateOnWrite(
+                GOOGLE_VERTEX_AI, TOOL_CALL_ID, Map.of("thought_signature_" + TOOL_CALL_ID, 42)))
+        .isEmpty();
+  }
+
+  @Test
+  void decorateOnRead_returnsPrefixedAttributeEntryForGoogleVertexAi() {
+    final var persisted =
+        Map.of(
+            GoogleVertexAiProviderConfiguration.GOOGLE_VERTEX_AI_ID,
+            Map.of("thoughtSignature", "c2ln"));
+
+    assertThat(ToolCallMetadataDecorator.decorateOnRead(GOOGLE_VERTEX_AI, TOOL_CALL_ID, persisted))
+        .containsExactly(entry("thought_signature_" + TOOL_CALL_ID, "c2ln"));
+  }
+
+  @Test
+  void decorateOnRead_dropsResultForGoogleVertexAiWhenSignatureValueIsNotAString() {
+    final var persisted =
+        Map.of(
+            GoogleVertexAiProviderConfiguration.GOOGLE_VERTEX_AI_ID,
+            Map.of("thoughtSignature", 42));
+
+    assertThat(ToolCallMetadataDecorator.decorateOnRead(GOOGLE_VERTEX_AI, TOOL_CALL_ID, persisted))
+        .isEmpty();
+  }
+
+  /**
+   * Persisted entries are namespaced by provider ID so that metadata left behind by a previous
+   * provider (e.g. after a config update or process instance migration) is never picked up as if it
+   * belonged to the current one.
+   */
+  @Test
+  void decorateOnRead_ignoresMetadataPersistedUnderADifferentProviderId() {
+    final var persisted = Map.of("some-other-provider", Map.of("thoughtSignature", "c2ln"));
+
+    assertThat(ToolCallMetadataDecorator.decorateOnRead(GOOGLE_VERTEX_AI, TOOL_CALL_ID, persisted))
+        .isEmpty();
+  }
+}

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -115,6 +115,8 @@ limitations under the License.</license.inlineheader>
     <version.google-libraries-bom>26.85.1</version.google-libraries-bom>
     <version.google-api-services-sheets>v4-rev20260610-2.0.0</version.google-api-services-sheets>
     <version.google-cloud-storage>2.71.0</version.google-cloud-storage>
+    <!-- keep in sync with langchain4j-google-genai -->
+    <version.google-genai>1.62.0</version.google-genai>
     <version.gson-extras>3.3.0</version.gson-extras>
 
     <version.httpcore>4.4.16</version.httpcore>
@@ -524,6 +526,11 @@ limitations under the License.</license.inlineheader>
         <groupId>com.google.apis</groupId>
         <artifactId>google-api-services-sheets</artifactId>
         <version>${version.google-api-services-sheets}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.genai</groupId>
+        <artifactId>google-genai</artifactId>
+        <version>${version.google-genai}</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
## Description

Manual backport of #8178 to `stable/8.8`. The automated backport bot failed to cherry-pick because 8.8 diverged too far from the PR's base (no A2A gateway, no per-tool-call metadata, no `TimeoutConfiguration`/`ChatModelHttpProxySupport`/`CloseableChatModel` infra), so this reimplements the relevant slice of the migration on top of 8.8's current code instead of cherry-picking directly.

**Core SDK migration:**
- `dev.langchain4j:langchain4j-vertex-ai-gemini` wraps `com.google.cloud:google-cloud-vertexai`, which Google sunset on 2026-06-24. It always builds the hostname as `<location>-aiplatform.googleapis.com`, so `region=global` 404s and global-only models (e.g. Gemini 3) can't be used at all - no config-only workaround exists.
- Switches to `langchain4j-google-genai` / `com.google.genai`, which maps `global` to `https://aiplatform.googleapis.com` at the source.
- Unlike #8178, the timeout is **not** configurable here - it stays the fixed `DEFAULT_MODEL_CALL_TIMEOUT` (3 min) already used by every provider on this branch, since 8.8 has no per-connection timeout config infra. Custom endpoint and HTTP proxy support are likewise out of scope (that infra doesn't exist on 8.8).
- No `CloseableChatModel` wrapper - `GoogleGenAiChatModel`'s underlying client (OkHttp dispatcher/pool) isn't explicitly closed, matching 8.8's existing behavior for every other provider (none of them close today).
- Kept from #8178: SDK-internal retries disabled (`maxRetries(0)` + `HttpRetryOptions.attempts(1)`, avoids stacking with langchain4j's own retry), eager service-account credential scoping to `cloud-platform` (required or the token request fails with `invalid_scope`).

**Gemini 3 thought signature preservation:**
- Gemini 3 rejects a follow-up request whose `functionCall` parts are missing the `thoughtSignature` the model returned with them, so tool calling failed on the second model call. langchain4j carries the signature on `AiMessage.attributes()` keyed by tool call ID, but `ChatMessageConverterImpl` only copied text and tool requests, dropping it once persisted to the conversation history.
- `ToolCall` gains a `metadata` map (BC 3-arg constructor kept for existing callers) to carry provider round-trip data attached to the specific tool call it belongs to.
- `ToolCallMetadataDecorator` un-flattens/re-flattens the attribute and namespaces it by provider ID, so every non-Google provider keeps dropping attributes entirely and a provider switch can't leak a previous provider's persisted metadata.
- `ChatMessageConverter`/`ChatMessageConverterImpl`/`Langchain4JAiFrameworkAdapter` thread `ProviderConfiguration` through the conversation-history round trip so the decorator can dispatch on it.

Not backported (infra doesn't exist on 8.8, or out of scope): configurable endpoint/timeout, HTTP proxy support, A2A/MCP gateway `ToolCall` changes (neither the A2A gateway nor the newer MCP metadata plumbing exist on this branch), the element-template version bump.

## Related issues

closes #

Backport of #8178.

## Checklist

- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest
  release, as this branch will be rebased onto main before the next release. Example backport labels:
    - `backport stable/8.8`: for changes that should be included in the next 8.8.x release.
    - **or** `backport release-8.8.7`: for changes that should be included in the specific release 8.8.7, and this
      *release has already been created*. The release branch will be merged back into stable/8.8 later, so the change
      will be included in future 8.8.x releases as well.
- [x] Tests/Integration tests for the changes have been added if applicable.