### PR TITLE
feat(embeddings-vector-db): add document input and response format dropdowns

### DIFF
--- a/connectors/embeddings-vector-database/element-templates/embeddings-vector-database-outbound-connector.json
+++ b/connectors/embeddings-vector-database/element-templates/embeddings-vector-database-outbound-connector.json
@@ -4,7 +4,7 @@
   "id" : "io.camunda.connectors.EmbeddingsVectorDB.v1",
   "description" : "Embed and download documents with vector databases",
   "documentationRef" : "https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/embeddings-vector-db/",
-  "version" : 3,
+  "version" : 4,
   "category" : {
     "id" : "connectors",
     "name" : "Connectors"
@@ -124,6 +124,29 @@
       "type" : "simple"
     },
     "type" : "Number"
+  }, {
+    "id" : "documentReturnFormat",
+    "label" : "Response format",
+    "description" : "Whether each retrieved chunk is stored as a document or returned as text only",
+    "value" : "DOCUMENT",
+    "group" : "query",
+    "binding" : {
+      "name" : "documentReturnFormat.choice",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "vectorDatabaseConnectorOperation.operationType",
+      "equals" : "retrieveDocumentOperation",
+      "type" : "simple"
+    },
+    "type" : "Dropdown",
+    "choices" : [ {
+      "name" : "Document reference",
+      "value" : "DOCUMENT"
+    }, {
+      "name" : "as text",
+      "value" : "TEXT"
+    } ]
   }, {
     "id" : "embeddingModelProvider.modelProvider",
     "label" : "Model provider",
@@ -1668,17 +1691,12 @@
     },
     "type" : "String"
   }, {
-    "id" : "vectorDatabaseConnectorOperation.documentSource",
-    "label" : "Document source",
-    "description" : "Whether you want to embed a Camunda document file or plain text",
-    "optional" : false,
-    "value" : "CamundaDocument",
-    "constraints" : {
-      "notEmpty" : true
-    },
+    "id" : "vectorDatabaseConnectorOperation.newDocuments_documentMode",
+    "label" : "Number of documents",
+    "value" : "single",
     "group" : "document",
     "binding" : {
-      "name" : "vectorDatabaseConnectorOperation.documentSource",
+      "name" : "vectorDatabaseConnectorOperation.newDocuments_documentMode",
       "type" : "zeebe:input"
     },
     "condition" : {
@@ -1688,29 +1706,218 @@
     },
     "type" : "Dropdown",
     "choices" : [ {
-      "name" : "Camunda document",
-      "value" : "CamundaDocument"
+      "name" : "Single document",
+      "value" : "single"
     }, {
-      "name" : "Plain text",
-      "value" : "PlainText"
+      "name" : "Multiple documents",
+      "value" : "multiple"
     } ]
   }, {
-    "id" : "vectorDatabaseConnectorOperation.documentSourceFromProcessVariable",
-    "label" : "Plain text to embed",
-    "optional" : false,
+    "id" : "vectorDatabaseConnectorOperation.newDocuments_single_documentSource",
+    "label" : "Document source",
+    "value" : "camunda",
+    "group" : "document",
+    "binding" : {
+      "name" : "vectorDatabaseConnectorOperation.newDocuments_single_documentSource",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "allMatch" : [ {
+        "property" : "vectorDatabaseConnectorOperation.newDocuments_documentMode",
+        "equals" : "single",
+        "type" : "simple"
+      }, {
+        "property" : "vectorDatabaseConnectorOperation.operationType",
+        "equals" : "embedDocumentOperation",
+        "type" : "simple"
+      } ]
+    },
+    "type" : "Dropdown",
+    "choices" : [ {
+      "name" : "Camunda Document",
+      "value" : "camunda"
+    }, {
+      "name" : "Inline Content",
+      "value" : "inline"
+    }, {
+      "name" : "From URL",
+      "value" : "external"
+    } ]
+  }, {
+    "id" : "vectorDatabaseConnectorOperation.newDocuments_single_camundaReference",
+    "label" : "Camunda document",
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "required",
+    "group" : "document",
+    "binding" : {
+      "name" : "vectorDatabaseConnectorOperation.newDocuments_single_camundaReference",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "allMatch" : [ {
+        "property" : "vectorDatabaseConnectorOperation.newDocuments_documentMode",
+        "equals" : "single",
+        "type" : "simple"
+      }, {
+        "property" : "vectorDatabaseConnectorOperation.newDocuments_single_documentSource",
+        "equals" : "camunda",
+        "type" : "simple"
+      }, {
+        "property" : "vectorDatabaseConnectorOperation.operationType",
+        "equals" : "embedDocumentOperation",
+        "type" : "simple"
+      } ]
+    },
+    "type" : "String"
+  }, {
+    "id" : "vectorDatabaseConnectorOperation.newDocuments_single_inline_content",
+    "label" : "Content",
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "document",
     "binding" : {
-      "name" : "vectorDatabaseConnectorOperation.documentSourceFromProcessVariable",
+      "name" : "vectorDatabaseConnectorOperation.newDocuments_single_inline_content",
       "type" : "zeebe:input"
     },
     "condition" : {
       "allMatch" : [ {
-        "property" : "vectorDatabaseConnectorOperation.documentSource",
-        "equals" : "PlainText",
+        "property" : "vectorDatabaseConnectorOperation.newDocuments_documentMode",
+        "equals" : "single",
+        "type" : "simple"
+      }, {
+        "property" : "vectorDatabaseConnectorOperation.newDocuments_single_documentSource",
+        "equals" : "inline",
+        "type" : "simple"
+      }, {
+        "property" : "vectorDatabaseConnectorOperation.operationType",
+        "equals" : "embedDocumentOperation",
+        "type" : "simple"
+      } ]
+    },
+    "type" : "String"
+  }, {
+    "id" : "vectorDatabaseConnectorOperation.newDocuments_single_inline_fileName",
+    "label" : "File name",
+    "feel" : "optional",
+    "group" : "document",
+    "binding" : {
+      "name" : "vectorDatabaseConnectorOperation.newDocuments_single_inline_fileName",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "allMatch" : [ {
+        "property" : "vectorDatabaseConnectorOperation.newDocuments_documentMode",
+        "equals" : "single",
+        "type" : "simple"
+      }, {
+        "property" : "vectorDatabaseConnectorOperation.newDocuments_single_documentSource",
+        "equals" : "inline",
+        "type" : "simple"
+      }, {
+        "property" : "vectorDatabaseConnectorOperation.operationType",
+        "equals" : "embedDocumentOperation",
+        "type" : "simple"
+      } ]
+    },
+    "type" : "String"
+  }, {
+    "id" : "vectorDatabaseConnectorOperation.newDocuments_single_inline_contentType",
+    "label" : "Content type",
+    "feel" : "optional",
+    "group" : "document",
+    "binding" : {
+      "name" : "vectorDatabaseConnectorOperation.newDocuments_single_inline_contentType",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "allMatch" : [ {
+        "property" : "vectorDatabaseConnectorOperation.newDocuments_documentMode",
+        "equals" : "single",
+        "type" : "simple"
+      }, {
+        "property" : "vectorDatabaseConnectorOperation.newDocuments_single_documentSource",
+        "equals" : "inline",
+        "type" : "simple"
+      }, {
+        "property" : "vectorDatabaseConnectorOperation.operationType",
+        "equals" : "embedDocumentOperation",
+        "type" : "simple"
+      } ]
+    },
+    "type" : "String"
+  }, {
+    "id" : "vectorDatabaseConnectorOperation.newDocuments_single_external_url",
+    "label" : "URL",
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "document",
+    "binding" : {
+      "name" : "vectorDatabaseConnectorOperation.newDocuments_single_external_url",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "allMatch" : [ {
+        "property" : "vectorDatabaseConnectorOperation.newDocuments_documentMode",
+        "equals" : "single",
+        "type" : "simple"
+      }, {
+        "property" : "vectorDatabaseConnectorOperation.newDocuments_single_documentSource",
+        "equals" : "external",
+        "type" : "simple"
+      }, {
+        "property" : "vectorDatabaseConnectorOperation.operationType",
+        "equals" : "embedDocumentOperation",
+        "type" : "simple"
+      } ]
+    },
+    "type" : "String"
+  }, {
+    "id" : "vectorDatabaseConnectorOperation.newDocuments_single_external_fileName",
+    "label" : "File name",
+    "feel" : "optional",
+    "group" : "document",
+    "binding" : {
+      "name" : "vectorDatabaseConnectorOperation.newDocuments_single_external_fileName",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "allMatch" : [ {
+        "property" : "vectorDatabaseConnectorOperation.newDocuments_documentMode",
+        "equals" : "single",
+        "type" : "simple"
+      }, {
+        "property" : "vectorDatabaseConnectorOperation.newDocuments_single_documentSource",
+        "equals" : "external",
+        "type" : "simple"
+      }, {
+        "property" : "vectorDatabaseConnectorOperation.operationType",
+        "equals" : "embedDocumentOperation",
+        "type" : "simple"
+      } ]
+    },
+    "type" : "String"
+  }, {
+    "id" : "vectorDatabaseConnectorOperation.newDocuments_multiple_expression",
+    "label" : "Documents",
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "required",
+    "group" : "document",
+    "binding" : {
+      "name" : "vectorDatabaseConnectorOperation.newDocuments_multiple_expression",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "allMatch" : [ {
+        "property" : "vectorDatabaseConnectorOperation.newDocuments_documentMode",
+        "equals" : "multiple",
         "type" : "simple"
       }, {
         "property" : "vectorDatabaseConnectorOperation.operationType",
@@ -1721,29 +1928,18 @@
     "type" : "String"
   }, {
     "id" : "vectorDatabaseConnectorOperation.newDocuments",
-    "label" : "Documents",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "feel" : "required",
+    "value" : "=if vectorDatabaseConnectorOperation.newDocuments_documentMode = \"multiple\" then vectorDatabaseConnectorOperation.newDocuments_multiple_expression else if vectorDatabaseConnectorOperation.newDocuments_documentMode = \"single\" then (if vectorDatabaseConnectorOperation.newDocuments_single_documentSource = \"camunda\" then [vectorDatabaseConnectorOperation.newDocuments_single_camundaReference] else if vectorDatabaseConnectorOperation.newDocuments_single_documentSource = \"inline\" then [{ \"camunda.document.type\": \"inline\", content: vectorDatabaseConnectorOperation.newDocuments_single_inline_content, name: vectorDatabaseConnectorOperation.newDocuments_single_inline_fileName, contentType: vectorDatabaseConnectorOperation.newDocuments_single_inline_contentType }] else if vectorDatabaseConnectorOperation.newDocuments_single_documentSource = \"external\" then [{ \"camunda.document.type\": \"external\", url: vectorDatabaseConnectorOperation.newDocuments_single_external_url, name: vectorDatabaseConnectorOperation.newDocuments_single_external_fileName }] else null) else null",
     "group" : "document",
     "binding" : {
       "name" : "vectorDatabaseConnectorOperation.newDocuments",
       "type" : "zeebe:input"
     },
     "condition" : {
-      "allMatch" : [ {
-        "property" : "vectorDatabaseConnectorOperation.documentSource",
-        "equals" : "CamundaDocument",
-        "type" : "simple"
-      }, {
-        "property" : "vectorDatabaseConnectorOperation.operationType",
-        "equals" : "embedDocumentOperation",
-        "type" : "simple"
-      } ]
+      "property" : "vectorDatabaseConnectorOperation.operationType",
+      "equals" : "embedDocumentOperation",
+      "type" : "simple"
     },
-    "type" : "String"
+    "type" : "Hidden"
   }, {
     "id" : "vectorDatabaseConnectorOperation.documentSplitter.documentSplitter",
     "label" : "Document splitting strategy",
@@ -1818,7 +2014,7 @@
     "id" : "version",
     "label" : "Version",
     "description" : "Version of the element template",
-    "value" : "3",
+    "value" : "4",
     "group" : "connector",
     "binding" : {
       "key" : "elementTemplateVersion",

--- a/connectors/embeddings-vector-database/element-templates/versioned/embeddings-vector-database-outbound-connector-3.json
+++ b/connectors/embeddings-vector-database/element-templates/versioned/embeddings-vector-database-outbound-connector-3.json
@@ -1,10 +1,10 @@
 {
   "$schema" : "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
-  "name" : "Hybrid Embeddings Vector DB Outbound Connector",
-  "id" : "io.camunda.connectors.EmbeddingsVectorDB.v1-hybrid",
+  "name" : "Embeddings Vector DB Outbound Connector",
+  "id" : "io.camunda.connectors.EmbeddingsVectorDB.v1",
   "description" : "Embed and download documents with vector databases",
   "documentationRef" : "https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/embeddings-vector-db/",
-  "version" : 4,
+  "version" : 3,
   "category" : {
     "id" : "connectors",
     "name" : "Connectors"
@@ -17,9 +17,6 @@
     "camunda" : "^8.8"
   },
   "groups" : [ {
-    "id" : "taskDefinitionType",
-    "label" : "Task definition type"
-  }, {
     "id" : "operation",
     "label" : "Operation"
   }, {
@@ -48,14 +45,12 @@
     "label" : "Retries"
   } ],
   "properties" : [ {
-    "id" : "taskDefinitionType",
     "value" : "io.camunda:embeddings-vector-database:1",
-    "group" : "taskDefinitionType",
     "binding" : {
       "property" : "type",
       "type" : "zeebe:taskDefinition"
     },
-    "type" : "String"
+    "type" : "Hidden"
   }, {
     "id" : "vectorDatabaseConnectorOperation.operationType",
     "label" : "Operation",
@@ -129,29 +124,6 @@
       "type" : "simple"
     },
     "type" : "Number"
-  }, {
-    "id" : "documentReturnFormat",
-    "label" : "Response format",
-    "description" : "Whether each retrieved chunk is stored as a document or returned as text only",
-    "value" : "DOCUMENT",
-    "group" : "query",
-    "binding" : {
-      "name" : "documentReturnFormat.choice",
-      "type" : "zeebe:input"
-    },
-    "condition" : {
-      "property" : "vectorDatabaseConnectorOperation.operationType",
-      "equals" : "retrieveDocumentOperation",
-      "type" : "simple"
-    },
-    "type" : "Dropdown",
-    "choices" : [ {
-      "name" : "Document reference",
-      "value" : "DOCUMENT"
-    }, {
-      "name" : "as text",
-      "value" : "TEXT"
-    } ]
   }, {
     "id" : "embeddingModelProvider.modelProvider",
     "label" : "Model provider",
@@ -1696,12 +1668,17 @@
     },
     "type" : "String"
   }, {
-    "id" : "vectorDatabaseConnectorOperation.newDocuments_documentMode",
-    "label" : "Number of documents",
-    "value" : "single",
+    "id" : "vectorDatabaseConnectorOperation.documentSource",
+    "label" : "Document source",
+    "description" : "Whether you want to embed a Camunda document file or plain text",
+    "optional" : false,
+    "value" : "CamundaDocument",
+    "constraints" : {
+      "notEmpty" : true
+    },
     "group" : "document",
     "binding" : {
-      "name" : "vectorDatabaseConnectorOperation.newDocuments_documentMode",
+      "name" : "vectorDatabaseConnectorOperation.documentSource",
       "type" : "zeebe:input"
     },
     "condition" : {
@@ -1711,218 +1688,29 @@
     },
     "type" : "Dropdown",
     "choices" : [ {
-      "name" : "Single document",
-      "value" : "single"
+      "name" : "Camunda document",
+      "value" : "CamundaDocument"
     }, {
-      "name" : "Multiple documents",
-      "value" : "multiple"
+      "name" : "Plain text",
+      "value" : "PlainText"
     } ]
   }, {
-    "id" : "vectorDatabaseConnectorOperation.newDocuments_single_documentSource",
-    "label" : "Document source",
-    "value" : "camunda",
-    "group" : "document",
-    "binding" : {
-      "name" : "vectorDatabaseConnectorOperation.newDocuments_single_documentSource",
-      "type" : "zeebe:input"
-    },
-    "condition" : {
-      "allMatch" : [ {
-        "property" : "vectorDatabaseConnectorOperation.newDocuments_documentMode",
-        "equals" : "single",
-        "type" : "simple"
-      }, {
-        "property" : "vectorDatabaseConnectorOperation.operationType",
-        "equals" : "embedDocumentOperation",
-        "type" : "simple"
-      } ]
-    },
-    "type" : "Dropdown",
-    "choices" : [ {
-      "name" : "Camunda Document",
-      "value" : "camunda"
-    }, {
-      "name" : "Inline Content",
-      "value" : "inline"
-    }, {
-      "name" : "From URL",
-      "value" : "external"
-    } ]
-  }, {
-    "id" : "vectorDatabaseConnectorOperation.newDocuments_single_camundaReference",
-    "label" : "Camunda document",
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "feel" : "required",
-    "group" : "document",
-    "binding" : {
-      "name" : "vectorDatabaseConnectorOperation.newDocuments_single_camundaReference",
-      "type" : "zeebe:input"
-    },
-    "condition" : {
-      "allMatch" : [ {
-        "property" : "vectorDatabaseConnectorOperation.newDocuments_documentMode",
-        "equals" : "single",
-        "type" : "simple"
-      }, {
-        "property" : "vectorDatabaseConnectorOperation.newDocuments_single_documentSource",
-        "equals" : "camunda",
-        "type" : "simple"
-      }, {
-        "property" : "vectorDatabaseConnectorOperation.operationType",
-        "equals" : "embedDocumentOperation",
-        "type" : "simple"
-      } ]
-    },
-    "type" : "String"
-  }, {
-    "id" : "vectorDatabaseConnectorOperation.newDocuments_single_inline_content",
-    "label" : "Content",
+    "id" : "vectorDatabaseConnectorOperation.documentSourceFromProcessVariable",
+    "label" : "Plain text to embed",
+    "optional" : false,
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "optional",
     "group" : "document",
     "binding" : {
-      "name" : "vectorDatabaseConnectorOperation.newDocuments_single_inline_content",
+      "name" : "vectorDatabaseConnectorOperation.documentSourceFromProcessVariable",
       "type" : "zeebe:input"
     },
     "condition" : {
       "allMatch" : [ {
-        "property" : "vectorDatabaseConnectorOperation.newDocuments_documentMode",
-        "equals" : "single",
-        "type" : "simple"
-      }, {
-        "property" : "vectorDatabaseConnectorOperation.newDocuments_single_documentSource",
-        "equals" : "inline",
-        "type" : "simple"
-      }, {
-        "property" : "vectorDatabaseConnectorOperation.operationType",
-        "equals" : "embedDocumentOperation",
-        "type" : "simple"
-      } ]
-    },
-    "type" : "String"
-  }, {
-    "id" : "vectorDatabaseConnectorOperation.newDocuments_single_inline_fileName",
-    "label" : "File name",
-    "feel" : "optional",
-    "group" : "document",
-    "binding" : {
-      "name" : "vectorDatabaseConnectorOperation.newDocuments_single_inline_fileName",
-      "type" : "zeebe:input"
-    },
-    "condition" : {
-      "allMatch" : [ {
-        "property" : "vectorDatabaseConnectorOperation.newDocuments_documentMode",
-        "equals" : "single",
-        "type" : "simple"
-      }, {
-        "property" : "vectorDatabaseConnectorOperation.newDocuments_single_documentSource",
-        "equals" : "inline",
-        "type" : "simple"
-      }, {
-        "property" : "vectorDatabaseConnectorOperation.operationType",
-        "equals" : "embedDocumentOperation",
-        "type" : "simple"
-      } ]
-    },
-    "type" : "String"
-  }, {
-    "id" : "vectorDatabaseConnectorOperation.newDocuments_single_inline_contentType",
-    "label" : "Content type",
-    "feel" : "optional",
-    "group" : "document",
-    "binding" : {
-      "name" : "vectorDatabaseConnectorOperation.newDocuments_single_inline_contentType",
-      "type" : "zeebe:input"
-    },
-    "condition" : {
-      "allMatch" : [ {
-        "property" : "vectorDatabaseConnectorOperation.newDocuments_documentMode",
-        "equals" : "single",
-        "type" : "simple"
-      }, {
-        "property" : "vectorDatabaseConnectorOperation.newDocuments_single_documentSource",
-        "equals" : "inline",
-        "type" : "simple"
-      }, {
-        "property" : "vectorDatabaseConnectorOperation.operationType",
-        "equals" : "embedDocumentOperation",
-        "type" : "simple"
-      } ]
-    },
-    "type" : "String"
-  }, {
-    "id" : "vectorDatabaseConnectorOperation.newDocuments_single_external_url",
-    "label" : "URL",
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "feel" : "optional",
-    "group" : "document",
-    "binding" : {
-      "name" : "vectorDatabaseConnectorOperation.newDocuments_single_external_url",
-      "type" : "zeebe:input"
-    },
-    "condition" : {
-      "allMatch" : [ {
-        "property" : "vectorDatabaseConnectorOperation.newDocuments_documentMode",
-        "equals" : "single",
-        "type" : "simple"
-      }, {
-        "property" : "vectorDatabaseConnectorOperation.newDocuments_single_documentSource",
-        "equals" : "external",
-        "type" : "simple"
-      }, {
-        "property" : "vectorDatabaseConnectorOperation.operationType",
-        "equals" : "embedDocumentOperation",
-        "type" : "simple"
-      } ]
-    },
-    "type" : "String"
-  }, {
-    "id" : "vectorDatabaseConnectorOperation.newDocuments_single_external_fileName",
-    "label" : "File name",
-    "feel" : "optional",
-    "group" : "document",
-    "binding" : {
-      "name" : "vectorDatabaseConnectorOperation.newDocuments_single_external_fileName",
-      "type" : "zeebe:input"
-    },
-    "condition" : {
-      "allMatch" : [ {
-        "property" : "vectorDatabaseConnectorOperation.newDocuments_documentMode",
-        "equals" : "single",
-        "type" : "simple"
-      }, {
-        "property" : "vectorDatabaseConnectorOperation.newDocuments_single_documentSource",
-        "equals" : "external",
-        "type" : "simple"
-      }, {
-        "property" : "vectorDatabaseConnectorOperation.operationType",
-        "equals" : "embedDocumentOperation",
-        "type" : "simple"
-      } ]
-    },
-    "type" : "String"
-  }, {
-    "id" : "vectorDatabaseConnectorOperation.newDocuments_multiple_expression",
-    "label" : "Documents",
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "feel" : "required",
-    "group" : "document",
-    "binding" : {
-      "name" : "vectorDatabaseConnectorOperation.newDocuments_multiple_expression",
-      "type" : "zeebe:input"
-    },
-    "condition" : {
-      "allMatch" : [ {
-        "property" : "vectorDatabaseConnectorOperation.newDocuments_documentMode",
-        "equals" : "multiple",
+        "property" : "vectorDatabaseConnectorOperation.documentSource",
+        "equals" : "PlainText",
         "type" : "simple"
       }, {
         "property" : "vectorDatabaseConnectorOperation.operationType",
@@ -1933,18 +1721,29 @@
     "type" : "String"
   }, {
     "id" : "vectorDatabaseConnectorOperation.newDocuments",
-    "value" : "=if vectorDatabaseConnectorOperation.newDocuments_documentMode = \"multiple\" then vectorDatabaseConnectorOperation.newDocuments_multiple_expression else if vectorDatabaseConnectorOperation.newDocuments_documentMode = \"single\" then (if vectorDatabaseConnectorOperation.newDocuments_single_documentSource = \"camunda\" then [vectorDatabaseConnectorOperation.newDocuments_single_camundaReference] else if vectorDatabaseConnectorOperation.newDocuments_single_documentSource = \"inline\" then [{ \"camunda.document.type\": \"inline\", content: vectorDatabaseConnectorOperation.newDocuments_single_inline_content, name: vectorDatabaseConnectorOperation.newDocuments_single_inline_fileName, contentType: vectorDatabaseConnectorOperation.newDocuments_single_inline_contentType }] else if vectorDatabaseConnectorOperation.newDocuments_single_documentSource = \"external\" then [{ \"camunda.document.type\": \"external\", url: vectorDatabaseConnectorOperation.newDocuments_single_external_url, name: vectorDatabaseConnectorOperation.newDocuments_single_external_fileName }] else null) else null",
+    "label" : "Documents",
+    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "required",
     "group" : "document",
     "binding" : {
       "name" : "vectorDatabaseConnectorOperation.newDocuments",
       "type" : "zeebe:input"
     },
     "condition" : {
-      "property" : "vectorDatabaseConnectorOperation.operationType",
-      "equals" : "embedDocumentOperation",
-      "type" : "simple"
+      "allMatch" : [ {
+        "property" : "vectorDatabaseConnectorOperation.documentSource",
+        "equals" : "CamundaDocument",
+        "type" : "simple"
+      }, {
+        "property" : "vectorDatabaseConnectorOperation.operationType",
+        "equals" : "embedDocumentOperation",
+        "type" : "simple"
+      } ]
     },
-    "type" : "Hidden"
+    "type" : "String"
   }, {
     "id" : "vectorDatabaseConnectorOperation.documentSplitter.documentSplitter",
     "label" : "Document splitting strategy",
@@ -2019,7 +1818,7 @@
     "id" : "version",
     "label" : "Version",
     "description" : "Version of the element template",
-    "value" : "4",
+    "value" : "3",
     "group" : "connector",
     "binding" : {
       "key" : "elementTemplateVersion",

--- a/connectors/embeddings-vector-database/src/main/java/io/camunda/connector/EmbeddingsVectorDBFunction.java
+++ b/connectors/embeddings-vector-database/src/main/java/io/camunda/connector/EmbeddingsVectorDBFunction.java
@@ -23,7 +23,7 @@ import io.camunda.connector.model.EmbeddingsVectorDBRequest;
     name = "Embeddings Vector DB Outbound Connector",
     description = "Embed and download documents with vector databases",
     inputDataClass = EmbeddingsVectorDBRequest.class,
-    version = 3,
+    version = 4,
     propertyGroups = {
       @ElementTemplate.PropertyGroup(id = "operation", label = "Operation"),
       @ElementTemplate.PropertyGroup(id = "query", label = "Query"),

--- a/connectors/embeddings-vector-database/src/main/java/io/camunda/connector/action/DefaultActionProcessor.java
+++ b/connectors/embeddings-vector-database/src/main/java/io/camunda/connector/action/DefaultActionProcessor.java
@@ -10,7 +10,9 @@ import io.camunda.connector.action.embed.DefaultEmbeddingActionProcessor;
 import io.camunda.connector.action.embed.EmbeddingActionProcessor;
 import io.camunda.connector.action.retrieve.DefaultRetrievingActionProcessor;
 import io.camunda.connector.action.retrieve.RetrievingActionProcessor;
-import io.camunda.connector.api.document.DocumentFactory;
+import io.camunda.connector.api.document.DocumentReturnChoice;
+import io.camunda.connector.api.document.DocumentReturnFormat;
+import io.camunda.connector.api.outbound.OutboundConnectorContext;
 import io.camunda.connector.http.client.proxy.EnvironmentProxyConfiguration;
 import io.camunda.connector.http.client.proxy.ProxyConfiguration;
 import io.camunda.connector.model.EmbeddingsVectorDBRequest;
@@ -42,12 +44,23 @@ public class DefaultActionProcessor {
     this.retrievingActionProcessor = retrievingActionProcessor;
   }
 
-  public Object handleFlow(EmbeddingsVectorDBRequest request, DocumentFactory documentFactory) {
+  public Object handleFlow(EmbeddingsVectorDBRequest request, OutboundConnectorContext context) {
     return switch (request.vectorDatabaseConnectorOperation()) {
       case EmbedDocumentOperation ignored -> embeddingActionProcessor.embed(request);
       case RetrieveDocumentOperation ignored ->
-          retrievingActionProcessor.retrieve(request, documentFactory);
+          retrievingActionProcessor.retrieve(request, context, resolveReturnChoice(context));
     };
+  }
+
+  /**
+   * Element templates up to version 3 have no response format dropdown, so an absent choice means
+   * the pre-dropdown behaviour: store every chunk as a document.
+   */
+  private static DocumentReturnChoice resolveReturnChoice(OutboundConnectorContext context) {
+    return context
+        .readDocumentReturnFormat()
+        .map(DocumentReturnFormat::choice)
+        .orElse(DocumentReturnChoice.DOCUMENT);
   }
 
   private static ProxyConfiguration resolveProxyConfiguration() {

--- a/connectors/embeddings-vector-database/src/main/java/io/camunda/connector/action/retrieve/DefaultRetrievingActionProcessor.java
+++ b/connectors/embeddings-vector-database/src/main/java/io/camunda/connector/action/retrieve/DefaultRetrievingActionProcessor.java
@@ -13,6 +13,8 @@ import dev.langchain4j.store.embedding.EmbeddingMatch;
 import dev.langchain4j.store.embedding.EmbeddingSearchRequest;
 import io.camunda.connector.api.document.DocumentCreationRequest;
 import io.camunda.connector.api.document.DocumentFactory;
+import io.camunda.connector.api.document.DocumentReference;
+import io.camunda.connector.api.document.DocumentReturnChoice;
 import io.camunda.connector.embeddingmodel.DefaultEmbeddingModelFactory;
 import io.camunda.connector.embeddingstore.ClosableEmbeddingStore;
 import io.camunda.connector.embeddingstore.DefaultEmbeddingStoreFactory;
@@ -44,7 +46,9 @@ public class DefaultRetrievingActionProcessor implements RetrievingActionProcess
 
   @Override
   public RetrievingActionProcessorResponse retrieve(
-      final EmbeddingsVectorDBRequest request, final DocumentFactory documentFactory) {
+      final EmbeddingsVectorDBRequest request,
+      final DocumentFactory documentFactory,
+      final DocumentReturnChoice returnChoice) {
     final var retrieveRequest =
         (RetrieveDocumentOperation) request.vectorDatabaseConnectorOperation();
     EmbeddingModel model =
@@ -67,25 +71,29 @@ public class DefaultRetrievingActionProcessor implements RetrievingActionProcess
       // original document was split into chunks,
       // thus we return most applicable chunks and,
       // store them into document storage;
-      // then they can be used by other connectors
+      // then they can be used by other connectors.
+      // Unless the user asked for text only — then the chunk text is all they get,
+      // and the document store is left untouched.
+      final var storeChunks = returnChoice != DocumentReturnChoice.TEXT;
       final var chunks = new ArrayList<RetrievedChunk>();
       for (EmbeddingMatch<TextSegment> matched : relevant) {
-        final var persistedDoc =
-            documentFactory.create(
-                DocumentCreationRequest.from(
-                        matched.embedded().text().getBytes(StandardCharsets.UTF_8))
-                    .contentType(
-                        Mimetype.MIMETYPE_TEXT_PLAIN) // TODO: for v1 we support only plain text
-                    .build());
-        chunks.add(
-            new RetrievedChunk(
-                matched.embeddingId(),
-                persistedDoc.reference(),
-                matched.score(),
-                matched.embedded().text()));
+        final var text = matched.embedded().text();
+        final var reference = storeChunks ? storeChunk(documentFactory, text) : null;
+        chunks.add(new RetrievedChunk(matched.embeddingId(), reference, matched.score(), text));
       }
 
       return new RetrievingActionProcessorResponse(chunks);
     }
+  }
+
+  private static DocumentReference storeChunk(
+      final DocumentFactory documentFactory, final String text) {
+    return documentFactory
+        .create(
+            DocumentCreationRequest.from(text.getBytes(StandardCharsets.UTF_8))
+                .contentType(
+                    Mimetype.MIMETYPE_TEXT_PLAIN) // TODO: for v1 we support only plain text
+                .build())
+        .reference();
   }
 }

--- a/connectors/embeddings-vector-database/src/main/java/io/camunda/connector/action/retrieve/RetrievingActionProcessor.java
+++ b/connectors/embeddings-vector-database/src/main/java/io/camunda/connector/action/retrieve/RetrievingActionProcessor.java
@@ -7,9 +7,18 @@
 package io.camunda.connector.action.retrieve;
 
 import io.camunda.connector.api.document.DocumentFactory;
+import io.camunda.connector.api.document.DocumentReturnChoice;
 import io.camunda.connector.model.EmbeddingsVectorDBRequest;
 
 public interface RetrievingActionProcessor {
+
+  /**
+   * @param returnChoice how the user wants each retrieved chunk returned. {@code DOCUMENT} stores
+   *     the chunk via {@code documentFactory} and returns its reference, {@code TEXT} returns the
+   *     chunk text only and writes nothing to the document store.
+   */
   RetrievingActionProcessorResponse retrieve(
-      EmbeddingsVectorDBRequest request, DocumentFactory documentFactory);
+      EmbeddingsVectorDBRequest request,
+      DocumentFactory documentFactory,
+      DocumentReturnChoice returnChoice);
 }

--- a/connectors/embeddings-vector-database/src/main/java/io/camunda/connector/doc/parsing/DefaultTextSegmentExtractor.java
+++ b/connectors/embeddings-vector-database/src/main/java/io/camunda/connector/doc/parsing/DefaultTextSegmentExtractor.java
@@ -10,6 +10,7 @@ import dev.langchain4j.data.document.DocumentLoader;
 import dev.langchain4j.data.document.parser.TextDocumentParser;
 import dev.langchain4j.data.document.parser.apache.tika.ApacheTikaDocumentParser;
 import dev.langchain4j.data.segment.TextSegment;
+import io.camunda.connector.api.error.ConnectorInputException;
 import io.camunda.connector.doc.parsing.source.CamundaDocumentSource;
 import io.camunda.connector.doc.parsing.source.PlainTextAsDocumentSource;
 import io.camunda.connector.doc.splitting.DefaultDocumentSplitterFactory;
@@ -17,8 +18,12 @@ import io.camunda.connector.model.EmbeddingsVectorDBRequest;
 import io.camunda.connector.model.operation.EmbedDocumentOperation;
 import io.camunda.connector.model.operation.EmbedDocumentSource;
 import java.util.List;
+import org.apache.commons.lang3.StringUtils;
 
 public class DefaultTextSegmentExtractor {
+
+  private static final String NOTHING_TO_EMBED =
+      "Nothing to embed: neither documents nor plain text were provided";
 
   private final DefaultDocumentSplitterFactory documentSplitterFactory;
 
@@ -34,23 +39,45 @@ public class DefaultTextSegmentExtractor {
     final var embedRequest = (EmbedDocumentOperation) request.vectorDatabaseConnectorOperation();
     final var splitter =
         documentSplitterFactory.createDocumentSplitter(embedRequest.documentSplitter());
-    if (embedRequest.documentSource() == EmbedDocumentSource.CamundaDocument) {
-      return embedRequest.newDocuments().stream()
-          .map(
-              camundaDoc ->
-                  DocumentLoader.load(
-                      new CamundaDocumentSource(camundaDoc),
-                      // Apache Tika includes metadata, such as
-                      // real content type, encoding
-                      new ApacheTikaDocumentParser(true)))
-          .map(splitter::split)
-          .flatMap(List::stream)
-          .toList();
-    } else {
+    if (usesPlainText(embedRequest)) {
+      if (StringUtils.isBlank(embedRequest.documentSourceFromProcessVariable())) {
+        throw new ConnectorInputException(NOTHING_TO_EMBED);
+      }
       return splitter.split(
           DocumentLoader.load(
               new PlainTextAsDocumentSource(embedRequest.documentSourceFromProcessVariable()),
               new TextDocumentParser()));
     }
+    if (isEmpty(embedRequest.newDocuments())) {
+      throw new ConnectorInputException(NOTHING_TO_EMBED);
+    }
+    return embedRequest.newDocuments().stream()
+        .map(
+            camundaDoc ->
+                DocumentLoader.load(
+                    new CamundaDocumentSource(camundaDoc),
+                    // Apache Tika includes metadata, such as
+                    // real content type, encoding
+                    new ApacheTikaDocumentParser(true)))
+        .map(splitter::split)
+        .flatMap(List::stream)
+        .toList();
+  }
+
+  /**
+   * Element templates up to version 3 state the source explicitly, and are honoured as-is —
+   * including the case where a document is left over in {@code newDocuments} from an earlier
+   * selection. From version 4 on the source dropdown is gone (inline content replaced plain text),
+   * so the path follows whichever input the template populated.
+   */
+  private static boolean usesPlainText(EmbedDocumentOperation embedRequest) {
+    if (embedRequest.documentSource() != null) {
+      return embedRequest.documentSource() == EmbedDocumentSource.PlainText;
+    }
+    return isEmpty(embedRequest.newDocuments());
+  }
+
+  private static boolean isEmpty(List<?> documents) {
+    return documents == null || documents.isEmpty();
   }
 }

--- a/connectors/embeddings-vector-database/src/main/java/io/camunda/connector/model/operation/EmbedDocumentOperation.java
+++ b/connectors/embeddings-vector-database/src/main/java/io/camunda/connector/model/operation/EmbedDocumentOperation.java
@@ -9,16 +9,23 @@ package io.camunda.connector.model.operation;
 import static io.camunda.connector.model.operation.EmbedDocumentOperation.EMBED_DOCUMENT_OPERATION;
 
 import io.camunda.connector.api.document.Document;
-import io.camunda.connector.generator.java.annotation.FeelMode;
+import io.camunda.connector.generator.java.annotation.TemplateDocumentProperty;
 import io.camunda.connector.generator.java.annotation.TemplateProperty;
-import io.camunda.connector.generator.java.annotation.TemplateProperty.PropertyCondition;
-import io.camunda.connector.generator.java.annotation.TemplateProperty.PropertyConstraints;
 import io.camunda.connector.generator.java.annotation.TemplateSubType;
 import io.camunda.connector.model.embedding.splitter.DocumentSplitter;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import java.util.List;
 
+/**
+ * @param documentSource legacy source discriminator, replaced by the unified document source
+ *     dropdown on {@code newDocuments} — inline content covers what {@code PlainText} used to. Kept
+ *     as a hidden runtime-only input so element templates up to version 3 keep working: when
+ *     present it still decides which path {@code DefaultTextSegmentExtractor} takes. Templates from
+ *     version 4 on never set it, and the path follows whichever input is populated.
+ * @param documentSourceFromProcessVariable legacy plain-text input, kept for the same reason as
+ *     {@code documentSource}.
+ */
 @TemplateSubType(
     label = "Embed document",
     id = EMBED_DOCUMENT_OPERATION,
@@ -31,38 +38,12 @@ import java.util.List;
       "semantic index"
     })
 public record EmbedDocumentOperation(
-    @NotNull
-        @TemplateProperty(
-            group = "document",
-            id = "documentSource",
-            label = "Document source",
-            feel = FeelMode.required,
-            type = TemplateProperty.PropertyType.Dropdown,
-            description = "Whether you want to embed a Camunda document file or plain text",
-            defaultValue = "CamundaDocument")
-        EmbedDocumentSource documentSource,
-    @TemplateProperty(
-            group = "document",
-            id = "documentSourceFromProcessVariable",
-            label = "Plain text to embed",
-            feel = FeelMode.optional,
-            constraints = @PropertyConstraints(notEmpty = true),
-            condition =
-                @PropertyCondition(
-                    property = "vectorDatabaseConnectorOperation.documentSource",
-                    equals = "PlainText"))
-        String documentSourceFromProcessVariable,
-    @TemplateProperty(
-            label = "Documents",
+    @TemplateProperty(ignore = true) EmbedDocumentSource documentSource,
+    @TemplateProperty(ignore = true) String documentSourceFromProcessVariable,
+    @TemplateDocumentProperty(
             group = "document",
             id = "newDocuments",
-            feel = FeelMode.required,
-            binding = @TemplateProperty.PropertyBinding(name = "newDocuments"),
-            constraints = @PropertyConstraints(notEmpty = true),
-            condition =
-                @PropertyCondition(
-                    property = "vectorDatabaseConnectorOperation.documentSource",
-                    equals = "CamundaDocument"))
+            binding = @TemplateProperty.PropertyBinding(name = "newDocuments"))
         List<Document> newDocuments,
     @NotNull @Valid DocumentSplitter documentSplitter)
     implements VectorDatabaseConnectorOperation {

--- a/connectors/embeddings-vector-database/src/main/java/io/camunda/connector/model/operation/RetrieveDocumentOperation.java
+++ b/connectors/embeddings-vector-database/src/main/java/io/camunda/connector/model/operation/RetrieveDocumentOperation.java
@@ -8,12 +8,25 @@ package io.camunda.connector.model.operation;
 
 import static io.camunda.connector.model.operation.RetrieveDocumentOperation.RETRIEVE_DOCUMENT_OPERATION;
 
+import io.camunda.connector.api.document.DocumentReturnChoice;
+import io.camunda.connector.generator.java.annotation.DocumentReturnFormat;
+import io.camunda.connector.generator.java.annotation.FieldVisibility;
 import io.camunda.connector.generator.java.annotation.TemplateProperty;
 import io.camunda.connector.generator.java.annotation.TemplateProperty.DefaultValueType;
 import io.camunda.connector.generator.java.annotation.TemplateSubType;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 
+// Retrieved chunks arrive from the vector store as text, so TEXT needs no decoding step and the
+// encoding sub-field would be inert — hidden. JSON is excluded: a chunk is a slice of a split
+// document, not a structured payload. DOCUMENT reproduces the pre-dropdown behaviour and stays the
+// default, so templates up to version 3 (which set no choice at all) keep their output shape.
+@DocumentReturnFormat(
+    group = "query",
+    supportedFormats = {DocumentReturnChoice.DOCUMENT, DocumentReturnChoice.TEXT},
+    defaultFormat = DocumentReturnChoice.DOCUMENT,
+    description = "Whether each retrieved chunk is stored as a document or returned as text only",
+    encoding = FieldVisibility.HIDDEN)
 @TemplateSubType(
     label = "Retrieve document",
     id = RETRIEVE_DOCUMENT_OPERATION,

--- a/connectors/embeddings-vector-database/src/test/java/io/camunda/connector/action/DefaultActionProcessorTest.java
+++ b/connectors/embeddings-vector-database/src/test/java/io/camunda/connector/action/DefaultActionProcessorTest.java
@@ -12,12 +12,15 @@ import io.camunda.connector.action.embed.DefaultEmbeddingActionProcessor;
 import io.camunda.connector.action.embed.EmbeddingActionProcessor;
 import io.camunda.connector.action.retrieve.DefaultRetrievingActionProcessor;
 import io.camunda.connector.action.retrieve.RetrievingActionProcessor;
-import io.camunda.connector.api.document.DocumentFactory;
+import io.camunda.connector.api.document.DocumentReturnChoice;
+import io.camunda.connector.api.document.DocumentReturnFormat;
+import io.camunda.connector.api.outbound.OutboundConnectorContext;
 import io.camunda.connector.fixture.EmbeddingsVectorDBRequestFixture;
 import io.camunda.connector.http.client.proxy.EnvironmentProxyConfiguration;
 import io.camunda.connector.http.client.proxy.ProxyConfiguration;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.MockedConstruction;
@@ -35,14 +38,14 @@ class DefaultActionProcessorTest {
       Mockito.mock(EmbeddingActionProcessor.class);
   private final RetrievingActionProcessor retrievingProcessor =
       Mockito.mock(RetrievingActionProcessor.class);
-  private final DocumentFactory documentFactory = Mockito.mock(DocumentFactory.class);
+  private final OutboundConnectorContext context = Mockito.mock(OutboundConnectorContext.class);
 
   @Test
   void handleEmbedRequest() {
     final var actionProcessor = new DefaultActionProcessor(embeddingProcessor, retrievingProcessor);
     final var embedRequest = EmbeddingsVectorDBRequestFixture.createDefaultEmbedOperation();
 
-    actionProcessor.handleFlow(embedRequest, documentFactory);
+    actionProcessor.handleFlow(embedRequest, context);
 
     Mockito.verify(embeddingProcessor).embed(embedRequest);
   }
@@ -52,9 +55,24 @@ class DefaultActionProcessorTest {
     final var actionProcessor = new DefaultActionProcessor(embeddingProcessor, retrievingProcessor);
     final var retrieveRequest = EmbeddingsVectorDBRequestFixture.createDefaultRetrieve();
 
-    actionProcessor.handleFlow(retrieveRequest, documentFactory);
+    actionProcessor.handleFlow(retrieveRequest, context);
 
-    Mockito.verify(retrievingProcessor).retrieve(retrieveRequest, documentFactory);
+    // no dropdown value (element templates up to version 3) keeps the pre-dropdown behaviour
+    Mockito.verify(retrievingProcessor)
+        .retrieve(retrieveRequest, context, DocumentReturnChoice.DOCUMENT);
+  }
+
+  @Test
+  void handleRetrieveRequestPassesSelectedReturnChoice() {
+    final var actionProcessor = new DefaultActionProcessor(embeddingProcessor, retrievingProcessor);
+    final var retrieveRequest = EmbeddingsVectorDBRequestFixture.createDefaultRetrieve();
+    Mockito.when(context.readDocumentReturnFormat())
+        .thenReturn(Optional.of(new DocumentReturnFormat(DocumentReturnChoice.TEXT, null)));
+
+    actionProcessor.handleFlow(retrieveRequest, context);
+
+    Mockito.verify(retrievingProcessor)
+        .retrieve(retrieveRequest, context, DocumentReturnChoice.TEXT);
   }
 
   @Test

--- a/connectors/embeddings-vector-database/src/test/java/io/camunda/connector/action/retrieve/DefaultRetrievingActionProcessorTest.java
+++ b/connectors/embeddings-vector-database/src/test/java/io/camunda/connector/action/retrieve/DefaultRetrievingActionProcessorTest.java
@@ -13,11 +13,13 @@ import dev.langchain4j.model.output.Response;
 import dev.langchain4j.store.embedding.EmbeddingMatch;
 import dev.langchain4j.store.embedding.EmbeddingSearchResult;
 import io.camunda.connector.api.document.DocumentFactory;
+import io.camunda.connector.api.document.DocumentReturnChoice;
 import io.camunda.connector.embeddingmodel.DefaultEmbeddingModelFactory;
 import io.camunda.connector.embeddingstore.ClosableEmbeddingStore;
 import io.camunda.connector.embeddingstore.DefaultEmbeddingStoreFactory;
 import io.camunda.connector.fixture.CamundaDocumentFixture;
 import io.camunda.connector.fixture.EmbeddingsVectorDBRequestFixture;
+import io.camunda.connector.model.EmbeddingsVectorDBRequest;
 import io.camunda.connector.model.operation.RetrieveDocumentOperation;
 import java.util.List;
 import org.assertj.core.api.Assertions;
@@ -66,12 +68,62 @@ class DefaultRetrievingActionProcessorTest {
     final var defaultRetrievingActionProcessor =
         new DefaultRetrievingActionProcessor(embeddingModelProvider, embeddingStoreProvider);
 
-    final var response = defaultRetrievingActionProcessor.retrieve(request, documentFactory);
+    final var response =
+        defaultRetrievingActionProcessor.retrieve(
+            request, documentFactory, DocumentReturnChoice.DOCUMENT);
 
     Mockito.verify(documentFactory, Mockito.times(1)).create(ArgumentMatchers.any());
     Assertions.assertThat(response.chunks()).hasSize(1);
     Assertions.assertThat(response.chunks().getFirst().score()).isEqualTo(matchedChunkScore);
     Assertions.assertThat(response.chunks().getFirst().chunkId())
         .isEqualTo(matchedChunkEmbeddingId);
+    Assertions.assertThat(response.chunks().getFirst().documentReference()).isNotNull();
+    Assertions.assertThat(response.chunks().getFirst().content()).isEqualTo(matchedChunkContent);
+  }
+
+  @Test
+  void retrieve_asText_returnsChunkTextWithoutStoringDocuments() {
+    final var request = EmbeddingsVectorDBRequestFixture.createDefaultRetrieve();
+    final var matchedChunkContent = "Returned content";
+    final var documentFactory = Mockito.mock(DocumentFactory.class);
+    final var processor = processorReturning(request, matchedChunkContent);
+
+    final var response = processor.retrieve(request, documentFactory, DocumentReturnChoice.TEXT);
+
+    Mockito.verifyNoInteractions(documentFactory);
+    Assertions.assertThat(response.chunks()).hasSize(1);
+    Assertions.assertThat(response.chunks().getFirst().documentReference()).isNull();
+    Assertions.assertThat(response.chunks().getFirst().content()).isEqualTo(matchedChunkContent);
+  }
+
+  private static DefaultRetrievingActionProcessor processorReturning(
+      final EmbeddingsVectorDBRequest request, final String chunkContent) {
+    final var embeddingModelProvider = Mockito.mock(DefaultEmbeddingModelFactory.class);
+    final var model = Mockito.mock(EmbeddingModel.class);
+    Mockito.when(embeddingModelProvider.createEmbeddingModel(request.embeddingModelProvider()))
+        .thenReturn(model);
+    Mockito.when(
+            model.embed(
+                ((RetrieveDocumentOperation) request.vectorDatabaseConnectorOperation()).query()))
+        .thenReturn(Response.from(Embedding.from(List.of(0.1f, 0.2f, 0.3f))));
+
+    final var embeddingStoreProvider = Mockito.mock(DefaultEmbeddingStoreFactory.class);
+    final var store = Mockito.mock(ClosableEmbeddingStore.class);
+    Mockito.when(
+            embeddingStoreProvider.initializeVectorStore(
+                request.vectorStore(), model, request.vectorDatabaseConnectorOperation()))
+        .thenReturn(store);
+    final var embeddingSearchResult = Mockito.mock(EmbeddingSearchResult.class);
+    Mockito.when(store.search(ArgumentMatchers.any())).thenReturn(embeddingSearchResult);
+    Mockito.when(embeddingSearchResult.matches())
+        .thenReturn(
+            List.of(
+                new EmbeddingMatch<>(
+                    0.88d,
+                    "emb-id-01",
+                    Embedding.from(List.of(0.2f, 0.3f, 0.4f)),
+                    TextSegment.from(chunkContent))));
+
+    return new DefaultRetrievingActionProcessor(embeddingModelProvider, embeddingStoreProvider);
   }
 }

--- a/connectors/embeddings-vector-database/src/test/java/io/camunda/connector/doc/parsing/DefaultTextSegmentExtractorTest.java
+++ b/connectors/embeddings-vector-database/src/test/java/io/camunda/connector/doc/parsing/DefaultTextSegmentExtractorTest.java
@@ -6,6 +6,7 @@
  */
 package io.camunda.connector.doc.parsing;
 
+import io.camunda.connector.api.error.ConnectorInputException;
 import io.camunda.connector.fixture.EmbeddingsVectorDBRequestFixture;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -40,5 +41,37 @@ class DefaultTextSegmentExtractorTest {
         extractor.fromRequest(EmbeddingsVectorDBRequestFixture.createEmbedOperationWithPlainText());
 
     Assertions.assertThat(segments).size().isEqualTo(1);
+  }
+
+  @Test
+  void segmentsFromRequestWithUnifiedDocumentInput() {
+    final var extractor = new DefaultTextSegmentExtractor();
+
+    final var segments =
+        extractor.fromRequest(
+            EmbeddingsVectorDBRequestFixture.createEmbedOperationWithUnifiedDocumentInput());
+
+    Assertions.assertThat(segments).size().isEqualTo(1);
+  }
+
+  @Test
+  void segmentsFromRequestWithPlainTextOnlyFallback() {
+    final var extractor = new DefaultTextSegmentExtractor();
+
+    final var segments =
+        extractor.fromRequest(
+            EmbeddingsVectorDBRequestFixture.createEmbedOperationWithPlainTextOnly());
+
+    Assertions.assertThat(segments).size().isEqualTo(1);
+  }
+
+  @Test
+  void throwsWhenNeitherDocumentsNorPlainTextProvided() {
+    final var extractor = new DefaultTextSegmentExtractor();
+    final var request = EmbeddingsVectorDBRequestFixture.createEmbedOperationWithoutInput();
+
+    Assertions.assertThatThrownBy(() -> extractor.fromRequest(request))
+        .isInstanceOf(ConnectorInputException.class)
+        .hasMessageContaining("Nothing to embed");
   }
 }

--- a/connectors/embeddings-vector-database/src/test/java/io/camunda/connector/fixture/EmbeddingsVectorDBRequestFixture.java
+++ b/connectors/embeddings-vector-database/src/test/java/io/camunda/connector/fixture/EmbeddingsVectorDBRequestFixture.java
@@ -59,6 +59,46 @@ public class EmbeddingsVectorDBRequestFixture {
     return request;
   }
 
+  /**
+   * What element templates from version 4 on produce: no source discriminator, documents supplied
+   * through the unified document source dropdown (Camunda / inline / URL all deserialize to {@code
+   * Document}).
+   */
+  public static EmbeddingsVectorDBRequest createEmbedOperationWithUnifiedDocumentInput() {
+    final var operation =
+        new EmbedDocumentOperation(
+            null,
+            null,
+            List.of(CamundaDocumentFixture.inMemoryTxtDocument()),
+            DocumentSplitterFixture.noopDocumentSplitter());
+    return new EmbeddingsVectorDBRequest(
+        operation,
+        EmbeddingModelProviderFixture.createDefaultBedrockEmbeddingModel(),
+        EmbeddingsVectorStoreFixture.createAmazonManagedOpenVectorStore());
+  }
+
+  /** Neither source populated — the connector has nothing to embed. */
+  public static EmbeddingsVectorDBRequest createEmbedOperationWithoutInput() {
+    final var operation =
+        new EmbedDocumentOperation(
+            null, null, List.of(), DocumentSplitterFixture.noopDocumentSplitter());
+    return new EmbeddingsVectorDBRequest(
+        operation,
+        EmbeddingModelProviderFixture.createDefaultBedrockEmbeddingModel(),
+        EmbeddingsVectorStoreFixture.createAmazonManagedOpenVectorStore());
+  }
+
+  /** Plain text without the legacy discriminator, as the hidden runtime fallback receives it. */
+  public static EmbeddingsVectorDBRequest createEmbedOperationWithPlainTextOnly() {
+    final var operation =
+        new EmbedDocumentOperation(
+            null, CONVERSATION, List.of(), DocumentSplitterFixture.noopDocumentSplitter());
+    return new EmbeddingsVectorDBRequest(
+        operation,
+        EmbeddingModelProviderFixture.createDefaultBedrockEmbeddingModel(),
+        EmbeddingsVectorStoreFixture.createAmazonManagedOpenVectorStore());
+  }
+
   public static EmbeddingsVectorDBRequest createEmbedOperationWithPlainText() {
     final var operation =
         new EmbedDocumentOperation(


### PR DESCRIPTION
## Description

Embeddings Vector DB document handling for camunda/product-hub#3224 (generator part camunda/connectors#7057, return format camunda/connectors#7058), following CSV (#8025) and Textract (#8243). Last connector on the `List<Document>` side of camunda/team-connectors#1251.

Element template **v3 → v4**; the v3 snapshot in `versioned/` is byte-identical to the template previously on `main`.

### Input — Embed document

`newDocuments` (`List<Document>`) now carries `@TemplateDocumentProperty`, so Modeler renders the standard **Number of documents** toggle (Single / Multiple) plus the unified **Document source** dropdown — Camunda Document / Inline Content / From URL — with `File name` and `Content type` left OPTIONAL, since embedding pushes the bytes through Apache Tika and both help it detect the real format.

The connector's own `Document source` dropdown (`Camunda document` / `Plain text`) is **gone from the UI**: inline content is what plain text now looks like. `documentSource` and `documentSourceFromProcessVariable` remain as hidden `@TemplateProperty(ignore = true)` inputs and `documentSource` lost its `@NotNull`, so **v3 models keep running unchanged** on both paths:

- v3 with `documentSource` set → honoured verbatim, including a document left over in `newDocuments` from an earlier selection.
- v4, which never sets it → the path follows whichever input the template populated.
- neither populated → `ConnectorInputException`, where before an empty `newDocuments` reached Tika.

The composer id stays `vectorDatabaseConnectorOperation.newDocuments` and binds to the same variable as before. This connector's document field is nested, so it depends on the composer-nesting fix from #8244 (now on `main`); the generated composer correctly reads `vectorDatabaseConnectorOperation.newDocuments_documentMode` and friends.

### Output — Retrieve document

`@DocumentReturnFormat(supportedFormats = {DOCUMENT, TEXT}, defaultFormat = DOCUMENT, group = "query", encoding = HIDDEN)` puts a **Response format** dropdown next to Search query / Max results / Min score.

Unlike S3/GCS, where the choice decides how bytes get decoded, a retrieved chunk is always available as text — so here the choice decides **whether the connector writes N documents to the document store**:

| Choice | `chunks[]` element | Store writes |
| :---- | :---- | :---- |
| `DOCUMENT` (default, = today) | `{chunkId, documentReference, score, content}` | one per chunk |
| `TEXT` | `{chunkId, documentReference: null, score, content}` | none |

`DOCUMENT` is the default and an absent choice resolves to it, so v3 templates keep today's output shape. `TEXT` is the cheaper path when the chunks are consumed inside the process. `JSON` is excluded (a chunk is a slice of a split document, not a structured payload) and the `Encoding` sub-field is hidden — the chunk arrives from the vector store as an already-decoded `String`, so a charset would be inert.

`RetrievingActionProcessor.retrieve` takes the resolved `DocumentReturnChoice`; `DefaultActionProcessor.handleFlow` now receives the `OutboundConnectorContext` to read it via `context.readDocumentReturnFormat()`.

## QA

- Module tests green (69), plus new coverage: unified document input, plain-text-only fallback, nothing-to-embed error, `TEXT` returning chunk text with `verifyNoInteractions(documentFactory)`, and both dropdown-absent and `TEXT` propagation through `DefaultActionProcessor`.
- `mvn verify` on the module passes, including spotless and license checks.
- Generated template verified: helper ids/bindings and composer references qualified by the `vectorDatabaseConnectorOperation` nesting path, sub-type discriminator conditions present on every generated property, legacy properties absent, response dropdown root-bound to `documentReturnFormat.choice`.
- [ ] Live 8.10 runtime QA against a real vector store — owner: @ztefanie.

## Related issues

partially implements https://github.com/camunda/team-connectors/issues/1251
epic https://github.com/camunda/product-hub/issues/3224

## Checklist

- [ ] Live runtime QA
- [ ] Backport labels added if needed — none intended, ships on `main` only
- [x] Tests for the changes have been added
- [ ] Documentation updated if required

🤖 Generated with [Claude Code](https://claude.com/claude-code)
