### PR TITLE
fix(embeddings-vector-db): strip scheme from Amazon managed OpenSearch server URL

### DIFF
--- a/connectors/embeddings-vector-database/src/main/java/io/camunda/connector/embeddingstore/OpenSearchVectorStoreFactory.java
+++ b/connectors/embeddings-vector-database/src/main/java/io/camunda/connector/embeddingstore/OpenSearchVectorStoreFactory.java
@@ -142,7 +142,10 @@ public class OpenSearchVectorStoreFactory {
     OpenSearchTransport transport =
         new AwsSdk2Transport(
             httpClient,
-            amazonManagedOpenSearch.serverUrl(),
+            // AwsSdk2Transport builds every request URL as "https://" + host, so it needs a bare
+            // hostname. Passing the fully qualified URL that the property asks for would yield
+            // "https://https://<host>" and a DNS lookup for the host "https".
+            openSearchHost.getHostName(),
             AMAZON_SIGNING_SERVICE_NAME,
             selectedRegion,
             AwsSdk2TransportOptions.builder()

--- a/connectors/embeddings-vector-database/src/main/java/io/camunda/connector/embeddingstore/OpenSearchVectorStoreFactory.java
+++ b/connectors/embeddings-vector-database/src/main/java/io/camunda/connector/embeddingstore/OpenSearchVectorStoreFactory.java
@@ -142,9 +142,6 @@ public class OpenSearchVectorStoreFactory {
     OpenSearchTransport transport =
         new AwsSdk2Transport(
             httpClient,
-            // AwsSdk2Transport builds every request URL as "https://" + host, so it needs a bare
-            // hostname. Passing the fully qualified URL that the property asks for would yield
-            // "https://https://<host>" and a DNS lookup for the host "https".
             openSearchHost.getHostName(),
             AMAZON_SIGNING_SERVICE_NAME,
             selectedRegion,

--- a/connectors/embeddings-vector-database/src/test/java/io/camunda/connector/embeddingstore/OpenSearchVectorStoreFactoryTest.java
+++ b/connectors/embeddings-vector-database/src/test/java/io/camunda/connector/embeddingstore/OpenSearchVectorStoreFactoryTest.java
@@ -295,11 +295,6 @@ class OpenSearchVectorStoreFactoryTest {
       assertTransportHost("opensearch.aws", "opensearch.aws");
     }
 
-    /**
-     * {@code AwsSdk2Transport} builds every request URL as {@code "https://" + host}, so passing a
-     * fully qualified URL — which is what the "Server URL" property asks for — yields {@code
-     * https://https://…} and a DNS lookup for the host {@code https}.
-     */
     private void assertTransportHost(String serverUrl, String expectedTransportHost) {
       var proxyConfig = mock(ProxyConfiguration.class);
       when(proxyConfig.getProxyDetails(ProxyConfiguration.SCHEME_HTTPS))

--- a/connectors/embeddings-vector-database/src/test/java/io/camunda/connector/embeddingstore/OpenSearchVectorStoreFactoryTest.java
+++ b/connectors/embeddings-vector-database/src/test/java/io/camunda/connector/embeddingstore/OpenSearchVectorStoreFactoryTest.java
@@ -12,6 +12,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockConstruction;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
@@ -23,6 +24,8 @@ import io.camunda.connector.http.client.client.apache.proxy.ProxyRoutePlanner;
 import io.camunda.connector.http.client.proxy.ProxyConfiguration;
 import io.camunda.connector.model.embedding.vector.store.AmazonManagedOpenSearchVectorStore;
 import io.camunda.connector.model.embedding.vector.store.OpenSearchVectorStore;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 import org.apache.hc.client5.http.auth.AuthScope;
 import org.apache.hc.client5.http.impl.async.HttpAsyncClientBuilder;
@@ -32,6 +35,7 @@ import org.assertj.core.api.ThrowingConsumer;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
+import org.opensearch.client.transport.aws.AwsSdk2Transport;
 import software.amazon.awssdk.http.apache.ApacheHttpClient;
 
 class OpenSearchVectorStoreFactoryTest {
@@ -279,6 +283,42 @@ class OpenSearchVectorStoreFactoryTest {
           proxyConfig,
           EmbeddingsVectorStoreFixture.createAmazonManagedOpenVectorStore(),
           true); // with credentials
+    }
+
+    @Test
+    void createAmazonManagedOpenSearchVectorStoreStripsSchemeFromServerUrl() {
+      assertTransportHost("https://opensearch.aws", "opensearch.aws");
+    }
+
+    @Test
+    void createAmazonManagedOpenSearchVectorStoreAcceptsBareHostname() {
+      assertTransportHost("opensearch.aws", "opensearch.aws");
+    }
+
+    /**
+     * {@code AwsSdk2Transport} builds every request URL as {@code "https://" + host}, so passing a
+     * fully qualified URL — which is what the "Server URL" property asks for — yields {@code
+     * https://https://…} and a DNS lookup for the host {@code https}.
+     */
+    private void assertTransportHost(String serverUrl, String expectedTransportHost) {
+      var proxyConfig = mock(ProxyConfiguration.class);
+      when(proxyConfig.getProxyDetails(ProxyConfiguration.SCHEME_HTTPS))
+          .thenReturn(Optional.empty());
+      var factory = new OpenSearchVectorStoreFactory(proxyConfig);
+      var vectorStore =
+          new AmazonManagedOpenSearchVectorStore(
+              new AmazonManagedOpenSearchVectorStore.Configuration(
+                  "ACCESS_KEY", "SECRET_KEY", serverUrl, "us-east-1", "embeddings_idx"));
+
+      List<List<?>> transportArgs = new ArrayList<>();
+      try (var ignored =
+          mockConstruction(
+              AwsSdk2Transport.class, (mock, context) -> transportArgs.add(context.arguments()))) {
+        factory.createAmazonManagedOpenSearchVectorStore(vectorStore);
+      }
+
+      assertThat(transportArgs).hasSize(1);
+      assertThat(transportArgs.getFirst().get(1)).isEqualTo(expectedTransportHost);
     }
 
     private void testAmazonManagedOpenSearchConfiguration(


### PR DESCRIPTION
## Description

The Amazon managed OpenSearch vector store is unusable when the **Server URL** property is filled in as documented. Its own description says *"Provide a fully qualified server URL"*, but the factory passed that string straight to `AwsSdk2Transport`, which builds every request URL as `"https://" + host` and therefore needs a bare hostname.

With `https://search-xyz.eu-central-1.es.amazonaws.com` the request URL becomes `https://https://search-xyz…`, and the job fails on the first index call:

```
dev.langchain4j.store.embedding.opensearch.OpenSearchRequestFailedException: Failed to add embeddings
  at …OpenSearchEmbeddingStore.addAll(OpenSearchEmbeddingStore.java:322)
Caused by: java.net.UnknownHostException: https: Name or service not known
  at …OpenSearchIndicesClient.exists(OpenSearchIndicesClient.java:507)
  at …OpenSearchEmbeddingStore.createIndexIfNotExist(OpenSearchEmbeddingStore.java:398)
```

The store only worked if a user happened to omit the scheme, contradicting the property's own instruction.

**Fix:** pass `openSearchHost.getHostName()` — the `HttpHost` the method already parses one line above — instead of the raw URL. Both inputs now work, so this is not a breaking change for anyone who had entered a bare hostname as a workaround.

### Affected versions

- `main` and `stable/8.9` — affected.
- `stable/8.8` — **not** affected: it used `OpenSearchEmbeddingStore.builder().serverUrl(...)`, which parses the URL itself. The defect arrived when the transport was hand-built with `new AwsSdk2Transport(...)`.

### Known adjacent limitation (not fixed here)

`HttpHost.create` rejects a URL with a trailing slash or path, so `https://search-xyz….es.amazonaws.com/` still fails — but with the clear, already-actionable `IllegalArgumentException: Invalid server URL` rather than a DNS error. Happy to fold in leniency for that if reviewers want it.

## QA

- New tests in `OpenSearchVectorStoreFactoryTest` capture the `AwsSdk2Transport` constructor arguments via `mockConstruction` and assert the host it receives:
  - `createAmazonManagedOpenSearchVectorStoreStripsSchemeFromServerUrl` — `https://opensearch.aws` → `opensearch.aws`. **Fails before this fix** with `expected "opensearch.aws" but was "https://opensearch.aws"`.
  - `createAmazonManagedOpenSearchVectorStoreAcceptsBareHostname` — `opensearch.aws` → `opensearch.aws`, guarding the workaround path.
- Full module suite green (66 tests), including spotless and license checks.
- Verified on a live 8.10 runtime against a real AWS managed OpenSearch domain: DNS resolution now succeeds and the request reaches the cluster.

## Checklist

- [ ] Backport label for `stable/8.9` (`stable/8.8` not applicable)
- [x] Tests for the changes have been added
- [ ] Documentation updated if required

🤖 Generated with [Claude Code](https://claude.com/claude-code)
