### PR TITLE
fix(pom): update repository layout and classpath configuration for connector generation

### DIFF
--- a/element-template-generator/congen-cli/pom.xml
+++ b/element-template-generator/congen-cli/pom.xml
@@ -122,6 +122,9 @@
           </execution>
         </executions>
         <configuration>
+          <!-- See https://github.com/camunda/connectors/issues/3808 -->
+          <repositoryLayout>flat</repositoryLayout>
+          <useWildcardClassPath>true</useWildcardClassPath>
           <programs>
             <program>
               <mainClass>io.camunda.connector.generator.cli.Main</mainClass>


### PR DESCRIPTION
This pull request makes a minor configuration update to the Maven build process for the `congen-cli` module. The update adds two new options to the Maven Shade Plugin to address an issue referenced in the Camunda Connectors repository.

* Build configuration:
  * [`element-template-generator/congen-cli/pom.xml`](diffhunk://#diff-44b094fd79c097a14052748ea6a2b02207651bbb8cd98bbe33baa6eb5c996393R125-R127): Added `<repositoryLayout>flat</repositoryLayout>` and `<useWildcardClassPath>true</useWildcardClassPath>` to the Maven Shade Plugin configuration to address connector packaging issues.