### PR TITLE
feat: outbound connector management endpoints for multi-engine support

### DIFF
--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/instances/service/OutboundConnectorsService.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/instances/service/OutboundConnectorsService.java
@@ -24,41 +24,115 @@ import io.camunda.connector.runtime.outbound.controller.OutboundConnectorRespons
 import io.camunda.connector.runtime.outbound.jobstream.BrokerJobStreamClient;
 import io.camunda.connector.runtime.outbound.jobstream.BrokerStreamsResult;
 import io.camunda.connector.runtime.outbound.jobstream.StreamConnectivity;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Backs the {@code /outbound} management endpoints. Every configured physical tenant (engine) runs
+ * a job worker for every registered outbound connector, so the registered connectors are listed
+ * once per (connector, physical tenant) pair, each entry enriched with the broker/stream
+ * connectivity observed on that tenant's own brokers.
+ */
 public class OutboundConnectorsService {
 
   private static final Logger LOG = LoggerFactory.getLogger(OutboundConnectorsService.class);
 
   private final OutboundConnectorFactory connectorFactory;
-  private final BrokerJobStreamClient brokerJobStreamClient;
 
+  /**
+   * All configured physical tenants, in iteration order, or a single {@code null} entry for the
+   * legacy single-engine wiring (whose responses carry no {@code physicalTenantId}, i.e. exactly
+   * the pre-multi-engine response shape). Deliberately kept separate from {@link
+   * #brokerJobStreamClientsByPhysicalTenantId}: broker monitoring can be disabled entirely (leaving
+   * no clients at all), and the endpoint must still report every engine's connectors.
+   */
+  private final List<String> physicalTenantIds;
+
+  private final Map<String, BrokerJobStreamClient> brokerJobStreamClientsByPhysicalTenantId;
+
+  /** Used for the {@code null} physical tenant of the legacy single-engine wiring. */
+  private final BrokerJobStreamClient legacyBrokerJobStreamClient;
+
+  /** Legacy single-engine constructor without broker monitoring. */
   public OutboundConnectorsService(OutboundConnectorFactory connectorFactory) {
-    this(connectorFactory, null);
+    this(connectorFactory, (BrokerJobStreamClient) null);
   }
 
+  /**
+   * Legacy single-engine constructor: one unnamed engine, whose responses carry no {@code
+   * physicalTenantId}.
+   */
   public OutboundConnectorsService(
       OutboundConnectorFactory connectorFactory, BrokerJobStreamClient brokerJobStreamClient) {
     this.connectorFactory = connectorFactory;
-    this.brokerJobStreamClient = brokerJobStreamClient;
+    this.physicalTenantIds = singletonListOfNull();
+    this.brokerJobStreamClientsByPhysicalTenantId = Map.of();
+    this.legacyBrokerJobStreamClient = brokerJobStreamClient;
+  }
+
+  /**
+   * @param physicalTenantIds every configured physical tenant (engine); each registered connector
+   *     is reported once per entry
+   * @param brokerJobStreamClientsByPhysicalTenantId one broker job-stream client per physical
+   *     tenant, or empty when broker monitoring is disabled. Tenants missing from this map report
+   *     {@link io.camunda.connector.runtime.outbound.jobstream.BrokerConnectivityState#UNKNOWN}.
+   */
+  public OutboundConnectorsService(
+      OutboundConnectorFactory connectorFactory,
+      Collection<String> physicalTenantIds,
+      Map<String, BrokerJobStreamClient> brokerJobStreamClientsByPhysicalTenantId) {
+    this.connectorFactory = connectorFactory;
+    this.physicalTenantIds =
+        physicalTenantIds == null || physicalTenantIds.isEmpty()
+            ? singletonListOfNull()
+            : List.copyOf(physicalTenantIds);
+    this.brokerJobStreamClientsByPhysicalTenantId =
+        brokerJobStreamClientsByPhysicalTenantId == null
+            ? Map.of()
+            : brokerJobStreamClientsByPhysicalTenantId;
+    this.legacyBrokerJobStreamClient = null;
   }
 
   public List<OutboundConnectorResponse> findAll(String runtimeId) {
-    Optional<BrokerStreamsResult> brokerStreams = queryBrokerStreams();
-    return connectorFactory.getRuntimeConfigurations().stream()
-        .map(config -> toResponse(config, runtimeId, brokerStreams))
-        .toList();
+    return findAll(runtimeId, null);
+  }
+
+  /**
+   * @param physicalTenantIdFilter when non-null and non-empty, restricts the result to these
+   *     physical tenants (engines); {@code null}/empty returns every configured engine, matching
+   *     the pre-existing (unfiltered) behavior of this endpoint.
+   */
+  public List<OutboundConnectorResponse> findAll(
+      String runtimeId, List<String> physicalTenantIdFilter) {
+    var brokerStreams = queryBrokerStreams(physicalTenantIdFilter);
+    var configurations = connectorFactory.getRuntimeConfigurations();
+    var results = new ArrayList<OutboundConnectorResponse>();
+    brokerStreams.forEach(
+        (physicalTenantId, streams) ->
+            configurations.forEach(
+                config -> results.add(toResponse(config, runtimeId, physicalTenantId, streams))));
+    return results;
   }
 
   public List<OutboundConnectorResponse> findByType(String type, String runtimeId) {
-    Optional<BrokerStreamsResult> brokerStreams = queryBrokerStreams();
+    return findByType(type, runtimeId, null);
+  }
+
+  /**
+   * @param physicalTenantIdFilter see {@link #findAll(String, List)}
+   */
+  public List<OutboundConnectorResponse> findByType(
+      String type, String runtimeId, List<String> physicalTenantIdFilter) {
     var results =
-        connectorFactory.getRuntimeConfigurations().stream()
-            .filter(config -> config.config().type().equals(type))
-            .map(config -> toResponse(config, runtimeId, brokerStreams))
+        findAll(runtimeId, physicalTenantIdFilter).stream()
+            .filter(response -> response.type().equals(type))
             .toList();
     if (results.isEmpty()) {
       throw new DataNotFoundException(OutboundConnectorResponse.class, type);
@@ -66,14 +140,50 @@ public class OutboundConnectorsService {
     return results;
   }
 
-  private Optional<BrokerStreamsResult> queryBrokerStreams() {
+  /**
+   * Queries every requested physical tenant's brokers, keeping the results attributed to their
+   * engine of origin. A tenant whose brokers cannot be reached (or that has no broker monitoring
+   * configured at all) is still present in the returned map, with an empty value — its connectors
+   * are reported with an {@code UNKNOWN} connectivity state rather than dropped from the listing.
+   */
+  private Map<String, Optional<BrokerStreamsResult>> queryBrokerStreams(
+      List<String> physicalTenantIdFilter) {
+    var streamsByPhysicalTenantId = new LinkedHashMap<String, Optional<BrokerStreamsResult>>();
+    for (String physicalTenantId : physicalTenantIds) {
+      if (!matchesFilter(physicalTenantId, physicalTenantIdFilter)) {
+        continue;
+      }
+      streamsByPhysicalTenantId.put(
+          physicalTenantId, fetchRemoteStreams(physicalTenantId, clientFor(physicalTenantId)));
+    }
+    return streamsByPhysicalTenantId;
+  }
+
+  private BrokerJobStreamClient clientFor(String physicalTenantId) {
+    return physicalTenantId == null
+        ? legacyBrokerJobStreamClient
+        : brokerJobStreamClientsByPhysicalTenantId.get(physicalTenantId);
+  }
+
+  /** Null-tolerant on both sides: an immutable {@code List.of(...)} filter rejects {@code null}. */
+  private static boolean matchesFilter(String physicalTenantId, List<String> filter) {
+    return filter == null
+        || filter.isEmpty()
+        || filter.stream().anyMatch(id -> Objects.equals(id, physicalTenantId));
+  }
+
+  private Optional<BrokerStreamsResult> fetchRemoteStreams(
+      String physicalTenantId, BrokerJobStreamClient brokerJobStreamClient) {
     if (brokerJobStreamClient == null) {
       return Optional.empty();
     }
     try {
       return Optional.of(brokerJobStreamClient.fetchRemoteStreams());
     } catch (Exception e) {
-      LOG.warn("Failed to fetch remote streams from brokers: {}", e.getMessage());
+      LOG.warn(
+          "Failed to fetch remote streams from brokers of physical tenant '{}': {}",
+          physicalTenantId,
+          e.getMessage());
       return Optional.empty();
     }
   }
@@ -81,6 +191,7 @@ public class OutboundConnectorsService {
   private OutboundConnectorResponse toResponse(
       AbstractConnectorFactory.ConnectorRuntimeConfiguration<OutboundConnectorConfiguration> config,
       String runtimeId,
+      String physicalTenantId,
       Optional<BrokerStreamsResult> brokerStreams) {
     var connectivity = StreamConnectivity.compute(config.config().type(), brokerStreams);
     var connectorConfig = config.config();
@@ -94,6 +205,14 @@ public class OutboundConnectorsService {
         config.isActive(),
         runtimeId,
         connectivity.brokerState(),
-        connectivity.streamIds());
+        connectivity.streamIds(),
+        physicalTenantId);
+  }
+
+  /** {@code List.of} rejects null elements, hence the explicit singleton construction. */
+  private static List<String> singletonListOfNull() {
+    var list = new ArrayList<String>(1);
+    list.add(null);
+    return list;
   }
 }

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/metrics/ConnectorMetrics.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/metrics/ConnectorMetrics.java
@@ -143,6 +143,15 @@ public class ConnectorMetrics {
    */
   public static final String DEFAULT_PHYSICAL_TENANT_ID = "default";
 
+  /**
+   * Attributes the counter to the job's own physical tenant. Callers that know which physical
+   * tenant's job worker received the job should prefer {@link #counter(ActivatedJob, String)}, so
+   * that the meter and the {@code /outbound} entry it belongs to always carry the same value.
+   */
+  public static CounterMetricsContext counter(ActivatedJob job) {
+    return counter(job, null);
+  }
+
   public static CounterMetricsContext counter(ActivatedJob job, String physicalTenantId) {
     Result result = Result.getResult(job);
     return new CounterMetricsContext(
@@ -155,6 +164,11 @@ public class ConnectorMetrics {
                 ConnectorMetrics.Tag.PHYSICAL_TENANT_ID,
                 resolvePhysicalTenantId(physicalTenantId, result))),
         1);
+  }
+
+  /** See {@link #counter(ActivatedJob)}; the equivalent for the execution-time timer. */
+  public static TimerMetricsContext timer(ActivatedJob job) {
+    return timer(job, null);
   }
 
   public static TimerMetricsContext timer(ActivatedJob job, String physicalTenantId) {

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/metrics/ConnectorMetrics.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/metrics/ConnectorMetrics.java
@@ -135,24 +135,55 @@ public class ConnectorMetrics {
     public static final String ACTION_CORRELATION_FAILED = "correlation-failed";
   }
 
-  public static CounterMetricsContext counter(ActivatedJob job) {
+  /**
+   * Physical tenant (engine) a meter is attributed to when none could be resolved — a job handled
+   * by legacy single-client wiring that configures no {@code physical-tenant-id}. Mirrors the same
+   * fallback applied to the scalar single-{@code CamundaClient} beans elsewhere in the runtime, so
+   * both sides agree on the tenant a single-engine deployment reports.
+   */
+  public static final String DEFAULT_PHYSICAL_TENANT_ID = "default";
+
+  public static CounterMetricsContext counter(ActivatedJob job, String physicalTenantId) {
     Result result = Result.getResult(job);
     return new CounterMetricsContext(
         Outbound.METRIC_NAME_INVOCATIONS,
         Map.ofEntries(
             Map.entry(ConnectorMetrics.Tag.TYPE, result.type()),
             Map.entry(ConnectorMetrics.Tag.ELEMENT_TEMPLATE_ID, result.id()),
-            Map.entry(ConnectorMetrics.Tag.ELEMENT_TEMPLATE_VERSION, result.version())),
+            Map.entry(ConnectorMetrics.Tag.ELEMENT_TEMPLATE_VERSION, result.version()),
+            Map.entry(
+                ConnectorMetrics.Tag.PHYSICAL_TENANT_ID,
+                resolvePhysicalTenantId(physicalTenantId, result))),
         1);
   }
 
-  public static TimerMetricsContext timer(ActivatedJob job) {
+  public static TimerMetricsContext timer(ActivatedJob job, String physicalTenantId) {
     Result result = Result.getResult(job);
     return new TimerMetricsContext(
         ConnectorMetrics.Outbound.METRIC_NAME_TIME,
         Map.ofEntries(
             Map.entry(ConnectorMetrics.Tag.TYPE, result.type()),
             Map.entry(ConnectorMetrics.Tag.ELEMENT_TEMPLATE_ID, result.id()),
-            Map.entry(ConnectorMetrics.Tag.ELEMENT_TEMPLATE_VERSION, result.version())));
+            Map.entry(ConnectorMetrics.Tag.ELEMENT_TEMPLATE_VERSION, result.version()),
+            Map.entry(
+                ConnectorMetrics.Tag.PHYSICAL_TENANT_ID,
+                resolvePhysicalTenantId(physicalTenantId, result))));
+  }
+
+  /**
+   * Prefers the physical tenant the job worker was opened for (the same ID the {@code /outbound}
+   * listing and the per-physical-tenant document/secret beans are keyed by) over the one reported
+   * on the job itself, so that a meter and the connector entry it belongs to always carry the same
+   * value. Falls back to the job's own physical tenant, then to {@link
+   * #DEFAULT_PHYSICAL_TENANT_ID}: a tag value is never allowed to be null.
+   */
+  private static String resolvePhysicalTenantId(String physicalTenantId, Result result) {
+    if (physicalTenantId != null && !physicalTenantId.isBlank()) {
+      return physicalTenantId;
+    }
+    if (result.physicalTenantId() != null && !result.physicalTenantId().isBlank()) {
+      return result.physicalTenantId();
+    }
+    return DEFAULT_PHYSICAL_TENANT_ID;
   }
 }

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/metrics/ConnectorMetricsAggregator.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/metrics/ConnectorMetricsAggregator.java
@@ -47,17 +47,43 @@ public final class ConnectorMetricsAggregator {
    */
   public static OutboundConnectorMetrics outbound(
       MeterRegistry registry, String connectorType, String runtimeId) {
+    return outbound(registry, connectorType, null, runtimeId);
+  }
+
+  /**
+   * @param physicalTenantIds when non-null and non-empty, restricts the sums to meters recorded for
+   *     one of these physical tenants (engines) — a distinct dimension from connector {@code type}.
+   *     {@code null}/empty sums across every physical tenant, matching the pre-existing behavior of
+   *     this method.
+   *     <p>The {@link OutboundConnectorMetrics.Worker} section is left {@code null} whenever a
+   *     filter is applied: those counters ({@code camunda.client.worker.*}) are recorded by the
+   *     Camunda client itself, which tags them by job type only, so they cannot be attributed to a
+   *     physical tenant. Reporting the unfiltered pod-wide totals inside an otherwise filtered
+   *     response would misattribute them, and reporting zeros would read as "no jobs activated".
+   */
+  public static OutboundConnectorMetrics outbound(
+      MeterRegistry registry,
+      String connectorType,
+      List<String> physicalTenantIds,
+      String runtimeId) {
     if (registry == null) {
       return new OutboundConnectorMetrics(runtimeId, null, null, null);
     }
     if (connectorType != null && !connectorType.isBlank()) {
-      return buildOutbound(registry, connectorType, runtimeId);
+      return buildOutbound(registry, connectorType, physicalTenantIds, runtimeId);
     }
-    return buildOutboundAggregate(registry, runtimeId);
+    return buildOutboundAggregate(registry, physicalTenantIds, runtimeId);
+  }
+
+  /**
+   * @return {@code true} when no physical-tenant filter was requested.
+   */
+  private static boolean isUnfiltered(List<String> physicalTenantIds) {
+    return physicalTenantIds == null || physicalTenantIds.isEmpty();
   }
 
   private static OutboundConnectorMetrics buildOutboundAggregate(
-      MeterRegistry registry, String runtimeId) {
+      MeterRegistry registry, List<String> physicalTenantIds, String runtimeId) {
     Set<String> types = discoverTypes(registry, null, allOutboundMetricNames());
 
     long completed = 0, failed = 0, bpmnError = 0;
@@ -74,19 +100,22 @@ public final class ConnectorMetricsAggregator {
               registry,
               ConnectorMetrics.Outbound.METRIC_NAME_INVOCATIONS,
               type,
-              ConnectorMetrics.Outbound.ACTION_COMPLETED);
+              ConnectorMetrics.Outbound.ACTION_COMPLETED,
+              physicalTenantIds);
       failed +=
           sumCounterByAction(
               registry,
               ConnectorMetrics.Outbound.METRIC_NAME_INVOCATIONS,
               type,
-              ConnectorMetrics.Outbound.ACTION_FAILED);
+              ConnectorMetrics.Outbound.ACTION_FAILED,
+              physicalTenantIds);
       bpmnError +=
           sumCounterByAction(
               registry,
               ConnectorMetrics.Outbound.METRIC_NAME_INVOCATIONS,
               type,
-              ConnectorMetrics.Outbound.ACTION_BPMN_ERROR);
+              ConnectorMetrics.Outbound.ACTION_BPMN_ERROR,
+              physicalTenantIds);
       jobsActivated +=
           (long)
               sumCounter(
@@ -105,21 +134,36 @@ public final class ConnectorMetricsAggregator {
               .find(ConnectorMetrics.Outbound.METRIC_NAME_TIME)
               .tag(ConnectorMetrics.Tag.TYPE, type)
               .timers()) {
+        if (!matchesPhysicalTenantIds(t.getId(), physicalTenantIds)) {
+          continue;
+        }
         totalMs += t.totalTime(TimeUnit.MILLISECONDS);
         totalCount += t.count();
       }
       maxMs =
           Math.max(
               maxMs,
-              readGauge(registry, ConnectorMetrics.Outbound.METRIC_NAME_MAX_EXECUTION_TIME, type));
+              readGauge(
+                  registry,
+                  ConnectorMetrics.Outbound.METRIC_NAME_MAX_EXECUTION_TIME,
+                  type,
+                  physicalTenantIds));
       maxLastCompleted =
           Math.max(
               maxLastCompleted,
-              readGauge(registry, ConnectorMetrics.Outbound.METRIC_NAME_LAST_COMPLETED, type));
+              readGauge(
+                  registry,
+                  ConnectorMetrics.Outbound.METRIC_NAME_LAST_COMPLETED,
+                  type,
+                  physicalTenantIds));
       maxLastFailed =
           Math.max(
               maxLastFailed,
-              readGauge(registry, ConnectorMetrics.Outbound.METRIC_NAME_LAST_FAILED, type));
+              readGauge(
+                  registry,
+                  ConnectorMetrics.Outbound.METRIC_NAME_LAST_FAILED,
+                  type,
+                  physicalTenantIds));
     }
 
     OutboundConnectorMetrics.ExecutionTime executionTime =
@@ -137,18 +181,29 @@ public final class ConnectorMetricsAggregator {
             executionTime,
             epochMsToInstant(maxLastCompleted),
             epochMsToInstant(maxLastFailed)),
-        new OutboundConnectorMetrics.Worker(jobsActivated, jobsHandled, streamRecreations));
+        isUnfiltered(physicalTenantIds)
+            ? new OutboundConnectorMetrics.Worker(jobsActivated, jobsHandled, streamRecreations)
+            : null);
   }
 
   private static OutboundConnectorMetrics buildOutbound(
-      MeterRegistry registry, String type, String runtimeId) {
-    OutboundConnectorMetrics.ExecutionTime executionTime = buildExecutionTime(registry, type);
+      MeterRegistry registry, String type, List<String> physicalTenantIds, String runtimeId) {
+    OutboundConnectorMetrics.ExecutionTime executionTime =
+        buildExecutionTime(registry, type, physicalTenantIds);
     Instant lastCompleted =
         epochMsToInstant(
-            readGauge(registry, ConnectorMetrics.Outbound.METRIC_NAME_LAST_COMPLETED, type));
+            readGauge(
+                registry,
+                ConnectorMetrics.Outbound.METRIC_NAME_LAST_COMPLETED,
+                type,
+                physicalTenantIds));
     Instant lastFailed =
         epochMsToInstant(
-            readGauge(registry, ConnectorMetrics.Outbound.METRIC_NAME_LAST_FAILED, type));
+            readGauge(
+                registry,
+                ConnectorMetrics.Outbound.METRIC_NAME_LAST_FAILED,
+                type,
+                physicalTenantIds));
 
     return new OutboundConnectorMetrics(
         runtimeId,
@@ -158,42 +213,48 @@ public final class ConnectorMetricsAggregator {
                 registry,
                 ConnectorMetrics.Outbound.METRIC_NAME_INVOCATIONS,
                 type,
-                ConnectorMetrics.Outbound.ACTION_COMPLETED),
+                ConnectorMetrics.Outbound.ACTION_COMPLETED,
+                physicalTenantIds),
             sumCounterByAction(
                 registry,
                 ConnectorMetrics.Outbound.METRIC_NAME_INVOCATIONS,
                 type,
-                ConnectorMetrics.Outbound.ACTION_FAILED),
+                ConnectorMetrics.Outbound.ACTION_FAILED,
+                physicalTenantIds),
             sumCounterByAction(
                 registry,
                 ConnectorMetrics.Outbound.METRIC_NAME_INVOCATIONS,
                 type,
-                ConnectorMetrics.Outbound.ACTION_BPMN_ERROR),
+                ConnectorMetrics.Outbound.ACTION_BPMN_ERROR,
+                physicalTenantIds),
             executionTime,
             lastCompleted,
             lastFailed),
-        new OutboundConnectorMetrics.Worker(
-            (long)
-                sumCounter(
-                    registry, ConnectorMetrics.Outbound.METRIC_NAME_WORKER_JOB_ACTIVATED, type),
-            (long)
-                sumCounter(
-                    registry, ConnectorMetrics.Outbound.METRIC_NAME_WORKER_JOB_HANDLED, type),
-            (long)
-                sumCounter(
-                    registry,
-                    ConnectorMetrics.Outbound.METRIC_NAME_WORKER_STREAM_INACTIVITY_RECREATED,
-                    type)));
+        isUnfiltered(physicalTenantIds)
+            ? new OutboundConnectorMetrics.Worker(
+                (long)
+                    sumCounter(
+                        registry, ConnectorMetrics.Outbound.METRIC_NAME_WORKER_JOB_ACTIVATED, type),
+                (long)
+                    sumCounter(
+                        registry, ConnectorMetrics.Outbound.METRIC_NAME_WORKER_JOB_HANDLED, type),
+                (long)
+                    sumCounter(
+                        registry,
+                        ConnectorMetrics.Outbound.METRIC_NAME_WORKER_STREAM_INACTIVITY_RECREATED,
+                        type))
+            : null);
   }
 
   private static OutboundConnectorMetrics.ExecutionTime buildExecutionTime(
-      MeterRegistry registry, String type) {
+      MeterRegistry registry, String type, List<String> physicalTenantIds) {
     List<Timer> timers =
         registry
             .find(ConnectorMetrics.Outbound.METRIC_NAME_TIME)
             .tag(ConnectorMetrics.Tag.TYPE, type)
             .timers()
             .stream()
+            .filter(timer -> matchesPhysicalTenantIds(timer.getId(), physicalTenantIds))
             .toList();
 
     if (timers.isEmpty()) {
@@ -210,7 +271,11 @@ public final class ConnectorMetricsAggregator {
 
     double meanMs = totalCount > 0 ? totalMs / totalCount : 0.0;
     double maxMs =
-        readGauge(registry, ConnectorMetrics.Outbound.METRIC_NAME_MAX_EXECUTION_TIME, type);
+        readGauge(
+            registry,
+            ConnectorMetrics.Outbound.METRIC_NAME_MAX_EXECUTION_TIME,
+            type,
+            physicalTenantIds);
     return new OutboundConnectorMetrics.ExecutionTime(meanMs, maxMs);
   }
 
@@ -422,25 +487,7 @@ public final class ConnectorMetricsAggregator {
     return types;
   }
 
-  private static long sumCounterByAction(
-      MeterRegistry registry, String metricName, String type, String action) {
-    double sum =
-        registry
-            .find(metricName)
-            .tag(ConnectorMetrics.Tag.TYPE, type)
-            .tag(ConnectorMetrics.Tag.ACTION, action)
-            .counters()
-            .stream()
-            .mapToDouble(Counter::count)
-            .sum();
-    return (long) sum;
-  }
-
-  /**
-   * Physical-tenant-aware variant used by inbound aggregation only — see {@link
-   * #matchesPhysicalTenantIds}. Outbound aggregation has no physical-tenant dimension yet and keeps
-   * using the 4-arg overload above unchanged.
-   */
+  /** Physical-tenant-aware — see {@link #matchesPhysicalTenantIds}. */
   private static long sumCounterByAction(
       MeterRegistry registry,
       String metricName,
@@ -492,17 +539,10 @@ public final class ConnectorMetricsAggregator {
   }
 
   /**
-   * Reads the value of a {@link Gauge} tagged with the given connector type. Returns {@code 0} if
-   * no gauge is registered for that type.
+   * Reads the value of a {@link Gauge} tagged with the given connector type, restricted to the
+   * requested physical tenants (see {@link #matchesPhysicalTenantIds}). Returns {@code 0} if no
+   * matching gauge is registered.
    */
-  private static long readGauge(MeterRegistry registry, String metricName, String type) {
-    return registry.find(metricName).tag(ConnectorMetrics.Tag.TYPE, type).gauges().stream()
-        .mapToLong(g -> (long) g.value())
-        .max()
-        .orElse(0L);
-  }
-
-  /** Physical-tenant-aware variant used by inbound aggregation only — see {@link #readGauge}. */
   private static long readGauge(
       MeterRegistry registry, String metricName, String type, List<String> physicalTenantIds) {
     return registry.find(metricName).tag(ConnectorMetrics.Tag.TYPE, type).gauges().stream()

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/metrics/ConnectorOutboundMetrics.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/metrics/ConnectorOutboundMetrics.java
@@ -36,13 +36,34 @@ public class ConnectorOutboundMetrics {
 
   private final MetricsRecorder delegate;
   private final MeterRegistry meterRegistry;
+  private final String physicalTenantId;
   private final ConcurrentHashMap<String, AtomicLong> lastCompleted = new ConcurrentHashMap<>();
   private final ConcurrentHashMap<String, AtomicLong> lastFailed = new ConcurrentHashMap<>();
   private final ConcurrentHashMap<String, AtomicLong> allTimeMaxMs = new ConcurrentHashMap<>();
 
   public ConnectorOutboundMetrics(MetricsRecorder delegate, MeterRegistry meterRegistry) {
+    this(delegate, meterRegistry, null);
+  }
+
+  /**
+   * @param physicalTenantId the physical tenant (engine) whose job worker these metrics are
+   *     recorded for; every gauge is tagged with it, so that two engines running the same connector
+   *     type report separately instead of colliding on one shared, wrongly-attributed gauge. {@code
+   *     null} falls back to {@link ConnectorMetrics#DEFAULT_PHYSICAL_TENANT_ID}.
+   */
+  public ConnectorOutboundMetrics(
+      MetricsRecorder delegate, MeterRegistry meterRegistry, String physicalTenantId) {
     this.delegate = delegate;
     this.meterRegistry = meterRegistry;
+    this.physicalTenantId =
+        physicalTenantId == null || physicalTenantId.isBlank()
+            ? ConnectorMetrics.DEFAULT_PHYSICAL_TENANT_ID
+            : physicalTenantId;
+  }
+
+  /** The physical tenant (engine) every meter recorded through this instance is tagged with. */
+  public String physicalTenantId() {
+    return physicalTenantId;
   }
 
   // -------------------------------------------------------------------------
@@ -111,6 +132,7 @@ public class ConnectorOutboundMetrics {
           if (meterRegistry != null) {
             Gauge.builder(metricName, gauge, AtomicLong::doubleValue)
                 .tag(ConnectorMetrics.Tag.TYPE, type)
+                .tag(ConnectorMetrics.Tag.PHYSICAL_TENANT_ID, physicalTenantId)
                 .register(meterRegistry);
           }
           return gauge;

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/OutboundConnectorRuntimeConfiguration.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/OutboundConnectorRuntimeConfiguration.java
@@ -347,11 +347,11 @@ public class OutboundConnectorRuntimeConfiguration {
    *       camunda.connector.broker.monitoring.port}.
    * </ul>
    *
-   * <p>Pre-existing, out-of-scope-for-#6961 limitation: in topology-discovery mode this still
-   * resolves a single {@code CamundaClient} (whichever is {@code @Primary} when multiple physical
-   * tenants are configured), so it only monitors that one physical tenant's brokers. Broker
-   * monitoring is informational/observability only, not part of job execution, so this is
-   * deliberately deferred rather than converted to a per-physical-tenant map.
+   * <p>This scalar bean monitors the brokers of a single {@code CamundaClient} (whichever is
+   * {@code @Primary} when several physical tenants are configured) and is kept for backward
+   * compatibility with runtimes injecting/overriding it directly. The {@code /outbound} endpoints
+   * instead go through the per-physical-tenant map built by {@link
+   * #buildBrokerJobStreamClientsByPhysicalTenantId}, which monitors every engine's brokers.
    */
   @Bean
   @ConditionalOnProperty(
@@ -363,26 +363,102 @@ public class OutboundConnectorRuntimeConfiguration {
       @ConnectorsObjectMapper ObjectMapper mapper,
       @Value("${camunda.connector.broker.monitoring.port:9600}") int monitoringPort,
       @Value("${camunda.connector.broker.monitoring.addresses:#{null}}") String addresses) {
-    if (StringUtils.isNotBlank(addresses)) {
-      List<URI> uris =
-          Arrays.stream(addresses.split(","))
-              .map(String::trim)
-              .filter(s -> !s.isBlank())
-              .map(URI::create)
-              .toList();
-      if (!uris.isEmpty()) {
-        return new BrokerJobStreamClient(uris, mapper);
-      }
+    List<URI> uris = parseMonitoringAddresses(addresses);
+    if (!uris.isEmpty()) {
+      return new BrokerJobStreamClient(uris, mapper);
     }
     return new BrokerJobStreamClient(camundaClient, monitoringPort, mapper);
+  }
+
+  private static List<URI> parseMonitoringAddresses(String addresses) {
+    if (StringUtils.isBlank(addresses)) {
+      return List.of();
+    }
+    return Arrays.stream(addresses.split(","))
+        .map(String::trim)
+        .filter(s -> !s.isBlank())
+        .map(URI::create)
+        .toList();
+  }
+
+  /**
+   * Resolves every configured physical tenant (engine) ID, sorted for a stable {@code /outbound}
+   * listing order.
+   */
+  private static List<String> physicalTenantIds(
+      CamundaClientRegistry registry, CamundaClient legacyCamundaClient) {
+    return clientNames(registry, legacyCamundaClient).stream()
+        .map(name -> resolvePhysicalTenantId(registry, name, legacyCamundaClient))
+        .distinct()
+        .sorted()
+        .toList();
+  }
+
+  /**
+   * Builds one {@link BrokerJobStreamClient} per configured physical tenant, so that {@code
+   * /outbound} can report each engine's own broker/stream connectivity (#7965).
+   *
+   * <p>{@code injectedBrokerJobStreamClient} doubles as the on/off switch: it is {@code null}
+   * exactly when broker monitoring is disabled (its bean is {@code @ConditionalOnProperty}-gated),
+   * in which case no client is built at all and every connector is reported with an {@code UNKNOWN}
+   * connectivity state, as before.
+   *
+   * <p>With a single physical tenant, the already-resolved scalar bean is reused as-is, preserving
+   * behavior (including any override) for existing single-engine deployments. In explicit-addresses
+   * mode the configured addresses are global rather than per-engine, so the same client — querying
+   * that same broker list — is shared by every physical tenant; only topology-discovery mode
+   * resolves each engine's brokers separately, through that engine's own {@code CamundaClient}.
+   *
+   * <p>Deliberately a plain (non-{@code @Bean}) static method: see {@link
+   * #buildOutboundConnectorObjectMappersByPhysicalTenantId} for why {@code Map<String,X>}-typed
+   * {@code @Bean} methods/parameters are avoided in this class.
+   */
+  private static Map<String, BrokerJobStreamClient> buildBrokerJobStreamClientsByPhysicalTenantId(
+      CamundaClientRegistry registry,
+      CamundaClient legacyCamundaClient,
+      BrokerJobStreamClient injectedBrokerJobStreamClient,
+      ObjectMapper mapper,
+      int monitoringPort,
+      String addresses) {
+    if (injectedBrokerJobStreamClient == null) {
+      return Map.of();
+    }
+    boolean shared =
+        clientNames(registry, legacyCamundaClient).size() <= 1
+            || !parseMonitoringAddresses(addresses).isEmpty();
+    return clientNames(registry, legacyCamundaClient).stream()
+        .collect(
+            toMapByPhysicalTenantId(
+                registry,
+                legacyCamundaClient,
+                name ->
+                    shared
+                        ? injectedBrokerJobStreamClient
+                        : new BrokerJobStreamClient(
+                            resolveClient(registry, name, legacyCamundaClient),
+                            monitoringPort,
+                            mapper)));
   }
 
   @Bean
   public OutboundConnectorsService outboundConnectorsService(
       OutboundConnectorFactory outboundConnectorConfigurationRegistry,
-      @Autowired(required = false) BrokerJobStreamClient brokerJobStreamClient) {
+      @Autowired(required = false) CamundaClientRegistry registry,
+      @Autowired(required = false) CamundaClient legacyCamundaClient,
+      @Autowired(required = false) BrokerJobStreamClient brokerJobStreamClient,
+      @ConnectorsObjectMapper ObjectMapper mapper,
+      @Value("${camunda.connector.broker.monitoring.port:9600}") int monitoringPort,
+      @Value("${camunda.connector.broker.monitoring.addresses:#{null}}") String addresses) {
     return new OutboundConnectorsService(
-        outboundConnectorConfigurationRegistry, brokerJobStreamClient);
+        outboundConnectorConfigurationRegistry,
+        physicalTenantIds(registry, legacyCamundaClient),
+        buildBrokerJobStreamClientsByPhysicalTenantId(
+            registry,
+            legacyCamundaClient,
+            brokerJobStreamClient,
+            mapper,
+            monitoringPort,
+            addresses));
   }
 
   @Bean

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/controller/OutboundConnectorResponse.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/controller/OutboundConnectorResponse.java
@@ -63,4 +63,30 @@ public record OutboundConnectorResponse(
       String runtimeId) {
     this(name, type, inputVariables, timeout, enabled, runtimeId, null, null, null);
   }
+
+  /**
+   * The canonical constructor as it stood before {@code physicalTenantId} was added — kept so
+   * callers compiled against the previous signature keep linking, mirroring the stream-less
+   * convenience constructor above.
+   */
+  public OutboundConnectorResponse(
+      String name,
+      String type,
+      List<String> inputVariables,
+      Long timeout,
+      boolean enabled,
+      String runtimeId,
+      BrokerConnectivityState brokerConnectivityState,
+      List<String> streamIds) {
+    this(
+        name,
+        type,
+        inputVariables,
+        timeout,
+        enabled,
+        runtimeId,
+        brokerConnectivityState,
+        streamIds,
+        null);
+  }
 }

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/controller/OutboundConnectorResponse.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/controller/OutboundConnectorResponse.java
@@ -31,10 +31,15 @@ import java.util.List;
  * @param enabled whether the connector is enabled or not
  * @param runtimeId hostname of the runtime node that reported this entry
  * @param brokerConnectivityState whether the connector's stream appears as a consumer on all
- *     brokers; {@link BrokerConnectivityState#UNKNOWN} when broker monitoring is not configured or
- *     unreachable
+ *     brokers of the physical tenant (engine) this entry belongs to; {@link
+ *     BrokerConnectivityState#UNKNOWN} when broker monitoring is not configured or unreachable
  * @param streamIds consumer IDs observed across all brokers for this job type; {@code null} when
  *     broker monitoring is unavailable or no consumers were found
+ * @param physicalTenantId the physical tenant (engine) this entry was reported for — the engine
+ *     identity, as opposed to {@code runtimeId}, which is the reporting pod's identity. One entry
+ *     per (connector, physical tenant) pair is returned, since every configured engine runs a job
+ *     worker for every registered connector. {@code null} when no physical tenant is known (legacy
+ *     single-client wiring that supplies no {@code CamundaClientRegistry}).
  */
 @JsonInclude(Include.NON_NULL)
 public record OutboundConnectorResponse(
@@ -45,7 +50,8 @@ public record OutboundConnectorResponse(
     boolean enabled,
     String runtimeId,
     BrokerConnectivityState brokerConnectivityState,
-    List<String> streamIds) {
+    List<String> streamIds,
+    String physicalTenantId) {
 
   /** Convenience constructor without stream enrichment (backward-compatible). */
   public OutboundConnectorResponse(
@@ -55,6 +61,6 @@ public record OutboundConnectorResponse(
       Long timeout,
       boolean enabled,
       String runtimeId) {
-    this(name, type, inputVariables, timeout, enabled, runtimeId, null, null);
+    this(name, type, inputVariables, timeout, enabled, runtimeId, null, null, null);
   }
 }

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/controller/OutboundConnectorsRestController.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/controller/OutboundConnectorsRestController.java
@@ -35,6 +35,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -65,56 +66,60 @@ public class OutboundConnectorsRestController {
     }
   }
 
+  /**
+   * Returns every registered outbound connector, once per physical tenant (engine) it runs a job
+   * worker for.
+   *
+   * @param physicalTenantIds when non-empty, restricts the result to connectors running on one of
+   *     these physical tenants (engines) — a distinct dimension from the logical {@code tenantId}
+   *     exposed elsewhere on this API. Omitted or empty returns every physical tenant, matching the
+   *     pre-existing (unfiltered) behavior of this endpoint.
+   */
   @GetMapping
   public List<OutboundConnectorResponse> getOutboundConnectors(
       HttpServletRequest request,
-      @RequestHeader(name = X_CAMUNDA_FORWARDED_FOR, required = false) String forwardedFor) {
-    return instanceForwardingRouter.forwardToInstancesAndReduceOrLocal(
-        request,
-        forwardedFor,
-        () -> outboundConnectorsService.findAll(hostname),
-        new TypeReference<>() {});
-  }
-
-  @GetMapping("/{type}")
-  public List<OutboundConnectorResponse> getOutboundConnectorByType(
-      HttpServletRequest request,
       @RequestHeader(name = X_CAMUNDA_FORWARDED_FOR, required = false) String forwardedFor,
-      @PathVariable(name = "type") String type) {
-    return Optional.ofNullable(
-            instanceForwardingRouter.forwardToInstancesAndReduceOrLocal(
-                request,
-                forwardedFor,
-                () -> outboundConnectorsService.findByType(type, hostname),
-                new TypeReference<>() {}))
-        .orElseThrow(() -> new DataNotFoundException(OutboundConnectorResponse.class, type));
-  }
-
-  /** Returns aggregated outbound connector metrics across all connector types. */
-  @GetMapping("/metrics")
-  public List<OutboundConnectorMetrics> getMetrics(
-      HttpServletRequest request,
-      @RequestHeader(name = X_CAMUNDA_FORWARDED_FOR, required = false) String forwardedFor) {
+      @RequestParam(required = false, value = "physicalTenantIds") List<String> physicalTenantIds) {
     return instanceForwardingRouter.forwardToInstancesAndReduceOrLocal(
         request,
         forwardedFor,
-        () ->
-            meterRegistry == null
-                ? List.of()
-                : List.of(ConnectorMetricsAggregator.outbound(meterRegistry, null, hostname)),
+        () -> outboundConnectorsService.findAll(hostname, physicalTenantIds),
         new TypeReference<>() {});
   }
 
   /**
-   * Returns outbound connector metrics for a specific connector type.
-   *
-   * @param connectorType connector type (e.g. {@code io.camunda:http-json:1})
+   * @param physicalTenantIds see {@link #getOutboundConnectors}
    */
-  @GetMapping("/metrics/{connectorType}")
-  public List<OutboundConnectorMetrics> getMetricsByType(
+  @GetMapping("/{type}")
+  public List<OutboundConnectorResponse> getOutboundConnectorByType(
       HttpServletRequest request,
       @RequestHeader(name = X_CAMUNDA_FORWARDED_FOR, required = false) String forwardedFor,
-      @PathVariable(name = "connectorType") String connectorType) {
+      @PathVariable(name = "type") String type,
+      @RequestParam(required = false, value = "physicalTenantIds") List<String> physicalTenantIds) {
+    return Optional.ofNullable(
+            instanceForwardingRouter.forwardToInstancesAndReduceOrLocal(
+                request,
+                forwardedFor,
+                () -> outboundConnectorsService.findByType(type, hostname, physicalTenantIds),
+                new TypeReference<>() {}))
+        .orElseThrow(() -> new DataNotFoundException(OutboundConnectorResponse.class, type));
+  }
+
+  /**
+   * Returns aggregated outbound connector metrics across all connector types.
+   *
+   * @param physicalTenantIds when non-empty, restricts the aggregate to jobs executed for one of
+   *     these physical tenants (engines) — a distinct dimension from the logical {@code tenantId}
+   *     exposed elsewhere on this API. Omitted or empty sums across every physical tenant, matching
+   *     the pre-existing (unfiltered) behavior of this endpoint. Note that the {@code worker}
+   *     section is omitted from a filtered response: those counters are recorded by the Camunda
+   *     client itself, which does not tag them by physical tenant.
+   */
+  @GetMapping("/metrics")
+  public List<OutboundConnectorMetrics> getMetrics(
+      HttpServletRequest request,
+      @RequestHeader(name = X_CAMUNDA_FORWARDED_FOR, required = false) String forwardedFor,
+      @RequestParam(required = false, value = "physicalTenantIds") List<String> physicalTenantIds) {
     return instanceForwardingRouter.forwardToInstancesAndReduceOrLocal(
         request,
         forwardedFor,
@@ -122,7 +127,32 @@ public class OutboundConnectorsRestController {
             meterRegistry == null
                 ? List.of()
                 : List.of(
-                    ConnectorMetricsAggregator.outbound(meterRegistry, connectorType, hostname)),
+                    ConnectorMetricsAggregator.outbound(
+                        meterRegistry, null, physicalTenantIds, hostname)),
+        new TypeReference<>() {});
+  }
+
+  /**
+   * Returns outbound connector metrics for a specific connector type.
+   *
+   * @param connectorType connector type (e.g. {@code io.camunda:http-json:1})
+   * @param physicalTenantIds see {@link #getMetrics}
+   */
+  @GetMapping("/metrics/{connectorType}")
+  public List<OutboundConnectorMetrics> getMetricsByType(
+      HttpServletRequest request,
+      @RequestHeader(name = X_CAMUNDA_FORWARDED_FOR, required = false) String forwardedFor,
+      @PathVariable(name = "connectorType") String connectorType,
+      @RequestParam(required = false, value = "physicalTenantIds") List<String> physicalTenantIds) {
+    return instanceForwardingRouter.forwardToInstancesAndReduceOrLocal(
+        request,
+        forwardedFor,
+        () ->
+            meterRegistry == null
+                ? List.of()
+                : List.of(
+                    ConnectorMetricsAggregator.outbound(
+                        meterRegistry, connectorType, physicalTenantIds, hostname)),
         new TypeReference<>() {});
   }
 }

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/SpringConnectorJobHandler.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/SpringConnectorJobHandler.java
@@ -164,8 +164,10 @@ public class SpringConnectorJobHandler implements JobHandler {
 
   @Override
   public void handle(JobClient client, ActivatedJob job) throws Exception {
-    CounterMetricsContext counterMetricsContext = ConnectorMetrics.counter(job);
-    TimerMetricsContext timerMetricsContext = ConnectorMetrics.timer(job);
+    // the physical tenant the worker was opened for — see ConnectorOutboundMetrics#physicalTenantId
+    var physicalTenantId = connectorsOutboundMetrics.physicalTenantId();
+    CounterMetricsContext counterMetricsContext = ConnectorMetrics.counter(job, physicalTenantId);
+    TimerMetricsContext timerMetricsContext = ConnectorMetrics.timer(job, physicalTenantId);
     connectorsOutboundMetrics.increaseActivated(counterMetricsContext);
     connectorsOutboundMetrics.executeWithTimer(
         timerMetricsContext,

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/lifecycle/OutboundConnectorManager.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/lifecycle/OutboundConnectorManager.java
@@ -202,7 +202,7 @@ public class OutboundConnectorManager implements CamundaClientLifecycleAware {
     JobHandlerFactory jobHandlerFactory =
         ctx ->
             new SpringConnectorJobHandler(
-                new ConnectorOutboundMetrics(metricsRecorder, meterRegistry),
+                new ConnectorOutboundMetrics(metricsRecorder, meterRegistry, physicalTenantId),
                 jobCallbackCommandWrapperFactory,
                 secretProviderAggregator,
                 validationProvider,

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/instances/reducer/OutboundConnectorResponseListReducerTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/instances/reducer/OutboundConnectorResponseListReducerTest.java
@@ -21,6 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import io.camunda.connector.runtime.outbound.controller.OutboundConnectorResponse;
+import io.camunda.connector.runtime.outbound.jobstream.BrokerConnectivityState;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 
@@ -79,5 +80,37 @@ public class OutboundConnectorResponseListReducerTest {
 
     assertEquals(1, result.size());
     assertTrue(result.containsAll(node2));
+  }
+
+  @Test
+  void shouldMergeResponsesBuiltFromTheStreamEnrichedConstructor() {
+    // the pre-physicalTenantId canonical signature, kept for callers compiled against it
+    var node1 =
+        List.of(
+            new OutboundConnectorResponse(
+                "HTTP JSON",
+                "io.camunda:http-json:1",
+                List.of("method", "url"),
+                30000L,
+                true,
+                "node-1",
+                BrokerConnectivityState.ALL_CONNECTED,
+                List.of("stream-1")));
+    var node2 =
+        List.of(
+            new OutboundConnectorResponse(
+                "HTTP JSON",
+                "io.camunda:http-json:1",
+                List.of("method", "url"),
+                30000L,
+                true,
+                "node-2",
+                BrokerConnectivityState.ALL_CONNECTED,
+                List.of("stream-2")));
+
+    List<OutboundConnectorResponse> result = reducer.reduce(node1, node2);
+
+    assertEquals(2, result.size());
+    assertTrue(result.stream().allMatch(r -> r.physicalTenantId() == null));
   }
 }

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/instances/service/OutboundConnectorsServiceTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/instances/service/OutboundConnectorsServiceTest.java
@@ -36,6 +36,8 @@ import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
 
 class OutboundConnectorsServiceTest {
 
@@ -319,12 +321,29 @@ class OutboundConnectorsServiceTest {
     verify(brokerClient, never()).fetchRemoteStreams();
   }
 
-  @Test
-  void shouldReturnEveryPhysicalTenant_whenFilterIsEmpty() throws Exception {
+  /** A {@code null} filter is what the endpoints pass when the query param is omitted entirely. */
+  @ParameterizedTest
+  @NullAndEmptySource
+  void shouldReturnEveryPhysicalTenant_whenFilterIsNullOrEmpty(List<String> filter)
+      throws Exception {
     when(brokerClient.fetchRemoteStreams()).thenReturn(new BrokerStreamsResult(List.of()));
     when(otherBrokerClient.fetchRemoteStreams()).thenReturn(new BrokerStreamsResult(List.of()));
 
-    assertThat(multiTenantService().findAll(RUNTIME_ID, List.of())).hasSize(2);
+    assertThat(multiTenantService().findAll(RUNTIME_ID, filter))
+        .extracting(OutboundConnectorResponse::physicalTenantId)
+        .containsExactlyInAnyOrder(TENANT_A, TENANT_B);
+  }
+
+  @ParameterizedTest
+  @NullAndEmptySource
+  void findByType_shouldReturnEveryPhysicalTenant_whenFilterIsNullOrEmpty(List<String> filter)
+      throws Exception {
+    when(brokerClient.fetchRemoteStreams()).thenReturn(new BrokerStreamsResult(List.of()));
+    when(otherBrokerClient.fetchRemoteStreams()).thenReturn(new BrokerStreamsResult(List.of()));
+
+    assertThat(multiTenantService().findByType(TYPE, RUNTIME_ID, filter))
+        .extracting(OutboundConnectorResponse::physicalTenantId)
+        .containsExactlyInAnyOrder(TENANT_A, TENANT_B);
   }
 
   @Test

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/instances/service/OutboundConnectorsServiceTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/instances/service/OutboundConnectorsServiceTest.java
@@ -19,12 +19,15 @@ package io.camunda.connector.runtime.instances.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.camunda.connector.runtime.core.common.AbstractConnectorFactory.ConnectorRuntimeConfiguration;
 import io.camunda.connector.runtime.core.config.OutboundConnectorConfiguration;
 import io.camunda.connector.runtime.core.outbound.OutboundConnectorFactory;
 import io.camunda.connector.runtime.inbound.controller.exception.DataNotFoundException;
+import io.camunda.connector.runtime.outbound.controller.OutboundConnectorResponse;
 import io.camunda.connector.runtime.outbound.jobstream.BrokerConnectivityState;
 import io.camunda.connector.runtime.outbound.jobstream.BrokerJobStreamClient;
 import io.camunda.connector.runtime.outbound.jobstream.BrokerStreamsResult;
@@ -40,9 +43,12 @@ class OutboundConnectorsServiceTest {
   private static final String TYPE = "io.camunda:http-json:1";
   private static final String OTHER_TYPE = "io.camunda:rabbitmq:1";
   private static final String STREAM_ID = "stream-abc-123";
+  private static final String TENANT_A = "tenanta";
+  private static final String TENANT_B = "tenantb";
 
   private final OutboundConnectorFactory factory = mock(OutboundConnectorFactory.class);
   private final BrokerJobStreamClient brokerClient = mock(BrokerJobStreamClient.class);
+  private final BrokerJobStreamClient otherBrokerClient = mock(BrokerJobStreamClient.class);
 
   @BeforeEach
   void setupFactory() {
@@ -216,5 +222,143 @@ class OutboundConnectorsServiceTest {
 
     assertThatThrownBy(() -> service.findByType("io.camunda:unknown:1", RUNTIME_ID))
         .isInstanceOf(DataNotFoundException.class);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Multiple physical tenants (engines)
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void shouldReportNoPhysicalTenant_whenWiredWithoutPhysicalTenantIds() throws Exception {
+    when(brokerClient.fetchRemoteStreams()).thenReturn(new BrokerStreamsResult(List.of()));
+
+    var service = new OutboundConnectorsService(factory, brokerClient);
+
+    assertThat(service.findAll(RUNTIME_ID)).singleElement().extracting("physicalTenantId").isNull();
+  }
+
+  @Test
+  void shouldReportEachConnectorOncePerPhysicalTenant() throws Exception {
+    when(brokerClient.fetchRemoteStreams()).thenReturn(new BrokerStreamsResult(List.of()));
+    when(otherBrokerClient.fetchRemoteStreams()).thenReturn(new BrokerStreamsResult(List.of()));
+
+    var results = multiTenantService().findAll(RUNTIME_ID);
+
+    assertThat(results).hasSize(2);
+    assertThat(results).allMatch(r -> TYPE.equals(r.type()));
+    assertThat(results)
+        .extracting(OutboundConnectorResponse::physicalTenantId)
+        .containsExactlyInAnyOrder(TENANT_A, TENANT_B);
+  }
+
+  @Test
+  void shouldReportEachPhysicalTenantsOwnBrokerConnectivity() throws Exception {
+    when(brokerClient.fetchRemoteStreams())
+        .thenReturn(
+            new BrokerStreamsResult(
+                List.of(List.of(new RemoteJobStream(TYPE, List.of(Map.of("id", STREAM_ID)))))));
+    when(otherBrokerClient.fetchRemoteStreams())
+        .thenReturn(
+            new BrokerStreamsResult(List.of(List.of(new RemoteJobStream(TYPE, List.of())))));
+
+    var results = multiTenantService().findAll(RUNTIME_ID);
+
+    var tenantA = responseOf(results, TENANT_A);
+    assertThat(tenantA.brokerConnectivityState()).isEqualTo(BrokerConnectivityState.ALL_CONNECTED);
+    assertThat(tenantA.streamIds()).containsExactly(STREAM_ID);
+
+    var tenantB = responseOf(results, TENANT_B);
+    assertThat(tenantB.brokerConnectivityState()).isEqualTo(BrokerConnectivityState.NONE);
+    assertThat(tenantB.streamIds()).isNull();
+  }
+
+  @Test
+  void shouldReportUnknown_forPhysicalTenantWithoutBrokerClient() throws Exception {
+    when(brokerClient.fetchRemoteStreams()).thenReturn(new BrokerStreamsResult(List.of()));
+
+    var service =
+        new OutboundConnectorsService(
+            factory, List.of(TENANT_A, TENANT_B), Map.of(TENANT_A, brokerClient));
+
+    var results = service.findAll(RUNTIME_ID);
+
+    assertThat(responseOf(results, TENANT_A).brokerConnectivityState())
+        .isEqualTo(BrokerConnectivityState.NONE);
+    assertThat(responseOf(results, TENANT_B).brokerConnectivityState())
+        .isEqualTo(BrokerConnectivityState.UNKNOWN);
+  }
+
+  @Test
+  void shouldStillReportOtherPhysicalTenants_whenOneEnginesBrokersAreUnreachable()
+      throws Exception {
+    when(brokerClient.fetchRemoteStreams()).thenThrow(new RuntimeException("connection refused"));
+    when(otherBrokerClient.fetchRemoteStreams()).thenReturn(new BrokerStreamsResult(List.of()));
+
+    var results = multiTenantService().findAll(RUNTIME_ID);
+
+    assertThat(responseOf(results, TENANT_A).brokerConnectivityState())
+        .isEqualTo(BrokerConnectivityState.UNKNOWN);
+    assertThat(responseOf(results, TENANT_B).brokerConnectivityState())
+        .isEqualTo(BrokerConnectivityState.NONE);
+  }
+
+  // ---------------------------------------------------------------------------
+  // physicalTenantIds filter
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void shouldFilterByPhysicalTenantId() throws Exception {
+    when(otherBrokerClient.fetchRemoteStreams()).thenReturn(new BrokerStreamsResult(List.of()));
+
+    var results = multiTenantService().findAll(RUNTIME_ID, List.of(TENANT_B));
+
+    assertThat(results)
+        .singleElement()
+        .extracting(OutboundConnectorResponse::physicalTenantId)
+        .isEqualTo(TENANT_B);
+    verify(brokerClient, never()).fetchRemoteStreams();
+  }
+
+  @Test
+  void shouldReturnEveryPhysicalTenant_whenFilterIsEmpty() throws Exception {
+    when(brokerClient.fetchRemoteStreams()).thenReturn(new BrokerStreamsResult(List.of()));
+    when(otherBrokerClient.fetchRemoteStreams()).thenReturn(new BrokerStreamsResult(List.of()));
+
+    assertThat(multiTenantService().findAll(RUNTIME_ID, List.of())).hasSize(2);
+  }
+
+  @Test
+  void findByType_shouldFilterByPhysicalTenantId() throws Exception {
+    when(otherBrokerClient.fetchRemoteStreams()).thenReturn(new BrokerStreamsResult(List.of()));
+
+    var results = multiTenantService().findByType(TYPE, RUNTIME_ID, List.of(TENANT_B));
+
+    assertThat(results)
+        .singleElement()
+        .extracting(OutboundConnectorResponse::physicalTenantId)
+        .isEqualTo(TENANT_B);
+  }
+
+  @Test
+  void findByType_shouldThrowDataNotFoundException_whenFilterMatchesNoPhysicalTenant() {
+    var service = multiTenantService();
+
+    assertThatThrownBy(() -> service.findByType(TYPE, RUNTIME_ID, List.of("unknown-tenant")))
+        .isInstanceOf(DataNotFoundException.class);
+  }
+
+  private OutboundConnectorsService multiTenantService() {
+    return new OutboundConnectorsService(
+        factory,
+        List.of(TENANT_A, TENANT_B),
+        Map.of(TENANT_A, brokerClient, TENANT_B, otherBrokerClient));
+  }
+
+  private static OutboundConnectorResponse responseOf(
+      List<OutboundConnectorResponse> responses, String physicalTenantId) {
+    return responses.stream()
+        .filter(r -> physicalTenantId.equals(r.physicalTenantId()))
+        .findFirst()
+        .orElseThrow();
   }
 }

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/metrics/ConnectorOutboundMetricsPhysicalTenantTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/metrics/ConnectorOutboundMetricsPhysicalTenantTest.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.runtime.metrics;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.camunda.client.api.response.ActivatedJob;
+import io.camunda.client.metrics.MicrometerMetricsRecorder;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Exercises the physical-tenant dimension added to the outbound metrics pipeline (#7965): two
+ * physical tenants (engines) executing the same connector type must land in separate,
+ * correctly-tagged meters, and {@link ConnectorMetricsAggregator#outbound} must sum across all
+ * tenants when unfiltered and scope down correctly when a {@code physicalTenantIds} filter is
+ * given.
+ */
+class ConnectorOutboundMetricsPhysicalTenantTest {
+
+  private static final String TYPE = "io.camunda:http-json:1";
+
+  private static ActivatedJob job() {
+    var job = mock(ActivatedJob.class);
+    when(job.getType()).thenReturn(TYPE);
+    when(job.getCustomHeaders())
+        .thenReturn(Map.of("elementTemplateId", "template", "elementTemplateVersion", "1"));
+    return job;
+  }
+
+  private static void recordCompletedJob(MeterRegistry registry, String physicalTenantId) {
+    new MicrometerMetricsRecorder(registry)
+        .increaseCompleted(ConnectorMetrics.counter(job(), physicalTenantId));
+  }
+
+  private static long completedFor(MeterRegistry registry, String physicalTenantId) {
+    return (long)
+        registry
+            .find(ConnectorMetrics.Outbound.METRIC_NAME_INVOCATIONS)
+            .tag(ConnectorMetrics.Tag.ACTION, ConnectorMetrics.Outbound.ACTION_COMPLETED)
+            .tag(ConnectorMetrics.Tag.PHYSICAL_TENANT_ID, physicalTenantId)
+            .counter()
+            .count();
+  }
+
+  @Test
+  void sameConnectorTypeAcrossTwoPhysicalTenants_recordsSeparatelyTaggedCounters() {
+    var registry = new SimpleMeterRegistry();
+
+    recordCompletedJob(registry, "tenant-a");
+    recordCompletedJob(registry, "tenant-a");
+    recordCompletedJob(registry, "tenant-b");
+
+    assertThat(completedFor(registry, "tenant-a")).isEqualTo(2);
+    assertThat(completedFor(registry, "tenant-b")).isEqualTo(1);
+  }
+
+  @Test
+  void jobWithoutResolvedPhysicalTenant_fallsBackToDefaultTag() {
+    var registry = new SimpleMeterRegistry();
+
+    recordCompletedJob(registry, null);
+
+    assertThat(completedFor(registry, ConnectorMetrics.DEFAULT_PHYSICAL_TENANT_ID)).isEqualTo(1);
+  }
+
+  @Test
+  void lastCompletedGauge_isTaggedPerPhysicalTenant() {
+    var registry = new SimpleMeterRegistry();
+    var recorder = new MicrometerMetricsRecorder(registry);
+
+    new ConnectorOutboundMetrics(recorder, registry, "tenant-a").recordCompleted(TYPE);
+    new ConnectorOutboundMetrics(recorder, registry, "tenant-b").recordCompleted(TYPE);
+
+    // one gauge per (type, physical tenant) — before #7965 the second registration silently
+    // collided with the first one's, leaving that engine's timestamp invisible
+    assertThat(registry.find(ConnectorMetrics.Outbound.METRIC_NAME_LAST_COMPLETED).gauges())
+        .hasSize(2);
+    assertThat(
+            registry
+                .find(ConnectorMetrics.Outbound.METRIC_NAME_LAST_COMPLETED)
+                .tag(ConnectorMetrics.Tag.PHYSICAL_TENANT_ID, "tenant-b")
+                .gauge()
+                .value())
+        .isPositive();
+  }
+
+  @Test
+  void aggregatorOutbound_withoutFilter_sumsAcrossAllPhysicalTenants() {
+    var registry = new SimpleMeterRegistry();
+    recordCompletedJob(registry, "tenant-a");
+    recordCompletedJob(registry, "tenant-b");
+
+    assertThat(
+            ConnectorMetricsAggregator.outbound(registry, TYPE, null, "runtime-1")
+                .job()
+                .completed())
+        .isEqualTo(2);
+    assertThat(
+            ConnectorMetricsAggregator.outbound(registry, null, null, "runtime-1")
+                .job()
+                .completed())
+        .isEqualTo(2);
+  }
+
+  @Test
+  void aggregatorOutbound_withFilter_scopesToMatchingPhysicalTenantsOnly() {
+    var registry = new SimpleMeterRegistry();
+    recordCompletedJob(registry, "tenant-a");
+    recordCompletedJob(registry, "tenant-a");
+    recordCompletedJob(registry, "tenant-b");
+
+    var tenantAOnly =
+        ConnectorMetricsAggregator.outbound(registry, TYPE, List.of("tenant-a"), "runtime-1");
+    var bothTenants =
+        ConnectorMetricsAggregator.outbound(
+            registry, TYPE, List.of("tenant-a", "tenant-b"), "runtime-1");
+    var unknownTenant =
+        ConnectorMetricsAggregator.outbound(
+            registry, TYPE, List.of("nonexistent-tenant"), "runtime-1");
+
+    assertThat(tenantAOnly.job().completed()).isEqualTo(2);
+    assertThat(bothTenants.job().completed()).isEqualTo(3);
+    assertThat(unknownTenant.job().completed()).isZero();
+  }
+
+  @Test
+  void aggregatorOutbound_aggregateAcrossTypes_appliesFilterConsistently() {
+    var registry = new SimpleMeterRegistry();
+    recordCompletedJob(registry, "tenant-a");
+    recordCompletedJob(registry, "tenant-b");
+
+    // connectorType == null -> aggregate across all discovered types
+    var unfiltered = ConnectorMetricsAggregator.outbound(registry, null, null, "runtime-1");
+    var filtered =
+        ConnectorMetricsAggregator.outbound(registry, null, List.of("tenant-a"), "runtime-1");
+
+    assertThat(unfiltered.job().completed()).isEqualTo(2);
+    assertThat(filtered.job().completed()).isEqualTo(1);
+  }
+
+  @Test
+  void aggregatorOutbound_scopesLastCompletedGaugeToTheFilteredPhysicalTenant() {
+    var registry = new SimpleMeterRegistry();
+    var recorder = new MicrometerMetricsRecorder(registry);
+    new ConnectorOutboundMetrics(recorder, registry, "tenant-a").recordCompleted(TYPE);
+
+    var tenantA =
+        ConnectorMetricsAggregator.outbound(registry, TYPE, List.of("tenant-a"), "runtime-1");
+    var tenantB =
+        ConnectorMetricsAggregator.outbound(registry, TYPE, List.of("tenant-b"), "runtime-1");
+
+    assertThat(tenantA.job().lastCompleted()).isNotNull();
+    assertThat(tenantB.job().lastCompleted()).isNull();
+  }
+
+  @Test
+  void aggregatorOutbound_omitsWorkerSection_whenFiltered() {
+    var registry = new SimpleMeterRegistry();
+    recordCompletedJob(registry, "tenant-a");
+
+    // the camunda.client.worker.* counters carry no physical-tenant tag, so they cannot be
+    // attributed to one engine — the section is omitted rather than reported unfiltered or as 0
+    assertThat(
+            ConnectorMetricsAggregator.outbound(registry, TYPE, List.of("tenant-a"), "runtime-1")
+                .worker())
+        .isNull();
+    assertThat(
+            ConnectorMetricsAggregator.outbound(registry, null, List.of("tenant-a"), "runtime-1")
+                .worker())
+        .isNull();
+    assertThat(ConnectorMetricsAggregator.outbound(registry, TYPE, null, "runtime-1").worker())
+        .isNotNull();
+  }
+}

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/metrics/ConnectorOutboundMetricsPhysicalTenantTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/metrics/ConnectorOutboundMetricsPhysicalTenantTest.java
@@ -84,6 +84,21 @@ class ConnectorOutboundMetricsPhysicalTenantTest {
   }
 
   @Test
+  void tenantLessOverloads_attributeTheJobToItsOwnPhysicalTenant() {
+    var registry = new SimpleMeterRegistry();
+    var recorder = new MicrometerMetricsRecorder(registry);
+    var job = job();
+    when(job.getPhysicalTenantId()).thenReturn("tenant-from-job");
+
+    // the pre-#7965 signatures, kept for callers compiled against them
+    recorder.increaseCompleted(ConnectorMetrics.counter(job));
+    var timerTags = ConnectorMetrics.timer(job).tags();
+
+    assertThat(completedFor(registry, "tenant-from-job")).isEqualTo(1);
+    assertThat(timerTags).containsEntry(ConnectorMetrics.Tag.PHYSICAL_TENANT_ID, "tenant-from-job");
+  }
+
+  @Test
   void lastCompletedGauge_isTaggedPerPhysicalTenant() {
     var registry = new SimpleMeterRegistry();
     var recorder = new MicrometerMetricsRecorder(registry);

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/OutboundConnectorsServiceWiringTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/OutboundConnectorsServiceWiringTest.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.runtime.outbound;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.spring.bean.CamundaClientRegistry;
+import io.camunda.connector.jackson.ConnectorsObjectMapperSupplier;
+import io.camunda.connector.runtime.core.common.AbstractConnectorFactory.ConnectorRuntimeConfiguration;
+import io.camunda.connector.runtime.core.config.OutboundConnectorConfiguration;
+import io.camunda.connector.runtime.core.outbound.OutboundConnectorFactory;
+import io.camunda.connector.runtime.instances.service.OutboundConnectorsService;
+import io.camunda.connector.runtime.outbound.controller.OutboundConnectorResponse;
+import io.camunda.connector.runtime.outbound.jobstream.BrokerConnectivityState;
+import io.camunda.connector.runtime.outbound.jobstream.BrokerJobStreamClient;
+import io.camunda.connector.runtime.outbound.jobstream.BrokerStreamsResult;
+import io.camunda.connector.runtime.outbound.jobstream.RemoteJobStream;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies how {@link OutboundConnectorRuntimeConfiguration} assembles the {@code
+ * OutboundConnectorsService} across physical tenants (#7965): which engines end up in the listing,
+ * and which {@link BrokerJobStreamClient} each of them is monitored through.
+ *
+ * <p>The {@code @Bean} method is invoked directly on a plain (non-CGLIB-proxied) configuration
+ * instance, so the assembled service — not just the bean graph — is what is exercised.
+ */
+class OutboundConnectorsServiceWiringTest {
+
+  private static final String TYPE = "io.camunda:http-json:1";
+  private static final String STREAM_ID = "stream-abc-123";
+
+  private final OutboundConnectorRuntimeConfiguration configuration =
+      new OutboundConnectorRuntimeConfiguration();
+
+  private final OutboundConnectorFactory connectorFactory = mock(OutboundConnectorFactory.class);
+  private final BrokerJobStreamClient injectedBrokerClient = mock(BrokerJobStreamClient.class);
+
+  @BeforeEach
+  void registerOneConnector() {
+    when(connectorFactory.getRuntimeConfigurations())
+        .thenReturn(
+            List.of(
+                new ConnectorRuntimeConfiguration<>(
+                    new OutboundConnectorConfiguration(
+                        "HTTP JSON", new String[] {"url"}, TYPE, () -> null, null),
+                    true)));
+  }
+
+  /**
+   * A registry whose clients resolve to the given physical tenant IDs. Deep stubs make the topology
+   * request each per-tenant {@link BrokerJobStreamClient} would issue resolve to zero brokers,
+   * rather than attempting a real connection.
+   */
+  private static CamundaClientRegistry registryWith(String... physicalTenantIds) {
+    var registry = mock(CamundaClientRegistry.class);
+    var names = new LinkedHashSet<String>();
+    for (String physicalTenantId : physicalTenantIds) {
+      var clientName = "engine-" + physicalTenantId;
+      names.add(clientName);
+      var client = mock(CamundaClient.class, RETURNS_DEEP_STUBS);
+      when(client.getConfiguration().getPhysicalTenantId()).thenReturn(physicalTenantId);
+      when(registry.get(clientName)).thenReturn(client);
+    }
+    when(registry.clientNames()).thenReturn(names);
+    return registry;
+  }
+
+  private OutboundConnectorsService serviceFor(
+      CamundaClientRegistry registry, BrokerJobStreamClient injected, String addresses) {
+    return configuration.outboundConnectorsService(
+        connectorFactory,
+        registry,
+        null,
+        injected,
+        ConnectorsObjectMapperSupplier.getCopy(),
+        9600,
+        addresses);
+  }
+
+  @Test
+  void listsEveryConfiguredPhysicalTenant_evenWithBrokerMonitoringDisabled() {
+    var service = serviceFor(registryWith("tenanta", "tenantb"), null, null);
+
+    var results = service.findAll("runtime-1");
+
+    assertThat(results)
+        .extracting(OutboundConnectorResponse::physicalTenantId)
+        .containsExactlyInAnyOrder("tenanta", "tenantb");
+    assertThat(results)
+        .allMatch(r -> r.brokerConnectivityState() == BrokerConnectivityState.UNKNOWN);
+  }
+
+  @Test
+  void reusesTheInjectedBrokerClient_forASinglePhysicalTenant() throws Exception {
+    when(injectedBrokerClient.fetchRemoteStreams())
+        .thenReturn(
+            new BrokerStreamsResult(
+                List.of(List.of(new RemoteJobStream(TYPE, List.of(Map.of("id", STREAM_ID)))))));
+
+    var service = serviceFor(registryWith("tenanta"), injectedBrokerClient, null);
+
+    assertThat(service.findAll("runtime-1"))
+        .singleElement()
+        .satisfies(
+            r -> {
+              assertThat(r.physicalTenantId()).isEqualTo("tenanta");
+              assertThat(r.brokerConnectivityState())
+                  .isEqualTo(BrokerConnectivityState.ALL_CONNECTED);
+            });
+  }
+
+  @Test
+  void sharesTheExplicitAddressClient_acrossEveryPhysicalTenant() throws Exception {
+    when(injectedBrokerClient.fetchRemoteStreams())
+        .thenReturn(
+            new BrokerStreamsResult(
+                List.of(List.of(new RemoteJobStream(TYPE, List.of(Map.of("id", STREAM_ID)))))));
+
+    var service =
+        serviceFor(
+            registryWith("tenanta", "tenantb"), injectedBrokerClient, "http://localhost:9600");
+
+    // the configured addresses are global, so both engines are monitored through the same client
+    assertThat(service.findAll("runtime-1"))
+        .hasSize(2)
+        .allMatch(r -> r.brokerConnectivityState() == BrokerConnectivityState.ALL_CONNECTED);
+  }
+
+  @Test
+  void buildsAPerPhysicalTenantClient_inTopologyDiscoveryMode() throws Exception {
+    // would be reported as ALL_CONNECTED if the single injected client were (wrongly) shared
+    when(injectedBrokerClient.fetchRemoteStreams())
+        .thenReturn(
+            new BrokerStreamsResult(
+                List.of(List.of(new RemoteJobStream(TYPE, List.of(Map.of("id", STREAM_ID)))))));
+
+    var service = serviceFor(registryWith("tenanta", "tenantb"), injectedBrokerClient, null);
+
+    // each engine is monitored through its own client, whose topology reports no brokers at all
+    assertThat(service.findAll("runtime-1"))
+        .hasSize(2)
+        .allMatch(r -> r.brokerConnectivityState() == BrokerConnectivityState.NONE);
+  }
+}

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/outbound/MultiClientOutboundPhysicalTenantWiringTest.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/outbound/MultiClientOutboundPhysicalTenantWiringTest.java
@@ -20,7 +20,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.client.spring.bean.CamundaClientRegistry;
 import io.camunda.connector.runtime.app.TestConnectorRuntimeApplication;
+import io.camunda.connector.runtime.app.TestSingletonOutboundConnector;
+import io.camunda.connector.runtime.instances.service.OutboundConnectorsService;
+import io.camunda.connector.runtime.outbound.controller.OutboundConnectorResponse;
 import io.camunda.connector.runtime.outbound.lifecycle.OutboundConnectorManager;
+import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -41,7 +45,7 @@ import org.springframework.context.ApplicationContext;
  * silently resolve to the single legacy scalar bean instead of the real per-physical-tenant map.
  */
 @SpringBootTest(
-    classes = TestConnectorRuntimeApplication.class,
+    classes = {TestConnectorRuntimeApplication.class, TestSingletonOutboundConnector.class},
     properties = {
       "camunda.clients.engine-a.mode=self-managed",
       "camunda.clients.engine-a.grpc-address=http://engine-a.internal:26500",
@@ -55,7 +59,10 @@ import org.springframework.context.ApplicationContext;
       "camunda.clients.engine-b.grpc-address=http://engine-b.internal:26500",
       "camunda.clients.engine-b.physical-tenant-id=tenantb",
       "camunda.connector.polling.enabled=false",
-      "camunda.connector.webhook.enabled=false"
+      "camunda.connector.webhook.enabled=false",
+      // keeps the assembled OutboundConnectorsService from issuing (unreachable) topology
+      // requests when the /outbound listing is built below
+      "camunda.connector.broker.monitoring.enabled=false"
     })
 class MultiClientOutboundPhysicalTenantWiringTest {
 
@@ -64,6 +71,8 @@ class MultiClientOutboundPhysicalTenantWiringTest {
   @Autowired private ApplicationContext applicationContext;
 
   @Autowired private OutboundConnectorManager outboundConnectorManager;
+
+  @Autowired private OutboundConnectorsService outboundConnectorsService;
 
   @SuppressWarnings("unchecked")
   private Map<String, Object> mapBean(String beanName) {
@@ -89,5 +98,21 @@ class MultiClientOutboundPhysicalTenantWiringTest {
   @Test
   void outboundConnectorManagerBeanWiresSuccessfully() {
     assertThat(outboundConnectorManager).isNotNull();
+  }
+
+  @Test
+  void outboundConnectorsServiceListsEveryConfiguredPhysicalTenant() {
+    assertThat(outboundConnectorsService.findAll("runtime-1"))
+        .isNotEmpty()
+        .extracting(OutboundConnectorResponse::physicalTenantId)
+        .containsOnly("tenanta", "tenantb");
+  }
+
+  @Test
+  void outboundConnectorsServiceNarrowsToTheRequestedPhysicalTenant() {
+    assertThat(outboundConnectorsService.findAll("runtime-1", List.of("tenantb")))
+        .isNotEmpty()
+        .extracting(OutboundConnectorResponse::physicalTenantId)
+        .containsOnly("tenantb");
   }
 }

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/outbound/OutboundConnectorsRestControllerMultiInstancesTest.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/outbound/OutboundConnectorsRestControllerMultiInstancesTest.java
@@ -40,6 +40,9 @@ import org.springframework.http.ResponseEntity;
 @ExtendWith(MockitoExtension.class)
 class OutboundConnectorsRestControllerMultiInstancesTest extends BaseOutboundMultiInstancesTest {
 
+  /** Physical tenant a legacy, single-{@code CamundaClient} configuration resolves to. */
+  private static final String DEFAULT_PHYSICAL_TENANT_ID = "default";
+
   @Test
   void shouldReturnConnectorsFromAllNodes() {
     ResponseEntity<List<OutboundConnectorResponse>> response =
@@ -189,5 +192,89 @@ class OutboundConnectorsRestControllerMultiInstancesTest extends BaseOutboundMul
     assertEquals(2, metrics.size());
     assertTrue(metrics.stream().anyMatch(m -> "instance1".equals(m.runtimeId())));
     assertTrue(metrics.stream().anyMatch(m -> "instance2".equals(m.runtimeId())));
+  }
+
+  @Test
+  void shouldReportThePhysicalTenantEachConnectorRunsOn() {
+    ResponseEntity<List<OutboundConnectorResponse>> response =
+        restTemplate.exchange(
+            "http://localhost:" + port1 + "/outbound",
+            HttpMethod.GET,
+            null,
+            new ParameterizedTypeReference<>() {});
+
+    // a single client is configured on both pods, so every entry belongs to the same engine
+    response.getBody().forEach(c -> assertEquals(DEFAULT_PHYSICAL_TENANT_ID, c.physicalTenantId()));
+  }
+
+  @Test
+  void shouldFilterByPhysicalTenantId() {
+    ResponseEntity<List<OutboundConnectorResponse>> response =
+        restTemplate.exchange(
+            "http://localhost:"
+                + port1
+                + "/outbound?physicalTenantIds="
+                + DEFAULT_PHYSICAL_TENANT_ID,
+            HttpMethod.GET,
+            null,
+            new ParameterizedTypeReference<>() {});
+
+    // same six entries as unfiltered — the pod fan-out is unaffected by the filter
+    assertEquals(6, response.getBody().size());
+  }
+
+  @Test
+  void shouldReturnNoConnectors_whenFilteringByAnUnknownPhysicalTenantId() {
+    ResponseEntity<List<OutboundConnectorResponse>> response =
+        restTemplate.exchange(
+            "http://localhost:" + port1 + "/outbound?physicalTenantIds=nonexistent-tenant",
+            HttpMethod.GET,
+            null,
+            new ParameterizedTypeReference<>() {});
+
+    assertTrue(response.getBody().isEmpty());
+  }
+
+  @Test
+  void shouldAcceptPhysicalTenantIdsFilter_onAggregateMetricsEndpoint() throws Exception {
+    ResponseEntity<String> response =
+        restTemplate.exchange(
+            "http://localhost:"
+                + port1
+                + "/outbound/metrics?physicalTenantIds="
+                + DEFAULT_PHYSICAL_TENANT_ID,
+            HttpMethod.GET,
+            null,
+            String.class);
+
+    assertEquals(200, response.getStatusCode().value());
+    List<OutboundConnectorMetrics> metrics =
+        ConnectorsObjectMapperSupplier.getCopy()
+            .readValue(response.getBody(), new TypeReference<>() {});
+    // still one entry per pod — the filter narrows each pod's own sums, not the pod fan-out itself
+    assertEquals(2, metrics.size());
+    // the client-owned worker counters carry no physical-tenant tag, so they are left out
+    assertTrue(metrics.stream().allMatch(m -> m.worker() == null));
+  }
+
+  @Test
+  void shouldAcceptPhysicalTenantIdsFilter_onMetricsByTypeEndpoint() throws Exception {
+    ResponseEntity<String> response =
+        restTemplate.exchange(
+            "http://localhost:"
+                + port1
+                + "/outbound/metrics/"
+                + TYPE_1
+                + "?physicalTenantIds=nonexistent-tenant",
+            HttpMethod.GET,
+            null,
+            String.class);
+
+    assertEquals(200, response.getStatusCode().value());
+    List<OutboundConnectorMetrics> metrics =
+        ConnectorsObjectMapperSupplier.getCopy()
+            .readValue(response.getBody(), new TypeReference<>() {});
+    assertEquals(2, metrics.size());
+    assertTrue(metrics.stream().allMatch(m -> m.job().completed() == 0));
   }
 }


### PR DESCRIPTION
## Description

Follow-up to #6961 on the outbound side, mirroring what #8184 did for inbound.

The `/outbound` management endpoints read from a single `OutboundConnectorFactory` list and one `BrokerJobStreamClient` wrapping one injected `CamundaClient`. With several engines configured, they only ever reported whichever client happened to be `@Primary`, and nothing in the response said which engine an entry belonged to.

**Aggregate broker connectivity across engines.** `OutboundConnectorsService` now takes the configured physical tenants plus one `BrokerJobStreamClient` per tenant, and lists each registered connector once per (connector, physical tenant) pair — every engine runs a job worker for every registered connector — each entry carrying that engine's own broker/stream connectivity. A tenant whose brokers are unreachable, or that has no broker monitoring at all, still appears with `UNKNOWN` rather than dropping out, so one engine's failure never hides another's connectors.

`OutboundConnectorRuntimeConfiguration` builds the per-tenant client map from the `CamundaClientRegistry`, via a plain static helper rather than a `Map`-typed `@Bean` parameter, for the reasons already documented in that class. Topology-discovery mode resolves each engine's brokers through that engine's own client; with a single tenant, or in explicit-addresses mode (where the addresses are global config rather than per-engine), the existing scalar `brokerJobStreamClient` bean is reused as-is — so single-engine deployments, and overrides of that bean, behave exactly as before.

**`physicalTenantId` on `OutboundConnectorResponse`.** It carried only `runtimeId` (pod identity), nothing for engine identity. Omitted (`NON_NULL`) for legacy wiring that supplies no registry, preserving the pre-multi-engine response shape.

**`physicalTenantIds` filter** on `/outbound`, `/outbound/{type}`, `/outbound/metrics` and `/outbound/metrics/{connectorType}` — same parameter name and null/empty-means-unfiltered semantics as the inbound endpoints. The filter narrows what each pod reports, not the pod fan-out: `InstanceForwardingRouter` forwarding is untouched and every pod still answers.

**Metrics tagged by physical tenant.** The filter would otherwise have been a no-op on `/outbound/metrics`: outbound meters had no tenant dimension at all. Invocation counters, the execution-time timer, and the `last-completed`/`last-failed`/`max-execution-time` gauges are now tagged with the tenant the job worker was opened for — the same ID the listing and the per-physical-tenant document/secret beans are keyed by, so a meter and the connector entry it belongs to always agree. This also fixes a latent bug: two engines running the same connector type registered the same gauge id, so the second registration silently collided with the first and that engine's timestamps were never visible.

One thing worth a reviewer's opinion: a **filtered** metrics response omits the `worker` section. Those counters (`camunda.client.worker.*`) are recorded by the Camunda client, whose `JobWorkerMetricsFactoryContext` exposes only the job type, so they cannot be attributed to an engine. Reporting the pod-wide totals inside an otherwise filtered response would misattribute them; reporting zeros would read as "no jobs activated". Unfiltered responses are unchanged.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #7965 
