### PR TITLE
refactor(agentic-ai): rename AnthropicChatModelApi, merge native provider Spring config

### DIFF
--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/wiremock/anthropic/AnthropicMessagesV2WireFormatFixture.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/wiremock/anthropic/AnthropicMessagesV2WireFormatFixture.java
@@ -27,7 +27,7 @@ import java.util.function.Function;
 /**
  * Plugs Anthropic's Messages API wire format into the provider-agnostic {@link
  * ProviderWireFormatFixture} SPI, driving the connector through the native v2 Anthropic provider —
- * see {@code AnthropicChatModelApi}. The *request* wire format is identical to the v1 fixture; see
+ * see {@code AnthropicChatModel}. The *request* wire format is identical to the v1 fixture; see
  * {@link AbstractAnthropicMessagesWireFormatFixture} for the shared plumbing ({@code
  * recordedRequests()}, {@code assertResponseFormatConfigured(...)}).
  *

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/anthropic/AnthropicChatModel.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/anthropic/AnthropicChatModel.java
@@ -38,9 +38,9 @@ import org.slf4j.LoggerFactory;
  * <p>The {@link AnthropicClient} is built once by the factory and owned for the lifetime of this
  * instance (one agent request, across all continuation rounds); {@link #close()} closes it once.
  */
-public class AnthropicChatModelApi implements ChatModel {
+public class AnthropicChatModel implements ChatModel {
 
-  private static final Logger LOG = LoggerFactory.getLogger(AnthropicChatModelApi.class);
+  private static final Logger LOG = LoggerFactory.getLogger(AnthropicChatModel.class);
   private static final ObjectMapper MAPPER = ObjectMappers.jsonMapper();
 
   private final AnthropicChatModelConfiguration configuration;
@@ -49,7 +49,7 @@ public class AnthropicChatModelApi implements ChatModel {
   private final AnthropicMessageResponseConverter responseConverter;
   private final AnthropicMessageStreamAssembler streamAssembler;
 
-  public AnthropicChatModelApi(
+  public AnthropicChatModel(
       AnthropicClient client,
       AnthropicChatModelConfiguration configuration,
       AnthropicMessageRequestConverter requestConverter,
@@ -62,7 +62,7 @@ public class AnthropicChatModelApi implements ChatModel {
         AnthropicMessageStreamAssembler.accumulating());
   }
 
-  AnthropicChatModelApi(
+  AnthropicChatModel(
       AnthropicClient client,
       AnthropicChatModelConfiguration configuration,
       AnthropicMessageRequestConverter requestConverter,

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/anthropic/AnthropicChatModelFactory.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/anthropic/AnthropicChatModelFactory.java
@@ -29,13 +29,13 @@ import org.jspecify.annotations.Nullable;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 
-public class AnthropicChatModelApiFactory implements ChatModelFactory {
+public class AnthropicChatModelFactory implements ChatModelFactory {
 
   private final AgenticAiHttpProxySupport httpProxySupport;
   private final AnthropicMessageRequestConverter requestConverter;
   private final AnthropicMessageResponseConverter responseConverter;
 
-  public AnthropicChatModelApiFactory(
+  public AnthropicChatModelFactory(
       AgenticAiHttpProxySupport httpProxySupport,
       AnthropicMessageRequestConverter requestConverter,
       AnthropicMessageResponseConverter responseConverter) {
@@ -56,7 +56,7 @@ public class AnthropicChatModelApiFactory implements ChatModelFactory {
     final var timeout = connection.timeouts() != null ? connection.timeouts().timeout() : null;
 
     final var client = buildClient(connection.backend(), timeout, httpProxySupport);
-    return new AnthropicChatModelApi(client, model, requestConverter, responseConverter);
+    return new AnthropicChatModel(client, model, requestConverter, responseConverter);
   }
 
   private static AnthropicClient buildClient(

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/anthropic/configuration/AgenticAiAnthropicProviderConfiguration.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/anthropic/configuration/AgenticAiAnthropicProviderConfiguration.java
@@ -7,7 +7,7 @@
 package io.camunda.connector.agenticai.aiagent.chatmodel.provider.anthropic.configuration;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.camunda.connector.agenticai.aiagent.chatmodel.provider.anthropic.AnthropicChatModelApiFactory;
+import io.camunda.connector.agenticai.aiagent.chatmodel.provider.anthropic.AnthropicChatModelFactory;
 import io.camunda.connector.agenticai.aiagent.chatmodel.provider.anthropic.AnthropicContentConverter;
 import io.camunda.connector.agenticai.aiagent.chatmodel.provider.anthropic.AnthropicMessageRequestConverter;
 import io.camunda.connector.agenticai.aiagent.chatmodel.provider.anthropic.AnthropicMessageResponseConverter;
@@ -18,7 +18,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 /**
- * Registers the {@link AnthropicChatModelApiFactory} as a {@code ChatModelFactory} bean so it is
+ * Registers the {@link AnthropicChatModelFactory} as a {@code ChatModelFactory} bean so it is
  * picked up by {@code aiAgentChatModelRegistry(List<ChatModelFactory>)} and resolved for the
  * configurations it supports. A dedicated, imported configuration per native provider, mirroring
  * {@code AgenticAiLangChain4JChatModelConfiguration}'s pattern for the LangChain4J-routed
@@ -29,12 +29,12 @@ public class AgenticAiAnthropicProviderConfiguration {
 
   @Bean
   @ConditionalOnMissingBean
-  public AnthropicChatModelApiFactory aiAgentAnthropicChatModelApiFactory(
+  public AnthropicChatModelFactory aiAgentAnthropicChatModelFactory(
       AgenticAiHttpProxySupport httpProxySupport,
       @ConnectorsObjectMapper ObjectMapper objectMapper) {
     final var contentConverter = new AnthropicContentConverter(objectMapper);
     final var requestConverter = new AnthropicMessageRequestConverter(contentConverter);
     final var responseConverter = new AnthropicMessageResponseConverter(objectMapper);
-    return new AnthropicChatModelApiFactory(httpProxySupport, requestConverter, responseConverter);
+    return new AnthropicChatModelFactory(httpProxySupport, requestConverter, responseConverter);
   }
 }

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/configuration/AgenticAiNativeProvidersConfiguration.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/configuration/AgenticAiNativeProvidersConfiguration.java
@@ -4,7 +4,7 @@
  * See the License.txt file for more information. You may not use this file
  * except in compliance with the proprietary license.
  */
-package io.camunda.connector.agenticai.aiagent.chatmodel.provider.anthropic.configuration;
+package io.camunda.connector.agenticai.aiagent.chatmodel.provider.configuration;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.connector.agenticai.aiagent.chatmodel.provider.anthropic.AnthropicChatModelFactory;
@@ -17,15 +17,8 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-/**
- * Registers the {@link AnthropicChatModelFactory} as a {@code ChatModelFactory} bean so it is
- * picked up by {@code aiAgentChatModelRegistry(List<ChatModelFactory>)} and resolved for the
- * configurations it supports. A dedicated, imported configuration per native provider, mirroring
- * {@code AgenticAiLangChain4JChatModelConfiguration}'s pattern for the LangChain4J-routed
- * providers.
- */
 @Configuration
-public class AgenticAiAnthropicProviderConfiguration {
+public class AgenticAiNativeProvidersConfiguration {
 
   @Bean
   @ConditionalOnMissingBean

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/configuration/package-info.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/configuration/package-info.java
@@ -5,6 +5,6 @@
  * except in compliance with the proprietary license.
  */
 @NullMarked
-package io.camunda.connector.agenticai.aiagent.chatmodel.provider.anthropic.configuration;
+package io.camunda.connector.agenticai.aiagent.chatmodel.provider.configuration;
 
 import org.jspecify.annotations.NullMarked;

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/autoconfigure/AgenticAiConnectorsAutoConfiguration.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/autoconfigure/AgenticAiConnectorsAutoConfiguration.java
@@ -47,7 +47,7 @@ import io.camunda.connector.agenticai.aiagent.agentinstance.CamundaAgentInstance
 import io.camunda.connector.agenticai.aiagent.chatmodel.ChatModelFactory;
 import io.camunda.connector.agenticai.aiagent.chatmodel.ChatModelRegistry;
 import io.camunda.connector.agenticai.aiagent.chatmodel.ChatModelRegistryImpl;
-import io.camunda.connector.agenticai.aiagent.chatmodel.provider.anthropic.configuration.AgenticAiAnthropicProviderConfiguration;
+import io.camunda.connector.agenticai.aiagent.chatmodel.provider.configuration.AgenticAiNativeProvidersConfiguration;
 import io.camunda.connector.agenticai.aiagent.chatmodel.provider.langchain4j.ChatModelHttpProxySupport;
 import io.camunda.connector.agenticai.aiagent.chatmodel.provider.langchain4j.configuration.AgenticAiLangChain4JFrameworkConfiguration;
 import io.camunda.connector.agenticai.aiagent.memory.conversation.ConversationStore;
@@ -89,7 +89,7 @@ import org.springframework.context.annotation.Import;
 @EnableConfigurationProperties(AgenticAiConnectorsConfigurationProperties.class)
 @Import({
   AgenticAiLangChain4JFrameworkConfiguration.class,
-  AgenticAiAnthropicProviderConfiguration.class,
+  AgenticAiNativeProvidersConfiguration.class,
   McpDiscoveryConfiguration.class,
   McpClientConfiguration.class,
   McpRemoteClientConfiguration.class,

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/anthropic/AnthropicChatModelFactoryClientTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/anthropic/AnthropicChatModelFactoryClientTest.java
@@ -58,23 +58,23 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 /**
- * Exercises {@link AnthropicChatModelApiFactory}'s {@code custom}-backend and proxy wiring through
- * its public surface ({@link AnthropicChatModelApiFactory#create} + {@link ChatModel#execute})
- * rather than reaching into the private client-building internals: the built {@link ChatModel}
- * issues a real (WireMock-backed) request, and assertions verify what actually went over the wire.
+ * Exercises {@link AnthropicChatModelFactory}'s {@code custom}-backend and proxy wiring through its
+ * public surface ({@link AnthropicChatModelFactory#create} + {@link ChatModel#execute}) rather than
+ * reaching into the private client-building internals: the built {@link ChatModel} issues a real
+ * (WireMock-backed) request, and assertions verify what actually went over the wire.
  *
  * <p>The {@code anthropic-api} backend normally targets the production Anthropic base URL; its
  * hidden {@code endpoint} override is exercised here the same way as the {@code custom} backend's
  * endpoint.
  */
 @WireMockTest
-class AnthropicChatModelApiFactoryClientTest {
+class AnthropicChatModelFactoryClientTest {
 
   private static final String MODEL_ID = "claude-sonnet-4-6";
 
   /*
    * Minimal Anthropic Messages streaming (SSE) response: message_start -> one text block -> a
-   * message_delta/stop_reason -> message_stop. AnthropicChatModelApi always drives
+   * message_delta/stop_reason -> message_stop. AnthropicChatModel always drives
    * createStreaming(), so a plain buffered JSON body (as a non-streaming stub would return) isn't
    * accepted by the vendor SDK's MessageAccumulator.
    */
@@ -198,7 +198,7 @@ class AnthropicChatModelApiFactoryClientTest {
       WireMockRuntimeInfo wireMock, AwsAuthentication authentication) {
     // the endpoint override must be the full Bedrock Mantle base URL, including the /anthropic
     // path segment BedrockMantleBackend's own default derivation appends (see
-    // AnthropicChatModelApiFactory#applyAwsBedrockMantleBackend).
+    // AnthropicChatModelFactory#applyAwsBedrockMantleBackend).
     executeAgainst(
         new AnthropicAwsBedrockMantleBackend(
             new AnthropicAwsBedrockMantleBackend.AwsBedrockMantleBackend(
@@ -264,7 +264,7 @@ class AnthropicChatModelApiFactoryClientTest {
   private void executeAgainst(
       AgenticAiHttpProxySupport httpProxySupport, AnthropicBackend backend) {
     final var factory =
-        new AnthropicChatModelApiFactory(
+        new AnthropicChatModelFactory(
             httpProxySupport,
             new AnthropicMessageRequestConverter(new AnthropicContentConverter(objectMapper)),
             new AnthropicMessageResponseConverter(objectMapper));
@@ -298,7 +298,7 @@ class AnthropicChatModelApiFactoryClientTest {
   }
 
   /**
-   * Minimal hand-rolled HTTP forward proxy used to exercise {@link AnthropicChatModelApiFactory}'s
+   * Minimal hand-rolled HTTP forward proxy used to exercise {@link AnthropicChatModelFactory}'s
    * real proxy-application branch end-to-end (rather than mocking {@link
    * AgenticAiHttpProxySupport}, which leaves that branch untested). When credentials are
    * configured, challenges the first request with {@code 407 Proxy Authentication Required} so the

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/anthropic/AnthropicChatModelFactoryTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/anthropic/AnthropicChatModelFactoryTest.java
@@ -35,7 +35,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
-class AnthropicChatModelApiFactoryTest {
+class AnthropicChatModelFactoryTest {
 
   private static final String MODEL_ID = "claude-sonnet-4-6";
 
@@ -43,12 +43,12 @@ class AnthropicChatModelApiFactoryTest {
 
   private final ObjectMapper objectMapper = new ObjectMapper();
 
-  private AnthropicChatModelApiFactory factory;
+  private AnthropicChatModelFactory factory;
 
   @BeforeEach
   void setUp() {
     factory =
-        new AnthropicChatModelApiFactory(
+        new AnthropicChatModelFactory(
             httpProxySupport,
             new AnthropicMessageRequestConverter(new AnthropicContentConverter(objectMapper)),
             new AnthropicMessageResponseConverter(objectMapper));
@@ -75,7 +75,7 @@ class AnthropicChatModelApiFactoryTest {
 
     final ChatModel api = factory.create(config);
 
-    assertThat(api).isNotNull().isInstanceOf(AnthropicChatModelApi.class);
+    assertThat(api).isNotNull().isInstanceOf(AnthropicChatModel.class);
     api.close();
   }
 
@@ -95,7 +95,7 @@ class AnthropicChatModelApiFactoryTest {
         factory.create(
             bedrockConfig(MODEL_ID, new AwsAuthentication.AwsApiKeyAuthentication("bedrock-key")));
 
-    assertThat(api).isNotNull().isInstanceOf(AnthropicChatModelApi.class);
+    assertThat(api).isNotNull().isInstanceOf(AnthropicChatModel.class);
     api.close();
   }
 
@@ -108,7 +108,7 @@ class AnthropicChatModelApiFactoryTest {
             bedrockConfig(
                 MODEL_ID, new AwsAuthentication.AwsDefaultCredentialsChainAuthentication()));
 
-    assertThat(api).isNotNull().isInstanceOf(AnthropicChatModelApi.class);
+    assertThat(api).isNotNull().isInstanceOf(AnthropicChatModel.class);
     api.close();
   }
 

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/anthropic/AnthropicChatModelTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/anthropic/AnthropicChatModelTest.java
@@ -47,7 +47,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
-class AnthropicChatModelApiTest {
+class AnthropicChatModelTest {
 
   @Mock private AnthropicClient client;
   @Mock private MessageService messageService;
@@ -70,13 +70,13 @@ class AnthropicChatModelApiTest {
   private final ChatRequest request =
       new ChatRequest(executionContext, new ConversationSnapshot(List.of(), List.of()));
 
-  private AnthropicChatModelApi api;
+  private AnthropicChatModel api;
 
   @BeforeEach
   void setUp() {
     when(executionContext.configuration()).thenReturn(mock(AgentConfiguration.class));
     api =
-        new AnthropicChatModelApi(
+        new AnthropicChatModel(
             client, configuration, requestConverter, responseConverter, streamAssembler);
   }
 

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/anthropic/AnthropicMessageRequestConverterTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/anthropic/AnthropicMessageRequestConverterTest.java
@@ -435,7 +435,7 @@ class AnthropicMessageRequestConverterTest {
       "deprecation") // temperature()/topP()/topK() deprecated in anthropic-java 2.48.0
   void mapsFullV1ParameterParitySet() {
     // v1 Anthropic exposed exactly: endpoint, apiKey, timeout, model, maxTokens, temperature,
-    // topP, topK. endpoint/apiKey/timeout are transport-layer (AnthropicChatModelApiFactory's
+    // topP, topK. endpoint/apiKey/timeout are transport-layer (AnthropicChatModelFactory's
     // concern); this asserts the remaining 5 model-parameter fields this converter is responsible
     // for.
     final var parameters = new AnthropicModelParameters(null, null, null, 2048, 0.5, 0.9, 40);

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/autoconfigure/AgenticAiConnectorsAutoConfigurationTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/autoconfigure/AgenticAiConnectorsAutoConfigurationTest.java
@@ -32,13 +32,12 @@ import io.camunda.connector.agenticai.aiagent.agentinstance.AgentInstanceClient;
 import io.camunda.connector.agenticai.aiagent.chatmodel.ChatModelConfiguration;
 import io.camunda.connector.agenticai.aiagent.chatmodel.ChatModelFactory;
 import io.camunda.connector.agenticai.aiagent.chatmodel.ChatModelRegistry;
-import io.camunda.connector.agenticai.aiagent.chatmodel.provider.anthropic.AnthropicChatModelApiFactory;
+import io.camunda.connector.agenticai.aiagent.chatmodel.provider.anthropic.AnthropicChatModelFactory;
 import io.camunda.connector.agenticai.aiagent.chatmodel.provider.langchain4j.ChatMessageConverter;
 import io.camunda.connector.agenticai.aiagent.chatmodel.provider.langchain4j.ChatModelHttpProxySupport;
 import io.camunda.connector.agenticai.aiagent.chatmodel.provider.langchain4j.CloseableChatModel;
 import io.camunda.connector.agenticai.aiagent.chatmodel.provider.langchain4j.ContentConverter;
 import io.camunda.connector.agenticai.aiagent.chatmodel.provider.langchain4j.document.DocumentToContentConverter;
-import io.camunda.connector.agenticai.aiagent.chatmodel.provider.langchain4j.factory.AnthropicChatModelFactory;
 import io.camunda.connector.agenticai.aiagent.chatmodel.provider.langchain4j.factory.AzureOpenAiChatModelFactory;
 import io.camunda.connector.agenticai.aiagent.chatmodel.provider.langchain4j.factory.BedrockChatModelFactory;
 import io.camunda.connector.agenticai.aiagent.chatmodel.provider.langchain4j.factory.GoogleVertexAiChatModelFactory;
@@ -128,7 +127,7 @@ class AgenticAiConnectorsAutoConfigurationTest {
           AgentSubProcessV2Function.class,
           AgentInstanceClient.class,
           ChatModelRegistry.class,
-          AnthropicChatModelApiFactory.class);
+          AnthropicChatModelFactory.class);
 
   private static final List<Class<?>> LANGCHAIN4J_BEANS =
       List.of(
@@ -139,7 +138,8 @@ class AgenticAiConnectorsAutoConfigurationTest {
           JsonSchemaConverter.class,
           ToolSpecificationConverter.class,
           ChatMessageConverter.class,
-          AnthropicChatModelFactory.class,
+          io.camunda.connector.agenticai.aiagent.chatmodel.provider.langchain4j.factory
+              .AnthropicChatModelFactory.class,
           AzureOpenAiChatModelFactory.class,
           BedrockChatModelFactory.class,
           GoogleVertexAiChatModelFactory.class,
@@ -337,7 +337,7 @@ class AgenticAiConnectorsAutoConfigurationTest {
                             "sk-ant-test", null, null, null, null)),
                     new AnthropicModel("claude-sonnet-5", null),
                     null)),
-            AnthropicChatModelApiFactory.class),
+            AnthropicChatModelFactory.class),
         new ChatModelResolutionCase(
             "anthropic (langchain4j)",
             new AnthropicProviderConfiguration(
@@ -346,7 +346,8 @@ class AgenticAiConnectorsAutoConfigurationTest {
                     new AnthropicProviderConfiguration.AnthropicAuthentication("sk-ant-test"),
                     null,
                     new AnthropicProviderConfiguration.AnthropicModel("claude-sonnet-5", null))),
-            AnthropicChatModelFactory.class),
+            io.camunda.connector.agenticai.aiagent.chatmodel.provider.langchain4j.factory
+                .AnthropicChatModelFactory.class),
         new ChatModelResolutionCase(
             "azure-openai",
             new AzureOpenAiProviderConfiguration(
@@ -431,7 +432,8 @@ class AgenticAiConnectorsAutoConfigurationTest {
           new FactoryOverrideCase(
               CustomAnthropicProviderConfig.class,
               "customAnthropicChatModelFactory",
-              AnthropicChatModelFactory.class,
+              io.camunda.connector.agenticai.aiagent.chatmodel.provider.langchain4j.factory
+                  .AnthropicChatModelFactory.class,
               CustomAnthropicChatModelFactory.class),
           new FactoryOverrideCase(
               CustomAzureOpenAiProviderConfig.class,
@@ -474,11 +476,15 @@ class AgenticAiConnectorsAutoConfigurationTest {
 
     static class CustomAnthropicProviderConfig {
       @Bean
-      AnthropicChatModelFactory customAnthropicChatModelFactory() {
+      io.camunda.connector.agenticai.aiagent.chatmodel.provider.langchain4j.factory
+              .AnthropicChatModelFactory
+          customAnthropicChatModelFactory() {
         return new CustomAnthropicChatModelFactory();
       }
 
-      static class CustomAnthropicChatModelFactory extends AnthropicChatModelFactory {
+      static class CustomAnthropicChatModelFactory
+          extends io.camunda.connector.agenticai.aiagent.chatmodel.provider.langchain4j.factory
+              .AnthropicChatModelFactory {
 
         CustomAnthropicChatModelFactory() {
           super(


### PR DESCRIPTION
## Description

Two small cleanups to the native (v2) Anthropic chat model provider in the agentic-ai connector:

- Rename `AnthropicChatModelApi` → `AnthropicChatModel` and `AnthropicChatModelApiFactory` → `AnthropicChatModelFactory` to align with the `ChatModel`/`ChatModelFactory` SPI naming (the `Api` suffix is a leftover from before that interface split).
- Merge the per-provider `AgenticAiAnthropicProviderConfiguration` into a shared `AgenticAiNativeProvidersConfiguration` (`chatmodel.provider.configuration`), mirroring how the LangChain4j-routed providers already share one configuration class. Future native providers add a bean here instead of a new per-provider class.

No behavioral change. `AnthropicChatModelFactory` collides in simple name with the existing LangChain4j-routed `AnthropicChatModelFactory`; the one test wiring both now references the LangChain4j variant by fully-qualified name instead of importing it.

## Related issues

closes #

## Checklist

- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest
  release, as this branch will be rebased onto main before the next release. Example backport labels:
    - `backport stable/8.8`: for changes that should be included in the next 8.8.x release.
    - **or** `backport release-8.8.7`: for changes that should be included in the specific release 8.8.7, and this
      *release has already been created*. The release branch will be merged back into stable/8.8 later, so the change
      will be included in future 8.8.x releases as well.
- [x] Tests/Integration tests for the changes have been added if applicable.
- [ ] If the change requires a documentation update, it has been added to the appropriate section in the documentation.
