### PR TITLE
test(agentic-ai): work around engine's zeebe:agentDefinition requirement

### DIFF
--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/BpmnUtil.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/BpmnUtil.java
@@ -84,4 +84,30 @@ public class BpmnUtil {
               return im;
             });
   }
+
+  /**
+   * TODO(camunda/camunda#59715): temporary workaround, remove once the v2 AI Agent element
+   * templates set {@code zeebe:agentDefinition} themselves. The engine rejects {@code
+   * AgentInstance} creation without that marker, but neither the v2 element templates nor
+   * element-templates-cli's bundled {@code zeebe-bpmn-moddle} support the element yet - the CLI
+   * strips it if added to the source BPMN. Needs element-templates-cli/library updates plus updated
+   * element templates; until then, add it here directly on the already-applied model.
+   */
+  public static BpmnModelInstance withAgentDefinitionMarker(
+      BpmnModelInstance model, String elementId, String agentType) {
+    final var element = model.getModelElementById(elementId);
+    assertThat(element)
+        .describedAs("Element with ID %s is expected to exist", elementId)
+        .isNotNull()
+        .describedAs(
+            "Element with ID %s is expected to be a child instance of BaseElement", elementId)
+        .isInstanceOf(BaseElement.class);
+
+    final var agentDefinition =
+        ((BaseElement) element)
+            .getExtensionElements()
+            .addExtensionElement("http://camunda.org/schema/zeebe/1.0", "agentDefinition");
+    agentDefinition.setAttributeValue("agentType", agentType);
+    return model;
+  }
 }

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/AgentTestFixtures.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/AgentTestFixtures.java
@@ -41,7 +41,7 @@ public interface AgentTestFixtures {
       "../../connectors/agentic-ai/connector-agentic-ai/element-templates/agenticai-adhoctoolsschema-outbound-connector.json";
 
   String AGENT_RESPONSE_VARIABLE = "agent";
-  String AI_AGENT_TASK_ID = "AI_Agent";
+  String AI_AGENT_ELEMENT_ID = "AI_Agent";
 
   Map<String, String> AI_AGENT_TASK_V1_ELEMENT_TEMPLATE_PROPERTIES =
       Map.ofEntries(

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/BaseAgentTest.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/BaseAgentTest.java
@@ -21,7 +21,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
-import static io.camunda.connector.e2e.agenticai.aiagent.AgentTestFixtures.AI_AGENT_TASK_ID;
+import static io.camunda.connector.e2e.agenticai.aiagent.AgentTestFixtures.AI_AGENT_ELEMENT_ID;
 import static io.camunda.connector.e2e.agenticai.aiagent.AgentToolSpecifications.EXPECTED_TOOL_SPECIFICATIONS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
@@ -216,7 +216,7 @@ public abstract class BaseAgentTest extends BaseAgenticAiTest {
 
   protected BpmnModelInstance modelWithModifications(File model, File elementTemplate) {
     return new BpmnFile(model)
-        .apply(elementTemplate, AI_AGENT_TASK_ID, new File(tempDir, "updated.bpmn"));
+        .apply(elementTemplate, AI_AGENT_ELEMENT_ID, new File(tempDir, "updated.bpmn"));
   }
 
   /**

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/subprocess/AgentSubProcessFeedbackLoopTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/subprocess/AgentSubProcessFeedbackLoopTests.java
@@ -16,7 +16,7 @@
  */
 package io.camunda.connector.e2e.agenticai.aiagent.subprocess;
 
-import static io.camunda.connector.e2e.agenticai.aiagent.AgentTestFixtures.AI_AGENT_TASK_ID;
+import static io.camunda.connector.e2e.agenticai.aiagent.AgentTestFixtures.AI_AGENT_ELEMENT_ID;
 import static io.camunda.connector.e2e.agenticai.aiagent.AgentTestFixtures.HAIKU_TEXT;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -111,7 +111,7 @@ public class AgentSubProcessFeedbackLoopTests extends BaseAgentSubProcessTest {
     assertIncident(
         zeebeTest,
         incident -> {
-          assertThat(incident.getElementId()).isEqualTo(AI_AGENT_TASK_ID);
+          assertThat(incident.getElementId()).isEqualTo(AI_AGENT_ELEMENT_ID);
           assertThat(incident.getErrorType())
               .isEqualTo(IncidentErrorType.AD_HOC_SUB_PROCESS_NO_RETRIES);
           assertThat(incident.getErrorMessage())
@@ -133,7 +133,7 @@ public class AgentSubProcessFeedbackLoopTests extends BaseAgentSubProcessTest {
     assertIncident(
         zeebeTest,
         incident -> {
-          assertThat(incident.getElementId()).isEqualTo(AI_AGENT_TASK_ID);
+          assertThat(incident.getElementId()).isEqualTo(AI_AGENT_ELEMENT_ID);
           assertThat(incident.getErrorType())
               .isEqualTo(IncidentErrorType.AD_HOC_SUB_PROCESS_NO_RETRIES);
           assertThat(incident.getErrorMessage())

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/subprocess/AgentSubProcessLimitsTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/subprocess/AgentSubProcessLimitsTests.java
@@ -16,7 +16,7 @@
  */
 package io.camunda.connector.e2e.agenticai.aiagent.subprocess;
 
-import static io.camunda.connector.e2e.agenticai.aiagent.AgentTestFixtures.AI_AGENT_TASK_ID;
+import static io.camunda.connector.e2e.agenticai.aiagent.AgentTestFixtures.AI_AGENT_ELEMENT_ID;
 import static io.camunda.connector.e2e.agenticai.aiagent.AgentTestFixtures.HAIKU_TEXT;
 import static io.camunda.process.test.api.CamundaAssert.assertThat;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -93,7 +93,7 @@ public class AgentSubProcessLimitsTests extends BaseAgentSubProcessTest {
     assertIncident(
         zeebeTest,
         incident -> {
-          assertThat(incident.getElementId()).isEqualTo(AI_AGENT_TASK_ID);
+          assertThat(incident.getElementId()).isEqualTo(AI_AGENT_ELEMENT_ID);
           assertThat(incident.getErrorMessage())
               .startsWith(
                   "Maximum number of model calls reached (modelCalls: %1$d, limit: %1$d)"

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/subprocess/AgentSubProcessProcessMigrationTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/subprocess/AgentSubProcessProcessMigrationTests.java
@@ -16,7 +16,7 @@
  */
 package io.camunda.connector.e2e.agenticai.aiagent.subprocess;
 
-import static io.camunda.connector.e2e.agenticai.aiagent.AgentTestFixtures.AI_AGENT_TASK_ID;
+import static io.camunda.connector.e2e.agenticai.aiagent.AgentTestFixtures.AI_AGENT_ELEMENT_ID;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.client.api.response.ProcessInstanceEvent;
@@ -142,7 +142,7 @@ public class AgentSubProcessProcessMigrationTests extends BaseAgentSubProcessTes
     assertIncident(
         zeebeTest,
         incident -> {
-          assertThat(incident.getElementId()).isEqualTo(AI_AGENT_TASK_ID);
+          assertThat(incident.getElementId()).isEqualTo(AI_AGENT_ELEMENT_ID);
           assertThat(incident.getErrorMessage())
               .contains("Removing or renaming existing tools is currently not supported.")
               .contains(
@@ -178,7 +178,7 @@ public class AgentSubProcessProcessMigrationTests extends BaseAgentSubProcessTes
     assertIncident(
         zeebeTest,
         incident -> {
-          assertThat(incident.getElementId()).isEqualTo(AI_AGENT_TASK_ID);
+          assertThat(incident.getElementId()).isEqualTo(AI_AGENT_ELEMENT_ID);
           assertThat(incident.getErrorMessage())
               .contains(
                   "Adding or removing gateway tool definitions to a running AI Agent is currently not supported.")

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/subprocess/AgentSubProcessResponseHandlingTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/subprocess/AgentSubProcessResponseHandlingTests.java
@@ -16,7 +16,7 @@
  */
 package io.camunda.connector.e2e.agenticai.aiagent.subprocess;
 
-import static io.camunda.connector.e2e.agenticai.aiagent.AgentTestFixtures.AI_AGENT_TASK_ID;
+import static io.camunda.connector.e2e.agenticai.aiagent.AgentTestFixtures.AI_AGENT_ELEMENT_ID;
 import static io.camunda.connector.e2e.agenticai.aiagent.AgentTestFixtures.HAIKU_JSON;
 import static io.camunda.connector.e2e.agenticai.aiagent.AgentTestFixtures.HAIKU_JSON_ASSERTIONS;
 import static io.camunda.connector.e2e.agenticai.aiagent.AgentTestFixtures.HAIKU_TEXT;
@@ -240,7 +240,7 @@ public class AgentSubProcessResponseHandlingTests extends BaseAgentSubProcessTes
       assertIncident(
           zeebeTest,
           incident -> {
-            assertThat(incident.getElementId()).isEqualTo(AI_AGENT_TASK_ID);
+            assertThat(incident.getElementId()).isEqualTo(AI_AGENT_ELEMENT_ID);
             assertThat(incident.getErrorMessage())
                 .startsWith("Failed to parse response content as JSON");
           });

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/subprocess/AgentSubProcessUserPromptDocumentsTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/subprocess/AgentSubProcessUserPromptDocumentsTests.java
@@ -16,7 +16,7 @@
  */
 package io.camunda.connector.e2e.agenticai.aiagent.subprocess;
 
-import static io.camunda.connector.e2e.agenticai.aiagent.AgentTestFixtures.AI_AGENT_TASK_ID;
+import static io.camunda.connector.e2e.agenticai.aiagent.AgentTestFixtures.AI_AGENT_ELEMENT_ID;
 import static io.camunda.connector.e2e.agenticai.aiagent.ToolCallResultDocumentAssertions.assertDocumentContentBlockJson;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -166,7 +166,7 @@ public class AgentSubProcessUserPromptDocumentsTests extends BaseAgentSubProcess
     assertIncident(
         zeebeTest,
         incident -> {
-          assertThat(incident.getElementId()).isEqualTo(AI_AGENT_TASK_ID);
+          assertThat(incident.getElementId()).isEqualTo(AI_AGENT_ELEMENT_ID);
           assertThat(incident.getErrorMessage())
               .startsWith("Unsupported content type 'application/zip' for document with reference");
         });

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/subprocess/BaseAgentSubProcessTest.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/subprocess/BaseAgentSubProcessTest.java
@@ -16,7 +16,9 @@
  */
 package io.camunda.connector.e2e.agenticai.aiagent.subprocess;
 
+import static io.camunda.connector.e2e.agenticai.BpmnUtil.withAgentDefinitionMarker;
 import static io.camunda.connector.e2e.agenticai.aiagent.AgentTestFixtures.AGENT_RESPONSE_VARIABLE;
+import static io.camunda.connector.e2e.agenticai.aiagent.AgentTestFixtures.AI_AGENT_ELEMENT_ID;
 import static io.camunda.connector.e2e.agenticai.aiagent.AgentTestFixtures.AI_AGENT_SUB_PROCESS_V1_ELEMENT_TEMPLATE_PATH;
 import static io.camunda.connector.e2e.agenticai.aiagent.AgentTestFixtures.AI_AGENT_SUB_PROCESS_V1_ELEMENT_TEMPLATE_PROPERTIES;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -27,6 +29,7 @@ import io.camunda.connector.agenticai.aiagent.model.AgentMetrics;
 import io.camunda.connector.agenticai.aiagent.model.AgentSubProcessResponse;
 import io.camunda.connector.e2e.ElementTemplate;
 import io.camunda.connector.e2e.ZeebeTest;
+import io.camunda.connector.e2e.agenticai.BpmnUtil;
 import io.camunda.connector.e2e.agenticai.aiagent.BaseAgentTest;
 import io.camunda.connector.e2e.agenticai.aiagent.task.BaseAgentTaskTest;
 import io.camunda.connector.e2e.agenticai.aiagent.wiremock.openai.OpenAiCompletionsChatModelStubs;
@@ -36,6 +39,7 @@ import io.camunda.connector.e2e.agenticai.aiagent.wiremock.openai.OpenAiCompleti
 import io.camunda.connector.e2e.agenticai.assertj.AgentSubProcessResponseAssert;
 import io.camunda.connector.test.utils.annotation.SlowTest;
 import io.camunda.process.test.api.CamundaAssert;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.HashMap;
@@ -97,6 +101,13 @@ public abstract class BaseAgentSubProcessTest extends BaseAgentTest {
 
   protected Function<ElementTemplate, ElementTemplate> providerConfigurer() {
     return this::withOpenAiCompatibleProvider;
+  }
+
+  /** See {@link BpmnUtil#withAgentDefinitionMarker} for why this is needed. */
+  @Override
+  protected BpmnModelInstance customizeModel(BpmnModelInstance model) {
+    return super.customizeModel(
+        withAgentDefinitionMarker(model, AI_AGENT_ELEMENT_ID, "aiAgentSubProcess"));
   }
 
   @Override

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/task/AgentTaskHttpTimeoutTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/task/AgentTaskHttpTimeoutTests.java
@@ -21,7 +21,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
-import static io.camunda.connector.e2e.agenticai.aiagent.AgentTestFixtures.AI_AGENT_TASK_ID;
+import static io.camunda.connector.e2e.agenticai.aiagent.AgentTestFixtures.AI_AGENT_ELEMENT_ID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -183,7 +183,7 @@ public class AgentTaskHttpTimeoutTests extends BaseAgentTaskTest {
       assertIncident(
           zeebeTest,
           incident -> {
-            assertThat(incident.getElementId()).isEqualTo(AI_AGENT_TASK_ID);
+            assertThat(incident.getElementId()).isEqualTo(AI_AGENT_ELEMENT_ID);
             assertThat(incident.getErrorMessage())
                 .containsPattern(Pattern.compile("timed out|timeout"));
             assertThat(incident.getErrorMessage()).contains("FAILED_MODEL_CALL");

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/task/AgentTaskLimitsTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/task/AgentTaskLimitsTests.java
@@ -16,7 +16,7 @@
  */
 package io.camunda.connector.e2e.agenticai.aiagent.task;
 
-import static io.camunda.connector.e2e.agenticai.aiagent.AgentTestFixtures.AI_AGENT_TASK_ID;
+import static io.camunda.connector.e2e.agenticai.aiagent.AgentTestFixtures.AI_AGENT_ELEMENT_ID;
 import static io.camunda.connector.e2e.agenticai.aiagent.AgentTestFixtures.HAIKU_TEXT;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -70,7 +70,7 @@ public class AgentTaskLimitsTests extends BaseAgentTaskTest {
     assertIncident(
         zeebeTest,
         incident -> {
-          assertThat(incident.getElementId()).isEqualTo(AI_AGENT_TASK_ID);
+          assertThat(incident.getElementId()).isEqualTo(AI_AGENT_ELEMENT_ID);
           assertThat(incident.getErrorMessage())
               .startsWith(
                   "Maximum number of model calls reached (modelCalls: %1$d, limit: %1$d)"

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/task/AgentTaskProcessMigrationTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/task/AgentTaskProcessMigrationTests.java
@@ -16,7 +16,7 @@
  */
 package io.camunda.connector.e2e.agenticai.aiagent.task;
 
-import static io.camunda.connector.e2e.agenticai.aiagent.AgentTestFixtures.AI_AGENT_TASK_ID;
+import static io.camunda.connector.e2e.agenticai.aiagent.AgentTestFixtures.AI_AGENT_ELEMENT_ID;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.client.api.response.ProcessInstanceEvent;
@@ -143,7 +143,7 @@ public class AgentTaskProcessMigrationTests extends BaseAgentTaskTest {
     assertIncident(
         zeebeTest,
         incident -> {
-          assertThat(incident.getElementId()).isEqualTo(AI_AGENT_TASK_ID);
+          assertThat(incident.getElementId()).isEqualTo(AI_AGENT_ELEMENT_ID);
           assertThat(incident.getErrorMessage())
               .contains("Removing or renaming existing tools is currently not supported.")
               .contains(
@@ -179,7 +179,7 @@ public class AgentTaskProcessMigrationTests extends BaseAgentTaskTest {
     assertIncident(
         zeebeTest,
         incident -> {
-          assertThat(incident.getElementId()).isEqualTo(AI_AGENT_TASK_ID);
+          assertThat(incident.getElementId()).isEqualTo(AI_AGENT_ELEMENT_ID);
           assertThat(incident.getErrorMessage())
               .contains(
                   "Adding or removing gateway tool definitions to a running AI Agent is currently not supported.")
@@ -235,7 +235,7 @@ public class AgentTaskProcessMigrationTests extends BaseAgentTaskTest {
     camundaClient
         .newMigrateProcessInstanceCommand(processInstanceEvent.getProcessInstanceKey())
         .migrationPlan(updatedProcessDefinition.getProcessDefinitionKey())
-        .addMappingInstruction(AI_AGENT_TASK_ID, AI_AGENT_TASK_ID)
+        .addMappingInstruction(AI_AGENT_ELEMENT_ID, AI_AGENT_ELEMENT_ID)
         .addMappingInstruction(AGENT_TOOLS_ID, AGENT_TOOLS_ID)
         .addMappingInstruction(COMPLEX_TOOL_ID, COMPLEX_TOOL_ID)
         .execute();

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/task/AgentTaskResponseHandlingTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/task/AgentTaskResponseHandlingTests.java
@@ -16,7 +16,7 @@
  */
 package io.camunda.connector.e2e.agenticai.aiagent.task;
 
-import static io.camunda.connector.e2e.agenticai.aiagent.AgentTestFixtures.AI_AGENT_TASK_ID;
+import static io.camunda.connector.e2e.agenticai.aiagent.AgentTestFixtures.AI_AGENT_ELEMENT_ID;
 import static io.camunda.connector.e2e.agenticai.aiagent.AgentTestFixtures.HAIKU_JSON;
 import static io.camunda.connector.e2e.agenticai.aiagent.AgentTestFixtures.HAIKU_JSON_ASSERTIONS;
 import static io.camunda.connector.e2e.agenticai.aiagent.AgentTestFixtures.HAIKU_TEXT;
@@ -237,7 +237,7 @@ public class AgentTaskResponseHandlingTests extends BaseAgentTaskTest {
       assertIncident(
           zeebeTest,
           incident -> {
-            assertThat(incident.getElementId()).isEqualTo(AI_AGENT_TASK_ID);
+            assertThat(incident.getElementId()).isEqualTo(AI_AGENT_ELEMENT_ID);
             assertThat(incident.getErrorMessage())
                 .startsWith("Failed to parse response content as JSON");
           });

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/task/AgentTaskUserPromptDocumentsTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/task/AgentTaskUserPromptDocumentsTests.java
@@ -16,7 +16,7 @@
  */
 package io.camunda.connector.e2e.agenticai.aiagent.task;
 
-import static io.camunda.connector.e2e.agenticai.aiagent.AgentTestFixtures.AI_AGENT_TASK_ID;
+import static io.camunda.connector.e2e.agenticai.aiagent.AgentTestFixtures.AI_AGENT_ELEMENT_ID;
 import static io.camunda.connector.e2e.agenticai.aiagent.ToolCallResultDocumentAssertions.assertDocumentContentBlockJson;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -170,7 +170,7 @@ public class AgentTaskUserPromptDocumentsTests extends BaseAgentTaskTest {
     assertIncident(
         zeebeTest,
         incident -> {
-          assertThat(incident.getElementId()).isEqualTo(AI_AGENT_TASK_ID);
+          assertThat(incident.getElementId()).isEqualTo(AI_AGENT_ELEMENT_ID);
           assertThat(incident.getErrorMessage())
               .startsWith("Unsupported content type 'application/zip' for document with reference");
         });

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/task/BaseAgentTaskTest.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/task/BaseAgentTaskTest.java
@@ -16,7 +16,9 @@
  */
 package io.camunda.connector.e2e.agenticai.aiagent.task;
 
+import static io.camunda.connector.e2e.agenticai.BpmnUtil.withAgentDefinitionMarker;
 import static io.camunda.connector.e2e.agenticai.aiagent.AgentTestFixtures.AGENT_RESPONSE_VARIABLE;
+import static io.camunda.connector.e2e.agenticai.aiagent.AgentTestFixtures.AI_AGENT_ELEMENT_ID;
 import static io.camunda.connector.e2e.agenticai.aiagent.AgentTestFixtures.AI_AGENT_TASK_V1_ELEMENT_TEMPLATE_PATH;
 import static io.camunda.connector.e2e.agenticai.aiagent.AgentTestFixtures.AI_AGENT_TASK_V1_ELEMENT_TEMPLATE_PROPERTIES;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -26,6 +28,7 @@ import io.camunda.connector.agenticai.aiagent.model.AgentMetrics;
 import io.camunda.connector.agenticai.aiagent.model.AgentResponse;
 import io.camunda.connector.e2e.ElementTemplate;
 import io.camunda.connector.e2e.ZeebeTest;
+import io.camunda.connector.e2e.agenticai.BpmnUtil;
 import io.camunda.connector.e2e.agenticai.aiagent.BaseAgentTest;
 import io.camunda.connector.e2e.agenticai.aiagent.wiremock.openai.OpenAiCompletionsChatModelStubs;
 import io.camunda.connector.e2e.agenticai.aiagent.wiremock.openai.OpenAiCompletionsChatModelStubs.ToolCall;
@@ -34,6 +37,7 @@ import io.camunda.connector.e2e.agenticai.aiagent.wiremock.openai.OpenAiCompleti
 import io.camunda.connector.e2e.agenticai.assertj.AgentResponseAssert;
 import io.camunda.connector.test.utils.annotation.SlowTest;
 import io.camunda.process.test.api.CamundaAssert;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
@@ -93,6 +97,13 @@ public abstract class BaseAgentTaskTest extends BaseAgentTest {
 
   protected Function<ElementTemplate, ElementTemplate> providerConfigurer() {
     return this::withOpenAiCompatibleProvider;
+  }
+
+  /** See {@link BpmnUtil#withAgentDefinitionMarker} for why this is needed. */
+  @Override
+  protected BpmnModelInstance customizeModel(BpmnModelInstance model) {
+    return super.customizeModel(
+        withAgentDefinitionMarker(model, AI_AGENT_ELEMENT_ID, "aiAgentTask"));
   }
 
   @Override


### PR DESCRIPTION
## Summary
The engine now rejects `AgentInstance` creation for elements without a `zeebe:agentDefinition` marker (or a recognized v1-only `modelerTemplate` id), breaking all v2 (native provider) e2e tests. Neither the v2 element templates nor element-templates-cli's bundled `zeebe-bpmn-moddle` support that element yet - the CLI silently strips it if added to the source BPMN. This injects the marker programmatically on the already-applied model via `BpmnUtil.withAgentDefinitionMarker`, called from both AI Agent flavors' `customizeModel` hook (`BaseAgentSubProcessTest` / `BaseAgentTaskTest`).

Temporary workaround until element-templates-cli/libraries and the v2 element templates support the element themselves.

See camunda/camunda#59715.

## Verification
Before this change, `AgentSubProcessAnthropicReasoningEffortTests` fails 6/6 (process instance stuck active, engine incident). After, it and `AgentTaskLimitsTests`/`AgentSubProcessLimitsTests` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)