### PR TITLE
fix(ci): skip versioned element template check on release branches

### DIFF
--- a/.github/workflows/TEST_FEATURE_BRANCH.yml
+++ b/.github/workflows/TEST_FEATURE_BRANCH.yml
@@ -370,6 +370,8 @@ jobs:
         shell: bash
 
       - name: Check versioned element templates match main
+        env:
+          TARGET_BRANCH: ${{ github.event.pull_request.base.ref || github.ref_name }}
         run: |
           chmod +x ./.github/workflows/scripts/check_versioned_element_templates.sh
           ./.github/workflows/scripts/check_versioned_element_templates.sh

--- a/.github/workflows/scripts/check_versioned_element_templates.sh
+++ b/.github/workflows/scripts/check_versioned_element_templates.sh
@@ -15,6 +15,17 @@
 # can be resolved for the three-dot diff below.
 set -e
 
+# Release branches (stable/*, alpha/*) accumulate their own versioned template
+# history independently of main and routinely diverge from it (e.g. main-only
+# template properties not yet backported). Comparing against main there
+# produces false-positive mismatches unrelated to the PR's actual change, so
+# the check only applies to PRs/pushes targeting main.
+TARGET_BRANCH="${TARGET_BRANCH:-main}"
+if [[ "$TARGET_BRANCH" =~ ^(stable|alpha)/ ]]; then
+  echo "Target branch '${TARGET_BRANCH}' is a release branch — skipping versioned element template check (only meaningful for main)."
+  exit 0
+fi
+
 BASE_REF="origin/main"
 ERRORS=0
 CHECKED=0


### PR DESCRIPTION
## Summary
- `check-versioned-element-templates` compares newly-added `versioned/*.json` snapshots against `origin/main`, hardcoded regardless of the PR's actual base branch.
- Release branches (`stable/*`, `alpha/*`) accumulate their own versioned template history independently of `main` and routinely diverge from it, so this comparison produces false-positive mismatches for files completely unrelated to the PR being checked (observed on #8283: 16 of 17 flagged files aren't touched by that PR at all).
- Skip the check when the PR/push target branch matches `stable/*` or `alpha/*` — it's only meaningful for PRs targeting `main`.

## Test plan
- [x] Ran the updated script locally with `TARGET_BRANCH=alpha/8.10` — exits 0 immediately with a skip message.
- [x] Verified `TARGET_BRANCH=main` (or unset) still falls through to the existing check logic.
- [ ] CI passes on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)