### PR TITLE
fix(runtime): fail 'as JSON' on trailing content after valid JSON

### DIFF
--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/document/DocumentReturnProcessor.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/document/DocumentReturnProcessor.java
@@ -118,6 +118,7 @@ public class DocumentReturnProcessor {
   }
 
   private Object parseJson(byte[] bytes) throws IOException {
+    // Not readTree: it stops after the first value, so trailing garbage would pass silently.
     List<Object> values = new ArrayList<>();
     ObjectReader reader = objectMapper.readerFor(Object.class);
     try (JsonParser parser = objectMapper.createParser(bytes)) {

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/document/DocumentReturnProcessor.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/document/DocumentReturnProcessor.java
@@ -16,9 +16,10 @@
  */
 package io.camunda.connector.runtime.core.document;
 
+import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
 import io.camunda.connector.api.document.DocumentCreationRequest;
 import io.camunda.connector.api.document.DocumentFactory;
 import io.camunda.connector.api.document.DocumentReturn;
@@ -32,6 +33,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -114,20 +117,44 @@ public class DocumentReturnProcessor {
     }
   }
 
+  /**
+   * Parses the payload as JSON, requiring it to be <em>fully</em> valid: the whole stream must
+   * consist of complete JSON values and nothing else. {@code ObjectMapper#readTree} would stop
+   * after the first value and silently drop whatever follows, so a body like {@code 123
+   * <html>error</html>} used to succeed as {@code 123}.
+   *
+   * <p>Multi-value streams (NDJSON / JSON Lines / concatenated values) are supported and yield a
+   * list; a body holding exactly one value yields that value unwrapped, so existing FEEL
+   * expressions over single-object responses keep working.
+   */
   private Object parseJson(byte[] bytes) throws IOException {
-    try {
-      JsonNode node = objectMapper.readTree(bytes);
-      if (node == null || node.isMissingNode()) {
-        throw new ConnectorException(
-            "JSON response format selected but payload was empty or could not be parsed.");
+    List<Object> values = new ArrayList<>();
+    // Advancing the parser to the end of the input (rather than enabling FAIL_ON_TRAILING_TOKENS)
+    // is what makes trailing garbage fail while keeping legitimate NDJSON bodies readable.
+    // MappingIterator is deliberately not used here: it unwraps a root-level JSON array into its
+    // elements, which would both flatten `[{"a":1}]` into a single object and swallow whatever
+    // follows the array.
+    ObjectReader reader = objectMapper.readerFor(Object.class);
+    try (JsonParser parser = objectMapper.createParser(bytes)) {
+      while (parser.nextToken() != null) {
+        values.add(reader.readValue(parser));
       }
-      return objectMapper.treeToValue(node, Object.class);
     } catch (JsonProcessingException e) {
-      throw new ConnectorException(
-          null,
-          "JSON response format selected but payload is not valid JSON: " + e.getMessage(),
-          e);
+      throw invalidJson(e.getMessage(), e);
     }
+    if (values.isEmpty()) {
+      throw invalidJson("no content to map due to end-of-input", null);
+    }
+    return values.size() == 1 ? values.getFirst() : values;
+  }
+
+  private static ConnectorException invalidJson(String detail, Throwable cause) {
+    return new ConnectorException(
+        null,
+        "JSON response format selected but payload is not valid JSON: "
+            + detail
+            + ". Use 'Text' or 'Document reference' as the response format for non-JSON payloads.",
+        cause);
   }
 
   private static Charset resolveEncoding(String encoding) {

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/document/DocumentReturnProcessor.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/document/DocumentReturnProcessor.java
@@ -117,23 +117,8 @@ public class DocumentReturnProcessor {
     }
   }
 
-  /**
-   * Parses the payload as JSON, requiring it to be <em>fully</em> valid: the whole stream must
-   * consist of complete JSON values and nothing else. {@code ObjectMapper#readTree} would stop
-   * after the first value and silently drop whatever follows, so a body like {@code 123
-   * <html>error</html>} used to succeed as {@code 123}.
-   *
-   * <p>Multi-value streams (NDJSON / JSON Lines / concatenated values) are supported and yield a
-   * list; a body holding exactly one value yields that value unwrapped, so existing FEEL
-   * expressions over single-object responses keep working.
-   */
   private Object parseJson(byte[] bytes) throws IOException {
     List<Object> values = new ArrayList<>();
-    // Advancing the parser to the end of the input (rather than enabling FAIL_ON_TRAILING_TOKENS)
-    // is what makes trailing garbage fail while keeping legitimate NDJSON bodies readable.
-    // MappingIterator is deliberately not used here: it unwraps a root-level JSON array into its
-    // elements, which would both flatten `[{"a":1}]` into a single object and swallow whatever
-    // follows the array.
     ObjectReader reader = objectMapper.readerFor(Object.class);
     try (JsonParser parser = objectMapper.createParser(bytes)) {
       while (parser.nextToken() != null) {

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/document/DocumentReturnProcessorTest.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/document/DocumentReturnProcessorTest.java
@@ -125,14 +125,14 @@ class DocumentReturnProcessorTest {
   @ParameterizedTest
   @ValueSource(
       strings = {
-        "123 <html>error</html>", // valid JSON prefix, trailing markup
-        "true then text", // valid JSON prefix, trailing bare word
-        "{\"a\":1} trailing junk", // valid JSON prefix, trailing bare words
-        "[1,2,3] </body>", // valid JSON prefix, trailing markup
-        "<html>err</html>", // no JSON at all
-        "OK", // no JSON at all
-        "", // empty payload
-        "   \n\t " // whitespace only
+        "123 <html>error</html>",
+        "true then text",
+        "{\"a\":1} trailing junk",
+        "[1,2,3] </body>",
+        "<html>err</html>",
+        "OK",
+        "",
+        "   \n\t "
       })
   void jsonChoiceFailsForPayloadThatIsNotFullyValidJson(String body) {
     RawPayload payload = RawPayload.of(body.getBytes(StandardCharsets.UTF_8), null, null);
@@ -161,21 +161,19 @@ class DocumentReturnProcessorTest {
         Arguments.of("{\"a\":1}", Map.of("a", 1)),
         Arguments.of("[1,2,3]", List.of(1, 2, 3)),
         Arguments.of("123", 123),
-        // A root-level array is one value: it must not be unwrapped into its elements.
         Arguments.of("[{\"a\":1}]", List.of(Map.of("a", 1))),
         Arguments.of("true", true),
         Arguments.of("\"plain string\"", "plain string"),
-        // A pretty-printed value spans several lines but is still exactly one value.
         Arguments.of("{\n  \"a\": 1\n}", Map.of("a", 1)));
   }
 
   @ParameterizedTest
   @ValueSource(
       strings = {
-        "{\"a\":1}\n{\"b\":2}", // newline-delimited (NDJSON)
-        "{\"a\":1} {\"b\":2}", // space-separated
-        "{\"a\":1}{\"b\":2}", // concatenated stream, no separator
-        "{\"a\":1}\r\n{\"b\":2}\r\n" // CRLF-delimited with trailing newline
+        "{\"a\":1}\n{\"b\":2}",
+        "{\"a\":1} {\"b\":2}",
+        "{\"a\":1}{\"b\":2}",
+        "{\"a\":1}\r\n{\"b\":2}\r\n"
       })
   void jsonChoiceCollectsMultiValueStreamIntoList(String body) {
     RawPayload payload =

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/document/DocumentReturnProcessorTest.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/document/DocumentReturnProcessorTest.java
@@ -131,6 +131,7 @@ class DocumentReturnProcessorTest {
         "[1,2,3] </body>",
         "<html>err</html>",
         "OK",
+        "{\"a\":1",
         "",
         "   \n\t "
       })
@@ -205,6 +206,28 @@ class DocumentReturnProcessorTest {
     assertThatThrownBy(() -> processor.process(ret, format(DocumentReturnChoice.JSON)))
         .isInstanceOf(ConnectorException.class)
         .hasMessageContaining("not valid JSON");
+  }
+
+  @Test
+  void textChoiceStillReturnsPayloadWithTrailingContentVerbatim() {
+    String body = "123 <html>error</html>";
+    RawPayload payload = RawPayload.of(body.getBytes(StandardCharsets.UTF_8), "text/html", null);
+
+    DocumentReturn<Object> ret = new DocumentReturn<>(payload, (converted, choice) -> converted);
+
+    assertThat(processor.process(ret, format(DocumentReturnChoice.TEXT))).isEqualTo(body);
+  }
+
+  @Test
+  void documentChoiceStillAcceptsPayloadWithTrailingContent() {
+    RawPayload payload =
+        RawPayload.of(
+            "123 <html>error</html>".getBytes(StandardCharsets.UTF_8), "text/html", "err.html");
+
+    DocumentReturn<Object> ret = new DocumentReturn<>(payload, (converted, choice) -> converted);
+
+    assertThat(processor.process(ret, format(DocumentReturnChoice.DOCUMENT)))
+        .isInstanceOf(Document.class);
   }
 
   @Test

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/document/DocumentReturnProcessorTest.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/document/DocumentReturnProcessorTest.java
@@ -33,7 +33,12 @@ import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 class DocumentReturnProcessorTest {
 
@@ -115,6 +120,103 @@ class DocumentReturnProcessorTest {
     assertThatThrownBy(() -> processor.process(ret, format(DocumentReturnChoice.JSON)))
         .isInstanceOf(ConnectorException.class)
         .hasMessageContaining("not valid JSON");
+  }
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "123 <html>error</html>", // valid JSON prefix, trailing markup
+        "true then text", // valid JSON prefix, trailing bare word
+        "{\"a\":1} trailing junk", // valid JSON prefix, trailing bare words
+        "[1,2,3] </body>", // valid JSON prefix, trailing markup
+        "<html>err</html>", // no JSON at all
+        "OK", // no JSON at all
+        "", // empty payload
+        "   \n\t " // whitespace only
+      })
+  void jsonChoiceFailsForPayloadThatIsNotFullyValidJson(String body) {
+    RawPayload payload = RawPayload.of(body.getBytes(StandardCharsets.UTF_8), null, null);
+
+    DocumentReturn<Object> ret = new DocumentReturn<>(payload, (converted, choice) -> converted);
+
+    assertThatThrownBy(() -> processor.process(ret, format(DocumentReturnChoice.JSON)))
+        .isInstanceOf(ConnectorException.class)
+        .hasMessageContaining("not valid JSON")
+        .hasMessageContaining("Document reference");
+  }
+
+  @ParameterizedTest
+  @MethodSource("singleJsonValues")
+  void jsonChoiceReturnsSingleValueUnwrapped(String body, Object expected) {
+    RawPayload payload =
+        RawPayload.of(body.getBytes(StandardCharsets.UTF_8), "application/json", null);
+
+    DocumentReturn<Object> ret = new DocumentReturn<>(payload, (converted, choice) -> converted);
+
+    assertThat(processor.process(ret, format(DocumentReturnChoice.JSON))).isEqualTo(expected);
+  }
+
+  static Stream<Arguments> singleJsonValues() {
+    return Stream.of(
+        Arguments.of("{\"a\":1}", Map.of("a", 1)),
+        Arguments.of("[1,2,3]", List.of(1, 2, 3)),
+        Arguments.of("123", 123),
+        // A root-level array is one value: it must not be unwrapped into its elements.
+        Arguments.of("[{\"a\":1}]", List.of(Map.of("a", 1))),
+        Arguments.of("true", true),
+        Arguments.of("\"plain string\"", "plain string"),
+        // A pretty-printed value spans several lines but is still exactly one value.
+        Arguments.of("{\n  \"a\": 1\n}", Map.of("a", 1)));
+  }
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "{\"a\":1}\n{\"b\":2}", // newline-delimited (NDJSON)
+        "{\"a\":1} {\"b\":2}", // space-separated
+        "{\"a\":1}{\"b\":2}", // concatenated stream, no separator
+        "{\"a\":1}\r\n{\"b\":2}\r\n" // CRLF-delimited with trailing newline
+      })
+  void jsonChoiceCollectsMultiValueStreamIntoList(String body) {
+    RawPayload payload =
+        RawPayload.of(body.getBytes(StandardCharsets.UTF_8), "application/x-ndjson", null);
+
+    DocumentReturn<Object> ret = new DocumentReturn<>(payload, (converted, choice) -> converted);
+
+    assertThat(processor.process(ret, format(DocumentReturnChoice.JSON)))
+        .isEqualTo(List.of(Map.of("a", 1), Map.of("b", 2)));
+  }
+
+  @Test
+  void jsonChoiceCollectsMultiValueStreamOfScalars() {
+    RawPayload payload = RawPayload.of("1 2 3".getBytes(StandardCharsets.UTF_8), null, null);
+
+    DocumentReturn<Object> ret = new DocumentReturn<>(payload, (converted, choice) -> converted);
+
+    assertThat(processor.process(ret, format(DocumentReturnChoice.JSON)))
+        .isEqualTo(List.of(1, 2, 3));
+  }
+
+  @Test
+  void jsonChoiceFailsWhenTrailingGarbageFollowsAMultiValueStream() {
+    RawPayload payload =
+        RawPayload.of("{\"a\":1}\n{\"b\":2}\noops".getBytes(StandardCharsets.UTF_8), null, null);
+
+    DocumentReturn<Object> ret = new DocumentReturn<>(payload, (converted, choice) -> converted);
+
+    assertThatThrownBy(() -> processor.process(ret, format(DocumentReturnChoice.JSON)))
+        .isInstanceOf(ConnectorException.class)
+        .hasMessageContaining("not valid JSON");
+  }
+
+  @Test
+  void jsonChoiceAcceptsLiteralNull() {
+    RawPayload payload =
+        RawPayload.of("null".getBytes(StandardCharsets.UTF_8), "application/json", null);
+
+    DocumentReturn<Object> ret = new DocumentReturn<>(payload, (converted, choice) -> converted);
+
+    assertThat(processor.process(ret, format(DocumentReturnChoice.JSON))).isNull();
   }
 
   @Test


### PR DESCRIPTION
## Description

`DocumentReturnProcessor.parseJson` used `objectMapper.readTree(bytes)`, which reads the *first* JSON value and silently ignores everything after it. A body like `123 <html>error</html>` parsed as `123` and the job completed successfully, even though the user selected `as JSON`.

Parsing now drives a `JsonParser` to the end of the input, so any leftover that is not a JSON value fails the job with the existing `ConnectorException`.

Because the conversion is centralized, this covers every connector on the unified `Response format` / `@DocumentReturnFormat` dropdown (AWS S3, Google Cloud Storage, Azure Blob Storage, Box, Google Drive, HTTP REST, GraphQL).

### Behavior

| Body | before | after |
| :-- | :-- | :-- |
| `123 <html>error</html>` | parsed as `123` | **fails** |
| `true then text` | parsed as `true` | **fails** |
| `{"a":1} trailing junk` | parsed as `{"a":1}` | **fails** |
| `<html>err</html>` / `OK` | fails | fails |
| `{"a":1}` / `[1,2,3]` / `123` | parsed | parsed (unchanged) |
| `{"a":1}\n{"b":2}` (NDJSON) | parsed as `{"a":1}` | `[{"a":1},{"b":2}]` |

Two deliberate choices beyond the strict-reader suggestion in the issue:

- **Multi-value streams are supported, not rejected.** NDJSON / JSON Lines / concatenated values are read to exhaustion and returned as a list, since some APIs legitimately return them. A body holding exactly one value still yields that value unwrapped, so existing FEEL expressions over single-object responses are unaffected.
- **`MappingIterator` is deliberately not used.** It unwraps a root-level JSON array into its elements, which would flatten `[{"a":1}]` into a single object *and* swallow content trailing the array (`[1,2,3] </body>` still parsed clean). Driving the parser directly avoids both.

Empty and whitespace-only payloads now surface through the same `not valid JSON` message rather than a separate one, and the message points at `Text` / `Document reference` for non-JSON payloads. The size-limit guard and the streaming bound are untouched.

Out of scope, as noted in the issue: the legacy `storeResponse` path in `HttpCommonResultMapper` stays intentionally graceful.

## Related issues

closes #8000

## Checklist

- [x] Tests added — parameterized coverage of the issue's full table (trailing junk after scalar/bool/object/array, plain HTML, `OK`, empty, whitespace-only), single-value-unwrapped cases including pretty-printed and `[{"a":1}]`, NDJSON variants (LF, space, no separator, CRLF), scalar streams, trailing garbage after a multi-value stream, and literal `null`.
- [x] `connector-runtime-core` suite green (429 tests); downstream consumers re-run green: `HttpServiceDocumentReturnTest`, `HttpJsonFunctionDocumentReturnTest`, `GraphQLFunctionDocumentReturnTest`, `S3ExecutorTest`, `CsvConnectorTests`, `SpringConnectorJobHandlerTest` (127).
