### PR TITLE
fix: match the alwaysgreen SM e2e surface across the matrix.suite job name

### DIFF
--- a/.github/scripts/alwaysgreen/classify.py
+++ b/.github/scripts/alwaysgreen/classify.py
@@ -119,12 +119,16 @@ DISPATCHABLE_SURFACES = frozenset({SURFACE_SM_E2E, SURFACE_SAAS_E2E})
 IGNORED_JOB_PREFIXES = ("Observe Helm chart Integration Tests status",)
 
 #: Literal prefixes, deliberately stopping before the first `${{`, matched
-#: against the trailing segment of a (possibly nested) job name.
+#: against the trailing segment of a (possibly nested) job name. An entry may
+#: be a compiled regex instead of a literal string when the interpolated job
+#: name has a rendered value (not just an unrendered `${{ }}`) in the middle
+#: of the fragment being matched, e.g. `${{ matrix.suite }}` in the SM e2e job
+#: name (camunda-platform-helm#6841) — a plain prefix can't skip over that.
 #:
 #: The first four come from camunda-platform-helm's test-integration-template, which
 #: INTEGRATION_TEST.yml calls, so their names are owned there rather than here.
-_SURFACE_PREFIXES: tuple[tuple[str, str], ...] = (
-    ("Playwright e2e after install", SURFACE_SM_E2E),
+_SURFACE_PREFIXES: tuple[tuple[str | re.Pattern[str], str], ...] = (
+    (re.compile(r"^Playwright e2e .*after install\b"), SURFACE_SM_E2E),
     ("install for install on", SURFACE_HELM_INSTALL),
     ("Cleanup - install on", SURFACE_HELM_CLEANUP),
     ("Generate test matrix", SURFACE_CI_INFRA),
@@ -154,7 +158,10 @@ def surface_for_job(job_name: str) -> str | None:
             return None
 
     for prefix, surface in _SURFACE_PREFIXES:
-        if leaf.startswith(prefix):
+        if isinstance(prefix, re.Pattern):
+            if prefix.match(leaf):
+                return surface
+        elif leaf.startswith(prefix):
             return surface
 
     return None

--- a/.github/scripts/alwaysgreen/test_classify.py
+++ b/.github/scripts/alwaysgreen/test_classify.py
@@ -89,6 +89,35 @@ def test_unrendered_template_job_name_still_matches_prefix():
     assert classify.surface_for_job(name) == classify.SURFACE_SM_E2E
 
 
+def test_sm_e2e_job_name_with_matrix_suite_maps_to_sm_surface():
+    # camunda-platform-helm#6841 inserted `${{ matrix.suite }}` between "e2e"
+    # and "after install" in test-integration-runner.yaml, which this repo's
+    # test-integration-template ultimately calls, to run a named suite (e.g.
+    # the alwaysgreen scenario's "full" suite). A plain
+    # `startswith("Playwright e2e after install")` stops matching this and the
+    # job silently drops out of triage with no evidence and no fix agent run.
+    name = (
+        "Helm chart Integration Tests / agrn - install - gke / "
+        "Playwright e2e full after install - install on gke - agrn (1 of 1)"
+    )
+    assert classify.surface_for_job(name) == classify.SURFACE_SM_E2E
+
+    smoke_name = name.replace("full after install", "smoke after install")
+    assert classify.surface_for_job(smoke_name) == classify.SURFACE_SM_E2E
+
+
+def test_unrendered_matrix_suite_job_name_still_matches_prefix():
+    # The unrendered form of `${{ matrix.suite }}` itself contains spaces, so
+    # a `\S+`-based fix for the case above would regress this one.
+    name = (
+        "Helm chart Integration Tests / agrn - install - gke / "
+        "Playwright e2e ${{ matrix.suite }} after install - "
+        "${{ inputs.flow }} on ${{ inputs.distro-platform }} - "
+        "${{ inputs.shortname }}"
+    )
+    assert classify.surface_for_job(name) == classify.SURFACE_SM_E2E
+
+
 def test_observe_status_job_is_ignored():
     assert classify.surface_for_job("Observe Helm chart Integration Tests status") is None
 


### PR DESCRIPTION
## Summary

`camunda-platform-helm#6841` inserted `${{ matrix.suite }}` between `"e2e"` and `"after install"` in `test-integration-runner.yaml` (to run a named suite, e.g. the alwaysgreen scenario's `"full"` suite). This repo's `INTEGRATION_TEST.yml` calls `camunda-platform-helm`'s `test-integration-template.yaml`, which itself calls `test-integration-runner.yaml` — so the SM e2e job here now renders as `Playwright e2e full after install - ...` instead of `Playwright e2e after install - ...`.

`classify.py`'s `surface_for_job` matched that job with a plain `startswith("Playwright e2e after install")`, which the inserted segment breaks. `surface_for_job` then returns `None`, and `discover.py` silently `continue`s past it — not suppressed, not logged as noise, just gone from triage. Since `SM e2e` is one of only two surfaces in this repo's `DISPATCHABLE_SURFACES`, this silently disabled half of what the AlwaysGreen fix agent can act on here.

Mirrors the identical fix already applied in `camunda/camunda` (camunda/camunda#60014), which hit the same drift.

## Change

- `classify.py`: the `SURFACE_SM_E2E` entry in `_SURFACE_PREFIXES` is now a regex (`^Playwright e2e .*after install\b`) instead of a literal prefix, tolerating arbitrary content between `"e2e"` and `"after install"` — both the rendered suite name and its unrendered `${{ matrix.suite }}` form (which itself contains spaces, so a `\S+` alternative would have regressed the unrendered-template case already covered by an existing test).
- `test_classify.py`: added two regression tests — one for the real rendered job name (`full`/`smoke`), one for the fully-unrendered `${{ matrix.suite }}` placeholder.

## Test plan

- [x] `pytest --verbose --color=yes --tb=short .github/scripts/alwaysgreen` — 92 passed, including the two new cases and the pre-existing SM e2e tests (both old- and new-format job names still classify correctly).