### PR TITLE
refactor(app-integrations): tooltip-first element-template field hints

### DIFF
--- a/connectors/app-integrations/element-templates/app-integrations-connector.json
+++ b/connectors/app-integrations/element-templates/app-integrations-connector.json
@@ -77,7 +77,6 @@
   }, {
     "id" : "createChannel:configuration.baseUrl",
     "label" : "Base URL",
-    "description" : "App Integrations backend URL.",
     "optional" : false,
     "feel" : "optional",
     "group" : "configuration",
@@ -92,12 +91,11 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "Tip: store the URL as a secret, e.g. <code>= secrets.APP_INTEGRATIONS_BASE_URL</code>.",
+    "tooltip" : "App Integrations backend URL. Tip: store this as a secret, e.g. <code>= secrets.APP_INTEGRATIONS_BASE_URL</code>.",
     "type" : "String"
   }, {
     "id" : "sendMessage:configuration.baseUrl",
     "label" : "Base URL",
-    "description" : "App Integrations backend URL.",
     "optional" : false,
     "feel" : "optional",
     "group" : "configuration",
@@ -112,7 +110,7 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "Tip: store the URL as a secret, e.g. <code>= secrets.APP_INTEGRATIONS_BASE_URL</code>.",
+    "tooltip" : "App Integrations backend URL. Tip: store this as a secret, e.g. <code>= secrets.APP_INTEGRATIONS_BASE_URL</code>.",
     "type" : "String"
   }, {
     "id" : "createChannel:configuration.authentication.type",
@@ -142,7 +140,6 @@
   }, {
     "id" : "createChannel:configuration.authentication.apiKey",
     "label" : "API key",
-    "description" : "Shared API key for authenticating to the App Integrations backend (self-managed).",
     "optional" : false,
     "feel" : "optional",
     "group" : "authentication",
@@ -161,12 +158,11 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "Tip: store the API key as a secret, e.g. <code>{{secrets.APP_INTEGRATIONS_API_KEY}}</code>.",
+    "tooltip" : "Shared API key for authenticating to the App Integrations backend (self-managed). Tip: store this as a secret, e.g. <code>{{secrets.APP_INTEGRATIONS_API_KEY}}</code>.",
     "type" : "String"
   }, {
     "id" : "createChannel:configuration.authentication.oauthTokenEndpoint",
     "label" : "OAuth 2.0 token endpoint",
-    "description" : "The OAuth token endpoint",
     "optional" : false,
     "constraints" : {
       "pattern" : {
@@ -195,7 +191,6 @@
   }, {
     "id" : "createChannel:configuration.authentication.clientId",
     "label" : "Client ID",
-    "description" : "Your application's client ID from the OAuth client",
     "optional" : false,
     "feel" : "optional",
     "group" : "authentication",
@@ -214,11 +209,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Your application's client ID from the OAuth client",
     "type" : "String"
   }, {
     "id" : "createChannel:configuration.authentication.clientSecret",
     "label" : "Client secret",
-    "description" : "Your application's client secret from the OAuth client",
     "optional" : false,
     "feel" : "optional",
     "group" : "authentication",
@@ -237,11 +232,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Your application's client secret from the OAuth client",
     "type" : "String"
   }, {
     "id" : "createChannel:configuration.authentication.audience",
     "label" : "Audience",
-    "description" : "The unique identifier of the target API you want to access",
     "optional" : true,
     "feel" : "optional",
     "group" : "authentication",
@@ -260,11 +255,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "The unique identifier of the target API you want to access",
     "type" : "String"
   }, {
     "id" : "createChannel:configuration.authentication.clientAuthentication",
     "label" : "Client authentication",
-    "description" : "Send client ID and client secret as Basic Auth request in the header, or as client credentials in the request body",
     "optional" : false,
     "value" : "credentialsBody",
     "group" : "authentication",
@@ -283,6 +278,7 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Send client ID and client secret as Basic Auth request in the header, or as client credentials in the request body",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "Send client credentials in body",
@@ -294,7 +290,6 @@
   }, {
     "id" : "createChannel:configuration.authentication.scopes",
     "label" : "Scopes",
-    "description" : "The scopes which you want to request authorization for (e.g. read:contacts)",
     "optional" : true,
     "feel" : "optional",
     "group" : "authentication",
@@ -313,6 +308,8 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "The scopes you want to request authorization for.",
+    "placeholder" : "read:contacts",
     "type" : "String"
   }, {
     "id" : "sendMessage:configuration.authentication.type",
@@ -342,7 +339,6 @@
   }, {
     "id" : "sendMessage:configuration.authentication.apiKey",
     "label" : "API key",
-    "description" : "Shared API key for authenticating to the App Integrations backend (self-managed).",
     "optional" : false,
     "feel" : "optional",
     "group" : "authentication",
@@ -361,12 +357,11 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "Tip: store the API key as a secret, e.g. <code>{{secrets.APP_INTEGRATIONS_API_KEY}}</code>.",
+    "tooltip" : "Shared API key for authenticating to the App Integrations backend (self-managed). Tip: store this as a secret, e.g. <code>{{secrets.APP_INTEGRATIONS_API_KEY}}</code>.",
     "type" : "String"
   }, {
     "id" : "sendMessage:configuration.authentication.oauthTokenEndpoint",
     "label" : "OAuth 2.0 token endpoint",
-    "description" : "The OAuth token endpoint",
     "optional" : false,
     "constraints" : {
       "pattern" : {
@@ -395,7 +390,6 @@
   }, {
     "id" : "sendMessage:configuration.authentication.clientId",
     "label" : "Client ID",
-    "description" : "Your application's client ID from the OAuth client",
     "optional" : false,
     "feel" : "optional",
     "group" : "authentication",
@@ -414,11 +408,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Your application's client ID from the OAuth client",
     "type" : "String"
   }, {
     "id" : "sendMessage:configuration.authentication.clientSecret",
     "label" : "Client secret",
-    "description" : "Your application's client secret from the OAuth client",
     "optional" : false,
     "feel" : "optional",
     "group" : "authentication",
@@ -437,11 +431,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Your application's client secret from the OAuth client",
     "type" : "String"
   }, {
     "id" : "sendMessage:configuration.authentication.audience",
     "label" : "Audience",
-    "description" : "The unique identifier of the target API you want to access",
     "optional" : true,
     "feel" : "optional",
     "group" : "authentication",
@@ -460,11 +454,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "The unique identifier of the target API you want to access",
     "type" : "String"
   }, {
     "id" : "sendMessage:configuration.authentication.clientAuthentication",
     "label" : "Client authentication",
-    "description" : "Send client ID and client secret as Basic Auth request in the header, or as client credentials in the request body",
     "optional" : false,
     "value" : "credentialsBody",
     "group" : "authentication",
@@ -483,6 +477,7 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Send client ID and client secret as Basic Auth request in the header, or as client credentials in the request body",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "Send client credentials in body",
@@ -494,7 +489,6 @@
   }, {
     "id" : "sendMessage:configuration.authentication.scopes",
     "label" : "Scopes",
-    "description" : "The scopes which you want to request authorization for (e.g. read:contacts)",
     "optional" : true,
     "feel" : "optional",
     "group" : "authentication",
@@ -513,11 +507,12 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "The scopes you want to request authorization for.",
+    "placeholder" : "read:contacts",
     "type" : "String"
   }, {
     "id" : "sendMessage:email",
     "label" : "User Email",
-    "description" : "Email address of the recipient. Use a FEEL expression to reference a process variable, e.g. =assigneeEmail.",
     "optional" : true,
     "feel" : "optional",
     "group" : "message",
@@ -532,11 +527,12 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Email address of the recipient. Use a FEEL expression to reference a process variable.",
+    "placeholder" : "=assigneeEmail",
     "type" : "String"
   }, {
     "id" : "sendMessage:channelId",
     "label" : "Channel ID",
-    "description" : "Microsoft Teams channel ID to send to directly, e.g. 19:xxx@thread.tacv2. Use when sending to a channel rather than a user.",
     "optional" : true,
     "feel" : "optional",
     "group" : "message",
@@ -551,11 +547,12 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Microsoft Teams channel ID to send to directly. Use when sending to a channel rather than a user.",
+    "placeholder" : "19:xxx@thread.tacv2",
     "type" : "String"
   }, {
     "id" : "sendMessage:message",
     "label" : "Message",
-    "description" : "Plain text content to send. Provide either this, an adaptive card, or link a form.",
     "optional" : true,
     "feel" : "optional",
     "group" : "message",
@@ -570,11 +567,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Plain text content to send. Provide either this, an adaptive card, or link a form.",
     "type" : "Text"
   }, {
     "id" : "sendMessage:adaptiveCardJson",
     "label" : "Adaptive card",
-    "description" : "JSON payload for a custom Teams adaptive card. Provide either this, a plain text message, or link a form.",
     "optional" : true,
     "feel" : "optional",
     "group" : "message",
@@ -589,6 +586,7 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "JSON payload for a custom Teams adaptive card. Provide either this, a plain text message, or link a form.",
     "type" : "Text"
   }, {
     "id" : "sendMessage:formDefinition.include",
@@ -717,7 +715,6 @@
   }, {
     "id" : "createChannel:teamId",
     "label" : "Team ID",
-    "description" : "ID of the Microsoft Teams team, or a full Teams URL (the groupId query parameter will be extracted automatically).",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -735,11 +732,12 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "ID of the Microsoft Teams team, or a full Teams URL (the groupId query parameter will be extracted automatically).",
     "type" : "String"
   }, {
     "id" : "createChannel:displayName",
     "label" : "Channel name",
-    "description" : "Display name for the new channel (max 50 characters).",
+    "description" : "Max 50 characters.",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true,
@@ -759,11 +757,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Display name for the new channel.",
     "type" : "String"
   }, {
     "id" : "createChannel:description",
     "label" : "Description",
-    "description" : "Optional description for the channel.",
     "optional" : true,
     "feel" : "optional",
     "group" : "channel",
@@ -782,7 +780,6 @@
   }, {
     "id" : "createChannel:membershipType",
     "label" : "Channel type",
-    "description" : "Membership type: standard (visible to all), private (invite-only), or shared.",
     "optional" : false,
     "value" : "standard",
     "feel" : "optional",
@@ -798,6 +795,7 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Membership type: standard (visible to all), private (invite-only), or shared.",
     "type" : "String"
   }, {
     "id" : "version",

--- a/connectors/app-integrations/element-templates/hybrid/app-integrations-connector-hybrid.json
+++ b/connectors/app-integrations/element-templates/hybrid/app-integrations-connector-hybrid.json
@@ -82,7 +82,6 @@
   }, {
     "id" : "createChannel:configuration.baseUrl",
     "label" : "Base URL",
-    "description" : "App Integrations backend URL.",
     "optional" : false,
     "feel" : "optional",
     "group" : "configuration",
@@ -97,12 +96,11 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "Tip: store the URL as a secret, e.g. <code>= secrets.APP_INTEGRATIONS_BASE_URL</code>.",
+    "tooltip" : "App Integrations backend URL. Tip: store this as a secret, e.g. <code>= secrets.APP_INTEGRATIONS_BASE_URL</code>.",
     "type" : "String"
   }, {
     "id" : "sendMessage:configuration.baseUrl",
     "label" : "Base URL",
-    "description" : "App Integrations backend URL.",
     "optional" : false,
     "feel" : "optional",
     "group" : "configuration",
@@ -117,7 +115,7 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "Tip: store the URL as a secret, e.g. <code>= secrets.APP_INTEGRATIONS_BASE_URL</code>.",
+    "tooltip" : "App Integrations backend URL. Tip: store this as a secret, e.g. <code>= secrets.APP_INTEGRATIONS_BASE_URL</code>.",
     "type" : "String"
   }, {
     "id" : "createChannel:configuration.authentication.type",
@@ -147,7 +145,6 @@
   }, {
     "id" : "createChannel:configuration.authentication.apiKey",
     "label" : "API key",
-    "description" : "Shared API key for authenticating to the App Integrations backend (self-managed).",
     "optional" : false,
     "feel" : "optional",
     "group" : "authentication",
@@ -166,12 +163,11 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "Tip: store the API key as a secret, e.g. <code>{{secrets.APP_INTEGRATIONS_API_KEY}}</code>.",
+    "tooltip" : "Shared API key for authenticating to the App Integrations backend (self-managed). Tip: store this as a secret, e.g. <code>{{secrets.APP_INTEGRATIONS_API_KEY}}</code>.",
     "type" : "String"
   }, {
     "id" : "createChannel:configuration.authentication.oauthTokenEndpoint",
     "label" : "OAuth 2.0 token endpoint",
-    "description" : "The OAuth token endpoint",
     "optional" : false,
     "constraints" : {
       "pattern" : {
@@ -200,7 +196,6 @@
   }, {
     "id" : "createChannel:configuration.authentication.clientId",
     "label" : "Client ID",
-    "description" : "Your application's client ID from the OAuth client",
     "optional" : false,
     "feel" : "optional",
     "group" : "authentication",
@@ -219,11 +214,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Your application's client ID from the OAuth client",
     "type" : "String"
   }, {
     "id" : "createChannel:configuration.authentication.clientSecret",
     "label" : "Client secret",
-    "description" : "Your application's client secret from the OAuth client",
     "optional" : false,
     "feel" : "optional",
     "group" : "authentication",
@@ -242,11 +237,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Your application's client secret from the OAuth client",
     "type" : "String"
   }, {
     "id" : "createChannel:configuration.authentication.audience",
     "label" : "Audience",
-    "description" : "The unique identifier of the target API you want to access",
     "optional" : true,
     "feel" : "optional",
     "group" : "authentication",
@@ -265,11 +260,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "The unique identifier of the target API you want to access",
     "type" : "String"
   }, {
     "id" : "createChannel:configuration.authentication.clientAuthentication",
     "label" : "Client authentication",
-    "description" : "Send client ID and client secret as Basic Auth request in the header, or as client credentials in the request body",
     "optional" : false,
     "value" : "credentialsBody",
     "group" : "authentication",
@@ -288,6 +283,7 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Send client ID and client secret as Basic Auth request in the header, or as client credentials in the request body",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "Send client credentials in body",
@@ -299,7 +295,6 @@
   }, {
     "id" : "createChannel:configuration.authentication.scopes",
     "label" : "Scopes",
-    "description" : "The scopes which you want to request authorization for (e.g. read:contacts)",
     "optional" : true,
     "feel" : "optional",
     "group" : "authentication",
@@ -318,6 +313,8 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "The scopes you want to request authorization for.",
+    "placeholder" : "read:contacts",
     "type" : "String"
   }, {
     "id" : "sendMessage:configuration.authentication.type",
@@ -347,7 +344,6 @@
   }, {
     "id" : "sendMessage:configuration.authentication.apiKey",
     "label" : "API key",
-    "description" : "Shared API key for authenticating to the App Integrations backend (self-managed).",
     "optional" : false,
     "feel" : "optional",
     "group" : "authentication",
@@ -366,12 +362,11 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "Tip: store the API key as a secret, e.g. <code>{{secrets.APP_INTEGRATIONS_API_KEY}}</code>.",
+    "tooltip" : "Shared API key for authenticating to the App Integrations backend (self-managed). Tip: store this as a secret, e.g. <code>{{secrets.APP_INTEGRATIONS_API_KEY}}</code>.",
     "type" : "String"
   }, {
     "id" : "sendMessage:configuration.authentication.oauthTokenEndpoint",
     "label" : "OAuth 2.0 token endpoint",
-    "description" : "The OAuth token endpoint",
     "optional" : false,
     "constraints" : {
       "pattern" : {
@@ -400,7 +395,6 @@
   }, {
     "id" : "sendMessage:configuration.authentication.clientId",
     "label" : "Client ID",
-    "description" : "Your application's client ID from the OAuth client",
     "optional" : false,
     "feel" : "optional",
     "group" : "authentication",
@@ -419,11 +413,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Your application's client ID from the OAuth client",
     "type" : "String"
   }, {
     "id" : "sendMessage:configuration.authentication.clientSecret",
     "label" : "Client secret",
-    "description" : "Your application's client secret from the OAuth client",
     "optional" : false,
     "feel" : "optional",
     "group" : "authentication",
@@ -442,11 +436,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Your application's client secret from the OAuth client",
     "type" : "String"
   }, {
     "id" : "sendMessage:configuration.authentication.audience",
     "label" : "Audience",
-    "description" : "The unique identifier of the target API you want to access",
     "optional" : true,
     "feel" : "optional",
     "group" : "authentication",
@@ -465,11 +459,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "The unique identifier of the target API you want to access",
     "type" : "String"
   }, {
     "id" : "sendMessage:configuration.authentication.clientAuthentication",
     "label" : "Client authentication",
-    "description" : "Send client ID and client secret as Basic Auth request in the header, or as client credentials in the request body",
     "optional" : false,
     "value" : "credentialsBody",
     "group" : "authentication",
@@ -488,6 +482,7 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Send client ID and client secret as Basic Auth request in the header, or as client credentials in the request body",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "Send client credentials in body",
@@ -499,7 +494,6 @@
   }, {
     "id" : "sendMessage:configuration.authentication.scopes",
     "label" : "Scopes",
-    "description" : "The scopes which you want to request authorization for (e.g. read:contacts)",
     "optional" : true,
     "feel" : "optional",
     "group" : "authentication",
@@ -518,11 +512,12 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "The scopes you want to request authorization for.",
+    "placeholder" : "read:contacts",
     "type" : "String"
   }, {
     "id" : "sendMessage:email",
     "label" : "User Email",
-    "description" : "Email address of the recipient. Use a FEEL expression to reference a process variable, e.g. =assigneeEmail.",
     "optional" : true,
     "feel" : "optional",
     "group" : "message",
@@ -537,11 +532,12 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Email address of the recipient. Use a FEEL expression to reference a process variable.",
+    "placeholder" : "=assigneeEmail",
     "type" : "String"
   }, {
     "id" : "sendMessage:channelId",
     "label" : "Channel ID",
-    "description" : "Microsoft Teams channel ID to send to directly, e.g. 19:xxx@thread.tacv2. Use when sending to a channel rather than a user.",
     "optional" : true,
     "feel" : "optional",
     "group" : "message",
@@ -556,11 +552,12 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Microsoft Teams channel ID to send to directly. Use when sending to a channel rather than a user.",
+    "placeholder" : "19:xxx@thread.tacv2",
     "type" : "String"
   }, {
     "id" : "sendMessage:message",
     "label" : "Message",
-    "description" : "Plain text content to send. Provide either this, an adaptive card, or link a form.",
     "optional" : true,
     "feel" : "optional",
     "group" : "message",
@@ -575,11 +572,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Plain text content to send. Provide either this, an adaptive card, or link a form.",
     "type" : "Text"
   }, {
     "id" : "sendMessage:adaptiveCardJson",
     "label" : "Adaptive card",
-    "description" : "JSON payload for a custom Teams adaptive card. Provide either this, a plain text message, or link a form.",
     "optional" : true,
     "feel" : "optional",
     "group" : "message",
@@ -594,6 +591,7 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "JSON payload for a custom Teams adaptive card. Provide either this, a plain text message, or link a form.",
     "type" : "Text"
   }, {
     "id" : "sendMessage:formDefinition.include",
@@ -722,7 +720,6 @@
   }, {
     "id" : "createChannel:teamId",
     "label" : "Team ID",
-    "description" : "ID of the Microsoft Teams team, or a full Teams URL (the groupId query parameter will be extracted automatically).",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -740,11 +737,12 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "ID of the Microsoft Teams team, or a full Teams URL (the groupId query parameter will be extracted automatically).",
     "type" : "String"
   }, {
     "id" : "createChannel:displayName",
     "label" : "Channel name",
-    "description" : "Display name for the new channel (max 50 characters).",
+    "description" : "Max 50 characters.",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true,
@@ -764,11 +762,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Display name for the new channel.",
     "type" : "String"
   }, {
     "id" : "createChannel:description",
     "label" : "Description",
-    "description" : "Optional description for the channel.",
     "optional" : true,
     "feel" : "optional",
     "group" : "channel",
@@ -787,7 +785,6 @@
   }, {
     "id" : "createChannel:membershipType",
     "label" : "Channel type",
-    "description" : "Membership type: standard (visible to all), private (invite-only), or shared.",
     "optional" : false,
     "value" : "standard",
     "feel" : "optional",
@@ -803,6 +800,7 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Membership type: standard (visible to all), private (invite-only), or shared.",
     "type" : "String"
   }, {
     "id" : "version",

--- a/connectors/app-integrations/src/main/java/io/camunda/connector/appintegrations/model/AppIntegrationsConfiguration.java
+++ b/connectors/app-integrations/src/main/java/io/camunda/connector/appintegrations/model/AppIntegrationsConfiguration.java
@@ -14,8 +14,7 @@ public record AppIntegrationsConfiguration(
     @TemplateProperty(
             group = "configuration",
             label = "Base URL",
-            description = "App Integrations backend URL.",
             tooltip =
-                "Tip: store the URL as a secret, e.g. <code>= secrets.APP_INTEGRATIONS_BASE_URL</code>.")
+                "App Integrations backend URL. Tip: store this as a secret, e.g. <code>= secrets.APP_INTEGRATIONS_BASE_URL</code>.")
         String baseUrl,
     @Valid AppIntegrationsAuthentication authentication) {}

--- a/connectors/app-integrations/src/main/java/io/camunda/connector/appintegrations/model/CreateChannelRequest.java
+++ b/connectors/app-integrations/src/main/java/io/camunda/connector/appintegrations/model/CreateChannelRequest.java
@@ -22,7 +22,7 @@ public record CreateChannelRequest(
         @TemplateProperty(
             group = "channel",
             label = "Team ID",
-            description =
+            tooltip =
                 "ID of the Microsoft Teams team, or a full Teams URL"
                     + " (the groupId query parameter will be extracted automatically).")
         String teamId,
@@ -31,18 +31,14 @@ public record CreateChannelRequest(
         @TemplateProperty(
             group = "channel",
             label = "Channel name",
-            description = "Display name for the new channel (max 50 characters).")
+            tooltip = "Display name for the new channel.",
+            description = "Max 50 characters.")
         String displayName,
-    @TemplateProperty(
-            group = "channel",
-            label = "Description",
-            description = "Optional description for the channel.",
-            optional = true)
-        String description,
+    @TemplateProperty(group = "channel", label = "Description", optional = true) String description,
     @TemplateProperty(
             group = "channel",
             label = "Channel type",
-            description =
+            tooltip =
                 "Membership type: standard (visible to all), private (invite-only), or shared.",
             choices = {
               @TemplateProperty.DropdownPropertyChoice(label = "Standard", value = "standard"),

--- a/connectors/app-integrations/src/main/java/io/camunda/connector/appintegrations/model/SendMessageRequest.java
+++ b/connectors/app-integrations/src/main/java/io/camunda/connector/appintegrations/model/SendMessageRequest.java
@@ -28,21 +28,23 @@ public record SendMessageRequest(
     @TemplateProperty(
             group = "message",
             label = "User Email",
-            description =
-                "Email address of the recipient. Use a FEEL expression to reference a process variable, e.g. =assigneeEmail.",
+            tooltip =
+                "Email address of the recipient. Use a FEEL expression to reference a process variable.",
+            placeholder = "=assigneeEmail",
             optional = true)
         String email,
     @TemplateProperty(
             group = "message",
             label = "Channel ID",
-            description =
-                "Microsoft Teams channel ID to send to directly, e.g. 19:xxx@thread.tacv2. Use when sending to a channel rather than a user.",
+            tooltip =
+                "Microsoft Teams channel ID to send to directly. Use when sending to a channel rather than a user.",
+            placeholder = "19:xxx@thread.tacv2",
             optional = true)
         String channelId,
     @TemplateProperty(
             group = "message",
             label = "Message",
-            description =
+            tooltip =
                 "Plain text content to send. Provide either this, an adaptive card, or link a form.",
             type = PropertyType.Text,
             optional = true)
@@ -50,7 +52,7 @@ public record SendMessageRequest(
     @TemplateProperty(
             group = "message",
             label = "Adaptive card",
-            description =
+            tooltip =
                 "JSON payload for a custom Teams adaptive card. Provide either this, a plain text message, or link a form.",
             type = PropertyType.Text,
             optional = true)

--- a/connectors/app-integrations/src/main/java/io/camunda/connector/appintegrations/model/auth/ApiKeyAuthentication.java
+++ b/connectors/app-integrations/src/main/java/io/camunda/connector/appintegrations/model/auth/ApiKeyAuthentication.java
@@ -14,10 +14,10 @@ public record ApiKeyAuthentication(
     @TemplateProperty(
             group = "authentication",
             label = "API key",
-            description =
-                "Shared API key for authenticating to the App Integrations backend (self-managed).",
             tooltip =
-                "Tip: store the API key as a secret, e.g. <code>{{secrets.APP_INTEGRATIONS_API_KEY}}</code>.")
+                "Shared API key for authenticating to the App Integrations backend (self-managed)."
+                    + " Tip: store this as a secret, e.g."
+                    + " <code>{{secrets.APP_INTEGRATIONS_API_KEY}}</code>.")
         String apiKey)
     implements AppIntegrationsAuthentication {
 

--- a/connectors/app-integrations/src/main/java/io/camunda/connector/appintegrations/model/auth/OAuthAuthentication.java
+++ b/connectors/app-integrations/src/main/java/io/camunda/connector/appintegrations/model/auth/OAuthAuthentication.java
@@ -18,25 +18,22 @@ public record OAuthAuthentication(
     @Pattern(
             regexp = "^($|=|(http://|https://|secrets|\\{\\{).*$)",
             message = "Must be a http(s) URL")
-        @TemplateProperty(
-            group = "authentication",
-            label = "OAuth 2.0 token endpoint",
-            description = "The OAuth token endpoint")
+        @TemplateProperty(group = "authentication", label = "OAuth 2.0 token endpoint")
         String oauthTokenEndpoint,
     @TemplateProperty(
             group = "authentication",
             label = "Client ID",
-            description = "Your application's client ID from the OAuth client")
+            tooltip = "Your application's client ID from the OAuth client")
         String clientId,
     @TemplateProperty(
             group = "authentication",
             label = "Client secret",
-            description = "Your application's client secret from the OAuth client")
+            tooltip = "Your application's client secret from the OAuth client")
         String clientSecret,
     @TemplateProperty(
             group = "authentication",
             label = "Audience",
-            description = "The unique identifier of the target API you want to access",
+            tooltip = "The unique identifier of the target API you want to access",
             optional = true)
         String audience,
     @TemplateProperty(
@@ -52,14 +49,14 @@ public record OAuthAuthentication(
                   value = OAuthConstants.BASIC_AUTH_HEADER,
                   label = "Send as Basic Auth header")
             },
-            description =
+            tooltip =
                 "Send client ID and client secret as Basic Auth request in the header, or as client credentials in the request body")
         String clientAuthentication,
     @TemplateProperty(
             group = "authentication",
             label = "Scopes",
-            description =
-                "The scopes which you want to request authorization for (e.g. read:contacts)",
+            tooltip = "The scopes you want to request authorization for.",
+            placeholder = "read:contacts",
             optional = true)
         String scopes)
     implements AppIntegrationsAuthentication {


### PR DESCRIPTION
## Description

`connectors/app-integrations` shipped in #7588 (merged 2026-07-10) — between the two `tooltip-first element-template field hints` migration waves from #7470 (authored 2026-07-01, merged 2026-07-14, e.g. #7742–#7745). No slice ever touched it: 36 `description=` properties, only 4 `tooltip=`.

This applies the same decision rules from #7470 to all 5 `@TemplateProperty`-annotated classes in the module (`AppIntegrationsConfiguration`, `OAuthAuthentication`, `ApiKeyAuthentication`, `SendMessageRequest`, `CreateChannelRequest`):

- Merged redundant dual `description=`+`tooltip=` pairs into a single tooltip (`baseUrl`, `apiKey`).
- Removed `oauthTokenEndpoint`'s hint entirely — `"The OAuth token endpoint"` is redundant with its label `"OAuth 2.0 token endpoint"`.
- Extracted `has-example` hints into `placeholder=` (`scopes` → `read:contacts`, `email` → `=assigneeEmail`, `channelId` → `19:xxx@thread.tacv2`).
- Kept `displayName`'s "max 50 characters" as `description=` — genuine value-constraint, must stay always-visible; its explanatory sentence moved to `tooltip=`.
- Removed the `description` field's redundant hint (`"Optional description for the channel."` restates its own label).

`TemplateLinkedResource`'s `resourceIdDescription` (form-linking on `SendMessageRequest`) is intentionally untouched — that annotation has no `tooltip` equivalent at the generator level, same class of hard exception as `@TemplateDiscriminatorProperty`. Out of scope without a generator change.

Templates regenerated via `process-classes`; diff is content-only (verified with `--ignore-cr-at-eol`, no EOL churn). **No template version bump** — content/wording change only, not breaking.

## Related issues

closes #8320

## Checklist

- [ ] Backport labels — not applicable, this connector didn't exist before `stable/8.8`/`8.9` per its own #7588 origin; no prior version to backport onto.
- [ ] Tests/Integration tests — none added; existing `AppIntegrationsConnectorTest`/`AppIntegrationsConnectorWireMockTest` pass unchanged (content-only template change, no behavioral change).
- [ ] No documentation update needed — hint text only, no API/behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
