### PR TITLE
fix: pin amqp-client to 5.34.0

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -99,6 +99,10 @@ limitations under the License.</license.inlineheader>
     <version.hamcrest>3.0</version.hamcrest>
 
     <version.spring-boot>4.1.0</version.spring-boot>
+    <!-- CVE-2026-63337 / GHSA-jh4v-gfqj-7rhx: amqp-client transitive override — remove once
+         spring-boot-dependencies ships rabbit-amqp-client >= 5.34.0
+         Ref: https://github.com/rabbitmq/rabbitmq-java-client/security/advisories/GHSA-jh4v-gfqj-7rhx -->
+    <version.amqp-client>5.34.0</version.amqp-client>
     <tomcat.version>11.0.24</tomcat.version>
     <version.netty>4.2.16.Final</version.netty>
     <version.spring-cloud-gcp-starter-logging>8.1.0</version.spring-cloud-gcp-starter-logging>
@@ -744,6 +748,16 @@ limitations under the License.</license.inlineheader>
         <version>${version.lz4-java}</version>
       </dependency>
 
+      <!-- Temporary override: remove once spring-boot-dependencies manages
+           rabbit-amqp-client >= 5.34.0. Guarded by the version.spring-boot enforcer rule below.
+           Setting Spring Boot's own rabbit-amqp-client.version property would not work here:
+           a same-named property does not override a dependency-management import. -->
+      <dependency>
+        <groupId>com.rabbitmq</groupId>
+        <artifactId>amqp-client</artifactId>
+        <version>${version.amqp-client}</version>
+      </dependency>
+
       <dependency>
         <groupId>org.xerial.snappy</groupId>
         <artifactId>snappy-java</artifactId>
@@ -1109,6 +1123,22 @@ If the new spring-boot-dependencies BOM ships tools.jackson:jackson-bom &gt;= 3.
 remove the version.jackson3-bom property, the tools.jackson:jackson-bom dependencyManagement entry,
 and this enforcer rule from parent/pom.xml.
 See: https://nvd.nist.gov/vuln/detail/CVE-2026-59889
+                </regexMessage>
+              </requireProperty>
+              <!-- CVE-2026-63337 / GHSA-jh4v-gfqj-7rhx guard: fails if version.spring-boot is
+                   bumped, as a reminder to check whether the amqp-client override can be removed
+                   (see version.amqp-client). spring-boot-dependencies manages
+                   com.rabbitmq:amqp-client via its own rabbit-amqp-client.version property. -->
+              <requireProperty>
+                <property>version.spring-boot</property>
+                <regex>^4\.1\.0$</regex>
+                <regexMessage>
+version.spring-boot was changed! Check if the amqp-client CVE-2026-63337 override can be removed.
+If the new spring-boot-dependencies BOM ships com.rabbitmq:amqp-client &gt;= 5.34.0 (confirm with
+`mvn dependency:tree -Dincludes=com.rabbitmq:amqp-client`, not just the property), remove the
+version.amqp-client property, the amqp-client dependencyManagement entry, and this enforcer rule
+from parent/pom.xml.
+See: https://github.com/rabbitmq/rabbitmq-java-client/security/advisories/GHSA-jh4v-gfqj-7rhx
                 </regexMessage>
               </requireProperty>
             </rules>


### PR DESCRIPTION
## Summary

Pins `com.rabbitmq:amqp-client` from `5.30.0` to `5.34.0`.

The version is managed by the `spring-boot-dependencies` BOM, which does not yet ship a release with the fixed version, so it is pinned explicitly via `dependencyManagement` and guarded by an enforcer rule on `version.spring-boot` — the build will fail on the next Spring Boot bump as a reminder to drop the override.

Security fix. Details in the internal tracking issue: camunda/team-connectors#1259