### PR TITLE
ci(e2e): parallelize Maven builds and cache full .m2 repo for e2e test matrix

### DIFF
--- a/.github/workflows/E2E_BRANCH_RUN.yml
+++ b/.github/workflows/E2E_BRANCH_RUN.yml
@@ -146,14 +146,6 @@ jobs:
             secret/data/products/connectors/ci/nexus USER | CI_NEXUS_USR;
             secret/data/products/connectors/ci/nexus PASSWORD | CI_NEXUS_PSW;
 
-      - name: Restore cache
-        uses: actions/cache@v6
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
-
       - uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
@@ -200,7 +192,7 @@ jobs:
       # Run only this module's tests. No -am: base/connector SNAPSHOTs come from the downloaded
       # artifact, so nothing upstream is rebuilt.
       - name: Test e2e module
-        run: ./mvnw --batch-mode -T1C test -pl "${{ matrix.entry.module }}" -f connectors-e2e-test/pom.xml
+        run: ./mvnw --batch-mode test -pl "${{ matrix.entry.module }}" -f connectors-e2e-test/pom.xml
 
       - name: Publish Test Report
         if: always()

--- a/.github/workflows/E2E_BRANCH_RUN.yml
+++ b/.github/workflows/E2E_BRANCH_RUN.yml
@@ -67,7 +67,7 @@ jobs:
       # POM and all first-party e2e artifacts land in ~/.m2 for the test matrix). Tests are skipped
       # here; connector tests run in the next step, e2e tests run isolated in the matrix.
       - name: Build connectors
-        run: ./mvnw --batch-mode -U clean install -PcheckFormat -DskipTests
+        run: ./mvnw --batch-mode -T1C -U clean install -PcheckFormat -DskipTests
 
       # Non-PR (nightly/manual): run unit/integration tests for the connector modules. The whole
       # connectors-e2e-test subtree is excluded by enumerating every e2e pom path: excluding only the
@@ -104,12 +104,16 @@ jobs:
         env:
           BRANCH: ${{ inputs.branch }}
 
-      # Hand the built artifacts (connectors + e2e subtree) to the test matrix.
-      - name: Upload first-party artifacts
+      # Hand the fully-populated local Maven repo (first-party SNAPSHOTs + all third-party
+      # dependencies resolved during the build) to the test matrix, so test jobs resolve
+      # everything from the artifact instead of re-downloading their dependency tree from
+      # Nexus. Maven stays online in the test jobs, so anything missing still falls back to
+      # Nexus - the artifact just eliminates the bulk of the per-job resolution.
+      - name: Upload Maven repository
         uses: actions/upload-artifact@v7
         with:
-          name: m2-firstparty-${{ steps.sanitize.outputs.branch }}-${{ github.run_id }}
-          path: ~/.m2/repository/io/camunda/connector
+          name: m2-repo-${{ steps.sanitize.outputs.branch }}-${{ github.run_id }}
+          path: ~/.m2/repository
           retention-days: 1
           include-hidden-files: true
           overwrite: true
@@ -183,18 +187,20 @@ jobs:
           BRANCH: ${{ inputs.branch }}
           MODULE: ${{ matrix.entry.module }}
 
-      # Restore the first-party SNAPSHOTs built by the build job; the test run resolves
-      # connectors + e2e base from here and does not rebuild them.
-      - name: Download first-party artifacts
+      # Restore the fully-populated Maven repo built by the build job (first-party SNAPSHOTs +
+      # third-party dependencies). This lets the test run resolve its dependency tree locally
+      # instead of re-downloading it from Nexus on every matrix job. Maven stays online, so any
+      # artifact not present still falls back to Nexus.
+      - name: Download Maven repository
         uses: actions/download-artifact@v8
         with:
-          name: m2-firstparty-${{ steps.sanitize.outputs.branch }}-${{ github.run_id }}
-          path: ~/.m2/repository/io/camunda/connector
+          name: m2-repo-${{ steps.sanitize.outputs.branch }}-${{ github.run_id }}
+          path: ~/.m2/repository
 
       # Run only this module's tests. No -am: base/connector SNAPSHOTs come from the downloaded
       # artifact, so nothing upstream is rebuilt.
       - name: Test e2e module
-        run: ./mvnw --batch-mode test -pl "${{ matrix.entry.module }}" -f connectors-e2e-test/pom.xml
+        run: ./mvnw --batch-mode -T1C test -pl "${{ matrix.entry.module }}" -f connectors-e2e-test/pom.xml
 
       - name: Publish Test Report
         if: always()


### PR DESCRIPTION
## Description

Two runtime tweaks to the e2e branch-run workflow (`.github/workflows/E2E_BRANCH_RUN.yml`):

1. **Parallel Maven builds**: add `-T1C` (one thread per core) to both mvnw invocations that build/run the e2e reactor, so the build and each matrix test job compile faster.
2. **Full `.m2` repo cache reuse**: the build job previously uploaded only the first-party artifacts (`~/.m2/repository/io/camunda/connector`) for the test matrix to download. Now the entire `~/.m2/repository` (first-party + all resolved third-party dependencies) is uploaded/downloaded, so test jobs stop re-resolving their dependency tree from Nexus on every matrix run. Maven stays online, so anything missing still falls back to Nexus.

## Checklist

- [ ] Backport labels are added if these code changes should be backported.
- [x] Tests/Integration tests for the changes have been added if applicable. (CI workflow change only; no application code affected.)
- [ ] If the change requires a documentation update, it has been added to the appropriate section in the documentation.