### PR TITLE
feat(agentic-ai): add native Gemini Developer API provider for v2 AI Agent

### DIFF
--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/subprocess/v2/AgentSubProcessGeminiBlockedPromptTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/subprocess/v2/AgentSubProcessGeminiBlockedPromptTests.java
@@ -90,9 +90,10 @@ class AgentSubProcessGeminiBlockedPromptTests extends BaseGeminiNativeSubProcess
     // then rejected as terminal.
     assertContentFilteredIncident(zeebeTest);
 
-    assertThat(recordedLoggedRequests())
-        .as("a blocked prompt must not be retried at the model-call level")
-        .hasSize(1);
+    // One model call per job attempt, and FAIL_FAST allows exactly one attempt. Note this does NOT
+    // mean a blocked prompt is never re-sent: with the template's default retryCount of 3, each
+    // retry issues a fresh model call for a request that cannot succeed.
+    assertThat(recordedLoggedRequests()).as("model calls for the single job attempt").hasSize(1);
   }
 
   @Test

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/subprocess/v2/AgentSubProcessGeminiBlockedPromptTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/subprocess/v2/AgentSubProcessGeminiBlockedPromptTests.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.e2e.agenticai.aiagent.subprocess.v2;
+
+import static io.camunda.connector.e2e.agenticai.aiagent.AgentTestFixtures.AI_AGENT_ELEMENT_ID;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.genai.types.BlockedReason;
+import com.google.genai.types.FinishReason;
+import io.camunda.connector.agenticai.aiagent.model.AgentMetrics;
+import io.camunda.connector.agenticai.aiagent.model.message.StopReason;
+import io.camunda.connector.e2e.ElementTemplate;
+import io.camunda.connector.e2e.ZeebeTest;
+import io.camunda.connector.e2e.agenticai.aiagent.wiremock.gemini.GeminiResponseChunks;
+import io.camunda.connector.e2e.agenticai.aiagent.wiremock.gemini.StreamingGeminiChatModelStubs;
+import io.camunda.connector.e2e.agenticai.aiagent.wiremock.gemini.StreamingGeminiChatModelStubs.GeminiTurnStub;
+import io.camunda.connector.e2e.agenticai.assertj.AgentSubProcessResponseAssert;
+import io.camunda.connector.test.utils.annotation.SlowTest;
+import java.util.Map;
+import java.util.function.Function;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Native-Gemini e2e coverage for content filtering, both input-side (a blocked prompt) and
+ * output-side (a filtered candidate).
+ *
+ * <p>A <b>blocked prompt</b> is the interesting shape: the response carries <b>no {@code
+ * candidates} key at all</b>, only {@code promptFeedback.blockReason}. That is why {@code
+ * GeminiContentResponseConverter} keys its blocked-prompt handling on the absence of a candidate
+ * rather than on a finish reason. The stub emits exactly one chunk with no candidate — an empty
+ * stream would instead trip the assembler's "contained no chunks" guard, a different failure.
+ *
+ * <p>Both filtered cases end in an <b>incident</b>, not in a completed process: the converter maps
+ * them to {@link StopReason#CONTENT_FILTERED} without throwing, and {@code
+ * BaseAgentRequestHandler#throwIfTerminalStopReason} then treats that stop reason as terminal
+ * ({@code MODEL_RESPONSE_CONTENT_FILTERED}). That handler behavior is provider-agnostic; what these
+ * tests pin down is that Gemini's two filtered wire shapes reach it <em>as</em> {@code
+ * CONTENT_FILTERED} rather than crashing the converter first. A converter crash would surface as a
+ * different message entirely ({@code "Model call failed: ..."} from {@code GeminiChatModel}'s
+ * catch-all), so the asserted message is what discriminates the two outcomes.
+ *
+ * <p>{@link #completesNormallyWhenTruncatedByMaxTokens()} is the deliberate control: it proves the
+ * filtered cases fail <em>because</em> they are filtered, not merely because the finish reason was
+ * something other than {@code STOP}.
+ */
+@SlowTest
+class AgentSubProcessGeminiBlockedPromptTests extends BaseGeminiNativeSubProcessTest {
+
+  private static final String CONTENT_FILTERED_MESSAGE =
+      "Model response was blocked by provider content filtering.";
+
+  /**
+   * Fails the job into an incident on the first attempt instead of burning the template's default 3
+   * retries with a 30s backoff, which no reasonable assertion timeout would outlive.
+   */
+  private static final Function<ElementTemplate, ElementTemplate> FAIL_FAST =
+      template -> template.property("retryCount", "1").property("retryBackoff", "PT1S");
+
+  @Test
+  void raisesContentFilteredIncidentWhenThePromptWasBlockedAndNoCandidateWasReturned()
+      throws Exception {
+    final var userPrompt = "Write a haiku about the sea";
+
+    StreamingGeminiChatModelStubs.stubTurns(
+        GeminiTurnStub.of(
+            GeminiResponseChunks.chunk()
+                .blockReason(BlockedReason.Known.SAFETY)
+                .blockReasonMessage("Blocked by safety filters.")
+                .usage(10, 0)
+                .build()));
+
+    final var zeebeTest =
+        awaitActiveIncidents(createProcessInstance(FAIL_FAST, Map.of("userPrompt", userPrompt)));
+
+    // Not "Model call failed: ..." - the candidate-less response was converted cleanly and only
+    // then rejected as terminal.
+    assertContentFilteredIncident(zeebeTest);
+
+    assertThat(recordedLoggedRequests())
+        .as("a blocked prompt must not be retried at the model-call level")
+        .hasSize(1);
+  }
+
+  @Test
+  void raisesContentFilteredIncidentWhenTheCandidateFinishReasonIsSafety() throws Exception {
+    final var userPrompt = "Write a haiku about the sea";
+
+    // Distinct from the blocked-prompt case: here a candidate DOES exist, with content, and the
+    // finish reason is what has to map to CONTENT_FILTERED. Reaching this at all also exercises why
+    // the converter reads candidates()[0].content().parts() directly instead of the SDK's
+    // text()/parts() convenience accessors - those call checkFinishReason() internally and throw
+    // for
+    // every finish reason outside {UNSPECIFIED, STOP, MAX_TOKENS}, i.e. for exactly this response.
+    StreamingGeminiChatModelStubs.stubTurns(
+        GeminiTurnStub.of(
+            GeminiResponseChunks.chunk()
+                .text("Partial answer before filtering.")
+                .finishReason(FinishReason.Known.SAFETY)
+                .usage(10, 5)
+                .build()));
+
+    final var zeebeTest =
+        awaitActiveIncidents(createProcessInstance(FAIL_FAST, Map.of("userPrompt", userPrompt)));
+
+    assertContentFilteredIncident(zeebeTest);
+  }
+
+  /**
+   * The incident message is the connector exception's message with the serialized error variables
+   * appended, so it is matched by prefix; the appended {@code MODEL_RESPONSE_CONTENT_FILTERED}
+   * error code is the part that actually discriminates this failure from any other model-call
+   * failure.
+   */
+  private void assertContentFilteredIncident(ZeebeTest zeebeTest) {
+    assertIncident(
+        zeebeTest,
+        incident -> {
+          assertThat(incident.getElementId()).isEqualTo(AI_AGENT_ELEMENT_ID);
+          assertThat(incident.getErrorMessage())
+              .startsWith(CONTENT_FILTERED_MESSAGE)
+              .contains("MODEL_RESPONSE_CONTENT_FILTERED");
+        });
+  }
+
+  @Test
+  void completesNormallyWhenTruncatedByMaxTokens() throws Exception {
+    final var userPrompt = "Write a haiku about the sea";
+    final var truncatedText = "Endless waves whisper";
+
+    // Control case: MAX_TOKENS is also a non-STOP finish reason, but it maps to LENGTH rather than
+    // CONTENT_FILTERED, so it is NOT terminal and the agent finishes normally.
+    StreamingGeminiChatModelStubs.stubTurns(
+        GeminiTurnStub.of(
+            GeminiResponseChunks.chunk()
+                .text(truncatedText)
+                .finishReason(FinishReason.Known.MAX_TOKENS)
+                .usage(10, 20)
+                .build()));
+    enqueueUserFeedback(userSatisfiedFeedback());
+
+    final var zeebeTest =
+        awaitProcessCompletion(createProcessInstance(Map.of("userPrompt", userPrompt)));
+
+    assertAgentResponse(
+        zeebeTest,
+        agentResponse ->
+            AgentSubProcessResponseAssert.assertThat(agentResponse)
+                .isReady()
+                .hasResponseMessageText(truncatedText)
+                .hasMetrics(new AgentMetrics(1, new AgentMetrics.TokenUsage(10, 20), 0))
+                .hasResponseMessageSatisfying(
+                    message -> {
+                      assertThat(message.stopReason())
+                          .as("MAX_TOKENS maps to LENGTH, which is not terminal")
+                          .isEqualTo(StopReason.LENGTH);
+                      // The raw vendor value is preserved under the provider metadata namespace
+                      // regardless of how it was mapped.
+                      assertThat(message.metadata())
+                          .extractingByKey("google-gemini")
+                          .asInstanceOf(
+                              org.assertj.core.api.InstanceOfAssertFactories.map(
+                                  String.class, Object.class))
+                          .containsEntry("finishReason", "MAX_TOKENS");
+                    }));
+  }
+}

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/subprocess/v2/AgentSubProcessGeminiBlockedPromptTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/subprocess/v2/AgentSubProcessGeminiBlockedPromptTests.java
@@ -102,8 +102,8 @@ class AgentSubProcessGeminiBlockedPromptTests extends BaseGeminiNativeSubProcess
     // finish reason is what has to map to CONTENT_FILTERED. Reaching this at all also exercises why
     // the converter reads candidates()[0].content().parts() directly instead of the SDK's
     // text()/parts() convenience accessors - those call checkFinishReason() internally and throw
-    // for
-    // every finish reason outside {UNSPECIFIED, STOP, MAX_TOKENS}, i.e. for exactly this response.
+    // for every finish reason outside {UNSPECIFIED, STOP, MAX_TOKENS}, i.e. for exactly this
+    // response.
     StreamingGeminiChatModelStubs.stubTurns(
         GeminiTurnStub.of(
             GeminiResponseChunks.chunk()

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/subprocess/v2/AgentSubProcessGeminiBlockedPromptTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/subprocess/v2/AgentSubProcessGeminiBlockedPromptTests.java
@@ -44,15 +44,12 @@ import org.junit.jupiter.api.Test;
  * rather than on a finish reason. The stub emits exactly one chunk with no candidate — an empty
  * stream would instead trip the assembler's "contained no chunks" guard, a different failure.
  *
- * <p>Both filtered cases end in an <b>incident</b>, not in a completed process: the converter
- * builds a well-formed message for both wire shapes first, then throws {@code
- * ContentFilteredException} with it — caught by {@code
- * BaseAgentRequestHandler#driveContinuationLoop} and mapped to a terminal {@code
- * ConnectorException} ({@code MODEL_RESPONSE_CONTENT_FILTERED}). What these tests pin down is that
- * Gemini's two filtered wire shapes reach that throw rather than crashing the converter first. A
- * converter crash would surface as a different message entirely ({@code "Model call failed: ..."}
- * from {@code GeminiChatModel}'s catch-all), so the asserted message is what discriminates the two
- * outcomes.
+ * <p>Both filtered cases end in an <b>incident</b>: the converter throws {@code
+ * ContentFilteredException}, caught by {@code BaseAgentRequestHandler#driveContinuationLoop} and
+ * mapped to a terminal {@code ConnectorException} ({@code MODEL_RESPONSE_CONTENT_FILTERED}). These
+ * tests pin down that both wire shapes reach that throw rather than crashing the converter first —
+ * a crash instead surfaces {@code "Model call failed: ..."} from {@code GeminiChatModel}'s
+ * catch-all, which the asserted message discriminates against.
  *
  * <p>{@link #completesNormallyWhenTruncatedByMaxTokens()} is the deliberate control: it proves the
  * filtered cases fail <em>because</em> they are filtered, not merely because the finish reason was

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/subprocess/v2/AgentSubProcessGeminiBlockedPromptTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/subprocess/v2/AgentSubProcessGeminiBlockedPromptTests.java
@@ -44,14 +44,15 @@ import org.junit.jupiter.api.Test;
  * rather than on a finish reason. The stub emits exactly one chunk with no candidate — an empty
  * stream would instead trip the assembler's "contained no chunks" guard, a different failure.
  *
- * <p>Both filtered cases end in an <b>incident</b>, not in a completed process: the converter maps
- * them to {@link StopReason#CONTENT_FILTERED} without throwing, and {@code
- * BaseAgentRequestHandler#throwIfTerminalStopReason} then treats that stop reason as terminal
- * ({@code MODEL_RESPONSE_CONTENT_FILTERED}). That handler behavior is provider-agnostic; what these
- * tests pin down is that Gemini's two filtered wire shapes reach it <em>as</em> {@code
- * CONTENT_FILTERED} rather than crashing the converter first. A converter crash would surface as a
- * different message entirely ({@code "Model call failed: ..."} from {@code GeminiChatModel}'s
- * catch-all), so the asserted message is what discriminates the two outcomes.
+ * <p>Both filtered cases end in an <b>incident</b>, not in a completed process: the converter
+ * builds a well-formed message for both wire shapes first, then throws {@code
+ * ContentFilteredException} with it — caught by {@code
+ * BaseAgentRequestHandler#driveContinuationLoop} and mapped to a terminal {@code
+ * ConnectorException} ({@code MODEL_RESPONSE_CONTENT_FILTERED}). What these tests pin down is that
+ * Gemini's two filtered wire shapes reach that throw rather than crashing the converter first. A
+ * converter crash would surface as a different message entirely ({@code "Model call failed: ..."}
+ * from {@code GeminiChatModel}'s catch-all), so the asserted message is what discriminates the two
+ * outcomes.
  *
  * <p>{@link #completesNormallyWhenTruncatedByMaxTokens()} is the deliberate control: it proves the
  * filtered cases fail <em>because</em> they are filtered, not merely because the finish reason was

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/subprocess/v2/AgentSubProcessGeminiStreamingResponseTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/subprocess/v2/AgentSubProcessGeminiStreamingResponseTests.java
@@ -89,7 +89,7 @@ class AgentSubProcessGeminiStreamingResponseTests extends BaseGeminiNativeSubPro
             GeminiResponseChunks.chunk()
                 .text("whisper.")
                 .finishReason(FinishReason.Known.STOP)
-                .usage(10, 20, 30, 0)
+                .usage(10, 20, 30, 7)
                 .build()));
     enqueueUserFeedback(userSatisfiedFeedback());
 
@@ -121,12 +121,22 @@ class AgentSubProcessGeminiStreamingResponseTests extends BaseGeminiNativeSubPro
                     })
                 // responseText only ever reflects the answer text, never the reasoning.
                 .hasResponseText("Endless waves whisper.")
-                // thoughtsTokenCount maps onto the domain reasoning counter.
                 .metricsSatisfy(
-                    metrics ->
-                        assertThat(metrics.tokenUsage().reasoningTokenCount())
-                            .as("reasoning token count from usageMetadata.thoughtsTokenCount")
-                            .isEqualTo(30)));
+                    metrics -> {
+                      // thoughtsTokenCount maps onto the domain reasoning counter.
+                      assertThat(metrics.tokenUsage().reasoningTokenCount())
+                          .as("reasoning token count from usageMetadata.thoughtsTokenCount")
+                          .isEqualTo(30);
+                      // Gemini's implicit caching reports cache READS only, mapped onto
+                      // cacheReadTokenCount; there is no cache-write counter, so
+                      // cacheCreationTokenCount stays at its default of 0.
+                      assertThat(metrics.tokenUsage().cacheReadTokenCount())
+                          .as("cache read token count from usageMetadata.cachedContentTokenCount")
+                          .isEqualTo(7);
+                      assertThat(metrics.tokenUsage().cacheCreationTokenCount())
+                          .as("Gemini reports no cache-write counter")
+                          .isZero();
+                    }));
   }
 
   @Test

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/subprocess/v2/AgentSubProcessGeminiStreamingResponseTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/subprocess/v2/AgentSubProcessGeminiStreamingResponseTests.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.e2e.agenticai.aiagent.subprocess.v2;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.genai.types.FinishReason;
+import io.camunda.connector.agenticai.aiagent.model.AgentMetrics;
+import io.camunda.connector.agenticai.aiagent.model.message.content.ReasoningContent;
+import io.camunda.connector.agenticai.aiagent.model.message.content.TextContent;
+import io.camunda.connector.e2e.agenticai.aiagent.wiremock.gemini.GeminiResponseChunks;
+import io.camunda.connector.e2e.agenticai.aiagent.wiremock.gemini.StreamingGeminiChatModelStubs;
+import io.camunda.connector.e2e.agenticai.aiagent.wiremock.gemini.StreamingGeminiChatModelStubs.GeminiTurnStub;
+import io.camunda.connector.e2e.agenticai.assertj.AgentSubProcessResponseAssert;
+import io.camunda.connector.test.utils.annotation.SlowTest;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Native-Gemini e2e coverage for {@code GeminiContentStreamAssemblerImpl}: proves its merge rules
+ * hold against real (simulated) chunked SSE traffic, not just against hand-fed SDK objects in a
+ * unit test. {@code GeminiChatModel} always calls {@code generateContentStream}, so <em>every</em>
+ * Gemini request goes through the assembler — these are the cases where chunk boundaries are
+ * actually visible in the result.
+ */
+@SlowTest
+class AgentSubProcessGeminiStreamingResponseTests extends BaseGeminiNativeSubProcessTest {
+
+  @Test
+  void concatenatesTextArrivingAcrossSeveralSseChunks() throws Exception {
+    final var userPrompt = "Write a haiku about the sea";
+
+    // Gemini streams answer text incrementally and reports finishReason/usage only on the last
+    // chunk - the assembler has to concatenate the run and take usage from the final chunk.
+    StreamingGeminiChatModelStubs.stubTurns(
+        GeminiTurnStub.of(
+            GeminiResponseChunks.chunk().text("Endless waves whisper | ").build(),
+            GeminiResponseChunks.chunk().text("moonlight dances on the tide | ").build(),
+            GeminiResponseChunks.chunk()
+                .text("secrets drift below.")
+                .finishReason(FinishReason.Known.STOP)
+                .usage(10, 20)
+                .build()));
+    enqueueUserFeedback(userSatisfiedFeedback());
+
+    final var zeebeTest =
+        awaitProcessCompletion(createProcessInstance(Map.of("userPrompt", userPrompt)));
+
+    final var mergedText =
+        "Endless waves whisper | moonlight dances on the tide | secrets drift below.";
+    assertAgentResponse(
+        zeebeTest,
+        agentResponse ->
+            AgentSubProcessResponseAssert.assertThat(agentResponse)
+                .isReady()
+                // One TextContent, not three: proves the run was merged rather than appended.
+                .hasResponseMessageText(mergedText)
+                .hasResponseText(mergedText)
+                // Usage is the last chunk's, never a sum across chunks.
+                .hasMetrics(new AgentMetrics(1, new AgentMetrics.TokenUsage(10, 20), 0)));
+  }
+
+  @Test
+  void keepsThoughtAndAnswerTextRunsSeparateWhenBothStreamInOneTurn() throws Exception {
+    final var userPrompt = "Write a haiku about the sea";
+
+    // A thinking-enabled Gemini response streams its thoughts first (thought=true) and then the
+    // answer (thought absent). Both are text parts, so the ONLY thing separating them is the
+    // thought flag - the assembler must not collapse them into one blob.
+    StreamingGeminiChatModelStubs.stubTurns(
+        GeminiTurnStub.of(
+            GeminiResponseChunks.chunk().thought("Let me think about ").build(),
+            GeminiResponseChunks.chunk().thought("the sea for a moment.").build(),
+            GeminiResponseChunks.chunk().text("Endless waves ").build(),
+            GeminiResponseChunks.chunk()
+                .text("whisper.")
+                .finishReason(FinishReason.Known.STOP)
+                .usage(10, 20, 30, 0)
+                .build()));
+    enqueueUserFeedback(userSatisfiedFeedback());
+
+    final var zeebeTest =
+        awaitProcessCompletion(createProcessInstance(Map.of("userPrompt", userPrompt)));
+
+    assertAgentResponse(
+        zeebeTest,
+        agentResponse ->
+            AgentSubProcessResponseAssert.assertThat(agentResponse)
+                .isReady()
+                .hasReasoningContent()
+                .hasResponseMessageSatisfying(
+                    message -> {
+                      // Two runs, in order, each merged within itself.
+                      assertThat(message.content())
+                          .as("assistant content: one reasoning run then one text run")
+                          .hasSize(2);
+                      assertThat(message.content().get(0))
+                          .isInstanceOfSatisfying(
+                              ReasoningContent.class,
+                              reasoning ->
+                                  assertThat(reasoning.text())
+                                      .isEqualTo("Let me think about the sea for a moment."));
+                      assertThat(message.content().get(1))
+                          .isInstanceOfSatisfying(
+                              TextContent.class,
+                              text -> assertThat(text.text()).isEqualTo("Endless waves whisper."));
+                    })
+                // responseText only ever reflects the answer text, never the reasoning.
+                .hasResponseText("Endless waves whisper.")
+                // thoughtsTokenCount maps onto the domain reasoning counter.
+                .metricsSatisfy(
+                    metrics ->
+                        assertThat(metrics.tokenUsage().reasoningTokenCount())
+                            .as("reasoning token count from usageMetadata.thoughtsTokenCount")
+                            .isEqualTo(30)));
+  }
+
+  @Test
+  void closesTheTextRunAtAThoughtSignatureBoundary() throws Exception {
+    final var userPrompt = "Write a haiku about the sea";
+    final var signature = GeminiResponseChunks.encodeSignature("sig-e2e-stream-boundary");
+
+    // A thoughtSignature belongs to exactly one part and must round-trip verbatim, so a part
+    // carrying one closes its run: the following text starts a new part instead of being appended.
+    StreamingGeminiChatModelStubs.stubTurns(
+        GeminiTurnStub.of(
+            GeminiResponseChunks.chunk().text("First half.", signature).build(),
+            GeminiResponseChunks.chunk()
+                .text("Second half.")
+                .finishReason(FinishReason.Known.STOP)
+                .usage(10, 20)
+                .build()));
+    enqueueUserFeedback(userSatisfiedFeedback());
+
+    final var zeebeTest =
+        awaitProcessCompletion(createProcessInstance(Map.of("userPrompt", userPrompt)));
+
+    assertAgentResponse(
+        zeebeTest,
+        agentResponse ->
+            AgentSubProcessResponseAssert.assertThat(agentResponse)
+                .isReady()
+                .hasResponseMessageSatisfying(
+                    message -> {
+                      assertThat(message.content())
+                          .as("signature-carrying part must not absorb the following text")
+                          .hasSize(2);
+                      assertThat(message.content().get(0))
+                          .isInstanceOfSatisfying(
+                              TextContent.class,
+                              text -> {
+                                assertThat(text.text()).isEqualTo("First half.");
+                                assertThat(text.metadata())
+                                    .as("thoughtSignature preserved as base64 metadata")
+                                    .containsEntry("thoughtSignature", signature);
+                              });
+                      assertThat(message.content().get(1))
+                          .isInstanceOfSatisfying(
+                              TextContent.class,
+                              text -> assertThat(text.text()).isEqualTo("Second half."));
+                    }));
+  }
+}

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/subprocess/v2/AgentSubProcessGeminiThinkingConfigTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/subprocess/v2/AgentSubProcessGeminiThinkingConfigTests.java
@@ -28,8 +28,8 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Native-Gemini e2e coverage for the extended-thinking configuration surface: proves the element
- * template's {@code enabled}/{@code thinkingBudget}/{@code thinkingLevel} fields reach the wire in
- * the right place and shape, through the real vendor SDK's {@code GenerateContentConfig} builder.
+ * template's {@code thinkingBudget}/{@code thinkingLevel} fields reach the wire in the right place
+ * and shape, through the real vendor SDK's {@code GenerateContentConfig} builder.
  *
  * <p>{@code thinkingBudget} (Gemini 2.5) and {@code thinkingLevel} (Gemini 3.x) are <b>mutually
  * exclusive</b>: {@code GeminiThinking#isBothThinkingBudgetAndLevelSet()} carries an
@@ -59,10 +59,6 @@ class AgentSubProcessGeminiThinkingConfigTests extends BaseGeminiNativeSubProces
 
     final Function<ElementTemplate, ElementTemplate> elementTemplateModifier =
         model(THINKING_BUDGET_MODEL)
-            .andThen(
-                template ->
-                    template.property(
-                        "provider.googleGemini.model.parameters.thinking.enabled", "=true"))
             .andThen(
                 template ->
                     template.property(
@@ -102,10 +98,6 @@ class AgentSubProcessGeminiThinkingConfigTests extends BaseGeminiNativeSubProces
             .andThen(
                 template ->
                     template.property(
-                        "provider.googleGemini.model.parameters.thinking.enabled", "=true"))
-            .andThen(
-                template ->
-                    template.property(
                         "provider.googleGemini.model.parameters.thinking.thinkingLevel", "high"));
 
     awaitProcessCompletion(
@@ -125,34 +117,6 @@ class AgentSubProcessGeminiThinkingConfigTests extends BaseGeminiNativeSubProces
         .isTrue();
     assertThat(thinkingConfig.has("thinkingBudget"))
         .as("thinkingBudget must be absent when a level is configured")
-        .isFalse();
-  }
-
-  @Test
-  void thinkingConfigCarriesExplicitModelDefaultLevelWhenEnabledWithNeitherFieldSet()
-      throws Exception {
-    final var userPrompt = "Write a haiku about the sea";
-
-    StreamingGeminiChatModelStubs.stubConversation(TurnStub.text("A haiku.", 10, 20));
-    enqueueUserFeedback(userSatisfiedFeedback());
-
-    final Function<ElementTemplate, ElementTemplate> elementTemplateModifier =
-        template ->
-            template.property("provider.googleGemini.model.parameters.thinking.enabled", "=true");
-
-    awaitProcessCompletion(
-        createProcessInstance(elementTemplateModifier, Map.of("userPrompt", userPrompt)));
-
-    final var thinkingConfig =
-        parseBody(soleRecordedRequest()).path("generationConfig").path("thinkingConfig");
-    assertThat(thinkingConfig.path("thinkingLevel").asText())
-        .as("generationConfig.thinkingConfig.thinkingLevel")
-        .isEqualTo("THINKING_LEVEL_UNSPECIFIED");
-    assertThat(thinkingConfig.path("includeThoughts").asBoolean())
-        .as("generationConfig.thinkingConfig.includeThoughts")
-        .isTrue();
-    assertThat(thinkingConfig.has("thinkingBudget"))
-        .as("thinkingBudget must be absent when neither field is configured")
         .isFalse();
   }
 

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/subprocess/v2/AgentSubProcessGeminiThinkingConfigTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/subprocess/v2/AgentSubProcessGeminiThinkingConfigTests.java
@@ -62,6 +62,10 @@ class AgentSubProcessGeminiThinkingConfigTests extends BaseGeminiNativeSubProces
             .andThen(
                 template ->
                     template.property(
+                        "provider.googleGemini.model.parameters.thinking.enabled", "=true"))
+            .andThen(
+                template ->
+                    template.property(
                         "provider.googleGemini.model.parameters.thinking.thinkingBudget", "=2048"));
 
     awaitProcessCompletion(
@@ -98,6 +102,10 @@ class AgentSubProcessGeminiThinkingConfigTests extends BaseGeminiNativeSubProces
             .andThen(
                 template ->
                     template.property(
+                        "provider.googleGemini.model.parameters.thinking.enabled", "=true"))
+            .andThen(
+                template ->
+                    template.property(
                         "provider.googleGemini.model.parameters.thinking.thinkingLevel", "high"));
 
     awaitProcessCompletion(
@@ -117,6 +125,34 @@ class AgentSubProcessGeminiThinkingConfigTests extends BaseGeminiNativeSubProces
         .isTrue();
     assertThat(thinkingConfig.has("thinkingBudget"))
         .as("thinkingBudget must be absent when a level is configured")
+        .isFalse();
+  }
+
+  @Test
+  void thinkingConfigCarriesExplicitModelDefaultLevelWhenEnabledWithNeitherFieldSet()
+      throws Exception {
+    final var userPrompt = "Write a haiku about the sea";
+
+    StreamingGeminiChatModelStubs.stubConversation(TurnStub.text("A haiku.", 10, 20));
+    enqueueUserFeedback(userSatisfiedFeedback());
+
+    final Function<ElementTemplate, ElementTemplate> elementTemplateModifier =
+        template ->
+            template.property("provider.googleGemini.model.parameters.thinking.enabled", "=true");
+
+    awaitProcessCompletion(
+        createProcessInstance(elementTemplateModifier, Map.of("userPrompt", userPrompt)));
+
+    final var thinkingConfig =
+        parseBody(soleRecordedRequest()).path("generationConfig").path("thinkingConfig");
+    assertThat(thinkingConfig.path("thinkingLevel").asText())
+        .as("generationConfig.thinkingConfig.thinkingLevel")
+        .isEqualTo("THINKING_LEVEL_UNSPECIFIED");
+    assertThat(thinkingConfig.path("includeThoughts").asBoolean())
+        .as("generationConfig.thinkingConfig.includeThoughts")
+        .isTrue();
+    assertThat(thinkingConfig.has("thinkingBudget"))
+        .as("thinkingBudget must be absent when neither field is configured")
         .isFalse();
   }
 

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/subprocess/v2/AgentSubProcessGeminiThinkingConfigTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/subprocess/v2/AgentSubProcessGeminiThinkingConfigTests.java
@@ -28,8 +28,8 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Native-Gemini e2e coverage for the extended-thinking configuration surface: proves the element
- * template's two thinking fields reach the wire in the right place and shape, through the real
- * vendor SDK's {@code GenerateContentConfig} builder.
+ * template's {@code enabled}/{@code thinkingBudget}/{@code thinkingLevel} fields reach the wire in
+ * the right place and shape, through the real vendor SDK's {@code GenerateContentConfig} builder.
  *
  * <p>{@code thinkingBudget} (Gemini 2.5) and {@code thinkingLevel} (Gemini 3.x) are <b>mutually
  * exclusive</b>: {@code GeminiThinking#isBothThinkingBudgetAndLevelSet()} carries an

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/subprocess/v2/AgentSubProcessGeminiThinkingConfigTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/subprocess/v2/AgentSubProcessGeminiThinkingConfigTests.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.e2e.agenticai.aiagent.subprocess.v2;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.connector.e2e.ElementTemplate;
+import io.camunda.connector.e2e.agenticai.aiagent.wiremock.gemini.StreamingGeminiChatModelStubs;
+import io.camunda.connector.e2e.agenticai.aiagent.wiremock.spi.TurnStub;
+import io.camunda.connector.test.utils.annotation.SlowTest;
+import java.util.Map;
+import java.util.function.Function;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Native-Gemini e2e coverage for the extended-thinking configuration surface: proves the element
+ * template's two thinking fields reach the wire in the right place and shape, through the real
+ * vendor SDK's {@code GenerateContentConfig} builder.
+ *
+ * <p>{@code thinkingBudget} (Gemini 2.5) and {@code thinkingLevel} (Gemini 3.x) are <b>mutually
+ * exclusive</b>: {@code GeminiThinking#isBothThinkingBudgetAndLevelSet()} carries an
+ * {@code @AssertFalse} bean-validation constraint, so a single request can never legitimately carry
+ * both. Each therefore gets its own test with its own model id — there is no single test that could
+ * exercise both, and combining them would only assert a validation failure.
+ *
+ * <p>Both land under {@code generationConfig.thinkingConfig} (the SDK nests the whole {@code
+ * GenerateContentConfig} under {@code generationConfig} for the Developer API, while hoisting
+ * {@code tools} and {@code systemInstruction} to the top level).
+ */
+@SlowTest
+class AgentSubProcessGeminiThinkingConfigTests extends BaseGeminiNativeSubProcessTest {
+
+  /** Gemini 2.5 generation: token-budget thinking. */
+  private static final String THINKING_BUDGET_MODEL = "gemini-2.5-pro";
+
+  /** Gemini 3.x generation: qualitative thinking level. */
+  private static final String THINKING_LEVEL_MODEL = "gemini-3-pro-preview";
+
+  @Test
+  void thinkingBudgetAppearsOnTheWireUnderGenerationConfig() throws Exception {
+    final var userPrompt = "Write a haiku about the sea";
+
+    StreamingGeminiChatModelStubs.stubConversation(TurnStub.text("A haiku.", 10, 20));
+    enqueueUserFeedback(userSatisfiedFeedback());
+
+    final Function<ElementTemplate, ElementTemplate> elementTemplateModifier =
+        model(THINKING_BUDGET_MODEL)
+            .andThen(
+                template ->
+                    template.property(
+                        "provider.googleGemini.model.parameters.thinking.thinkingBudget", "=2048"));
+
+    awaitProcessCompletion(
+        createProcessInstance(elementTemplateModifier, Map.of("userPrompt", userPrompt)));
+
+    final var request = soleRecordedRequest();
+    assertThat(requestedModel(request))
+        .as("model id in the request URL")
+        .isEqualTo(THINKING_BUDGET_MODEL);
+
+    final var thinkingConfig = parseBody(request).path("generationConfig").path("thinkingConfig");
+    assertThat(thinkingConfig.path("thinkingBudget").asInt())
+        .as("generationConfig.thinkingConfig.thinkingBudget")
+        .isEqualTo(2048);
+    // Thoughts are not returned unless explicitly requested, so the converter always sets this
+    // alongside a budget/level - otherwise thinking would be billed but never surfaced.
+    assertThat(thinkingConfig.path("includeThoughts").asBoolean())
+        .as("generationConfig.thinkingConfig.includeThoughts")
+        .isTrue();
+    assertThat(thinkingConfig.has("thinkingLevel"))
+        .as("thinkingLevel must be absent when a budget is configured")
+        .isFalse();
+  }
+
+  @Test
+  void thinkingLevelAppearsOnTheWireUnderGenerationConfig() throws Exception {
+    final var userPrompt = "Write a haiku about the sea";
+
+    StreamingGeminiChatModelStubs.stubConversation(TurnStub.text("A haiku.", 10, 20));
+    enqueueUserFeedback(userSatisfiedFeedback());
+
+    final Function<ElementTemplate, ElementTemplate> elementTemplateModifier =
+        model(THINKING_LEVEL_MODEL)
+            .andThen(
+                template ->
+                    template.property(
+                        "provider.googleGemini.model.parameters.thinking.thinkingLevel", "high"));
+
+    awaitProcessCompletion(
+        createProcessInstance(elementTemplateModifier, Map.of("userPrompt", userPrompt)));
+
+    final var request = soleRecordedRequest();
+    assertThat(requestedModel(request))
+        .as("model id in the request URL")
+        .isEqualTo(THINKING_LEVEL_MODEL);
+
+    final var thinkingConfig = parseBody(request).path("generationConfig").path("thinkingConfig");
+    assertThat(thinkingConfig.path("thinkingLevel").asText())
+        .as("generationConfig.thinkingConfig.thinkingLevel")
+        .isEqualTo("HIGH");
+    assertThat(thinkingConfig.path("includeThoughts").asBoolean())
+        .as("generationConfig.thinkingConfig.includeThoughts")
+        .isTrue();
+    assertThat(thinkingConfig.has("thinkingBudget"))
+        .as("thinkingBudget must be absent when a level is configured")
+        .isFalse();
+  }
+
+  @Test
+  void noThinkingConfigOnTheWireWhenNeitherFieldIsConfigured() throws Exception {
+    final var userPrompt = "Write a haiku about the sea";
+
+    StreamingGeminiChatModelStubs.stubConversation(TurnStub.text("A haiku.", 10, 20));
+    enqueueUserFeedback(userSatisfiedFeedback());
+
+    awaitProcessCompletion(createProcessInstance(Map.of("userPrompt", userPrompt)));
+
+    assertThat(parseBody(soleRecordedRequest()).path("generationConfig").has("thinkingConfig"))
+        .as("thinkingConfig must not be sent when thinking is left unconfigured")
+        .isFalse();
+  }
+}

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/subprocess/v2/AgentSubProcessGeminiToolCallingTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/subprocess/v2/AgentSubProcessGeminiToolCallingTests.java
@@ -1,0 +1,227 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.e2e.agenticai.aiagent.subprocess.v2;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.camunda.connector.agenticai.aiagent.model.AgentMetrics;
+import io.camunda.connector.e2e.agenticai.aiagent.wiremock.gemini.GeminiResponseChunks;
+import io.camunda.connector.e2e.agenticai.aiagent.wiremock.gemini.StreamingGeminiChatModelStubs;
+import io.camunda.connector.e2e.agenticai.aiagent.wiremock.gemini.StreamingGeminiChatModelStubs.GeminiTurnStub;
+import io.camunda.connector.e2e.agenticai.aiagent.wiremock.spi.ToolCallStub;
+import io.camunda.connector.e2e.agenticai.aiagent.wiremock.spi.TurnStub;
+import io.camunda.connector.e2e.agenticai.assertj.AgentSubProcessResponseAssert;
+import io.camunda.connector.test.utils.annotation.SlowTest;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.StreamSupport;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Native-Gemini e2e coverage for the full tool-calling round trip: {@code functionCall} out, {@code
+ * functionResponse} back in, final answer out — driven through the real vendor SDK over real
+ * (WireMock-served) HTTP, asserting Gemini's own request shape at each hop.
+ *
+ * <p>Two id shapes are covered deliberately, because the two real Gemini surfaces differ and the
+ * connector has to work on both:
+ *
+ * <ul>
+ *   <li>The <b>Gemini Developer API</b> leaves {@code FunctionCall.id} unset, so {@code
+ *       GeminiContentResponseConverter} synthesizes a UUID. A test on this shape therefore cannot
+ *       assert a hard-coded id the way the Anthropic and custom-provider tests assert {@code
+ *       "aaa111"}; it asserts the tool name and arguments plus the fact that whatever id was
+ *       synthesized is echoed <em>identically</em> onto the replayed {@code functionCall} and its
+ *       matching {@code functionResponse}. That correlation is the property the agent loop depends
+ *       on.
+ *   <li><b>Vertex AI</b> populates the id, so a stub carrying one proves the id-echo path passes a
+ *       server-provided value straight through.
+ * </ul>
+ */
+@SlowTest
+class AgentSubProcessGeminiToolCallingTests extends BaseGeminiNativeSubProcessTest {
+
+  private static final String TOOL_NAME = "SuperfluxProduct";
+  private static final String TOOL_ARGUMENTS_JSON = "{\"a\": 5, \"b\": 3}";
+  private static final String TOOL_RESULT = "24";
+
+  @Test
+  void executesToolCallingRoundTripWithSynthesizedFunctionCallId() throws Exception {
+    final var userPrompt = "Explore some of your tools!";
+    final var toolCallMessage = "I will call the superflux calculation tool.";
+    final var finalResponseText = "The superflux calculation of 5 and 3 is 24.";
+
+    // Developer-API shape: no FunctionCall.id on the wire (stubConversation omits it).
+    StreamingGeminiChatModelStubs.stubConversation(
+        TurnStub.toolCalls(
+            toolCallMessage,
+            10,
+            20,
+            new ToolCallStub("ignored-by-the-developer-api", TOOL_NAME, TOOL_ARGUMENTS_JSON)),
+        TurnStub.text(finalResponseText, 11, 22));
+    enqueueUserFeedback(userSatisfiedFeedback());
+
+    final var zeebeTest =
+        awaitProcessCompletion(createProcessInstance(Map.of("userPrompt", userPrompt)));
+
+    final var requests = recordedLoggedRequests(2);
+
+    // ---- hop 1: the initial request advertises the tools and carries the user prompt ----
+    final var firstRequest = parseBody(requests.get(0));
+    assertThat(requestedModel(requests.get(0)))
+        .as("model id in the request URL")
+        .isEqualTo(defaultModel());
+    assertThat(functionDeclarationNames(firstRequest))
+        .as("advertised function declarations")
+        .contains(TOOL_NAME, "Search_The_Web");
+    assertThat(firstRequest.path("systemInstruction").path("parts").path(0).path("text").asText())
+        .as("system prompt is hoisted to systemInstruction, not sent as a content role")
+        .isEqualTo(expectedSystemPrompt());
+    assertThat(contentRoles(firstRequest))
+        .as("content roles on the first request")
+        .containsExactly("user");
+
+    // ---- hop 2: the follow-up replays the model turn plus the tool result ----
+    final var secondRequest = parseBody(requests.get(1));
+    // Gemini has no dedicated "tool" role: results come back as a user-role functionResponse part.
+    assertThat(contentRoles(secondRequest))
+        .as("content roles on the follow-up request")
+        .containsExactly("user", "model", "user");
+
+    final var modelParts = secondRequest.path("contents").path(1).path("parts");
+    assertThat(modelParts.path(0).path("text").asText())
+        .as("replayed assistant text")
+        .isEqualTo(toolCallMessage);
+
+    final var functionCall = modelParts.path(1).path("functionCall");
+    assertThat(functionCall.path("name").asText())
+        .as("replayed functionCall.name")
+        .isEqualTo(TOOL_NAME);
+    assertThat(functionCall.path("args").path("a").asInt()).as("replayed arg a").isEqualTo(5);
+    assertThat(functionCall.path("args").path("b").asInt()).as("replayed arg b").isEqualTo(3);
+
+    final var functionResponse =
+        secondRequest.path("contents").path(2).path("parts").path(0).path("functionResponse");
+    assertThat(functionResponse.path("name").asText())
+        .as("functionResponse.name correlates by tool name")
+        .isEqualTo(TOOL_NAME);
+    assertThat(functionResponse.path("response").path("output").asText())
+        .as("tool result payload")
+        .isEqualTo(TOOL_RESULT);
+
+    // The synthesized id is not predictable, but it MUST be the same on both sides - that identity
+    // is what lets the agent loop correlate a result back to its originating call.
+    final var synthesizedId = functionCall.path("id").asText();
+    assertThat(synthesizedId).as("synthesized functionCall.id").isNotBlank();
+    assertThat(functionResponse.path("id").asText())
+        .as("functionResponse.id must echo the functionCall.id verbatim")
+        .isEqualTo(synthesizedId);
+
+    assertAgentResponse(
+        zeebeTest,
+        agentResponse ->
+            AgentSubProcessResponseAssert.assertThat(agentResponse)
+                .isReady()
+                .hasResponseMessageText(finalResponseText)
+                .hasResponseText(finalResponseText)
+                .hasMetrics(new AgentMetrics(2, new AgentMetrics.TokenUsage(21, 42), 1)));
+
+    assertThat(userFeedbackJobWorkerCounter.get()).isEqualTo(1);
+  }
+
+  @Test
+  void echoesServerProvidedFunctionCallIdOnTheFollowUpRequest() throws Exception {
+    final var userPrompt = "Explore some of your tools!";
+    final var serverProvidedId = "gemini-call-0001";
+    final var finalResponseText = "The superflux calculation of 5 and 3 is 24.";
+
+    // Vertex-AI shape: the server supplies the functionCall id, so it must survive the round trip
+    // untouched rather than being replaced by a synthesized UUID.
+    StreamingGeminiChatModelStubs.stubTurns(
+        StreamingGeminiChatModelStubs.toolCallTurnWithIds(
+            "Calling the tool.",
+            10,
+            20,
+            new ToolCallStub(serverProvidedId, TOOL_NAME, TOOL_ARGUMENTS_JSON)),
+        GeminiTurnStub.of(GeminiResponseChunks.text(finalResponseText, 11, 22)));
+    enqueueUserFeedback(userSatisfiedFeedback());
+
+    awaitProcessCompletion(createProcessInstance(Map.of("userPrompt", userPrompt)));
+
+    final var secondRequest = parseBody(recordedLoggedRequests(2).get(1));
+    final var functionCall =
+        secondRequest.path("contents").path(1).path("parts").path(1).path("functionCall");
+    final var functionResponse =
+        secondRequest.path("contents").path(2).path("parts").path(0).path("functionResponse");
+
+    assertThat(functionCall.path("id").asText())
+        .as("server-provided functionCall.id is replayed unchanged")
+        .isEqualTo(serverProvidedId);
+    assertThat(functionResponse.path("id").asText())
+        .as("functionResponse.id matches the server-provided id")
+        .isEqualTo(serverProvidedId);
+  }
+
+  @Test
+  void replaysThoughtSignatureOnTheFunctionCallPartOfTheFollowUpRequest() throws Exception {
+    final var userPrompt = "Use the superflux tool on 5 and 3, thinking it through first.";
+    final var signature = GeminiResponseChunks.encodeSignature("sig-e2e-gemini-toolcall");
+    final var finalResponseText = "The superflux calculation of 5 and 3 is 24.";
+
+    // Gemini 3 stamps a thoughtSignature onto a functionCall it reasoned about and REJECTS a
+    // follow-up request whose replayed history dropped it, so this round trip is load-bearing.
+    StreamingGeminiChatModelStubs.stubTurns(
+        GeminiTurnStub.of(
+            GeminiResponseChunks.chunk().thought("Superflux needs both operands.").build(),
+            GeminiResponseChunks.chunk()
+                .functionCall(
+                    new ToolCallStub("unused", TOOL_NAME, TOOL_ARGUMENTS_JSON), false, signature)
+                .usage(10, 20, 5, 0)
+                .build()),
+        GeminiTurnStub.of(GeminiResponseChunks.text(finalResponseText, 11, 22)));
+    enqueueUserFeedback(userSatisfiedFeedback());
+
+    awaitProcessCompletion(createProcessInstance(Map.of("userPrompt", userPrompt)));
+
+    final var secondRequest = parseBody(recordedLoggedRequests(2).get(1));
+    final var modelParts = secondRequest.path("contents").path(1).path("parts");
+
+    final var functionCallPart =
+        StreamSupport.stream(modelParts.spliterator(), false)
+            .filter(part -> part.has("functionCall"))
+            .findFirst()
+            .orElseThrow(
+                () -> new AssertionError("No functionCall part replayed on the follow-up request"));
+
+    assertThat(functionCallPart.path("thoughtSignature").asText())
+        .as("thoughtSignature replayed verbatim (base64) alongside the functionCall")
+        .isEqualTo(signature);
+  }
+
+  private List<String> functionDeclarationNames(JsonNode request) {
+    return StreamSupport.stream(
+            request.path("tools").path(0).path("functionDeclarations").spliterator(), false)
+        .map(declaration -> declaration.path("name").asText())
+        .toList();
+  }
+
+  private List<String> contentRoles(JsonNode request) {
+    return StreamSupport.stream(request.path("contents").spliterator(), false)
+        .map(content -> content.path("role").asText())
+        .toList();
+  }
+}

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/subprocess/v2/BaseGeminiNativeSubProcessTest.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/subprocess/v2/BaseGeminiNativeSubProcessTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.e2e.agenticai.aiagent.subprocess.v2;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.github.tomakehurst.wiremock.verification.LoggedRequest;
+import io.camunda.connector.e2e.ElementTemplate;
+import io.camunda.connector.e2e.agenticai.aiagent.wiremock.gemini.GeminiStreamGenerateContentRequests;
+import java.util.List;
+import java.util.function.Function;
+
+/**
+ * Base class for native-Gemini e2e tests on the AI Agent Sub-process (v2 element template),
+ * mirroring {@link BaseAnthropicNativeSubProcessTest}.
+ *
+ * <p>The hidden {@code endpoint} field is what makes this work: {@code GeminiChatModelFactory}
+ * passes it to {@code HttpOptions.baseUrl()}, so the vendor SDK talks to WireMock instead of
+ * Google. That field exists for exactly this reason and is never surfaced in the modeler.
+ */
+abstract class BaseGeminiNativeSubProcessTest extends BaseAgentSubProcessV2Test {
+
+  /**
+   * A Gemini 3.x model id, i.e. the {@code thinkingLevel} generation. Tests needing 2.5-style
+   * {@code thinkingBudget} semantics override the id per test via {@link #model(String)}; the
+   * WireMock stub matches any model id, so no stub change is needed.
+   */
+  private static final String DEFAULT_MODEL = "gemini-3-pro-preview";
+
+  @Override
+  protected Function<ElementTemplate, ElementTemplate> providerConfigurer() {
+    return this::configureGeminiBackend;
+  }
+
+  /**
+   * Model id to configure alongside the backend wiring. Override to fix a different model for the
+   * whole test class, or leave the default when a test doesn't care which model is used.
+   */
+  protected String defaultModel() {
+    return DEFAULT_MODEL;
+  }
+
+  private ElementTemplate configureGeminiBackend(ElementTemplate template) {
+    return template
+        .property("provider.type", "google-gemini")
+        .property("provider.googleGemini.backend.type", "google-gemini-api")
+        .property(
+            "provider.googleGemini.backend.googleGeminiApi.endpoint", wireMock.getHttpBaseUrl())
+        .property("provider.googleGemini.backend.googleGeminiApi.apiKey", "dummy")
+        .property("provider.googleGemini.model.model", defaultModel());
+  }
+
+  static Function<ElementTemplate, ElementTemplate> model(String modelId) {
+    return template -> template.property("provider.googleGemini.model.model", modelId);
+  }
+
+  static LoggedRequest soleRecordedRequest() {
+    return GeminiStreamGenerateContentRequests.sole();
+  }
+
+  static List<LoggedRequest> recordedLoggedRequests() {
+    return GeminiStreamGenerateContentRequests.recorded();
+  }
+
+  static List<LoggedRequest> recordedLoggedRequests(int expectedCount) {
+    return GeminiStreamGenerateContentRequests.recorded(expectedCount);
+  }
+
+  JsonNode parseBody(LoggedRequest loggedRequest) {
+    return GeminiStreamGenerateContentRequests.parseBody(loggedRequest);
+  }
+
+  static String requestedModel(LoggedRequest loggedRequest) {
+    return GeminiStreamGenerateContentRequests.requestedModel(loggedRequest);
+  }
+}

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/task/v2/AgentTaskGeminiToolCallingTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/task/v2/AgentTaskGeminiToolCallingTests.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.e2e.agenticai.aiagent.task.v2;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.camunda.connector.agenticai.aiagent.model.AgentMetrics;
+import io.camunda.connector.e2e.agenticai.aiagent.wiremock.gemini.StreamingGeminiChatModelStubs;
+import io.camunda.connector.e2e.agenticai.aiagent.wiremock.spi.ToolCallStub;
+import io.camunda.connector.e2e.agenticai.aiagent.wiremock.spi.TurnStub;
+import io.camunda.connector.e2e.agenticai.assertj.AgentResponseAssert;
+import io.camunda.connector.test.utils.annotation.SlowTest;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.StreamSupport;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Native-Gemini e2e coverage for the AI Agent <b>Task</b> flavor: the same WireMock-served Gemini
+ * traffic as the sub-process tests, but driven through the Task flavor's explicitly-modeled BPMN
+ * tool-calling loop, whose provider configuration is re-evaluated per iteration rather than frozen
+ * at sub-process entry.
+ *
+ * <p>The point of this class is not to re-verify Gemini's wire format (the {@code subprocess/v2}
+ * tests do that in depth) but to prove the native Gemini provider resolves and drives correctly on
+ * the Task flavor too — the v2 Task template's {@code provider.googleGemini.*} properties, the same
+ * multi-turn {@code functionCall}/{@code functionResponse} exchange, and the Task-flavor agent
+ * response.
+ */
+@SlowTest
+class AgentTaskGeminiToolCallingTests extends BaseGeminiNativeTaskV2Test {
+
+  private static final String TOOL_NAME = "SuperfluxProduct";
+
+  @Test
+  void executesToolCallingLoopAgainstNativeGeminiProvider() throws Exception {
+    final var initialUserPrompt = "Explore some of your tools!";
+    final var toolCallMessage = "I will call the superflux calculation tool.";
+    final var finalResponseText = "The superflux calculation of 5 and 3 is 24.";
+
+    StreamingGeminiChatModelStubs.stubConversation(
+        TurnStub.toolCalls(
+            toolCallMessage,
+            10,
+            20,
+            new ToolCallStub("unused-on-the-developer-api", TOOL_NAME, "{\"a\": 5, \"b\": 3}")),
+        TurnStub.text(finalResponseText, 11, 22));
+    enqueueUserFeedback(userSatisfiedFeedback());
+
+    final var zeebeTest =
+        awaitProcessCompletion(createProcessInstance(Map.of("userPrompt", initialUserPrompt)));
+
+    final var requests = recordedLoggedRequests(2);
+
+    assertThat(requestedModel(requests.get(0)))
+        .as("model id in the request URL")
+        .isEqualTo(defaultModel());
+
+    final var firstRequest = parseBody(requests.get(0));
+    assertThat(functionDeclarationNames(firstRequest))
+        .as("advertised function declarations")
+        .contains(TOOL_NAME);
+    assertThat(firstRequest.path("systemInstruction").path("parts").path(0).path("text").asText())
+        .as("system prompt is hoisted to systemInstruction")
+        .isEqualTo(expectedSystemPrompt());
+
+    // The follow-up request replays the model's functionCall turn plus the tool result, which on
+    // Gemini is a user-role functionResponse part (there is no dedicated "tool" role).
+    final var secondRequest = parseBody(requests.get(1));
+    assertThat(contentRoles(secondRequest))
+        .as("content roles on the follow-up request")
+        .containsExactly("user", "model", "user");
+
+    final var functionCall =
+        secondRequest.path("contents").path(1).path("parts").path(1).path("functionCall");
+    final var functionResponse =
+        secondRequest.path("contents").path(2).path("parts").path(0).path("functionResponse");
+
+    assertThat(functionCall.path("name").asText())
+        .as("replayed functionCall.name")
+        .isEqualTo(TOOL_NAME);
+    assertThat(functionResponse.path("response").path("output").asText())
+        .as("tool result payload")
+        .isEqualTo("24");
+    assertThat(functionResponse.path("id").asText())
+        .as("functionResponse.id echoes the functionCall.id, correlating the result to its call")
+        .isEqualTo(functionCall.path("id").asText());
+
+    assertAgentResponse(
+        zeebeTest,
+        agentResponse ->
+            AgentResponseAssert.assertThat(agentResponse)
+                .isReady()
+                .hasNoToolCalls()
+                .hasMetrics(new AgentMetrics(2, new AgentMetrics.TokenUsage(21, 42), 1))
+                .hasResponseMessageText(finalResponseText)
+                .hasResponseText(finalResponseText));
+
+    assertThat(userFeedbackJobWorkerCounter.get()).isEqualTo(1);
+  }
+
+  private List<String> functionDeclarationNames(JsonNode request) {
+    return StreamSupport.stream(
+            request.path("tools").path(0).path("functionDeclarations").spliterator(), false)
+        .map(declaration -> declaration.path("name").asText())
+        .toList();
+  }
+
+  private List<String> contentRoles(JsonNode request) {
+    return StreamSupport.stream(request.path("contents").spliterator(), false)
+        .map(content -> content.path("role").asText())
+        .toList();
+  }
+}

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/task/v2/AgentTaskGeminiToolCallingTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/task/v2/AgentTaskGeminiToolCallingTests.java
@@ -43,7 +43,7 @@ import org.junit.jupiter.api.Test;
  * response.
  */
 @SlowTest
-class AgentTaskGeminiToolCallingTests extends BaseGeminiNativeTaskV2Test {
+class AgentTaskGeminiToolCallingTests extends BaseGeminiNativeTaskTest {
 
   private static final String TOOL_NAME = "SuperfluxProduct";
 

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/task/v2/BaseGeminiNativeTaskTest.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/task/v2/BaseGeminiNativeTaskTest.java
@@ -46,7 +46,7 @@ import java.util.function.Function;
  * helper lives in the wiremock package instead of on a base class the way Anthropic's single base
  * class could afford to.
  */
-abstract class BaseGeminiNativeTaskV2Test extends BaseAgentTaskV2Test {
+abstract class BaseGeminiNativeTaskTest extends BaseAgentTaskV2Test {
 
   private static final String DEFAULT_MODEL = "gemini-3-pro-preview";
 

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/task/v2/BaseGeminiNativeTaskV2Test.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/task/v2/BaseGeminiNativeTaskV2Test.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.e2e.agenticai.aiagent.task.v2;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.github.tomakehurst.wiremock.verification.LoggedRequest;
+import io.camunda.connector.e2e.ElementTemplate;
+import io.camunda.connector.e2e.agenticai.aiagent.wiremock.gemini.GeminiStreamGenerateContentRequests;
+import java.util.List;
+import java.util.function.Function;
+
+/**
+ * Base class for native-Gemini e2e tests on the AI Agent <b>Task</b> (v2 element template).
+ *
+ * <p>No native-provider {@code task/v2} precedent existed to copy: Anthropic's native provider only
+ * has a {@code subprocess/v2} base class, and the only existing {@code task/v2} test uses the
+ * {@code custom} provider backed by an in-process {@code ChatModelFactory} rather than real HTTP
+ * traffic. This class therefore combines the two halves that did exist:
+ *
+ * <ul>
+ *   <li>from {@code BaseAgentTaskV2Test}: the Task flavor's element template and property defaults,
+ *       plus the {@code providerConfigurer()} composition hook that {@code BaseAgentTaskTest}
+ *       applies to every process instance;
+ *   <li>from {@code BaseAnthropicNativeSubProcessTest}: the native-provider wiring shape — the
+ *       provider properties pointed at WireMock via the hidden {@code endpoint} field, an
+ *       overridable {@code defaultModel()}, a {@code model(String)} per-test override, and the
+ *       recorded-request helpers.
+ * </ul>
+ *
+ * <p>It is an exact mirror of {@code BaseGeminiNativeSubProcessTest} apart from its superclass; the
+ * recorded-request helpers both delegate to {@link GeminiStreamGenerateContentRequests} rather than
+ * being duplicated, which is why that helper lives in the wiremock package instead of on a base
+ * class the way Anthropic's single base class could afford to.
+ */
+abstract class BaseGeminiNativeTaskV2Test extends BaseAgentTaskV2Test {
+
+  private static final String DEFAULT_MODEL = "gemini-3-pro-preview";
+
+  @Override
+  protected Function<ElementTemplate, ElementTemplate> providerConfigurer() {
+    return this::configureGeminiBackend;
+  }
+
+  /**
+   * Model id to configure alongside the backend wiring. Override to fix a different model for the
+   * whole test class, or leave the default when a test doesn't care which model is used.
+   */
+  protected String defaultModel() {
+    return DEFAULT_MODEL;
+  }
+
+  private ElementTemplate configureGeminiBackend(ElementTemplate template) {
+    return template
+        .property("provider.type", "google-gemini")
+        .property("provider.googleGemini.backend.type", "google-gemini-api")
+        .property(
+            "provider.googleGemini.backend.googleGeminiApi.endpoint", wireMock.getHttpBaseUrl())
+        .property("provider.googleGemini.backend.googleGeminiApi.apiKey", "dummy")
+        .property("provider.googleGemini.model.model", defaultModel());
+  }
+
+  static Function<ElementTemplate, ElementTemplate> model(String modelId) {
+    return template -> template.property("provider.googleGemini.model.model", modelId);
+  }
+
+  static LoggedRequest soleRecordedRequest() {
+    return GeminiStreamGenerateContentRequests.sole();
+  }
+
+  static List<LoggedRequest> recordedLoggedRequests() {
+    return GeminiStreamGenerateContentRequests.recorded();
+  }
+
+  static List<LoggedRequest> recordedLoggedRequests(int expectedCount) {
+    return GeminiStreamGenerateContentRequests.recorded(expectedCount);
+  }
+
+  JsonNode parseBody(LoggedRequest loggedRequest) {
+    return GeminiStreamGenerateContentRequests.parseBody(loggedRequest);
+  }
+
+  static String requestedModel(LoggedRequest loggedRequest) {
+    return GeminiStreamGenerateContentRequests.requestedModel(loggedRequest);
+  }
+}

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/task/v2/BaseGeminiNativeTaskV2Test.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/task/v2/BaseGeminiNativeTaskV2Test.java
@@ -37,14 +37,14 @@ import java.util.function.Function;
  *       applies to every process instance;
  *   <li>from {@code BaseAnthropicNativeSubProcessTest}: the native-provider wiring shape — the
  *       provider properties pointed at WireMock via the hidden {@code endpoint} field, an
- *       overridable {@code defaultModel()}, a {@code model(String)} per-test override, and the
- *       recorded-request helpers.
+ *       overridable {@code defaultModel()}, and the recorded-request helpers.
  * </ul>
  *
- * <p>It is an exact mirror of {@code BaseGeminiNativeSubProcessTest} apart from its superclass; the
- * recorded-request helpers both delegate to {@link GeminiStreamGenerateContentRequests} rather than
- * being duplicated, which is why that helper lives in the wiremock package instead of on a base
- * class the way Anthropic's single base class could afford to.
+ * <p>It mirrors {@code BaseGeminiNativeSubProcessTest} apart from its superclass, carrying only the
+ * helpers the Task-flavor tests actually use. Both bases delegate their recorded-request helpers to
+ * {@link GeminiStreamGenerateContentRequests} rather than duplicating them, which is why that
+ * helper lives in the wiremock package instead of on a base class the way Anthropic's single base
+ * class could afford to.
  */
 abstract class BaseGeminiNativeTaskV2Test extends BaseAgentTaskV2Test {
 
@@ -71,18 +71,6 @@ abstract class BaseGeminiNativeTaskV2Test extends BaseAgentTaskV2Test {
             "provider.googleGemini.backend.googleGeminiApi.endpoint", wireMock.getHttpBaseUrl())
         .property("provider.googleGemini.backend.googleGeminiApi.apiKey", "dummy")
         .property("provider.googleGemini.model.model", defaultModel());
-  }
-
-  static Function<ElementTemplate, ElementTemplate> model(String modelId) {
-    return template -> template.property("provider.googleGemini.model.model", modelId);
-  }
-
-  static LoggedRequest soleRecordedRequest() {
-    return GeminiStreamGenerateContentRequests.sole();
-  }
-
-  static List<LoggedRequest> recordedLoggedRequests() {
-    return GeminiStreamGenerateContentRequests.recorded();
   }
 
   static List<LoggedRequest> recordedLoggedRequests(int expectedCount) {

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/wiremock/gemini/GeminiResponseChunks.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/wiremock/gemini/GeminiResponseChunks.java
@@ -1,0 +1,294 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.e2e.agenticai.aiagent.wiremock.gemini;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.genai.types.BlockedReason;
+import com.google.genai.types.Candidate;
+import com.google.genai.types.Content;
+import com.google.genai.types.FinishReason;
+import com.google.genai.types.FunctionCall;
+import com.google.genai.types.GenerateContentResponse;
+import com.google.genai.types.GenerateContentResponsePromptFeedback;
+import com.google.genai.types.GenerateContentResponseUsageMetadata;
+import com.google.genai.types.Part;
+import io.camunda.connector.e2e.agenticai.aiagent.wiremock.spi.ToolCallStub;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.List;
+import java.util.Map;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Builds single Gemini streaming chunks as real SDK {@link GenerateContentResponse} instances, so
+ * that {@link StreamingGeminiChatModelStubs} can serialize them with the vendor SDK's own mapper
+ * instead of hand-written JSON string literals. Every field name on the wire therefore comes from
+ * the SDK's own {@code @JsonProperty} annotations rather than from a guess.
+ *
+ * <p>One chunk equals one {@code data: {...}} SSE line. A realistic Gemini turn is a sequence of
+ * them: text arrives incrementally across several chunks, and the <em>final</em> chunk is the one
+ * carrying {@code finishReason} and the cumulative {@code usageMetadata} (which is exactly what
+ * {@code GeminiContentStreamAssemblerImpl} relies on: last-wins for usage, last candidate for
+ * candidate-level metadata, text runs concatenated).
+ *
+ * <p>A candidate is emitted only when the chunk has parts or a finish reason. That rule is what
+ * makes a blocked-prompt chunk ({@link Builder#blockReason}) come out with <b>no {@code candidates}
+ * key at all</b> — the shape {@code GeminiContentResponseConverter} keys its blocked-prompt
+ * handling on, and the shape real Gemini returns when input-side filtering rejects a prompt.
+ */
+public final class GeminiResponseChunks {
+
+  /** Role Gemini reports on an assistant candidate's content. */
+  private static final String ROLE_MODEL = "model";
+
+  private static final ObjectMapper ARGUMENTS_MAPPER = new ObjectMapper();
+
+  private GeminiResponseChunks() {}
+
+  public static Builder chunk() {
+    return new Builder();
+  }
+
+  /**
+   * A complete single-chunk turn: text plus {@code STOP} and usage, i.e. what a non-streaming
+   * response would have looked like. Convenience for tests that care about something other than
+   * chunking.
+   */
+  public static GenerateContentResponse text(String text, int promptTokens, int candidateTokens) {
+    return chunk()
+        .text(text)
+        .finishReason(FinishReason.Known.STOP)
+        .usage(promptTokens, candidateTokens)
+        .build();
+  }
+
+  /**
+   * A complete single-chunk turn carrying optional leading text plus one or more {@code
+   * functionCall} parts. Gemini reports {@code STOP} even for a tool-calling turn (it has no
+   * tool-use finish reason), which is precisely the vendor quirk {@code
+   * GeminiContentResponseConverter} overrides to {@code TOOL_USE}.
+   */
+  public static GenerateContentResponse toolCalls(
+      @Nullable String text,
+      int promptTokens,
+      int candidateTokens,
+      List<ToolCallStub> toolCalls,
+      boolean includeFunctionCallIds) {
+    final Builder builder = chunk();
+    if (text != null && !text.isBlank()) {
+      builder.text(text);
+    }
+    for (final ToolCallStub toolCall : toolCalls) {
+      builder.functionCall(toolCall, includeFunctionCallIds);
+    }
+    return builder
+        .finishReason(FinishReason.Known.STOP)
+        .usage(promptTokens, candidateTokens)
+        .build();
+  }
+
+  /** Base64-encodes a signature the way Gemini reports {@code thoughtSignature} on the wire. */
+  public static String encodeSignature(String rawSignature) {
+    return Base64.getEncoder().encodeToString(rawSignature.getBytes(StandardCharsets.UTF_8));
+  }
+
+  public static final class Builder {
+
+    private final List<Part> parts = new ArrayList<>();
+    // Not annotated @Nullable: a type annotation on a qualified nested type is a compile error
+    // here.
+    private FinishReason.Known finishReason;
+    private BlockedReason.Known blockReason;
+    private @Nullable String blockReasonMessage;
+    private @Nullable GenerateContentResponseUsageMetadata usageMetadata;
+    private @Nullable String responseId;
+    private @Nullable String modelVersion;
+
+    private Builder() {}
+
+    /** A plain answer-text part. */
+    public Builder text(String text) {
+      parts.add(Part.builder().text(text).build());
+      return this;
+    }
+
+    /** An answer-text part carrying a {@code thoughtSignature} (base64 on the wire). */
+    public Builder text(String text, String signatureBase64) {
+      parts.add(
+          Part.builder().text(text).thoughtSignature(decodeSignature(signatureBase64)).build());
+      return this;
+    }
+
+    /** A {@code thought}-flagged text part, i.e. streamed reasoning. */
+    public Builder thought(String text) {
+      parts.add(Part.builder().text(text).thought(true).build());
+      return this;
+    }
+
+    /**
+     * A {@code thought}-flagged text part carrying its {@code thoughtSignature}. A signature closes
+     * its text run in the assembler, so this is also how a test forces a run boundary.
+     */
+    public Builder thought(String text, String signatureBase64) {
+      parts.add(
+          Part.builder()
+              .text(text)
+              .thought(true)
+              .thoughtSignature(decodeSignature(signatureBase64))
+              .build());
+      return this;
+    }
+
+    /**
+     * A {@code functionCall} part. {@code includeId} chooses between the two real Gemini surfaces:
+     * the Developer API leaves {@code FunctionCall.id} unset (the converter then synthesizes a
+     * UUID), while Vertex AI populates it.
+     */
+    public Builder functionCall(ToolCallStub toolCall, boolean includeId) {
+      final var functionCall =
+          FunctionCall.builder().name(toolCall.name()).args(parseArguments(toolCall));
+      if (includeId) {
+        functionCall.id(toolCall.id());
+      }
+      parts.add(Part.builder().functionCall(functionCall.build()).build());
+      return this;
+    }
+
+    /**
+     * A {@code functionCall} part carrying the {@code thoughtSignature} Gemini 3 stamps on a call
+     * it thought about — the value the request converter must replay on the follow-up request.
+     */
+    public Builder functionCall(ToolCallStub toolCall, boolean includeId, String signatureBase64) {
+      functionCall(toolCall, includeId);
+      final int lastIndex = parts.size() - 1;
+      parts.set(
+          lastIndex,
+          parts.get(lastIndex).toBuilder()
+              .thoughtSignature(decodeSignature(signatureBase64))
+              .build());
+      return this;
+    }
+
+    public Builder finishReason(FinishReason.Known finishReason) {
+      this.finishReason = finishReason;
+      return this;
+    }
+
+    /** Prompt-token / candidate-token counts, the two the domain metrics always report. */
+    public Builder usage(int promptTokens, int candidateTokens) {
+      this.usageMetadata =
+          GenerateContentResponseUsageMetadata.builder()
+              .promptTokenCount(promptTokens)
+              .candidatesTokenCount(candidateTokens)
+              .totalTokenCount(promptTokens + candidateTokens)
+              .build();
+      return this;
+    }
+
+    /**
+     * Usage including the thinking-specific {@code thoughtsTokenCount} and the implicit-cache
+     * {@code cachedContentTokenCount}, which map to the domain reasoning / cache-read counters.
+     */
+    public Builder usage(
+        int promptTokens, int candidateTokens, int thoughtsTokens, int cachedTokens) {
+      this.usageMetadata =
+          GenerateContentResponseUsageMetadata.builder()
+              .promptTokenCount(promptTokens)
+              .candidatesTokenCount(candidateTokens)
+              .thoughtsTokenCount(thoughtsTokens)
+              .cachedContentTokenCount(cachedTokens)
+              .totalTokenCount(promptTokens + candidateTokens + thoughtsTokens)
+              .build();
+      return this;
+    }
+
+    /**
+     * Marks this chunk as a blocked prompt: it then carries only {@code promptFeedback} and no
+     * candidate whatsoever (see the class javadoc).
+     */
+    public Builder blockReason(BlockedReason.Known blockReason) {
+      this.blockReason = blockReason;
+      return this;
+    }
+
+    public Builder blockReasonMessage(String blockReasonMessage) {
+      this.blockReasonMessage = blockReasonMessage;
+      return this;
+    }
+
+    public Builder responseId(String responseId) {
+      this.responseId = responseId;
+      return this;
+    }
+
+    public Builder modelVersion(String modelVersion) {
+      this.modelVersion = modelVersion;
+      return this;
+    }
+
+    public GenerateContentResponse build() {
+      final var response = GenerateContentResponse.builder();
+      if (responseId != null) {
+        response.responseId(responseId);
+      }
+      if (modelVersion != null) {
+        response.modelVersion(modelVersion);
+      }
+      if (usageMetadata != null) {
+        response.usageMetadata(usageMetadata);
+      }
+      if (blockReason != null) {
+        final var promptFeedback =
+            GenerateContentResponsePromptFeedback.builder().blockReason(blockReason);
+        if (blockReasonMessage != null) {
+          promptFeedback.blockReasonMessage(blockReasonMessage);
+        }
+        response.promptFeedback(promptFeedback.build());
+      }
+
+      // No parts and no finish reason means there is nothing candidate-shaped to report: leave
+      // `candidates` off entirely rather than emitting an empty shell.
+      if (!parts.isEmpty() || finishReason != null) {
+        final var candidate = Candidate.builder().index(0);
+        if (!parts.isEmpty()) {
+          candidate.content(Content.builder().role(ROLE_MODEL).parts(parts).build());
+        }
+        if (finishReason != null) {
+          candidate.finishReason(finishReason);
+        }
+        response.candidates(List.of(candidate.build()));
+      }
+
+      return response.build();
+    }
+  }
+
+  private static byte[] decodeSignature(String signatureBase64) {
+    return Base64.getDecoder().decode(signatureBase64);
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Map<String, Object> parseArguments(ToolCallStub toolCall) {
+    try {
+      return ARGUMENTS_MAPPER.readValue(toolCall.argumentsJson(), Map.class);
+    } catch (Exception e) {
+      throw new IllegalArgumentException(
+          "Failed to parse stubbed tool call arguments: " + toolCall.argumentsJson(), e);
+    }
+  }
+}

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/wiremock/gemini/GeminiResponseChunks.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/wiremock/gemini/GeminiResponseChunks.java
@@ -116,8 +116,6 @@ public final class GeminiResponseChunks {
     private BlockedReason.Known blockReason;
     private @Nullable String blockReasonMessage;
     private @Nullable GenerateContentResponseUsageMetadata usageMetadata;
-    private @Nullable String responseId;
-    private @Nullable String modelVersion;
 
     private Builder() {}
 
@@ -137,20 +135,6 @@ public final class GeminiResponseChunks {
     /** A {@code thought}-flagged text part, i.e. streamed reasoning. */
     public Builder thought(String text) {
       parts.add(Part.builder().text(text).thought(true).build());
-      return this;
-    }
-
-    /**
-     * A {@code thought}-flagged text part carrying its {@code thoughtSignature}. A signature closes
-     * its text run in the assembler, so this is also how a test forces a run boundary.
-     */
-    public Builder thought(String text, String signatureBase64) {
-      parts.add(
-          Part.builder()
-              .text(text)
-              .thought(true)
-              .thoughtSignature(decodeSignature(signatureBase64))
-              .build());
       return this;
     }
 
@@ -231,24 +215,8 @@ public final class GeminiResponseChunks {
       return this;
     }
 
-    public Builder responseId(String responseId) {
-      this.responseId = responseId;
-      return this;
-    }
-
-    public Builder modelVersion(String modelVersion) {
-      this.modelVersion = modelVersion;
-      return this;
-    }
-
     public GenerateContentResponse build() {
       final var response = GenerateContentResponse.builder();
-      if (responseId != null) {
-        response.responseId(responseId);
-      }
-      if (modelVersion != null) {
-        response.modelVersion(modelVersion);
-      }
       if (usageMetadata != null) {
         response.usageMetadata(usageMetadata);
       }

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/wiremock/gemini/GeminiResponseChunks.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/wiremock/gemini/GeminiResponseChunks.java
@@ -110,10 +110,8 @@ public final class GeminiResponseChunks {
   public static final class Builder {
 
     private final List<Part> parts = new ArrayList<>();
-    // Both nullable. Annotating a qualified nested type requires the FinishReason.@Nullable Known
-    // form, which is not worth the noise on a private field in a test builder.
-    private FinishReason.Known finishReason;
-    private BlockedReason.Known blockReason;
+    private FinishReason.@Nullable Known finishReason;
+    private BlockedReason.@Nullable Known blockReason;
     private @Nullable String blockReasonMessage;
     private @Nullable GenerateContentResponseUsageMetadata usageMetadata;
 

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/wiremock/gemini/GeminiResponseChunks.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/wiremock/gemini/GeminiResponseChunks.java
@@ -110,8 +110,8 @@ public final class GeminiResponseChunks {
   public static final class Builder {
 
     private final List<Part> parts = new ArrayList<>();
-    // Not annotated @Nullable: a type annotation on a qualified nested type is a compile error
-    // here.
+    // Both nullable. Annotating a qualified nested type requires the FinishReason.@Nullable Known
+    // form, which is not worth the noise on a private field in a test builder.
     private FinishReason.Known finishReason;
     private BlockedReason.Known blockReason;
     private @Nullable String blockReasonMessage;

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/wiremock/gemini/GeminiStreamGenerateContentRequests.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/wiremock/gemini/GeminiStreamGenerateContentRequests.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.e2e.agenticai.aiagent.wiremock.gemini;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.findAll;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathMatching;
+import static io.camunda.connector.e2e.agenticai.aiagent.wiremock.gemini.StreamingGeminiChatModelStubs.STREAM_GENERATE_CONTENT_PATH_PATTERN;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.tomakehurst.wiremock.verification.LoggedRequest;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Inspects the {@code POST /v1beta/models/{model}:streamGenerateContent} requests the connector
+ * actually sent to WireMock.
+ *
+ * <p>Lives here rather than on a base test class because <em>both</em> Gemini e2e base classes (the
+ * sub-process flavor and the task flavor) need it; Anthropic could keep the equivalent helpers on
+ * its single base class, this provider has two.
+ *
+ * <p>Deliberately thinner than {@code AnthropicMessagesRecordedConversation}: no normalization into
+ * the shared {@code ProviderWireFormatExpectedMessage} DSL, because these tests assert Gemini's own
+ * wire shape ({@code contents[].parts[]}, {@code generationConfig.thinkingConfig}, ...) directly
+ * rather than a provider-agnostic projection of it.
+ */
+public final class GeminiStreamGenerateContentRequests {
+
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+  /** Extracts the model id out of the request path the SDK built. */
+  private static final Pattern MODEL_PATTERN =
+      Pattern.compile("/v1beta/models/(?<model>[^/]+):streamGenerateContent");
+
+  private GeminiStreamGenerateContentRequests() {}
+
+  /** All recorded model-call requests, oldest first. */
+  public static List<LoggedRequest> recorded() {
+    final List<LoggedRequest> requests =
+        new ArrayList<>(
+            findAll(postRequestedFor(urlPathMatching(STREAM_GENERATE_CONTENT_PATH_PATTERN))));
+    requests.sort(Comparator.comparing(LoggedRequest::getLoggedDate));
+    return requests;
+  }
+
+  /** The single recorded model-call request, failing the test if there was not exactly one. */
+  public static LoggedRequest sole() {
+    final var requests = recorded();
+    assertThat(requests).as("recorded model-call requests").hasSize(1);
+    return requests.get(0);
+  }
+
+  /** Asserts the expected number of model calls happened and returns them, oldest first. */
+  public static List<LoggedRequest> recorded(int expectedCount) {
+    final var requests = recorded();
+    assertThat(requests).as("recorded model-call requests").hasSize(expectedCount);
+    return requests;
+  }
+
+  public static JsonNode parseBody(LoggedRequest loggedRequest) {
+    try {
+      return OBJECT_MAPPER.readTree(loggedRequest.getBodyAsString());
+    } catch (Exception e) {
+      throw new IllegalStateException(
+          "Failed to parse recorded Gemini generateContent request body: "
+              + loggedRequest.getBodyAsString(),
+          e);
+    }
+  }
+
+  /**
+   * The model id the SDK put into the request URL. Asserted instead of a fixed stub URL because the
+   * stub matches any model id (see {@link StreamingGeminiChatModelStubs}).
+   */
+  public static String requestedModel(LoggedRequest loggedRequest) {
+    final Matcher matcher = MODEL_PATTERN.matcher(loggedRequest.getUrl());
+    if (!matcher.find()) {
+      throw new IllegalStateException(
+          "Recorded request URL does not look like a streamGenerateContent call: "
+              + loggedRequest.getUrl());
+    }
+    return matcher.group("model");
+  }
+}

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/wiremock/gemini/GeminiStreamGenerateContentRequests.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/wiremock/gemini/GeminiStreamGenerateContentRequests.java
@@ -16,6 +16,7 @@
  */
 package io.camunda.connector.e2e.agenticai.aiagent.wiremock.gemini;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.findAll;
 import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathMatching;
@@ -54,11 +55,19 @@ public final class GeminiStreamGenerateContentRequests {
 
   private GeminiStreamGenerateContentRequests() {}
 
-  /** All recorded model-call requests, oldest first. */
+  /**
+   * All recorded model-call requests, oldest first. Filters on the {@code alt=sse} query parameter
+   * as well as the path, matching {@link StreamingGeminiChatModelStubs}' stub: a regression that
+   * dropped SSE framing then surfaces as zero recorded requests instead of passing unnoticed.
+   */
   public static List<LoggedRequest> recorded() {
     final List<LoggedRequest> requests =
         new ArrayList<>(
-            findAll(postRequestedFor(urlPathMatching(STREAM_GENERATE_CONTENT_PATH_PATTERN))));
+            findAll(
+                postRequestedFor(urlPathMatching(STREAM_GENERATE_CONTENT_PATH_PATTERN))
+                    .withQueryParam(
+                        StreamingGeminiChatModelStubs.ALT_QUERY_PARAM,
+                        equalTo(StreamingGeminiChatModelStubs.ALT_SSE))));
     requests.sort(Comparator.comparing(LoggedRequest::getLoggedDate));
     return requests;
   }

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/wiremock/gemini/StreamingGeminiChatModelStubs.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/wiremock/gemini/StreamingGeminiChatModelStubs.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.e2e.agenticai.aiagent.wiremock.gemini;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathMatching;
+
+import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder;
+import com.github.tomakehurst.wiremock.client.ScenarioMappingBuilder;
+import com.github.tomakehurst.wiremock.stubbing.Scenario;
+import com.google.genai.types.GenerateContentResponse;
+import io.camunda.connector.e2e.agenticai.aiagent.wiremock.spi.ToolCallStub;
+import io.camunda.connector.e2e.agenticai.aiagent.wiremock.spi.TurnStub;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Stubs the Gemini Developer API's <strong>streaming</strong> generate-content endpoint ({@code
+ * POST {baseUrl}/v1beta/models/{model}:streamGenerateContent?alt=sse}) with real Server-Sent-Events
+ * framing. This is the only endpoint the Gemini provider ever calls: {@code GeminiChatModel} drives
+ * {@code generateContentStream} for every request, streaming or not.
+ *
+ * <p>Each chunk is a real SDK {@link GenerateContentResponse} (built via {@link
+ * GeminiResponseChunks}) serialized with the SDK's own mapper, so the bytes are guaranteed to
+ * deserialize exactly as real Gemini traffic would. Unlike Anthropic's SSE, Gemini emits <b>no
+ * {@code event:} lines and no terminator event</b> — the whole stream is bare {@code data: {...}}
+ * lines, each a complete {@code GenerateContentResponse}, and the stream simply ends. {@code
+ * ResponseStream#readNextJson} ignores any non-{@code data} field name, so emitting only {@code
+ * data:} is both correct and what real Gemini sends.
+ *
+ * <p>Multi-turn conversations use the same WireMock {@link Scenario} state chaining as {@code
+ * StreamingAnthropicMessagesSseChatModelStubs}: turn <i>n</i>'s mapping returns turn <i>n</i>'s
+ * chunks and advances the scenario to state {@code turn-(n+1)}.
+ *
+ * <p>The URL is matched by <b>pattern</b>, not by a fixed model id, so a single test class can
+ * drive several model ids (e.g. a Gemini 2.5 id for {@code thinkingBudget} and a Gemini 3.x id for
+ * {@code thinkingLevel}) against the same stub. Tests that care about which model was requested
+ * assert it from the recorded request URL via {@link
+ * GeminiStreamGenerateContentRequests#requestedModel}.
+ */
+public final class StreamingGeminiChatModelStubs {
+
+  /**
+   * URL-path pattern for the streaming generate-content endpoint. The SDK builds {@code baseUrl +
+   * "/" + apiVersion + "/" + "{model}:streamGenerateContent?alt=sse"}, where {@code {model}} is
+   * resolved to {@code models/<id>} for the Gemini Developer API.
+   */
+  public static final String STREAM_GENERATE_CONTENT_PATH_PATTERN =
+      "/v1beta/models/[^/]+:streamGenerateContent";
+
+  private static final String SCENARIO_NAME = "gemini-llm-conversation-sse";
+
+  private StreamingGeminiChatModelStubs() {}
+
+  /**
+   * A single stubbed turn as its ordered SSE chunks. More than one chunk is how a test exercises
+   * the stream assembler against genuinely chunked traffic.
+   */
+  public record GeminiTurnStub(List<GenerateContentResponse> chunks) {
+
+    public GeminiTurnStub {
+      if (chunks.isEmpty()) {
+        // GeminiContentStreamAssemblerImpl rejects an empty stream outright; a turn with no chunks
+        // could never be a realistic stub.
+        throw new IllegalArgumentException("A stubbed turn requires at least one chunk");
+      }
+    }
+
+    public static GeminiTurnStub of(GenerateContentResponse... chunks) {
+      return new GeminiTurnStub(List.of(chunks));
+    }
+  }
+
+  /**
+   * Wires the scenario chain returning each turn's chunks in order, with full control over how each
+   * turn is split into chunks.
+   */
+  public static void stubTurns(GeminiTurnStub... turns) {
+    if (turns.length == 0) {
+      throw new IllegalArgumentException("At least one conversation turn is required");
+    }
+    stubScenario(Arrays.stream(turns).map(StreamingGeminiChatModelStubs::sseBody).toList());
+  }
+
+  /**
+   * Wires the scenario chain from the provider-agnostic {@link TurnStub} shape, one single chunk
+   * per turn. Tool calls are stubbed <b>without</b> {@code FunctionCall.id}, matching the Gemini
+   * Developer API (which never populates it) and therefore exercising the converter's UUID
+   * synthesis; use {@link #stubTurns} with {@link GeminiResponseChunks} when a test needs
+   * server-provided ids.
+   */
+  public static void stubConversation(TurnStub... turns) {
+    stubTurns(
+        Arrays.stream(turns)
+            .map(StreamingGeminiChatModelStubs::toTurnStub)
+            .toArray(GeminiTurnStub[]::new));
+  }
+
+  private static GeminiTurnStub toTurnStub(TurnStub turn) {
+    return switch (turn) {
+      case TurnStub.Text text ->
+          GeminiTurnStub.of(
+              GeminiResponseChunks.text(text.text(), text.inputTokens(), text.outputTokens()));
+      case TurnStub.ToolCalls toolCalls ->
+          GeminiTurnStub.of(
+              GeminiResponseChunks.toolCalls(
+                  toolCalls.text(),
+                  toolCalls.inputTokens(),
+                  toolCalls.outputTokens(),
+                  toolCalls.toolCalls(),
+                  false));
+    };
+  }
+
+  /**
+   * Convenience for the single most common bespoke turn: a tool-calling turn whose {@code
+   * functionCall} parts carry server-provided ids (the Vertex AI shape) rather than relying on the
+   * converter's UUID synthesis.
+   */
+  public static GeminiTurnStub toolCallTurnWithIds(
+      String text, int promptTokens, int candidateTokens, ToolCallStub... toolCalls) {
+    return GeminiTurnStub.of(
+        GeminiResponseChunks.toolCalls(
+            text, promptTokens, candidateTokens, List.of(toolCalls), true));
+  }
+
+  /** Shared scenario-chaining plumbing: returns each pre-rendered SSE body in order. */
+  private static void stubScenario(List<String> bodies) {
+    for (int i = 0; i < bodies.size(); i++) {
+      final String fromState = i == 0 ? Scenario.STARTED : stateName(i);
+
+      ScenarioMappingBuilder mapping =
+          post(urlPathMatching(STREAM_GENERATE_CONTENT_PATH_PATTERN))
+              .inScenario(SCENARIO_NAME)
+              .whenScenarioStateIs(fromState)
+              .willReturn(sseResponse(bodies.get(i)));
+
+      if (i < bodies.size() - 1) {
+        mapping = mapping.willSetStateTo(stateName(i + 1));
+      }
+
+      stubFor(mapping);
+    }
+  }
+
+  private static String stateName(int index) {
+    return "turn-" + index;
+  }
+
+  private static ResponseDefinitionBuilder sseResponse(String body) {
+    return aResponse()
+        .withStatus(200)
+        .withHeader("Content-Type", "text/event-stream")
+        .withBody(body);
+  }
+
+  /**
+   * Frames a turn's chunks as bare {@code data: {...}} SSE lines, Gemini's own streaming format.
+   */
+  private static String sseBody(GeminiTurnStub turn) {
+    final StringBuilder body = new StringBuilder();
+    for (final GenerateContentResponse chunk : turn.chunks()) {
+      body.append("data: ").append(chunk.toJson()).append("\n\n");
+    }
+    return body.toString();
+  }
+}

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/wiremock/gemini/StreamingGeminiChatModelStubs.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/wiremock/gemini/StreamingGeminiChatModelStubs.java
@@ -17,6 +17,7 @@
 package io.camunda.connector.e2e.agenticai.aiagent.wiremock.gemini;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathMatching;
@@ -63,6 +64,11 @@ public final class StreamingGeminiChatModelStubs {
    */
   public static final String STREAM_GENERATE_CONTENT_PATH_PATTERN =
       "/v1beta/models/[^/]+:streamGenerateContent";
+
+  /** Query parameter the SDK appends to request SSE framing ({@code ?alt=sse}). */
+  public static final String ALT_QUERY_PARAM = "alt";
+
+  public static final String ALT_SSE = "sse";
 
   private static final String SCENARIO_NAME = "gemini-llm-conversation-sse";
 
@@ -147,6 +153,11 @@ public final class StreamingGeminiChatModelStubs {
 
       ScenarioMappingBuilder mapping =
           post(urlPathMatching(STREAM_GENERATE_CONTENT_PATH_PATTERN))
+              // Matching the query parameter too, not just the path: the SDK must request SSE
+              // framing explicitly (Gemini returns a buffered JSON array without it), so a
+              // regression that dropped `alt=sse` would leave this stub unmatched and fail a test
+              // rather than silently still matching.
+              .withQueryParam(ALT_QUERY_PARAM, equalTo(ALT_SSE))
               .inScenario(SCENARIO_NAME)
               .whenScenarioStateIs(fromState)
               .willReturn(sseResponse(bodies.get(i)));

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/e2e/RealProviderApiSmokeIT.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/e2e/RealProviderApiSmokeIT.java
@@ -351,6 +351,24 @@ class RealProviderApiSmokeIT {
         false);
   }
 
+  static Provider googleGeminiApi(
+      String model, Map<Capability, Map<String, String>> capabilityProperties) {
+    return new Provider(
+        "google-gemini-api/" + model,
+        List.of("GOOGLE_GEMINI_API_KEY"),
+        Map.of(
+            "provider.type",
+            "google-gemini",
+            "provider.googleGemini.backend.type",
+            "google-gemini-api",
+            "provider.googleGemini.backend.googleGeminiApi.apiKey",
+            envOrPlaceholder("GOOGLE_GEMINI_API_KEY"),
+            "provider.googleGemini.model.model",
+            model),
+        capabilityProperties,
+        false);
+  }
+
   static Stream<Provider> providers() {
     return Stream.of(
             // claude-sonnet-4-6 only supports thinking mode "enabled" (explicit budget) — the model
@@ -498,7 +516,14 @@ class RealProviderApiSmokeIT {
                 Map.of(
                     Capability.STRUCTURED_OUTPUT, Map.of(),
                     Capability.MULTIMODAL_USER_MESSAGE, Map.of(),
-                    Capability.PROMPT_CACHING, Map.of())))
+                    Capability.PROMPT_CACHING, Map.of())),
+            // Conservative row, matching the Vertex AI row below: no REASONING/PROMPT_CACHING
+            // claim, since neither has been manually verified against a live Gemini endpoint yet.
+            googleGeminiApi(
+                "gemini-3-pro-preview",
+                Map.of(
+                    Capability.STRUCTURED_OUTPUT, Map.of(),
+                    Capability.MULTIMODAL_USER_MESSAGE, Map.of())))
         .filter(Provider::isEnabled);
   }
 

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/e2e/RealProviderApiSmokeIT.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/e2e/RealProviderApiSmokeIT.java
@@ -517,8 +517,8 @@ class RealProviderApiSmokeIT {
                     Capability.STRUCTURED_OUTPUT, Map.of(),
                     Capability.MULTIMODAL_USER_MESSAGE, Map.of(),
                     Capability.PROMPT_CACHING, Map.of())),
-            // Conservative row, matching the Vertex AI row below: no REASONING/PROMPT_CACHING
-            // claim, since neither has been manually verified against a live Gemini endpoint yet.
+            // Conservative row: no REASONING/PROMPT_CACHING claim, since neither has been manually
+            // verified against a live Gemini endpoint yet.
             googleGeminiApi(
                 "gemini-3-pro-preview",
                 Map.of(

--- a/connectors/agentic-ai/connector-agentic-ai/element-templates/agenticai-ai-agent-subprocess.v2.json
+++ b/connectors/agentic-ai/connector-agentic-ai/element-templates/agenticai-ai-agent-subprocess.v2.json
@@ -132,6 +132,9 @@
       "name" : "OpenAI",
       "value" : "openai"
     }, {
+      "name" : "Google Gemini",
+      "value" : "google-gemini"
+    }, {
       "name" : "Custom Implementation (Self-Managed/Hybrid only)",
       "value" : "custom"
     } ]
@@ -1113,6 +1116,89 @@
     },
     "type" : "String"
   }, {
+    "id" : "provider.googleGemini.backend.type",
+    "label" : "Backend",
+    "description" : "Specify how the Gemini Developer API is reached.",
+    "value" : "google-gemini-api",
+    "group" : "provider",
+    "binding" : {
+      "name" : "provider.googleGemini.backend.type",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "provider.type",
+      "equals" : "google-gemini",
+      "type" : "simple"
+    },
+    "type" : "Dropdown",
+    "choices" : [ {
+      "name" : "Google Gemini API",
+      "value" : "google-gemini-api"
+    } ]
+  }, {
+    "id" : "provider.googleGemini.backend.googleGeminiApi.apiKey",
+    "label" : "Gemini API key",
+    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "provider",
+    "binding" : {
+      "name" : "provider.googleGemini.backend.googleGeminiApi.apiKey",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "allMatch" : [ {
+        "property" : "provider.googleGemini.backend.type",
+        "equals" : "google-gemini-api",
+        "type" : "simple"
+      }, {
+        "property" : "provider.type",
+        "equals" : "google-gemini",
+        "type" : "simple"
+      } ]
+    },
+    "type" : "String"
+  }, {
+    "id" : "provider.googleGemini.backend.googleGeminiApi.endpoint",
+    "label" : "API endpoint",
+    "optional" : true,
+    "group" : "provider",
+    "binding" : {
+      "name" : "provider.googleGemini.backend.googleGeminiApi.endpoint",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "allMatch" : [ {
+        "property" : "provider.googleGemini.backend.type",
+        "equals" : "google-gemini-api",
+        "type" : "simple"
+      }, {
+        "property" : "provider.type",
+        "equals" : "google-gemini",
+        "type" : "simple"
+      } ]
+    },
+    "type" : "Hidden"
+  }, {
+    "id" : "provider.googleGemini.timeouts.timeout",
+    "label" : "Timeout",
+    "description" : "Timeout specification for API calls to the model provider defined as ISO-8601 duration (example: <code>PT60S</code>).",
+    "optional" : true,
+    "feel" : "optional",
+    "group" : "provider",
+    "binding" : {
+      "name" : "provider.googleGemini.timeouts.timeout",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "provider.type",
+      "equals" : "google-gemini",
+      "type" : "simple"
+    },
+    "type" : "String"
+  }, {
     "id" : "provider.providerType",
     "label" : "Provider type",
     "description" : "Identifier for the custom chat model provider.",
@@ -1918,6 +2004,83 @@
     "placeholder" : "gpt-5.5",
     "type" : "String"
   }, {
+    "id" : "provider.googleGemini.model.model",
+    "label" : "Model",
+    "description" : "Specify the model ID. Details in the <a href=\"https://ai.google.dev/gemini-api/docs/models\" target=\"_blank\">documentation</a>.",
+    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "model",
+    "binding" : {
+      "name" : "provider.googleGemini.model.model",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "provider.type",
+      "equals" : "google-gemini",
+      "type" : "simple"
+    },
+    "placeholder" : "gemini-3-pro-preview",
+    "type" : "String"
+  }, {
+    "id" : "provider.googleGemini.model.parameters.thinking.thinkingBudget",
+    "label" : "Thinking budget (tokens)",
+    "optional" : true,
+    "feel" : "required",
+    "group" : "model",
+    "binding" : {
+      "name" : "provider.googleGemini.model.parameters.thinking.thinkingBudget",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "allMatch" : [ {
+        "property" : "provider.googleGemini.model.parameters.thinking.thinkingLevel",
+        "equals" : "modelDefault",
+        "type" : "simple"
+      }, {
+        "property" : "provider.type",
+        "equals" : "google-gemini",
+        "type" : "simple"
+      } ]
+    },
+    "tooltip" : "Gemini 2.5 models: token budget for extended thinking. -1 = dynamic, 0 = disabled. Mutually exclusive with Thinking level (Gemini 3.x). <br><br>Details in the <a href=\"https://ai.google.dev/gemini-api/docs/thinking\" target=\"_blank\">documentation</a>.",
+    "type" : "Number"
+  }, {
+    "id" : "provider.googleGemini.model.parameters.thinking.thinkingLevel",
+    "label" : "Thinking level",
+    "optional" : false,
+    "value" : "modelDefault",
+    "group" : "model",
+    "binding" : {
+      "name" : "provider.googleGemini.model.parameters.thinking.thinkingLevel",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "provider.type",
+      "equals" : "google-gemini",
+      "type" : "simple"
+    },
+    "tooltip" : "Gemini 3.x models: qualitative thinking effort. \"default\" lets the model choose its own reasoning depth. Mutually exclusive with Thinking budget (Gemini 2.5). <br><br>Details in the <a href=\"https://ai.google.dev/gemini-api/docs/thinking\" target=\"_blank\">documentation</a>.",
+    "type" : "Dropdown",
+    "choices" : [ {
+      "name" : "default",
+      "value" : "modelDefault"
+    }, {
+      "name" : "minimal",
+      "value" : "minimal"
+    }, {
+      "name" : "low",
+      "value" : "low"
+    }, {
+      "name" : "medium",
+      "value" : "medium"
+    }, {
+      "name" : "high",
+      "value" : "high"
+    } ]
+  }, {
     "id" : "provider.model",
     "label" : "Model",
     "description" : "Identifier of the model to use.",
@@ -2193,6 +2356,74 @@
       } ]
     },
     "tooltip" : "Recommended for advanced use cases only (you usually only need to use temperature). <br><br>Details in the <a href=\"https://developers.openai.com/api/reference/resources/responses/methods/create\" target=\"_blank\">documentation</a>.",
+    "type" : "Number"
+  }, {
+    "id" : "provider.googleGemini.model.parameters.maxTokens",
+    "label" : "Maximum tokens",
+    "optional" : true,
+    "feel" : "required",
+    "group" : "model-options",
+    "binding" : {
+      "name" : "provider.googleGemini.model.parameters.maxTokens",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "provider.type",
+      "equals" : "google-gemini",
+      "type" : "simple"
+    },
+    "tooltip" : "The maximum number of tokens to generate before stopping. <br><br>Details in the <a href=\"https://ai.google.dev/api/generate-content#v1beta.GenerationConfig\" target=\"_blank\">documentation</a>.",
+    "type" : "Number"
+  }, {
+    "id" : "provider.googleGemini.model.parameters.temperature",
+    "label" : "Temperature",
+    "optional" : true,
+    "feel" : "required",
+    "group" : "model-options",
+    "binding" : {
+      "name" : "provider.googleGemini.model.parameters.temperature",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "provider.type",
+      "equals" : "google-gemini",
+      "type" : "simple"
+    },
+    "tooltip" : "Controls the randomness of the output. The higher the number, the more randomness will be injected into the response. <br><br>Details in the <a href=\"https://ai.google.dev/api/generate-content#v1beta.GenerationConfig\" target=\"_blank\">documentation</a>.",
+    "type" : "Number"
+  }, {
+    "id" : "provider.googleGemini.model.parameters.topP",
+    "label" : "top P",
+    "optional" : true,
+    "feel" : "required",
+    "group" : "model-options",
+    "binding" : {
+      "name" : "provider.googleGemini.model.parameters.topP",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "provider.type",
+      "equals" : "google-gemini",
+      "type" : "simple"
+    },
+    "tooltip" : "Floating point number between 0 and 1. Recommended for advanced use cases only (you usually only need to use temperature). <br><br>Details in the <a href=\"https://ai.google.dev/api/generate-content#v1beta.GenerationConfig\" target=\"_blank\">documentation</a>.",
+    "type" : "Number"
+  }, {
+    "id" : "provider.googleGemini.model.parameters.topK",
+    "label" : "top K",
+    "optional" : true,
+    "feel" : "required",
+    "group" : "model-options",
+    "binding" : {
+      "name" : "provider.googleGemini.model.parameters.topK",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "provider.type",
+      "equals" : "google-gemini",
+      "type" : "simple"
+    },
+    "tooltip" : "Integer greater than 0. Recommended for advanced use cases only (you usually only need to use temperature). <br><br>Details in the <a href=\"https://ai.google.dev/api/generate-content#v1beta.GenerationConfig\" target=\"_blank\">documentation</a>.",
     "type" : "Number"
   }, {
     "id" : "data.systemPrompt.prompt",

--- a/connectors/agentic-ai/connector-agentic-ai/element-templates/agenticai-ai-agent-task.v2.json
+++ b/connectors/agentic-ai/connector-agentic-ai/element-templates/agenticai-ai-agent-task.v2.json
@@ -104,6 +104,9 @@
       "name" : "OpenAI",
       "value" : "openai"
     }, {
+      "name" : "Google Gemini",
+      "value" : "google-gemini"
+    }, {
       "name" : "Custom Implementation (Self-Managed/Hybrid only)",
       "value" : "custom"
     } ]
@@ -1085,6 +1088,89 @@
     },
     "type" : "String"
   }, {
+    "id" : "provider.googleGemini.backend.type",
+    "label" : "Backend",
+    "description" : "Specify how the Gemini Developer API is reached.",
+    "value" : "google-gemini-api",
+    "group" : "provider",
+    "binding" : {
+      "name" : "provider.googleGemini.backend.type",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "provider.type",
+      "equals" : "google-gemini",
+      "type" : "simple"
+    },
+    "type" : "Dropdown",
+    "choices" : [ {
+      "name" : "Google Gemini API",
+      "value" : "google-gemini-api"
+    } ]
+  }, {
+    "id" : "provider.googleGemini.backend.googleGeminiApi.apiKey",
+    "label" : "Gemini API key",
+    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "provider",
+    "binding" : {
+      "name" : "provider.googleGemini.backend.googleGeminiApi.apiKey",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "allMatch" : [ {
+        "property" : "provider.googleGemini.backend.type",
+        "equals" : "google-gemini-api",
+        "type" : "simple"
+      }, {
+        "property" : "provider.type",
+        "equals" : "google-gemini",
+        "type" : "simple"
+      } ]
+    },
+    "type" : "String"
+  }, {
+    "id" : "provider.googleGemini.backend.googleGeminiApi.endpoint",
+    "label" : "API endpoint",
+    "optional" : true,
+    "group" : "provider",
+    "binding" : {
+      "name" : "provider.googleGemini.backend.googleGeminiApi.endpoint",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "allMatch" : [ {
+        "property" : "provider.googleGemini.backend.type",
+        "equals" : "google-gemini-api",
+        "type" : "simple"
+      }, {
+        "property" : "provider.type",
+        "equals" : "google-gemini",
+        "type" : "simple"
+      } ]
+    },
+    "type" : "Hidden"
+  }, {
+    "id" : "provider.googleGemini.timeouts.timeout",
+    "label" : "Timeout",
+    "description" : "Timeout specification for API calls to the model provider defined as ISO-8601 duration (example: <code>PT60S</code>).",
+    "optional" : true,
+    "feel" : "optional",
+    "group" : "provider",
+    "binding" : {
+      "name" : "provider.googleGemini.timeouts.timeout",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "provider.type",
+      "equals" : "google-gemini",
+      "type" : "simple"
+    },
+    "type" : "String"
+  }, {
     "id" : "provider.providerType",
     "label" : "Provider type",
     "description" : "Identifier for the custom chat model provider.",
@@ -1890,6 +1976,83 @@
     "placeholder" : "gpt-5.5",
     "type" : "String"
   }, {
+    "id" : "provider.googleGemini.model.model",
+    "label" : "Model",
+    "description" : "Specify the model ID. Details in the <a href=\"https://ai.google.dev/gemini-api/docs/models\" target=\"_blank\">documentation</a>.",
+    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "model",
+    "binding" : {
+      "name" : "provider.googleGemini.model.model",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "provider.type",
+      "equals" : "google-gemini",
+      "type" : "simple"
+    },
+    "placeholder" : "gemini-3-pro-preview",
+    "type" : "String"
+  }, {
+    "id" : "provider.googleGemini.model.parameters.thinking.thinkingBudget",
+    "label" : "Thinking budget (tokens)",
+    "optional" : true,
+    "feel" : "required",
+    "group" : "model",
+    "binding" : {
+      "name" : "provider.googleGemini.model.parameters.thinking.thinkingBudget",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "allMatch" : [ {
+        "property" : "provider.googleGemini.model.parameters.thinking.thinkingLevel",
+        "equals" : "modelDefault",
+        "type" : "simple"
+      }, {
+        "property" : "provider.type",
+        "equals" : "google-gemini",
+        "type" : "simple"
+      } ]
+    },
+    "tooltip" : "Gemini 2.5 models: token budget for extended thinking. -1 = dynamic, 0 = disabled. Mutually exclusive with Thinking level (Gemini 3.x). <br><br>Details in the <a href=\"https://ai.google.dev/gemini-api/docs/thinking\" target=\"_blank\">documentation</a>.",
+    "type" : "Number"
+  }, {
+    "id" : "provider.googleGemini.model.parameters.thinking.thinkingLevel",
+    "label" : "Thinking level",
+    "optional" : false,
+    "value" : "modelDefault",
+    "group" : "model",
+    "binding" : {
+      "name" : "provider.googleGemini.model.parameters.thinking.thinkingLevel",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "provider.type",
+      "equals" : "google-gemini",
+      "type" : "simple"
+    },
+    "tooltip" : "Gemini 3.x models: qualitative thinking effort. \"default\" lets the model choose its own reasoning depth. Mutually exclusive with Thinking budget (Gemini 2.5). <br><br>Details in the <a href=\"https://ai.google.dev/gemini-api/docs/thinking\" target=\"_blank\">documentation</a>.",
+    "type" : "Dropdown",
+    "choices" : [ {
+      "name" : "default",
+      "value" : "modelDefault"
+    }, {
+      "name" : "minimal",
+      "value" : "minimal"
+    }, {
+      "name" : "low",
+      "value" : "low"
+    }, {
+      "name" : "medium",
+      "value" : "medium"
+    }, {
+      "name" : "high",
+      "value" : "high"
+    } ]
+  }, {
     "id" : "provider.model",
     "label" : "Model",
     "description" : "Identifier of the model to use.",
@@ -2165,6 +2328,74 @@
       } ]
     },
     "tooltip" : "Recommended for advanced use cases only (you usually only need to use temperature). <br><br>Details in the <a href=\"https://developers.openai.com/api/reference/resources/responses/methods/create\" target=\"_blank\">documentation</a>.",
+    "type" : "Number"
+  }, {
+    "id" : "provider.googleGemini.model.parameters.maxTokens",
+    "label" : "Maximum tokens",
+    "optional" : true,
+    "feel" : "required",
+    "group" : "model-options",
+    "binding" : {
+      "name" : "provider.googleGemini.model.parameters.maxTokens",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "provider.type",
+      "equals" : "google-gemini",
+      "type" : "simple"
+    },
+    "tooltip" : "The maximum number of tokens to generate before stopping. <br><br>Details in the <a href=\"https://ai.google.dev/api/generate-content#v1beta.GenerationConfig\" target=\"_blank\">documentation</a>.",
+    "type" : "Number"
+  }, {
+    "id" : "provider.googleGemini.model.parameters.temperature",
+    "label" : "Temperature",
+    "optional" : true,
+    "feel" : "required",
+    "group" : "model-options",
+    "binding" : {
+      "name" : "provider.googleGemini.model.parameters.temperature",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "provider.type",
+      "equals" : "google-gemini",
+      "type" : "simple"
+    },
+    "tooltip" : "Controls the randomness of the output. The higher the number, the more randomness will be injected into the response. <br><br>Details in the <a href=\"https://ai.google.dev/api/generate-content#v1beta.GenerationConfig\" target=\"_blank\">documentation</a>.",
+    "type" : "Number"
+  }, {
+    "id" : "provider.googleGemini.model.parameters.topP",
+    "label" : "top P",
+    "optional" : true,
+    "feel" : "required",
+    "group" : "model-options",
+    "binding" : {
+      "name" : "provider.googleGemini.model.parameters.topP",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "provider.type",
+      "equals" : "google-gemini",
+      "type" : "simple"
+    },
+    "tooltip" : "Floating point number between 0 and 1. Recommended for advanced use cases only (you usually only need to use temperature). <br><br>Details in the <a href=\"https://ai.google.dev/api/generate-content#v1beta.GenerationConfig\" target=\"_blank\">documentation</a>.",
+    "type" : "Number"
+  }, {
+    "id" : "provider.googleGemini.model.parameters.topK",
+    "label" : "top K",
+    "optional" : true,
+    "feel" : "required",
+    "group" : "model-options",
+    "binding" : {
+      "name" : "provider.googleGemini.model.parameters.topK",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "provider.type",
+      "equals" : "google-gemini",
+      "type" : "simple"
+    },
+    "tooltip" : "Integer greater than 0. Recommended for advanced use cases only (you usually only need to use temperature). <br><br>Details in the <a href=\"https://ai.google.dev/api/generate-content#v1beta.GenerationConfig\" target=\"_blank\">documentation</a>.",
     "type" : "Number"
   }, {
     "id" : "data.systemPrompt.prompt",

--- a/connectors/agentic-ai/connector-agentic-ai/element-templates/hybrid/agenticai-ai-agent-subprocess.v2-hybrid.json
+++ b/connectors/agentic-ai/connector-agentic-ai/element-templates/hybrid/agenticai-ai-agent-subprocess.v2-hybrid.json
@@ -137,6 +137,9 @@
       "name" : "OpenAI",
       "value" : "openai"
     }, {
+      "name" : "Google Gemini",
+      "value" : "google-gemini"
+    }, {
       "name" : "Custom Implementation (Self-Managed/Hybrid only)",
       "value" : "custom"
     } ]
@@ -1118,6 +1121,89 @@
     },
     "type" : "String"
   }, {
+    "id" : "provider.googleGemini.backend.type",
+    "label" : "Backend",
+    "description" : "Specify how the Gemini Developer API is reached.",
+    "value" : "google-gemini-api",
+    "group" : "provider",
+    "binding" : {
+      "name" : "provider.googleGemini.backend.type",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "provider.type",
+      "equals" : "google-gemini",
+      "type" : "simple"
+    },
+    "type" : "Dropdown",
+    "choices" : [ {
+      "name" : "Google Gemini API",
+      "value" : "google-gemini-api"
+    } ]
+  }, {
+    "id" : "provider.googleGemini.backend.googleGeminiApi.apiKey",
+    "label" : "Gemini API key",
+    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "provider",
+    "binding" : {
+      "name" : "provider.googleGemini.backend.googleGeminiApi.apiKey",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "allMatch" : [ {
+        "property" : "provider.googleGemini.backend.type",
+        "equals" : "google-gemini-api",
+        "type" : "simple"
+      }, {
+        "property" : "provider.type",
+        "equals" : "google-gemini",
+        "type" : "simple"
+      } ]
+    },
+    "type" : "String"
+  }, {
+    "id" : "provider.googleGemini.backend.googleGeminiApi.endpoint",
+    "label" : "API endpoint",
+    "optional" : true,
+    "group" : "provider",
+    "binding" : {
+      "name" : "provider.googleGemini.backend.googleGeminiApi.endpoint",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "allMatch" : [ {
+        "property" : "provider.googleGemini.backend.type",
+        "equals" : "google-gemini-api",
+        "type" : "simple"
+      }, {
+        "property" : "provider.type",
+        "equals" : "google-gemini",
+        "type" : "simple"
+      } ]
+    },
+    "type" : "Hidden"
+  }, {
+    "id" : "provider.googleGemini.timeouts.timeout",
+    "label" : "Timeout",
+    "description" : "Timeout specification for API calls to the model provider defined as ISO-8601 duration (example: <code>PT60S</code>).",
+    "optional" : true,
+    "feel" : "optional",
+    "group" : "provider",
+    "binding" : {
+      "name" : "provider.googleGemini.timeouts.timeout",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "provider.type",
+      "equals" : "google-gemini",
+      "type" : "simple"
+    },
+    "type" : "String"
+  }, {
     "id" : "provider.providerType",
     "label" : "Provider type",
     "description" : "Identifier for the custom chat model provider.",
@@ -1923,6 +2009,83 @@
     "placeholder" : "gpt-5.5",
     "type" : "String"
   }, {
+    "id" : "provider.googleGemini.model.model",
+    "label" : "Model",
+    "description" : "Specify the model ID. Details in the <a href=\"https://ai.google.dev/gemini-api/docs/models\" target=\"_blank\">documentation</a>.",
+    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "model",
+    "binding" : {
+      "name" : "provider.googleGemini.model.model",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "provider.type",
+      "equals" : "google-gemini",
+      "type" : "simple"
+    },
+    "placeholder" : "gemini-3-pro-preview",
+    "type" : "String"
+  }, {
+    "id" : "provider.googleGemini.model.parameters.thinking.thinkingBudget",
+    "label" : "Thinking budget (tokens)",
+    "optional" : true,
+    "feel" : "required",
+    "group" : "model",
+    "binding" : {
+      "name" : "provider.googleGemini.model.parameters.thinking.thinkingBudget",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "allMatch" : [ {
+        "property" : "provider.googleGemini.model.parameters.thinking.thinkingLevel",
+        "equals" : "modelDefault",
+        "type" : "simple"
+      }, {
+        "property" : "provider.type",
+        "equals" : "google-gemini",
+        "type" : "simple"
+      } ]
+    },
+    "tooltip" : "Gemini 2.5 models: token budget for extended thinking. -1 = dynamic, 0 = disabled. Mutually exclusive with Thinking level (Gemini 3.x). <br><br>Details in the <a href=\"https://ai.google.dev/gemini-api/docs/thinking\" target=\"_blank\">documentation</a>.",
+    "type" : "Number"
+  }, {
+    "id" : "provider.googleGemini.model.parameters.thinking.thinkingLevel",
+    "label" : "Thinking level",
+    "optional" : false,
+    "value" : "modelDefault",
+    "group" : "model",
+    "binding" : {
+      "name" : "provider.googleGemini.model.parameters.thinking.thinkingLevel",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "provider.type",
+      "equals" : "google-gemini",
+      "type" : "simple"
+    },
+    "tooltip" : "Gemini 3.x models: qualitative thinking effort. \"default\" lets the model choose its own reasoning depth. Mutually exclusive with Thinking budget (Gemini 2.5). <br><br>Details in the <a href=\"https://ai.google.dev/gemini-api/docs/thinking\" target=\"_blank\">documentation</a>.",
+    "type" : "Dropdown",
+    "choices" : [ {
+      "name" : "default",
+      "value" : "modelDefault"
+    }, {
+      "name" : "minimal",
+      "value" : "minimal"
+    }, {
+      "name" : "low",
+      "value" : "low"
+    }, {
+      "name" : "medium",
+      "value" : "medium"
+    }, {
+      "name" : "high",
+      "value" : "high"
+    } ]
+  }, {
     "id" : "provider.model",
     "label" : "Model",
     "description" : "Identifier of the model to use.",
@@ -2198,6 +2361,74 @@
       } ]
     },
     "tooltip" : "Recommended for advanced use cases only (you usually only need to use temperature). <br><br>Details in the <a href=\"https://developers.openai.com/api/reference/resources/responses/methods/create\" target=\"_blank\">documentation</a>.",
+    "type" : "Number"
+  }, {
+    "id" : "provider.googleGemini.model.parameters.maxTokens",
+    "label" : "Maximum tokens",
+    "optional" : true,
+    "feel" : "required",
+    "group" : "model-options",
+    "binding" : {
+      "name" : "provider.googleGemini.model.parameters.maxTokens",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "provider.type",
+      "equals" : "google-gemini",
+      "type" : "simple"
+    },
+    "tooltip" : "The maximum number of tokens to generate before stopping. <br><br>Details in the <a href=\"https://ai.google.dev/api/generate-content#v1beta.GenerationConfig\" target=\"_blank\">documentation</a>.",
+    "type" : "Number"
+  }, {
+    "id" : "provider.googleGemini.model.parameters.temperature",
+    "label" : "Temperature",
+    "optional" : true,
+    "feel" : "required",
+    "group" : "model-options",
+    "binding" : {
+      "name" : "provider.googleGemini.model.parameters.temperature",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "provider.type",
+      "equals" : "google-gemini",
+      "type" : "simple"
+    },
+    "tooltip" : "Controls the randomness of the output. The higher the number, the more randomness will be injected into the response. <br><br>Details in the <a href=\"https://ai.google.dev/api/generate-content#v1beta.GenerationConfig\" target=\"_blank\">documentation</a>.",
+    "type" : "Number"
+  }, {
+    "id" : "provider.googleGemini.model.parameters.topP",
+    "label" : "top P",
+    "optional" : true,
+    "feel" : "required",
+    "group" : "model-options",
+    "binding" : {
+      "name" : "provider.googleGemini.model.parameters.topP",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "provider.type",
+      "equals" : "google-gemini",
+      "type" : "simple"
+    },
+    "tooltip" : "Floating point number between 0 and 1. Recommended for advanced use cases only (you usually only need to use temperature). <br><br>Details in the <a href=\"https://ai.google.dev/api/generate-content#v1beta.GenerationConfig\" target=\"_blank\">documentation</a>.",
+    "type" : "Number"
+  }, {
+    "id" : "provider.googleGemini.model.parameters.topK",
+    "label" : "top K",
+    "optional" : true,
+    "feel" : "required",
+    "group" : "model-options",
+    "binding" : {
+      "name" : "provider.googleGemini.model.parameters.topK",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "provider.type",
+      "equals" : "google-gemini",
+      "type" : "simple"
+    },
+    "tooltip" : "Integer greater than 0. Recommended for advanced use cases only (you usually only need to use temperature). <br><br>Details in the <a href=\"https://ai.google.dev/api/generate-content#v1beta.GenerationConfig\" target=\"_blank\">documentation</a>.",
     "type" : "Number"
   }, {
     "id" : "data.systemPrompt.prompt",

--- a/connectors/agentic-ai/connector-agentic-ai/element-templates/hybrid/agenticai-ai-agent-task.v2-hybrid.json
+++ b/connectors/agentic-ai/connector-agentic-ai/element-templates/hybrid/agenticai-ai-agent-task.v2-hybrid.json
@@ -109,6 +109,9 @@
       "name" : "OpenAI",
       "value" : "openai"
     }, {
+      "name" : "Google Gemini",
+      "value" : "google-gemini"
+    }, {
       "name" : "Custom Implementation (Self-Managed/Hybrid only)",
       "value" : "custom"
     } ]
@@ -1090,6 +1093,89 @@
     },
     "type" : "String"
   }, {
+    "id" : "provider.googleGemini.backend.type",
+    "label" : "Backend",
+    "description" : "Specify how the Gemini Developer API is reached.",
+    "value" : "google-gemini-api",
+    "group" : "provider",
+    "binding" : {
+      "name" : "provider.googleGemini.backend.type",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "provider.type",
+      "equals" : "google-gemini",
+      "type" : "simple"
+    },
+    "type" : "Dropdown",
+    "choices" : [ {
+      "name" : "Google Gemini API",
+      "value" : "google-gemini-api"
+    } ]
+  }, {
+    "id" : "provider.googleGemini.backend.googleGeminiApi.apiKey",
+    "label" : "Gemini API key",
+    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "provider",
+    "binding" : {
+      "name" : "provider.googleGemini.backend.googleGeminiApi.apiKey",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "allMatch" : [ {
+        "property" : "provider.googleGemini.backend.type",
+        "equals" : "google-gemini-api",
+        "type" : "simple"
+      }, {
+        "property" : "provider.type",
+        "equals" : "google-gemini",
+        "type" : "simple"
+      } ]
+    },
+    "type" : "String"
+  }, {
+    "id" : "provider.googleGemini.backend.googleGeminiApi.endpoint",
+    "label" : "API endpoint",
+    "optional" : true,
+    "group" : "provider",
+    "binding" : {
+      "name" : "provider.googleGemini.backend.googleGeminiApi.endpoint",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "allMatch" : [ {
+        "property" : "provider.googleGemini.backend.type",
+        "equals" : "google-gemini-api",
+        "type" : "simple"
+      }, {
+        "property" : "provider.type",
+        "equals" : "google-gemini",
+        "type" : "simple"
+      } ]
+    },
+    "type" : "Hidden"
+  }, {
+    "id" : "provider.googleGemini.timeouts.timeout",
+    "label" : "Timeout",
+    "description" : "Timeout specification for API calls to the model provider defined as ISO-8601 duration (example: <code>PT60S</code>).",
+    "optional" : true,
+    "feel" : "optional",
+    "group" : "provider",
+    "binding" : {
+      "name" : "provider.googleGemini.timeouts.timeout",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "provider.type",
+      "equals" : "google-gemini",
+      "type" : "simple"
+    },
+    "type" : "String"
+  }, {
     "id" : "provider.providerType",
     "label" : "Provider type",
     "description" : "Identifier for the custom chat model provider.",
@@ -1895,6 +1981,83 @@
     "placeholder" : "gpt-5.5",
     "type" : "String"
   }, {
+    "id" : "provider.googleGemini.model.model",
+    "label" : "Model",
+    "description" : "Specify the model ID. Details in the <a href=\"https://ai.google.dev/gemini-api/docs/models\" target=\"_blank\">documentation</a>.",
+    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "model",
+    "binding" : {
+      "name" : "provider.googleGemini.model.model",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "provider.type",
+      "equals" : "google-gemini",
+      "type" : "simple"
+    },
+    "placeholder" : "gemini-3-pro-preview",
+    "type" : "String"
+  }, {
+    "id" : "provider.googleGemini.model.parameters.thinking.thinkingBudget",
+    "label" : "Thinking budget (tokens)",
+    "optional" : true,
+    "feel" : "required",
+    "group" : "model",
+    "binding" : {
+      "name" : "provider.googleGemini.model.parameters.thinking.thinkingBudget",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "allMatch" : [ {
+        "property" : "provider.googleGemini.model.parameters.thinking.thinkingLevel",
+        "equals" : "modelDefault",
+        "type" : "simple"
+      }, {
+        "property" : "provider.type",
+        "equals" : "google-gemini",
+        "type" : "simple"
+      } ]
+    },
+    "tooltip" : "Gemini 2.5 models: token budget for extended thinking. -1 = dynamic, 0 = disabled. Mutually exclusive with Thinking level (Gemini 3.x). <br><br>Details in the <a href=\"https://ai.google.dev/gemini-api/docs/thinking\" target=\"_blank\">documentation</a>.",
+    "type" : "Number"
+  }, {
+    "id" : "provider.googleGemini.model.parameters.thinking.thinkingLevel",
+    "label" : "Thinking level",
+    "optional" : false,
+    "value" : "modelDefault",
+    "group" : "model",
+    "binding" : {
+      "name" : "provider.googleGemini.model.parameters.thinking.thinkingLevel",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "provider.type",
+      "equals" : "google-gemini",
+      "type" : "simple"
+    },
+    "tooltip" : "Gemini 3.x models: qualitative thinking effort. \"default\" lets the model choose its own reasoning depth. Mutually exclusive with Thinking budget (Gemini 2.5). <br><br>Details in the <a href=\"https://ai.google.dev/gemini-api/docs/thinking\" target=\"_blank\">documentation</a>.",
+    "type" : "Dropdown",
+    "choices" : [ {
+      "name" : "default",
+      "value" : "modelDefault"
+    }, {
+      "name" : "minimal",
+      "value" : "minimal"
+    }, {
+      "name" : "low",
+      "value" : "low"
+    }, {
+      "name" : "medium",
+      "value" : "medium"
+    }, {
+      "name" : "high",
+      "value" : "high"
+    } ]
+  }, {
     "id" : "provider.model",
     "label" : "Model",
     "description" : "Identifier of the model to use.",
@@ -2170,6 +2333,74 @@
       } ]
     },
     "tooltip" : "Recommended for advanced use cases only (you usually only need to use temperature). <br><br>Details in the <a href=\"https://developers.openai.com/api/reference/resources/responses/methods/create\" target=\"_blank\">documentation</a>.",
+    "type" : "Number"
+  }, {
+    "id" : "provider.googleGemini.model.parameters.maxTokens",
+    "label" : "Maximum tokens",
+    "optional" : true,
+    "feel" : "required",
+    "group" : "model-options",
+    "binding" : {
+      "name" : "provider.googleGemini.model.parameters.maxTokens",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "provider.type",
+      "equals" : "google-gemini",
+      "type" : "simple"
+    },
+    "tooltip" : "The maximum number of tokens to generate before stopping. <br><br>Details in the <a href=\"https://ai.google.dev/api/generate-content#v1beta.GenerationConfig\" target=\"_blank\">documentation</a>.",
+    "type" : "Number"
+  }, {
+    "id" : "provider.googleGemini.model.parameters.temperature",
+    "label" : "Temperature",
+    "optional" : true,
+    "feel" : "required",
+    "group" : "model-options",
+    "binding" : {
+      "name" : "provider.googleGemini.model.parameters.temperature",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "provider.type",
+      "equals" : "google-gemini",
+      "type" : "simple"
+    },
+    "tooltip" : "Controls the randomness of the output. The higher the number, the more randomness will be injected into the response. <br><br>Details in the <a href=\"https://ai.google.dev/api/generate-content#v1beta.GenerationConfig\" target=\"_blank\">documentation</a>.",
+    "type" : "Number"
+  }, {
+    "id" : "provider.googleGemini.model.parameters.topP",
+    "label" : "top P",
+    "optional" : true,
+    "feel" : "required",
+    "group" : "model-options",
+    "binding" : {
+      "name" : "provider.googleGemini.model.parameters.topP",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "provider.type",
+      "equals" : "google-gemini",
+      "type" : "simple"
+    },
+    "tooltip" : "Floating point number between 0 and 1. Recommended for advanced use cases only (you usually only need to use temperature). <br><br>Details in the <a href=\"https://ai.google.dev/api/generate-content#v1beta.GenerationConfig\" target=\"_blank\">documentation</a>.",
+    "type" : "Number"
+  }, {
+    "id" : "provider.googleGemini.model.parameters.topK",
+    "label" : "top K",
+    "optional" : true,
+    "feel" : "required",
+    "group" : "model-options",
+    "binding" : {
+      "name" : "provider.googleGemini.model.parameters.topK",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "provider.type",
+      "equals" : "google-gemini",
+      "type" : "simple"
+    },
+    "tooltip" : "Integer greater than 0. Recommended for advanced use cases only (you usually only need to use temperature). <br><br>Details in the <a href=\"https://ai.google.dev/api/generate-content#v1beta.GenerationConfig\" target=\"_blank\">documentation</a>.",
     "type" : "Number"
   }, {
     "id" : "data.systemPrompt.prompt",

--- a/connectors/agentic-ai/connector-agentic-ai/pom.xml
+++ b/connectors/agentic-ai/connector-agentic-ai/pom.xml
@@ -369,10 +369,8 @@
       <artifactId>feel-engine</artifactId>
     </dependency>
 
-    <!-- Compile-scoped (the natural transitive scope from google-genai, which returns Guava
-         types such as ImmutableList from GenerateContentResponse#parts()): main compilation runs
-         with -XDaddTypeAnnotationsToSymbol=true, and javac cannot complete those SDK types
-         without Guava's class files on the compile classpath. Also used directly by tests. -->
+    <!-- Compile scope: javac (running with -XDaddTypeAnnotationsToSymbol=true) needs Guava's
+         class files to complete the google-genai SDK types it's transitively pulled in from. -->
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>

--- a/connectors/agentic-ai/connector-agentic-ai/pom.xml
+++ b/connectors/agentic-ai/connector-agentic-ai/pom.xml
@@ -495,10 +495,6 @@
                 <ignoredDependency>io.modelcontextprotocol.sdk:mcp</ignoredDependency>
                 <ignoredDependency>io.modelcontextprotocol.sdk:mcp-core</ignoredDependency>
                 <ignoredDependency>io.modelcontextprotocol.sdk:mcp-json</ignoredDependency>
-                <!-- okhttp-jvm has no direct source import (it's only reflectively required by
-                     anthropic-java-client-okhttp's AnthropicOkHttpClient at runtime, see the
-                     dependency declaration above); the analyzer would otherwise flag it unused. -->
-                <ignoredDependency>com.squareup.okhttp3:okhttp-jvm</ignoredDependency>
                 <!-- guava is compile-scoped for javac's benefit only (see the dependency
                      declaration above): main code never imports it, so the analyzer would
                      otherwise flag it as a non-test scoped test-only dependency. -->

--- a/connectors/agentic-ai/connector-agentic-ai/pom.xml
+++ b/connectors/agentic-ai/connector-agentic-ai/pom.xml
@@ -369,12 +369,16 @@
       <artifactId>feel-engine</artifactId>
     </dependency>
 
-    <!-- Test dependencies -->
+    <!-- Compile-scoped (the natural transitive scope from google-genai, which returns Guava
+         types such as ImmutableList from GenerateContentResponse#parts()): main compilation runs
+         with -XDaddTypeAnnotationsToSymbol=true, and javac cannot complete those SDK types
+         without Guava's class files on the compile classpath. Also used directly by tests. -->
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <scope>test</scope>
     </dependency>
+
+    <!-- Test dependencies -->
     <dependency>
       <groupId>io.camunda.connector</groupId>
       <artifactId>connector-object-mapper</artifactId>
@@ -495,6 +499,10 @@
                      anthropic-java-client-okhttp's AnthropicOkHttpClient at runtime, see the
                      dependency declaration above); the analyzer would otherwise flag it unused. -->
                 <ignoredDependency>com.squareup.okhttp3:okhttp-jvm</ignoredDependency>
+                <!-- guava is compile-scoped for javac's benefit only (see the dependency
+                     declaration above): main code never imports it, so the analyzer would
+                     otherwise flag it as a non-test scoped test-only dependency. -->
+                <ignoredDependency>com.google.guava:guava</ignoredDependency>
               </ignoredDependencies>
             </configuration>
           </execution>

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/configuration/AgenticAiNativeProvidersConfiguration.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/configuration/AgenticAiNativeProvidersConfiguration.java
@@ -16,6 +16,10 @@ import io.camunda.connector.agenticai.aiagent.chatmodel.provider.bedrock.Bedrock
 import io.camunda.connector.agenticai.aiagent.chatmodel.provider.bedrock.BedrockConverseContentConverter;
 import io.camunda.connector.agenticai.aiagent.chatmodel.provider.bedrock.BedrockConverseRequestConverter;
 import io.camunda.connector.agenticai.aiagent.chatmodel.provider.bedrock.BedrockConverseResponseConverter;
+import io.camunda.connector.agenticai.aiagent.chatmodel.provider.gemini.GeminiChatModelFactory;
+import io.camunda.connector.agenticai.aiagent.chatmodel.provider.gemini.GeminiContentConverter;
+import io.camunda.connector.agenticai.aiagent.chatmodel.provider.gemini.GeminiContentRequestConverter;
+import io.camunda.connector.agenticai.aiagent.chatmodel.provider.gemini.GeminiContentResponseConverter;
 import io.camunda.connector.agenticai.aiagent.chatmodel.provider.openai.OpenAiChatModelFactory;
 import io.camunda.connector.agenticai.aiagent.chatmodel.provider.openai.OpenAiContentConverter;
 import io.camunda.connector.agenticai.aiagent.chatmodel.provider.openai.OpenAiFoundryCredentialResolver;
@@ -101,5 +105,16 @@ public class AgenticAiNativeProvidersConfiguration {
             OpenAiResponsesStreamAssembler.accumulating());
     return new OpenAiChatModelFactory(
         httpProxySupport, completionsStrategy, responsesStrategy, openAiFoundryCredentialResolver);
+  }
+
+  @Bean
+  @ConditionalOnMissingBean
+  public GeminiChatModelFactory aiAgentGeminiChatModelFactory(
+      AgenticAiHttpProxySupport httpProxySupport,
+      @ConnectorsObjectMapper ObjectMapper objectMapper) {
+    final var contentConverter = new GeminiContentConverter(objectMapper);
+    final var requestConverter = new GeminiContentRequestConverter(contentConverter);
+    final var responseConverter = new GeminiContentResponseConverter();
+    return new GeminiChatModelFactory(httpProxySupport, requestConverter, responseConverter);
   }
 }

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiChatModel.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiChatModel.java
@@ -18,6 +18,7 @@ import io.camunda.connector.agenticai.aiagent.chatmodel.ChatModel;
 import io.camunda.connector.agenticai.aiagent.chatmodel.ChatModelRejectedException;
 import io.camunda.connector.agenticai.aiagent.chatmodel.ChatRequest;
 import io.camunda.connector.agenticai.aiagent.chatmodel.ChatResult;
+import io.camunda.connector.agenticai.aiagent.chatmodel.ContextWindowExceededException;
 import io.camunda.connector.agenticai.aiagent.model.request.v2.GeminiChatModelConfiguration;
 import io.camunda.connector.api.error.ConnectorException;
 import java.time.Duration;
@@ -95,6 +96,12 @@ public class GeminiChatModel implements ChatModel {
       // ConnectorException.
       throw e;
     } catch (ApiException e) {
+      if (isContextWindowExceeded(e)) {
+        throw new ContextWindowExceededException(
+            "Model's context window was exceeded before it could finish generating a response.",
+            e,
+            null);
+      }
       final String status =
           Optional.ofNullable(e.status())
               .filter(s -> !s.isBlank())
@@ -115,6 +122,19 @@ public class GeminiChatModel implements ChatModel {
       throw new ConnectorException(
           ERROR_CODE_FAILED_MODEL_CALL, "Model call failed: %s".formatted(detail), e);
     }
+  }
+
+  /**
+   * Gemini has no dedicated exception type or error code for an over-length prompt -- {@code
+   * ApiException.code()}/{@code status()} (400, {@code INVALID_ARGUMENT}) are shared with many
+   * unrelated validation failures, so detection falls back to matching this specific, stable
+   * substring of the message text. Confirmed identical across the Developer API and Vertex AI
+   * backends; the surrounding token counts vary per request and are excluded from the match.
+   */
+  private boolean isContextWindowExceeded(ApiException e) {
+    return e.code() == 400
+        && e.message() != null
+        && e.message().contains("exceeds the maximum number of tokens allowed");
   }
 
   @Override

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiChatModel.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiChatModel.java
@@ -57,25 +57,11 @@ public class GeminiChatModel implements ChatModel {
       GeminiChatModelConfiguration configuration,
       GeminiContentRequestConverter requestConverter,
       GeminiContentResponseConverter responseConverter) {
-    this(
-        client,
-        configuration,
-        requestConverter,
-        responseConverter,
-        new GeminiContentStreamAssemblerImpl());
-  }
-
-  GeminiChatModel(
-      Client client,
-      GeminiChatModelConfiguration configuration,
-      GeminiContentRequestConverter requestConverter,
-      GeminiContentResponseConverter responseConverter,
-      GeminiContentStreamAssembler streamAssembler) {
     this.client = client;
     this.configuration = configuration;
     this.requestConverter = requestConverter;
     this.responseConverter = responseConverter;
-    this.streamAssembler = streamAssembler;
+    this.streamAssembler = new GeminiContentStreamAssemblerImpl();
   }
 
   @Override

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiChatModel.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiChatModel.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.agenticai.aiagent.chatmodel.provider.gemini;
+
+import static io.camunda.connector.agenticai.aiagent.agent.AgentErrorCodes.ERROR_CODE_FAILED_MODEL_CALL;
+
+import com.google.genai.Client;
+import com.google.genai.ResponseStream;
+import com.google.genai.errors.ApiException;
+import com.google.genai.types.Content;
+import com.google.genai.types.GenerateContentConfig;
+import com.google.genai.types.GenerateContentResponse;
+import io.camunda.connector.agenticai.aiagent.chatmodel.ChatModel;
+import io.camunda.connector.agenticai.aiagent.chatmodel.ChatRequest;
+import io.camunda.connector.agenticai.aiagent.chatmodel.ChatResult;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.GeminiChatModelConfiguration;
+import io.camunda.connector.api.error.ConnectorException;
+import java.time.Duration;
+import java.util.List;
+import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Gemini {@link ChatModel}: drives the vendor SDK's streaming {@code generateContentStream} for
+ * every call, accumulates the chunks via a {@link GeminiContentStreamAssembler} into the single
+ * {@link GenerateContentResponse} shape a non-streaming call would have returned, then delegates to
+ * {@link GeminiContentRequestConverter} and {@link GeminiContentResponseConverter} to translate
+ * to/from the domain model.
+ *
+ * <p>The {@link Client} is built once by the factory and owned for the lifetime of this instance
+ * (one agent request, across all continuation rounds); {@link #close()} closes it once.
+ */
+public class GeminiChatModel implements ChatModel {
+
+  private static final Logger LOG = LoggerFactory.getLogger(GeminiChatModel.class);
+
+  private final Client client;
+  private final GeminiChatModelConfiguration configuration;
+  private final GeminiContentRequestConverter requestConverter;
+  private final GeminiContentResponseConverter responseConverter;
+  private final GeminiContentStreamAssembler streamAssembler;
+
+  public GeminiChatModel(
+      Client client,
+      GeminiChatModelConfiguration configuration,
+      GeminiContentRequestConverter requestConverter,
+      GeminiContentResponseConverter responseConverter) {
+    this(
+        client,
+        configuration,
+        requestConverter,
+        responseConverter,
+        new GeminiContentStreamAssemblerImpl());
+  }
+
+  GeminiChatModel(
+      Client client,
+      GeminiChatModelConfiguration configuration,
+      GeminiContentRequestConverter requestConverter,
+      GeminiContentResponseConverter responseConverter,
+      GeminiContentStreamAssembler streamAssembler) {
+    this.client = client;
+    this.configuration = configuration;
+    this.requestConverter = requestConverter;
+    this.responseConverter = responseConverter;
+    this.streamAssembler = streamAssembler;
+  }
+
+  @Override
+  public ChatResult execute(ChatRequest request) {
+    final GenerateContentConfig config =
+        requestConverter.toGenerateContentConfig(
+            configuration,
+            request.executionContext().configuration().response(),
+            request.snapshot());
+    final List<Content> contents = requestConverter.toContents(request.snapshot());
+
+    final long startNanos = System.nanoTime();
+    try {
+      final GenerateContentResponse response;
+      try (ResponseStream<GenerateContentResponse> stream =
+          client.models.generateContentStream(configuration.model(), contents, config)) {
+        response = streamAssembler.assemble(stream);
+      }
+      final Duration executionTime = Duration.ofNanos(System.nanoTime() - startNanos);
+      return responseConverter.toResult(response, executionTime);
+    } catch (ApiException e) {
+      throw new ConnectorException(
+          ERROR_CODE_FAILED_MODEL_CALL,
+          "Model call failed with HTTP %d (%s): %s".formatted(e.code(), e.status(), e.message()),
+          e);
+    } catch (Exception e) {
+      final String detail =
+          Optional.ofNullable(e.getMessage())
+              .filter(m -> !m.isBlank())
+              .orElseGet(() -> e.getClass().getSimpleName());
+      throw new ConnectorException(
+          ERROR_CODE_FAILED_MODEL_CALL, "Model call failed: %s".formatted(detail), e);
+    }
+  }
+
+  @Override
+  public void close() {
+    try {
+      client.close();
+    } catch (Exception e) {
+      LOG.warn("Failed to close Gemini Client", e);
+    }
+  }
+}

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiChatModel.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiChatModel.java
@@ -8,11 +8,14 @@ package io.camunda.connector.agenticai.aiagent.chatmodel.provider.gemini;
 
 import static io.camunda.connector.agenticai.aiagent.agent.AgentErrorCodes.ERROR_CODE_FAILED_MODEL_CALL;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.genai.Client;
+import com.google.genai.JsonSerializable;
 import com.google.genai.ResponseStream;
 import com.google.genai.errors.ApiException;
 import com.google.genai.types.Content;
 import com.google.genai.types.GenerateContentConfig;
+import com.google.genai.types.GenerateContentParameters;
 import com.google.genai.types.GenerateContentResponse;
 import io.camunda.connector.agenticai.aiagent.chatmodel.ChatModel;
 import io.camunda.connector.agenticai.aiagent.chatmodel.ChatModelRejectedException;
@@ -20,6 +23,7 @@ import io.camunda.connector.agenticai.aiagent.chatmodel.ChatRequest;
 import io.camunda.connector.agenticai.aiagent.chatmodel.ChatResult;
 import io.camunda.connector.agenticai.aiagent.chatmodel.ContextWindowExceededException;
 import io.camunda.connector.agenticai.aiagent.model.request.v2.GeminiChatModelConfiguration;
+import io.camunda.connector.agenticai.aiagent.util.LoggingSupport;
 import io.camunda.connector.api.error.ConnectorException;
 import java.time.Duration;
 import java.util.List;
@@ -40,6 +44,7 @@ import org.slf4j.LoggerFactory;
 public class GeminiChatModel implements ChatModel {
 
   private static final Logger LOG = LoggerFactory.getLogger(GeminiChatModel.class);
+  private static final ObjectMapper MAPPER = JsonSerializable.objectMapper();
 
   private final Client client;
   private final GeminiChatModelConfiguration configuration;
@@ -82,12 +87,27 @@ public class GeminiChatModel implements ChatModel {
             request.snapshot());
     final List<Content> contents = requestConverter.toContents(request.snapshot());
 
+    if (LOG.isTraceEnabled()) {
+      LOG.trace(
+          "Gemini generateContent request: {}",
+          LoggingSupport.toJson(
+              MAPPER,
+              GenerateContentParameters.builder()
+                  .model(configuration.model())
+                  .contents(contents)
+                  .config(config)
+                  .build()));
+    }
+
     final long startNanos = System.nanoTime();
     try {
       final GenerateContentResponse response;
       try (ResponseStream<GenerateContentResponse> stream =
           client.models.generateContentStream(configuration.model(), contents, config)) {
         response = streamAssembler.assemble(stream);
+      }
+      if (LOG.isTraceEnabled()) {
+        LOG.trace("Gemini generateContent response: {}", LoggingSupport.toJson(MAPPER, response));
       }
       final Duration executionTime = Duration.ofNanos(System.nanoTime() - startNanos);
       return responseConverter.toResult(response, executionTime);

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiChatModel.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiChatModel.java
@@ -90,9 +90,17 @@ public class GeminiChatModel implements ChatModel {
       final Duration executionTime = Duration.ofNanos(System.nanoTime() - startNanos);
       return responseConverter.toResult(response, executionTime);
     } catch (ApiException e) {
+      final String status =
+          Optional.ofNullable(e.status())
+              .filter(s -> !s.isBlank())
+              .orElseGet(() -> e.getClass().getSimpleName());
+      final String message =
+          Optional.ofNullable(e.message())
+              .filter(m -> !m.isBlank())
+              .orElseGet(() -> e.getClass().getSimpleName());
       throw new ConnectorException(
           ERROR_CODE_FAILED_MODEL_CALL,
-          "Model call failed with HTTP %d (%s): %s".formatted(e.code(), e.status(), e.message()),
+          "Model call failed with HTTP %d (%s): %s".formatted(e.code(), status, message),
           e);
     } catch (Exception e) {
       final String detail =

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiChatModel.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiChatModel.java
@@ -15,6 +15,7 @@ import com.google.genai.types.Content;
 import com.google.genai.types.GenerateContentConfig;
 import com.google.genai.types.GenerateContentResponse;
 import io.camunda.connector.agenticai.aiagent.chatmodel.ChatModel;
+import io.camunda.connector.agenticai.aiagent.chatmodel.ChatModelRejectedException;
 import io.camunda.connector.agenticai.aiagent.chatmodel.ChatRequest;
 import io.camunda.connector.agenticai.aiagent.chatmodel.ChatResult;
 import io.camunda.connector.agenticai.aiagent.model.request.v2.GeminiChatModelConfiguration;
@@ -89,6 +90,8 @@ public class GeminiChatModel implements ChatModel {
       }
       final Duration executionTime = Duration.ofNanos(System.nanoTime() - startNanos);
       return responseConverter.toResult(response, executionTime);
+    } catch (ChatModelRejectedException e) {
+      throw e;
     } catch (ApiException e) {
       final String status =
           Optional.ofNullable(e.status())

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiChatModel.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiChatModel.java
@@ -91,6 +91,8 @@ public class GeminiChatModel implements ChatModel {
       final Duration executionTime = Duration.ofNanos(System.nanoTime() - startNanos);
       return responseConverter.toResult(response, executionTime);
     } catch (ChatModelRejectedException e) {
+      // Rethrown unwrapped so the catch-all below does not flatten it into a generic
+      // ConnectorException.
       throw e;
     } catch (ApiException e) {
       final String status =

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiChatModelFactory.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiChatModelFactory.java
@@ -48,6 +48,13 @@ public class GeminiChatModelFactory implements ChatModelFactory {
    * HttpOptions#timeout} and {@code ClientOptions#proxyOptions} entirely and trusts the supplied
    * client as-is. {@link #buildClient} therefore applies the overall timeout and proxy directly on
    * this custom client instead of through those SDK options.
+   *
+   * <p>A bare {@code new OkHttpClient.Builder()}, unlike the SDK's own default client, does not
+   * default {@code readTimeout}/{@code writeTimeout} to zero -- it defaults them to OkHttp's own
+   * stock 10-second value. Left alone, a Gemini SSE stream with a longer gap between chunks (e.g.
+   * during an extended thinking phase) would abort mid-stream regardless of how generous the
+   * configured overall timeout is, so {@link #buildClient} explicitly zeroes both, leaving only
+   * connect bounded and {@code callTimeout} governing the overall budget.
    */
   private static final Duration CONNECT_TIMEOUT = Duration.ofSeconds(10);
 
@@ -105,7 +112,11 @@ public class GeminiChatModelFactory implements ChatModelFactory {
       httpOptionsBuilder.timeout(toGeminiTimeoutMillis(timeout));
     }
 
-    final var okHttpClientBuilder = new OkHttpClient.Builder().connectTimeout(CONNECT_TIMEOUT);
+    final var okHttpClientBuilder =
+        new OkHttpClient.Builder()
+            .connectTimeout(CONNECT_TIMEOUT)
+            .readTimeout(Duration.ZERO)
+            .writeTimeout(Duration.ZERO);
     if (timeout != null) {
       okHttpClientBuilder.callTimeout(Duration.ofMillis(toGeminiTimeoutMillis(timeout)));
     }

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiChatModelFactory.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiChatModelFactory.java
@@ -18,8 +18,6 @@ import io.camunda.connector.agenticai.aiagent.model.request.v2.GeminiChatModelCo
 import io.camunda.connector.agenticai.common.AgenticAiHttpProxySupport;
 import io.camunda.connector.api.error.ConnectorInputException;
 import io.camunda.connector.http.client.proxy.ProxyConfiguration;
-import java.net.InetSocketAddress;
-import java.net.Proxy;
 import java.net.URI;
 import java.time.Duration;
 import java.util.Optional;
@@ -124,9 +122,8 @@ public class GeminiChatModelFactory implements ChatModelFactory {
     final String scheme =
         Optional.ofNullable(endpoint).map(e -> URI.create(e).getScheme()).orElse(null);
     httpProxySupport
-        .getProxyConfiguration()
-        .getProxyDetails(scheme != null ? scheme : ProxyConfiguration.SCHEME_HTTPS)
-        .ifPresent(proxyDetails -> applyProxy(okHttpClientBuilder, proxyDetails));
+        .okHttpProxy(scheme != null ? scheme : ProxyConfiguration.SCHEME_HTTPS)
+        .ifPresent(proxy -> applyProxy(okHttpClientBuilder, proxy));
 
     return Client.builder()
         .apiKey(googleGeminiApi.apiKey())
@@ -136,15 +133,18 @@ public class GeminiChatModelFactory implements ChatModelFactory {
         .build();
   }
 
-  /** Only HTTP proxies are supported today; matches what this connector's proxy support offers. */
+  /**
+   * Resolution and logging are shared with the Anthropic/OpenAI providers via {@link
+   * AgenticAiHttpProxySupport#okHttpProxy}; only the authenticator differs, since those providers'
+   * SDKs accept a {@code Proxy} directly while Gemini's raw {@link OkHttpClient.Builder} needs its
+   * own {@link okhttp3.Authenticator}.
+   */
   private static void applyProxy(
-      OkHttpClient.Builder builder, ProxyConfiguration.ProxyDetails proxyDetails) {
-    builder.proxy(
-        new Proxy(
-            Proxy.Type.HTTP, new InetSocketAddress(proxyDetails.host(), proxyDetails.port())));
+      OkHttpClient.Builder builder, AgenticAiHttpProxySupport.OkHttpProxy proxy) {
+    builder.proxy(proxy.proxy());
 
-    if (proxyDetails.hasCredentials()) {
-      final String credential = Credentials.basic(proxyDetails.user(), proxyDetails.password());
+    if (proxy.hasCredentials()) {
+      final String credential = Credentials.basic(proxy.username(), proxy.password());
       // Only answers a proxy's 407 challenge once per request: if the prior attempt already
       // carried this header, OkHttp calls the authenticator again because the proxy rejected it a
       // second time, and returning the same credential again would retry forever.

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiChatModelFactory.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiChatModelFactory.java
@@ -71,8 +71,7 @@ public class GeminiChatModelFactory implements ChatModelFactory {
       GeminiBackend backend,
       @Nullable Duration timeout,
       AgenticAiHttpProxySupport httpProxySupport) {
-    // Only one backend variant exists today (google-gemini-api); a Vertex AI backend is tracked
-    // separately in #8066.
+    // Only one backend variant exists today (google-gemini-api), so this cast is safe.
     final var apiBackend = (GeminiApiBackend) backend;
     final var googleGeminiApi = apiBackend.googleGeminiApi();
     final String endpoint = googleGeminiApi.endpoint();

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiChatModelFactory.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiChatModelFactory.java
@@ -9,8 +9,6 @@ package io.camunda.connector.agenticai.aiagent.chatmodel.provider.gemini;
 import com.google.genai.Client;
 import com.google.genai.types.ClientOptions;
 import com.google.genai.types.HttpOptions;
-import com.google.genai.types.ProxyOptions;
-import com.google.genai.types.ProxyType;
 import io.camunda.connector.agenticai.aiagent.chatmodel.ChatModel;
 import io.camunda.connector.agenticai.aiagent.chatmodel.ChatModelConfiguration;
 import io.camunda.connector.agenticai.aiagent.chatmodel.ChatModelFactory;
@@ -20,9 +18,13 @@ import io.camunda.connector.agenticai.aiagent.model.request.v2.GeminiChatModelCo
 import io.camunda.connector.agenticai.common.AgenticAiHttpProxySupport;
 import io.camunda.connector.api.error.ConnectorInputException;
 import io.camunda.connector.http.client.proxy.ProxyConfiguration;
+import java.net.InetSocketAddress;
+import java.net.Proxy;
 import java.net.URI;
 import java.time.Duration;
 import java.util.Optional;
+import okhttp3.Credentials;
+import okhttp3.OkHttpClient;
 import org.jspecify.annotations.Nullable;
 
 public class GeminiChatModelFactory implements ChatModelFactory {
@@ -32,6 +34,22 @@ public class GeminiChatModelFactory implements ChatModelFactory {
    * connector accepts any positive {@link Duration}.
    */
   private static final Duration MAX_GEMINI_TIMEOUT = Duration.ofMillis(Integer.MAX_VALUE);
+
+  /**
+   * The SDK's own default {@link OkHttpClient} (built when no {@code customHttpClient} is supplied)
+   * sets {@code connectTimeout}/{@code readTimeout}/{@code writeTimeout} to zero (unbounded) and
+   * relies solely on {@link HttpOptions#timeout} as an overall {@code callTimeout} -- a hung TCP
+   * connect would otherwise consume the whole, often much longer, configured request budget before
+   * failing. Bounding connect separately, at OkHttp's own upstream default, lets a genuinely
+   * unreachable host fail fast regardless of how generous the configured overall timeout is.
+   *
+   * <p>Supplying a {@code customHttpClient} at all changes {@code ApiClient#createHttpClient}'s
+   * behavior beyond just the timeouts: on that branch, the SDK skips applying {@code
+   * HttpOptions#timeout} and {@code ClientOptions#proxyOptions} entirely and trusts the supplied
+   * client as-is. {@link #buildClient} therefore applies the overall timeout and proxy directly on
+   * this custom client instead of through those SDK options.
+   */
+  private static final Duration CONNECT_TIMEOUT = Duration.ofSeconds(10);
 
   private final AgenticAiHttpProxySupport httpProxySupport;
   private final GeminiContentRequestConverter requestConverter;
@@ -80,38 +98,55 @@ public class GeminiChatModelFactory implements ChatModelFactory {
     if (endpoint != null) {
       httpOptionsBuilder.baseUrl(endpoint);
     }
+    // Stored for introspection/consistency only -- because a customHttpClient is always supplied
+    // below, the SDK never reads this value itself; okHttpClientBuilder.callTimeout is what
+    // actually enforces the overall timeout.
     if (timeout != null) {
       httpOptionsBuilder.timeout(toGeminiTimeoutMillis(timeout));
     }
 
-    final var clientBuilder =
-        Client.builder().apiKey(googleGeminiApi.apiKey()).httpOptions(httpOptionsBuilder.build());
+    final var okHttpClientBuilder = new OkHttpClient.Builder().connectTimeout(CONNECT_TIMEOUT);
+    if (timeout != null) {
+      okHttpClientBuilder.callTimeout(Duration.ofMillis(toGeminiTimeoutMillis(timeout)));
+    }
 
     final String scheme =
         Optional.ofNullable(endpoint).map(e -> URI.create(e).getScheme()).orElse(null);
     httpProxySupport
         .getProxyConfiguration()
         .getProxyDetails(scheme != null ? scheme : ProxyConfiguration.SCHEME_HTTPS)
-        .ifPresent(
-            proxyDetails ->
-                clientBuilder.clientOptions(
-                    ClientOptions.builder().proxyOptions(toProxyOptions(proxyDetails)).build()));
+        .ifPresent(proxyDetails -> applyProxy(okHttpClientBuilder, proxyDetails));
 
-    return clientBuilder.build();
+    return Client.builder()
+        .apiKey(googleGeminiApi.apiKey())
+        .httpOptions(httpOptionsBuilder.build())
+        .clientOptions(
+            ClientOptions.builder().customHttpClient(okHttpClientBuilder.build()).build())
+        .build();
   }
 
-  private static ProxyOptions toProxyOptions(ProxyConfiguration.ProxyDetails proxyDetails) {
-    final var builder =
-        ProxyOptions.builder()
-            .type(ProxyType.Known.HTTP)
-            .host(proxyDetails.host())
-            .port(proxyDetails.port());
+  /** Only HTTP proxies are supported today; matches what this connector's proxy support offers. */
+  private static void applyProxy(
+      OkHttpClient.Builder builder, ProxyConfiguration.ProxyDetails proxyDetails) {
+    builder.proxy(
+        new Proxy(
+            Proxy.Type.HTTP, new InetSocketAddress(proxyDetails.host(), proxyDetails.port())));
 
     if (proxyDetails.hasCredentials()) {
-      builder.username(proxyDetails.user()).password(proxyDetails.password());
+      final String credential = Credentials.basic(proxyDetails.user(), proxyDetails.password());
+      // Only answers a proxy's 407 challenge once per request: if the prior attempt already
+      // carried this header, OkHttp calls the authenticator again because the proxy rejected it a
+      // second time, and returning the same credential again would retry forever.
+      builder.proxyAuthenticator(
+          (route, response) ->
+              response.request().header("Proxy-Authorization") != null
+                  ? null
+                  : response
+                      .request()
+                      .newBuilder()
+                      .header("Proxy-Authorization", credential)
+                      .build());
     }
-
-    return builder.build();
   }
 
   /**

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiChatModelFactory.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiChatModelFactory.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.agenticai.aiagent.chatmodel.provider.gemini;
+
+import com.google.genai.Client;
+import com.google.genai.types.ClientOptions;
+import com.google.genai.types.HttpOptions;
+import com.google.genai.types.ProxyOptions;
+import com.google.genai.types.ProxyType;
+import io.camunda.connector.agenticai.aiagent.chatmodel.ChatModel;
+import io.camunda.connector.agenticai.aiagent.chatmodel.ChatModelConfiguration;
+import io.camunda.connector.agenticai.aiagent.chatmodel.ChatModelFactory;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.GeminiChatModelConfiguration;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.GeminiChatModelConfiguration.GeminiBackend;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.GeminiChatModelConfiguration.GeminiBackend.GeminiApiBackend;
+import io.camunda.connector.agenticai.common.AgenticAiHttpProxySupport;
+import io.camunda.connector.api.error.ConnectorInputException;
+import io.camunda.connector.http.client.proxy.ProxyConfiguration;
+import java.net.URI;
+import java.time.Duration;
+import java.util.Optional;
+import org.jspecify.annotations.Nullable;
+
+public class GeminiChatModelFactory implements ChatModelFactory {
+
+  /**
+   * {@code HttpOptions.timeout} only accepts an {@code Integer} millisecond value, while the
+   * connector accepts any positive {@link Duration}.
+   */
+  private static final Duration MAX_GEMINI_TIMEOUT = Duration.ofMillis(Integer.MAX_VALUE);
+
+  private final AgenticAiHttpProxySupport httpProxySupport;
+  private final GeminiContentRequestConverter requestConverter;
+  private final GeminiContentResponseConverter responseConverter;
+
+  public GeminiChatModelFactory(
+      AgenticAiHttpProxySupport httpProxySupport,
+      GeminiContentRequestConverter requestConverter,
+      GeminiContentResponseConverter responseConverter) {
+    this.httpProxySupport = httpProxySupport;
+    this.requestConverter = requestConverter;
+    this.responseConverter = responseConverter;
+  }
+
+  @Override
+  public boolean supports(ChatModelConfiguration configuration) {
+    return configuration instanceof GeminiChatModelConfiguration;
+  }
+
+  @Override
+  public ChatModel create(ChatModelConfiguration configuration) {
+    final var model = (GeminiChatModelConfiguration) configuration;
+    final var connection = model.googleGemini();
+    final var timeout = connection.timeouts() != null ? connection.timeouts().timeout() : null;
+
+    final var client = buildClient(connection.backend(), timeout, httpProxySupport);
+    return new GeminiChatModel(client, model, requestConverter, responseConverter);
+  }
+
+  private static Client buildClient(
+      GeminiBackend backend,
+      @Nullable Duration timeout,
+      AgenticAiHttpProxySupport httpProxySupport) {
+    // Only one backend variant exists today (google-gemini-api); a Vertex AI backend is tracked
+    // separately in #8066.
+    final var apiBackend = (GeminiApiBackend) backend;
+    final var googleGeminiApi = apiBackend.googleGeminiApi();
+    final String endpoint = googleGeminiApi.endpoint();
+
+    final var httpOptionsBuilder = HttpOptions.builder();
+    if (endpoint != null) {
+      httpOptionsBuilder.baseUrl(endpoint);
+    }
+    if (timeout != null) {
+      httpOptionsBuilder.timeout(toGeminiTimeoutMillis(timeout));
+    }
+
+    final var clientBuilder =
+        Client.builder().apiKey(googleGeminiApi.apiKey()).httpOptions(httpOptionsBuilder.build());
+
+    final String scheme =
+        Optional.ofNullable(endpoint).map(e -> URI.create(e).getScheme()).orElse(null);
+    httpProxySupport
+        .getProxyConfiguration()
+        .getProxyDetails(scheme != null ? scheme : ProxyConfiguration.SCHEME_HTTPS)
+        .ifPresent(
+            proxyDetails ->
+                clientBuilder.clientOptions(
+                    ClientOptions.builder().proxyOptions(toProxyOptions(proxyDetails)).build()));
+
+    return clientBuilder.build();
+  }
+
+  private static ProxyOptions toProxyOptions(ProxyConfiguration.ProxyDetails proxyDetails) {
+    final var builder =
+        ProxyOptions.builder()
+            .type(ProxyType.Known.HTTP)
+            .host(proxyDetails.host())
+            .port(proxyDetails.port());
+
+    if (proxyDetails.hasCredentials()) {
+      builder.username(proxyDetails.user()).password(proxyDetails.password());
+    }
+
+    return builder.build();
+  }
+
+  /**
+   * Values above {@code Integer.MAX_VALUE} ms (~24.8 days) would silently overflow on a raw cast,
+   * so reject them with a clear input error instead. A positive sub-millisecond timeout would
+   * otherwise truncate to 0, which is clamped to the shortest possible timeout (1ms) instead.
+   */
+  private static int toGeminiTimeoutMillis(Duration timeout) {
+    if (timeout.compareTo(MAX_GEMINI_TIMEOUT) > 0) {
+      throw new ConnectorInputException(
+          "Configured timeout of %s exceeds the maximum supported by the Google GenAI SDK (%dms)"
+              .formatted(timeout, Integer.MAX_VALUE));
+    }
+
+    return (int) Math.max(1, timeout.toMillis());
+  }
+}

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiChatModelFactory.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiChatModelFactory.java
@@ -55,7 +55,13 @@ public class GeminiChatModelFactory implements ChatModelFactory {
   public ChatModel create(ChatModelConfiguration configuration) {
     final var model = (GeminiChatModelConfiguration) configuration;
     final var connection = model.googleGemini();
-    final var timeout = connection.timeouts() != null ? connection.timeouts().timeout() : null;
+    final var configuredTimeout =
+        connection.timeouts() != null ? connection.timeouts().timeout() : null;
+    // a non-positive configured timeout (e.g. PT0S, or a negative FEEL result) falls back to
+    // the SDK default rather than being passed through - see toGeminiTimeoutMillis, which
+    // would otherwise clamp it to an unusable 1ms call timeout
+    final var timeout =
+        configuredTimeout != null && configuredTimeout.isPositive() ? configuredTimeout : null;
 
     final var client = buildClient(connection.backend(), timeout, httpProxySupport);
     return new GeminiChatModel(client, model, requestConverter, responseConverter);

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiContentConverter.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiContentConverter.java
@@ -101,7 +101,11 @@ public class GeminiContentConverter {
    * embedded natively as {@code inlineData}: the document's actual bytes are already delivered to
    * the model elsewhere for tool results, so embedding it here as well would send it twice. Matches
    * {@code AnthropicContentConverter#toToolResultBlocks} and {@code
-   * OpenAiContentConverter#toResponsesToolResultOutputItems}.
+   * OpenAiContentConverter#toResponsesToolResultOutputItems}. Every branch still wraps its payload
+   * in a {@code functionResponse}, the reference-only document included: a plain text {@link Part}
+   * would carry no {@code name}/{@code id} to correlate with the preceding {@code functionCall}, so
+   * a tool result whose only content is a document (or reasoning/provider content) would never
+   * close out that call.
    */
   public List<Part> toFunctionResponseParts(List<Content> content) {
     final List<Part> parts = new ArrayList<>();
@@ -109,8 +113,8 @@ public class GeminiContentConverter {
       switch (c) {
         case TextContent text -> parts.add(toFunctionResponsePart(text.text()));
         case ObjectContent obj -> parts.add(toFunctionResponsePart(obj.content()));
-        case DocumentContent doc -> parts.add(Part.fromText(writeAsJson(doc.document())));
-        default -> parts.add(Part.fromText(writeAsJson(c)));
+        case DocumentContent doc -> parts.add(toFunctionResponsePart(writeAsJson(doc.document())));
+        default -> parts.add(toFunctionResponsePart(writeAsJson(c)));
       }
     }
     return parts;

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiContentConverter.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiContentConverter.java
@@ -90,14 +90,18 @@ public class GeminiContentConverter {
    *
    * <p>The {@code functionResponse} parts built here deliberately omit {@code name}/{@code id}:
    * that correlating identity lives on the wrapping {@code ToolCallResultContent}, not on the
-   * individual {@link Content} items converted here -- mirroring {@code
-   * AnthropicContentConverter#toToolResultBlocks}, whose {@code ToolResultBlockParam.toolUseId} is
-   * likewise stamped by its caller one level up. The caller of this method is expected to rebuild
-   * each returned {@link FunctionResponse} via {@code toBuilder()} to add {@code name}/{@code id}
-   * before sending the request. This assumes one {@link Part} per tool call (the current shape of
-   * {@code ToolCallResultContent.content()}); if that list ever becomes multi-element for a single
-   * tool call, the caller must merge the results into a single {@code functionResponse} rather than
-   * emit sibling parts sharing one name/id.
+   * individual {@link Content} items converted here, and this method's signature (like {@code
+   * AnthropicContentConverter#toToolResultBlocks}'s) only receives the latter. For {@code id} this
+   * mirrors Anthropic exactly: its {@code ToolResultBlockParam.toolUseId} is likewise stamped by
+   * its caller one level up. {@code name} has no Anthropic equivalent to mirror -- {@code
+   * ToolResultBlockParam} has no {@code name} field at all -- but Gemini's {@link FunctionResponse}
+   * does carry one, so for consistency with {@code id} (and because neither is available at this
+   * layer) it is deferred to the same caller. The caller of this method is expected to rebuild each
+   * returned {@link FunctionResponse} via {@code toBuilder()} to add {@code name}/{@code id} before
+   * sending the request. This assumes one {@link Part} per tool call (the current shape of {@code
+   * ToolCallResultContent.content()}); if that list ever becomes multi-element for a single tool
+   * call, the caller must merge the results into a single {@code functionResponse} rather than emit
+   * sibling parts sharing one name/id.
    */
   public List<Part> toFunctionResponseParts(List<Content> content) {
     final List<Part> parts = new ArrayList<>();

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiContentConverter.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiContentConverter.java
@@ -75,7 +75,7 @@ public class GeminiContentConverter {
     final List<Part> parts = new ArrayList<>();
     for (final Content c : content) {
       switch (c) {
-        case TextContent text -> parts.add(Part.fromText(text.text()));
+        case TextContent text -> parts.add(toTextPart(text));
         case DocumentContent doc -> parts.add(toDocumentPart(doc));
         case ObjectContent obj -> parts.add(Part.fromText(writeAsJson(obj.content())));
         case ReasoningContent rc -> parts.add(toThoughtPart(rc));
@@ -120,6 +120,19 @@ public class GeminiContentConverter {
     return Part.builder()
         .functionResponse(FunctionResponse.builder().response(Map.of("output", value)).build())
         .build();
+  }
+
+  /**
+   * A {@code thoughtSignature} is not exclusive to thinking parts: Gemini attaches it to whichever
+   * part the reasoning continuity belongs to, a plain answer text part included. The response
+   * converter therefore records it on {@link TextContent#metadata()} under the same {@link
+   * #THOUGHT_SIGNATURE_METADATA_KEY}, and it must be restored here verbatim or Gemini 3 rejects the
+   * follow-up request that replays this message.
+   */
+  private Part toTextPart(TextContent text) {
+    final Part part = Part.fromText(text.text());
+    final byte @Nullable [] signature = thoughtSignature(text.metadata());
+    return signature == null ? part : part.toBuilder().thoughtSignature(signature).build();
   }
 
   private Part toThoughtPart(ReasoningContent rc) {

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiContentConverter.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiContentConverter.java
@@ -121,7 +121,7 @@ public class GeminiContentConverter {
     for (final Content c : content) {
       switch (c) {
         case TextContent text -> parts.add(toFunctionResponsePart(text.text()));
-        case ObjectContent obj -> parts.add(toFunctionResponsePart(obj.content()));
+        case ObjectContent obj -> parts.add(toFunctionResponsePart(writeAsJson(obj.content())));
         case DocumentContent doc -> parts.add(toFunctionResponsePart(writeAsJson(doc.document())));
         default -> parts.add(toFunctionResponsePart(writeAsJson(c)));
       }

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiContentConverter.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiContentConverter.java
@@ -89,19 +89,13 @@ public class GeminiContentConverter {
    * Converts tool-result {@link Content} into {@link Part}s carrying the result payload.
    *
    * <p>The {@code functionResponse} parts built here deliberately omit {@code name}/{@code id}:
-   * that correlating identity lives on the wrapping {@code ToolCallResultContent}, not on the
-   * individual {@link Content} items converted here, and this method's signature (like {@code
-   * AnthropicContentConverter#toToolResultBlocks}'s) only receives the latter. For {@code id} this
-   * mirrors Anthropic exactly: its {@code ToolResultBlockParam.toolUseId} is likewise stamped by
-   * its caller one level up. {@code name} has no Anthropic equivalent to mirror -- {@code
-   * ToolResultBlockParam} has no {@code name} field at all -- but Gemini's {@link FunctionResponse}
-   * does carry one, so for consistency with {@code id} (and because neither is available at this
-   * layer) it is deferred to the same caller. The caller of this method is expected to rebuild each
-   * returned {@link FunctionResponse} via {@code toBuilder()} to add {@code name}/{@code id} before
-   * sending the request. This assumes one {@link Part} per tool call (the current shape of {@code
-   * ToolCallResultContent.content()}); if that list ever becomes multi-element for a single tool
-   * call, the caller must merge the results into a single {@code functionResponse} rather than emit
-   * sibling parts sharing one name/id.
+   * that correlating identity lives on the wrapping {@code ToolCallResultContent}, one level above
+   * the individual {@link Content} items this method receives. The caller is expected to rebuild
+   * each returned {@link FunctionResponse} via {@code toBuilder()} to add {@code name}/{@code id}
+   * before sending the request. This assumes one {@link Part} per tool call (the current shape of
+   * {@code ToolCallResultContent.content()}); if that list ever becomes multi-element for a single
+   * tool call, the caller must merge the results into a single {@code functionResponse} rather than
+   * emit sibling parts sharing one name/id.
    */
   public List<Part> toFunctionResponseParts(List<Content> content) {
     final List<Part> parts = new ArrayList<>();

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiContentConverter.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiContentConverter.java
@@ -1,0 +1,260 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.agenticai.aiagent.chatmodel.provider.gemini;
+
+import static io.camunda.connector.agenticai.aiagent.agent.AgentErrorCodes.ERROR_CODE_FAILED_MODEL_CALL;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.genai.JsonSerializable;
+import com.google.genai.types.Blob;
+import com.google.genai.types.FunctionResponse;
+import com.google.genai.types.Part;
+import io.camunda.connector.agenticai.aiagent.model.message.content.Content;
+import io.camunda.connector.agenticai.aiagent.model.message.content.DocumentContent;
+import io.camunda.connector.agenticai.aiagent.model.message.content.ObjectContent;
+import io.camunda.connector.agenticai.aiagent.model.message.content.ProviderContent;
+import io.camunda.connector.agenticai.aiagent.model.message.content.ReasoningContent;
+import io.camunda.connector.agenticai.aiagent.model.message.content.TextContent;
+import io.camunda.connector.api.document.Document;
+import io.camunda.connector.api.error.ConnectorException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import org.apache.hc.core5.http.ContentType;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Converts the domain {@link Content} model to Gemini SDK {@link Part}s: {@link #toParts(List)} for
+ * user/assistant message bodies, {@link #toFunctionResponseParts(List)} for tool-result bodies.
+ *
+ * <p>Request direction only. The reverse direction ({@link Part} to domain {@link Content}) is
+ * handled inline by the response converter, not delegated to this class.
+ */
+public class GeminiContentConverter {
+
+  /**
+   * Metadata key under which the Gemini {@code thoughtSignature} is stored on a {@link
+   * ReasoningContent}'s {@link Content#metadata()}, base64-encoded as a {@link String}.
+   *
+   * <p>The response converter writes this exact key when it first extracts the signature from a
+   * live response; {@link #toParts(List)} reads it back here to restore the signature verbatim on
+   * replay, which Gemini 3 requires for follow-up tool-calling requests.
+   */
+  public static final String THOUGHT_SIGNATURE_METADATA_KEY = "thoughtSignature";
+
+  private static final List<ContentType> PDF_CONTENT_TYPES = List.of(ContentType.APPLICATION_PDF);
+
+  private static final List<ContentType> IMAGE_CONTENT_TYPES =
+      List.of(
+          ContentType.IMAGE_JPEG,
+          ContentType.IMAGE_PNG,
+          ContentType.IMAGE_GIF,
+          ContentType.IMAGE_WEBP);
+
+  private static final List<ContentType> ADDITIONAL_TEXT_FILE_CONTENT_TYPES =
+      List.of(
+          ContentType.APPLICATION_JSON,
+          ContentType.APPLICATION_XML,
+          ContentType.create("application/yaml"));
+
+  private final ObjectMapper objectMapper;
+
+  public GeminiContentConverter(ObjectMapper objectMapper) {
+    this.objectMapper = objectMapper;
+  }
+
+  public List<Part> toParts(List<Content> content) {
+    final List<Part> parts = new ArrayList<>();
+    for (final Content c : content) {
+      switch (c) {
+        case TextContent text -> parts.add(Part.fromText(text.text()));
+        case DocumentContent doc -> parts.add(toDocumentPart(doc));
+        case ObjectContent obj -> parts.add(Part.fromText(writeAsJson(obj.content())));
+        case ReasoningContent rc -> parts.add(toThoughtPart(rc));
+        case ProviderContent pc -> parts.add(toProviderPart(pc));
+      }
+    }
+    return parts;
+  }
+
+  /**
+   * Converts tool-result {@link Content} into {@link Part}s carrying the result payload.
+   *
+   * <p>The {@code functionResponse} parts built here deliberately omit {@code name}/{@code id}:
+   * that correlating identity lives on the wrapping {@code ToolCallResultContent}, not on the
+   * individual {@link Content} items converted here -- mirroring {@code
+   * AnthropicContentConverter#toToolResultBlocks}, whose {@code ToolResultBlockParam.toolUseId} is
+   * likewise stamped by its caller one level up. The caller of this method is expected to rebuild
+   * each returned {@link FunctionResponse} via {@code toBuilder()} to add {@code name}/{@code id}
+   * before sending the request. This assumes one {@link Part} per tool call (the current shape of
+   * {@code ToolCallResultContent.content()}); if that list ever becomes multi-element for a single
+   * tool call, the caller must merge the results into a single {@code functionResponse} rather than
+   * emit sibling parts sharing one name/id.
+   */
+  public List<Part> toFunctionResponseParts(List<Content> content) {
+    final List<Part> parts = new ArrayList<>();
+    for (final Content c : content) {
+      switch (c) {
+        case TextContent text -> parts.add(toFunctionResponsePart(text.text()));
+        case ObjectContent obj -> parts.add(toFunctionResponsePart(obj.content()));
+        case DocumentContent doc -> parts.add(toDocumentPart(doc));
+        default -> parts.add(Part.fromText(writeAsJson(c)));
+      }
+    }
+    return parts;
+  }
+
+  private Part toFunctionResponsePart(Object value) {
+    return Part.builder()
+        .functionResponse(FunctionResponse.builder().response(Map.of("output", value)).build())
+        .build();
+  }
+
+  private Part toThoughtPart(ReasoningContent rc) {
+    final Part.Builder builder = Part.builder().thought(true);
+    if (rc.text() != null) {
+      builder.text(rc.text());
+    }
+    final byte @Nullable [] signature = thoughtSignature(rc.metadata());
+    if (signature != null) {
+      builder.thoughtSignature(signature);
+    }
+    return builder.build();
+  }
+
+  private byte @Nullable [] thoughtSignature(@Nullable Map<String, Object> metadata) {
+    if (metadata == null) {
+      return null;
+    }
+    final Object value = metadata.get(THOUGHT_SIGNATURE_METADATA_KEY);
+    if (value == null) {
+      return null;
+    }
+    if (value instanceof byte[] bytes) {
+      return bytes;
+    }
+    if (value instanceof String base64) {
+      return Base64.getDecoder().decode(base64);
+    }
+    throw new ConnectorException(
+        ERROR_CODE_FAILED_MODEL_CALL,
+        "Unsupported %s metadata value type '%s'"
+            .formatted(THOUGHT_SIGNATURE_METADATA_KEY, value.getClass().getSimpleName()));
+  }
+
+  /**
+   * Converts a {@link ProviderContent} payload straight to a {@link Part} using the Gemini SDK's
+   * own {@link JsonSerializable#objectMapper()} rather than the injected {@link #objectMapper} --
+   * {@link Part} is built via an AutoValue builder whose fields are {@code Optional<...>}, which
+   * requires the SDK's {@code Jdk8Module} registration to deserialize correctly (mirrors {@code
+   * AnthropicContentConverter} using {@code com.anthropic.core.ObjectMappers.jsonMapper()} for the
+   * equivalent lossless round-trip).
+   */
+  private Part toProviderPart(ProviderContent pc) {
+    return JsonSerializable.objectMapper().convertValue(pc.payload(), Part.class);
+  }
+
+  private Part toDocumentPart(DocumentContent doc) {
+    final var contentType = contentType(doc.document());
+    return switch (classify(contentType)) {
+      case IMAGE, PDF ->
+          Part.builder()
+              .inlineData(
+                  Blob.builder()
+                      .data(doc.document().asByteArray())
+                      .mimeType(normalizedMimeType(contentType))
+                      .build())
+              .build();
+      case TEXT -> Part.fromText(decodeUtf8(doc.document()));
+      case UNSUPPORTED ->
+          throw new ConnectorException(
+              ERROR_CODE_FAILED_MODEL_CALL,
+              "Unsupported content type '%s' for document with reference '%s'"
+                  .formatted(contentType, doc.document().reference()));
+    };
+  }
+
+  private static String contentType(Document document) {
+    final var metadata = document.metadata();
+    final var type = metadata != null ? metadata.getContentType() : null;
+    return type != null ? type : "application/octet-stream";
+  }
+
+  private static String decodeUtf8(Document document) {
+    return new String(document.asByteArray(), StandardCharsets.UTF_8);
+  }
+
+  private String writeAsJson(Object value) {
+    try {
+      return objectMapper.writeValueAsString(value);
+    } catch (JsonProcessingException e) {
+      throw new IllegalStateException("Failed to serialize content to JSON", e);
+    }
+  }
+
+  /**
+   * Coarse content-type buckets driving {@link #toDocumentPart(DocumentContent)}'s choice of Gemini
+   * part shape. Unknown/blank/unparseable types map conservatively to {@link #UNSUPPORTED}, which
+   * fails the request.
+   */
+  private enum DocumentPartKind {
+    IMAGE,
+    PDF,
+    TEXT,
+    UNSUPPORTED
+  }
+
+  private static DocumentPartKind classify(String contentType) {
+    if (contentType.isBlank()) {
+      return DocumentPartKind.UNSUPPORTED;
+    }
+
+    final ContentType parsed;
+    try {
+      parsed = ContentType.parse(contentType.trim().toLowerCase(Locale.ROOT));
+    } catch (RuntimeException e) {
+      return DocumentPartKind.UNSUPPORTED;
+    }
+    if (parsed == null) {
+      return DocumentPartKind.UNSUPPORTED;
+    }
+
+    if (isCompatibleWithAnyOf(parsed, IMAGE_CONTENT_TYPES)) {
+      return DocumentPartKind.IMAGE;
+    }
+    if (isCompatibleWithAnyOf(parsed, PDF_CONTENT_TYPES)) {
+      return DocumentPartKind.PDF;
+    }
+
+    final var mime = parsed.getMimeType();
+    if (mime.startsWith("text/")
+        || isCompatibleWithAnyOf(parsed, ADDITIONAL_TEXT_FILE_CONTENT_TYPES)
+        || mime.equals("application/x-yaml")
+        || mime.endsWith("+json")
+        || mime.endsWith("+xml")) {
+      return DocumentPartKind.TEXT;
+    }
+    return DocumentPartKind.UNSUPPORTED;
+  }
+
+  private static boolean isCompatibleWithAnyOf(
+      ContentType contentType, List<ContentType> contentTypes) {
+    return contentTypes.stream().anyMatch(contentType::isSameMimeType);
+  }
+
+  /**
+   * Strips parameters (e.g. {@code ; charset=UTF-8}) from a content type, matching the
+   * normalization {@link #classify(String)} already applies before comparing MIME types.
+   */
+  private static String normalizedMimeType(String contentType) {
+    return ContentType.parse(contentType.trim().toLowerCase(Locale.ROOT)).getMimeType();
+  }
+}

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiContentConverter.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiContentConverter.java
@@ -96,6 +96,12 @@ public class GeminiContentConverter {
    * {@code ToolCallResultContent.content()}); if that list ever becomes multi-element for a single
    * tool call, the caller must merge the results into a single {@code functionResponse} rather than
    * emit sibling parts sharing one name/id.
+   *
+   * <p>Unlike {@link #toParts(List)}, a document here is flattened to a JSON reference rather than
+   * embedded natively as {@code inlineData}: the document's actual bytes are already delivered to
+   * the model elsewhere for tool results, so embedding it here as well would send it twice. Matches
+   * {@code AnthropicContentConverter#toToolResultBlocks} and {@code
+   * OpenAiContentConverter#toResponsesToolResultOutputItems}.
    */
   public List<Part> toFunctionResponseParts(List<Content> content) {
     final List<Part> parts = new ArrayList<>();
@@ -103,7 +109,7 @@ public class GeminiContentConverter {
       switch (c) {
         case TextContent text -> parts.add(toFunctionResponsePart(text.text()));
         case ObjectContent obj -> parts.add(toFunctionResponsePart(obj.content()));
-        case DocumentContent doc -> parts.add(toDocumentPart(doc));
+        case DocumentContent doc -> parts.add(Part.fromText(writeAsJson(doc.document())));
         default -> parts.add(Part.fromText(writeAsJson(c)));
       }
     }

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiContentConverter.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiContentConverter.java
@@ -7,6 +7,7 @@
 package io.camunda.connector.agenticai.aiagent.chatmodel.provider.gemini;
 
 import static io.camunda.connector.agenticai.aiagent.agent.AgentErrorCodes.ERROR_CODE_FAILED_MODEL_CALL;
+import static io.camunda.connector.agenticai.aiagent.model.request.v2.GeminiChatModelConfiguration.GOOGLE_GEMINI_ID;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -78,8 +79,16 @@ public class GeminiContentConverter {
         case TextContent text -> parts.add(toTextPart(text));
         case DocumentContent doc -> parts.add(toDocumentPart(doc));
         case ObjectContent obj -> parts.add(Part.fromText(writeAsJson(obj.content())));
-        case ReasoningContent rc -> parts.add(toThoughtPart(rc));
-        case ProviderContent pc -> parts.add(toProviderPart(pc));
+        // Content tagged for a different provider is dropped rather than replayed: a Gemini part
+        // built from an Anthropic/OpenAI-native payload can fail conversion or send invalid
+        // history if a persisted conversation is resumed after switching providers. Matches
+        // AnthropicContentConverter#toContentBlockParams.
+        case ReasoningContent rc when GOOGLE_GEMINI_ID.equals(rc.provider()) ->
+            parts.add(toThoughtPart(rc));
+        case ReasoningContent ignored -> {}
+        case ProviderContent pc when GOOGLE_GEMINI_ID.equals(pc.provider()) ->
+            parts.add(toProviderPart(pc));
+        case ProviderContent ignored -> {}
       }
     }
     return parts;

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiContentRequestConverter.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiContentRequestConverter.java
@@ -25,6 +25,7 @@ import io.camunda.connector.agenticai.aiagent.model.message.MessageUtil;
 import io.camunda.connector.agenticai.aiagent.model.message.SystemMessage;
 import io.camunda.connector.agenticai.aiagent.model.message.ToolCallResultMessage;
 import io.camunda.connector.agenticai.aiagent.model.message.UserMessage;
+import io.camunda.connector.agenticai.aiagent.model.message.content.TextContent;
 import io.camunda.connector.agenticai.aiagent.model.request.ResponseConfiguration;
 import io.camunda.connector.agenticai.aiagent.model.request.ResponseFormatConfiguration.JsonResponseFormatConfiguration;
 import io.camunda.connector.agenticai.aiagent.model.request.v2.GeminiChatModelConfiguration;
@@ -32,6 +33,7 @@ import io.camunda.connector.agenticai.aiagent.model.request.v2.GeminiChatModelCo
 import io.camunda.connector.agenticai.aiagent.model.request.v2.GeminiChatModelConfiguration.GeminiModel.GeminiThinking;
 import io.camunda.connector.agenticai.aiagent.model.request.v2.GeminiChatModelConfiguration.GeminiModel.GeminiThinkingLevel;
 import io.camunda.connector.agenticai.aiagent.model.tool.ToolCall;
+import io.camunda.connector.agenticai.aiagent.model.tool.ToolCallResult;
 import io.camunda.connector.agenticai.aiagent.model.tool.ToolCallResultContent;
 import io.camunda.connector.agenticai.aiagent.model.tool.ToolDefinition;
 import io.camunda.connector.api.error.ConnectorException;
@@ -323,6 +325,12 @@ public class GeminiContentRequestConverter {
    * #mergeFunctionResponseParts(List, String, String)} does that, combining their {@code response}
    * payloads. Non-{@code functionResponse} parts (e.g. a document's {@code inlineData}) pass
    * through unchanged; they carry no name/id to begin with.
+   *
+   * <p>A tool returning null/blank content normalizes to an empty {@code List<Content>} ({@link
+   * ToolCallResultContent#contentFromObject}), which would otherwise produce no parts at all here,
+   * leaving the preceding {@code functionCall} without a correlated response. Fall back to a single
+   * {@link ToolCallResult#CONTENT_NO_RESULT} functionResponse in that case, same convention already
+   * used for a canceled tool call.
    */
   private List<Part> toolResultParts(ToolCallResultContent result) {
     final List<Part> parts = contentConverter.toFunctionResponseParts(result.content());
@@ -335,6 +343,11 @@ public class GeminiContentRequestConverter {
     final List<Part> merged = new ArrayList<>();
     if (!functionResponseParts.isEmpty()) {
       merged.add(mergeFunctionResponseParts(functionResponseParts, result.name(), result.id()));
+    } else if (otherParts.isEmpty()) {
+      final var noResultParts =
+          contentConverter.toFunctionResponseParts(
+              List.of(TextContent.textContent(ToolCallResult.CONTENT_NO_RESULT)));
+      merged.add(mergeFunctionResponseParts(noResultParts, result.name(), result.id()));
     }
     merged.addAll(otherParts);
     return merged;

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiContentRequestConverter.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiContentRequestConverter.java
@@ -6,6 +6,7 @@
  */
 package io.camunda.connector.agenticai.aiagent.chatmodel.provider.gemini;
 
+import static io.camunda.connector.agenticai.aiagent.agent.AgentErrorCodes.ERROR_CODE_FAILED_MODEL_CALL;
 import static io.camunda.connector.agenticai.aiagent.agent.AgentErrorCodes.ERROR_CODE_UNSUPPORTED_MODEL_CONFIGURATION;
 
 import com.google.genai.types.Content;
@@ -35,6 +36,7 @@ import io.camunda.connector.agenticai.aiagent.model.tool.ToolCallResultContent;
 import io.camunda.connector.agenticai.aiagent.model.tool.ToolDefinition;
 import io.camunda.connector.api.error.ConnectorException;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.List;
 import java.util.Map;
 import org.jspecify.annotations.Nullable;
@@ -232,17 +234,62 @@ public class GeminiContentRequestConverter {
   private List<Part> assistantParts(AssistantMessage assistant) {
     final List<Part> parts = new ArrayList<>(contentConverter.toParts(assistant.content()));
     for (final ToolCall toolCall : assistant.toolCalls()) {
-      parts.add(
-          Part.builder()
-              .functionCall(
-                  FunctionCall.builder()
-                      .id(toolCall.id())
-                      .name(toolCall.name())
-                      .args(toolCall.arguments())
-                      .build())
-              .build());
+      parts.add(toFunctionCallPart(toolCall));
     }
     return parts;
+  }
+
+  /**
+   * Rebuilds a {@code functionCall} {@link Part} for replay, restoring the {@code thoughtSignature}
+   * Gemini 3 stamps on the original call -- Gemini 3 rejects a follow-up tool-calling request whose
+   * replayed {@code functionCall} dropped it. {@code
+   * GeminiContentResponseConverter#toolCallMetadata} captures that signature onto {@link
+   * ToolCall#metadata()}, namespaced under {@link GeminiChatModelConfiguration#GOOGLE_GEMINI_ID}
+   * exactly like {@code ToolCallMetadataDecorator} does for the langchain4j path; this reads it
+   * back from that same key. Absent for a Gemini 2.5 response (no signature to begin with) or a
+   * conversation persisted before this was captured -- the field is omitted rather than failing in
+   * that case.
+   */
+  private Part toFunctionCallPart(ToolCall toolCall) {
+    final Part part =
+        Part.builder()
+            .functionCall(
+                FunctionCall.builder()
+                    .id(toolCall.id())
+                    .name(toolCall.name())
+                    .args(toolCall.arguments())
+                    .build())
+            .build();
+
+    final byte @Nullable [] signature = thoughtSignatureBytes(toolCall.metadata());
+    return signature == null ? part : part.toBuilder().thoughtSignature(signature).build();
+  }
+
+  private byte @Nullable [] thoughtSignatureBytes(@Nullable Map<String, Object> toolCallMetadata) {
+    if (toolCallMetadata == null) {
+      return null;
+    }
+    final Object namespaced = toolCallMetadata.get(GeminiChatModelConfiguration.GOOGLE_GEMINI_ID);
+    if (!(namespaced instanceof Map<?, ?> namespacedMetadata)) {
+      return null;
+    }
+    final Object signature =
+        namespacedMetadata.get(GeminiContentConverter.THOUGHT_SIGNATURE_METADATA_KEY);
+    if (signature == null) {
+      return null;
+    }
+    if (signature instanceof byte[] bytes) {
+      return bytes;
+    }
+    if (signature instanceof String base64) {
+      return Base64.getDecoder().decode(base64);
+    }
+    throw new ConnectorException(
+        ERROR_CODE_FAILED_MODEL_CALL,
+        "Unsupported %s metadata value type '%s'"
+            .formatted(
+                GeminiContentConverter.THOUGHT_SIGNATURE_METADATA_KEY,
+                signature.getClass().getSimpleName()));
   }
 
   private List<Part> toolResultParts(ToolCallResultMessage message) {

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiContentRequestConverter.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiContentRequestConverter.java
@@ -1,0 +1,306 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.agenticai.aiagent.chatmodel.provider.gemini;
+
+import static io.camunda.connector.agenticai.aiagent.agent.AgentErrorCodes.ERROR_CODE_UNSUPPORTED_MODEL_CONFIGURATION;
+
+import com.google.genai.types.Content;
+import com.google.genai.types.FunctionCall;
+import com.google.genai.types.FunctionDeclaration;
+import com.google.genai.types.FunctionResponse;
+import com.google.genai.types.GenerateContentConfig;
+import com.google.genai.types.Part;
+import com.google.genai.types.ThinkingConfig;
+import com.google.genai.types.ThinkingLevel;
+import com.google.genai.types.Tool;
+import io.camunda.connector.agenticai.aiagent.memory.ConversationSnapshot;
+import io.camunda.connector.agenticai.aiagent.model.message.AssistantMessage;
+import io.camunda.connector.agenticai.aiagent.model.message.Message;
+import io.camunda.connector.agenticai.aiagent.model.message.MessageUtil;
+import io.camunda.connector.agenticai.aiagent.model.message.SystemMessage;
+import io.camunda.connector.agenticai.aiagent.model.message.ToolCallResultMessage;
+import io.camunda.connector.agenticai.aiagent.model.message.UserMessage;
+import io.camunda.connector.agenticai.aiagent.model.request.ResponseConfiguration;
+import io.camunda.connector.agenticai.aiagent.model.request.ResponseFormatConfiguration.JsonResponseFormatConfiguration;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.GeminiChatModelConfiguration;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.GeminiChatModelConfiguration.GeminiModel.GeminiModelParameters;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.GeminiChatModelConfiguration.GeminiModel.GeminiThinking;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.GeminiChatModelConfiguration.GeminiModel.GeminiThinkingLevel;
+import io.camunda.connector.agenticai.aiagent.model.tool.ToolCall;
+import io.camunda.connector.agenticai.aiagent.model.tool.ToolCallResultContent;
+import io.camunda.connector.agenticai.aiagent.model.tool.ToolDefinition;
+import io.camunda.connector.api.error.ConnectorException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Maps a windowed {@link ConversationSnapshot} plus the resolved Gemini model configuration to the
+ * Gemini SDK's {@link GenerateContentConfig} (model parameters, thinking, system instruction,
+ * tools, structured output) and {@link Content} history (message-by-message), translating the
+ * domain {@link Message} / {@link ToolCall} / {@link ToolCallResultContent} model into the wire
+ * shape via the {@link GeminiContentConverter} built for parts.
+ *
+ * <p>Two methods rather than one combined request object: {@code
+ * GeminiChatModel#generateContentStream(model, contents, config)} (Task 6) takes contents and
+ * config as separate arguments, so returning them separately avoids an intermediate wrapper type
+ * with no other consumer.
+ */
+public class GeminiContentRequestConverter {
+
+  private static final String ROLE_USER = "user";
+  private static final String ROLE_MODEL = "model";
+
+  private final GeminiContentConverter contentConverter;
+
+  public GeminiContentRequestConverter(GeminiContentConverter contentConverter) {
+    this.contentConverter = contentConverter;
+  }
+
+  public GenerateContentConfig toGenerateContentConfig(
+      GeminiChatModelConfiguration configuration,
+      @Nullable ResponseConfiguration response,
+      ConversationSnapshot snapshot) {
+    final var params = configuration.googleGemini().model().parameters();
+
+    final var builder = GenerateContentConfig.builder();
+
+    applyModelParameters(builder, params);
+    applyThinking(builder, params);
+    applySystemInstruction(builder, snapshot);
+    applyTools(builder, snapshot.toolDefinitions());
+    applyStructuredOutput(builder, response);
+
+    return builder.build();
+  }
+
+  public List<Content> toContents(ConversationSnapshot snapshot) {
+    // Seed an empty list so an all-system/empty snapshot returns empty rather than null.
+    final List<Content> contents = new ArrayList<>();
+    for (final Message message : snapshot.messages()) {
+      switch (message) {
+        case SystemMessage ignored -> {
+          // hoisted to systemInstruction, see applySystemInstruction()
+        }
+        case UserMessage user ->
+            addContent(contents, ROLE_USER, contentConverter.toParts(user.content()));
+        case AssistantMessage assistant ->
+            addContent(contents, ROLE_MODEL, assistantParts(assistant));
+        case ToolCallResultMessage toolResults ->
+            addContent(contents, ROLE_USER, toolResultParts(toolResults));
+        default ->
+            throw new IllegalArgumentException(
+                "Unsupported message type: " + message.getClass().getSimpleName());
+      }
+    }
+    return contents;
+  }
+
+  /**
+   * Skips emitting a {@link Content} for a message that would otherwise carry an empty {@code
+   * parts} list (e.g. a {@link UserMessage} or {@link AssistantMessage} with no content and, for
+   * the latter, no tool calls) -- Gemini's own examples never send an empty parts array, and this
+   * mirrors the Anthropic converter's care to never emit an empty content array.
+   */
+  private void addContent(List<Content> contents, String role, List<Part> parts) {
+    if (parts.isEmpty()) {
+      return;
+    }
+    contents.add(Content.builder().role(role).parts(parts).build());
+  }
+
+  private void applyModelParameters(
+      GenerateContentConfig.Builder builder, @Nullable GeminiModelParameters params) {
+    if (params == null) {
+      return;
+    }
+    if (params.temperature() != null) {
+      builder.temperature(params.temperature().floatValue());
+    }
+    if (params.topP() != null) {
+      builder.topP(params.topP().floatValue());
+    }
+    if (params.topK() != null) {
+      builder.topK(params.topK().floatValue());
+    }
+    if (params.maxTokens() != null) {
+      builder.maxOutputTokens(params.maxTokens());
+    }
+  }
+
+  /**
+   * Maps {@code thinking} onto the SDK's {@link ThinkingConfig}: {@code thinkingBudget} xor {@code
+   * thinkingLevel}, never both. {@link GeminiThinking#isBothThinkingBudgetAndLevelSet()}'s
+   * {@code @AssertFalse} bean validation should already prevent both being set by the time a real
+   * request reaches this converter, but this is defended here too rather than silently picking one.
+   */
+  private void applyThinking(
+      GenerateContentConfig.Builder builder, @Nullable GeminiModelParameters params) {
+    final GeminiThinking thinking = params == null ? null : params.thinking();
+    if (thinking == null) {
+      return;
+    }
+
+    final Integer budget = thinking.thinkingBudget();
+    final GeminiThinkingLevel level = thinking.thinkingLevel();
+    if (budget != null && level != null) {
+      throw new ConnectorException(
+          ERROR_CODE_UNSUPPORTED_MODEL_CONFIGURATION,
+          "thinking.thinkingBudget and thinking.thinkingLevel are mutually exclusive");
+    }
+    if (budget == null && level == null) {
+      return;
+    }
+
+    final var thinkingConfigBuilder = ThinkingConfig.builder();
+    if (budget != null) {
+      thinkingConfigBuilder.thinkingBudget(budget);
+    } else if (level != null) {
+      thinkingConfigBuilder.thinkingLevel(toThinkingLevel(level));
+    }
+    builder.thinkingConfig(thinkingConfigBuilder.build());
+  }
+
+  private ThinkingLevel.Known toThinkingLevel(GeminiThinkingLevel level) {
+    return switch (level) {
+      case LOW -> ThinkingLevel.Known.LOW;
+      case MEDIUM -> ThinkingLevel.Known.MEDIUM;
+      case HIGH -> ThinkingLevel.Known.HIGH;
+    };
+  }
+
+  private void applySystemInstruction(
+      GenerateContentConfig.Builder builder, ConversationSnapshot snapshot) {
+    final var systemMessage = MessageUtil.leadingSystemMessage(snapshot.messages());
+    if (systemMessage.isEmpty()) {
+      return;
+    }
+    final List<Part> parts = contentConverter.toParts(systemMessage.get().content());
+    if (parts.isEmpty()) {
+      return;
+    }
+    builder.systemInstruction(Content.builder().parts(parts).build());
+  }
+
+  private void applyTools(
+      GenerateContentConfig.Builder builder, List<ToolDefinition> toolDefinitions) {
+    if (toolDefinitions.isEmpty()) {
+      return;
+    }
+    final List<FunctionDeclaration> declarations = new ArrayList<>();
+    for (final ToolDefinition definition : toolDefinitions) {
+      final var declarationBuilder =
+          FunctionDeclaration.builder()
+              .name(definition.name())
+              .parametersJsonSchema(definition.inputSchema());
+      if (definition.description() != null) {
+        declarationBuilder.description(definition.description());
+      }
+      declarations.add(declarationBuilder.build());
+    }
+    // A single Tool carrying every function declaration -- Gemini's own convention, not one Tool
+    // per function (which the API rejects).
+    builder.tools(Tool.builder().functionDeclarations(declarations).build());
+  }
+
+  /**
+   * Maps the structured-output JSON schema via {@code responseJsonSchema}, the SDK's raw
+   * JSON-Schema passthrough (as opposed to {@code responseSchema}, which requires translating into
+   * the SDK's own restricted {@code Schema} type). This preserves the domain schema byte-for-byte,
+   * mirroring the {@code additionalProperties} passthrough {@code
+   * AnthropicMessageRequestConverter#applyOutputConfig} uses for the same field. Per the SDK's own
+   * {@code responseJsonSchema} javadoc, {@code responseMimeType} must accompany it.
+   */
+  private void applyStructuredOutput(
+      GenerateContentConfig.Builder builder, @Nullable ResponseConfiguration response) {
+    final Map<String, Object> schema =
+        response != null && response.format() instanceof JsonResponseFormatConfiguration json
+            ? json.schema()
+            : null;
+    if (schema == null) {
+      return;
+    }
+    builder.responseMimeType("application/json");
+    builder.responseJsonSchema(schema);
+  }
+
+  private List<Part> assistantParts(AssistantMessage assistant) {
+    final List<Part> parts = new ArrayList<>(contentConverter.toParts(assistant.content()));
+    for (final ToolCall toolCall : assistant.toolCalls()) {
+      parts.add(
+          Part.builder()
+              .functionCall(
+                  FunctionCall.builder()
+                      .id(toolCall.id())
+                      .name(toolCall.name())
+                      .args(toolCall.arguments())
+                      .build())
+              .build());
+    }
+    return parts;
+  }
+
+  private List<Part> toolResultParts(ToolCallResultMessage message) {
+    final List<Part> parts = new ArrayList<>();
+    for (final ToolCallResultContent result : message.results()) {
+      parts.addAll(toolResultParts(result));
+    }
+    return parts;
+  }
+
+  /**
+   * Converts a single tool result into {@link Part}s, stamping {@code name}/{@code id} onto the
+   * {@code functionResponse} part(s) {@link GeminiContentConverter#toFunctionResponseParts(List)}
+   * deliberately leaves blank (see that method's javadoc -- the correlating identity lives on this
+   * {@link ToolCallResultContent}, one level up from the individual {@link
+   * io.camunda.connector.agenticai.aiagent.model.message.content.Content} items it converts).
+   *
+   * <p>{@code toFunctionResponseParts} emits one {@link Part} per {@code Content} item, so a
+   * multi-element result (e.g. two {@code TextContent}s) comes back as multiple sibling {@code
+   * functionResponse} parts. Per that method's javadoc, these must be merged into a single {@code
+   * functionResponse} rather than sent as siblings sharing one name/id -- {@link
+   * #mergeFunctionResponseParts(List, String, String)} does that, combining their {@code response}
+   * payloads. Non-{@code functionResponse} parts (e.g. a document's {@code inlineData}) pass
+   * through unchanged; they carry no name/id to begin with.
+   */
+  private List<Part> toolResultParts(ToolCallResultContent result) {
+    final List<Part> parts = contentConverter.toFunctionResponseParts(result.content());
+
+    final List<Part> functionResponseParts =
+        parts.stream().filter(part -> part.functionResponse().isPresent()).toList();
+    final List<Part> otherParts =
+        parts.stream().filter(part -> part.functionResponse().isEmpty()).toList();
+
+    final List<Part> merged = new ArrayList<>();
+    if (!functionResponseParts.isEmpty()) {
+      merged.add(mergeFunctionResponseParts(functionResponseParts, result.name(), result.id()));
+    }
+    merged.addAll(otherParts);
+    return merged;
+  }
+
+  private Part mergeFunctionResponseParts(
+      List<Part> functionResponseParts, @Nullable String name, @Nullable String id) {
+    final List<Object> outputs =
+        functionResponseParts.stream()
+            .map(
+                part ->
+                    part.functionResponse().orElseThrow().response().orElseThrow().get("output"))
+            .toList();
+    final Object output = outputs.size() == 1 ? outputs.get(0) : outputs;
+
+    final var responseBuilder = FunctionResponse.builder().response(Map.of("output", output));
+    if (name != null) {
+      responseBuilder.name(name);
+    }
+    if (id != null) {
+      responseBuilder.id(id);
+    }
+    return Part.builder().functionResponse(responseBuilder.build()).build();
+  }
+}

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiContentRequestConverter.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiContentRequestConverter.java
@@ -159,7 +159,13 @@ public class GeminiContentRequestConverter {
       return;
     }
 
-    final var thinkingConfigBuilder = ThinkingConfig.builder();
+    // Thoughts are not returned unless explicitly asked for (per ThinkingConfig#includeThoughts:
+    // "If true, thoughts are returned only if the model supports thought and thoughts are
+    // available"), so configuring a budget/level without this would enable thinking the connector
+    // could never surface. Not configurable: the config record has no separate toggle, and this
+    // matches Anthropic, which always returns thinking content once thinking is enabled and only
+    // lets ThinkingDisplay control how it is formatted.
+    final var thinkingConfigBuilder = ThinkingConfig.builder().includeThoughts(true);
     if (budget != null) {
       thinkingConfigBuilder.thinkingBudget(budget);
     } else if (level != null) {

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiContentRequestConverter.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiContentRequestConverter.java
@@ -39,6 +39,7 @@ import java.util.ArrayList;
 import java.util.Base64;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -136,39 +137,41 @@ public class GeminiContentRequestConverter {
   }
 
   /**
-   * Maps {@code thinking} onto the SDK's {@link ThinkingConfig}: {@code thinkingBudget} xor {@code
-   * thinkingLevel}, never both. {@link GeminiThinking#isBothThinkingBudgetAndLevelSet()}'s
-   * {@code @AssertFalse} bean validation should already prevent both being set by the time a real
-   * request reaches this converter, but this is defended here too rather than silently picking one.
+   * Maps {@code thinking} onto the SDK's {@link ThinkingConfig} when the modeler has opted in via
+   * {@code enabled}. {@code thinkingBudget} xor an explicit {@code thinkingLevel}, never both;
+   * {@link GeminiThinking#isBothThinkingBudgetAndLevelSet()}'s {@code @AssertFalse} bean validation
+   * should already prevent both being set, but this is defended here too rather than silently
+   * picking one.
    */
   private void applyThinking(
       GenerateContentConfig.Builder builder, @Nullable GeminiModelParameters params) {
     final GeminiThinking thinking = params == null ? null : params.thinking();
-    if (thinking == null) {
+    if (thinking == null || !Boolean.TRUE.equals(thinking.enabled())) {
       return;
     }
 
     final Integer budget = thinking.thinkingBudget();
-    final GeminiThinkingLevel level = thinking.thinkingLevel();
-    if (budget != null && level != null) {
+    // GeminiThinking's compact constructor already normalizes a null thinkingLevel to
+    // MODEL_DEFAULT; this repeats the default defensively since the record component itself is
+    // still typed @Nullable (a caller could in principle bypass the compact constructor).
+    final GeminiThinkingLevel level =
+        Objects.requireNonNullElse(thinking.thinkingLevel(), GeminiThinkingLevel.MODEL_DEFAULT);
+    final boolean explicitLevel = level != GeminiThinkingLevel.MODEL_DEFAULT;
+    if (budget != null && explicitLevel) {
       throw new ConnectorException(
           ERROR_CODE_UNSUPPORTED_MODEL_CONFIGURATION,
           "thinking.thinkingBudget and thinking.thinkingLevel are mutually exclusive");
     }
-    if (budget == null && level == null) {
-      return;
-    }
 
     // Thoughts are not returned unless explicitly asked for (per ThinkingConfig#includeThoughts:
     // "If true, thoughts are returned only if the model supports thought and thoughts are
-    // available"), so configuring a budget/level without this would enable thinking the connector
-    // could never surface. Not configurable: the config record has no separate toggle, and this
-    // matches Anthropic, which always returns thinking content once thinking is enabled and only
-    // lets ThinkingDisplay control how it is formatted.
+    // available"); enabling thinking at all is the signal to also request them back. Matches
+    // Anthropic, which always returns thinking content once thinking is enabled and only lets
+    // ThinkingDisplay control how it is formatted.
     final var thinkingConfigBuilder = ThinkingConfig.builder().includeThoughts(true);
     if (budget != null) {
       thinkingConfigBuilder.thinkingBudget(budget);
-    } else if (level != null) {
+    } else {
       thinkingConfigBuilder.thinkingLevel(toThinkingLevel(level));
     }
     builder.thinkingConfig(thinkingConfigBuilder.build());
@@ -176,6 +179,8 @@ public class GeminiContentRequestConverter {
 
   private ThinkingLevel.Known toThinkingLevel(GeminiThinkingLevel level) {
     return switch (level) {
+      case MODEL_DEFAULT -> ThinkingLevel.Known.THINKING_LEVEL_UNSPECIFIED;
+      case MINIMAL -> ThinkingLevel.Known.MINIMAL;
       case LOW -> ThinkingLevel.Known.LOW;
       case MEDIUM -> ThinkingLevel.Known.MEDIUM;
       case HIGH -> ThinkingLevel.Known.HIGH;

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiContentRequestConverter.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiContentRequestConverter.java
@@ -226,15 +226,13 @@ public class GeminiContentRequestConverter {
    */
   private void applyStructuredOutput(
       GenerateContentConfig.Builder builder, @Nullable ResponseConfiguration response) {
-    final Map<String, Object> schema =
-        response != null && response.format() instanceof JsonResponseFormatConfiguration json
-            ? json.schema()
-            : null;
-    if (schema == null) {
+    if (!(response != null && response.format() instanceof JsonResponseFormatConfiguration json)) {
       return;
     }
     builder.responseMimeType("application/json");
-    builder.responseJsonSchema(schema);
+    if (json.schema() != null) {
+      builder.responseJsonSchema(json.schema());
+    }
   }
 
   private List<Part> assistantParts(AssistantMessage assistant) {

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiContentRequestConverter.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiContentRequestConverter.java
@@ -139,16 +139,18 @@ public class GeminiContentRequestConverter {
   }
 
   /**
-   * Maps {@code thinking} onto the SDK's {@link ThinkingConfig} when the modeler has opted in via
-   * {@code enabled}. {@code thinkingBudget} xor an explicit {@code thinkingLevel}, never both;
-   * {@link GeminiThinking#isBothThinkingBudgetAndLevelSet()}'s {@code @AssertFalse} bean validation
-   * should already prevent both being set, but this is defended here too rather than silently
-   * picking one.
+   * Maps {@code thinking} onto the SDK's {@link ThinkingConfig}. A {@code thinkingBudget} or an
+   * explicit (non-default) {@code thinkingLevel} is the signal to configure thinking at all;
+   * leaving both unset (the "default" thinking level with no budget) sets no {@link
+   * ThinkingConfig}, letting the model apply its own default behavior. {@code thinkingBudget} xor
+   * an explicit {@code thinkingLevel}, never both; {@link
+   * GeminiThinking#isBothThinkingBudgetAndLevelSet()}'s {@code @AssertFalse} bean validation should
+   * already prevent both being set, but this is defended here too rather than silently picking one.
    */
   private void applyThinking(
       GenerateContentConfig.Builder builder, @Nullable GeminiModelParameters params) {
     final GeminiThinking thinking = params == null ? null : params.thinking();
-    if (thinking == null || !Boolean.TRUE.equals(thinking.enabled())) {
+    if (thinking == null) {
       return;
     }
 
@@ -164,10 +166,13 @@ public class GeminiContentRequestConverter {
           ERROR_CODE_UNSUPPORTED_MODEL_CONFIGURATION,
           "thinking.thinkingBudget and thinking.thinkingLevel are mutually exclusive");
     }
+    if (budget == null && !explicitLevel) {
+      return;
+    }
 
     // Thoughts are not returned unless explicitly asked for (per ThinkingConfig#includeThoughts:
     // "If true, thoughts are returned only if the model supports thought and thoughts are
-    // available"); enabling thinking at all is the signal to also request them back. Matches
+    // available"); configuring thinking at all is the signal to also request them back. Matches
     // Anthropic, which always returns thinking content once thinking is enabled and only lets
     // ThinkingDisplay control how it is formatted.
     final var thinkingConfigBuilder = ThinkingConfig.builder().includeThoughts(true);

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiContentResponseConverter.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiContentResponseConverter.java
@@ -1,0 +1,340 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.agenticai.aiagent.chatmodel.provider.gemini;
+
+import static io.camunda.connector.agenticai.aiagent.chatmodel.provider.gemini.GeminiContentConverter.THOUGHT_SIGNATURE_METADATA_KEY;
+import static io.camunda.connector.agenticai.aiagent.model.request.v2.GeminiChatModelConfiguration.GOOGLE_GEMINI_ID;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.google.genai.JsonSerializable;
+import com.google.genai.types.BlockedReason;
+import com.google.genai.types.Candidate;
+import com.google.genai.types.FinishReason;
+import com.google.genai.types.FunctionCall;
+import com.google.genai.types.GenerateContentResponse;
+import com.google.genai.types.GenerateContentResponsePromptFeedback;
+import com.google.genai.types.GenerateContentResponseUsageMetadata;
+import com.google.genai.types.Part;
+import io.camunda.connector.agenticai.aiagent.chatmodel.ChatResult;
+import io.camunda.connector.agenticai.aiagent.model.AgentMetrics;
+import io.camunda.connector.agenticai.aiagent.model.message.AssistantMessage;
+import io.camunda.connector.agenticai.aiagent.model.message.AssistantMessageBuilder;
+import io.camunda.connector.agenticai.aiagent.model.message.StopReason;
+import io.camunda.connector.agenticai.aiagent.model.message.content.Content;
+import io.camunda.connector.agenticai.aiagent.model.message.content.ProviderContent;
+import io.camunda.connector.agenticai.aiagent.model.message.content.ReasoningContent;
+import io.camunda.connector.agenticai.aiagent.model.message.content.TextContent;
+import io.camunda.connector.agenticai.aiagent.model.tool.ToolCall;
+import io.camunda.connector.agenticai.aiagent.util.AssistantMessageMetadata;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import org.jspecify.annotations.Nullable;
+import org.springframework.util.StringUtils;
+
+/**
+ * Maps the assembled Gemini SDK {@link GenerateContentResponse} (see {@link
+ * GeminiContentStreamAssembler}) to the domain {@link AssistantMessage}, its {@link AgentMetrics},
+ * and a {@link ChatResult}.
+ *
+ * <p>{@code text} parts become {@link TextContent}, {@code functionCall} parts become {@link
+ * ToolCall}s, {@code thought}-flagged parts become {@link ReasoningContent}, and every other part
+ * shape is captured losslessly as {@link ProviderContent} rather than dropped.
+ *
+ * <p>Two Gemini specifics drive the finish-reason handling:
+ *
+ * <ul>
+ *   <li><b>No tool-use finish reason.</b> Gemini reports {@code STOP} even when the candidate
+ *       contains {@code functionCall} parts, so the mapped stop reason is overridden with {@link
+ *       StopReason#TOOL_USE} whenever the response produced tool calls. The raw vendor value is
+ *       preserved unchanged under the {@code google-gemini} metadata key regardless.
+ *   <li><b>A blocked prompt has no candidate.</b> The response then carries only {@code
+ *       promptFeedback}, which is surfaced as a {@link StopReason#CONTENT_FILTERED} message
+ *       explaining the block instead of an empty message or an exception.
+ * </ul>
+ *
+ * <p>Every result is a {@link ChatResult.Completed}: Gemini has no equivalent of Anthropic's {@code
+ * pause_turn}. {@code FinishReason.Known} contains no paused/continuation value and nothing else in
+ * the SDK models a turn the provider expects to be resumed without new input, so {@link
+ * ChatResult.Continuation} is never produced.
+ *
+ * <p>The candidate's parts are read via {@code candidates().get(0).content().parts()} rather than
+ * the {@link GenerateContentResponse#parts()}/{@code text()}/{@code functionCalls()} convenience
+ * accessors on purpose: those call {@code checkFinishReason()} internally, which throws for every
+ * finish reason outside {@code {FINISH_REASON_UNSPECIFIED, STOP, MAX_TOKENS}} — i.e. exactly for
+ * the truncated and filtered responses this converter most needs to convert.
+ */
+public class GeminiContentResponseConverter {
+
+  private static final String FINISH_REASON_METADATA_KEY = "finishReason";
+  private static final String BLOCK_REASON_METADATA_KEY = "blockReason";
+
+  public ChatResult toResult(GenerateContentResponse response, Duration executionTime) {
+    final AssistantMessage assistantMessage = toAssistantMessage(response);
+    final AgentMetrics metrics =
+        toMetrics(response, assistantMessage.toolCalls().size(), executionTime);
+
+    return new ChatResult.Completed(assistantMessage, metrics);
+  }
+
+  AssistantMessage toAssistantMessage(GenerateContentResponse response) {
+    // Covers both shapes of "no candidate": the absent Optional a blocked prompt actually produces,
+    // and a defensively handled empty list.
+    final Candidate candidate =
+        response
+            .candidates()
+            .filter(candidates -> !candidates.isEmpty())
+            .map(List::getFirst)
+            .orElse(null);
+    if (candidate == null) {
+      return blockedPromptMessage(response);
+    }
+
+    final List<Part> parts =
+        candidate.content().flatMap(content -> content.parts()).orElse(List.of());
+    final List<Content> content = new ArrayList<>();
+    final List<ToolCall> toolCalls = new ArrayList<>();
+
+    for (final Part part : parts) {
+      final ToolCall toolCall = toToolCall(part);
+      if (toolCall != null) {
+        toolCalls.add(toolCall);
+      } else {
+        content.add(toContent(part));
+      }
+    }
+
+    final FinishReason finishReason = candidate.finishReason().orElse(null);
+    final Map<String, Object> geminiMetadata =
+        finishReason != null
+            ? Map.of(GOOGLE_GEMINI_ID, Map.of(FINISH_REASON_METADATA_KEY, finishReason.toString()))
+            : Map.of();
+
+    return assistantMessageBuilder(response)
+        .content(content)
+        .toolCalls(toolCalls)
+        .stopReason(mapStopReason(finishReason, !toolCalls.isEmpty()))
+        .metadata(AssistantMessageMetadata.withDefaults(geminiMetadata))
+        .build();
+  }
+
+  /**
+   * Builds the message for a response Gemini returned without any candidate, which is what a prompt
+   * blocked by input-side filtering looks like. Never throws: the block reason (when reported) is
+   * lifted into an explanatory {@link TextContent} so the blocked turn is visible in the
+   * conversation rather than silently empty.
+   */
+  private AssistantMessage blockedPromptMessage(GenerateContentResponse response) {
+    final String blockReason =
+        response
+            .promptFeedback()
+            .flatMap(GenerateContentResponsePromptFeedback::blockReason)
+            .map(BlockedReason::toString)
+            .orElse(null);
+
+    final String text =
+        blockReason != null
+            ? "Prompt blocked: " + blockReason
+            : "Prompt blocked (no block reason reported)";
+    final Map<String, Object> geminiMetadata =
+        blockReason != null
+            ? Map.of(GOOGLE_GEMINI_ID, Map.of(BLOCK_REASON_METADATA_KEY, blockReason))
+            : Map.of();
+
+    return assistantMessageBuilder(response)
+        .content(List.of(TextContent.textContent(text)))
+        .toolCalls(List.of())
+        .stopReason(StopReason.CONTENT_FILTERED)
+        .metadata(AssistantMessageMetadata.withDefaults(geminiMetadata))
+        .build();
+  }
+
+  private AssistantMessageBuilder assistantMessageBuilder(GenerateContentResponse response) {
+    return AssistantMessage.builder()
+        .messageId(response.responseId().orElse(null))
+        .modelId(response.modelVersion().orElse(null));
+  }
+
+  /**
+   * Converts a {@code functionCall} part into a {@link ToolCall}, or returns {@code null} when the
+   * part is not one the agent loop can execute as a tool call — including a {@code functionCall}
+   * without a {@code name}, which the caller then preserves as {@link ProviderContent} instead of
+   * emitting a nameless, unexecutable tool call.
+   */
+  private @Nullable ToolCall toToolCall(Part part) {
+    final FunctionCall functionCall = part.functionCall().orElse(null);
+    if (functionCall == null) {
+      return null;
+    }
+    final String name = functionCall.name().orElse(null);
+    if (name == null) {
+      return null;
+    }
+
+    return new ToolCall(
+        toolCallId(functionCall),
+        name,
+        functionCall.args().orElse(Map.of()),
+        toolCallMetadata(part));
+  }
+
+  /**
+   * Gemini's Developer API leaves {@code FunctionCall.id} unset (it is populated on other surfaces,
+   * e.g. Vertex AI), while the domain {@link ToolCall} requires an id: the agent loop correlates
+   * each {@code ToolCallResult} back to its originating call by id, and {@code
+   * GeminiContentRequestConverter} echoes that id on every replayed turn of the conversation.
+   *
+   * <p>A random UUID is therefore synthesized rather than a value derived from the function name
+   * and part index: a derived id would be unique within the response but would repeat across turns,
+   * putting duplicate {@code functionCall}/{@code functionResponse} ids into a single replayed
+   * request. This matches what langchain4j's own {@code google-genai} integration does against the
+   * same SDK, and what {@code ToolCallConverterImpl} does for a blank framework-provided id.
+   */
+  private String toolCallId(FunctionCall functionCall) {
+    return functionCall.id().orElseGet(() -> UUID.randomUUID().toString());
+  }
+
+  /**
+   * Preserves a {@code thoughtSignature} carried on a {@code functionCall} part — Gemini 3 rejects
+   * a follow-up tool-calling request whose history dropped it. Namespaced under the provider id,
+   * mirroring how the langchain4j path persists the same value onto {@link ToolCall#metadata()}
+   * (see {@code ToolCallMetadataDecorator}), so switching a running instance's provider cannot leak
+   * one provider's metadata into another. {@link ReasoningContent#metadata()} needs no such
+   * namespace: it carries the provider as a first-class field.
+   */
+  private @Nullable Map<String, Object> toolCallMetadata(Part part) {
+    return part.thoughtSignature()
+        .<Map<String, Object>>map(
+            signature ->
+                Map.of(
+                    GOOGLE_GEMINI_ID,
+                    Map.of(THOUGHT_SIGNATURE_METADATA_KEY, encodeSignature(signature))))
+        .orElse(null);
+  }
+
+  private Content toContent(Part part) {
+    if (part.thought().orElse(false)) {
+      return toReasoningContent(part);
+    }
+
+    final String text = part.text().orElse(null);
+    if (text != null) {
+      return TextContent.textContent(text);
+    }
+
+    // Fallback for any Gemini part shape not explicitly handled above: preserve it losslessly, in
+    // original order, as ProviderContent
+    return new ProviderContent(GOOGLE_GEMINI_ID, rawPart(part), null);
+  }
+
+  /**
+   * Splits a thinking part into the three places {@link GeminiContentConverter#toParts(List)} reads
+   * it back from on replay: the thinking text into {@code text}, the {@code thoughtSignature}
+   * base64-encoded into {@code metadata}, and whatever remains of the raw part into {@code payload}
+   * so nothing is dropped.
+   */
+  private ReasoningContent toReasoningContent(Part part) {
+    final Map<String, Object> raw = new LinkedHashMap<>(rawPart(part));
+    raw.remove("thoughtSignature");
+
+    final String text = part.text().filter(StringUtils::hasText).orElse(null);
+    if (text != null) {
+      raw.remove("text");
+    }
+
+    final Map<String, Object> metadata =
+        part.thoughtSignature()
+            .<Map<String, Object>>map(
+                signature -> Map.of(THOUGHT_SIGNATURE_METADATA_KEY, encodeSignature(signature)))
+            .orElse(null);
+
+    return new ReasoningContent(GOOGLE_GEMINI_ID, raw, text, metadata);
+  }
+
+  /**
+   * Serializes a {@link Part} through the Gemini SDK's own {@link JsonSerializable#objectMapper()}
+   * rather than an injected {@code ObjectMapper} — {@link Part}'s AutoValue fields are all {@code
+   * Optional<...>}, which needs the SDK's {@code Jdk8Module} registration to (de)serialize as bare
+   * values. This is the exact mapper {@code GeminiContentConverter} converts the payload back with,
+   * and mirrors {@code AnthropicMessageResponseConverter} using the Anthropic SDK's mapper for the
+   * equivalent lossless round trip.
+   */
+  private Map<String, Object> rawPart(Part part) {
+    return JsonSerializable.objectMapper()
+        .convertValue(part, new TypeReference<Map<String, Object>>() {});
+  }
+
+  private String encodeSignature(byte[] signature) {
+    return Base64.getEncoder().encodeToString(signature);
+  }
+
+  private AgentMetrics toMetrics(
+      GenerateContentResponse response, int toolCalls, Duration executionTime) {
+    final Optional<GenerateContentResponseUsageMetadata> usage = response.usageMetadata();
+    final var tokenUsage =
+        AgentMetrics.TokenUsage.builder()
+            .inputTokenCount(
+                usage.flatMap(GenerateContentResponseUsageMetadata::promptTokenCount).orElse(0))
+            .outputTokenCount(
+                usage.flatMap(GenerateContentResponseUsageMetadata::candidatesTokenCount).orElse(0))
+            // Gemini's implicit caching reports cache reads only; there is no cache-write counter,
+            // so cacheCreationTokenCount stays at its default of 0.
+            .cacheReadTokenCount(
+                usage
+                    .flatMap(GenerateContentResponseUsageMetadata::cachedContentTokenCount)
+                    .orElse(0))
+            .reasoningTokenCount(
+                usage.flatMap(GenerateContentResponseUsageMetadata::thoughtsTokenCount).orElse(0))
+            .build();
+
+    return AgentMetrics.builder()
+        .modelCalls(1)
+        .toolCalls(toolCalls)
+        .tokenUsage(tokenUsage)
+        .executionTime(executionTime)
+        .build();
+  }
+
+  /**
+   * Normalizes Gemini's finish reason, overriding it with {@link StopReason#TOOL_USE} whenever the
+   * response produced tool calls (Gemini has no tool-use finish reason of its own). The override is
+   * applied before the null check so that a response reporting no finish reason at all still
+   * surfaces as {@code TOOL_USE} when it carries function calls.
+   */
+  private @Nullable StopReason mapStopReason(
+      @Nullable FinishReason finishReason, boolean hasToolCalls) {
+    if (hasToolCalls) {
+      return StopReason.TOOL_USE;
+    }
+    if (finishReason == null) {
+      return null;
+    }
+
+    return switch (finishReason.knownEnum()) {
+      case STOP -> StopReason.STOP;
+      case MAX_TOKENS -> StopReason.LENGTH;
+      case SAFETY,
+          RECITATION,
+          BLOCKLIST,
+          PROHIBITED_CONTENT,
+          SPII,
+          IMAGE_SAFETY,
+          IMAGE_PROHIBITED_CONTENT,
+          IMAGE_RECITATION ->
+          StopReason.CONTENT_FILTERED;
+      // LANGUAGE, OTHER, MALFORMED_FUNCTION_CALL, UNEXPECTED_TOOL_CALL, NO_IMAGE and any value the
+      // SDK does not recognise (knownEnum() collapses those to FINISH_REASON_UNSPECIFIED, while
+      // toString() still returns the raw vendor string)
+      default -> new StopReason.UnknownStopReason(finishReason.toString());
+    };
+  }
+}

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiContentResponseConverter.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiContentResponseConverter.java
@@ -92,7 +92,12 @@ public class GeminiContentResponseConverter {
     final AgentMetrics metrics =
         toMetrics(response, assistantMessage.toolCalls().size(), executionTime);
 
-    if (assistantMessage.stopReason() == StopReason.CONTENT_FILTERED) {
+    final boolean blockedPrompt = response.candidates().filter(c -> !c.isEmpty()).isEmpty();
+    final FinishReason finishReason =
+        blockedPrompt
+            ? null
+            : response.candidates().orElseThrow().getFirst().finishReason().orElse(null);
+    if (blockedPrompt || (finishReason != null && isFilteringFinishReason(finishReason))) {
       throw new ContentFilteredException(
           "Model response was blocked by provider content filtering.",
           new ChatModelRejectedException.PartialResult(assistantMessage, metrics));
@@ -171,7 +176,6 @@ public class GeminiContentResponseConverter {
     return assistantMessageBuilder(response)
         .content(List.of(TextContent.textContent(text)))
         .toolCalls(List.of())
-        .stopReason(StopReason.CONTENT_FILTERED)
         .metadata(AssistantMessageMetadata.withDefaults(geminiMetadata))
         .build();
   }
@@ -352,9 +356,8 @@ public class GeminiContentResponseConverter {
    */
   private @Nullable StopReason mapStopReason(
       @Nullable FinishReason finishReason, boolean hasToolCalls) {
-    final StopReason filtered = finishReason != null ? filteredStopReason(finishReason) : null;
-    if (filtered != null) {
-      return filtered;
+    if (finishReason != null && isFilteringFinishReason(finishReason)) {
+      return new StopReason.UnknownStopReason(finishReason.toString());
     }
     if (hasToolCalls) {
       return StopReason.TOOL_USE;
@@ -373,7 +376,13 @@ public class GeminiContentResponseConverter {
     };
   }
 
-  private @Nullable StopReason filteredStopReason(FinishReason finishReason) {
+  /**
+   * Gemini's filtering finish reasons: no {@link StopReason} constant represents these (terminal
+   * rejections are signalled by throwing {@link ContentFilteredException} instead, see {@link
+   * #toResult}), so a match here both wins priority in {@link #mapStopReason} and is {@link
+   * #toResult}'s trigger to throw.
+   */
+  private boolean isFilteringFinishReason(FinishReason finishReason) {
     return switch (finishReason.knownEnum()) {
       case SAFETY,
           RECITATION,
@@ -383,8 +392,8 @@ public class GeminiContentResponseConverter {
           IMAGE_SAFETY,
           IMAGE_PROHIBITED_CONTENT,
           IMAGE_RECITATION ->
-          StopReason.CONTENT_FILTERED;
-      default -> null;
+          true;
+      default -> false;
     };
   }
 }

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiContentResponseConverter.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiContentResponseConverter.java
@@ -59,11 +59,9 @@ import org.springframework.util.StringUtils;
  *       contains {@code functionCall} parts, so the mapped stop reason is overridden with {@link
  *       StopReason#TOOL_USE} whenever the response produced tool calls. The raw vendor value is
  *       preserved unchanged under the {@code google-gemini} metadata key regardless.
- *   <li><b>A blocked prompt has no candidate.</b> The response then carries only {@code
- *       promptFeedback}, which is converted into a well-formed message (the block reason preserved
- *       as content and under {@code blockReason} metadata) instead of an empty message or a
- *       converter crash, so {@link #toResult} has a well-formed message to throw {@link
- *       ContentFilteredException} with rather than something it chokes on.
+ *   <li><b>A blocked prompt has no candidate.</b> The response carries only {@code promptFeedback};
+ *       the block reason is preserved as content and under {@code blockReason} metadata so {@link
+ *       #toResult} has a well-formed message to throw {@link ContentFilteredException} with.
  * </ul>
  *
  * <p>Every non-thrown result is a {@link ChatResult.Completed}: Gemini has no equivalent of
@@ -83,11 +81,10 @@ public class GeminiContentResponseConverter {
   private static final String BLOCK_REASON_METADATA_KEY = "blockReason";
 
   /**
-   * @throws ContentFilteredException when the prompt was blocked, or the candidate's finish reason
-   *     indicates the response was filtered ({@code SAFETY}, {@code RECITATION}, {@code BLOCKLIST},
-   *     {@code PROHIBITED_CONTENT}, {@code SPII}, or one of the {@code IMAGE_*} variants) — in both
-   *     cases carrying the {@link ChatModelRejectedException.PartialResult} built for the turn so
-   *     far.
+   * @throws ContentFilteredException if the prompt was blocked, or the candidate's finish reason is
+   *     {@code SAFETY}, {@code RECITATION}, {@code BLOCKLIST}, {@code PROHIBITED_CONTENT}, {@code
+   *     SPII}, or an {@code IMAGE_*} variant. Carries the {@link
+   *     ChatModelRejectedException.PartialResult} built so far.
    */
   public ChatResult toResult(GenerateContentResponse response, Duration executionTime) {
     final AssistantMessage assistantMessage = toAssistantMessage(response);
@@ -148,13 +145,10 @@ public class GeminiContentResponseConverter {
   }
 
   /**
-   * Builds the message for a response Gemini returned without any candidate, which is what a prompt
-   * blocked by input-side filtering looks like. The block reason (when reported) is preserved as an
-   * explanatory {@link TextContent} and under {@code blockReason} metadata, so the message is
-   * well-formed rather than silently empty; {@link #toResult} then throws {@link
-   * ContentFilteredException} carrying this message as its {@link
-   * ChatModelRejectedException.PartialResult}, rather than the converter crashing on an empty
-   * message.
+   * Builds the message for a candidate-less response (a prompt blocked by input-side filtering).
+   * Preserves the block reason as an explanatory {@link TextContent} and under {@code blockReason}
+   * metadata; {@link #toResult} throws {@link ContentFilteredException} carrying this as its {@link
+   * ChatModelRejectedException.PartialResult}.
    */
   private AssistantMessage blockedPromptMessage(GenerateContentResponse response) {
     final String blockReason =
@@ -349,14 +343,11 @@ public class GeminiContentResponseConverter {
   }
 
   /**
-   * Normalizes Gemini's finish reason, overriding it with {@link StopReason#TOOL_USE} whenever the
-   * response produced tool calls (Gemini has no tool-use finish reason of its own) — but only once
-   * a filtering finish reason has already been ruled out: Gemini always reports its real finish
-   * reason regardless of whether the candidate also carries {@code functionCall} parts, so a
-   * filtered-and-tool-calling response must still surface as {@code CONTENT_FILTERED} rather than
-   * losing that classification to the tool-use override. The tool-use override is otherwise applied
-   * before the null check so that a response reporting no finish reason at all still surfaces as
-   * {@code TOOL_USE} when it carries function calls.
+   * Normalizes Gemini's finish reason. A filtering finish reason wins first — Gemini reports its
+   * real finish reason even when the candidate carries {@code functionCall} parts, so filtered
+   * content must not be reclassified as {@code TOOL_USE}. Otherwise, tool calls override to {@link
+   * StopReason#TOOL_USE} (Gemini has no tool-use finish reason of its own), applied before the null
+   * check so a missing finish reason still surfaces as {@code TOOL_USE} when calls are present.
    */
   private @Nullable StopReason mapStopReason(
       @Nullable FinishReason finishReason, boolean hasToolCalls) {

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiContentResponseConverter.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiContentResponseConverter.java
@@ -106,7 +106,7 @@ public class GeminiContentResponseConverter {
     return new ChatResult.Completed(assistantMessage, metrics);
   }
 
-  AssistantMessage toAssistantMessage(GenerateContentResponse response) {
+  private AssistantMessage toAssistantMessage(GenerateContentResponse response) {
     // Covers both shapes of "no candidate": the absent Optional a blocked prompt actually produces,
     // and a defensively handled empty list.
     final Candidate candidate =

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiContentResponseConverter.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiContentResponseConverter.java
@@ -108,8 +108,11 @@ public class GeminiContentResponseConverter {
       final ToolCall toolCall = toToolCall(part);
       if (toolCall != null) {
         toolCalls.add(toolCall);
-      } else {
-        content.add(toContent(part));
+        continue;
+      }
+      final Content converted = toContent(part);
+      if (converted != null) {
+        content.add(converted);
       }
     }
 
@@ -221,19 +224,32 @@ public class GeminiContentResponseConverter {
         .orElse(null);
   }
 
-  private Content toContent(Part part) {
+  /**
+   * Maps a single non-tool-call {@link Part} to its domain {@link Content}, or returns {@code null}
+   * for a part that carries nothing worth keeping (blank text and no other field) — {@link
+   * TextContent} rejects blank text, and the stream assembler can pass an empty-text part straight
+   * through from real SSE traffic.
+   */
+  private @Nullable Content toContent(Part part) {
     if (part.thought().orElse(false)) {
       return toReasoningContent(part);
     }
 
-    final String text = part.text().orElse(null);
+    // A thoughtSignature is not exclusive to thinking/function-call parts: Gemini attaches it to
+    // whichever part the reasoning continuity belongs to, including a plain answer text part. Since
+    // every assistant message is replayed back into the next request, dropping it here would break
+    // the same follow-up requests the function-call handling above protects.
+    final String text = part.text().filter(StringUtils::hasText).orElse(null);
     if (text != null) {
-      return TextContent.textContent(text);
+      return new TextContent(text, thoughtSignatureMetadata(part));
     }
 
-    // Fallback for any Gemini part shape not explicitly handled above: preserve it losslessly, in
-    // original order, as ProviderContent
-    return new ProviderContent(GOOGLE_GEMINI_ID, rawPart(part), null);
+    // Fallback for any Gemini part shape not explicitly handled above (including a signature-only
+    // part with blank text): preserve it losslessly, in original order, as ProviderContent.
+    final Map<String, Object> raw = rawPart(part);
+    final Map<String, Object> withoutText = new LinkedHashMap<>(raw);
+    withoutText.remove("text");
+    return withoutText.isEmpty() ? null : new ProviderContent(GOOGLE_GEMINI_ID, raw, null);
   }
 
   /**
@@ -251,13 +267,21 @@ public class GeminiContentResponseConverter {
       raw.remove("text");
     }
 
-    final Map<String, Object> metadata =
-        part.thoughtSignature()
-            .<Map<String, Object>>map(
-                signature -> Map.of(THOUGHT_SIGNATURE_METADATA_KEY, encodeSignature(signature)))
-            .orElse(null);
+    return new ReasoningContent(GOOGLE_GEMINI_ID, raw, text, thoughtSignatureMetadata(part));
+  }
 
-    return new ReasoningContent(GOOGLE_GEMINI_ID, raw, text, metadata);
+  /**
+   * The base64-encoded {@code thoughtSignature} as {@link Content#metadata()}, flat under {@link
+   * GeminiContentConverter#THOUGHT_SIGNATURE_METADATA_KEY} — the exact shape {@link
+   * GeminiContentConverter#toParts(List)} reads back on replay. No provider namespace is needed
+   * here (unlike on a {@link ToolCall}): every {@link Content} carrying this already names its
+   * provider as a first-class field.
+   */
+  private @Nullable Map<String, Object> thoughtSignatureMetadata(Part part) {
+    return part.thoughtSignature()
+        .<Map<String, Object>>map(
+            signature -> Map.of(THOUGHT_SIGNATURE_METADATA_KEY, encodeSignature(signature)))
+        .orElse(null);
   }
 
   /**

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiContentResponseConverter.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiContentResponseConverter.java
@@ -57,8 +57,9 @@ import org.springframework.util.StringUtils;
  * <ul>
  *   <li><b>No tool-use finish reason.</b> Gemini reports {@code STOP} even when the candidate
  *       contains {@code functionCall} parts, so the mapped stop reason is overridden with {@link
- *       StopReason#TOOL_USE} whenever the response produced tool calls. The raw vendor value is
- *       preserved unchanged under the {@code google-gemini} metadata key regardless.
+ *       StopReason#TOOL_USE} when the response produced tool calls and was not filtered (see {@link
+ *       #mapStopReason}). The raw vendor value is preserved unchanged under the {@code
+ *       google-gemini} metadata key regardless.
  *   <li><b>A blocked prompt has no candidate.</b> The response carries only {@code promptFeedback};
  *       the block reason is preserved as content and under {@code blockReason} metadata so {@link
  *       #toResult} has a well-formed message to throw {@link ContentFilteredException} with.

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiContentResponseConverter.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiContentResponseConverter.java
@@ -19,7 +19,9 @@ import com.google.genai.types.GenerateContentResponse;
 import com.google.genai.types.GenerateContentResponsePromptFeedback;
 import com.google.genai.types.GenerateContentResponseUsageMetadata;
 import com.google.genai.types.Part;
+import io.camunda.connector.agenticai.aiagent.chatmodel.ChatModelRejectedException;
 import io.camunda.connector.agenticai.aiagent.chatmodel.ChatResult;
+import io.camunda.connector.agenticai.aiagent.chatmodel.ContentFilteredException;
 import io.camunda.connector.agenticai.aiagent.model.AgentMetrics;
 import io.camunda.connector.agenticai.aiagent.model.message.AssistantMessage;
 import io.camunda.connector.agenticai.aiagent.model.message.AssistantMessageBuilder;
@@ -58,16 +60,16 @@ import org.springframework.util.StringUtils;
  *       StopReason#TOOL_USE} whenever the response produced tool calls. The raw vendor value is
  *       preserved unchanged under the {@code google-gemini} metadata key regardless.
  *   <li><b>A blocked prompt has no candidate.</b> The response then carries only {@code
- *       promptFeedback}, which is converted into a well-formed {@link StopReason#CONTENT_FILTERED}
- *       message (the block reason preserved as content and under {@code blockReason} metadata)
- *       instead of an empty message or a converter crash, so the terminal stop-reason guard
- *       downstream receives a message it can act on rather than something it chokes on.
+ *       promptFeedback}, which is converted into a well-formed message (the block reason preserved
+ *       as content and under {@code blockReason} metadata) instead of an empty message or a
+ *       converter crash, so {@link #toResult} has a well-formed message to throw {@link
+ *       ContentFilteredException} with rather than something it chokes on.
  * </ul>
  *
- * <p>Every result is a {@link ChatResult.Completed}: Gemini has no equivalent of Anthropic's {@code
- * pause_turn}. {@code FinishReason.Known} contains no paused/continuation value and nothing else in
- * the SDK models a turn the provider expects to be resumed without new input, so {@link
- * ChatResult.Continuation} is never produced.
+ * <p>Every non-thrown result is a {@link ChatResult.Completed}: Gemini has no equivalent of
+ * Anthropic's {@code pause_turn}. {@code FinishReason.Known} contains no paused/continuation value
+ * and nothing else in the SDK models a turn the provider expects to be resumed without new input,
+ * so {@link ChatResult.Continuation} is never produced.
  *
  * <p>The candidate's parts are read via {@code candidates().get(0).content().parts()} rather than
  * the {@link GenerateContentResponse#parts()}/{@code text()}/{@code functionCalls()} convenience
@@ -80,10 +82,23 @@ public class GeminiContentResponseConverter {
   private static final String FINISH_REASON_METADATA_KEY = "finishReason";
   private static final String BLOCK_REASON_METADATA_KEY = "blockReason";
 
+  /**
+   * @throws ContentFilteredException when the prompt was blocked, or the candidate's finish reason
+   *     indicates the response was filtered ({@code SAFETY}, {@code RECITATION}, {@code BLOCKLIST},
+   *     {@code PROHIBITED_CONTENT}, {@code SPII}, or one of the {@code IMAGE_*} variants) — in both
+   *     cases carrying the {@link ChatModelRejectedException.PartialResult} built for the turn so
+   *     far.
+   */
   public ChatResult toResult(GenerateContentResponse response, Duration executionTime) {
     final AssistantMessage assistantMessage = toAssistantMessage(response);
     final AgentMetrics metrics =
         toMetrics(response, assistantMessage.toolCalls().size(), executionTime);
+
+    if (assistantMessage.stopReason() == StopReason.CONTENT_FILTERED) {
+      throw new ContentFilteredException(
+          "Model response was blocked by provider content filtering.",
+          new ChatModelRejectedException.PartialResult(assistantMessage, metrics));
+    }
 
     return new ChatResult.Completed(assistantMessage, metrics);
   }
@@ -134,11 +149,12 @@ public class GeminiContentResponseConverter {
 
   /**
    * Builds the message for a response Gemini returned without any candidate, which is what a prompt
-   * blocked by input-side filtering looks like. Never throws: the block reason (when reported) is
-   * preserved as an explanatory {@link TextContent} and under {@code blockReason} metadata, so the
-   * message is well-formed rather than silently empty. The {@link StopReason#CONTENT_FILTERED} stop
-   * reason this message carries is still terminal downstream, by design shared with every other
-   * provider — this only avoids an empty message or a converter crash, not the eventual incident.
+   * blocked by input-side filtering looks like. The block reason (when reported) is preserved as an
+   * explanatory {@link TextContent} and under {@code blockReason} metadata, so the message is
+   * well-formed rather than silently empty; {@link #toResult} then throws {@link
+   * ContentFilteredException} carrying this message as its {@link
+   * ChatModelRejectedException.PartialResult}, rather than the converter crashing on an empty
+   * message.
    */
   private AssistantMessage blockedPromptMessage(GenerateContentResponse response) {
     final String blockReason =
@@ -334,12 +350,20 @@ public class GeminiContentResponseConverter {
 
   /**
    * Normalizes Gemini's finish reason, overriding it with {@link StopReason#TOOL_USE} whenever the
-   * response produced tool calls (Gemini has no tool-use finish reason of its own). The override is
-   * applied before the null check so that a response reporting no finish reason at all still
-   * surfaces as {@code TOOL_USE} when it carries function calls.
+   * response produced tool calls (Gemini has no tool-use finish reason of its own) — but only once
+   * a filtering finish reason has already been ruled out: Gemini always reports its real finish
+   * reason regardless of whether the candidate also carries {@code functionCall} parts, so a
+   * filtered-and-tool-calling response must still surface as {@code CONTENT_FILTERED} rather than
+   * losing that classification to the tool-use override. The tool-use override is otherwise applied
+   * before the null check so that a response reporting no finish reason at all still surfaces as
+   * {@code TOOL_USE} when it carries function calls.
    */
   private @Nullable StopReason mapStopReason(
       @Nullable FinishReason finishReason, boolean hasToolCalls) {
+    final StopReason filtered = finishReason != null ? filteredStopReason(finishReason) : null;
+    if (filtered != null) {
+      return filtered;
+    }
     if (hasToolCalls) {
       return StopReason.TOOL_USE;
     }
@@ -350,6 +374,15 @@ public class GeminiContentResponseConverter {
     return switch (finishReason.knownEnum()) {
       case STOP -> StopReason.STOP;
       case MAX_TOKENS -> StopReason.LENGTH;
+      // LANGUAGE, OTHER, MALFORMED_FUNCTION_CALL, UNEXPECTED_TOOL_CALL, NO_IMAGE and any value the
+      // SDK does not recognise (knownEnum() collapses those to FINISH_REASON_UNSPECIFIED, while
+      // toString() still returns the raw vendor string)
+      default -> new StopReason.UnknownStopReason(finishReason.toString());
+    };
+  }
+
+  private @Nullable StopReason filteredStopReason(FinishReason finishReason) {
+    return switch (finishReason.knownEnum()) {
       case SAFETY,
           RECITATION,
           BLOCKLIST,
@@ -359,10 +392,7 @@ public class GeminiContentResponseConverter {
           IMAGE_PROHIBITED_CONTENT,
           IMAGE_RECITATION ->
           StopReason.CONTENT_FILTERED;
-      // LANGUAGE, OTHER, MALFORMED_FUNCTION_CALL, UNEXPECTED_TOOL_CALL, NO_IMAGE and any value the
-      // SDK does not recognise (knownEnum() collapses those to FINISH_REASON_UNSPECIFIED, while
-      // toString() still returns the raw vendor string)
-      default -> new StopReason.UnknownStopReason(finishReason.toString());
+      default -> null;
     };
   }
 }

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiContentResponseConverter.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiContentResponseConverter.java
@@ -58,8 +58,10 @@ import org.springframework.util.StringUtils;
  *       StopReason#TOOL_USE} whenever the response produced tool calls. The raw vendor value is
  *       preserved unchanged under the {@code google-gemini} metadata key regardless.
  *   <li><b>A blocked prompt has no candidate.</b> The response then carries only {@code
- *       promptFeedback}, which is surfaced as a {@link StopReason#CONTENT_FILTERED} message
- *       explaining the block instead of an empty message or an exception.
+ *       promptFeedback}, which is converted into a well-formed {@link StopReason#CONTENT_FILTERED}
+ *       message (the block reason preserved as content and under {@code blockReason} metadata)
+ *       instead of an empty message or a converter crash, so the terminal stop-reason guard
+ *       downstream receives a message it can act on rather than something it chokes on.
  * </ul>
  *
  * <p>Every result is a {@link ChatResult.Completed}: Gemini has no equivalent of Anthropic's {@code
@@ -133,8 +135,10 @@ public class GeminiContentResponseConverter {
   /**
    * Builds the message for a response Gemini returned without any candidate, which is what a prompt
    * blocked by input-side filtering looks like. Never throws: the block reason (when reported) is
-   * lifted into an explanatory {@link TextContent} so the blocked turn is visible in the
-   * conversation rather than silently empty.
+   * preserved as an explanatory {@link TextContent} and under {@code blockReason} metadata, so the
+   * message is well-formed rather than silently empty. The {@link StopReason#CONTENT_FILTERED} stop
+   * reason this message carries is still terminal downstream, by design shared with every other
+   * provider — this only avoids an empty message or a converter crash, not the eventual incident.
    */
   private AssistantMessage blockedPromptMessage(GenerateContentResponse response) {
     final String blockReason =

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiContentStreamAssembler.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiContentStreamAssembler.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.agenticai.aiagent.chatmodel.provider.gemini;
+
+import com.google.genai.ResponseStream;
+import com.google.genai.types.GenerateContentResponse;
+
+/**
+ * Collapses a streamed Gemini response into the single {@link GenerateContentResponse} a
+ * non-streaming {@code generateContent()} call would have returned, so the response converter only
+ * ever deals with one response shape.
+ *
+ * <p>Unlike the Anthropic SDK, {@code com.google.genai} ships no chunk accumulator, so the merge is
+ * hand-written: see {@link GeminiContentStreamAssemblerImpl}.
+ *
+ * <p>Implementations iterate the stream but never close it — the caller owns the stream (and closes
+ * it via try-with-resources).
+ */
+@FunctionalInterface
+public interface GeminiContentStreamAssembler {
+
+  GenerateContentResponse assemble(ResponseStream<GenerateContentResponse> stream);
+}

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiContentStreamAssemblerImpl.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiContentStreamAssemblerImpl.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.agenticai.aiagent.chatmodel.provider.gemini;
+
+import com.google.genai.ResponseStream;
+import com.google.genai.types.Candidate;
+import com.google.genai.types.Content;
+import com.google.genai.types.GenerateContentResponse;
+import com.google.genai.types.GenerateContentResponsePromptFeedback;
+import com.google.genai.types.GenerateContentResponseUsageMetadata;
+import com.google.genai.types.Part;
+import java.util.ArrayList;
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Merges Gemini's streamed {@link GenerateContentResponse} chunks into one response:
+ *
+ * <ul>
+ *   <li><b>Candidates</b>: only the first candidate of each chunk is considered (the connector
+ *       never requests more than one); the synthesized response carries exactly that one candidate.
+ *       It is based on the <b>last</b> candidate seen, so candidate-level metadata (finish reason,
+ *       token count, safety ratings) is the final chunk's — which is where Gemini reports it.
+ *   <li><b>Text parts</b>: consecutive text parts sharing the same {@code thought} flag form one
+ *       "run" and are concatenated across chunks, since Gemini streams text incrementally. A part
+ *       carrying a {@code thoughtSignature} closes its run (signatures belong to exactly one part
+ *       and must round-trip verbatim, so they are never conflated); an incoming signature is
+ *       carried onto the merged part.
+ *   <li><b>Other parts</b> ({@code functionCall}, {@code inlineData}, {@code fileData}, ...) are
+ *       complete units per chunk and are appended in arrival order, never merged field-wise.
+ *   <li><b>Usage metadata</b>: last chunk that reports it wins (Gemini reports cumulative counts on
+ *       the final chunk); never summed across chunks.
+ *   <li><b>{@code promptFeedback}</b> (blocked prompt, typically the only chunk and without any
+ *       candidate): passed through unmodified, first chunk reporting it wins. The synthesized
+ *       response then has no candidates at all, which is what the response converter keys on.
+ *   <li><b>{@code modelVersion}/{@code responseId}/content role</b>: first non-empty value wins.
+ * </ul>
+ */
+public class GeminiContentStreamAssemblerImpl implements GeminiContentStreamAssembler {
+
+  private static final Logger LOG = LoggerFactory.getLogger(GeminiContentStreamAssemblerImpl.class);
+
+  @Override
+  public GenerateContentResponse assemble(ResponseStream<GenerateContentResponse> stream) {
+    final List<Part> parts = new ArrayList<>();
+    Candidate lastCandidate = null;
+    String role = null;
+    String modelVersion = null;
+    String responseId = null;
+    GenerateContentResponseUsageMetadata usageMetadata = null;
+    GenerateContentResponsePromptFeedback promptFeedback = null;
+    boolean hasChunks = false;
+
+    for (final GenerateContentResponse chunk : stream) {
+      hasChunks = true;
+
+      if (modelVersion == null) {
+        modelVersion = chunk.modelVersion().filter(value -> !value.isBlank()).orElse(null);
+      }
+      if (responseId == null) {
+        responseId = chunk.responseId().filter(value -> !value.isBlank()).orElse(null);
+      }
+      if (promptFeedback == null) {
+        promptFeedback = chunk.promptFeedback().orElse(null);
+      }
+      usageMetadata = chunk.usageMetadata().orElse(usageMetadata);
+
+      final Candidate candidate =
+          chunk
+              .candidates()
+              .filter(candidates -> !candidates.isEmpty())
+              .map(List::getFirst)
+              .orElse(null);
+      if (candidate == null) {
+        continue;
+      }
+      lastCandidate = candidate;
+
+      final Content content = candidate.content().orElse(null);
+      if (content == null) {
+        continue;
+      }
+      if (role == null) {
+        role = content.role().filter(value -> !value.isBlank()).orElse(null);
+      }
+      content.parts().orElse(List.of()).forEach(part -> appendPart(parts, part));
+    }
+
+    if (!hasChunks) {
+      throw new IllegalStateException("Gemini streaming response contained no chunks");
+    }
+
+    final GenerateContentResponse.Builder response = GenerateContentResponse.builder();
+    if (modelVersion != null) {
+      response.modelVersion(modelVersion);
+    }
+    if (responseId != null) {
+      response.responseId(responseId);
+    }
+    if (usageMetadata != null) {
+      response.usageMetadata(usageMetadata);
+    }
+    if (promptFeedback != null) {
+      response.promptFeedback(promptFeedback);
+    }
+    if (lastCandidate != null) {
+      final Candidate.Builder candidate = lastCandidate.toBuilder();
+      if (!parts.isEmpty()) {
+        final Content.Builder content = Content.builder().parts(parts);
+        if (role != null) {
+          content.role(role);
+        }
+        candidate.content(content.build());
+      }
+      response.candidates(List.of(candidate.build()));
+    }
+
+    return response.build();
+  }
+
+  private static void appendPart(List<Part> parts, Part part) {
+    warnOnPartialFunctionCall(part);
+
+    if (!parts.isEmpty() && part.text().isPresent()) {
+      final int lastIndex = parts.size() - 1;
+      final Part accumulated = parts.get(lastIndex);
+      if (isMergeableWith(accumulated, part)) {
+        parts.set(lastIndex, merge(accumulated, part));
+        return;
+      }
+    }
+
+    parts.add(part);
+  }
+
+  private static boolean isMergeableWith(Part accumulated, Part incoming) {
+    return accumulated.text().isPresent()
+        && accumulated.thoughtSignature().isEmpty()
+        && isThought(accumulated) == isThought(incoming);
+  }
+
+  private static Part merge(Part accumulated, Part incoming) {
+    final Part.Builder merged =
+        accumulated.toBuilder().text(accumulated.text().orElse("") + incoming.text().orElse(""));
+    incoming.thoughtSignature().ifPresent(merged::thoughtSignature);
+    return merged.build();
+  }
+
+  private static boolean isThought(Part part) {
+    return part.thought().orElse(false);
+  }
+
+  /**
+   * Function-call arguments arrive whole for the Gemini Developer API: each SSE chunk deserializes
+   * into a complete {@link GenerateContentResponse}, and {@code FunctionCall.args()} is a parsed
+   * map, so a fragment cannot be represented. The SDK does model incremental arguments via {@code
+   * FunctionCall.partialArgs()}/{@code willContinue()}, but documents both as unsupported on this
+   * API. Rather than guessing at an unverified merge strategy, make the case visible if it ever
+   * shows up.
+   */
+  private static void warnOnPartialFunctionCall(Part part) {
+    part.functionCall()
+        .filter(
+            functionCall ->
+                functionCall.partialArgs().isPresent() || functionCall.willContinue().isPresent())
+        .ifPresent(
+            functionCall ->
+                LOG.warn(
+                    "Gemini streamed a partial function call (partialArgs/willContinue set) for '{}'. Partial function-call arguments are not merged, the resulting tool call may be incomplete.",
+                    functionCall.name().orElse("<unknown>")));
+  }
+}

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/package-info.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/package-info.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+@NullMarked
+package io.camunda.connector.agenticai.aiagent.chatmodel.provider.gemini;
+
+import org.jspecify.annotations.NullMarked;

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/v2/GeminiChatModelConfiguration.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/v2/GeminiChatModelConfiguration.java
@@ -167,22 +167,13 @@ public record GeminiChatModelConfiguration(@Valid @NotNull GeminiConnection goog
         @Valid @Nullable GeminiThinking thinking) {}
 
     /**
-     * Gemini extended-thinking configuration for a single model, applied only when {@code enabled}.
-     * Gemini 2.5 models use {@code thinkingBudget}; Gemini 3.x models use an explicit {@code
-     * thinkingLevel} (unset defaults to {@code MODEL_DEFAULT}, letting the model choose its own
-     * reasoning depth). Setting a budget alongside an explicit level is a hard API error on 3.x
-     * models &mdash; this is validated below ({@link #isBothThinkingBudgetAndLevelSet()}), not
-     * auto-resolved.
+     * Gemini extended-thinking configuration for a single model. Gemini 2.5 models use {@code
+     * thinkingBudget}; Gemini 3.x models use an explicit {@code thinkingLevel} (unset defaults to
+     * {@code MODEL_DEFAULT}, letting the model choose its own reasoning depth). Setting a budget
+     * alongside an explicit level is a hard API error on 3.x models &mdash; this is validated below
+     * ({@link #isBothThinkingBudgetAndLevelSet()}), not auto-resolved.
      */
     public record GeminiThinking(
-        @TemplateProperty(
-                group = "model",
-                label = "Enable thinking",
-                tooltip =
-                    "Enables Gemini's extended-thinking mode. Configure a token budget (Gemini 2.5) or a qualitative level (Gemini 3.x) below once enabled. <br><br>Details in the <a href=\"https://ai.google.dev/gemini-api/docs/thinking\" target=\"_blank\">documentation</a>.",
-                type = TemplateProperty.PropertyType.Boolean,
-                optional = true)
-            Boolean enabled,
         @Min(-1)
             @TemplateProperty(
                 group = "model",
@@ -194,28 +185,24 @@ public record GeminiChatModelConfiguration(@Valid @NotNull GeminiConnection goog
                 optional = true,
                 condition =
                     @TemplateProperty.PropertyCondition(
-                        property = "provider.googleGemini.model.parameters.thinking.enabled",
-                        equalsBoolean = TemplateProperty.EqualsBoolean.TRUE))
+                        property = "provider.googleGemini.model.parameters.thinking.thinkingLevel",
+                        equals = "modelDefault"))
             @Nullable Integer thinkingBudget,
         @TemplateProperty(
                 group = "model",
                 label = "Thinking level",
                 tooltip =
-                    "Gemini 3.x models: qualitative thinking effort. \"Model default\" lets the model choose its own reasoning depth. Mutually exclusive with Thinking budget (Gemini 2.5). <br><br>Details in the <a href=\"https://ai.google.dev/gemini-api/docs/thinking\" target=\"_blank\">documentation</a>.",
+                    "Gemini 3.x models: qualitative thinking effort. \"default\" lets the model choose its own reasoning depth. Mutually exclusive with Thinking budget (Gemini 2.5). <br><br>Details in the <a href=\"https://ai.google.dev/gemini-api/docs/thinking\" target=\"_blank\">documentation</a>.",
                 type = TemplateProperty.PropertyType.Dropdown,
                 choices = {
-                  @DropdownPropertyChoice(value = "modelDefault", label = "Model default"),
+                  @DropdownPropertyChoice(value = "modelDefault", label = "default"),
                   @DropdownPropertyChoice(value = "minimal", label = "minimal"),
                   @DropdownPropertyChoice(value = "low", label = "low"),
                   @DropdownPropertyChoice(value = "medium", label = "medium"),
                   @DropdownPropertyChoice(value = "high", label = "high")
                 },
                 defaultValue = "modelDefault",
-                optional = true,
-                condition =
-                    @TemplateProperty.PropertyCondition(
-                        property = "provider.googleGemini.model.parameters.thinking.enabled",
-                        equalsBoolean = TemplateProperty.EqualsBoolean.TRUE))
+                optional = true)
             @Nullable GeminiThinkingLevel thinkingLevel) {
 
       public GeminiThinking {

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/v2/GeminiChatModelConfiguration.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/v2/GeminiChatModelConfiguration.java
@@ -136,6 +136,7 @@ public record GeminiChatModelConfiguration(@Valid @NotNull GeminiConnection goog
                 optional = true)
             @Nullable Integer maxTokens,
         @DecimalMin("0.0")
+            @DecimalMax("2.0")
             @TemplateProperty(
                 group = "model-options",
                 label = "Temperature",

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/v2/GeminiChatModelConfiguration.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/v2/GeminiChatModelConfiguration.java
@@ -201,8 +201,7 @@ public record GeminiChatModelConfiguration(@Valid @NotNull GeminiConnection goog
                   @DropdownPropertyChoice(value = "medium", label = "medium"),
                   @DropdownPropertyChoice(value = "high", label = "high")
                 },
-                defaultValue = "modelDefault",
-                optional = true)
+                defaultValue = "modelDefault")
             @Nullable GeminiThinkingLevel thinkingLevel) {
 
       public GeminiThinking {

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/v2/GeminiChatModelConfiguration.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/v2/GeminiChatModelConfiguration.java
@@ -178,37 +178,66 @@ public record GeminiChatModelConfiguration(@Valid @NotNull GeminiConnection goog
     public record GeminiThinking(
         @TemplateProperty(
                 group = "model-options",
+                label = "Enable thinking",
+                tooltip =
+                    "Enables Gemini's extended-thinking mode. Configure a token budget (Gemini 2.5) or a qualitative level (Gemini 3.x) below once enabled. <br><br>Details in the <a href=\"https://ai.google.dev/gemini-api/docs/thinking\" target=\"_blank\">documentation</a>.",
+                type = TemplateProperty.PropertyType.Boolean,
+                optional = true)
+            Boolean enabled,
+        @TemplateProperty(
+                group = "model-options",
                 label = "Thinking budget (tokens)",
                 tooltip =
                     "Gemini 2.5 models: token budget for extended thinking. -1 = dynamic, 0 = disabled. Mutually exclusive with Thinking level (Gemini 3.x). <br><br>Details in the <a href=\"https://ai.google.dev/gemini-api/docs/thinking\" target=\"_blank\">documentation</a>.",
                 type = TemplateProperty.PropertyType.Number,
                 feel = FeelMode.required,
-                optional = true)
+                optional = true,
+                condition =
+                    @TemplateProperty.PropertyCondition(
+                        property = "provider.googleGemini.model.parameters.thinking.enabled",
+                        equalsBoolean = TemplateProperty.EqualsBoolean.TRUE))
             @Nullable Integer thinkingBudget,
         @TemplateProperty(
                 group = "model-options",
                 label = "Thinking level",
                 tooltip =
-                    "Gemini 3.x models: qualitative thinking effort. Mutually exclusive with Thinking budget (Gemini 2.5). <br><br>Details in the <a href=\"https://ai.google.dev/gemini-api/docs/thinking\" target=\"_blank\">documentation</a>.",
+                    "Gemini 3.x models: qualitative thinking effort. \"Model default\" lets the model choose its own reasoning depth. Mutually exclusive with Thinking budget (Gemini 2.5). <br><br>Details in the <a href=\"https://ai.google.dev/gemini-api/docs/thinking\" target=\"_blank\">documentation</a>.",
                 type = TemplateProperty.PropertyType.Dropdown,
                 choices = {
+                  @DropdownPropertyChoice(value = "modelDefault", label = "Model default"),
+                  @DropdownPropertyChoice(value = "minimal", label = "minimal"),
                   @DropdownPropertyChoice(value = "low", label = "low"),
                   @DropdownPropertyChoice(value = "medium", label = "medium"),
                   @DropdownPropertyChoice(value = "high", label = "high")
                 },
-                optional = true)
+                defaultValue = "modelDefault",
+                optional = true,
+                condition =
+                    @TemplateProperty.PropertyCondition(
+                        property = "provider.googleGemini.model.parameters.thinking.enabled",
+                        equalsBoolean = TemplateProperty.EqualsBoolean.TRUE))
             @Nullable GeminiThinkingLevel thinkingLevel) {
+
+      public GeminiThinking {
+        if (thinkingLevel == null) {
+          thinkingLevel = GeminiThinkingLevel.MODEL_DEFAULT;
+        }
+      }
 
       @JsonIgnore
       @AssertFalse(
           message = "thinking.thinkingBudget and thinking.thinkingLevel are mutually exclusive")
       public boolean isBothThinkingBudgetAndLevelSet() {
-        return thinkingBudget != null && thinkingLevel != null;
+        return thinkingBudget != null && thinkingLevel != GeminiThinkingLevel.MODEL_DEFAULT;
       }
     }
 
     /** Gemini qualitative thinking-effort levels (Gemini 3.x models). */
     public enum GeminiThinkingLevel {
+      @JsonProperty("modelDefault")
+      MODEL_DEFAULT,
+      @JsonProperty("minimal")
+      MINIMAL,
       @JsonProperty("low")
       LOW,
       @JsonProperty("medium")

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/v2/GeminiChatModelConfiguration.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/v2/GeminiChatModelConfiguration.java
@@ -186,7 +186,8 @@ public record GeminiChatModelConfiguration(@Valid @NotNull GeminiConnection goog
                 type = TemplateProperty.PropertyType.Boolean,
                 optional = true)
             Boolean enabled,
-        @TemplateProperty(
+        @Min(-1)
+            @TemplateProperty(
                 group = "model-options",
                 label = "Thinking budget (tokens)",
                 tooltip =

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/v2/GeminiChatModelConfiguration.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/v2/GeminiChatModelConfiguration.java
@@ -88,9 +88,6 @@ public record GeminiChatModelConfiguration(@Valid @NotNull GeminiConnection goog
                   feel = FeelMode.optional,
                   constraints = @TemplateProperty.PropertyConstraints(notEmpty = true))
               String apiKey,
-          // Hidden: never shown in the modeler. Exists solely so e2e tests can point the client
-          // at a local WireMock server via HttpOptions.baseUrl(); real deployments never set it.
-          // Mirrors AnthropicApiBackend's own hidden endpoint field 1:1 (same rationale).
           @HttpUrl
               @TemplateProperty(
                   group = "provider",
@@ -179,7 +176,7 @@ public record GeminiChatModelConfiguration(@Valid @NotNull GeminiConnection goog
      */
     public record GeminiThinking(
         @TemplateProperty(
-                group = "model-options",
+                group = "model",
                 label = "Enable thinking",
                 tooltip =
                     "Enables Gemini's extended-thinking mode. Configure a token budget (Gemini 2.5) or a qualitative level (Gemini 3.x) below once enabled. <br><br>Details in the <a href=\"https://ai.google.dev/gemini-api/docs/thinking\" target=\"_blank\">documentation</a>.",
@@ -188,7 +185,7 @@ public record GeminiChatModelConfiguration(@Valid @NotNull GeminiConnection goog
             Boolean enabled,
         @Min(-1)
             @TemplateProperty(
-                group = "model-options",
+                group = "model",
                 label = "Thinking budget (tokens)",
                 tooltip =
                     "Gemini 2.5 models: token budget for extended thinking. -1 = dynamic, 0 = disabled. Mutually exclusive with Thinking level (Gemini 3.x). <br><br>Details in the <a href=\"https://ai.google.dev/gemini-api/docs/thinking\" target=\"_blank\">documentation</a>.",
@@ -201,7 +198,7 @@ public record GeminiChatModelConfiguration(@Valid @NotNull GeminiConnection goog
                         equalsBoolean = TemplateProperty.EqualsBoolean.TRUE))
             @Nullable Integer thinkingBudget,
         @TemplateProperty(
-                group = "model-options",
+                group = "model",
                 label = "Thinking level",
                 tooltip =
                     "Gemini 3.x models: qualitative thinking effort. \"Model default\" lets the model choose its own reasoning depth. Mutually exclusive with Thinking budget (Gemini 2.5). <br><br>Details in the <a href=\"https://ai.google.dev/gemini-api/docs/thinking\" target=\"_blank\">documentation</a>.",

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/v2/GeminiChatModelConfiguration.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/v2/GeminiChatModelConfiguration.java
@@ -1,0 +1,219 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.agenticai.aiagent.model.request.v2;
+
+import static io.camunda.connector.agenticai.aiagent.model.request.v2.GeminiChatModelConfiguration.GOOGLE_GEMINI_ID;
+import static io.camunda.connector.agenticai.aiagent.model.request.v2.GeminiChatModelConfiguration.GeminiBackend.GeminiApiBackend.GOOGLE_GEMINI_API_ID;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import io.camunda.connector.agenticai.aiagent.model.request.v1.shared.HttpUrl;
+import io.camunda.connector.agenticai.aiagent.model.request.v1.shared.TimeoutConfiguration;
+import io.camunda.connector.generator.java.annotation.FeelMode;
+import io.camunda.connector.generator.java.annotation.TemplateDiscriminatorProperty;
+import io.camunda.connector.generator.java.annotation.TemplateProperty;
+import io.camunda.connector.generator.java.annotation.TemplateProperty.DropdownPropertyChoice;
+import io.camunda.connector.generator.java.annotation.TemplateSubType;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.AssertFalse;
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import org.jspecify.annotations.Nullable;
+
+@TemplateSubType(id = GOOGLE_GEMINI_ID, label = "Google Gemini")
+public record GeminiChatModelConfiguration(@Valid @NotNull GeminiConnection googleGemini)
+    implements ProviderConfiguration {
+
+  @TemplateProperty(ignore = true)
+  public static final String GOOGLE_GEMINI_ID = "google-gemini";
+
+  @Override
+  public String provider() {
+    return GOOGLE_GEMINI_ID;
+  }
+
+  @Override
+  public String model() {
+    return googleGemini.model().model();
+  }
+
+  /** All Gemini-specific configuration, nested under the {@code googleGemini} wire key. */
+  public record GeminiConnection(
+      @Valid @NotNull GeminiBackend backend,
+      @Valid @NotNull GeminiModel model,
+      @Valid @Nullable TimeoutConfiguration timeouts) {}
+
+  @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+  @JsonSubTypes({
+    @JsonSubTypes.Type(value = GeminiBackend.GeminiApiBackend.class, name = GOOGLE_GEMINI_API_ID)
+  })
+  @TemplateDiscriminatorProperty(
+      label = "Backend",
+      group = "provider",
+      name = "type",
+      defaultValue = GOOGLE_GEMINI_API_ID,
+      description = "Specify how the Gemini Developer API is reached.")
+  public sealed interface GeminiBackend {
+
+    /** The backend discriminator string. */
+    String type();
+
+    @TemplateSubType(id = GOOGLE_GEMINI_API_ID, label = "Google Gemini API")
+    record GeminiApiBackend(@Valid @NotNull GoogleGeminiApi googleGeminiApi)
+        implements GeminiBackend {
+
+      @TemplateProperty(ignore = true)
+      public static final String GOOGLE_GEMINI_API_ID = "google-gemini-api";
+
+      @Override
+      public String type() {
+        return GOOGLE_GEMINI_API_ID;
+      }
+
+      public record GoogleGeminiApi(
+          @NotBlank
+              @TemplateProperty(
+                  group = "provider",
+                  label = "Gemini API key",
+                  type = TemplateProperty.PropertyType.String,
+                  feel = FeelMode.optional,
+                  constraints = @TemplateProperty.PropertyConstraints(notEmpty = true))
+              String apiKey,
+          // Hidden: never shown in the modeler. Exists solely so e2e tests can point the client
+          // at a local WireMock server via HttpOptions.baseUrl(); real deployments never set it.
+          // Mirrors AnthropicApiBackend's own hidden endpoint field 1:1 (same rationale).
+          @HttpUrl
+              @TemplateProperty(
+                  group = "provider",
+                  label = "API endpoint",
+                  type = TemplateProperty.PropertyType.Hidden,
+                  feel = FeelMode.disabled,
+                  optional = true)
+              @Nullable String endpoint) {
+
+        @Override
+        public String toString() {
+          return "GoogleGeminiApi{apiKey=[REDACTED], endpoint=" + endpoint + "}";
+        }
+      }
+    }
+  }
+
+  public record GeminiModel(
+      @NotBlank
+          @TemplateProperty(
+              group = "model",
+              label = "Model",
+              description =
+                  "Specify the model ID. Details in the <a href=\"https://ai.google.dev/gemini-api/docs/models\" target=\"_blank\">documentation</a>.",
+              type = TemplateProperty.PropertyType.String,
+              feel = FeelMode.optional,
+              defaultValue = "",
+              defaultValueType = TemplateProperty.DefaultValueType.String,
+              placeholder = "gemini-3-pro-preview",
+              constraints = @TemplateProperty.PropertyConstraints(notEmpty = true))
+          String model,
+      @Valid @Nullable GeminiModelParameters parameters) {
+
+    public record GeminiModelParameters(
+        @Min(1)
+            @TemplateProperty(
+                group = "model-options",
+                label = "Maximum tokens",
+                tooltip =
+                    "The maximum number of tokens to generate before stopping. <br><br>Details in the <a href=\"https://ai.google.dev/api/generate-content#v1beta.GenerationConfig\" target=\"_blank\">documentation</a>.",
+                type = TemplateProperty.PropertyType.Number,
+                feel = FeelMode.required,
+                optional = true)
+            @Nullable Integer maxTokens,
+        @DecimalMin("0.0")
+            @TemplateProperty(
+                group = "model-options",
+                label = "Temperature",
+                tooltip =
+                    "Controls the randomness of the output. The higher the number, the more randomness will be injected into the response. <br><br>Details in the <a href=\"https://ai.google.dev/api/generate-content#v1beta.GenerationConfig\" target=\"_blank\">documentation</a>.",
+                type = TemplateProperty.PropertyType.Number,
+                feel = FeelMode.required,
+                optional = true)
+            @Nullable Double temperature,
+        @DecimalMin("0.0")
+            @DecimalMax("1.0")
+            @TemplateProperty(
+                group = "model-options",
+                label = "top P",
+                tooltip =
+                    "Floating point number between 0 and 1. Recommended for advanced use cases only (you usually only need to use temperature). <br><br>Details in the <a href=\"https://ai.google.dev/api/generate-content#v1beta.GenerationConfig\" target=\"_blank\">documentation</a>.",
+                type = TemplateProperty.PropertyType.Number,
+                feel = FeelMode.required,
+                optional = true)
+            @Nullable Double topP,
+        @Min(1)
+            @TemplateProperty(
+                group = "model-options",
+                label = "top K",
+                tooltip =
+                    "Integer greater than 0. Recommended for advanced use cases only (you usually only need to use temperature). <br><br>Details in the <a href=\"https://ai.google.dev/api/generate-content#v1beta.GenerationConfig\" target=\"_blank\">documentation</a>.",
+                type = TemplateProperty.PropertyType.Number,
+                feel = FeelMode.required,
+                optional = true)
+            @Nullable Integer topK,
+        @Valid @Nullable GeminiThinking thinking) {}
+
+    /**
+     * Gemini extended-thinking configuration for a single model. Gemini 2.5 models use {@code
+     * thinkingBudget}; Gemini 3.x models use {@code thinkingLevel}. Setting both is a hard API
+     * error on 3.x models &mdash; this is validated below ({@link
+     * #isBothThinkingBudgetAndLevelSet()}), not auto-resolved.
+     */
+    public record GeminiThinking(
+        @TemplateProperty(
+                group = "model-options",
+                label = "Thinking budget (tokens)",
+                tooltip =
+                    "Gemini 2.5 models: token budget for extended thinking. -1 = dynamic, 0 = disabled. Mutually exclusive with Thinking level (Gemini 3.x). <br><br>Details in the <a href=\"https://ai.google.dev/gemini-api/docs/thinking\" target=\"_blank\">documentation</a>.",
+                type = TemplateProperty.PropertyType.Number,
+                feel = FeelMode.required,
+                optional = true)
+            @Nullable Integer thinkingBudget,
+        @TemplateProperty(
+                group = "model-options",
+                label = "Thinking level",
+                tooltip =
+                    "Gemini 3.x models: qualitative thinking effort. Mutually exclusive with Thinking budget (Gemini 2.5). <br><br>Details in the <a href=\"https://ai.google.dev/gemini-api/docs/thinking\" target=\"_blank\">documentation</a>.",
+                type = TemplateProperty.PropertyType.Dropdown,
+                choices = {
+                  @DropdownPropertyChoice(value = "low", label = "low"),
+                  @DropdownPropertyChoice(value = "medium", label = "medium"),
+                  @DropdownPropertyChoice(value = "high", label = "high")
+                },
+                optional = true)
+            @Nullable GeminiThinkingLevel thinkingLevel) {
+
+      @JsonIgnore
+      @AssertFalse(
+          message = "thinking.thinkingBudget and thinking.thinkingLevel are mutually exclusive")
+      public boolean isBothThinkingBudgetAndLevelSet() {
+        return thinkingBudget != null && thinkingLevel != null;
+      }
+    }
+
+    /** Gemini qualitative thinking-effort levels (Gemini 3.x models). */
+    public enum GeminiThinkingLevel {
+      @JsonProperty("low")
+      LOW,
+      @JsonProperty("medium")
+      MEDIUM,
+      @JsonProperty("high")
+      HIGH
+    }
+  }
+}

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/v2/GeminiChatModelConfiguration.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/v2/GeminiChatModelConfiguration.java
@@ -170,10 +170,12 @@ public record GeminiChatModelConfiguration(@Valid @NotNull GeminiConnection goog
         @Valid @Nullable GeminiThinking thinking) {}
 
     /**
-     * Gemini extended-thinking configuration for a single model. Gemini 2.5 models use {@code
-     * thinkingBudget}; Gemini 3.x models use {@code thinkingLevel}. Setting both is a hard API
-     * error on 3.x models &mdash; this is validated below ({@link
-     * #isBothThinkingBudgetAndLevelSet()}), not auto-resolved.
+     * Gemini extended-thinking configuration for a single model, applied only when {@code enabled}.
+     * Gemini 2.5 models use {@code thinkingBudget}; Gemini 3.x models use an explicit {@code
+     * thinkingLevel} (unset defaults to {@code MODEL_DEFAULT}, letting the model choose its own
+     * reasoning depth). Setting a budget alongside an explicit level is a hard API error on 3.x
+     * models &mdash; this is validated below ({@link #isBothThinkingBudgetAndLevelSet()}), not
+     * auto-resolved.
      */
     public record GeminiThinking(
         @TemplateProperty(

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/v2/ProviderConfiguration.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/v2/ProviderConfiguration.java
@@ -9,6 +9,7 @@ package io.camunda.connector.agenticai.aiagent.model.request.v2;
 import static io.camunda.connector.agenticai.aiagent.model.request.v2.AnthropicChatModelConfiguration.ANTHROPIC_ID;
 import static io.camunda.connector.agenticai.aiagent.model.request.v2.BedrockConverseChatModelConfiguration.BEDROCK_CONVERSE_ID;
 import static io.camunda.connector.agenticai.aiagent.model.request.v2.CustomProviderConfiguration.CUSTOM_ID;
+import static io.camunda.connector.agenticai.aiagent.model.request.v2.GeminiChatModelConfiguration.GOOGLE_GEMINI_ID;
 import static io.camunda.connector.agenticai.aiagent.model.request.v2.OpenAiChatModelConfiguration.OPENAI_ID;
 
 import com.fasterxml.jackson.annotation.JsonSubTypes;
@@ -23,6 +24,7 @@ import io.camunda.connector.generator.java.annotation.TemplateDiscriminatorPrope
       value = BedrockConverseChatModelConfiguration.class,
       name = BEDROCK_CONVERSE_ID),
   @JsonSubTypes.Type(value = OpenAiChatModelConfiguration.class, name = OPENAI_ID),
+  @JsonSubTypes.Type(value = GeminiChatModelConfiguration.class, name = GOOGLE_GEMINI_ID),
   @JsonSubTypes.Type(value = CustomProviderConfiguration.class, name = CUSTOM_ID)
 })
 @TemplateDiscriminatorProperty(
@@ -35,6 +37,7 @@ public sealed interface ProviderConfiguration extends ChatModelConfiguration
     permits AnthropicChatModelConfiguration,
         BedrockConverseChatModelConfiguration,
         OpenAiChatModelConfiguration,
+        GeminiChatModelConfiguration,
         CustomProviderConfiguration {
 
   @Override

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiChatModelFactoryClientTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiChatModelFactoryClientTest.java
@@ -173,10 +173,8 @@ class GeminiChatModelFactoryClientTest {
 
   private static AgenticAiHttpProxySupport noProxy() {
     final var httpProxySupport = mock(AgenticAiHttpProxySupport.class);
-    final var proxyConfiguration = mock(ProxyConfiguration.class);
+    final ProxyConfiguration proxyConfiguration = scheme -> Optional.empty();
     when(httpProxySupport.getProxyConfiguration()).thenReturn(proxyConfiguration);
-    when(proxyConfiguration.getProxyDetails(org.mockito.ArgumentMatchers.anyString()))
-        .thenReturn(Optional.empty());
     return httpProxySupport;
   }
 

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiChatModelFactoryClientTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiChatModelFactoryClientTest.java
@@ -14,6 +14,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathMatching;
 import static com.github.tomakehurst.wiremock.client.WireMock.verify;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -173,8 +174,7 @@ class GeminiChatModelFactoryClientTest {
 
   private static AgenticAiHttpProxySupport noProxy() {
     final var httpProxySupport = mock(AgenticAiHttpProxySupport.class);
-    final ProxyConfiguration proxyConfiguration = scheme -> Optional.empty();
-    when(httpProxySupport.getProxyConfiguration()).thenReturn(proxyConfiguration);
+    when(httpProxySupport.okHttpProxy(any())).thenReturn(Optional.empty());
     return httpProxySupport;
   }
 

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiChatModelFactoryClientTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiChatModelFactoryClientTest.java
@@ -1,0 +1,369 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.agenticai.aiagent.chatmodel.provider.gemini;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathMatching;
+import static com.github.tomakehurst.wiremock.client.WireMock.verify;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import com.google.genai.types.Candidate;
+import com.google.genai.types.Content;
+import com.google.genai.types.FinishReason;
+import com.google.genai.types.GenerateContentResponse;
+import com.google.genai.types.GenerateContentResponseUsageMetadata;
+import com.google.genai.types.Part;
+import io.camunda.connector.agenticai.aiagent.chatmodel.ChatModel;
+import io.camunda.connector.agenticai.aiagent.chatmodel.ChatRequest;
+import io.camunda.connector.agenticai.aiagent.memory.ConversationSnapshot;
+import io.camunda.connector.agenticai.aiagent.model.AgentConfiguration;
+import io.camunda.connector.agenticai.aiagent.model.AgentExecutionContext;
+import io.camunda.connector.agenticai.aiagent.model.message.UserMessage;
+import io.camunda.connector.agenticai.aiagent.model.message.content.TextContent;
+import io.camunda.connector.agenticai.aiagent.model.request.PromptConfiguration.SystemPromptConfiguration;
+import io.camunda.connector.agenticai.aiagent.model.request.PromptConfiguration.UserPromptConfiguration;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.GeminiChatModelConfiguration;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.GeminiChatModelConfiguration.GeminiBackend.GeminiApiBackend;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.GeminiChatModelConfiguration.GeminiBackend.GeminiApiBackend.GoogleGeminiApi;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.GeminiChatModelConfiguration.GeminiConnection;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.GeminiChatModelConfiguration.GeminiModel;
+import io.camunda.connector.agenticai.common.AgenticAiHttpProxySupport;
+import io.camunda.connector.http.client.proxy.ProxyConfiguration;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.InetAddress;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.jspecify.annotations.Nullable;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Exercises {@link GeminiChatModelFactory}'s endpoint and <strong>proxy</strong> wiring through its
+ * public surface ({@link GeminiChatModelFactory#create} + {@link ChatModel#execute}) rather than
+ * reaching into the private client-building internals: the built {@link ChatModel} issues a real
+ * HTTP request, and assertions verify what actually went over the wire.
+ *
+ * <p>This is the deliberate counterpart to {@link GeminiChatModelFactoryTest}, which asserts only
+ * that we <em>configure</em> {@code ClientOptions.proxyOptions} correctly (host/port/credentials,
+ * via a mocked {@link AgenticAiHttpProxySupport}). That leaves the real question untested: whether
+ * the google-genai SDK actually <em>honors</em> those options on the wire. Mirrors {@code
+ * AnthropicChatModelFactoryClientTest} for the sibling native provider, which exists for exactly
+ * this reason.
+ *
+ * <p>The SDK applies {@code ProxyOptions} to its OkHttp client ({@code
+ * ApiClient#applyProxyOptions}: {@code builder.proxy(...)} plus a {@code proxyAuthenticator} when
+ * credentials are present), so both the credential-less and the authenticating proxy paths are
+ * covered below.
+ */
+@WireMockTest
+class GeminiChatModelFactoryClientTest {
+
+  private static final String MODEL_ID = "gemini-3-pro-preview";
+  private static final String API_KEY = "gemini-api-secret-key";
+
+  /**
+   * Target used by the proxy tests: a non-routable address (RFC 5737 TEST-NET-1). Reaching it
+   * directly would hang or fail, so a successful response proves the request actually went through
+   * the configured proxy rather than straight to the (unreachable) target.
+   */
+  private static final String UNREACHABLE_ENDPOINT = "http://192.0.2.1:1";
+
+  /**
+   * Minimal Gemini streaming (SSE) response: a single {@code data:} line carrying one complete
+   * {@link GenerateContentResponse}. {@code GeminiChatModel} always drives {@code
+   * generateContentStream}, so a plain buffered JSON body would not be read as a stream; and the
+   * stream assembler rejects a stream with no chunks at all.
+   *
+   * <p>Built through the SDK's own builders and {@code toJson()} so every field name comes from the
+   * SDK's {@code @JsonProperty} annotations rather than a hand-written literal.
+   */
+  private static final String SSE_RESPONSE_BODY =
+      "data: "
+          + GenerateContentResponse.builder()
+              .candidates(
+                  List.of(
+                      Candidate.builder()
+                          .index(0)
+                          .content(
+                              Content.builder()
+                                  .role("model")
+                                  .parts(List.of(Part.builder().text("hi").build()))
+                                  .build())
+                          .finishReason(FinishReason.Known.STOP)
+                          .build()))
+              .usageMetadata(
+                  GenerateContentResponseUsageMetadata.builder()
+                      .promptTokenCount(1)
+                      .candidatesTokenCount(1)
+                      .totalTokenCount(2)
+                      .build())
+              .build()
+              .toJson()
+          + "\n\n";
+
+  private final ObjectMapper objectMapper = new ObjectMapper();
+
+  @Test
+  void hiddenEndpointOverrideRedirectsRequestAndKeepsApiKeyHeaderAndSseQueryParam(
+      WireMockRuntimeInfo wireMock) {
+    stubStreamGenerateContent();
+
+    executeAgainst(noProxy(), wireMock.getHttpBaseUrl());
+
+    // Baseline for the proxy tests below: proves the built client really issues the request, so the
+    // fake-proxy assertions are meaningful by contrast rather than vacuous.
+    verify(
+        postRequestedFor(urlPathMatching("/v1beta/models/.+:streamGenerateContent"))
+            .withHeader("x-goog-api-key", equalTo(API_KEY))
+            // The SDK requests SSE framing explicitly; without it Gemini would return a JSON array.
+            .withQueryParam("alt", equalTo("sse")));
+  }
+
+  @Test
+  void appliesConfiguredProxyToBuiltClient() throws Exception {
+    try (var fakeProxy = new FakeProxyServer(null, null)) {
+      executeAgainst(
+          new AgenticAiHttpProxySupport(fakeProxy.toProxyConfiguration()), UNREACHABLE_ENDPOINT);
+
+      assertThat(fakeProxy.lastRequestLine()).contains("192.0.2.1");
+    }
+  }
+
+  @Test
+  void appliesProxyCredentialsViaProxyAuthenticator() throws Exception {
+    try (var fakeProxy = new FakeProxyServer("proxyuser", "proxypass")) {
+      executeAgainst(
+          new AgenticAiHttpProxySupport(fakeProxy.toProxyConfiguration()), UNREACHABLE_ENDPOINT);
+
+      assertThat(fakeProxy.lastProxyAuthorizationHeader())
+          .isEqualTo(
+              "Basic "
+                  + Base64.getEncoder()
+                      .encodeToString("proxyuser:proxypass".getBytes(StandardCharsets.UTF_8)));
+    }
+  }
+
+  private static void stubStreamGenerateContent() {
+    stubFor(
+        post(urlPathMatching(".*/v1beta/models/.+:streamGenerateContent"))
+            .willReturn(
+                aResponse()
+                    .withStatus(200)
+                    .withHeader("Content-Type", "text/event-stream")
+                    .withBody(SSE_RESPONSE_BODY)));
+  }
+
+  private static AgenticAiHttpProxySupport noProxy() {
+    final var httpProxySupport = mock(AgenticAiHttpProxySupport.class);
+    final var proxyConfiguration = mock(ProxyConfiguration.class);
+    when(httpProxySupport.getProxyConfiguration()).thenReturn(proxyConfiguration);
+    when(proxyConfiguration.getProxyDetails(org.mockito.ArgumentMatchers.anyString()))
+        .thenReturn(Optional.empty());
+    return httpProxySupport;
+  }
+
+  private void executeAgainst(AgenticAiHttpProxySupport httpProxySupport, String endpoint) {
+    final var factory =
+        new GeminiChatModelFactory(
+            httpProxySupport,
+            new GeminiContentRequestConverter(new GeminiContentConverter(objectMapper)),
+            new GeminiContentResponseConverter());
+    final var configuration =
+        new GeminiChatModelConfiguration(
+            new GeminiConnection(
+                new GeminiApiBackend(new GoogleGeminiApi(API_KEY, endpoint)),
+                new GeminiModel(MODEL_ID, null),
+                null));
+
+    try (ChatModel chatModel = factory.create(configuration)) {
+      chatModel.execute(new ChatRequest(executionContext(configuration), snapshot()));
+    }
+  }
+
+  private static AgentExecutionContext executionContext(GeminiChatModelConfiguration model) {
+    final var agentConfiguration =
+        new AgentConfiguration(
+            model,
+            new SystemPromptConfiguration("system prompt"),
+            new UserPromptConfiguration("user prompt", null),
+            null,
+            null,
+            null,
+            null);
+
+    final var executionContext = mock(AgentExecutionContext.class);
+    when(executionContext.configuration()).thenReturn(agentConfiguration);
+    return executionContext;
+  }
+
+  private static ConversationSnapshot snapshot() {
+    return new ConversationSnapshot(
+        List.of(UserMessage.builder().content(List.of(TextContent.textContent("hi"))).build()),
+        List.of());
+  }
+
+  /**
+   * Minimal hand-rolled HTTP forward proxy used to exercise {@link GeminiChatModelFactory}'s real
+   * proxy-application branch end-to-end (rather than mocking {@link AgenticAiHttpProxySupport},
+   * which leaves that branch untested). When credentials are configured, challenges the first
+   * request with {@code 407 Proxy Authentication Required} so the vendor SDK's OkHttp {@code
+   * proxyAuthenticator} actually has to respond, mirroring how a real authenticating proxy behaves.
+   *
+   * <p>Structurally identical to {@code AnthropicChatModelFactoryClientTest}'s helper (both SDKs
+   * are OkHttp-based, so both forward a plain absolute-URI request for an {@code http://} target
+   * rather than opening a {@code CONNECT} tunnel); only the returned response body differs, Gemini
+   * SSE instead of Anthropic SSE.
+   */
+  private static final class FakeProxyServer implements AutoCloseable {
+    private final ServerSocket serverSocket;
+    private final Thread acceptThread;
+    private final @Nullable String username;
+    private final @Nullable String password;
+    private volatile @Nullable String lastRequestLine;
+    private volatile @Nullable String lastProxyAuthorizationHeader;
+
+    FakeProxyServer(@Nullable String username, @Nullable String password) throws IOException {
+      this.username = username;
+      this.password = password;
+      this.serverSocket = new ServerSocket(0, 0, InetAddress.getLoopbackAddress());
+      this.acceptThread = new Thread(this::acceptLoop, "fake-proxy-accept");
+      this.acceptThread.setDaemon(true);
+      this.acceptThread.start();
+    }
+
+    @Nullable String lastRequestLine() {
+      return lastRequestLine;
+    }
+
+    @Nullable String lastProxyAuthorizationHeader() {
+      return lastProxyAuthorizationHeader;
+    }
+
+    ProxyConfiguration toProxyConfiguration() {
+      return scheme ->
+          Optional.of(
+              new ProxyConfiguration.ProxyDetails(
+                  scheme, "127.0.0.1", serverSocket.getLocalPort(), username, password));
+    }
+
+    private void acceptLoop() {
+      while (!serverSocket.isClosed()) {
+        try (Socket socket = serverSocket.accept()) {
+          handle(socket);
+        } catch (IOException e) {
+          // server socket closed (test cleanup) or connection reset -- exit the loop
+          return;
+        }
+      }
+    }
+
+    private void handle(Socket socket) throws IOException {
+      // Reads directly off the socket's InputStream rather than through a BufferedReader /
+      // InputStreamReader: closing that wrapper closes the underlying socket (per Socket's
+      // documented stream-close coupling), which would break the response write below.
+      final InputStream in = socket.getInputStream();
+      String requestLine = readLine(in);
+      if (requestLine == null) {
+        return;
+      }
+      lastRequestLine = requestLine;
+
+      int contentLength = 0;
+      String proxyAuthorizationHeader = null;
+      String line;
+      while ((line = readLine(in)) != null && !line.isEmpty()) {
+        if (line.regionMatches(true, 0, "Content-Length:", 0, "Content-Length:".length())) {
+          try {
+            contentLength = Integer.parseInt(line.substring("Content-Length:".length()).trim());
+          } catch (NumberFormatException e) {
+            contentLength = 0;
+          }
+        }
+        if (line.regionMatches(
+            true, 0, "Proxy-Authorization:", 0, "Proxy-Authorization:".length())) {
+          proxyAuthorizationHeader = line.substring("Proxy-Authorization:".length()).trim();
+        }
+      }
+
+      int read = 0;
+      while (read < contentLength) {
+        if (in.read() < 0) {
+          break;
+        }
+        read++;
+      }
+
+      boolean authRequired = username != null;
+      boolean authSatisfied = !authRequired || proxyAuthorizationHeader != null;
+      if (authSatisfied) {
+        lastProxyAuthorizationHeader = proxyAuthorizationHeader;
+        writeResponse(
+            socket,
+            200,
+            "OK",
+            Map.of("Content-Type", "text/event-stream"),
+            SSE_RESPONSE_BODY.getBytes(StandardCharsets.UTF_8));
+      } else {
+        writeResponse(
+            socket,
+            407,
+            "Proxy Authentication Required",
+            Map.of("Proxy-Authenticate", "Basic realm=\"fake-proxy\""),
+            new byte[0]);
+      }
+    }
+
+    /** Reads one CRLF- or LF-terminated line as US-ASCII; returns null at end of stream. */
+    private static @Nullable String readLine(InputStream in) throws IOException {
+      var line = new StringBuilder();
+      int c;
+      while ((c = in.read()) != -1 && c != '\n') {
+        if (c != '\r') {
+          line.append((char) c);
+        }
+      }
+      if (c == -1 && line.isEmpty()) {
+        return null;
+      }
+      return line.toString();
+    }
+
+    private static void writeResponse(
+        Socket socket, int status, String reason, Map<String, String> headers, byte[] body)
+        throws IOException {
+      var out = socket.getOutputStream();
+      var responseHeaders = new StringBuilder();
+      responseHeaders.append("HTTP/1.1 ").append(status).append(' ').append(reason).append("\r\n");
+      headers.forEach(
+          (name, value) -> responseHeaders.append(name).append(": ").append(value).append("\r\n"));
+      responseHeaders.append("Content-Length: ").append(body.length).append("\r\n");
+      responseHeaders.append("Connection: close\r\n\r\n");
+      out.write(responseHeaders.toString().getBytes(StandardCharsets.US_ASCII));
+      out.write(body);
+      out.flush();
+    }
+
+    @Override
+    public void close() throws IOException {
+      serverSocket.close();
+    }
+  }
+}

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiChatModelFactoryTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiChatModelFactoryTest.java
@@ -213,6 +213,24 @@ class GeminiChatModelFactoryTest {
     model.close();
   }
 
+  @Test
+  void createLeavesReadAndWriteTimeoutsUnboundedEvenWithAnOverallTimeoutConfigured() {
+    noProxyConfigured();
+
+    // A bare OkHttpClient.Builder() defaults readTimeout/writeTimeout to OkHttp's own stock
+    // 10-second value (unlike the SDK's own default client, which zeroes them) - left alone, a
+    // Gemini SSE stream with a longer gap between chunks would abort mid-stream regardless of how
+    // generous this configured overall timeout is.
+    final ChatModel model = factory.create(apiConfig(null, Duration.ofMinutes(5)));
+
+    final var customHttpClient = clientOptionsOf(model).orElseThrow().customHttpClient();
+    assertThat(customHttpClient).isPresent();
+    assertThat(customHttpClient.get().readTimeoutMillis()).isZero();
+    assertThat(customHttpClient.get().writeTimeoutMillis()).isZero();
+
+    model.close();
+  }
+
   private void noProxyConfigured() {
     when(httpProxySupport.getProxyConfiguration()).thenReturn(proxyConfiguration);
     when(proxyConfiguration.getProxyDetails(any())).thenReturn(Optional.empty());

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiChatModelFactoryTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiChatModelFactoryTest.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.agenticai.aiagent.chatmodel.provider.gemini;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.genai.ApiClient;
+import com.google.genai.Client;
+import com.google.genai.types.ClientOptions;
+import com.google.genai.types.HttpOptions;
+import io.camunda.connector.agenticai.aiagent.chatmodel.ChatModel;
+import io.camunda.connector.agenticai.aiagent.chatmodel.ChatModelConfiguration;
+import io.camunda.connector.agenticai.aiagent.model.request.v1.shared.TimeoutConfiguration;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.CustomProviderConfiguration;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.GeminiChatModelConfiguration;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.GeminiChatModelConfiguration.GeminiBackend.GeminiApiBackend;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.GeminiChatModelConfiguration.GeminiBackend.GeminiApiBackend.GoogleGeminiApi;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.GeminiChatModelConfiguration.GeminiConnection;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.GeminiChatModelConfiguration.GeminiModel;
+import io.camunda.connector.agenticai.common.AgenticAiHttpProxySupport;
+import io.camunda.connector.api.error.ConnectorInputException;
+import io.camunda.connector.http.client.proxy.ProxyConfiguration;
+import java.time.Duration;
+import java.util.Map;
+import java.util.Optional;
+import org.jspecify.annotations.Nullable;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class GeminiChatModelFactoryTest {
+
+  private static final String MODEL_ID = "gemini-3-pro-preview";
+  private static final String API_KEY = "test-api-key";
+
+  @Mock private AgenticAiHttpProxySupport httpProxySupport;
+  @Mock private ProxyConfiguration proxyConfiguration;
+
+  private GeminiChatModelFactory factory;
+
+  @BeforeEach
+  void setUp() {
+    factory =
+        new GeminiChatModelFactory(
+            httpProxySupport,
+            new GeminiContentRequestConverter(new GeminiContentConverter(new ObjectMapper())),
+            new GeminiContentResponseConverter());
+  }
+
+  @Test
+  void supportsGeminiV2Config() {
+    assertThat(factory.supports(apiConfig(null, null))).isTrue();
+  }
+
+  @Test
+  void doesNotSupportOtherProviderConfiguration() {
+    final ChatModelConfiguration config =
+        new CustomProviderConfiguration("some-custom-provider", MODEL_ID, Map.of());
+
+    assertThat(factory.supports(config)).isFalse();
+  }
+
+  @Test
+  void createBuildsWorkingChatModelWithDefaultEndpoint() {
+    noProxyConfigured();
+
+    final ChatModel model = factory.create(apiConfig(null, null));
+
+    assertThat(model).isNotNull().isInstanceOf(GeminiChatModel.class);
+
+    final HttpOptions httpOptions = httpOptionsOf(model);
+    // the SDK fills in its production default base URL when no override is configured
+    assertThat(httpOptions.baseUrl()).contains("https://generativelanguage.googleapis.com");
+    assertThat(httpOptions.timeout()).isEmpty();
+    assertThat(clientOf(model).apiKey()).isEqualTo(API_KEY);
+
+    verify(proxyConfiguration).getProxyDetails(ProxyConfiguration.SCHEME_HTTPS);
+
+    model.close();
+  }
+
+  @Test
+  void createBuildsWorkingChatModelWithHiddenEndpoint() {
+    final String endpoint = "http://localhost:8080";
+    noProxyConfigured();
+
+    final ChatModel model = factory.create(apiConfig(endpoint, null));
+
+    assertThat(httpOptionsOf(model).baseUrl()).contains(endpoint);
+
+    verify(proxyConfiguration).getProxyDetails(ProxyConfiguration.SCHEME_HTTP);
+
+    model.close();
+  }
+
+  @Test
+  void createSetsConfiguredTimeout() {
+    noProxyConfigured();
+
+    final ChatModel model = factory.create(apiConfig(null, Duration.ofSeconds(30)));
+
+    assertThat(httpOptionsOf(model).timeout()).contains(30_000);
+
+    model.close();
+  }
+
+  @Test
+  void createClampsSubMillisecondTimeoutToOneMillisecond() {
+    noProxyConfigured();
+
+    final ChatModel model = factory.create(apiConfig(null, Duration.ofNanos(500)));
+
+    assertThat(httpOptionsOf(model).timeout()).contains(1);
+
+    model.close();
+  }
+
+  @Test
+  void createThrowsWhenTimeoutExceedsMaximumSupportedMillis() {
+    final GeminiChatModelConfiguration config =
+        apiConfig(null, Duration.ofMillis(Integer.MAX_VALUE).plusMillis(1));
+
+    assertThatThrownBy(() -> factory.create(config)).isInstanceOf(ConnectorInputException.class);
+  }
+
+  @Test
+  void createWiresProxyOptionsWhenProxyConfigured() {
+    when(httpProxySupport.getProxyConfiguration()).thenReturn(proxyConfiguration);
+    when(proxyConfiguration.getProxyDetails(any()))
+        .thenReturn(
+            Optional.of(
+                new ProxyConfiguration.ProxyDetails(
+                    "https", "proxy.example.com", 8080, "proxy-user", "proxy-pass")));
+
+    final ChatModel model = factory.create(apiConfig(null, null));
+
+    final ApiClient apiClient = apiClientOf(model);
+    @SuppressWarnings("unchecked")
+    final Optional<ClientOptions> clientOptions =
+        (Optional<ClientOptions>) ReflectionTestUtils.getField(apiClient, "clientOptions");
+
+    assertThat(clientOptions).isPresent();
+    final var proxyOptions = clientOptions.get().proxyOptions();
+    assertThat(proxyOptions).isPresent();
+    assertThat(proxyOptions.get().host()).contains("proxy.example.com");
+    assertThat(proxyOptions.get().port()).contains(8080);
+    assertThat(proxyOptions.get().username()).contains("proxy-user");
+    assertThat(proxyOptions.get().password()).contains("proxy-pass");
+
+    verify(proxyConfiguration).getProxyDetails(ProxyConfiguration.SCHEME_HTTPS);
+
+    model.close();
+  }
+
+  private void noProxyConfigured() {
+    when(httpProxySupport.getProxyConfiguration()).thenReturn(proxyConfiguration);
+    when(proxyConfiguration.getProxyDetails(any())).thenReturn(Optional.empty());
+  }
+
+  private static Client clientOf(ChatModel model) {
+    return (Client) ReflectionTestUtils.getField(model, "client");
+  }
+
+  private static ApiClient apiClientOf(ChatModel model) {
+    return (ApiClient) ReflectionTestUtils.getField(clientOf(model), "apiClient");
+  }
+
+  private static HttpOptions httpOptionsOf(ChatModel model) {
+    return apiClientOf(model).httpOptions();
+  }
+
+  private static GeminiChatModelConfiguration apiConfig(
+      @Nullable String endpoint, @Nullable Duration timeout) {
+    return new GeminiChatModelConfiguration(
+        new GeminiConnection(
+            new GeminiApiBackend(new GoogleGeminiApi(API_KEY, endpoint)),
+            new GeminiModel(MODEL_ID, null),
+            timeout != null ? new TimeoutConfiguration(timeout) : null));
+  }
+}

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiChatModelFactoryTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiChatModelFactoryTest.java
@@ -129,6 +129,19 @@ class GeminiChatModelFactoryTest {
   }
 
   @Test
+  void createIgnoresNonPositiveConfiguredTimeout() {
+    noProxyConfigured();
+
+    final ChatModel zeroTimeoutModel = factory.create(apiConfig(null, Duration.ZERO));
+    assertThat(httpOptionsOf(zeroTimeoutModel).timeout()).isEmpty();
+    zeroTimeoutModel.close();
+
+    final ChatModel negativeTimeoutModel = factory.create(apiConfig(null, Duration.ofSeconds(-1)));
+    assertThat(httpOptionsOf(negativeTimeoutModel).timeout()).isEmpty();
+    negativeTimeoutModel.close();
+  }
+
+  @Test
   void createThrowsWhenTimeoutExceedsMaximumSupportedMillis() {
     final GeminiChatModelConfiguration config =
         apiConfig(null, Duration.ofMillis(Integer.MAX_VALUE).plusMillis(1));

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiChatModelFactoryTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiChatModelFactoryTest.java
@@ -29,9 +29,11 @@ import io.camunda.connector.agenticai.aiagent.model.request.v2.GeminiChatModelCo
 import io.camunda.connector.agenticai.common.AgenticAiHttpProxySupport;
 import io.camunda.connector.api.error.ConnectorInputException;
 import io.camunda.connector.http.client.proxy.ProxyConfiguration;
+import java.net.InetSocketAddress;
 import java.time.Duration;
 import java.util.Map;
 import java.util.Optional;
+import okhttp3.Authenticator;
 import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -150,7 +152,12 @@ class GeminiChatModelFactoryTest {
   }
 
   @Test
-  void createWiresProxyOptionsWhenProxyConfigured() {
+  void createAppliesProxyDirectlyToTheCustomHttpClient() {
+    // Applied directly to the OkHttp client we own, not via ClientOptions.proxyOptions() -
+    // supplying a customHttpClient (required for the connect timeout) makes the SDK skip applying
+    // that option entirely, see GeminiChatModelFactory#buildClient's javadoc on CONNECT_TIMEOUT.
+    // GeminiChatModelFactoryClientTest exercises the real wire behavior (address + credentials)
+    // end to end; this only checks that the client we hand the SDK is configured at all.
     when(httpProxySupport.getProxyConfiguration()).thenReturn(proxyConfiguration);
     when(proxyConfiguration.getProxyDetails(any()))
         .thenReturn(
@@ -160,20 +167,48 @@ class GeminiChatModelFactoryTest {
 
     final ChatModel model = factory.create(apiConfig(null, null));
 
-    final ApiClient apiClient = apiClientOf(model);
-    @SuppressWarnings("unchecked")
-    final Optional<ClientOptions> clientOptions =
-        (Optional<ClientOptions>) ReflectionTestUtils.getField(apiClient, "clientOptions");
-
-    assertThat(clientOptions).isPresent();
-    final var proxyOptions = clientOptions.get().proxyOptions();
-    assertThat(proxyOptions).isPresent();
-    assertThat(proxyOptions.get().host()).contains("proxy.example.com");
-    assertThat(proxyOptions.get().port()).contains(8080);
-    assertThat(proxyOptions.get().username()).contains("proxy-user");
-    assertThat(proxyOptions.get().password()).contains("proxy-pass");
+    final var customHttpClient = clientOptionsOf(model).orElseThrow().customHttpClient();
+    assertThat(customHttpClient).isPresent();
+    final var proxyAddress = (InetSocketAddress) customHttpClient.get().proxy().address();
+    assertThat(proxyAddress.getHostString()).isEqualTo("proxy.example.com");
+    assertThat(proxyAddress.getPort()).isEqualTo(8080);
+    assertThat(customHttpClient.get().proxyAuthenticator()).isNotEqualTo(Authenticator.NONE);
 
     verify(proxyConfiguration).getProxyDetails(ProxyConfiguration.SCHEME_HTTPS);
+
+    model.close();
+  }
+
+  @Test
+  void createOmitsProxyAuthenticatorWhenProxyHasNoCredentials() {
+    when(httpProxySupport.getProxyConfiguration()).thenReturn(proxyConfiguration);
+    when(proxyConfiguration.getProxyDetails(any()))
+        .thenReturn(
+            Optional.of(
+                new ProxyConfiguration.ProxyDetails(
+                    "https", "proxy.example.com", 8080, null, null)));
+
+    final ChatModel model = factory.create(apiConfig(null, null));
+
+    final var customHttpClient = clientOptionsOf(model).orElseThrow().customHttpClient();
+    assertThat(customHttpClient.get().proxyAuthenticator()).isEqualTo(Authenticator.NONE);
+
+    model.close();
+  }
+
+  @Test
+  void createSetsConnectTimeoutIndependentlyOfOverallTimeout() {
+    noProxyConfigured();
+
+    // The overall (callTimeout) timeout is deliberately left unset here: connect timeout must be
+    // wired even when no overall timeout is configured at all.
+    final ChatModel model = factory.create(apiConfig(null, null));
+
+    final Optional<ClientOptions> clientOptions = clientOptionsOf(model);
+    assertThat(clientOptions).isPresent();
+    final var customHttpClient = clientOptions.get().customHttpClient();
+    assertThat(customHttpClient).isPresent();
+    assertThat(customHttpClient.get().connectTimeoutMillis()).isEqualTo(10_000);
 
     model.close();
   }
@@ -193,6 +228,12 @@ class GeminiChatModelFactoryTest {
 
   private static HttpOptions httpOptionsOf(ChatModel model) {
     return apiClientOf(model).httpOptions();
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Optional<ClientOptions> clientOptionsOf(ChatModel model) {
+    return (Optional<ClientOptions>)
+        ReflectionTestUtils.getField(apiClientOf(model), "clientOptions");
   }
 
   private static GeminiChatModelConfiguration apiConfig(

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiChatModelFactoryTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiChatModelFactoryTest.java
@@ -30,6 +30,7 @@ import io.camunda.connector.agenticai.common.AgenticAiHttpProxySupport;
 import io.camunda.connector.api.error.ConnectorInputException;
 import io.camunda.connector.http.client.proxy.ProxyConfiguration;
 import java.net.InetSocketAddress;
+import java.net.Proxy;
 import java.time.Duration;
 import java.util.Map;
 import java.util.Optional;
@@ -49,7 +50,6 @@ class GeminiChatModelFactoryTest {
   private static final String API_KEY = "test-api-key";
 
   @Mock private AgenticAiHttpProxySupport httpProxySupport;
-  @Mock private ProxyConfiguration proxyConfiguration;
 
   private GeminiChatModelFactory factory;
 
@@ -89,7 +89,7 @@ class GeminiChatModelFactoryTest {
     assertThat(httpOptions.timeout()).isEmpty();
     assertThat(clientOf(model).apiKey()).isEqualTo(API_KEY);
 
-    verify(proxyConfiguration).getProxyDetails(ProxyConfiguration.SCHEME_HTTPS);
+    verify(httpProxySupport).okHttpProxy(ProxyConfiguration.SCHEME_HTTPS);
 
     model.close();
   }
@@ -103,7 +103,7 @@ class GeminiChatModelFactoryTest {
 
     assertThat(httpOptionsOf(model).baseUrl()).contains(endpoint);
 
-    verify(proxyConfiguration).getProxyDetails(ProxyConfiguration.SCHEME_HTTP);
+    verify(httpProxySupport).okHttpProxy(ProxyConfiguration.SCHEME_HTTP);
 
     model.close();
   }
@@ -158,12 +158,8 @@ class GeminiChatModelFactoryTest {
     // that option entirely, see GeminiChatModelFactory#buildClient's javadoc on CONNECT_TIMEOUT.
     // GeminiChatModelFactoryClientTest exercises the real wire behavior (address + credentials)
     // end to end; this only checks that the client we hand the SDK is configured at all.
-    when(httpProxySupport.getProxyConfiguration()).thenReturn(proxyConfiguration);
-    when(proxyConfiguration.getProxyDetails(any()))
-        .thenReturn(
-            Optional.of(
-                new ProxyConfiguration.ProxyDetails(
-                    "https", "proxy.example.com", 8080, "proxy-user", "proxy-pass")));
+    when(httpProxySupport.okHttpProxy(any()))
+        .thenReturn(Optional.of(proxyOf("proxy.example.com", 8080, "proxy-user", "proxy-pass")));
 
     final ChatModel model = factory.create(apiConfig(null, null));
 
@@ -174,19 +170,15 @@ class GeminiChatModelFactoryTest {
     assertThat(proxyAddress.getPort()).isEqualTo(8080);
     assertThat(customHttpClient.get().proxyAuthenticator()).isNotEqualTo(Authenticator.NONE);
 
-    verify(proxyConfiguration).getProxyDetails(ProxyConfiguration.SCHEME_HTTPS);
+    verify(httpProxySupport).okHttpProxy(ProxyConfiguration.SCHEME_HTTPS);
 
     model.close();
   }
 
   @Test
   void createOmitsProxyAuthenticatorWhenProxyHasNoCredentials() {
-    when(httpProxySupport.getProxyConfiguration()).thenReturn(proxyConfiguration);
-    when(proxyConfiguration.getProxyDetails(any()))
-        .thenReturn(
-            Optional.of(
-                new ProxyConfiguration.ProxyDetails(
-                    "https", "proxy.example.com", 8080, null, null)));
+    when(httpProxySupport.okHttpProxy(any()))
+        .thenReturn(Optional.of(proxyOf("proxy.example.com", 8080, null, null)));
 
     final ChatModel model = factory.create(apiConfig(null, null));
 
@@ -232,8 +224,13 @@ class GeminiChatModelFactoryTest {
   }
 
   private void noProxyConfigured() {
-    when(httpProxySupport.getProxyConfiguration()).thenReturn(proxyConfiguration);
-    when(proxyConfiguration.getProxyDetails(any())).thenReturn(Optional.empty());
+    when(httpProxySupport.okHttpProxy(any())).thenReturn(Optional.empty());
+  }
+
+  private static AgenticAiHttpProxySupport.OkHttpProxy proxyOf(
+      String host, int port, @Nullable String username, @Nullable String password) {
+    return new AgenticAiHttpProxySupport.OkHttpProxy(
+        new Proxy(Proxy.Type.HTTP, new InetSocketAddress(host, port)), username, password);
   }
 
   private static Client clientOf(ChatModel model) {

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiChatModelTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiChatModelTest.java
@@ -27,6 +27,7 @@ import com.google.genai.types.GenerateContentConfig;
 import com.google.genai.types.GenerateContentResponse;
 import io.camunda.connector.agenticai.aiagent.chatmodel.ChatRequest;
 import io.camunda.connector.agenticai.aiagent.chatmodel.ChatResult;
+import io.camunda.connector.agenticai.aiagent.chatmodel.ContentFilteredException;
 import io.camunda.connector.agenticai.aiagent.memory.ConversationSnapshot;
 import io.camunda.connector.agenticai.aiagent.model.AgentConfiguration;
 import io.camunda.connector.agenticai.aiagent.model.AgentExecutionContext;
@@ -112,6 +113,30 @@ class GeminiChatModelTest {
     verify(streamAssembler).assemble(responseStream);
     verify(responseStream).close();
     verify(client, never()).close();
+  }
+
+  @Test
+  void propagatesContentFilteredExceptionFromResponseConverterUnwrapped() {
+    final var responseConfiguration = mock(ResponseConfiguration.class);
+    when(agentConfiguration.response()).thenReturn(responseConfiguration);
+
+    final var config = GenerateContentConfig.builder().build();
+    final List<Content> contents = List.of();
+    final var assembledResponse = GenerateContentResponse.builder().build();
+    final var rejection =
+        new ContentFilteredException(
+            "Model response was blocked by provider content filtering.", null);
+
+    when(requestConverter.toGenerateContentConfig(any(), any(), any())).thenReturn(config);
+    when(requestConverter.toContents(any())).thenReturn(contents);
+    when(models.generateContentStream(configuration.model(), contents, config))
+        .thenReturn(responseStream);
+    when(streamAssembler.assemble(responseStream)).thenReturn(assembledResponse);
+    when(responseConverter.toResult(eq(assembledResponse), any())).thenThrow(rejection);
+
+    assertThatThrownBy(() -> api.execute(request)).isSameAs(rejection);
+
+    verify(responseStream).close();
   }
 
   @Test

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiChatModelTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiChatModelTest.java
@@ -80,9 +80,8 @@ class GeminiChatModelTest {
     // Client#models is a plain public final field populated by the SDK's real constructor, which a
     // Mockito mock never runs -- inject the mocked Models directly onto the mocked Client instance.
     ReflectionTestUtils.setField(client, "models", models);
-    api =
-        new GeminiChatModel(
-            client, configuration, requestConverter, responseConverter, streamAssembler);
+    api = new GeminiChatModel(client, configuration, requestConverter, responseConverter);
+    ReflectionTestUtils.setField(api, "streamAssembler", streamAssembler);
   }
 
   @Test

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiChatModelTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiChatModelTest.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.agenticai.aiagent.chatmodel.provider.gemini;
+
+import static io.camunda.connector.agenticai.aiagent.agent.AgentErrorCodes.ERROR_CODE_FAILED_MODEL_CALL;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.genai.Client;
+import com.google.genai.Models;
+import com.google.genai.ResponseStream;
+import com.google.genai.errors.ClientException;
+import com.google.genai.types.Content;
+import com.google.genai.types.GenerateContentConfig;
+import com.google.genai.types.GenerateContentResponse;
+import io.camunda.connector.agenticai.aiagent.chatmodel.ChatRequest;
+import io.camunda.connector.agenticai.aiagent.chatmodel.ChatResult;
+import io.camunda.connector.agenticai.aiagent.memory.ConversationSnapshot;
+import io.camunda.connector.agenticai.aiagent.model.AgentConfiguration;
+import io.camunda.connector.agenticai.aiagent.model.AgentExecutionContext;
+import io.camunda.connector.agenticai.aiagent.model.AgentMetrics;
+import io.camunda.connector.agenticai.aiagent.model.message.AssistantMessage;
+import io.camunda.connector.agenticai.aiagent.model.request.ResponseConfiguration;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.GeminiChatModelConfiguration;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.GeminiChatModelConfiguration.GeminiBackend.GeminiApiBackend;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.GeminiChatModelConfiguration.GeminiBackend.GeminiApiBackend.GoogleGeminiApi;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.GeminiChatModelConfiguration.GeminiConnection;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.GeminiChatModelConfiguration.GeminiModel;
+import io.camunda.connector.api.error.ConnectorException;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class GeminiChatModelTest {
+
+  @Mock private Client client;
+  @Mock private Models models;
+  @Mock private ResponseStream<GenerateContentResponse> responseStream;
+  @Mock private GeminiContentRequestConverter requestConverter;
+  @Mock private GeminiContentResponseConverter responseConverter;
+  @Mock private GeminiContentStreamAssembler streamAssembler;
+
+  private final GeminiChatModelConfiguration configuration =
+      new GeminiChatModelConfiguration(
+          new GeminiConnection(
+              new GeminiApiBackend(new GoogleGeminiApi("gm-test", null)),
+              new GeminiModel("gemini-3-pro-preview", null),
+              null));
+
+  private final AgentExecutionContext executionContext = mock(AgentExecutionContext.class);
+  private final AgentConfiguration agentConfiguration = mock(AgentConfiguration.class);
+
+  private final ChatRequest request =
+      new ChatRequest(executionContext, new ConversationSnapshot(List.of(), List.of()));
+
+  private GeminiChatModel api;
+
+  @BeforeEach
+  void setUp() {
+    when(executionContext.configuration()).thenReturn(agentConfiguration);
+    // Client#models is a plain public final field populated by the SDK's real constructor, which a
+    // Mockito mock never runs -- inject the mocked Models directly onto the mocked Client instance.
+    ReflectionTestUtils.setField(client, "models", models);
+    api =
+        new GeminiChatModel(
+            client, configuration, requestConverter, responseConverter, streamAssembler);
+  }
+
+  @Test
+  void drivesStreamingAccumulatesAndDelegatesToConverters() {
+    final var responseConfiguration = mock(ResponseConfiguration.class);
+    when(agentConfiguration.response()).thenReturn(responseConfiguration);
+
+    final var config = GenerateContentConfig.builder().build();
+    final List<Content> contents = List.of();
+    final var assembledResponse = GenerateContentResponse.builder().build();
+    final var expected =
+        new ChatResult.Completed(
+            AssistantMessage.builder().build(), AgentMetrics.builder().build());
+
+    when(requestConverter.toGenerateContentConfig(any(), any(), any())).thenReturn(config);
+    when(requestConverter.toContents(any())).thenReturn(contents);
+    when(models.generateContentStream(configuration.model(), contents, config))
+        .thenReturn(responseStream);
+    when(streamAssembler.assemble(responseStream)).thenReturn(assembledResponse);
+    when(responseConverter.toResult(eq(assembledResponse), any())).thenReturn(expected);
+
+    final var result = api.execute(request);
+
+    assertThat(result).isSameAs(expected);
+    verify(requestConverter)
+        .toGenerateContentConfig(configuration, responseConfiguration, request.snapshot());
+    verify(requestConverter).toContents(request.snapshot());
+    verify(models).generateContentStream(configuration.model(), contents, config);
+    verify(streamAssembler).assemble(responseStream);
+    verify(responseStream).close();
+    verify(client, never()).close();
+  }
+
+  @Test
+  void wrapsSdkFailureAsConnectorException() {
+    when(requestConverter.toGenerateContentConfig(any(), any(), any()))
+        .thenReturn(GenerateContentConfig.builder().build());
+    when(requestConverter.toContents(any())).thenReturn(List.of());
+    when(models.generateContentStream(any(), anyList(), any()))
+        .thenThrow(new RuntimeException("boom"));
+
+    assertThatThrownBy(() -> api.execute(request))
+        .isInstanceOf(ConnectorException.class)
+        .extracting(e -> ((ConnectorException) e).getErrorCode())
+        .isEqualTo(ERROR_CODE_FAILED_MODEL_CALL);
+  }
+
+  @Test
+  void wrapsApiExceptionWithStatusCodeAndStatus() {
+    when(requestConverter.toGenerateContentConfig(any(), any(), any()))
+        .thenReturn(GenerateContentConfig.builder().build());
+    when(requestConverter.toContents(any())).thenReturn(List.of());
+    when(models.generateContentStream(any(), anyList(), any()))
+        .thenThrow(new ClientException(429, "RESOURCE_EXHAUSTED", "slow down"));
+
+    assertThatThrownBy(() -> api.execute(request))
+        .isInstanceOf(ConnectorException.class)
+        .satisfies(
+            e -> {
+              final var connectorException = (ConnectorException) e;
+              assertThat(connectorException.getErrorCode()).isEqualTo(ERROR_CODE_FAILED_MODEL_CALL);
+              assertThat(connectorException.getMessage())
+                  .contains("429")
+                  .contains("RESOURCE_EXHAUSTED")
+                  .contains("slow down");
+            });
+  }
+
+  @Test
+  void wrapsAssemblerIllegalStateExceptionAsConnectorExceptionRatherThanSpecialCasingIt() {
+    when(requestConverter.toGenerateContentConfig(any(), any(), any()))
+        .thenReturn(GenerateContentConfig.builder().build());
+    when(requestConverter.toContents(any())).thenReturn(List.of());
+    when(models.generateContentStream(any(), anyList(), any())).thenReturn(responseStream);
+    when(streamAssembler.assemble(responseStream))
+        .thenThrow(new IllegalStateException("Gemini streaming response contained no chunks"));
+
+    assertThatThrownBy(() -> api.execute(request))
+        .isInstanceOf(ConnectorException.class)
+        .extracting(e -> ((ConnectorException) e).getErrorCode())
+        .isEqualTo(ERROR_CODE_FAILED_MODEL_CALL);
+
+    verify(responseStream).close();
+  }
+
+  @Test
+  void closesUnderlyingClient() {
+    api.close();
+
+    verify(client).close();
+  }
+
+  @Test
+  void closeLogsWarningInsteadOfThrowingWhenClientCloseFails() {
+    doThrow(new RuntimeException("boom")).when(client).close();
+
+    api.close();
+
+    verify(client).close();
+  }
+}

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiChatModelTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiChatModelTest.java
@@ -28,6 +28,7 @@ import com.google.genai.types.GenerateContentResponse;
 import io.camunda.connector.agenticai.aiagent.chatmodel.ChatRequest;
 import io.camunda.connector.agenticai.aiagent.chatmodel.ChatResult;
 import io.camunda.connector.agenticai.aiagent.chatmodel.ContentFilteredException;
+import io.camunda.connector.agenticai.aiagent.chatmodel.ContextWindowExceededException;
 import io.camunda.connector.agenticai.aiagent.memory.ConversationSnapshot;
 import io.camunda.connector.agenticai.aiagent.model.AgentConfiguration;
 import io.camunda.connector.agenticai.aiagent.model.AgentExecutionContext;
@@ -171,6 +172,29 @@ class GeminiChatModelTest {
                   .contains("429")
                   .contains("RESOURCE_EXHAUSTED")
                   .contains("slow down");
+            });
+  }
+
+  @Test
+  void throwsContextWindowExceededExceptionForOverLengthPrompt() {
+    when(requestConverter.toGenerateContentConfig(any(), any(), any()))
+        .thenReturn(GenerateContentConfig.builder().build());
+    when(requestConverter.toContents(any())).thenReturn(List.of());
+    when(models.generateContentStream(any(), anyList(), any()))
+        .thenThrow(
+            new ClientException(
+                400,
+                "INVALID_ARGUMENT",
+                "The input token count (1236488) exceeds the maximum number of tokens allowed"
+                    + " (1048576)."));
+
+    assertThatThrownBy(() -> api.execute(request))
+        .isInstanceOf(ContextWindowExceededException.class)
+        .satisfies(
+            e -> {
+              final var cwe = (ContextWindowExceededException) e;
+              assertThat(cwe.partialResult()).isNull();
+              assertThat(cwe.getCause()).isInstanceOf(ClientException.class);
             });
   }
 

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiContentConverterTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiContentConverterTest.java
@@ -11,7 +11,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.genai.types.FunctionCall;
 import io.camunda.connector.agenticai.aiagent.model.message.content.Content;
 import io.camunda.connector.agenticai.aiagent.model.message.content.DocumentContent;
@@ -19,9 +18,11 @@ import io.camunda.connector.agenticai.aiagent.model.message.content.ObjectConten
 import io.camunda.connector.agenticai.aiagent.model.message.content.ProviderContent;
 import io.camunda.connector.agenticai.aiagent.model.message.content.ReasoningContent;
 import io.camunda.connector.agenticai.aiagent.model.message.content.TextContent;
+import io.camunda.connector.agenticai.testutil.TestObjectMapperSupplier;
 import io.camunda.connector.api.document.Document;
 import io.camunda.connector.api.document.DocumentMetadata;
 import io.camunda.connector.api.error.ConnectorException;
+import io.camunda.connector.document.jackson.DocumentReferenceModel.ExternalDocumentReferenceModel;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.List;
@@ -31,8 +32,8 @@ import org.junit.jupiter.api.Test;
 
 class GeminiContentConverterTest {
 
-  private final ObjectMapper objectMapper = new ObjectMapper();
-  private final GeminiContentConverter converter = new GeminiContentConverter(objectMapper);
+  private final GeminiContentConverter converter =
+      new GeminiContentConverter(TestObjectMapperSupplier.INSTANCE);
 
   private static Document mockDocument(String contentType, byte[] bytes) {
     final var document = mock(Document.class);
@@ -40,6 +41,10 @@ class GeminiContentConverterTest {
     when(document.metadata()).thenReturn(metadata);
     when(metadata.getContentType()).thenReturn(contentType);
     when(document.asByteArray()).thenReturn(bytes);
+    // stubbed so a reference-only fallback (tool-result documents) can serialize this mock via
+    // JacksonModuleDocumentSerializer, which dispatches on Document#reference()
+    when(document.reference())
+        .thenReturn(new ExternalDocumentReferenceModel("https://example.com/document", "document"));
     return document;
   }
 
@@ -307,36 +312,34 @@ class GeminiContentConverterTest {
     }
 
     @Test
-    void mapsImageDocumentToInlineDataPart() {
+    void mapsDocumentContentToTextPartReference() {
+      // never embedded natively here, regardless of content type - the composer's synthetic
+      // <doc/> fallback message already delivers the actual bytes for tool results, so this
+      // renders the same JSON reference ObjectContent would, avoiding a double-send
       final var doc = mockDocument("image/jpeg", "ABC".getBytes(StandardCharsets.UTF_8));
 
       final var parts = converter.toFunctionResponseParts(List.of(new DocumentContent(doc, null)));
 
       assertThat(parts).hasSize(1);
-      assertThat(parts.get(0).inlineData()).isPresent();
       assertThat(parts.get(0).functionResponse()).isEmpty();
+      assertThat(parts.get(0).inlineData()).isEmpty();
+      assertThat(parts.get(0).text().orElseThrow())
+          .isEqualTo(
+              "{\"url\":\"https://example.com/document\",\"name\":\"document\","
+                  + "\"camunda.document.type\":\"external\"}");
     }
 
     @Test
-    void mapsPdfDocumentToInlineDataPart() {
+    void mapsUnsupportedDocumentContentTypeToTextPartReference() {
+      // an unsupported content type is fine here, unlike toParts's native-embedding path -
+      // classification never runs since the document is always flattened to a reference
       final var doc =
-          mockDocument("application/pdf", "PDFCONTENT".getBytes(StandardCharsets.UTF_8));
+          mockDocument("application/zip", "ZIPCONTENT".getBytes(StandardCharsets.UTF_8));
 
       final var parts = converter.toFunctionResponseParts(List.of(new DocumentContent(doc, null)));
 
       assertThat(parts).hasSize(1);
-      assertThat(parts.get(0).inlineData()).isPresent();
-    }
-
-    @Test
-    void throwsForUnsupportedDocumentContentType() {
-      final var doc =
-          mockDocument("application/zip", "ZIPCONTENT".getBytes(StandardCharsets.UTF_8));
-
-      assertThatThrownBy(
-              () -> converter.toFunctionResponseParts(List.of(new DocumentContent(doc, null))))
-          .isInstanceOf(ConnectorException.class)
-          .hasMessageContaining("application/zip");
+      assertThat(parts.get(0).text()).isPresent();
     }
 
     @Test

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiContentConverterTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiContentConverterTest.java
@@ -147,6 +147,59 @@ class GeminiContentConverterTest {
     }
 
     @Test
+    void mapsReasoningContentWithRawByteArraySignaturePassesThrough() {
+      final var signatureBytes = "sig-bytes".getBytes(StandardCharsets.UTF_8);
+      final var metadata = Map.<String, Object>of("thoughtSignature", signatureBytes);
+
+      final var parts =
+          converter.toParts(
+              List.of(
+                  new ReasoningContent(
+                      "gemini", Map.of("type", "thought"), "Let me think it through", metadata)));
+
+      assertThat(parts).hasSize(1);
+      assertThat(parts.get(0).thoughtSignature().orElseThrow()).isEqualTo(signatureBytes);
+    }
+
+    @Test
+    void throwsForUnsupportedThoughtSignatureMetadataValueType() {
+      final var metadata = Map.<String, Object>of("thoughtSignature", 42);
+
+      assertThatThrownBy(
+              () ->
+                  converter.toParts(
+                      List.of(
+                          new ReasoningContent(
+                              "gemini",
+                              Map.of("type", "thought"),
+                              "Let me think it through",
+                              metadata))))
+          .isInstanceOf(ConnectorException.class)
+          .hasMessageContaining("thoughtSignature")
+          .hasMessageContaining("Integer");
+    }
+
+    @Test
+    void mapsReasoningContentWithNullTextDoesNotSetText() {
+      final var parts =
+          converter.toParts(
+              List.of(new ReasoningContent("gemini", Map.of("type", "thought"), null, null)));
+
+      assertThat(parts).hasSize(1);
+      final var part = parts.get(0);
+      assertThat(part.thought()).contains(true);
+      assertThat(part.text()).isEmpty();
+    }
+
+    @Test
+    void throwsForBlankDocumentContentType() {
+      final var doc = mockDocument("", "CONTENT".getBytes(StandardCharsets.UTF_8));
+
+      assertThatThrownBy(() -> converter.toParts(List.of(new DocumentContent(doc, null))))
+          .isInstanceOf(ConnectorException.class);
+    }
+
+    @Test
     void mapsProviderContentPayloadToNativePartRoundTrip() {
       final var payload =
           Map.<String, Object>of(

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiContentConverterTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiContentConverterTest.java
@@ -312,25 +312,27 @@ class GeminiContentConverterTest {
     }
 
     @Test
-    void mapsDocumentContentToTextPartReference() {
+    void mapsDocumentContentToFunctionResponsePartWithJsonReference() {
       // never embedded natively here, regardless of content type - the composer's synthetic
       // <doc/> fallback message already delivers the actual bytes for tool results, so this
-      // renders the same JSON reference ObjectContent would, avoiding a double-send
+      // renders the same JSON reference ObjectContent would, avoiding a double-send. Still wrapped
+      // in a functionResponse (not a bare text Part): a document-only tool result must close out
+      // the preceding functionCall like any other result content.
       final var doc = mockDocument("image/jpeg", "ABC".getBytes(StandardCharsets.UTF_8));
 
       final var parts = converter.toFunctionResponseParts(List.of(new DocumentContent(doc, null)));
 
       assertThat(parts).hasSize(1);
-      assertThat(parts.get(0).functionResponse()).isEmpty();
       assertThat(parts.get(0).inlineData()).isEmpty();
-      assertThat(parts.get(0).text().orElseThrow())
+      final var response = parts.get(0).functionResponse().orElseThrow();
+      assertThat(response.response().orElseThrow().get("output"))
           .isEqualTo(
               "{\"url\":\"https://example.com/document\",\"name\":\"document\","
                   + "\"camunda.document.type\":\"external\"}");
     }
 
     @Test
-    void mapsUnsupportedDocumentContentTypeToTextPartReference() {
+    void mapsUnsupportedDocumentContentTypeToFunctionResponsePart() {
       // an unsupported content type is fine here, unlike toParts's native-embedding path -
       // classification never runs since the document is always flattened to a reference
       final var doc =
@@ -339,11 +341,11 @@ class GeminiContentConverterTest {
       final var parts = converter.toFunctionResponseParts(List.of(new DocumentContent(doc, null)));
 
       assertThat(parts).hasSize(1);
-      assertThat(parts.get(0).text()).isPresent();
+      assertThat(parts.get(0).functionResponse()).isPresent();
     }
 
     @Test
-    void mapsReasoningContentToJsonTextPartFallback() {
+    void mapsReasoningContentToFunctionResponsePartWithJsonFallback() {
       final var parts =
           converter.toFunctionResponseParts(
               List.of(
@@ -351,19 +353,20 @@ class GeminiContentConverterTest {
                       "gemini", Map.of("thinking", "some reasoning"), null, null)));
 
       assertThat(parts).hasSize(1);
-      assertThat(parts.get(0).text().orElseThrow()).contains("some reasoning");
-      assertThat(parts.get(0).functionResponse()).isEmpty();
+      final var response = parts.get(0).functionResponse().orElseThrow();
+      assertThat(response.response().orElseThrow().get("output").toString())
+          .contains("some reasoning");
     }
 
     @Test
-    void mapsProviderContentToJsonTextPartFallback() {
+    void mapsProviderContentToFunctionResponsePartWithJsonFallback() {
       final var parts =
           converter.toFunctionResponseParts(
               List.of(new ProviderContent("gemini", Map.of("foo", "bar"), null)));
 
       assertThat(parts).hasSize(1);
-      assertThat(parts.get(0).text().orElseThrow()).contains("bar");
-      assertThat(parts.get(0).functionResponse()).isEmpty();
+      final var response = parts.get(0).functionResponse().orElseThrow();
+      assertThat(response.response().orElseThrow().get("output").toString()).contains("bar");
     }
   }
 }

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiContentConverterTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiContentConverterTest.java
@@ -1,0 +1,267 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.agenticai.aiagent.chatmodel.provider.gemini;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.genai.types.FunctionCall;
+import io.camunda.connector.agenticai.aiagent.model.message.content.Content;
+import io.camunda.connector.agenticai.aiagent.model.message.content.DocumentContent;
+import io.camunda.connector.agenticai.aiagent.model.message.content.ObjectContent;
+import io.camunda.connector.agenticai.aiagent.model.message.content.ProviderContent;
+import io.camunda.connector.agenticai.aiagent.model.message.content.ReasoningContent;
+import io.camunda.connector.agenticai.aiagent.model.message.content.TextContent;
+import io.camunda.connector.api.document.Document;
+import io.camunda.connector.api.document.DocumentMetadata;
+import io.camunda.connector.api.error.ConnectorException;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class GeminiContentConverterTest {
+
+  private final ObjectMapper objectMapper = new ObjectMapper();
+  private final GeminiContentConverter converter = new GeminiContentConverter(objectMapper);
+
+  private static Document mockDocument(String contentType, byte[] bytes) {
+    final var document = mock(Document.class);
+    final var metadata = mock(DocumentMetadata.class);
+    when(document.metadata()).thenReturn(metadata);
+    when(metadata.getContentType()).thenReturn(contentType);
+    when(document.asByteArray()).thenReturn(bytes);
+    return document;
+  }
+
+  @Nested
+  class ToParts {
+
+    @Test
+    void mapsTextContentToTextPart() {
+      final var parts = converter.toParts(List.of(new TextContent("hello world", null)));
+
+      assertThat(parts).hasSize(1);
+      assertThat(parts.get(0).text()).contains("hello world");
+    }
+
+    @Test
+    void mapsImageDocumentToInlineDataPart() {
+      final var doc = mockDocument("image/png", "ABC".getBytes(StandardCharsets.UTF_8));
+
+      final var parts = converter.toParts(List.of(new DocumentContent(doc, null)));
+
+      assertThat(parts).hasSize(1);
+      final var inlineData = parts.get(0).inlineData().orElseThrow();
+      assertThat(inlineData.data().orElseThrow()).isEqualTo("ABC".getBytes(StandardCharsets.UTF_8));
+      assertThat(inlineData.mimeType()).contains("image/png");
+    }
+
+    @Test
+    void mapsImageDocumentWithContentTypeParametersToInlineDataPart() {
+      final var doc =
+          mockDocument("image/png; charset=UTF-8", "ABC".getBytes(StandardCharsets.UTF_8));
+
+      final var parts = converter.toParts(List.of(new DocumentContent(doc, null)));
+
+      assertThat(parts).hasSize(1);
+      final var inlineData = parts.get(0).inlineData().orElseThrow();
+      assertThat(inlineData.mimeType()).contains("image/png");
+    }
+
+    @Test
+    void mapsPdfDocumentToInlineDataPart() {
+      final var doc =
+          mockDocument("application/pdf", "PDFCONTENT".getBytes(StandardCharsets.UTF_8));
+
+      final var parts = converter.toParts(List.of(new DocumentContent(doc, null)));
+
+      assertThat(parts).hasSize(1);
+      final var inlineData = parts.get(0).inlineData().orElseThrow();
+      assertThat(inlineData.data().orElseThrow())
+          .isEqualTo("PDFCONTENT".getBytes(StandardCharsets.UTF_8));
+      assertThat(inlineData.mimeType()).contains("application/pdf");
+    }
+
+    @Test
+    void mapsTextDocumentToTextPart() {
+      final var doc =
+          mockDocument("text/plain", "plain text content".getBytes(StandardCharsets.UTF_8));
+
+      final var parts = converter.toParts(List.of(new DocumentContent(doc, null)));
+
+      assertThat(parts).hasSize(1);
+      assertThat(parts.get(0).text()).contains("plain text content");
+    }
+
+    @Test
+    void mapsObjectContentToJsonTextPart() {
+      final var parts = converter.toParts(List.of(new ObjectContent(Map.of("key", "value"), null)));
+
+      assertThat(parts).hasSize(1);
+      assertThat(parts.get(0).text()).contains("{\"key\":\"value\"}");
+    }
+
+    @Test
+    void mapsReasoningContentToThoughtPartWithSignatureRoundTrip() {
+      final var signatureBytes = "sig-bytes".getBytes(StandardCharsets.UTF_8);
+      final var metadata =
+          Map.<String, Object>of(
+              "thoughtSignature", Base64.getEncoder().encodeToString(signatureBytes));
+
+      final var parts =
+          converter.toParts(
+              List.of(
+                  new ReasoningContent(
+                      "gemini", Map.of("type", "thought"), "Let me think it through", metadata)));
+
+      assertThat(parts).hasSize(1);
+      final var part = parts.get(0);
+      assertThat(part.thought()).contains(true);
+      assertThat(part.text()).contains("Let me think it through");
+      assertThat(part.thoughtSignature().orElseThrow()).isEqualTo(signatureBytes);
+    }
+
+    @Test
+    void mapsReasoningContentWithoutSignatureOmitsThoughtSignature() {
+      final var parts =
+          converter.toParts(
+              List.of(
+                  new ReasoningContent(
+                      "gemini", Map.of("type", "thought"), "Let me think it through", null)));
+
+      assertThat(parts).hasSize(1);
+      final var part = parts.get(0);
+      assertThat(part.thought()).contains(true);
+      assertThat(part.text()).contains("Let me think it through");
+      assertThat(part.thoughtSignature()).isEmpty();
+    }
+
+    @Test
+    void mapsProviderContentPayloadToNativePartRoundTrip() {
+      final var payload =
+          Map.<String, Object>of(
+              "functionCall", Map.of("name", "myFunction", "args", Map.of("a", 1)));
+
+      final var parts = converter.toParts(List.of(new ProviderContent("gemini", payload, null)));
+
+      assertThat(parts).hasSize(1);
+      final FunctionCall functionCall = parts.get(0).functionCall().orElseThrow();
+      assertThat(functionCall.name()).contains("myFunction");
+    }
+
+    @Test
+    void throwsForUnsupportedDocumentContentType() {
+      final var doc =
+          mockDocument("application/zip", "ZIPCONTENT".getBytes(StandardCharsets.UTF_8));
+
+      assertThatThrownBy(() -> converter.toParts(List.of(new DocumentContent(doc, null))))
+          .isInstanceOf(ConnectorException.class)
+          .hasMessageContaining("application/zip");
+    }
+
+    @Test
+    void mapsMultipleContentItemsInOrder() {
+      final var doc = mockDocument("image/png", "ABC".getBytes(StandardCharsets.UTF_8));
+      final List<Content> content =
+          List.of(new TextContent("first", null), new DocumentContent(doc, null));
+
+      final var parts = converter.toParts(content);
+
+      assertThat(parts).hasSize(2);
+      assertThat(parts.get(0).text()).isPresent();
+      assertThat(parts.get(1).inlineData()).isPresent();
+    }
+  }
+
+  @Nested
+  class ToFunctionResponseParts {
+
+    @Test
+    void mapsTextContentToFunctionResponsePart() {
+      final var parts = converter.toFunctionResponseParts(List.of(new TextContent("hello", null)));
+
+      assertThat(parts).hasSize(1);
+      final var response = parts.get(0).functionResponse().orElseThrow();
+      assertThat(response.response().orElseThrow()).isEqualTo(Map.of("output", "hello"));
+      assertThat(response.name()).isEmpty();
+      assertThat(response.id()).isEmpty();
+    }
+
+    @Test
+    void mapsObjectContentToFunctionResponsePartWrappedUnderOutputKey() {
+      final var parts =
+          converter.toFunctionResponseParts(List.of(new ObjectContent(Map.of("a", 1), null)));
+
+      assertThat(parts).hasSize(1);
+      final var response = parts.get(0).functionResponse().orElseThrow();
+      assertThat(response.response().orElseThrow()).isEqualTo(Map.of("output", Map.of("a", 1)));
+    }
+
+    @Test
+    void mapsImageDocumentToInlineDataPart() {
+      final var doc = mockDocument("image/jpeg", "ABC".getBytes(StandardCharsets.UTF_8));
+
+      final var parts = converter.toFunctionResponseParts(List.of(new DocumentContent(doc, null)));
+
+      assertThat(parts).hasSize(1);
+      assertThat(parts.get(0).inlineData()).isPresent();
+      assertThat(parts.get(0).functionResponse()).isEmpty();
+    }
+
+    @Test
+    void mapsPdfDocumentToInlineDataPart() {
+      final var doc =
+          mockDocument("application/pdf", "PDFCONTENT".getBytes(StandardCharsets.UTF_8));
+
+      final var parts = converter.toFunctionResponseParts(List.of(new DocumentContent(doc, null)));
+
+      assertThat(parts).hasSize(1);
+      assertThat(parts.get(0).inlineData()).isPresent();
+    }
+
+    @Test
+    void throwsForUnsupportedDocumentContentType() {
+      final var doc =
+          mockDocument("application/zip", "ZIPCONTENT".getBytes(StandardCharsets.UTF_8));
+
+      assertThatThrownBy(
+              () -> converter.toFunctionResponseParts(List.of(new DocumentContent(doc, null))))
+          .isInstanceOf(ConnectorException.class)
+          .hasMessageContaining("application/zip");
+    }
+
+    @Test
+    void mapsReasoningContentToJsonTextPartFallback() {
+      final var parts =
+          converter.toFunctionResponseParts(
+              List.of(
+                  new ReasoningContent(
+                      "gemini", Map.of("thinking", "some reasoning"), null, null)));
+
+      assertThat(parts).hasSize(1);
+      assertThat(parts.get(0).text().orElseThrow()).contains("some reasoning");
+      assertThat(parts.get(0).functionResponse()).isEmpty();
+    }
+
+    @Test
+    void mapsProviderContentToJsonTextPartFallback() {
+      final var parts =
+          converter.toFunctionResponseParts(
+              List.of(new ProviderContent("gemini", Map.of("foo", "bar"), null)));
+
+      assertThat(parts).hasSize(1);
+      assertThat(parts.get(0).text().orElseThrow()).contains("bar");
+      assertThat(parts.get(0).functionResponse()).isEmpty();
+    }
+  }
+}

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiContentConverterTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiContentConverterTest.java
@@ -6,6 +6,7 @@
  */
 package io.camunda.connector.agenticai.aiagent.chatmodel.provider.gemini;
 
+import static io.camunda.connector.agenticai.aiagent.model.request.v2.GeminiChatModelConfiguration.GOOGLE_GEMINI_ID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
@@ -173,7 +174,10 @@ class GeminiContentConverterTest {
           converter.toParts(
               List.of(
                   new ReasoningContent(
-                      "gemini", Map.of("type", "thought"), "Let me think it through", metadata)));
+                      GOOGLE_GEMINI_ID,
+                      Map.of("type", "thought"),
+                      "Let me think it through",
+                      metadata)));
 
       assertThat(parts).hasSize(1);
       final var part = parts.get(0);
@@ -188,7 +192,10 @@ class GeminiContentConverterTest {
           converter.toParts(
               List.of(
                   new ReasoningContent(
-                      "gemini", Map.of("type", "thought"), "Let me think it through", null)));
+                      GOOGLE_GEMINI_ID,
+                      Map.of("type", "thought"),
+                      "Let me think it through",
+                      null)));
 
       assertThat(parts).hasSize(1);
       final var part = parts.get(0);
@@ -206,7 +213,10 @@ class GeminiContentConverterTest {
           converter.toParts(
               List.of(
                   new ReasoningContent(
-                      "gemini", Map.of("type", "thought"), "Let me think it through", metadata)));
+                      GOOGLE_GEMINI_ID,
+                      Map.of("type", "thought"),
+                      "Let me think it through",
+                      metadata)));
 
       assertThat(parts).hasSize(1);
       assertThat(parts.get(0).thoughtSignature().orElseThrow()).isEqualTo(signatureBytes);
@@ -221,7 +231,7 @@ class GeminiContentConverterTest {
                   converter.toParts(
                       List.of(
                           new ReasoningContent(
-                              "gemini",
+                              GOOGLE_GEMINI_ID,
                               Map.of("type", "thought"),
                               "Let me think it through",
                               metadata))))
@@ -234,7 +244,8 @@ class GeminiContentConverterTest {
     void mapsReasoningContentWithNullTextDoesNotSetText() {
       final var parts =
           converter.toParts(
-              List.of(new ReasoningContent("gemini", Map.of("type", "thought"), null, null)));
+              List.of(
+                  new ReasoningContent(GOOGLE_GEMINI_ID, Map.of("type", "thought"), null, null)));
 
       assertThat(parts).hasSize(1);
       final var part = parts.get(0);
@@ -256,11 +267,30 @@ class GeminiContentConverterTest {
           Map.<String, Object>of(
               "functionCall", Map.of("name", "myFunction", "args", Map.of("a", 1)));
 
-      final var parts = converter.toParts(List.of(new ProviderContent("gemini", payload, null)));
+      final var parts =
+          converter.toParts(List.of(new ProviderContent(GOOGLE_GEMINI_ID, payload, null)));
 
       assertThat(parts).hasSize(1);
       final FunctionCall functionCall = parts.get(0).functionCall().orElseThrow();
       assertThat(functionCall.name()).contains("myFunction");
+    }
+
+    @Test
+    void dropsReasoningContentFromAForeignProvider() {
+      final var parts =
+          converter.toParts(
+              List.of(new ReasoningContent("openai", Map.of("type", "reasoning"), null, null)));
+
+      assertThat(parts).isEmpty();
+    }
+
+    @Test
+    void dropsProviderContentFromAForeignProvider() {
+      final var parts =
+          converter.toParts(
+              List.of(new ProviderContent("anthropic", Map.of("type", "web_search"), null)));
+
+      assertThat(parts).isEmpty();
     }
 
     @Test
@@ -350,7 +380,7 @@ class GeminiContentConverterTest {
           converter.toFunctionResponseParts(
               List.of(
                   new ReasoningContent(
-                      "gemini", Map.of("thinking", "some reasoning"), null, null)));
+                      GOOGLE_GEMINI_ID, Map.of("thinking", "some reasoning"), null, null)));
 
       assertThat(parts).hasSize(1);
       final var response = parts.get(0).functionResponse().orElseThrow();
@@ -362,7 +392,7 @@ class GeminiContentConverterTest {
     void mapsProviderContentToFunctionResponsePartWithJsonFallback() {
       final var parts =
           converter.toFunctionResponseParts(
-              List.of(new ProviderContent("gemini", Map.of("foo", "bar"), null)));
+              List.of(new ProviderContent(GOOGLE_GEMINI_ID, Map.of("foo", "bar"), null)));
 
       assertThat(parts).hasSize(1);
       final var response = parts.get(0).functionResponse().orElseThrow();

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiContentConverterTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiContentConverterTest.java
@@ -332,13 +332,17 @@ class GeminiContentConverterTest {
     }
 
     @Test
-    void mapsObjectContentToFunctionResponsePartWrappedUnderOutputKey() {
+    void mapsObjectContentToFunctionResponsePartAsJsonString() {
+      // serialized to a JSON string via the connector's own ObjectMapper rather than handed to
+      // the SDK as a raw object graph - the SDK's own (unconfigured) Jackson mapper has no
+      // serializer for domain types such as Document that may be nested inside tool call output
+      // (e.g. an ad-hoc tool result containing document attachments)
       final var parts =
           converter.toFunctionResponseParts(List.of(new ObjectContent(Map.of("a", 1), null)));
 
       assertThat(parts).hasSize(1);
       final var response = parts.get(0).functionResponse().orElseThrow();
-      assertThat(response.response().orElseThrow()).isEqualTo(Map.of("output", Map.of("a", 1)));
+      assertThat(response.response().orElseThrow()).isEqualTo(Map.of("output", "{\"a\":1}"));
     }
 
     @Test

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiContentConverterTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiContentConverterTest.java
@@ -52,6 +52,52 @@ class GeminiContentConverterTest {
 
       assertThat(parts).hasSize(1);
       assertThat(parts.get(0).text()).contains("hello world");
+      assertThat(parts.get(0).thoughtSignature()).isEmpty();
+    }
+
+    @Test
+    void mapsTextContentWithSignatureMetadataToTextPartCarryingTheSignature() {
+      // Gemini attaches a thoughtSignature to whichever part carries the reasoning continuity,
+      // including a plain answer text part - it must survive the replay, not just on thought parts.
+      final var signatureBytes = "sig-bytes".getBytes(StandardCharsets.UTF_8);
+      final var metadata =
+          Map.<String, Object>of(
+              "thoughtSignature", Base64.getEncoder().encodeToString(signatureBytes));
+
+      final var parts = converter.toParts(List.of(new TextContent("the answer", metadata)));
+
+      assertThat(parts).hasSize(1);
+      final var part = parts.get(0);
+      assertThat(part.text()).contains("the answer");
+      assertThat(part.thought()).isEmpty();
+      assertThat(part.thoughtSignature().orElseThrow()).isEqualTo(signatureBytes);
+    }
+
+    @Test
+    void mapsTextContentWithRawByteArraySignatureMetadataPassesThrough() {
+      // Same tolerance as the reasoning path: the in-process conversation store can hand back the
+      // raw byte[] with no JSON round trip in between.
+      final var signatureBytes = "sig-bytes".getBytes(StandardCharsets.UTF_8);
+
+      final var parts =
+          converter.toParts(
+              List.of(
+                  new TextContent(
+                      "the answer", Map.of("thoughtSignature", (Object) signatureBytes))));
+
+      assertThat(parts).hasSize(1);
+      assertThat(parts.get(0).thoughtSignature().orElseThrow()).isEqualTo(signatureBytes);
+    }
+
+    @Test
+    void mapsTextContentWithUnrelatedMetadataWithoutSettingASignature() {
+      final var parts =
+          converter.toParts(
+              List.of(new TextContent("the answer", Map.of("somethingElse", "value"))));
+
+      assertThat(parts).hasSize(1);
+      assertThat(parts.get(0).text()).contains("the answer");
+      assertThat(parts.get(0).thoughtSignature()).isEmpty();
     }
 
     @Test

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiContentRequestConverterTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiContentRequestConverterTest.java
@@ -1,0 +1,433 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.agenticai.aiagent.chatmodel.provider.gemini;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.connector.agenticai.aiagent.memory.ConversationSnapshot;
+import io.camunda.connector.agenticai.aiagent.model.message.AssistantMessage;
+import io.camunda.connector.agenticai.aiagent.model.message.SystemMessage;
+import io.camunda.connector.agenticai.aiagent.model.message.ToolCallResultMessage;
+import io.camunda.connector.agenticai.aiagent.model.message.UserMessage;
+import io.camunda.connector.agenticai.aiagent.model.message.content.DocumentContent;
+import io.camunda.connector.agenticai.aiagent.model.message.content.TextContent;
+import io.camunda.connector.agenticai.aiagent.model.request.AgentTaskResponseConfiguration;
+import io.camunda.connector.agenticai.aiagent.model.request.ResponseFormatConfiguration.JsonResponseFormatConfiguration;
+import io.camunda.connector.agenticai.aiagent.model.request.ResponseFormatConfiguration.TextResponseFormatConfiguration;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.GeminiChatModelConfiguration;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.GeminiChatModelConfiguration.GeminiBackend.GeminiApiBackend;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.GeminiChatModelConfiguration.GeminiBackend.GeminiApiBackend.GoogleGeminiApi;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.GeminiChatModelConfiguration.GeminiConnection;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.GeminiChatModelConfiguration.GeminiModel;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.GeminiChatModelConfiguration.GeminiModel.GeminiModelParameters;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.GeminiChatModelConfiguration.GeminiModel.GeminiThinking;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.GeminiChatModelConfiguration.GeminiModel.GeminiThinkingLevel;
+import io.camunda.connector.agenticai.aiagent.model.tool.ToolCall;
+import io.camunda.connector.agenticai.aiagent.model.tool.ToolCallResultContent;
+import io.camunda.connector.agenticai.aiagent.model.tool.ToolDefinition;
+import io.camunda.connector.api.document.Document;
+import io.camunda.connector.api.document.DocumentMetadata;
+import io.camunda.connector.api.error.ConnectorException;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+import org.jspecify.annotations.Nullable;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+class GeminiContentRequestConverterTest {
+
+  private final ObjectMapper objectMapper = new ObjectMapper();
+  private final GeminiContentConverter contentConverter = new GeminiContentConverter(objectMapper);
+  private final GeminiContentRequestConverter converter =
+      new GeminiContentRequestConverter(contentConverter);
+
+  private static GeminiChatModelConfiguration model(@Nullable GeminiModelParameters parameters) {
+    return new GeminiChatModelConfiguration(
+        new GeminiConnection(
+            new GeminiApiBackend(new GoogleGeminiApi("gm-test", null)),
+            new GeminiModel("gemini-3-pro-preview", parameters),
+            null));
+  }
+
+  private static Document mockDocument(String contentType, byte[] bytes) {
+    final var document = Mockito.mock(Document.class);
+    final var metadata = Mockito.mock(DocumentMetadata.class);
+    Mockito.when(document.metadata()).thenReturn(metadata);
+    Mockito.when(metadata.getContentType()).thenReturn(contentType);
+    Mockito.when(document.asByteArray()).thenReturn(bytes);
+    return document;
+  }
+
+  // --- Model parameters -------------------------------------------------------------------------
+
+  @Test
+  void mapsModelParameters() {
+    final var parameters = new GeminiModelParameters(1024, 0.5, 0.9, 40, null);
+    final var snapshot = new ConversationSnapshot(List.of(), List.of());
+
+    final var config = converter.toGenerateContentConfig(model(parameters), null, snapshot);
+
+    assertThat(config.maxOutputTokens()).contains(1024);
+    assertThat(config.temperature()).contains(0.5f);
+    assertThat(config.topP()).contains(0.9f);
+    assertThat(config.topK()).contains(40f);
+  }
+
+  @Test
+  void omitsUnsetModelParameters() {
+    final var snapshot = new ConversationSnapshot(List.of(), List.of());
+
+    final var config = converter.toGenerateContentConfig(model(null), null, snapshot);
+
+    assertThat(config.maxOutputTokens()).isEmpty();
+    assertThat(config.temperature()).isEmpty();
+    assertThat(config.topP()).isEmpty();
+    assertThat(config.topK()).isEmpty();
+    assertThat(config.thinkingConfig()).isEmpty();
+  }
+
+  // --- Thinking
+  // -----------------------------------------------------------------------------------
+
+  @Test
+  void mapsThinkingBudgetOnly() {
+    final var parameters =
+        new GeminiModelParameters(null, null, null, null, new GeminiThinking(2048, null));
+    final var snapshot = new ConversationSnapshot(List.of(), List.of());
+
+    final var config = converter.toGenerateContentConfig(model(parameters), null, snapshot);
+
+    assertThat(config.thinkingConfig()).isPresent();
+    assertThat(config.thinkingConfig().orElseThrow().thinkingBudget()).contains(2048);
+    assertThat(config.thinkingConfig().orElseThrow().thinkingLevel()).isEmpty();
+  }
+
+  @Test
+  void mapsThinkingLevelOnly() {
+    final var parameters =
+        new GeminiModelParameters(
+            null, null, null, null, new GeminiThinking(null, GeminiThinkingLevel.HIGH));
+    final var snapshot = new ConversationSnapshot(List.of(), List.of());
+
+    final var config = converter.toGenerateContentConfig(model(parameters), null, snapshot);
+
+    assertThat(config.thinkingConfig()).isPresent();
+    assertThat(config.thinkingConfig().orElseThrow().thinkingBudget()).isEmpty();
+    assertThat(config.thinkingConfig().orElseThrow().thinkingLevel().orElseThrow().toString())
+        .isEqualToIgnoringCase("high");
+  }
+
+  @Test
+  void bothThinkingBudgetAndLevelSetThrows() {
+    // Defensive check: the config record's own @AssertFalse should already prevent this, but the
+    // converter guards it too rather than silently picking one (constructed directly here,
+    // bypassing bean validation, to exercise that defense).
+    final var parameters =
+        new GeminiModelParameters(
+            null, null, null, null, new GeminiThinking(2048, GeminiThinkingLevel.HIGH));
+    final var snapshot = new ConversationSnapshot(List.of(), List.of());
+
+    assertThatThrownBy(() -> converter.toGenerateContentConfig(model(parameters), null, snapshot))
+        .isInstanceOf(ConnectorException.class);
+  }
+
+  @Test
+  void noThinkingConfiguredEmitsNoThinkingConfig() {
+    final var parameters = new GeminiModelParameters(null, null, null, null, null);
+    final var snapshot = new ConversationSnapshot(List.of(), List.of());
+
+    final var config = converter.toGenerateContentConfig(model(parameters), null, snapshot);
+
+    assertThat(config.thinkingConfig()).isEmpty();
+  }
+
+  // --- System prompt hoisting -----------------------------------------------------------------
+
+  @Test
+  void hoistsLeadingSystemMessageToSystemInstructionAndExcludesItFromContents() {
+    final var snapshot =
+        new ConversationSnapshot(
+            List.of(
+                SystemMessage.builder().content(List.of(TextContent.textContent("sys"))).build(),
+                UserMessage.builder().content(List.of(TextContent.textContent("hi"))).build()),
+            List.of());
+
+    final var config = converter.toGenerateContentConfig(model(null), null, snapshot);
+    final var contents = converter.toContents(snapshot);
+
+    assertThat(config.systemInstruction()).isPresent();
+    assertThat(config.systemInstruction().orElseThrow().text()).isEqualTo("sys");
+
+    assertThat(contents).hasSize(1);
+    assertThat(contents.get(0).role()).contains("user");
+    assertThat(contents.get(0).text()).isEqualTo("hi");
+  }
+
+  @Test
+  void noSystemMessageEmitsNoSystemInstruction() {
+    final var snapshot =
+        new ConversationSnapshot(
+            List.of(UserMessage.builder().content(List.of(TextContent.textContent("hi"))).build()),
+            List.of());
+
+    final var config = converter.toGenerateContentConfig(model(null), null, snapshot);
+
+    assertThat(config.systemInstruction()).isEmpty();
+  }
+
+  // --- Message-history mapping
+  // --------------------------------------------------------------------
+
+  @Test
+  void mapsUserMessageToUserRoleContent() {
+    final var snapshot =
+        new ConversationSnapshot(
+            List.of(UserMessage.builder().content(List.of(TextContent.textContent("hi"))).build()),
+            List.of());
+
+    final var contents = converter.toContents(snapshot);
+
+    assertThat(contents).hasSize(1);
+    assertThat(contents.get(0).role()).contains("user");
+    assertThat(contents.get(0).text()).isEqualTo("hi");
+  }
+
+  @Test
+  void mapsAssistantMessageToModelRoleContentWithToolCallAsFunctionCallPart() {
+    final var snapshot =
+        new ConversationSnapshot(
+            List.of(
+                AssistantMessage.builder()
+                    .content(List.of(TextContent.textContent("calling tool")))
+                    .toolCalls(
+                        List.of(
+                            ToolCall.builder()
+                                .id("call-1")
+                                .name("getWeather")
+                                .arguments(Map.of("city", "Berlin"))
+                                .build()))
+                    .build()),
+            List.of());
+
+    final var contents = converter.toContents(snapshot);
+
+    assertThat(contents).hasSize(1);
+    final var content = contents.get(0);
+    assertThat(content.role()).contains("model");
+    assertThat(content.parts().orElseThrow()).hasSize(2);
+    assertThat(content.parts().orElseThrow().get(0).text()).contains("calling tool");
+
+    final var functionCall = content.parts().orElseThrow().get(1).functionCall().orElseThrow();
+    assertThat(functionCall.id()).contains("call-1");
+    assertThat(functionCall.name()).contains("getWeather");
+    assertThat(functionCall.args().orElseThrow()).isEqualTo(Map.of("city", "Berlin"));
+  }
+
+  @Test
+  void mapsToolCallResultMessageToUserRoleContentWithFunctionResponsePart() {
+    final var snapshot =
+        new ConversationSnapshot(
+            List.of(
+                ToolCallResultMessage.builder()
+                    .results(
+                        List.of(
+                            ToolCallResultContent.builder()
+                                .id("call-1")
+                                .name("getWeather")
+                                .content(List.of(TextContent.textContent("sunny")))
+                                .build()))
+                    .build()),
+            List.of());
+
+    final var contents = converter.toContents(snapshot);
+
+    assertThat(contents).hasSize(1);
+    final var content = contents.get(0);
+    assertThat(content.role()).contains("user");
+    assertThat(content.parts().orElseThrow()).hasSize(1);
+
+    final var functionResponse =
+        content.parts().orElseThrow().get(0).functionResponse().orElseThrow();
+    assertThat(functionResponse.id()).contains("call-1");
+    assertThat(functionResponse.name()).contains("getWeather");
+    assertThat(functionResponse.response().orElseThrow()).isEqualTo(Map.of("output", "sunny"));
+  }
+
+  @Test
+  void mergesMultiPartToolResultIntoASingleFunctionResponsePart() {
+    final var snapshot =
+        new ConversationSnapshot(
+            List.of(
+                ToolCallResultMessage.builder()
+                    .results(
+                        List.of(
+                            ToolCallResultContent.builder()
+                                .id("call-1")
+                                .name("multiPart")
+                                .content(
+                                    List.of(
+                                        TextContent.textContent("a"), TextContent.textContent("b")))
+                                .build()))
+                    .build()),
+            List.of());
+
+    final var contents = converter.toContents(snapshot);
+
+    assertThat(contents).hasSize(1);
+    final var parts = contents.get(0).parts().orElseThrow();
+    assertThat(parts).hasSize(1);
+
+    final var functionResponse = parts.get(0).functionResponse().orElseThrow();
+    assertThat(functionResponse.id()).contains("call-1");
+    assertThat(functionResponse.name()).contains("multiPart");
+    assertThat(functionResponse.response().orElseThrow())
+        .isEqualTo(Map.of("output", List.of("a", "b")));
+  }
+
+  @Test
+  void toolResultWithTextAndDocumentContentKeepsNonFunctionResponsePartAsSibling() {
+    final var doc = mockDocument("image/png", "ABC".getBytes(StandardCharsets.UTF_8));
+    final var snapshot =
+        new ConversationSnapshot(
+            List.of(
+                ToolCallResultMessage.builder()
+                    .results(
+                        List.of(
+                            ToolCallResultContent.builder()
+                                .id("call-1")
+                                .name("withImage")
+                                .content(
+                                    List.of(
+                                        TextContent.textContent("described"),
+                                        new DocumentContent(doc, null)))
+                                .build()))
+                    .build()),
+            List.of());
+
+    final var contents = converter.toContents(snapshot);
+
+    final var parts = contents.get(0).parts().orElseThrow();
+    assertThat(parts).hasSize(2);
+
+    final var functionResponse = parts.get(0).functionResponse().orElseThrow();
+    assertThat(functionResponse.id()).contains("call-1");
+    assertThat(functionResponse.response().orElseThrow()).isEqualTo(Map.of("output", "described"));
+
+    assertThat(parts.get(1).inlineData()).isPresent();
+    assertThat(parts.get(1).functionResponse()).isEmpty();
+  }
+
+  @Test
+  void emptySnapshotReturnsEmptyContentsListNotNull() {
+    final var contents = converter.toContents(new ConversationSnapshot(List.of(), List.of()));
+
+    assertThat(contents).isNotNull();
+    assertThat(contents).isEmpty();
+  }
+
+  @Test
+  void assistantMessageWithNoContentAndNoToolCallsEmitsNoContent() {
+    final var snapshot =
+        new ConversationSnapshot(List.of(AssistantMessage.builder().build()), List.of());
+
+    final var contents = converter.toContents(snapshot);
+
+    assertThat(contents).isEmpty();
+  }
+
+  // --- Tools ----------------------------------------------------------------------------------
+
+  @Test
+  void mapsToolDefinitionsToASingleToolWithFunctionDeclarations() {
+    final Map<String, Object> schema =
+        Map.of(
+            "type",
+            "object",
+            "properties",
+            Map.of("quantity", Map.of("type", "integer")),
+            "required",
+            List.of("quantity"));
+    final var snapshot =
+        new ConversationSnapshot(
+            List.of(),
+            List.of(
+                ToolDefinition.builder()
+                    .name("SuperfluxProduct")
+                    .description("desc")
+                    .inputSchema(schema)
+                    .build()));
+
+    final var config = converter.toGenerateContentConfig(model(null), null, snapshot);
+
+    assertThat(config.tools()).isPresent();
+    assertThat(config.tools().orElseThrow()).hasSize(1);
+
+    final var declarations =
+        config.tools().orElseThrow().get(0).functionDeclarations().orElseThrow();
+    assertThat(declarations).hasSize(1);
+    assertThat(declarations.get(0).name()).contains("SuperfluxProduct");
+    assertThat(declarations.get(0).description()).contains("desc");
+    assertThat(declarations.get(0).parametersJsonSchema()).contains(schema);
+  }
+
+  @Test
+  void noToolDefinitionsEmitsNoTools() {
+    final var snapshot = new ConversationSnapshot(List.of(), List.of());
+
+    final var config = converter.toGenerateContentConfig(model(null), null, snapshot);
+
+    assertThat(config.tools()).isEmpty();
+  }
+
+  // --- Structured output -----------------------------------------------------------------------
+
+  @Test
+  void configuresStructuredOutputFromJsonSchema() {
+    final Map<String, Object> schema =
+        Map.of("type", "object", "properties", Map.of("answer", Map.of("type", "string")));
+    final var response =
+        new AgentTaskResponseConfiguration(
+            new JsonResponseFormatConfiguration(schema, "Answer"), null);
+    final var snapshot = new ConversationSnapshot(List.of(), List.of());
+
+    final var config = converter.toGenerateContentConfig(model(null), response, snapshot);
+
+    assertThat(config.responseMimeType()).contains("application/json");
+    assertThat(config.responseSchema()).isEmpty();
+    assertThat(config.responseJsonSchema()).contains(schema);
+
+    // Prove the raw schema actually survives SDK serialization, not just the in-memory getter.
+    final String json = config.toJson();
+    assertThat(json).contains("\"answer\"");
+    assertThat(json).contains("\"responseMimeType\":\"application/json\"");
+  }
+
+  @Test
+  void textResponseFormatHasNoRequestSideEffect() {
+    final var response =
+        new AgentTaskResponseConfiguration(new TextResponseFormatConfiguration(true), null);
+    final var snapshot = new ConversationSnapshot(List.of(), List.of());
+
+    final var config = converter.toGenerateContentConfig(model(null), response, snapshot);
+
+    assertThat(config.responseMimeType()).isEmpty();
+    assertThat(config.responseJsonSchema()).isEmpty();
+  }
+
+  @Test
+  void nullResponseConfigurationHasNoRequestSideEffect() {
+    final var snapshot = new ConversationSnapshot(List.of(), List.of());
+
+    final var config = converter.toGenerateContentConfig(model(null), null, snapshot);
+
+    assertThat(config.responseMimeType()).isEmpty();
+    assertThat(config.responseJsonSchema()).isEmpty();
+  }
+}

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiContentRequestConverterTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiContentRequestConverterTest.java
@@ -108,6 +108,8 @@ class GeminiContentRequestConverterTest {
     assertThat(config.thinkingConfig()).isPresent();
     assertThat(config.thinkingConfig().orElseThrow().thinkingBudget()).contains(2048);
     assertThat(config.thinkingConfig().orElseThrow().thinkingLevel()).isEmpty();
+    // without includeThoughts, thinking would be billed but never returned
+    assertThat(config.thinkingConfig().orElseThrow().includeThoughts()).contains(true);
   }
 
   @Test
@@ -123,6 +125,7 @@ class GeminiContentRequestConverterTest {
     assertThat(config.thinkingConfig().orElseThrow().thinkingBudget()).isEmpty();
     assertThat(config.thinkingConfig().orElseThrow().thinkingLevel().orElseThrow().toString())
         .isEqualToIgnoringCase("high");
+    assertThat(config.thinkingConfig().orElseThrow().includeThoughts()).contains(true);
   }
 
   @Test

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiContentRequestConverterTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiContentRequestConverterTest.java
@@ -413,7 +413,7 @@ class GeminiContentRequestConverterTest {
   }
 
   @Test
-  void toolResultWithTextAndDocumentContentKeepsNonFunctionResponsePartAsSibling() {
+  void toolResultWithTextAndDocumentContentMergesIntoSingleFunctionResponse() {
     final var doc = mockDocument("image/png", "ABC".getBytes(StandardCharsets.UTF_8));
     final var snapshot =
         new ConversationSnapshot(
@@ -435,17 +435,53 @@ class GeminiContentRequestConverterTest {
     final var contents = converter.toContents(snapshot);
 
     final var parts = contents.get(0).parts().orElseThrow();
-    assertThat(parts).hasSize(2);
+    assertThat(parts).hasSize(1);
 
+    // the document is flattened to a JSON reference rather than embedded natively (see
+    // GeminiContentConverter#toFunctionResponseParts), but still wrapped in a functionResponse
+    // like the text content, so both merge into one functionResponse instead of leaving the
+    // document as an uncorrelated sibling part.
     final var functionResponse = parts.get(0).functionResponse().orElseThrow();
     assertThat(functionResponse.id()).contains("call-1");
-    assertThat(functionResponse.response().orElseThrow()).isEqualTo(Map.of("output", "described"));
+    assertThat(functionResponse.response().orElseThrow().get("output"))
+        .isEqualTo(
+            List.of(
+                "described",
+                "{\"url\":\"https://example.com/document\",\"name\":\"document\","
+                    + "\"camunda.document.type\":\"external\"}"));
+  }
 
-    // flattened to a JSON reference, not embedded natively - see GeminiContentConverter
-    // #toFunctionResponseParts
-    assertThat(parts.get(1).functionResponse()).isEmpty();
-    assertThat(parts.get(1).inlineData()).isEmpty();
-    assertThat(parts.get(1).text()).isPresent();
+  @Test
+  void toolResultWithOnlyDocumentContentStillClosesOutTheFunctionCall() {
+    final var doc = mockDocument("image/png", "ABC".getBytes(StandardCharsets.UTF_8));
+    final var snapshot =
+        new ConversationSnapshot(
+            List.of(
+                ToolCallResultMessage.builder()
+                    .results(
+                        List.of(
+                            ToolCallResultContent.builder()
+                                .id("call-1")
+                                .name("readDocument")
+                                .content(List.of(new DocumentContent(doc, null)))
+                                .build()))
+                    .build()),
+            List.of());
+
+    final var contents = converter.toContents(snapshot);
+
+    final var parts = contents.get(0).parts().orElseThrow();
+    assertThat(parts).hasSize(1);
+
+    // a document-only result must still produce a functionResponse carrying name/id - a bare
+    // text Part here would never correlate with the preceding functionCall
+    final var functionResponse = parts.get(0).functionResponse().orElseThrow();
+    assertThat(functionResponse.id()).contains("call-1");
+    assertThat(functionResponse.name()).contains("readDocument");
+    assertThat(functionResponse.response().orElseThrow().get("output"))
+        .isEqualTo(
+            "{\"url\":\"https://example.com/document\",\"name\":\"document\","
+                + "\"camunda.document.type\":\"external\"}");
   }
 
   @Test

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiContentRequestConverterTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiContentRequestConverterTest.java
@@ -35,6 +35,7 @@ import io.camunda.connector.api.document.Document;
 import io.camunda.connector.api.document.DocumentMetadata;
 import io.camunda.connector.api.error.ConnectorException;
 import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 import java.util.List;
 import java.util.Map;
 import org.jspecify.annotations.Nullable;
@@ -228,6 +229,60 @@ class GeminiContentRequestConverterTest {
     assertThat(functionCall.id()).contains("call-1");
     assertThat(functionCall.name()).contains("getWeather");
     assertThat(functionCall.args().orElseThrow()).isEqualTo(Map.of("city", "Berlin"));
+  }
+
+  @Test
+  void restoresThoughtSignatureOnReplayedFunctionCallPartWhenPresentOnToolCallMetadata() {
+    final var signatureBytes = "sig-bytes".getBytes(StandardCharsets.UTF_8);
+    final var metadata =
+        Map.<String, Object>of(
+            GeminiChatModelConfiguration.GOOGLE_GEMINI_ID,
+            Map.of(
+                GeminiContentConverter.THOUGHT_SIGNATURE_METADATA_KEY,
+                Base64.getEncoder().encodeToString(signatureBytes)));
+    final var snapshot =
+        new ConversationSnapshot(
+            List.of(
+                AssistantMessage.builder()
+                    .toolCalls(
+                        List.of(
+                            ToolCall.builder()
+                                .id("call-1")
+                                .name("getWeather")
+                                .arguments(Map.of("city", "Berlin"))
+                                .metadata(metadata)
+                                .build()))
+                    .build()),
+            List.of());
+
+    final var contents = converter.toContents(snapshot);
+
+    final var functionCallPart = contents.get(0).parts().orElseThrow().get(0);
+    assertThat(functionCallPart.functionCall()).isPresent();
+    assertThat(functionCallPart.thoughtSignature().orElseThrow()).isEqualTo(signatureBytes);
+  }
+
+  @Test
+  void omitsThoughtSignatureOnReplayedFunctionCallPartWhenAbsentFromToolCallMetadata() {
+    final var snapshot =
+        new ConversationSnapshot(
+            List.of(
+                AssistantMessage.builder()
+                    .toolCalls(
+                        List.of(
+                            ToolCall.builder()
+                                .id("call-1")
+                                .name("getWeather")
+                                .arguments(Map.of("city", "Berlin"))
+                                .build()))
+                    .build()),
+            List.of());
+
+    final var contents = converter.toContents(snapshot);
+
+    final var functionCallPart = contents.get(0).parts().orElseThrow().get(0);
+    assertThat(functionCallPart.functionCall()).isPresent();
+    assertThat(functionCallPart.thoughtSignature()).isEmpty();
   }
 
   @Test

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiContentRequestConverterTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiContentRequestConverterTest.java
@@ -100,7 +100,7 @@ class GeminiContentRequestConverterTest {
   @Test
   void mapsThinkingBudgetOnly() {
     final var parameters =
-        new GeminiModelParameters(null, null, null, null, new GeminiThinking(2048, null));
+        new GeminiModelParameters(null, null, null, null, new GeminiThinking(true, 2048, null));
     final var snapshot = new ConversationSnapshot(List.of(), List.of());
 
     final var config = converter.toGenerateContentConfig(model(parameters), null, snapshot);
@@ -116,7 +116,7 @@ class GeminiContentRequestConverterTest {
   void mapsThinkingLevelOnly() {
     final var parameters =
         new GeminiModelParameters(
-            null, null, null, null, new GeminiThinking(null, GeminiThinkingLevel.HIGH));
+            null, null, null, null, new GeminiThinking(true, null, GeminiThinkingLevel.HIGH));
     final var snapshot = new ConversationSnapshot(List.of(), List.of());
 
     final var config = converter.toGenerateContentConfig(model(parameters), null, snapshot);
@@ -129,13 +129,41 @@ class GeminiContentRequestConverterTest {
   }
 
   @Test
+  void mapsThinkingLevelMinimal() {
+    final var parameters =
+        new GeminiModelParameters(
+            null, null, null, null, new GeminiThinking(true, null, GeminiThinkingLevel.MINIMAL));
+    final var snapshot = new ConversationSnapshot(List.of(), List.of());
+
+    final var config = converter.toGenerateContentConfig(model(parameters), null, snapshot);
+
+    assertThat(config.thinkingConfig().orElseThrow().thinkingLevel().orElseThrow().toString())
+        .isEqualToIgnoringCase("minimal");
+  }
+
+  @Test
+  void mapsUnconfiguredThinkingLevelToExplicitModelDefault() {
+    final var parameters =
+        new GeminiModelParameters(null, null, null, null, new GeminiThinking(true, null, null));
+    final var snapshot = new ConversationSnapshot(List.of(), List.of());
+
+    final var config = converter.toGenerateContentConfig(model(parameters), null, snapshot);
+
+    assertThat(config.thinkingConfig()).isPresent();
+    assertThat(config.thinkingConfig().orElseThrow().thinkingBudget()).isEmpty();
+    assertThat(config.thinkingConfig().orElseThrow().thinkingLevel().orElseThrow().toString())
+        .isEqualToIgnoringCase("THINKING_LEVEL_UNSPECIFIED");
+    assertThat(config.thinkingConfig().orElseThrow().includeThoughts()).contains(true);
+  }
+
+  @Test
   void bothThinkingBudgetAndLevelSetThrows() {
     // Defensive check: the config record's own @AssertFalse should already prevent this, but the
     // converter guards it too rather than silently picking one (constructed directly here,
     // bypassing bean validation, to exercise that defense).
     final var parameters =
         new GeminiModelParameters(
-            null, null, null, null, new GeminiThinking(2048, GeminiThinkingLevel.HIGH));
+            null, null, null, null, new GeminiThinking(true, 2048, GeminiThinkingLevel.HIGH));
     final var snapshot = new ConversationSnapshot(List.of(), List.of());
 
     assertThatThrownBy(() -> converter.toGenerateContentConfig(model(parameters), null, snapshot))
@@ -143,10 +171,40 @@ class GeminiContentRequestConverterTest {
   }
 
   @Test
+  void budgetWithModelDefaultLevelDoesNotThrow() {
+    final var parameters =
+        new GeminiModelParameters(
+            null,
+            null,
+            null,
+            null,
+            new GeminiThinking(true, 2048, GeminiThinkingLevel.MODEL_DEFAULT));
+    final var snapshot = new ConversationSnapshot(List.of(), List.of());
+
+    final var config = converter.toGenerateContentConfig(model(parameters), null, snapshot);
+
+    assertThat(config.thinkingConfig().orElseThrow().thinkingBudget()).contains(2048);
+  }
+
+  @Test
   void noThinkingConfiguredEmitsNoThinkingConfig() {
     final var parameters = new GeminiModelParameters(null, null, null, null, null);
     final var snapshot = new ConversationSnapshot(List.of(), List.of());
 
+    final var config = converter.toGenerateContentConfig(model(parameters), null, snapshot);
+
+    assertThat(config.thinkingConfig()).isEmpty();
+  }
+
+  @Test
+  void thinkingNotEnabledEmitsNoThinkingConfigEvenIfBudgetOrLevelSet() {
+    final var parameters =
+        new GeminiModelParameters(
+            null, null, null, null, new GeminiThinking(null, 2048, GeminiThinkingLevel.HIGH));
+    final var snapshot = new ConversationSnapshot(List.of(), List.of());
+
+    // Constructed directly (bypassing bean validation) purely to prove the `enabled` gate is
+    // checked before the mutual-exclusivity check -- an unrealistic combination otherwise.
     final var config = converter.toGenerateContentConfig(model(parameters), null, snapshot);
 
     assertThat(config.thinkingConfig()).isEmpty();

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiContentRequestConverterTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiContentRequestConverterTest.java
@@ -468,6 +468,18 @@ class GeminiContentRequestConverterTest {
   }
 
   @Test
+  void configuresJsonResponseFormatWithoutSchema() {
+    final var response =
+        new AgentTaskResponseConfiguration(new JsonResponseFormatConfiguration(null, null), null);
+    final var snapshot = new ConversationSnapshot(List.of(), List.of());
+
+    final var config = converter.toGenerateContentConfig(model(null), response, snapshot);
+
+    assertThat(config.responseMimeType()).contains("application/json");
+    assertThat(config.responseJsonSchema()).isEmpty();
+  }
+
+  @Test
   void textResponseFormatHasNoRequestSideEffect() {
     final var response =
         new AgentTaskResponseConfiguration(new TextResponseFormatConfiguration(true), null);

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiContentRequestConverterTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiContentRequestConverterTest.java
@@ -9,7 +9,6 @@ package io.camunda.connector.agenticai.aiagent.chatmodel.provider.gemini;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.connector.agenticai.aiagent.memory.ConversationSnapshot;
 import io.camunda.connector.agenticai.aiagent.model.message.AssistantMessage;
 import io.camunda.connector.agenticai.aiagent.model.message.SystemMessage;
@@ -31,9 +30,11 @@ import io.camunda.connector.agenticai.aiagent.model.request.v2.GeminiChatModelCo
 import io.camunda.connector.agenticai.aiagent.model.tool.ToolCall;
 import io.camunda.connector.agenticai.aiagent.model.tool.ToolCallResultContent;
 import io.camunda.connector.agenticai.aiagent.model.tool.ToolDefinition;
+import io.camunda.connector.agenticai.testutil.TestObjectMapperSupplier;
 import io.camunda.connector.api.document.Document;
 import io.camunda.connector.api.document.DocumentMetadata;
 import io.camunda.connector.api.error.ConnectorException;
+import io.camunda.connector.document.jackson.DocumentReferenceModel.ExternalDocumentReferenceModel;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.List;
@@ -44,8 +45,8 @@ import org.mockito.Mockito;
 
 class GeminiContentRequestConverterTest {
 
-  private final ObjectMapper objectMapper = new ObjectMapper();
-  private final GeminiContentConverter contentConverter = new GeminiContentConverter(objectMapper);
+  private final GeminiContentConverter contentConverter =
+      new GeminiContentConverter(TestObjectMapperSupplier.INSTANCE);
   private final GeminiContentRequestConverter converter =
       new GeminiContentRequestConverter(contentConverter);
 
@@ -63,6 +64,10 @@ class GeminiContentRequestConverterTest {
     Mockito.when(document.metadata()).thenReturn(metadata);
     Mockito.when(metadata.getContentType()).thenReturn(contentType);
     Mockito.when(document.asByteArray()).thenReturn(bytes);
+    // stubbed so a tool-result document (flattened to a JSON reference) can serialize this mock
+    // via JacksonModuleDocumentSerializer, which dispatches on Document#reference()
+    Mockito.when(document.reference())
+        .thenReturn(new ExternalDocumentReferenceModel("https://example.com/document", "document"));
     return document;
   }
 
@@ -436,8 +441,11 @@ class GeminiContentRequestConverterTest {
     assertThat(functionResponse.id()).contains("call-1");
     assertThat(functionResponse.response().orElseThrow()).isEqualTo(Map.of("output", "described"));
 
-    assertThat(parts.get(1).inlineData()).isPresent();
+    // flattened to a JSON reference, not embedded natively - see GeminiContentConverter
+    // #toFunctionResponseParts
     assertThat(parts.get(1).functionResponse()).isEmpty();
+    assertThat(parts.get(1).inlineData()).isEmpty();
+    assertThat(parts.get(1).text()).isPresent();
   }
 
   @Test

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiContentRequestConverterTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiContentRequestConverterTest.java
@@ -28,6 +28,7 @@ import io.camunda.connector.agenticai.aiagent.model.request.v2.GeminiChatModelCo
 import io.camunda.connector.agenticai.aiagent.model.request.v2.GeminiChatModelConfiguration.GeminiModel.GeminiThinking;
 import io.camunda.connector.agenticai.aiagent.model.request.v2.GeminiChatModelConfiguration.GeminiModel.GeminiThinkingLevel;
 import io.camunda.connector.agenticai.aiagent.model.tool.ToolCall;
+import io.camunda.connector.agenticai.aiagent.model.tool.ToolCallResult;
 import io.camunda.connector.agenticai.aiagent.model.tool.ToolCallResultContent;
 import io.camunda.connector.agenticai.aiagent.model.tool.ToolDefinition;
 import io.camunda.connector.agenticai.testutil.TestObjectMapperSupplier;
@@ -482,6 +483,37 @@ class GeminiContentRequestConverterTest {
         .isEqualTo(
             "{\"url\":\"https://example.com/document\",\"name\":\"document\","
                 + "\"camunda.document.type\":\"external\"}");
+  }
+
+  @Test
+  void toolResultWithEmptyContentStillClosesOutTheFunctionCall() {
+    final var snapshot =
+        new ConversationSnapshot(
+            List.of(
+                ToolCallResultMessage.builder()
+                    .results(
+                        List.of(
+                            ToolCallResultContent.builder()
+                                .id("call-1")
+                                .name("noOpTool")
+                                .content(List.of())
+                                .build()))
+                    .build()),
+            List.of());
+
+    final var contents = converter.toContents(snapshot);
+
+    final var parts = contents.get(0).parts().orElseThrow();
+    assertThat(parts).hasSize(1);
+
+    // a null/blank tool result normalizes to an empty content list (ToolCallResultContent
+    // #contentFromObject); without a fallback, that produces no parts at all here, leaving the
+    // preceding functionCall without a correlated response
+    final var functionResponse = parts.get(0).functionResponse().orElseThrow();
+    assertThat(functionResponse.id()).contains("call-1");
+    assertThat(functionResponse.name()).contains("noOpTool");
+    assertThat(functionResponse.response().orElseThrow().get("output"))
+        .isEqualTo(ToolCallResult.CONTENT_NO_RESULT);
   }
 
   @Test

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiContentRequestConverterTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiContentRequestConverterTest.java
@@ -106,7 +106,7 @@ class GeminiContentRequestConverterTest {
   @Test
   void mapsThinkingBudgetOnly() {
     final var parameters =
-        new GeminiModelParameters(null, null, null, null, new GeminiThinking(true, 2048, null));
+        new GeminiModelParameters(null, null, null, null, new GeminiThinking(2048, null));
     final var snapshot = new ConversationSnapshot(List.of(), List.of());
 
     final var config = converter.toGenerateContentConfig(model(parameters), null, snapshot);
@@ -122,7 +122,7 @@ class GeminiContentRequestConverterTest {
   void mapsThinkingLevelOnly() {
     final var parameters =
         new GeminiModelParameters(
-            null, null, null, null, new GeminiThinking(true, null, GeminiThinkingLevel.HIGH));
+            null, null, null, null, new GeminiThinking(null, GeminiThinkingLevel.HIGH));
     final var snapshot = new ConversationSnapshot(List.of(), List.of());
 
     final var config = converter.toGenerateContentConfig(model(parameters), null, snapshot);
@@ -138,7 +138,7 @@ class GeminiContentRequestConverterTest {
   void mapsThinkingLevelMinimal() {
     final var parameters =
         new GeminiModelParameters(
-            null, null, null, null, new GeminiThinking(true, null, GeminiThinkingLevel.MINIMAL));
+            null, null, null, null, new GeminiThinking(null, GeminiThinkingLevel.MINIMAL));
     final var snapshot = new ConversationSnapshot(List.of(), List.of());
 
     final var config = converter.toGenerateContentConfig(model(parameters), null, snapshot);
@@ -148,28 +148,23 @@ class GeminiContentRequestConverterTest {
   }
 
   @Test
-  void mapsUnconfiguredThinkingLevelToExplicitModelDefault() {
+  void modelDefaultLevelWithNoBudgetEmitsNoThinkingConfig() {
     final var parameters =
-        new GeminiModelParameters(null, null, null, null, new GeminiThinking(true, null, null));
+        new GeminiModelParameters(null, null, null, null, new GeminiThinking(null, null));
     final var snapshot = new ConversationSnapshot(List.of(), List.of());
 
     final var config = converter.toGenerateContentConfig(model(parameters), null, snapshot);
 
-    assertThat(config.thinkingConfig()).isPresent();
-    assertThat(config.thinkingConfig().orElseThrow().thinkingBudget()).isEmpty();
-    assertThat(config.thinkingConfig().orElseThrow().thinkingLevel().orElseThrow().toString())
-        .isEqualToIgnoringCase("THINKING_LEVEL_UNSPECIFIED");
-    assertThat(config.thinkingConfig().orElseThrow().includeThoughts()).contains(true);
+    assertThat(config.thinkingConfig()).isEmpty();
   }
 
   @Test
   void bothThinkingBudgetAndLevelSetThrows() {
     // Defensive check: the config record's own @AssertFalse should already prevent this, but the
-    // converter guards it too rather than silently picking one (constructed directly here,
-    // bypassing bean validation, to exercise that defense).
+    // converter guards it too rather than silently picking one.
     final var parameters =
         new GeminiModelParameters(
-            null, null, null, null, new GeminiThinking(true, 2048, GeminiThinkingLevel.HIGH));
+            null, null, null, null, new GeminiThinking(2048, GeminiThinkingLevel.HIGH));
     final var snapshot = new ConversationSnapshot(List.of(), List.of());
 
     assertThatThrownBy(() -> converter.toGenerateContentConfig(model(parameters), null, snapshot))
@@ -180,11 +175,7 @@ class GeminiContentRequestConverterTest {
   void budgetWithModelDefaultLevelDoesNotThrow() {
     final var parameters =
         new GeminiModelParameters(
-            null,
-            null,
-            null,
-            null,
-            new GeminiThinking(true, 2048, GeminiThinkingLevel.MODEL_DEFAULT));
+            null, null, null, null, new GeminiThinking(2048, GeminiThinkingLevel.MODEL_DEFAULT));
     final var snapshot = new ConversationSnapshot(List.of(), List.of());
 
     final var config = converter.toGenerateContentConfig(model(parameters), null, snapshot);
@@ -197,20 +188,6 @@ class GeminiContentRequestConverterTest {
     final var parameters = new GeminiModelParameters(null, null, null, null, null);
     final var snapshot = new ConversationSnapshot(List.of(), List.of());
 
-    final var config = converter.toGenerateContentConfig(model(parameters), null, snapshot);
-
-    assertThat(config.thinkingConfig()).isEmpty();
-  }
-
-  @Test
-  void thinkingNotEnabledEmitsNoThinkingConfigEvenIfBudgetOrLevelSet() {
-    final var parameters =
-        new GeminiModelParameters(
-            null, null, null, null, new GeminiThinking(null, 2048, GeminiThinkingLevel.HIGH));
-    final var snapshot = new ConversationSnapshot(List.of(), List.of());
-
-    // Constructed directly (bypassing bean validation) purely to prove the `enabled` gate is
-    // checked before the mutual-exclusivity check -- an unrealistic combination otherwise.
     final var config = converter.toGenerateContentConfig(model(parameters), null, snapshot);
 
     assertThat(config.thinkingConfig()).isEmpty();

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiContentResponseConverterTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiContentResponseConverterTest.java
@@ -1,0 +1,627 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.agenticai.aiagent.chatmodel.provider.gemini;
+
+import static io.camunda.connector.agenticai.aiagent.chatmodel.provider.gemini.GeminiContentConverter.THOUGHT_SIGNATURE_METADATA_KEY;
+import static io.camunda.connector.agenticai.aiagent.model.request.v2.GeminiChatModelConfiguration.GOOGLE_GEMINI_ID;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.groups.Tuple.tuple;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.genai.types.Blob;
+import com.google.genai.types.BlockedReason;
+import com.google.genai.types.Candidate;
+import com.google.genai.types.Content;
+import com.google.genai.types.FileData;
+import com.google.genai.types.FinishReason;
+import com.google.genai.types.FunctionCall;
+import com.google.genai.types.GenerateContentResponse;
+import com.google.genai.types.GenerateContentResponsePromptFeedback;
+import com.google.genai.types.GenerateContentResponseUsageMetadata;
+import com.google.genai.types.Part;
+import io.camunda.connector.agenticai.aiagent.chatmodel.ChatResult;
+import io.camunda.connector.agenticai.aiagent.model.message.StopReason;
+import io.camunda.connector.agenticai.aiagent.model.message.StopReason.UnknownStopReason;
+import io.camunda.connector.agenticai.aiagent.model.message.content.ProviderContent;
+import io.camunda.connector.agenticai.aiagent.model.message.content.ReasoningContent;
+import io.camunda.connector.agenticai.aiagent.model.message.content.TextContent;
+import io.camunda.connector.agenticai.aiagent.model.tool.ToolCall;
+import io.camunda.connector.agenticai.aiagent.util.AssistantMessageMetadata;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Base64;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ * Response objects are real SDK types built through their AutoValue builders (same approach as
+ * {@code GeminiContentStreamAssemblerTest}), so the fixtures exercise the exact {@code Optional}
+ * shapes a live response has.
+ */
+class GeminiContentResponseConverterTest {
+
+  private static final Duration EXECUTION_TIME = Duration.ofMillis(42);
+  private static final byte[] THOUGHT_SIGNATURE = "signature".getBytes(StandardCharsets.UTF_8);
+  private static final String THOUGHT_SIGNATURE_BASE64 =
+      Base64.getEncoder().encodeToString(THOUGHT_SIGNATURE);
+
+  private final GeminiContentResponseConverter converter = new GeminiContentResponseConverter();
+
+  // ---------------------------------------------------------------------------------------------
+  // content mapping
+  // ---------------------------------------------------------------------------------------------
+
+  @Test
+  void mapsTextPartToTextContentAndStopFinishReasonToStop() {
+    final var response =
+        responseBuilder(candidate(FinishReason.Known.STOP, Part.fromText("Hello there")))
+            .responseId("resp-1")
+            .modelVersion("gemini-3-pro-preview")
+            .usageMetadata(
+                GenerateContentResponseUsageMetadata.builder()
+                    .promptTokenCount(10)
+                    .candidatesTokenCount(20)
+                    .build())
+            .build();
+
+    final var result = converter.toResult(response, EXECUTION_TIME);
+
+    assertThat(result).isInstanceOf(ChatResult.Completed.class);
+
+    final var assistantMessage = result.assistantMessage();
+    assertThat(assistantMessage.content()).containsExactly(TextContent.textContent("Hello there"));
+    assertThat(assistantMessage.toolCalls()).isEmpty();
+    assertThat(assistantMessage.messageId()).isEqualTo("resp-1");
+    assertThat(assistantMessage.modelId()).isEqualTo("gemini-3-pro-preview");
+    assertThat(assistantMessage.stopReason()).isEqualTo(StopReason.STOP);
+    assertThat(assistantMessage.metadata())
+        .containsEntry(GOOGLE_GEMINI_ID, Map.of("finishReason", "STOP"))
+        .containsKey(AssistantMessageMetadata.TIMESTAMP_KEY);
+
+    final var metrics = result.metrics();
+    assertThat(metrics.modelCalls()).isEqualTo(1);
+    assertThat(metrics.toolCalls()).isZero();
+    assertThat(metrics.tokenUsage().inputTokenCount()).isEqualTo(10);
+    assertThat(metrics.tokenUsage().outputTokenCount()).isEqualTo(20);
+    assertThat(metrics.executionTime()).isEqualTo(EXECUTION_TIME);
+  }
+
+  @Test
+  void mapsPartsWithoutAKnownShapeToProviderContentPreservingOrder() {
+    final var fileDataPart =
+        Part.builder()
+            .fileData(FileData.builder().fileUri("gs://bucket/chart.png").mimeType("image/png"))
+            .build();
+
+    final var response =
+        response(
+            candidate(
+                FinishReason.Known.STOP,
+                Part.fromText("before"),
+                fileDataPart,
+                Part.fromText("after")));
+
+    final var assistantMessage = converter.toAssistantMessage(response);
+
+    assertThat(assistantMessage.content())
+        .containsExactly(
+            TextContent.textContent("before"),
+            new ProviderContent(
+                GOOGLE_GEMINI_ID,
+                Map.of(
+                    "fileData",
+                    Map.of("fileUri", "gs://bucket/chart.png", "mimeType", "image/png")),
+                null),
+            TextContent.textContent("after"));
+  }
+
+  @Test
+  void preservesABinaryProviderPartLosslesslyAcrossTheRoundTrip() {
+    // Binary part data stays a byte[] inside the ProviderContent payload (Jackson's convertValue
+    // does not base64-encode it); what matters is that the request converter rebuilds the identical
+    // Part from it, whether the payload was JSON-persisted in between or not.
+    final var inlineDataPart =
+        Part.builder()
+            .inlineData(
+                Blob.builder()
+                    .data("image-bytes".getBytes(StandardCharsets.UTF_8))
+                    .mimeType("image/png"))
+            .build();
+
+    final var content =
+        converter
+            .toAssistantMessage(response(candidate(FinishReason.Known.STOP, inlineDataPart)))
+            .content();
+
+    assertThat(content).singleElement().isInstanceOf(ProviderContent.class);
+    assertThat(new GeminiContentConverter(new ObjectMapper()).toParts(content))
+        .singleElement()
+        .satisfies(
+            part -> {
+              final var blob = part.inlineData().orElseThrow();
+              assertThat(blob.mimeType()).contains("image/png");
+              assertThat(blob.data().orElseThrow())
+                  .isEqualTo("image-bytes".getBytes(StandardCharsets.UTF_8));
+            });
+  }
+
+  @Test
+  void mapsCandidateWithoutContentToAnEmptyMessage() {
+    // The real shape of a SAFETY-filtered (and of some MAX_TOKENS) candidate: no content at all.
+    final var response =
+        response(Candidate.builder().finishReason(FinishReason.Known.SAFETY).build());
+
+    final var assistantMessage = converter.toAssistantMessage(response);
+
+    assertThat(assistantMessage.content()).isEmpty();
+    assertThat(assistantMessage.toolCalls()).isEmpty();
+    assertThat(assistantMessage.stopReason()).isEqualTo(StopReason.CONTENT_FILTERED);
+  }
+
+  @Test
+  void convertsAFilteredResponseTheSdkConvenienceAccessorsRefuseToRead() {
+    final var response =
+        response(candidate(FinishReason.Known.SAFETY, Part.fromText("partial answer")));
+
+    // Guards the reason this converter reads candidates().get(0).content().parts() directly:
+    // GenerateContentResponse#parts()/text()/functionCalls() call checkFinishReason() internally,
+    // which throws for every finish reason outside {UNSPECIFIED, STOP, MAX_TOKENS}.
+    assertThatThrownBy(response::parts).isInstanceOf(IllegalArgumentException.class);
+
+    final var assistantMessage = converter.toAssistantMessage(response);
+
+    assertThat(assistantMessage.content())
+        .containsExactly(TextContent.textContent("partial answer"));
+    assertThat(assistantMessage.stopReason()).isEqualTo(StopReason.CONTENT_FILTERED);
+  }
+
+  // ---------------------------------------------------------------------------------------------
+  // tool calls
+  // ---------------------------------------------------------------------------------------------
+
+  @Test
+  void mapsFunctionCallToToolCallAndOverridesStopWithToolUse() {
+    // Gemini reports finishReason STOP even when the candidate contains function calls.
+    final var response =
+        response(
+            candidate(
+                FinishReason.Known.STOP,
+                Part.fromText("Checking the weather"),
+                functionCallPart("call-1", "get_weather", Map.of("city", "Berlin"))));
+
+    final var result = converter.toResult(response, EXECUTION_TIME);
+    final var assistantMessage = result.assistantMessage();
+
+    assertThat(assistantMessage.toolCalls())
+        .containsExactly(new ToolCall("call-1", "get_weather", Map.of("city", "Berlin")));
+    assertThat(assistantMessage.content())
+        .containsExactly(TextContent.textContent("Checking the weather"));
+    assertThat(assistantMessage.stopReason()).isEqualTo(StopReason.TOOL_USE);
+    // the raw vendor finish reason is preserved unchanged, independent of the override
+    assertThat(assistantMessage.metadata())
+        .containsEntry(GOOGLE_GEMINI_ID, Map.of("finishReason", "STOP"));
+    assertThat(result.metrics().toolCalls()).isEqualTo(1);
+  }
+
+  @Test
+  void derivesToolUseEvenWithoutAFinishReason() {
+    final var response =
+        response(
+            Candidate.builder().content(contentOf(functionCallPart(null, "now", null))).build());
+
+    assertThat(converter.toAssistantMessage(response).stopReason()).isEqualTo(StopReason.TOOL_USE);
+  }
+
+  @Test
+  void synthesizesDistinctToolCallIdsWhenTheResponseCarriesNone() {
+    // Gemini's Developer API routinely omits FunctionCall.id, including for parallel calls to the
+    // same function - the synthesized ids must still be distinct so the agent loop can correlate
+    // each result back to its own call.
+    final var response =
+        response(
+            candidate(
+                FinishReason.Known.STOP,
+                functionCallPart(null, "get_weather", Map.of("city", "Berlin")),
+                functionCallPart(null, "get_weather", Map.of("city", "Hamburg"))));
+
+    final var toolCalls = converter.toAssistantMessage(response).toolCalls();
+
+    assertThat(toolCalls).hasSize(2);
+    assertThat(toolCalls).extracting(ToolCall::id).doesNotContainNull().doesNotHaveDuplicates();
+    assertThat(toolCalls)
+        .extracting(ToolCall::name, ToolCall::arguments)
+        .containsExactly(
+            tuple("get_weather", Map.of("city", "Berlin")),
+            tuple("get_weather", Map.of("city", "Hamburg")));
+  }
+
+  @Test
+  void mapsFunctionCallWithoutArgumentsToEmptyArguments() {
+    final var response =
+        response(candidate(FinishReason.Known.STOP, functionCallPart("call-1", "now", null)));
+
+    assertThat(converter.toAssistantMessage(response).toolCalls())
+        .containsExactly(new ToolCall("call-1", "now", Map.of()));
+  }
+
+  @Test
+  void keepsAFunctionCallWithoutANameAsProviderContentRatherThanAnUnexecutableToolCall() {
+    final var response =
+        response(
+            candidate(
+                FinishReason.Known.STOP,
+                Part.builder().functionCall(FunctionCall.builder().args(Map.of("a", 1))).build()));
+
+    final var assistantMessage = converter.toAssistantMessage(response);
+
+    assertThat(assistantMessage.toolCalls()).isEmpty();
+    assertThat(assistantMessage.content()).singleElement().isInstanceOf(ProviderContent.class);
+    // no executable tool call -> no TOOL_USE override
+    assertThat(assistantMessage.stopReason()).isEqualTo(StopReason.STOP);
+  }
+
+  @Test
+  void preservesAThoughtSignatureCarriedOnAFunctionCallPart() {
+    final var part =
+        functionCallPart("call-1", "get_weather", Map.of("city", "Berlin")).toBuilder()
+            .thoughtSignature(THOUGHT_SIGNATURE)
+            .build();
+
+    final var toolCalls =
+        converter
+            .toAssistantMessage(response(candidate(FinishReason.Known.STOP, part)))
+            .toolCalls();
+
+    assertThat(toolCalls)
+        .singleElement()
+        .satisfies(
+            toolCall ->
+                assertThat(toolCall.metadata())
+                    .isEqualTo(
+                        Map.of(
+                            GOOGLE_GEMINI_ID,
+                            Map.of(THOUGHT_SIGNATURE_METADATA_KEY, THOUGHT_SIGNATURE_BASE64))));
+  }
+
+  // ---------------------------------------------------------------------------------------------
+  // reasoning
+  // ---------------------------------------------------------------------------------------------
+
+  @Test
+  void mapsThoughtPartToReasoningContentLiftingTextAndSignature() {
+    final var thoughtPart =
+        Part.builder()
+            .thought(true)
+            .text("Let me think it through")
+            .thoughtSignature(THOUGHT_SIGNATURE)
+            .build();
+
+    final var assistantMessage =
+        converter.toAssistantMessage(
+            response(candidate(FinishReason.Known.STOP, thoughtPart, Part.fromText("the answer"))));
+
+    assertThat(assistantMessage.content())
+        .containsExactly(
+            new ReasoningContent(
+                GOOGLE_GEMINI_ID,
+                Map.of("thought", true),
+                "Let me think it through",
+                Map.of(THOUGHT_SIGNATURE_METADATA_KEY, THOUGHT_SIGNATURE_BASE64)),
+            TextContent.textContent("the answer"));
+  }
+
+  @Test
+  void writesAThoughtSignatureTheRequestConverterReadsBackVerbatim() {
+    final var thoughtPart =
+        Part.builder()
+            .thought(true)
+            .text("Let me think it through")
+            .thoughtSignature(THOUGHT_SIGNATURE)
+            .build();
+
+    final var content =
+        converter
+            .toAssistantMessage(response(candidate(FinishReason.Known.STOP, thoughtPart)))
+            .content();
+
+    // Round trip through the request-direction converter: same metadata key, same base64 alphabet.
+    final var replayed = new GeminiContentConverter(new ObjectMapper()).toParts(content);
+
+    assertThat(replayed)
+        .singleElement()
+        .satisfies(
+            part -> {
+              assertThat(part.thought()).contains(true);
+              assertThat(part.text()).contains("Let me think it through");
+              assertThat(part.thoughtSignature()).contains(THOUGHT_SIGNATURE);
+            });
+  }
+
+  @Test
+  void mapsThoughtPartWithoutTextToReasoningContentWithoutText() {
+    final var thoughtPart =
+        Part.builder().thought(true).thoughtSignature(THOUGHT_SIGNATURE).build();
+
+    assertThat(
+            converter
+                .toAssistantMessage(response(candidate(FinishReason.Known.STOP, thoughtPart)))
+                .content())
+        .containsExactly(
+            new ReasoningContent(
+                GOOGLE_GEMINI_ID,
+                Map.of("thought", true),
+                null,
+                Map.of(THOUGHT_SIGNATURE_METADATA_KEY, THOUGHT_SIGNATURE_BASE64)));
+  }
+
+  @Test
+  void mapsThoughtPartWithoutSignatureToReasoningContentWithoutMetadata() {
+    final var thoughtPart = Part.builder().thought(true).text("thinking").build();
+
+    assertThat(
+            converter
+                .toAssistantMessage(response(candidate(FinishReason.Known.STOP, thoughtPart)))
+                .content())
+        .containsExactly(
+            new ReasoningContent(GOOGLE_GEMINI_ID, Map.of("thought", true), "thinking", null));
+  }
+
+  // ---------------------------------------------------------------------------------------------
+  // finish reason mapping
+  // ---------------------------------------------------------------------------------------------
+
+  @Test
+  void mapsMaxTokensToLength() {
+    final var response =
+        response(candidate(FinishReason.Known.MAX_TOKENS, Part.fromText("cut off")));
+
+    final var result = converter.toResult(response, EXECUTION_TIME);
+
+    assertThat(result).isInstanceOf(ChatResult.Completed.class);
+    assertThat(result.assistantMessage().stopReason()).isEqualTo(StopReason.LENGTH);
+    assertThat(result.assistantMessage().metadata())
+        .containsEntry(GOOGLE_GEMINI_ID, Map.of("finishReason", "MAX_TOKENS"));
+  }
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "SAFETY",
+        "RECITATION",
+        "BLOCKLIST",
+        "PROHIBITED_CONTENT",
+        "SPII",
+        "IMAGE_SAFETY",
+        "IMAGE_PROHIBITED_CONTENT",
+        "IMAGE_RECITATION"
+      })
+  void mapsFilteringFinishReasonsToContentFiltered(String finishReason) {
+    final var response =
+        response(
+            Candidate.builder()
+                .finishReason(finishReason)
+                .content(contentOf(Part.fromText("filtered")))
+                .build());
+
+    final var result = converter.toResult(response, EXECUTION_TIME);
+
+    assertThat(result.assistantMessage().stopReason()).isEqualTo(StopReason.CONTENT_FILTERED);
+    assertThat(result.assistantMessage().metadata())
+        .containsEntry(GOOGLE_GEMINI_ID, Map.of("finishReason", finishReason));
+  }
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "LANGUAGE",
+        "OTHER",
+        "MALFORMED_FUNCTION_CALL",
+        "UNEXPECTED_TOOL_CALL",
+        "NO_IMAGE",
+        "SOME_FUTURE_VENDOR_FINISH_REASON"
+      })
+  void mapsEveryOtherFinishReasonToUnknownStopReasonCarryingTheRawValue(String finishReason) {
+    final var response =
+        response(
+            Candidate.builder()
+                .finishReason(finishReason)
+                .content(contentOf(Part.fromText("??")))
+                .build());
+
+    final var result = converter.toResult(response, EXECUTION_TIME);
+
+    assertThat(result).isInstanceOf(ChatResult.Completed.class);
+    assertThat(result.assistantMessage().stopReason())
+        .isEqualTo(new UnknownStopReason(finishReason));
+    assertThat(result.assistantMessage().metadata())
+        .containsEntry(GOOGLE_GEMINI_ID, Map.of("finishReason", finishReason));
+  }
+
+  @Test
+  void stampsTimestampMetadataEvenWithoutAFinishReason() {
+    final var response =
+        response(Candidate.builder().content(contentOf(Part.fromText("partial answer"))).build());
+
+    final var assistantMessage = converter.toAssistantMessage(response);
+
+    assertThat(assistantMessage.stopReason()).isNull();
+    assertThat(assistantMessage.metadata())
+        .containsOnlyKeys(AssistantMessageMetadata.TIMESTAMP_KEY);
+  }
+
+  // ---------------------------------------------------------------------------------------------
+  // blocked prompt
+  // ---------------------------------------------------------------------------------------------
+
+  @Test
+  void mapsABlockedPromptToContentFilteredCarryingAnExplanation() {
+    // A blocked prompt yields promptFeedback and NO candidates at all (absent Optional).
+    final var response =
+        GenerateContentResponse.builder()
+            .responseId("resp-blocked")
+            .modelVersion("gemini-3-pro-preview")
+            .promptFeedback(
+                GenerateContentResponsePromptFeedback.builder()
+                    .blockReason(BlockedReason.Known.SAFETY)
+                    .build())
+            .usageMetadata(
+                GenerateContentResponseUsageMetadata.builder().promptTokenCount(7).build())
+            .build();
+
+    final var result = converter.toResult(response, EXECUTION_TIME);
+
+    assertThat(result).isInstanceOf(ChatResult.Completed.class);
+
+    final var assistantMessage = result.assistantMessage();
+    assertThat(assistantMessage.content())
+        .containsExactly(TextContent.textContent("Prompt blocked: SAFETY"));
+    assertThat(assistantMessage.toolCalls()).isEmpty();
+    assertThat(assistantMessage.stopReason()).isEqualTo(StopReason.CONTENT_FILTERED);
+    assertThat(assistantMessage.messageId()).isEqualTo("resp-blocked");
+    assertThat(assistantMessage.modelId()).isEqualTo("gemini-3-pro-preview");
+    assertThat(assistantMessage.metadata())
+        .containsEntry(GOOGLE_GEMINI_ID, Map.of("blockReason", "SAFETY"))
+        .containsKey(AssistantMessageMetadata.TIMESTAMP_KEY);
+
+    assertThat(result.metrics().tokenUsage().inputTokenCount()).isEqualTo(7);
+    assertThat(result.metrics().modelCalls()).isEqualTo(1);
+    assertThat(result.metrics().toolCalls()).isZero();
+  }
+
+  @Test
+  void treatsAnEmptyCandidateListLikeAnAbsentOne() {
+    final var response =
+        GenerateContentResponse.builder()
+            .candidates(List.of())
+            .promptFeedback(
+                GenerateContentResponsePromptFeedback.builder()
+                    .blockReason(BlockedReason.Known.PROHIBITED_CONTENT)
+                    .build())
+            .build();
+
+    final var assistantMessage = converter.toAssistantMessage(response);
+
+    assertThat(assistantMessage.content())
+        .containsExactly(TextContent.textContent("Prompt blocked: PROHIBITED_CONTENT"));
+    assertThat(assistantMessage.stopReason()).isEqualTo(StopReason.CONTENT_FILTERED);
+  }
+
+  @Test
+  void explainsAResponseWithoutCandidatesEvenWithoutABlockReason() {
+    final var response = GenerateContentResponse.builder().build();
+
+    final var assistantMessage = converter.toAssistantMessage(response);
+
+    assertThat(assistantMessage.content())
+        .containsExactly(TextContent.textContent("Prompt blocked (no block reason reported)"));
+    assertThat(assistantMessage.stopReason()).isEqualTo(StopReason.CONTENT_FILTERED);
+    assertThat(assistantMessage.metadata())
+        .containsOnlyKeys(AssistantMessageMetadata.TIMESTAMP_KEY);
+  }
+
+  // ---------------------------------------------------------------------------------------------
+  // metrics
+  // ---------------------------------------------------------------------------------------------
+
+  @Test
+  void mapsUsageMetadataIncludingImplicitCacheReadsAndThoughtTokens() {
+    final var response =
+        responseBuilder(candidate(FinishReason.Known.STOP, Part.fromText("ok")))
+            .usageMetadata(
+                GenerateContentResponseUsageMetadata.builder()
+                    .promptTokenCount(100)
+                    .candidatesTokenCount(50)
+                    .cachedContentTokenCount(3)
+                    .thoughtsTokenCount(5)
+                    .totalTokenCount(158)
+                    .build())
+            .build();
+
+    final var tokenUsage = converter.toResult(response, EXECUTION_TIME).metrics().tokenUsage();
+
+    assertThat(tokenUsage.inputTokenCount()).isEqualTo(100);
+    assertThat(tokenUsage.outputTokenCount()).isEqualTo(50);
+    assertThat(tokenUsage.cacheReadTokenCount()).isEqualTo(3);
+    assertThat(tokenUsage.reasoningTokenCount()).isEqualTo(5);
+    // Gemini's implicit caching reports reads only; there is no cache-write counter to map.
+    assertThat(tokenUsage.cacheCreationTokenCount()).isZero();
+  }
+
+  @Test
+  void defaultsEveryTokenCountToZeroWhenUsageMetadataIsMissing() {
+    final var response = response(candidate(FinishReason.Known.STOP, Part.fromText("ok")));
+
+    final var tokenUsage = converter.toResult(response, EXECUTION_TIME).metrics().tokenUsage();
+
+    assertThat(tokenUsage.inputTokenCount()).isZero();
+    assertThat(tokenUsage.outputTokenCount()).isZero();
+    assertThat(tokenUsage.cacheReadTokenCount()).isZero();
+    assertThat(tokenUsage.cacheCreationTokenCount()).isZero();
+    assertThat(tokenUsage.reasoningTokenCount()).isZero();
+  }
+
+  @Test
+  void defaultsPartiallyReportedTokenCountsToZero() {
+    final var response =
+        responseBuilder(candidate(FinishReason.Known.STOP, Part.fromText("ok")))
+            .usageMetadata(
+                GenerateContentResponseUsageMetadata.builder().promptTokenCount(11).build())
+            .build();
+
+    final var tokenUsage = converter.toResult(response, EXECUTION_TIME).metrics().tokenUsage();
+
+    assertThat(tokenUsage.inputTokenCount()).isEqualTo(11);
+    assertThat(tokenUsage.outputTokenCount()).isZero();
+    assertThat(tokenUsage.cacheReadTokenCount()).isZero();
+    assertThat(tokenUsage.reasoningTokenCount()).isZero();
+  }
+
+  @Test
+  void leavesMessageIdAndModelIdUnsetWhenTheResponseDoesNotReportThem() {
+    final var response = response(candidate(FinishReason.Known.STOP, Part.fromText("ok")));
+
+    final var assistantMessage = converter.toAssistantMessage(response);
+
+    assertThat(assistantMessage.messageId()).isNull();
+    assertThat(assistantMessage.modelId()).isNull();
+  }
+
+  // ---------------------------------------------------------------------------------------------
+  // fixtures
+  // ---------------------------------------------------------------------------------------------
+
+  private static GenerateContentResponse response(Candidate candidate) {
+    return responseBuilder(candidate).build();
+  }
+
+  private static GenerateContentResponse.Builder responseBuilder(Candidate candidate) {
+    return GenerateContentResponse.builder().candidates(List.of(candidate));
+  }
+
+  private static Candidate candidate(FinishReason.Known finishReason, Part... parts) {
+    return Candidate.builder().finishReason(finishReason).content(contentOf(parts)).build();
+  }
+
+  private static Content contentOf(Part... parts) {
+    return Content.builder().role("model").parts(List.of(parts)).build();
+  }
+
+  private static Part functionCallPart(String id, String name, Map<String, Object> args) {
+    final var functionCall = FunctionCall.builder().name(name);
+    if (id != null) {
+      functionCall.id(id);
+    }
+    if (args != null) {
+      functionCall.args(args);
+    }
+    return Part.builder().functionCall(functionCall).build();
+  }
+}

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiContentResponseConverterTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiContentResponseConverterTest.java
@@ -25,6 +25,7 @@ import com.google.genai.types.GenerateContentResponsePromptFeedback;
 import com.google.genai.types.GenerateContentResponseUsageMetadata;
 import com.google.genai.types.Part;
 import io.camunda.connector.agenticai.aiagent.chatmodel.ChatResult;
+import io.camunda.connector.agenticai.aiagent.chatmodel.ContentFilteredException;
 import io.camunda.connector.agenticai.aiagent.model.message.StopReason;
 import io.camunda.connector.agenticai.aiagent.model.message.StopReason.UnknownStopReason;
 import io.camunda.connector.agenticai.aiagent.model.message.content.ProviderContent;
@@ -476,7 +477,7 @@ class GeminiContentResponseConverterTest {
         "IMAGE_PROHIBITED_CONTENT",
         "IMAGE_RECITATION"
       })
-  void mapsFilteringFinishReasonsToContentFiltered(String finishReason) {
+  void throwsContentFilteredExceptionForFilteringFinishReasons(String finishReason) {
     final var response =
         response(
             Candidate.builder()
@@ -484,11 +485,32 @@ class GeminiContentResponseConverterTest {
                 .content(contentOf(Part.fromText("filtered")))
                 .build());
 
-    final var result = converter.toResult(response, EXECUTION_TIME);
+    assertThatThrownBy(() -> converter.toResult(response, EXECUTION_TIME))
+        .isInstanceOf(ContentFilteredException.class)
+        .extracting(e -> ((ContentFilteredException) e).partialResult())
+        .satisfies(
+            partialResult -> {
+              assertThat(partialResult).isNotNull();
+              final var assistantMessage = partialResult.assistantMessage();
+              assertThat(assistantMessage.stopReason()).isEqualTo(StopReason.CONTENT_FILTERED);
+              assertThat(assistantMessage.metadata())
+                  .containsEntry(GOOGLE_GEMINI_ID, Map.of("finishReason", finishReason));
+            });
+  }
 
-    assertThat(result.assistantMessage().stopReason()).isEqualTo(StopReason.CONTENT_FILTERED);
-    assertThat(result.assistantMessage().metadata())
-        .containsEntry(GOOGLE_GEMINI_ID, Map.of("finishReason", finishReason));
+  @Test
+  void throwsContentFilteredExceptionEvenWhenTheFilteredCandidateAlsoCarriesToolCalls() {
+    // Gemini always reports its real finish reason even when the candidate carries functionCall
+    // parts; a filtered-and-tool-calling response must not lose CONTENT_FILTERED to the TOOL_USE
+    // override applied elsewhere.
+    final var response =
+        response(
+            candidate(
+                FinishReason.Known.SAFETY,
+                functionCallPart("call-1", "get_weather", Map.of("city", "Berlin"))));
+
+    assertThatThrownBy(() -> converter.toResult(response, EXECUTION_TIME))
+        .isInstanceOf(ContentFilteredException.class);
   }
 
   @ParameterizedTest
@@ -535,7 +557,7 @@ class GeminiContentResponseConverterTest {
   // ---------------------------------------------------------------------------------------------
 
   @Test
-  void mapsABlockedPromptToContentFilteredCarryingAnExplanation() {
+  void throwsContentFilteredExceptionForABlockedPromptCarryingAnExplanation() {
     // A blocked prompt yields promptFeedback and NO candidates at all (absent Optional).
     final var response =
         GenerateContentResponse.builder()
@@ -549,24 +571,28 @@ class GeminiContentResponseConverterTest {
                 GenerateContentResponseUsageMetadata.builder().promptTokenCount(7).build())
             .build();
 
-    final var result = converter.toResult(response, EXECUTION_TIME);
+    assertThatThrownBy(() -> converter.toResult(response, EXECUTION_TIME))
+        .isInstanceOf(ContentFilteredException.class)
+        .extracting(e -> ((ContentFilteredException) e).partialResult())
+        .satisfies(
+            partialResult -> {
+              assertThat(partialResult).isNotNull();
+              final var assistantMessage = partialResult.assistantMessage();
+              assertThat(assistantMessage.content())
+                  .containsExactly(TextContent.textContent("Prompt blocked: SAFETY"));
+              assertThat(assistantMessage.toolCalls()).isEmpty();
+              assertThat(assistantMessage.stopReason()).isEqualTo(StopReason.CONTENT_FILTERED);
+              assertThat(assistantMessage.messageId()).isEqualTo("resp-blocked");
+              assertThat(assistantMessage.modelId()).isEqualTo("gemini-3-pro-preview");
+              assertThat(assistantMessage.metadata())
+                  .containsEntry(GOOGLE_GEMINI_ID, Map.of("blockReason", "SAFETY"))
+                  .containsKey(AssistantMessageMetadata.TIMESTAMP_KEY);
 
-    assertThat(result).isInstanceOf(ChatResult.Completed.class);
-
-    final var assistantMessage = result.assistantMessage();
-    assertThat(assistantMessage.content())
-        .containsExactly(TextContent.textContent("Prompt blocked: SAFETY"));
-    assertThat(assistantMessage.toolCalls()).isEmpty();
-    assertThat(assistantMessage.stopReason()).isEqualTo(StopReason.CONTENT_FILTERED);
-    assertThat(assistantMessage.messageId()).isEqualTo("resp-blocked");
-    assertThat(assistantMessage.modelId()).isEqualTo("gemini-3-pro-preview");
-    assertThat(assistantMessage.metadata())
-        .containsEntry(GOOGLE_GEMINI_ID, Map.of("blockReason", "SAFETY"))
-        .containsKey(AssistantMessageMetadata.TIMESTAMP_KEY);
-
-    assertThat(result.metrics().tokenUsage().inputTokenCount()).isEqualTo(7);
-    assertThat(result.metrics().modelCalls()).isEqualTo(1);
-    assertThat(result.metrics().toolCalls()).isZero();
+              final var metrics = partialResult.metrics();
+              assertThat(metrics.tokenUsage().inputTokenCount()).isEqualTo(7);
+              assertThat(metrics.modelCalls()).isEqualTo(1);
+              assertThat(metrics.toolCalls()).isZero();
+            });
   }
 
   @Test

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiContentResponseConverterTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiContentResponseConverterTest.java
@@ -110,7 +110,7 @@ class GeminiContentResponseConverterTest {
                 fileDataPart,
                 Part.fromText("after")));
 
-    final var assistantMessage = converter.toAssistantMessage(response);
+    final var assistantMessage = converter.toResult(response, EXECUTION_TIME).assistantMessage();
 
     assertThat(assistantMessage.content())
         .containsExactly(
@@ -139,7 +139,8 @@ class GeminiContentResponseConverterTest {
 
     final var content =
         converter
-            .toAssistantMessage(response(candidate(FinishReason.Known.STOP, inlineDataPart)))
+            .toResult(response(candidate(FinishReason.Known.STOP, inlineDataPart)), EXECUTION_TIME)
+            .assistantMessage()
             .content();
 
     assertThat(content).singleElement().isInstanceOf(ProviderContent.class);
@@ -164,7 +165,8 @@ class GeminiContentResponseConverterTest {
 
     final var content =
         converter
-            .toAssistantMessage(response(candidate(FinishReason.Known.STOP, textPart)))
+            .toResult(response(candidate(FinishReason.Known.STOP, textPart)), EXECUTION_TIME)
+            .assistantMessage()
             .content();
 
     assertThat(content)
@@ -180,7 +182,8 @@ class GeminiContentResponseConverterTest {
 
     final var content =
         converter
-            .toAssistantMessage(response(candidate(FinishReason.Known.STOP, textPart)))
+            .toResult(response(candidate(FinishReason.Known.STOP, textPart)), EXECUTION_TIME)
+            .assistantMessage()
             .content();
 
     assertThat(new GeminiContentConverter(new ObjectMapper()).toParts(content))
@@ -205,7 +208,7 @@ class GeminiContentResponseConverterTest {
                 Part.fromText("   "),
                 Part.fromText("the answer")));
 
-    final var assistantMessage = converter.toAssistantMessage(response);
+    final var assistantMessage = converter.toResult(response, EXECUTION_TIME).assistantMessage();
 
     assertThat(assistantMessage.content()).containsExactly(TextContent.textContent("the answer"));
   }
@@ -218,7 +221,9 @@ class GeminiContentResponseConverterTest {
 
     final var content =
         converter
-            .toAssistantMessage(response(candidate(FinishReason.Known.STOP, signatureOnlyPart)))
+            .toResult(
+                response(candidate(FinishReason.Known.STOP, signatureOnlyPart)), EXECUTION_TIME)
+            .assistantMessage()
             .content();
 
     assertThat(content).singleElement().isInstanceOf(ProviderContent.class);
@@ -233,11 +238,16 @@ class GeminiContentResponseConverterTest {
     final var response =
         response(Candidate.builder().finishReason(FinishReason.Known.SAFETY).build());
 
-    final var assistantMessage = converter.toAssistantMessage(response);
-
-    assertThat(assistantMessage.content()).isEmpty();
-    assertThat(assistantMessage.toolCalls()).isEmpty();
-    assertThat(assistantMessage.stopReason()).isEqualTo(new UnknownStopReason("SAFETY"));
+    assertThatThrownBy(() -> converter.toResult(response, EXECUTION_TIME))
+        .isInstanceOf(ContentFilteredException.class)
+        .extracting(e -> ((ContentFilteredException) e).partialResult())
+        .satisfies(
+            partialResult -> {
+              final var assistantMessage = partialResult.assistantMessage();
+              assertThat(assistantMessage.content()).isEmpty();
+              assertThat(assistantMessage.toolCalls()).isEmpty();
+              assertThat(assistantMessage.stopReason()).isEqualTo(new UnknownStopReason("SAFETY"));
+            });
   }
 
   @Test
@@ -250,11 +260,16 @@ class GeminiContentResponseConverterTest {
     // which throws for every finish reason outside {UNSPECIFIED, STOP, MAX_TOKENS}.
     assertThatThrownBy(response::parts).isInstanceOf(IllegalArgumentException.class);
 
-    final var assistantMessage = converter.toAssistantMessage(response);
-
-    assertThat(assistantMessage.content())
-        .containsExactly(TextContent.textContent("partial answer"));
-    assertThat(assistantMessage.stopReason()).isEqualTo(new UnknownStopReason("SAFETY"));
+    assertThatThrownBy(() -> converter.toResult(response, EXECUTION_TIME))
+        .isInstanceOf(ContentFilteredException.class)
+        .extracting(e -> ((ContentFilteredException) e).partialResult())
+        .satisfies(
+            partialResult -> {
+              final var assistantMessage = partialResult.assistantMessage();
+              assertThat(assistantMessage.content())
+                  .containsExactly(TextContent.textContent("partial answer"));
+              assertThat(assistantMessage.stopReason()).isEqualTo(new UnknownStopReason("SAFETY"));
+            });
   }
 
   // ---------------------------------------------------------------------------------------------
@@ -291,7 +306,8 @@ class GeminiContentResponseConverterTest {
         response(
             Candidate.builder().content(contentOf(functionCallPart(null, "now", null))).build());
 
-    assertThat(converter.toAssistantMessage(response).stopReason()).isEqualTo(StopReason.TOOL_USE);
+    assertThat(converter.toResult(response, EXECUTION_TIME).assistantMessage().stopReason())
+        .isEqualTo(StopReason.TOOL_USE);
   }
 
   @Test
@@ -306,7 +322,8 @@ class GeminiContentResponseConverterTest {
                 functionCallPart(null, "get_weather", Map.of("city", "Berlin")),
                 functionCallPart(null, "get_weather", Map.of("city", "Hamburg"))));
 
-    final var toolCalls = converter.toAssistantMessage(response).toolCalls();
+    final var toolCalls =
+        converter.toResult(response, EXECUTION_TIME).assistantMessage().toolCalls();
 
     assertThat(toolCalls).hasSize(2);
     assertThat(toolCalls).extracting(ToolCall::id).doesNotContainNull().doesNotHaveDuplicates();
@@ -322,7 +339,7 @@ class GeminiContentResponseConverterTest {
     final var response =
         response(candidate(FinishReason.Known.STOP, functionCallPart("call-1", "now", null)));
 
-    assertThat(converter.toAssistantMessage(response).toolCalls())
+    assertThat(converter.toResult(response, EXECUTION_TIME).assistantMessage().toolCalls())
         .containsExactly(new ToolCall("call-1", "now", Map.of()));
   }
 
@@ -334,7 +351,7 @@ class GeminiContentResponseConverterTest {
                 FinishReason.Known.STOP,
                 Part.builder().functionCall(FunctionCall.builder().args(Map.of("a", 1))).build()));
 
-    final var assistantMessage = converter.toAssistantMessage(response);
+    final var assistantMessage = converter.toResult(response, EXECUTION_TIME).assistantMessage();
 
     assertThat(assistantMessage.toolCalls()).isEmpty();
     assertThat(assistantMessage.content()).singleElement().isInstanceOf(ProviderContent.class);
@@ -351,7 +368,8 @@ class GeminiContentResponseConverterTest {
 
     final var toolCalls =
         converter
-            .toAssistantMessage(response(candidate(FinishReason.Known.STOP, part)))
+            .toResult(response(candidate(FinishReason.Known.STOP, part)), EXECUTION_TIME)
+            .assistantMessage()
             .toolCalls();
 
     assertThat(toolCalls)
@@ -379,8 +397,12 @@ class GeminiContentResponseConverterTest {
             .build();
 
     final var assistantMessage =
-        converter.toAssistantMessage(
-            response(candidate(FinishReason.Known.STOP, thoughtPart, Part.fromText("the answer"))));
+        converter
+            .toResult(
+                response(
+                    candidate(FinishReason.Known.STOP, thoughtPart, Part.fromText("the answer"))),
+                EXECUTION_TIME)
+            .assistantMessage();
 
     assertThat(assistantMessage.content())
         .containsExactly(
@@ -403,7 +425,8 @@ class GeminiContentResponseConverterTest {
 
     final var content =
         converter
-            .toAssistantMessage(response(candidate(FinishReason.Known.STOP, thoughtPart)))
+            .toResult(response(candidate(FinishReason.Known.STOP, thoughtPart)), EXECUTION_TIME)
+            .assistantMessage()
             .content();
 
     // Round trip through the request-direction converter: same metadata key, same base64 alphabet.
@@ -426,7 +449,8 @@ class GeminiContentResponseConverterTest {
 
     assertThat(
             converter
-                .toAssistantMessage(response(candidate(FinishReason.Known.STOP, thoughtPart)))
+                .toResult(response(candidate(FinishReason.Known.STOP, thoughtPart)), EXECUTION_TIME)
+                .assistantMessage()
                 .content())
         .containsExactly(
             new ReasoningContent(
@@ -442,7 +466,8 @@ class GeminiContentResponseConverterTest {
 
     assertThat(
             converter
-                .toAssistantMessage(response(candidate(FinishReason.Known.STOP, thoughtPart)))
+                .toResult(response(candidate(FinishReason.Known.STOP, thoughtPart)), EXECUTION_TIME)
+                .assistantMessage()
                 .content())
         .containsExactly(
             new ReasoningContent(GOOGLE_GEMINI_ID, Map.of("thought", true), "thinking", null));
@@ -544,7 +569,7 @@ class GeminiContentResponseConverterTest {
     final var response =
         response(Candidate.builder().content(contentOf(Part.fromText("partial answer"))).build());
 
-    final var assistantMessage = converter.toAssistantMessage(response);
+    final var assistantMessage = converter.toResult(response, EXECUTION_TIME).assistantMessage();
 
     assertThat(assistantMessage.stopReason()).isNull();
     assertThat(assistantMessage.metadata())
@@ -605,24 +630,35 @@ class GeminiContentResponseConverterTest {
                     .build())
             .build();
 
-    final var assistantMessage = converter.toAssistantMessage(response);
-
-    assertThat(assistantMessage.content())
-        .containsExactly(TextContent.textContent("Prompt blocked: PROHIBITED_CONTENT"));
-    assertThat(assistantMessage.stopReason()).isNull();
+    assertThatThrownBy(() -> converter.toResult(response, EXECUTION_TIME))
+        .isInstanceOf(ContentFilteredException.class)
+        .extracting(e -> ((ContentFilteredException) e).partialResult())
+        .satisfies(
+            partialResult -> {
+              final var assistantMessage = partialResult.assistantMessage();
+              assertThat(assistantMessage.content())
+                  .containsExactly(TextContent.textContent("Prompt blocked: PROHIBITED_CONTENT"));
+              assertThat(assistantMessage.stopReason()).isNull();
+            });
   }
 
   @Test
   void explainsAResponseWithoutCandidatesEvenWithoutABlockReason() {
     final var response = GenerateContentResponse.builder().build();
 
-    final var assistantMessage = converter.toAssistantMessage(response);
-
-    assertThat(assistantMessage.content())
-        .containsExactly(TextContent.textContent("Prompt blocked (no block reason reported)"));
-    assertThat(assistantMessage.stopReason()).isNull();
-    assertThat(assistantMessage.metadata())
-        .containsOnlyKeys(AssistantMessageMetadata.TIMESTAMP_KEY);
+    assertThatThrownBy(() -> converter.toResult(response, EXECUTION_TIME))
+        .isInstanceOf(ContentFilteredException.class)
+        .extracting(e -> ((ContentFilteredException) e).partialResult())
+        .satisfies(
+            partialResult -> {
+              final var assistantMessage = partialResult.assistantMessage();
+              assertThat(assistantMessage.content())
+                  .containsExactly(
+                      TextContent.textContent("Prompt blocked (no block reason reported)"));
+              assertThat(assistantMessage.stopReason()).isNull();
+              assertThat(assistantMessage.metadata())
+                  .containsOnlyKeys(AssistantMessageMetadata.TIMESTAMP_KEY);
+            });
   }
 
   // ---------------------------------------------------------------------------------------------
@@ -686,7 +722,7 @@ class GeminiContentResponseConverterTest {
   void leavesMessageIdAndModelIdUnsetWhenTheResponseDoesNotReportThem() {
     final var response = response(candidate(FinishReason.Known.STOP, Part.fromText("ok")));
 
-    final var assistantMessage = converter.toAssistantMessage(response);
+    final var assistantMessage = converter.toResult(response, EXECUTION_TIME).assistantMessage();
 
     assertThat(assistantMessage.messageId()).isNull();
     assertThat(assistantMessage.modelId()).isNull();

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiContentResponseConverterTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiContentResponseConverterTest.java
@@ -237,7 +237,7 @@ class GeminiContentResponseConverterTest {
 
     assertThat(assistantMessage.content()).isEmpty();
     assertThat(assistantMessage.toolCalls()).isEmpty();
-    assertThat(assistantMessage.stopReason()).isEqualTo(StopReason.CONTENT_FILTERED);
+    assertThat(assistantMessage.stopReason()).isEqualTo(new UnknownStopReason("SAFETY"));
   }
 
   @Test
@@ -254,7 +254,7 @@ class GeminiContentResponseConverterTest {
 
     assertThat(assistantMessage.content())
         .containsExactly(TextContent.textContent("partial answer"));
-    assertThat(assistantMessage.stopReason()).isEqualTo(StopReason.CONTENT_FILTERED);
+    assertThat(assistantMessage.stopReason()).isEqualTo(new UnknownStopReason("SAFETY"));
   }
 
   // ---------------------------------------------------------------------------------------------
@@ -492,7 +492,8 @@ class GeminiContentResponseConverterTest {
             partialResult -> {
               assertThat(partialResult).isNotNull();
               final var assistantMessage = partialResult.assistantMessage();
-              assertThat(assistantMessage.stopReason()).isEqualTo(StopReason.CONTENT_FILTERED);
+              assertThat(assistantMessage.stopReason())
+                  .isEqualTo(new UnknownStopReason(finishReason));
               assertThat(assistantMessage.metadata())
                   .containsEntry(GOOGLE_GEMINI_ID, Map.of("finishReason", finishReason));
             });
@@ -579,7 +580,7 @@ class GeminiContentResponseConverterTest {
               assertThat(assistantMessage.content())
                   .containsExactly(TextContent.textContent("Prompt blocked: SAFETY"));
               assertThat(assistantMessage.toolCalls()).isEmpty();
-              assertThat(assistantMessage.stopReason()).isEqualTo(StopReason.CONTENT_FILTERED);
+              assertThat(assistantMessage.stopReason()).isNull();
               assertThat(assistantMessage.messageId()).isEqualTo("resp-blocked");
               assertThat(assistantMessage.modelId()).isEqualTo("gemini-3-pro-preview");
               assertThat(assistantMessage.metadata())
@@ -608,7 +609,7 @@ class GeminiContentResponseConverterTest {
 
     assertThat(assistantMessage.content())
         .containsExactly(TextContent.textContent("Prompt blocked: PROHIBITED_CONTENT"));
-    assertThat(assistantMessage.stopReason()).isEqualTo(StopReason.CONTENT_FILTERED);
+    assertThat(assistantMessage.stopReason()).isNull();
   }
 
   @Test
@@ -619,7 +620,7 @@ class GeminiContentResponseConverterTest {
 
     assertThat(assistantMessage.content())
         .containsExactly(TextContent.textContent("Prompt blocked (no block reason reported)"));
-    assertThat(assistantMessage.stopReason()).isEqualTo(StopReason.CONTENT_FILTERED);
+    assertThat(assistantMessage.stopReason()).isNull();
     assertThat(assistantMessage.metadata())
         .containsOnlyKeys(AssistantMessageMetadata.TIMESTAMP_KEY);
   }

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiContentResponseConverterTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiContentResponseConverterTest.java
@@ -154,6 +154,79 @@ class GeminiContentResponseConverterTest {
   }
 
   @Test
+  void preservesAThoughtSignatureCarriedOnAPlainTextPart() {
+    // Gemini attaches a thoughtSignature to whichever part the reasoning continuity belongs to,
+    // including a non-thought answer part. Every assistant message is replayed into the next
+    // request, so dropping it here breaks follow-ups exactly like dropping it on a functionCall.
+    final var textPart =
+        Part.builder().text("the answer").thoughtSignature(THOUGHT_SIGNATURE).build();
+
+    final var content =
+        converter
+            .toAssistantMessage(response(candidate(FinishReason.Known.STOP, textPart)))
+            .content();
+
+    assertThat(content)
+        .containsExactly(
+            new TextContent(
+                "the answer", Map.of(THOUGHT_SIGNATURE_METADATA_KEY, THOUGHT_SIGNATURE_BASE64)));
+  }
+
+  @Test
+  void writesATextPartThoughtSignatureTheRequestConverterReadsBackVerbatim() {
+    final var textPart =
+        Part.builder().text("the answer").thoughtSignature(THOUGHT_SIGNATURE).build();
+
+    final var content =
+        converter
+            .toAssistantMessage(response(candidate(FinishReason.Known.STOP, textPart)))
+            .content();
+
+    assertThat(new GeminiContentConverter(new ObjectMapper()).toParts(content))
+        .singleElement()
+        .satisfies(
+            part -> {
+              assertThat(part.text()).contains("the answer");
+              assertThat(part.thought()).isEmpty();
+              assertThat(part.thoughtSignature()).contains(THOUGHT_SIGNATURE);
+            });
+  }
+
+  @Test
+  void skipsAnEmptyTextPartRatherThanRejectingIt() {
+    // TextContent rejects blank text, and the stream assembler passes empty-text parts straight
+    // through from real SSE traffic - this must not blow up the whole conversion.
+    final var response =
+        response(
+            candidate(
+                FinishReason.Known.STOP,
+                Part.fromText(""),
+                Part.fromText("   "),
+                Part.fromText("the answer")));
+
+    final var assistantMessage = converter.toAssistantMessage(response);
+
+    assertThat(assistantMessage.content()).containsExactly(TextContent.textContent("the answer"));
+  }
+
+  @Test
+  void keepsASignatureOnlyPartWithBlankTextAsProviderContent() {
+    // A blank-text part is only skippable when it carries nothing else; a signature must survive.
+    final var signatureOnlyPart =
+        Part.builder().text("").thoughtSignature(THOUGHT_SIGNATURE).build();
+
+    final var content =
+        converter
+            .toAssistantMessage(response(candidate(FinishReason.Known.STOP, signatureOnlyPart)))
+            .content();
+
+    assertThat(content).singleElement().isInstanceOf(ProviderContent.class);
+    assertThat(new GeminiContentConverter(new ObjectMapper()).toParts(content))
+        .singleElement()
+        .satisfies(part -> assertThat(part.thoughtSignature()).contains(THOUGHT_SIGNATURE));
+  }
+
+  @Test
   void mapsCandidateWithoutContentToAnEmptyMessage() {
     // The real shape of a SAFETY-filtered (and of some MAX_TOKENS) candidate: no content at all.
     final var response =

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiContentResponseConverterTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiContentResponseConverterTest.java
@@ -500,9 +500,7 @@ class GeminiContentResponseConverterTest {
 
   @Test
   void throwsContentFilteredExceptionEvenWhenTheFilteredCandidateAlsoCarriesToolCalls() {
-    // Gemini always reports its real finish reason even when the candidate carries functionCall
-    // parts; a filtered-and-tool-calling response must not lose CONTENT_FILTERED to the TOOL_USE
-    // override applied elsewhere.
+    // A filtered finish reason must win over the TOOL_USE override.
     final var response =
         response(
             candidate(

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiContentStreamAssemblerTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiContentStreamAssemblerTest.java
@@ -1,0 +1,302 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.agenticai.aiagent.chatmodel.provider.gemini;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.genai.ResponseStream;
+import com.google.genai.types.BlockedReason;
+import com.google.genai.types.Candidate;
+import com.google.genai.types.Content;
+import com.google.genai.types.FinishReason;
+import com.google.genai.types.FunctionCall;
+import com.google.genai.types.GenerateContentResponse;
+import com.google.genai.types.GenerateContentResponsePromptFeedback;
+import com.google.genai.types.GenerateContentResponseUsageMetadata;
+import com.google.genai.types.Part;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+/**
+ * {@link ResponseStream} cannot be constructed without a live HTTP {@link
+ * com.google.genai.ApiResponse}, so the streamed chunks are fed in through a Mockito mock stubbing
+ * only {@link ResponseStream#iterator()} (the sole method the assembler uses) - the same approach
+ * {@code AnthropicMessageStreamAssemblerTest} takes for the Anthropic SDK's {@code StreamResponse}.
+ * Chunks themselves are real SDK types built through their AutoValue builders.
+ */
+class GeminiContentStreamAssemblerTest {
+
+  private static final byte[] THOUGHT_SIGNATURE = "signature".getBytes(StandardCharsets.UTF_8);
+
+  private final GeminiContentStreamAssembler assembler = new GeminiContentStreamAssemblerImpl();
+
+  @Test
+  void mergesConsecutiveTextPartsAcrossChunks() {
+    final GenerateContentResponse assembled =
+        assembler.assemble(
+            streamOf(chunk(textPart("Hello")), chunk(textPart(", ")), chunk(textPart("world!"))));
+
+    assertThat(partsOf(assembled))
+        .singleElement()
+        .satisfies(part -> assertThat(part.text()).contains("Hello, world!"));
+    assertThat(contentOf(assembled).role()).contains("model");
+  }
+
+  @Test
+  void keepsThoughtAndTextRunsSeparate() {
+    final GenerateContentResponse assembled =
+        assembler.assemble(
+            streamOf(
+                chunk(thoughtPart("Let me ")),
+                chunk(thoughtPart("think.")),
+                chunk(textPart("The ")),
+                chunk(textPart("answer."))));
+
+    assertThat(partsOf(assembled))
+        .satisfiesExactly(
+            thought -> {
+              assertThat(thought.thought()).contains(true);
+              assertThat(thought.text()).contains("Let me think.");
+            },
+            text -> {
+              assertThat(text.thought()).isEmpty();
+              assertThat(text.text()).contains("The answer.");
+            });
+  }
+
+  @Test
+  void doesNotMergeTextRunsSeparatedByANonTextPart() {
+    final GenerateContentResponse assembled =
+        assembler.assemble(
+            streamOf(
+                chunk(textPart("before")),
+                chunk(functionCallPart("myTool")),
+                chunk(textPart("after"))));
+
+    assertThat(partsOf(assembled))
+        .satisfiesExactly(
+            first -> assertThat(first.text()).contains("before"),
+            second -> assertThat(second.functionCall()).isPresent(),
+            third -> assertThat(third.text()).contains("after"));
+  }
+
+  @Test
+  void passesFunctionCallPartsThroughUnmodifiedInArrivalOrder() {
+    final Part first = functionCallPart("firstTool");
+    final Part second = functionCallPart("secondTool");
+
+    final GenerateContentResponse assembled =
+        assembler.assemble(streamOf(chunk(first), chunk(second)));
+
+    assertThat(partsOf(assembled)).containsExactly(first, second);
+  }
+
+  @Test
+  void mergesThoughtRunAndCarriesThoughtSignatureOver() {
+    final GenerateContentResponse assembled =
+        assembler.assemble(
+            streamOf(
+                chunk(thoughtPart("thin")),
+                chunk(
+                    thoughtPart("king").toBuilder().thoughtSignature(THOUGHT_SIGNATURE).build())));
+
+    assertThat(partsOf(assembled))
+        .singleElement()
+        .satisfies(
+            part -> {
+              assertThat(part.text()).contains("thinking");
+              assertThat(part.thoughtSignature().orElseThrow()).isEqualTo(THOUGHT_SIGNATURE);
+            });
+  }
+
+  @Test
+  void startsANewRunAfterAPartCarryingAThoughtSignature() {
+    final GenerateContentResponse assembled =
+        assembler.assemble(
+            streamOf(
+                chunk(thoughtPart("first").toBuilder().thoughtSignature(THOUGHT_SIGNATURE).build()),
+                chunk(thoughtPart("second"))));
+
+    assertThat(partsOf(assembled))
+        .satisfiesExactly(
+            signed -> {
+              assertThat(signed.text()).contains("first");
+              assertThat(signed.thoughtSignature().orElseThrow()).isEqualTo(THOUGHT_SIGNATURE);
+            },
+            unsigned -> {
+              assertThat(unsigned.text()).contains("second");
+              assertThat(unsigned.thoughtSignature()).isEmpty();
+            });
+  }
+
+  @Test
+  void takesUsageMetadataAndFinishReasonFromTheFinalChunk() {
+    final GenerateContentResponse intermediate =
+        chunk(textPart("partial")).toBuilder()
+            .usageMetadata(
+                GenerateContentResponseUsageMetadata.builder()
+                    .promptTokenCount(10)
+                    .candidatesTokenCount(2)
+                    .totalTokenCount(12))
+            .build();
+    final GenerateContentResponse last =
+        GenerateContentResponse.builder()
+            .candidates(
+                Candidate.builder().finishReason(new FinishReason(FinishReason.Known.MAX_TOKENS)))
+            .usageMetadata(
+                GenerateContentResponseUsageMetadata.builder()
+                    .promptTokenCount(10)
+                    .candidatesTokenCount(42)
+                    .totalTokenCount(52))
+            .build();
+
+    final GenerateContentResponse assembled = assembler.assemble(streamOf(intermediate, last));
+
+    final GenerateContentResponseUsageMetadata usage = assembled.usageMetadata().orElseThrow();
+    assertThat(usage.candidatesTokenCount()).contains(42);
+    assertThat(usage.totalTokenCount()).contains(52);
+    assertThat(candidateOf(assembled).finishReason().orElseThrow().knownEnum())
+        .isEqualTo(FinishReason.Known.MAX_TOKENS);
+    assertThat(partsOf(assembled))
+        .singleElement()
+        .satisfies(part -> assertThat(part.text()).contains("partial"));
+  }
+
+  @Test
+  void passesPromptFeedbackThroughWhenNoCandidatesArePresent() {
+    final GenerateContentResponsePromptFeedback promptFeedback =
+        GenerateContentResponsePromptFeedback.builder()
+            .blockReason(new BlockedReason(BlockedReason.Known.SAFETY))
+            .blockReasonMessage("blocked by safety filters")
+            .build();
+
+    final GenerateContentResponse assembled =
+        assembler.assemble(
+            streamOf(GenerateContentResponse.builder().promptFeedback(promptFeedback).build()));
+
+    assertThat(assembled.promptFeedback()).contains(promptFeedback);
+    assertThat(assembled.candidates()).isEmpty();
+  }
+
+  @Test
+  void assemblesASingleChunkStream() {
+    final GenerateContentResponse single =
+        chunk(textPart("all at once"), functionCallPart("myTool")).toBuilder()
+            .modelVersion("gemini-test-model")
+            .responseId("response-1")
+            .build();
+
+    final GenerateContentResponse assembled = assembler.assemble(streamOf(single));
+
+    assertThat(partsOf(assembled))
+        .satisfiesExactly(
+            text -> assertThat(text.text()).contains("all at once"),
+            functionCall ->
+                assertThat(functionCall.functionCall().orElseThrow().name()).contains("myTool"));
+    assertThat(assembled.modelVersion()).contains("gemini-test-model");
+    assertThat(assembled.responseId()).contains("response-1");
+  }
+
+  @Test
+  void keepsFirstNonEmptyModelVersionAndResponseId() {
+    final GenerateContentResponse first = chunk(textPart("a"));
+    final GenerateContentResponse second =
+        chunk(textPart("b")).toBuilder().modelVersion("gemini-test-model").responseId("r1").build();
+    final GenerateContentResponse third =
+        chunk(textPart("c")).toBuilder().modelVersion("other-model").responseId("r2").build();
+
+    final GenerateContentResponse assembled = assembler.assemble(streamOf(first, second, third));
+
+    assertThat(assembled.modelVersion()).contains("gemini-test-model");
+    assertThat(assembled.responseId()).contains("r1");
+  }
+
+  @Test
+  void usesTheFirstCandidateWhenAChunkCarriesMultiple() {
+    final GenerateContentResponse multiCandidate =
+        GenerateContentResponse.builder()
+            .candidates(
+                Candidate.builder()
+                    .content(Content.builder().role("model").parts(textPart("first candidate"))),
+                Candidate.builder()
+                    .content(Content.builder().role("model").parts(textPart("second candidate"))))
+            .build();
+
+    final GenerateContentResponse assembled = assembler.assemble(streamOf(multiCandidate));
+
+    assertThat(assembled.candidates().orElseThrow()).hasSize(1);
+    assertThat(partsOf(assembled))
+        .singleElement()
+        .satisfies(part -> assertThat(part.text()).contains("first candidate"));
+  }
+
+  @Test
+  void doesNotCloseTheStream() {
+    final ResponseStream<GenerateContentResponse> stream = streamOf(chunk(textPart("text")));
+
+    assembler.assemble(stream);
+
+    verify(stream, never()).close();
+  }
+
+  @Test
+  void throwsOnAnEmptyStream() {
+    final ResponseStream<GenerateContentResponse> stream = streamOf();
+
+    assertThatThrownBy(() -> assembler.assemble(stream))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("no chunks");
+  }
+
+  private static ResponseStream<GenerateContentResponse> streamOf(
+      GenerateContentResponse... chunks) {
+    @SuppressWarnings("unchecked")
+    final ResponseStream<GenerateContentResponse> stream = mock(ResponseStream.class);
+    when(stream.iterator()).thenReturn(List.of(chunks).iterator());
+    return stream;
+  }
+
+  private static GenerateContentResponse chunk(Part... parts) {
+    return GenerateContentResponse.builder()
+        .candidates(
+            Candidate.builder().content(Content.builder().role("model").parts(parts).build()))
+        .build();
+  }
+
+  private static Part textPart(String text) {
+    return Part.builder().text(text).build();
+  }
+
+  private static Part thoughtPart(String text) {
+    return Part.builder().thought(true).text(text).build();
+  }
+
+  private static Part functionCallPart(String name) {
+    return Part.builder()
+        .functionCall(FunctionCall.builder().name(name).args(Map.of("arg", "value")).build())
+        .build();
+  }
+
+  private static Candidate candidateOf(GenerateContentResponse response) {
+    return response.candidates().orElseThrow().get(0);
+  }
+
+  private static Content contentOf(GenerateContentResponse response) {
+    return candidateOf(response).content().orElseThrow();
+  }
+
+  private static List<Part> partsOf(GenerateContentResponse response) {
+    return contentOf(response).parts().orElseThrow();
+  }
+}

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiContentStreamAssemblerTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiContentStreamAssemblerTest.java
@@ -103,6 +103,22 @@ class GeminiContentStreamAssemblerTest {
   }
 
   @Test
+  void passesThroughAPartialFunctionCallWithoutThrowing() {
+    final Part partial =
+        Part.builder()
+            .functionCall(
+                FunctionCall.builder().name("myTool").args(Map.of()).willContinue(true).build())
+            .build();
+
+    final GenerateContentResponse assembled = assembler.assemble(streamOf(chunk(partial)));
+
+    assertThat(partsOf(assembled))
+        .singleElement()
+        .satisfies(
+            part -> assertThat(part.functionCall().orElseThrow().willContinue()).contains(true));
+  }
+
+  @Test
   void mergesThoughtRunAndCarriesThoughtSignatureOver() {
     final GenerateContentResponse assembled =
         assembler.assemble(
@@ -141,8 +157,8 @@ class GeminiContentStreamAssemblerTest {
   }
 
   @Test
-  void takesUsageMetadataAndFinishReasonFromTheFinalChunk() {
-    final GenerateContentResponse intermediate =
+  void takesUsageMetadataFromTheLastChunkReportingItAndFinishReasonFromTheFinalChunk() {
+    final GenerateContentResponse first =
         chunk(textPart("partial")).toBuilder()
             .usageMetadata(
                 GenerateContentResponseUsageMetadata.builder()
@@ -150,18 +166,25 @@ class GeminiContentStreamAssemblerTest {
                     .candidatesTokenCount(2)
                     .totalTokenCount(12))
             .build();
-    final GenerateContentResponse last =
+    final GenerateContentResponse middle =
         GenerateContentResponse.builder()
-            .candidates(
-                Candidate.builder().finishReason(new FinishReason(FinishReason.Known.MAX_TOKENS)))
             .usageMetadata(
                 GenerateContentResponseUsageMetadata.builder()
                     .promptTokenCount(10)
                     .candidatesTokenCount(42)
                     .totalTokenCount(52))
             .build();
+    // The final chunk deliberately omits usageMetadata, so the assembled result can only end up
+    // with the middle chunk's usage by falling back to the last chunk that actually reported it
+    // (`chunk.usageMetadata().orElse(...)` in the assembler) rather than the final chunk supplying
+    // its own value or the fallback overwriting it with nothing.
+    final GenerateContentResponse last =
+        GenerateContentResponse.builder()
+            .candidates(
+                Candidate.builder().finishReason(new FinishReason(FinishReason.Known.MAX_TOKENS)))
+            .build();
 
-    final GenerateContentResponse assembled = assembler.assemble(streamOf(intermediate, last));
+    final GenerateContentResponse assembled = assembler.assemble(streamOf(first, middle, last));
 
     final GenerateContentResponseUsageMetadata usage = assembled.usageMetadata().orElseThrow();
     assertThat(usage.candidatesTokenCount()).contains(42);

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/model/request/v2/GeminiChatModelConfigurationTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/model/request/v2/GeminiChatModelConfigurationTest.java
@@ -48,7 +48,7 @@ class GeminiChatModelConfigurationTest {
                 "temperature": 0.5,
                 "topP": 0.9,
                 "topK": 40,
-                "thinking": { "enabled": true, "thinkingLevel": "high" }
+                "thinking": { "thinkingLevel": "high" }
               }
             }
           }
@@ -71,8 +71,7 @@ class GeminiChatModelConfigurationTest {
     assertThat(parameters.temperature()).isEqualTo(0.5);
     assertThat(parameters.topP()).isEqualTo(0.9);
     assertThat(parameters.topK()).isEqualTo(40);
-    assertThat(parameters.thinking())
-        .isEqualTo(new GeminiThinking(true, null, GeminiThinkingLevel.HIGH));
+    assertThat(parameters.thinking()).isEqualTo(new GeminiThinking(null, GeminiThinkingLevel.HIGH));
 
     final String reserialised = mapper.writeValueAsString(parsed);
     assertThat(mapper.readValue(reserialised, ProviderConfiguration.class)).isEqualTo(parsed);
@@ -111,7 +110,7 @@ class GeminiChatModelConfigurationTest {
 
   @Test
   void bothThinkingBudgetAndLevelSetIsRejected() {
-    final var thinking = new GeminiThinking(true, 1024, GeminiThinkingLevel.HIGH);
+    final var thinking = new GeminiThinking(1024, GeminiThinkingLevel.HIGH);
     final var parameters = new GeminiModelParameters(null, null, null, null, thinking);
     final var config =
         new GeminiChatModelConfiguration(
@@ -134,7 +133,7 @@ class GeminiChatModelConfigurationTest {
 
   @Test
   void onlyThinkingBudgetSetHasNoViolations() {
-    final var thinking = new GeminiThinking(true, 1024, null);
+    final var thinking = new GeminiThinking(1024, null);
     final var parameters = new GeminiModelParameters(null, null, null, null, thinking);
     final var config =
         new GeminiChatModelConfiguration(
@@ -148,7 +147,7 @@ class GeminiChatModelConfigurationTest {
 
   @Test
   void thinkingBudgetBelowMinusOneIsRejected() {
-    final var thinking = new GeminiThinking(true, -2, null);
+    final var thinking = new GeminiThinking(-2, null);
     final var parameters = new GeminiModelParameters(null, null, null, null, thinking);
     final var config =
         new GeminiChatModelConfiguration(
@@ -170,7 +169,7 @@ class GeminiChatModelConfigurationTest {
 
   @Test
   void thinkingBudgetOfMinusOneHasNoViolations() {
-    final var thinking = new GeminiThinking(true, -1, null);
+    final var thinking = new GeminiThinking(-1, null);
     final var parameters = new GeminiModelParameters(null, null, null, null, thinking);
     final var config =
         new GeminiChatModelConfiguration(
@@ -184,7 +183,7 @@ class GeminiChatModelConfigurationTest {
 
   @Test
   void budgetWithModelDefaultLevelHasNoViolations() {
-    final var thinking = new GeminiThinking(true, 1024, GeminiThinkingLevel.MODEL_DEFAULT);
+    final var thinking = new GeminiThinking(1024, GeminiThinkingLevel.MODEL_DEFAULT);
     final var parameters = new GeminiModelParameters(null, null, null, null, thinking);
     final var config =
         new GeminiChatModelConfiguration(
@@ -198,14 +197,14 @@ class GeminiChatModelConfigurationTest {
 
   @Test
   void omittedThinkingLevelDefaultsToModelDefault() {
-    final var thinking = new GeminiThinking(true, 1024, null);
+    final var thinking = new GeminiThinking(1024, null);
 
     assertThat(thinking.thinkingLevel()).isEqualTo(GeminiThinkingLevel.MODEL_DEFAULT);
   }
 
   @Test
   void onlyThinkingLevelSetHasNoViolations() {
-    final var thinking = new GeminiThinking(true, null, GeminiThinkingLevel.LOW);
+    final var thinking = new GeminiThinking(null, GeminiThinkingLevel.LOW);
     final var parameters = new GeminiModelParameters(null, null, null, null, thinking);
     final var config =
         new GeminiChatModelConfiguration(

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/model/request/v2/GeminiChatModelConfigurationTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/model/request/v2/GeminiChatModelConfigurationTest.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.agenticai.aiagent.model.request.v2;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.GeminiChatModelConfiguration.GeminiBackend.GeminiApiBackend;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.GeminiChatModelConfiguration.GeminiConnection;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.GeminiChatModelConfiguration.GeminiModel;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.GeminiChatModelConfiguration.GeminiModel.GeminiModelParameters;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.GeminiChatModelConfiguration.GeminiModel.GeminiThinking;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.GeminiChatModelConfiguration.GeminiModel.GeminiThinkingLevel;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validator;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.validation.autoconfigure.ValidationAutoConfiguration;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+@ExtendWith(SpringExtension.class)
+@Import(ValidationAutoConfiguration.class)
+class GeminiChatModelConfigurationTest {
+
+  private final ObjectMapper mapper = new ObjectMapper();
+
+  @Autowired private Validator validator;
+
+  @Test
+  void deserialisesGeminiApiBackendWithModelParametersAndRoundTrips() throws Exception {
+    final String json =
+        """
+        {
+          "type": "google-gemini",
+          "googleGemini": {
+            "backend": { "type": "google-gemini-api", "googleGeminiApi": { "apiKey": "gm-123" } },
+            "model": {
+              "model": "gemini-3-pro-preview",
+              "parameters": {
+                "maxTokens": 1024,
+                "temperature": 0.5,
+                "topP": 0.9,
+                "topK": 40,
+                "thinking": { "thinkingLevel": "high" }
+              }
+            }
+          }
+        }
+        """;
+
+    final ProviderConfiguration parsed = mapper.readValue(json, ProviderConfiguration.class);
+
+    assertThat(parsed).isInstanceOf(GeminiChatModelConfiguration.class);
+    assertThat(parsed.provider()).isEqualTo("google-gemini");
+    assertThat(parsed.model()).isEqualTo("gemini-3-pro-preview");
+
+    final GeminiChatModelConfiguration gemini = (GeminiChatModelConfiguration) parsed;
+    assertThat(gemini.googleGemini().backend()).isInstanceOf(GeminiApiBackend.class);
+    assertThat(((GeminiApiBackend) gemini.googleGemini().backend()).googleGeminiApi().apiKey())
+        .isEqualTo("gm-123");
+    final GeminiModelParameters parameters = gemini.googleGemini().model().parameters();
+    assertThat(parameters).isNotNull();
+    assertThat(parameters.maxTokens()).isEqualTo(1024);
+    assertThat(parameters.temperature()).isEqualTo(0.5);
+    assertThat(parameters.topP()).isEqualTo(0.9);
+    assertThat(parameters.topK()).isEqualTo(40);
+    assertThat(parameters.thinking()).isEqualTo(new GeminiThinking(null, GeminiThinkingLevel.HIGH));
+
+    final String reserialised = mapper.writeValueAsString(parsed);
+    assertThat(mapper.readValue(reserialised, ProviderConfiguration.class)).isEqualTo(parsed);
+  }
+
+  @Test
+  void googleGeminiApiRedactsApiKeyInToString() {
+    final var backend =
+        new GeminiApiBackend(
+            new GeminiApiBackend.GoogleGeminiApi("gm-super-secret", "https://example.com"));
+
+    final String toString = backend.toString();
+    assertThat(toString).doesNotContain("gm-super-secret");
+    assertThat(toString).contains("apiKey=[REDACTED]", "endpoint=https://example.com");
+  }
+
+  @Test
+  void geminiApiBackendRejectsBlankApiKey() {
+    final var config =
+        new GeminiChatModelConfiguration(
+            new GeminiConnection(
+                new GeminiApiBackend(new GeminiApiBackend.GoogleGeminiApi("  ", null)),
+                new GeminiModel("gemini-3-pro-preview", null),
+                null));
+
+    final var violations = validator.validate(config);
+
+    assertThat(violations)
+        .anySatisfy(
+            v -> {
+              assertThat(v.getPropertyPath().toString())
+                  .isEqualTo("googleGemini.backend.googleGeminiApi.apiKey");
+              assertThat(v.getMessage()).isEqualTo("must not be blank");
+            });
+  }
+
+  @Test
+  void bothThinkingBudgetAndLevelSetIsRejected() {
+    final var thinking = new GeminiThinking(1024, GeminiThinkingLevel.HIGH);
+    final var parameters = new GeminiModelParameters(null, null, null, null, thinking);
+    final var config =
+        new GeminiChatModelConfiguration(
+            new GeminiConnection(
+                new GeminiApiBackend(new GeminiApiBackend.GoogleGeminiApi("gm-123", null)),
+                new GeminiModel("gemini-3-pro-preview", parameters),
+                null));
+
+    final Set<ConstraintViolation<GeminiChatModelConfiguration>> violations =
+        validator.validate(config);
+
+    assertThat(violations)
+        .anySatisfy(
+            v ->
+                assertThat(v.getMessage())
+                    .isEqualTo(
+                        "thinking.thinkingBudget and thinking.thinkingLevel are mutually"
+                            + " exclusive"));
+  }
+
+  @Test
+  void onlyThinkingBudgetSetHasNoViolations() {
+    final var thinking = new GeminiThinking(1024, null);
+    final var parameters = new GeminiModelParameters(null, null, null, null, thinking);
+    final var config =
+        new GeminiChatModelConfiguration(
+            new GeminiConnection(
+                new GeminiApiBackend(new GeminiApiBackend.GoogleGeminiApi("gm-123", null)),
+                new GeminiModel("gemini-3-pro-preview", parameters),
+                null));
+
+    assertThat(validator.validate(config)).isEmpty();
+  }
+
+  @Test
+  void onlyThinkingLevelSetHasNoViolations() {
+    final var thinking = new GeminiThinking(null, GeminiThinkingLevel.LOW);
+    final var parameters = new GeminiModelParameters(null, null, null, null, thinking);
+    final var config =
+        new GeminiChatModelConfiguration(
+            new GeminiConnection(
+                new GeminiApiBackend(new GeminiApiBackend.GoogleGeminiApi("gm-123", null)),
+                new GeminiModel("gemini-3-pro-preview", parameters),
+                null));
+
+    assertThat(validator.validate(config)).isEmpty();
+  }
+
+  @Test
+  void validGeminiConfigurationHasNoViolations() {
+    final var config =
+        new GeminiChatModelConfiguration(
+            new GeminiConnection(
+                new GeminiApiBackend(new GeminiApiBackend.GoogleGeminiApi("gm-123", null)),
+                new GeminiModel("gemini-3-pro-preview", null),
+                null));
+
+    assertThat(validator.validate(config)).isEmpty();
+  }
+
+  @Test
+  void requiredModelFieldIsEnforced() {
+    final var config =
+        new GeminiChatModelConfiguration(
+            new GeminiConnection(
+                new GeminiApiBackend(new GeminiApiBackend.GoogleGeminiApi("gm-123", null)),
+                new GeminiModel("  ", null),
+                null));
+
+    final var violations = validator.validate(config);
+
+    assertThat(violations)
+        .anySatisfy(
+            v -> {
+              assertThat(v.getPropertyPath().toString()).isEqualTo("googleGemini.model.model");
+              assertThat(v.getMessage()).isEqualTo("must not be blank");
+            });
+  }
+}

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/model/request/v2/GeminiChatModelConfigurationTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/model/request/v2/GeminiChatModelConfigurationTest.java
@@ -147,6 +147,42 @@ class GeminiChatModelConfigurationTest {
   }
 
   @Test
+  void thinkingBudgetBelowMinusOneIsRejected() {
+    final var thinking = new GeminiThinking(true, -2, null);
+    final var parameters = new GeminiModelParameters(null, null, null, null, thinking);
+    final var config =
+        new GeminiChatModelConfiguration(
+            new GeminiConnection(
+                new GeminiApiBackend(new GeminiApiBackend.GoogleGeminiApi("gm-123", null)),
+                new GeminiModel("gemini-3-pro-preview", parameters),
+                null));
+
+    final var violations = validator.validate(config);
+
+    assertThat(violations)
+        .anySatisfy(
+            v -> {
+              assertThat(v.getPropertyPath().toString())
+                  .isEqualTo("googleGemini.model.parameters.thinking.thinkingBudget");
+              assertThat(v.getMessage()).isEqualTo("must be greater than or equal to -1");
+            });
+  }
+
+  @Test
+  void thinkingBudgetOfMinusOneHasNoViolations() {
+    final var thinking = new GeminiThinking(true, -1, null);
+    final var parameters = new GeminiModelParameters(null, null, null, null, thinking);
+    final var config =
+        new GeminiChatModelConfiguration(
+            new GeminiConnection(
+                new GeminiApiBackend(new GeminiApiBackend.GoogleGeminiApi("gm-123", null)),
+                new GeminiModel("gemini-3-pro-preview", parameters),
+                null));
+
+    assertThat(validator.validate(config)).isEmpty();
+  }
+
+  @Test
   void onlyThinkingLevelSetHasNoViolations() {
     final var thinking = new GeminiThinking(true, null, GeminiThinkingLevel.LOW);
     final var parameters = new GeminiModelParameters(null, null, null, null, thinking);

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/model/request/v2/GeminiChatModelConfigurationTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/model/request/v2/GeminiChatModelConfigurationTest.java
@@ -48,7 +48,7 @@ class GeminiChatModelConfigurationTest {
                 "temperature": 0.5,
                 "topP": 0.9,
                 "topK": 40,
-                "thinking": { "thinkingLevel": "high" }
+                "thinking": { "enabled": true, "thinkingLevel": "high" }
               }
             }
           }
@@ -71,7 +71,8 @@ class GeminiChatModelConfigurationTest {
     assertThat(parameters.temperature()).isEqualTo(0.5);
     assertThat(parameters.topP()).isEqualTo(0.9);
     assertThat(parameters.topK()).isEqualTo(40);
-    assertThat(parameters.thinking()).isEqualTo(new GeminiThinking(null, GeminiThinkingLevel.HIGH));
+    assertThat(parameters.thinking())
+        .isEqualTo(new GeminiThinking(true, null, GeminiThinkingLevel.HIGH));
 
     final String reserialised = mapper.writeValueAsString(parsed);
     assertThat(mapper.readValue(reserialised, ProviderConfiguration.class)).isEqualTo(parsed);
@@ -110,7 +111,7 @@ class GeminiChatModelConfigurationTest {
 
   @Test
   void bothThinkingBudgetAndLevelSetIsRejected() {
-    final var thinking = new GeminiThinking(1024, GeminiThinkingLevel.HIGH);
+    final var thinking = new GeminiThinking(true, 1024, GeminiThinkingLevel.HIGH);
     final var parameters = new GeminiModelParameters(null, null, null, null, thinking);
     final var config =
         new GeminiChatModelConfiguration(
@@ -133,7 +134,7 @@ class GeminiChatModelConfigurationTest {
 
   @Test
   void onlyThinkingBudgetSetHasNoViolations() {
-    final var thinking = new GeminiThinking(1024, null);
+    final var thinking = new GeminiThinking(true, 1024, null);
     final var parameters = new GeminiModelParameters(null, null, null, null, thinking);
     final var config =
         new GeminiChatModelConfiguration(
@@ -147,7 +148,7 @@ class GeminiChatModelConfigurationTest {
 
   @Test
   void onlyThinkingLevelSetHasNoViolations() {
-    final var thinking = new GeminiThinking(null, GeminiThinkingLevel.LOW);
+    final var thinking = new GeminiThinking(true, null, GeminiThinkingLevel.LOW);
     final var parameters = new GeminiModelParameters(null, null, null, null, thinking);
     final var config =
         new GeminiChatModelConfiguration(
@@ -157,6 +158,27 @@ class GeminiChatModelConfigurationTest {
                 null));
 
     assertThat(validator.validate(config)).isEmpty();
+  }
+
+  @Test
+  void budgetWithModelDefaultLevelHasNoViolations() {
+    final var thinking = new GeminiThinking(true, 1024, GeminiThinkingLevel.MODEL_DEFAULT);
+    final var parameters = new GeminiModelParameters(null, null, null, null, thinking);
+    final var config =
+        new GeminiChatModelConfiguration(
+            new GeminiConnection(
+                new GeminiApiBackend(new GeminiApiBackend.GoogleGeminiApi("gm-123", null)),
+                new GeminiModel("gemini-3-pro-preview", parameters),
+                null));
+
+    assertThat(validator.validate(config)).isEmpty();
+  }
+
+  @Test
+  void omittedThinkingLevelDefaultsToModelDefault() {
+    final var thinking = new GeminiThinking(true, 1024, null);
+
+    assertThat(thinking.thinkingLevel()).isEqualTo(GeminiThinkingLevel.MODEL_DEFAULT);
   }
 
   @Test

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/model/request/v2/GeminiChatModelConfigurationTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/model/request/v2/GeminiChatModelConfigurationTest.java
@@ -183,20 +183,6 @@ class GeminiChatModelConfigurationTest {
   }
 
   @Test
-  void onlyThinkingLevelSetHasNoViolations() {
-    final var thinking = new GeminiThinking(true, null, GeminiThinkingLevel.LOW);
-    final var parameters = new GeminiModelParameters(null, null, null, null, thinking);
-    final var config =
-        new GeminiChatModelConfiguration(
-            new GeminiConnection(
-                new GeminiApiBackend(new GeminiApiBackend.GoogleGeminiApi("gm-123", null)),
-                new GeminiModel("gemini-3-pro-preview", parameters),
-                null));
-
-    assertThat(validator.validate(config)).isEmpty();
-  }
-
-  @Test
   void budgetWithModelDefaultLevelHasNoViolations() {
     final var thinking = new GeminiThinking(true, 1024, GeminiThinkingLevel.MODEL_DEFAULT);
     final var parameters = new GeminiModelParameters(null, null, null, null, thinking);
@@ -215,6 +201,20 @@ class GeminiChatModelConfigurationTest {
     final var thinking = new GeminiThinking(true, 1024, null);
 
     assertThat(thinking.thinkingLevel()).isEqualTo(GeminiThinkingLevel.MODEL_DEFAULT);
+  }
+
+  @Test
+  void onlyThinkingLevelSetHasNoViolations() {
+    final var thinking = new GeminiThinking(true, null, GeminiThinkingLevel.LOW);
+    final var parameters = new GeminiModelParameters(null, null, null, null, thinking);
+    final var config =
+        new GeminiChatModelConfiguration(
+            new GeminiConnection(
+                new GeminiApiBackend(new GeminiApiBackend.GoogleGeminiApi("gm-123", null)),
+                new GeminiModel("gemini-3-pro-preview", parameters),
+                null));
+
+    assertThat(validator.validate(config)).isEmpty();
   }
 
   @Test

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/autoconfigure/AgenticAiConnectorsAutoConfigurationTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/autoconfigure/AgenticAiConnectorsAutoConfigurationTest.java
@@ -37,6 +37,7 @@ import io.camunda.connector.agenticai.aiagent.chatmodel.provider.anthropic.Anthr
 import io.camunda.connector.agenticai.aiagent.chatmodel.provider.anthropic.AnthropicMessageRequestConverter;
 import io.camunda.connector.agenticai.aiagent.chatmodel.provider.anthropic.AnthropicMessageResponseConverter;
 import io.camunda.connector.agenticai.aiagent.chatmodel.provider.bedrock.BedrockConverseChatModelFactory;
+import io.camunda.connector.agenticai.aiagent.chatmodel.provider.gemini.GeminiChatModelFactory;
 import io.camunda.connector.agenticai.aiagent.chatmodel.provider.langchain4j.ChatMessageConverter;
 import io.camunda.connector.agenticai.aiagent.chatmodel.provider.langchain4j.ChatModelHttpProxySupport;
 import io.camunda.connector.agenticai.aiagent.chatmodel.provider.langchain4j.CloseableChatModel;
@@ -82,6 +83,10 @@ import io.camunda.connector.agenticai.aiagent.model.request.v2.AnthropicChatMode
 import io.camunda.connector.agenticai.aiagent.model.request.v2.AnthropicChatModelConfiguration.AnthropicBackend.AnthropicApiBackend;
 import io.camunda.connector.agenticai.aiagent.model.request.v2.AnthropicChatModelConfiguration.AnthropicConnection;
 import io.camunda.connector.agenticai.aiagent.model.request.v2.AnthropicChatModelConfiguration.AnthropicModel;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.GeminiChatModelConfiguration;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.GeminiChatModelConfiguration.GeminiBackend.GeminiApiBackend;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.GeminiChatModelConfiguration.GeminiConnection;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.GeminiChatModelConfiguration.GeminiModel;
 import io.camunda.connector.agenticai.aiagent.model.request.v2.OpenAiChatModelConfiguration;
 import io.camunda.connector.agenticai.aiagent.tool.GatewayToolHandlerRegistry;
 import io.camunda.connector.agenticai.autoconfigure.AgenticAiConnectorsAutoConfigurationTest.CustomLangChain4JChatModelFactoryOverrides.CustomAnthropicProviderConfig.CustomAnthropicChatModelFactory;
@@ -135,7 +140,8 @@ class AgenticAiConnectorsAutoConfigurationTest {
           ChatModelRegistry.class,
           AnthropicChatModelFactory.class,
           BedrockConverseChatModelFactory.class,
-          OpenAiChatModelFactory.class);
+          OpenAiChatModelFactory.class,
+          GeminiChatModelFactory.class);
 
   private static final List<Class<?>> LANGCHAIN4J_BEANS =
       List.of(
@@ -366,6 +372,15 @@ class AgenticAiConnectorsAutoConfigurationTest {
                     new AnthropicModel("claude-sonnet-5", null),
                     null)),
             AnthropicChatModelFactory.class),
+        new ChatModelResolutionCase(
+            "google-gemini (native)",
+            new GeminiChatModelConfiguration(
+                new GeminiConnection(
+                    new GeminiApiBackend(
+                        new GeminiApiBackend.GoogleGeminiApi("test-api-key", null)),
+                    new GeminiModel("gemini-3-pro-preview", null),
+                    null)),
+            GeminiChatModelFactory.class),
         new ChatModelResolutionCase(
             "anthropic (langchain4j)",
             new AnthropicProviderConfiguration(

--- a/connectors/agentic-ai/docs/reference/ai-agent.md
+++ b/connectors/agentic-ai/docs/reference/ai-agent.md
@@ -1317,6 +1317,7 @@ If the `processDefinitionKey` stored in the agent context doesn't match the curr
 - `anthropic.AnthropicChatModelFactory` / `anthropic.AnthropicChatModel.execute()` → Drives the Anthropic Java SDK's stable Messages client directly, for `AnthropicChatModelConfiguration`
 - `bedrock.BedrockConverseChatModelFactory` / `bedrock.BedrockConverseChatModel.execute()` → Drives the AWS SDK's async `converseStream` operation (the synchronous `BedrockRuntimeClient` has no streaming operation), assembling the streamed events into a `ConverseResponse` via `BedrockConverseStreamAssembler`, for `BedrockConverseChatModelConfiguration`
 - `openai.OpenAiChatModelFactory` / `openai.OpenAiChatModel.execute()` → Drives the OpenAI Java SDK directly across both wire formats (Chat Completions, Responses) via the per-family `OpenAiApiFamilyStrategy` seam, for `OpenAiChatModelConfiguration`
+- `gemini.GeminiChatModelFactory` / `gemini.GeminiChatModel.execute()` → Drives the Google GenAI Java SDK's streaming `generateContentStream` directly, for `GeminiChatModelConfiguration`
 
 ### Configuration
 - `AgenticAiConnectorsAutoConfiguration` → Spring Boot bean definitions

--- a/connectors/agentic-ai/docs/reference/native-providers.md
+++ b/connectors/agentic-ai/docs/reference/native-providers.md
@@ -243,3 +243,65 @@ An over-length request is rejected outright with an HTTP 400 (`BadRequestExcepti
 `code=context_length_exceeded`) on both API families, rather than completing with a stop reason;
 `OpenAiChatModel.execute` catches it directly and throws `ContextWindowExceededException` with no
 `PartialResult` (the request was rejected before any response body could be converted).
+
+## Gemini
+
+One backend today, `GeminiBackend.GeminiApiBackend` (`google-gemini-api`, API-key auth) against the
+Google GenAI Java SDK's Developer API. A second backend, `google-vertex-ai`, is added on a stacked
+branch and shares every converter described below unchanged.
+
+### Backends
+
+`GeminiChatModelFactory.buildClient` builds the SDK's `Client` directly from the API key; there is no
+custom-backend variant (no user-configurable headers/query params, unlike Anthropic/OpenAI's
+`*CustomBackend`).
+
+### Reasoning
+
+`GeminiThinking.enabled` gates `thinkingBudget` (Gemini 2.5, token budget) and `thinkingLevel`
+(Gemini 3.x: `minimal`/`low`/`medium`/`high`, plus `MODEL_DEFAULT`) — both stay unset and no
+`ThinkingConfig` is sent unless `enabled` is `true`. An omitted/`MODEL_DEFAULT` level is not simply
+left out when thinking is enabled: `GeminiContentRequestConverter.toThinkingLevel` sends it as the
+SDK's own `THINKING_LEVEL_UNSPECIFIED` sentinel, so "let the model choose" is explicit on the wire
+rather than inferred from absence. Setting both a budget and an explicit level is rejected client-side
+(`GeminiThinking.isBothThinkingBudgetAndLevelSet`, `@AssertFalse`) — stricter than the real API, which
+only errors on Gemini 3.x (2.5 just ignores `thinkingLevel`); a deliberate simplification, not a bug.
+`thoughtSignature` is preserved verbatim on any part it appears on (not only `functionCall`/thinking
+parts — a plain text part can carry one too) and restored byte-identical on replay; Gemini 3 rejects a
+follow-up request whose history dropped it.
+
+### Caching
+
+Implicit and read-only, like OpenAI: `GeminiContentResponseConverter.toMetrics` reads
+`cachedContentTokenCount` for `cacheReadTokenCount` only, nothing to configure, no cache-write metric.
+Gemini's explicit caching (`CachedContent`, a session-scoped resource with its own
+create/reference/expire lifecycle) is out of scope for the same reason it's out of scope everywhere
+else in this file — a different feature from a per-request model call, not a per-provider gap.
+
+### Tool-result documents
+
+Unlike Anthropic and OpenAI, a document inside a tool result is embedded natively, not flattened to a
+JSON reference: `GeminiContentConverter.toFunctionResponseParts` calls the same `toDocumentPart` used
+for ordinary message content, so an image/PDF becomes an `inlineData` `Part` and text becomes a plain
+text `Part`, sent as a sibling of the `functionResponse` part rather than referenced from inside it.
+This is a real, unreviewed divergence from the other two providers' consistent "always JSON-reference,
+never native" rule — flagged here as a decision that still needs making, not as settled behavior.
+
+### Truncation
+
+`SAFETY`/`RECITATION`/`BLOCKLIST`/`PROHIBITED_CONTENT`/`SPII`/`IMAGE_SAFETY`/
+`IMAGE_PROHIBITED_CONTENT`/`IMAGE_RECITATION` finish reasons, and a blocked prompt (no candidate at
+all, only `promptFeedback`), never reach `StopReason`: `toResult` checks the raw response shape
+directly and throws `ContentFilteredException` before any of that finish-reason mapping runs — Gemini
+has no refusal-without-a-signal case the way OpenAI does, since a blocked prompt is its own distinct
+wire shape. `MAX_TOKENS` maps to `LENGTH`; a missing tool-use finish reason is synthesized as
+`TOOL_USE` when the candidate carries `functionCall` parts, but only after the filtering check, so a
+filtered candidate that also happens to carry a tool call is never misclassified. Every other finish
+reason falls back to `UnknownStopReason` with the raw value preserved.
+
+Gemini has no context-window-specific error signal to catch: an over-length prompt surfaces from the
+SDK as a plain `ApiException` (HTTP 400, `status="INVALID_ARGUMENT"`, no dedicated code or exception
+subclass — unlike OpenAI's `BadRequestException` with `code=context_length_exceeded`), which
+`GeminiChatModel.execute`'s catch-all currently reports as a generic `ERROR_CODE_FAILED_MODEL_CALL`
+rather than `ContextWindowExceededException`. Distinguishing it would require matching on the error
+message text, which is fragile; not yet done.

--- a/connectors/agentic-ai/docs/reference/native-providers.md
+++ b/connectors/agentic-ai/docs/reference/native-providers.md
@@ -280,12 +280,12 @@ else in this file — a different feature from a per-request model call, not a p
 
 ### Tool-result documents
 
-Unlike Anthropic and OpenAI, a document inside a tool result is embedded natively, not flattened to a
-JSON reference: `GeminiContentConverter.toFunctionResponseParts` calls the same `toDocumentPart` used
-for ordinary message content, so an image/PDF becomes an `inlineData` `Part` and text becomes a plain
-text `Part`, sent as a sibling of the `functionResponse` part rather than referenced from inside it.
-This is a real, unreviewed divergence from the other two providers' consistent "always JSON-reference,
-never native" rule — flagged here as a decision that still needs making, not as settled behavior.
+Like Anthropic and OpenAI, a document inside a tool result is flattened to a JSON reference rather
+than embedded natively: `GeminiContentConverter.toFunctionResponseParts` serializes just
+`doc.document()` to a text `Part`, the same reference-only shape `AnthropicContentConverter
+#toToolResultBlocks`/`OpenAiContentConverter#toResponsesToolResultOutputItems` produce — the
+document's actual bytes are already delivered to the model elsewhere for tool results, so embedding
+them here too would send them twice. Only `#toParts` (ordinary message content) embeds natively.
 
 ### Truncation
 
@@ -299,9 +299,26 @@ wire shape. `MAX_TOKENS` maps to `LENGTH`; a missing tool-use finish reason is s
 filtered candidate that also happens to carry a tool call is never misclassified. Every other finish
 reason falls back to `UnknownStopReason` with the raw value preserved.
 
-Gemini has no context-window-specific error signal to catch: an over-length prompt surfaces from the
-SDK as a plain `ApiException` (HTTP 400, `status="INVALID_ARGUMENT"`, no dedicated code or exception
-subclass — unlike OpenAI's `BadRequestException` with `code=context_length_exceeded`), which
-`GeminiChatModel.execute`'s catch-all currently reports as a generic `ERROR_CODE_FAILED_MODEL_CALL`
-rather than `ContextWindowExceededException`. Distinguishing it would require matching on the error
-message text, which is fragile; not yet done.
+Gemini has no context-window-specific error signal, unlike OpenAI's `BadRequestException` with
+`code=context_length_exceeded`: an over-length prompt surfaces as a plain `ApiException` (HTTP 400,
+`status="INVALID_ARGUMENT"`, shared with many unrelated validation failures). `GeminiChatModel
+#isContextWindowExceeded` matches on the one stable, distinctive substring of the message text
+("exceeds the maximum number of tokens allowed", confirmed identical across the Developer API and
+Vertex AI backends) to throw `ContextWindowExceededException` instead of the generic
+`ERROR_CODE_FAILED_MODEL_CALL` — message-matching is inherently brittle against upstream wording
+changes, but the SDK exposes no more reliable signal for this condition.
+
+### Timeout and retry
+
+`GeminiChatModelFactory.buildClient` always installs a `ClientOptions.customHttpClient` with a fixed
+10-second OkHttp `connectTimeout`, merged into the same `ClientOptions` builder as any proxy
+configuration. Without it, the SDK's own default `OkHttpClient` (built when no custom client is
+supplied) leaves `connectTimeout`/`readTimeout`/`writeTimeout` at zero (unbounded) and relies solely
+on `HttpOptions#timeout` as an overall `callTimeout` — a hung TCP connect would otherwise consume the
+whole, often much longer, configured request budget before failing. The overall timeout itself stays
+exactly as configurable as before (`TimeoutConfiguration`, shared with Anthropic/OpenAI); only connect
+is bounded separately, and only at this fixed default — there is no user-facing property for it.
+Retry needs no equivalent fix: the SDK unconditionally wraps every call in a `RetryInterceptor`
+(decompiled defaults: 5 attempts, exponential backoff with full jitter, retrying on
+408/429/500/502/503/504) whether or not `HttpOptions.retryOptions()` is configured, matching
+Anthropic/OpenAI's own SDK-default retry behavior (neither configures anything explicitly either).


### PR DESCRIPTION
## Description

- Adds a native (non-LangChain4j) Google Gemini provider for v2 AI Agent connector templates, Google Gemini Developer API (API-key) backend.
- Adds `GeminiChatModel`, `GeminiChatModelFactory`, `GeminiChatModelConfiguration`, request/response converters, and a streaming (SSE) assembler, wired via the v2 provider SPI.
- Throws the existing `ContentFilteredException`/`ContextWindowExceededException` (added by the OpenAI provider): a blocked prompt or filtered finish reason throws `ContentFilteredException`; an over-length prompt is detected via message-pattern matching on `ApiException` (the SDK has no dedicated exception/error code for this) and throws `ContextWindowExceededException`.
- Flattens a document inside a tool result to a JSON reference instead of embedding it natively, matching the Anthropic/OpenAI convention (the document's bytes are already delivered to the model elsewhere for tool results).
- Separates connect timeout (fixed at 10s) from the overall configurable request timeout by building a custom OkHttp client - required because supplying one makes the SDK skip applying its own `HttpOptions#timeout`/`ClientOptions#proxyOptions` - with read/write left unbounded so a long gap between SSE chunks doesn't trip a stray per-I/O timeout.
- Adds an "Enable thinking" toggle gating `thinkingBudget`/`thinkingLevel`, a "Model default" `thinkingLevel` choice (maps to the SDK's `THINKING_LEVEL_UNSPECIFIED`), and a `minimal` choice; validates `thinkingBudget`'s documented `-1`/`0`/positive domain locally.
- Fixes JSON response format silently sending nothing to the Gemini API when the modeler configures `json` format without a schema; now sets `responseMimeType` unconditionally for JSON format.
- Wraps every tool-result content branch (including the document JSON reference and the reasoning/provider-content fallback) in a `functionResponse`, so a tool result whose only content is a document still correlates with its `functionCall`.
- Drops `ReasoningContent`/`ProviderContent` tagged for a different provider instead of replaying it as Gemini-native, matching the Anthropic converter's precedent.
- Regenerates v2 AI Agent element templates to add the Gemini provider choice.
- Adds unit tests for the converters/assembler/factory, a WireMock e2e suite (tool-calling, streaming, thinking-config, blocked-prompt), a real-proxy-wire test, and a Google Gemini API row in `RealProviderApiSmokeIT`.
- Documents the provider in `native-providers.md` (backends, reasoning, caching, tool-result documents, truncation, timeout/retry) and adds a one-line entry to `ai-agent.md`'s provider list.

## Related issues

Part of #7222

## Checklist

- [x] Backport labels are added if these code changes should be backported. No backport label is added to the latest
  release, as this branch will be rebased onto main before the next release. Example backport labels:
    - `backport stable/8.8`: for changes that should be included in the next 8.8.x release.
    - **or** `backport release-8.8.7`: for changes that should be included in the specific release 8.8.7, and this
      *release has already been created*. The release branch will be merged back into stable/8.8 later, so the change
      will be included in future 8.8.x releases as well.
- [x] Tests/Integration tests for the changes have been added if applicable.
- [x] If the change requires a documentation update, it has been added to the appropriate section in the documentation.
