### PR TITLE
feat(agentic-ai): add native Vertex AI backend to Gemini provider

### DIFF
--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/subprocess/v2/AgentSubProcessGeminiStreamingResponseTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/subprocess/v2/AgentSubProcessGeminiStreamingResponseTests.java
@@ -164,6 +164,9 @@ class AgentSubProcessGeminiStreamingResponseTests extends BaseGeminiNativeSubPro
         agentResponse ->
             AgentSubProcessResponseAssert.assertThat(agentResponse)
                 .isReady()
+                // the two TextContent blocks are joined with no separator into the response text
+                // - it must not be truncated to just the first, signature-carrying block
+                .hasResponseText("First half.Second half.")
                 .hasResponseMessageSatisfying(
                     message -> {
                       assertThat(message.content())

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/e2e/RealProviderApiSmokeIT.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/e2e/RealProviderApiSmokeIT.java
@@ -558,7 +558,8 @@ class RealProviderApiSmokeIT {
                     Capability.PROMPT_CACHING,
                     Map.of(),
                     Capability.REASONING,
-                    Map.of("provider.googleGemini.model.parameters.thinking.thinkingLevel", "high"))),
+                    Map.of(
+                        "provider.googleGemini.model.parameters.thinking.thinkingLevel", "high"))),
             // No PROMPT_CACHING claim, since it has not been manually verified against a live
             // Vertex endpoint yet. STRUCTURED_OUTPUT, REASONING and the multimodal capabilities are
             // claimed because the request/response converters contain no backend branching at all
@@ -574,7 +575,7 @@ class RealProviderApiSmokeIT {
                     Capability.REASONING,
                         Map.of(
                             "provider.googleGemini.model.parameters.thinking.thinkingLevel",
-                                "high"))),
+                            "high"))),
             // Gemini 2.5 models use a numeric thinkingBudget rather than a qualitative level.
             // No STRUCTURED_OUTPUT claim: the Gemini API rejects a JSON response mime type
             // whenever function declarations are also present in the request, and this scenario
@@ -589,7 +590,7 @@ class RealProviderApiSmokeIT {
                     Capability.REASONING,
                         Map.of(
                             "provider.googleGemini.model.parameters.thinking.thinkingBudget",
-                                "24576"))),
+                            "24576"))),
             googleVertexAi(
                 "gemini-2.5-pro",
                 Map.of(
@@ -598,7 +599,7 @@ class RealProviderApiSmokeIT {
                     Capability.REASONING,
                         Map.of(
                             "provider.googleGemini.model.parameters.thinking.thinkingBudget",
-                                "24576"))))
+                            "24576"))))
         .filter(Provider::isEnabled);
   }
 

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/e2e/RealProviderApiSmokeIT.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/e2e/RealProviderApiSmokeIT.java
@@ -545,9 +545,6 @@ class RealProviderApiSmokeIT {
                     Capability.STRUCTURED_OUTPUT, Map.of(),
                     Capability.MULTIMODAL_USER_MESSAGE, Map.of(),
                     Capability.PROMPT_CACHING, Map.of())),
-            // Gemini 3.x models use a qualitative thinkingLevel rather than a token budget.
-            // No PROMPT_CACHING claim, since it has not been manually verified against a live
-            // Gemini endpoint yet.
             googleGeminiApi(
                 "gemini-3.7-flash",
                 Map.of(
@@ -560,12 +557,6 @@ class RealProviderApiSmokeIT {
                     Capability.REASONING,
                     Map.of(
                         "provider.googleGemini.model.parameters.thinking.thinkingLevel", "high"))),
-            // No PROMPT_CACHING claim, since it has not been manually verified against a live
-            // Vertex endpoint yet. STRUCTURED_OUTPUT, REASONING and the multimodal capabilities are
-            // claimed because the request/response converters contain no backend branching at all
-            // (only GeminiChatModelFactory branches on backend, for client/auth/base-URL
-            // construction), so this claim is expected to hold. Model id matches the existing
-            // Vertex AI e2e precedent on this branch (BaseGeminiVertexAiNativeTaskV2Test).
             googleVertexAi(
                 "gemini-3.7-flash",
                 Map.of(
@@ -578,10 +569,6 @@ class RealProviderApiSmokeIT {
                             "high"))),
             // Gemini 2.5 models use a numeric thinkingBudget rather than a qualitative level.
             // No STRUCTURED_OUTPUT claim: the Gemini API rejects a JSON response mime type
-            // whenever function declarations are also present in the request, and this scenario
-            // always wires the Lookup_Classified_Fact tool via the ad-hoc sub-process BPMN
-            // (confirmed with a live 400 INVALID_ARGUMENT: "Function calling with a response mime
-            // type: 'application/json' is unsupported" on gemini-2.5-pro).
             googleGeminiApi(
                 "gemini-2.5-pro",
                 Map.of(

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/e2e/RealProviderApiSmokeIT.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/e2e/RealProviderApiSmokeIT.java
@@ -111,8 +111,9 @@ class RealProviderApiSmokeIT {
           + "\"properties\":{\"codeName\":{\"type\":\"string\"},\"clearanceLevel\":{\"type\":\"string\"}},"
           + "\"required\":[\"codeName\",\"clearanceLevel\"]}";
 
-  // Repeated to clear Anthropic's minimum cacheable-prefix size (~1024 tokens for Sonnet-class
-  // models); each repeat is ~65 tokens, so 24 repeats gives comfortable margin.
+  // Repeated to clear the largest minimum cacheable-prefix size among providers under test:
+  // Anthropic needs ~1024 tokens (Sonnet-class models), Gemini needs ~4096. Each repeat is ~65
+  // tokens, so 80 repeats (~5200 tokens) gives comfortable margin over both.
   private static final String LONG_SYSTEM_PROMPT =
       """
       You are an assistant operating under a detailed classified-information handling protocol. \
@@ -121,7 +122,7 @@ class RealProviderApiSmokeIT {
       its result verbatim without paraphrasing. Follow every rule in this protocol \
       carefully and consistently across the whole conversation. \
       """
-          .repeat(24);
+          .repeat(80);
 
   private static final String DOC_DIR = "document-tool-call-results/";
   private static final String DOC_PROJECT_LAUNCH = DOC_DIR + "project-launch.pdf";
@@ -369,6 +370,33 @@ class RealProviderApiSmokeIT {
         false);
   }
 
+  static Provider googleVertexAi(
+      String model, Map<Capability, Map<String, String>> capabilityProperties) {
+    return new Provider(
+        "google-vertex-ai/" + model,
+        List.of(
+            "GOOGLE_VERTEX_AI_PROJECT_ID",
+            "GOOGLE_VERTEX_AI_REGION",
+            "GOOGLE_VERTEX_AI_SERVICE_ACCOUNT_JSON"),
+        Map.of(
+            "provider.type",
+            "google-gemini",
+            "provider.googleGemini.backend.type",
+            "google-vertex-ai",
+            "provider.googleGemini.backend.googleVertexAi.projectId",
+            envOrPlaceholder("GOOGLE_VERTEX_AI_PROJECT_ID"),
+            "provider.googleGemini.backend.googleVertexAi.region",
+            envOrPlaceholder("GOOGLE_VERTEX_AI_REGION"),
+            "provider.googleGemini.backend.googleVertexAi.authentication.type",
+            "serviceAccountCredentials",
+            "provider.googleGemini.backend.googleVertexAi.authentication.jsonKey",
+            envOrPlaceholder("GOOGLE_VERTEX_AI_SERVICE_ACCOUNT_JSON"),
+            "provider.googleGemini.model.model",
+            model),
+        capabilityProperties,
+        false);
+  }
+
   static Stream<Provider> providers() {
     return Stream.of(
             // claude-sonnet-4-6 only supports thinking mode "enabled" (explicit budget) — the model
@@ -517,13 +545,60 @@ class RealProviderApiSmokeIT {
                     Capability.STRUCTURED_OUTPUT, Map.of(),
                     Capability.MULTIMODAL_USER_MESSAGE, Map.of(),
                     Capability.PROMPT_CACHING, Map.of())),
-            // Conservative row: no REASONING/PROMPT_CACHING claim, since neither has been manually
-            // verified against a live Gemini endpoint yet.
+            // Gemini 3.x models use a qualitative thinkingLevel rather than a token budget.
+            // No PROMPT_CACHING claim, since it has not been manually verified against a live
+            // Gemini endpoint yet.
             googleGeminiApi(
-                "gemini-3-pro-preview",
+                "gemini-3.7-flash",
+                Map.of(
+                    Capability.STRUCTURED_OUTPUT,
+                    Map.of(),
+                    Capability.MULTIMODAL_USER_MESSAGE,
+                    Map.of(),
+                    Capability.PROMPT_CACHING,
+                    Map.of(),
+                    Capability.REASONING,
+                    Map.of("provider.googleGemini.model.parameters.thinking.thinkingLevel", "high"))),
+            // No PROMPT_CACHING claim, since it has not been manually verified against a live
+            // Vertex endpoint yet. STRUCTURED_OUTPUT, REASONING and the multimodal capabilities are
+            // claimed because the request/response converters contain no backend branching at all
+            // (only GeminiChatModelFactory branches on backend, for client/auth/base-URL
+            // construction), so this claim is expected to hold. Model id matches the existing
+            // Vertex AI e2e precedent on this branch (BaseGeminiVertexAiNativeTaskV2Test).
+            googleVertexAi(
+                "gemini-3.7-flash",
                 Map.of(
                     Capability.STRUCTURED_OUTPUT, Map.of(),
-                    Capability.MULTIMODAL_USER_MESSAGE, Map.of())))
+                    Capability.MULTIMODAL_USER_MESSAGE, Map.of(),
+                    Capability.PROMPT_CACHING, Map.of(),
+                    Capability.REASONING,
+                        Map.of(
+                            "provider.googleGemini.model.parameters.thinking.thinkingLevel",
+                                "high"))),
+            // Gemini 2.5 models use a numeric thinkingBudget rather than a qualitative level.
+            // No STRUCTURED_OUTPUT claim: the Gemini API rejects a JSON response mime type
+            // whenever function declarations are also present in the request, and this scenario
+            // always wires the Lookup_Classified_Fact tool via the ad-hoc sub-process BPMN
+            // (confirmed with a live 400 INVALID_ARGUMENT: "Function calling with a response mime
+            // type: 'application/json' is unsupported" on gemini-2.5-pro).
+            googleGeminiApi(
+                "gemini-2.5-pro",
+                Map.of(
+                    Capability.MULTIMODAL_USER_MESSAGE, Map.of(),
+                    Capability.PROMPT_CACHING, Map.of(),
+                    Capability.REASONING,
+                        Map.of(
+                            "provider.googleGemini.model.parameters.thinking.thinkingBudget",
+                                "24576"))),
+            googleVertexAi(
+                "gemini-2.5-pro",
+                Map.of(
+                    Capability.MULTIMODAL_USER_MESSAGE, Map.of(),
+                    Capability.PROMPT_CACHING, Map.of(),
+                    Capability.REASONING,
+                        Map.of(
+                            "provider.googleGemini.model.parameters.thinking.thinkingBudget",
+                                "24576"))))
         .filter(Provider::isEnabled);
   }
 
@@ -644,14 +719,14 @@ class RealProviderApiSmokeIT {
             provider,
             AI_AGENT_SUB_PROCESS_V2_ELEMENT_TEMPLATE_PATH,
             BPMN_RESOURCE,
-            "You are a careful reasoner. Think step by step before answering.",
+            "You are a careful reasoner. Think step by step before answering. Before providing your final answer, break down your reasoning step-by-step.",
             template -> provider.propertiesFor(Capability.REASONING).forEach(template::property));
 
     var instance =
         startAgent(
             model,
             PROCESS_ID,
-            "You are a careful reasoner. Think step by step before answering.",
+            "You are a careful reasoner. Think step by step before answering. Before providing your final answer, break down your reasoning step-by-step.",
             Map.of(
                 "userPrompt",
                 "A farmer has chickens and rabbits. Together they have 35 heads and 94 legs. How "

--- a/connectors/agentic-ai/connector-agentic-ai/element-templates/agenticai-ai-agent-subprocess.v2.json
+++ b/connectors/agentic-ai/connector-agentic-ai/element-templates/agenticai-ai-agent-subprocess.v2.json
@@ -1118,7 +1118,7 @@
   }, {
     "id" : "provider.googleGemini.backend.type",
     "label" : "Backend",
-    "description" : "Specify how the Gemini Developer API is reached.",
+    "description" : "Specify which Google backend serves the Gemini model.",
     "value" : "google-gemini-api",
     "group" : "provider",
     "binding" : {
@@ -1134,6 +1134,9 @@
     "choices" : [ {
       "name" : "Google Gemini API",
       "value" : "google-gemini-api"
+    }, {
+      "name" : "Google Vertex AI",
+      "value" : "google-vertex-ai"
     } ]
   }, {
     "id" : "provider.googleGemini.backend.googleGeminiApi.apiKey",
@@ -1181,6 +1184,138 @@
       } ]
     },
     "type" : "Hidden"
+  }, {
+    "id" : "provider.googleGemini.backend.googleVertexAi.projectId",
+    "label" : "Project ID",
+    "description" : "Specify Google Cloud project ID",
+    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "provider",
+    "binding" : {
+      "name" : "provider.googleGemini.backend.googleVertexAi.projectId",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "allMatch" : [ {
+        "property" : "provider.googleGemini.backend.type",
+        "equals" : "google-vertex-ai",
+        "type" : "simple"
+      }, {
+        "property" : "provider.type",
+        "equals" : "google-gemini",
+        "type" : "simple"
+      } ]
+    },
+    "type" : "String"
+  }, {
+    "id" : "provider.googleGemini.backend.googleVertexAi.region",
+    "label" : "Region",
+    "description" : "Specify the region where AI inference should take place",
+    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "provider",
+    "binding" : {
+      "name" : "provider.googleGemini.backend.googleVertexAi.region",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "allMatch" : [ {
+        "property" : "provider.googleGemini.backend.type",
+        "equals" : "google-vertex-ai",
+        "type" : "simple"
+      }, {
+        "property" : "provider.type",
+        "equals" : "google-gemini",
+        "type" : "simple"
+      } ]
+    },
+    "type" : "String"
+  }, {
+    "id" : "provider.googleGemini.backend.googleVertexAi.endpoint",
+    "label" : "API endpoint",
+    "optional" : true,
+    "group" : "provider",
+    "binding" : {
+      "name" : "provider.googleGemini.backend.googleVertexAi.endpoint",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "allMatch" : [ {
+        "property" : "provider.googleGemini.backend.type",
+        "equals" : "google-vertex-ai",
+        "type" : "simple"
+      }, {
+        "property" : "provider.type",
+        "equals" : "google-gemini",
+        "type" : "simple"
+      } ]
+    },
+    "type" : "Hidden"
+  }, {
+    "id" : "provider.googleGemini.backend.googleVertexAi.authentication.type",
+    "label" : "Authentication",
+    "description" : "Specify the Google Vertex AI authentication strategy.",
+    "value" : "serviceAccountCredentials",
+    "group" : "provider",
+    "binding" : {
+      "name" : "provider.googleGemini.backend.googleVertexAi.authentication.type",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "allMatch" : [ {
+        "property" : "provider.googleGemini.backend.type",
+        "equals" : "google-vertex-ai",
+        "type" : "simple"
+      }, {
+        "property" : "provider.type",
+        "equals" : "google-gemini",
+        "type" : "simple"
+      } ]
+    },
+    "type" : "Dropdown",
+    "choices" : [ {
+      "name" : "Service account credentials",
+      "value" : "serviceAccountCredentials"
+    }, {
+      "name" : "Application default credentials (Hybrid/Self-Managed only)",
+      "value" : "applicationDefaultCredentials"
+    } ]
+  }, {
+    "id" : "provider.googleGemini.backend.googleVertexAi.authentication.jsonKey",
+    "label" : "JSON key of the service account",
+    "description" : "This is the key of the service account in JSON format.",
+    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "provider",
+    "binding" : {
+      "name" : "provider.googleGemini.backend.googleVertexAi.authentication.jsonKey",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "allMatch" : [ {
+        "property" : "provider.googleGemini.backend.googleVertexAi.authentication.type",
+        "equals" : "serviceAccountCredentials",
+        "type" : "simple"
+      }, {
+        "property" : "provider.googleGemini.backend.type",
+        "equals" : "google-vertex-ai",
+        "type" : "simple"
+      }, {
+        "property" : "provider.type",
+        "equals" : "google-gemini",
+        "type" : "simple"
+      } ]
+    },
+    "type" : "String"
   }, {
     "id" : "provider.googleGemini.timeouts.timeout",
     "label" : "Timeout",

--- a/connectors/agentic-ai/connector-agentic-ai/element-templates/agenticai-ai-agent-task.v2.json
+++ b/connectors/agentic-ai/connector-agentic-ai/element-templates/agenticai-ai-agent-task.v2.json
@@ -1090,7 +1090,7 @@
   }, {
     "id" : "provider.googleGemini.backend.type",
     "label" : "Backend",
-    "description" : "Specify how the Gemini Developer API is reached.",
+    "description" : "Specify which Google backend serves the Gemini model.",
     "value" : "google-gemini-api",
     "group" : "provider",
     "binding" : {
@@ -1106,6 +1106,9 @@
     "choices" : [ {
       "name" : "Google Gemini API",
       "value" : "google-gemini-api"
+    }, {
+      "name" : "Google Vertex AI",
+      "value" : "google-vertex-ai"
     } ]
   }, {
     "id" : "provider.googleGemini.backend.googleGeminiApi.apiKey",
@@ -1153,6 +1156,138 @@
       } ]
     },
     "type" : "Hidden"
+  }, {
+    "id" : "provider.googleGemini.backend.googleVertexAi.projectId",
+    "label" : "Project ID",
+    "description" : "Specify Google Cloud project ID",
+    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "provider",
+    "binding" : {
+      "name" : "provider.googleGemini.backend.googleVertexAi.projectId",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "allMatch" : [ {
+        "property" : "provider.googleGemini.backend.type",
+        "equals" : "google-vertex-ai",
+        "type" : "simple"
+      }, {
+        "property" : "provider.type",
+        "equals" : "google-gemini",
+        "type" : "simple"
+      } ]
+    },
+    "type" : "String"
+  }, {
+    "id" : "provider.googleGemini.backend.googleVertexAi.region",
+    "label" : "Region",
+    "description" : "Specify the region where AI inference should take place",
+    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "provider",
+    "binding" : {
+      "name" : "provider.googleGemini.backend.googleVertexAi.region",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "allMatch" : [ {
+        "property" : "provider.googleGemini.backend.type",
+        "equals" : "google-vertex-ai",
+        "type" : "simple"
+      }, {
+        "property" : "provider.type",
+        "equals" : "google-gemini",
+        "type" : "simple"
+      } ]
+    },
+    "type" : "String"
+  }, {
+    "id" : "provider.googleGemini.backend.googleVertexAi.endpoint",
+    "label" : "API endpoint",
+    "optional" : true,
+    "group" : "provider",
+    "binding" : {
+      "name" : "provider.googleGemini.backend.googleVertexAi.endpoint",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "allMatch" : [ {
+        "property" : "provider.googleGemini.backend.type",
+        "equals" : "google-vertex-ai",
+        "type" : "simple"
+      }, {
+        "property" : "provider.type",
+        "equals" : "google-gemini",
+        "type" : "simple"
+      } ]
+    },
+    "type" : "Hidden"
+  }, {
+    "id" : "provider.googleGemini.backend.googleVertexAi.authentication.type",
+    "label" : "Authentication",
+    "description" : "Specify the Google Vertex AI authentication strategy.",
+    "value" : "serviceAccountCredentials",
+    "group" : "provider",
+    "binding" : {
+      "name" : "provider.googleGemini.backend.googleVertexAi.authentication.type",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "allMatch" : [ {
+        "property" : "provider.googleGemini.backend.type",
+        "equals" : "google-vertex-ai",
+        "type" : "simple"
+      }, {
+        "property" : "provider.type",
+        "equals" : "google-gemini",
+        "type" : "simple"
+      } ]
+    },
+    "type" : "Dropdown",
+    "choices" : [ {
+      "name" : "Service account credentials",
+      "value" : "serviceAccountCredentials"
+    }, {
+      "name" : "Application default credentials (Hybrid/Self-Managed only)",
+      "value" : "applicationDefaultCredentials"
+    } ]
+  }, {
+    "id" : "provider.googleGemini.backend.googleVertexAi.authentication.jsonKey",
+    "label" : "JSON key of the service account",
+    "description" : "This is the key of the service account in JSON format.",
+    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "provider",
+    "binding" : {
+      "name" : "provider.googleGemini.backend.googleVertexAi.authentication.jsonKey",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "allMatch" : [ {
+        "property" : "provider.googleGemini.backend.googleVertexAi.authentication.type",
+        "equals" : "serviceAccountCredentials",
+        "type" : "simple"
+      }, {
+        "property" : "provider.googleGemini.backend.type",
+        "equals" : "google-vertex-ai",
+        "type" : "simple"
+      }, {
+        "property" : "provider.type",
+        "equals" : "google-gemini",
+        "type" : "simple"
+      } ]
+    },
+    "type" : "String"
   }, {
     "id" : "provider.googleGemini.timeouts.timeout",
     "label" : "Timeout",

--- a/connectors/agentic-ai/connector-agentic-ai/element-templates/hybrid/agenticai-ai-agent-subprocess.v2-hybrid.json
+++ b/connectors/agentic-ai/connector-agentic-ai/element-templates/hybrid/agenticai-ai-agent-subprocess.v2-hybrid.json
@@ -1123,7 +1123,7 @@
   }, {
     "id" : "provider.googleGemini.backend.type",
     "label" : "Backend",
-    "description" : "Specify how the Gemini Developer API is reached.",
+    "description" : "Specify which Google backend serves the Gemini model.",
     "value" : "google-gemini-api",
     "group" : "provider",
     "binding" : {
@@ -1139,6 +1139,9 @@
     "choices" : [ {
       "name" : "Google Gemini API",
       "value" : "google-gemini-api"
+    }, {
+      "name" : "Google Vertex AI",
+      "value" : "google-vertex-ai"
     } ]
   }, {
     "id" : "provider.googleGemini.backend.googleGeminiApi.apiKey",
@@ -1186,6 +1189,138 @@
       } ]
     },
     "type" : "Hidden"
+  }, {
+    "id" : "provider.googleGemini.backend.googleVertexAi.projectId",
+    "label" : "Project ID",
+    "description" : "Specify Google Cloud project ID",
+    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "provider",
+    "binding" : {
+      "name" : "provider.googleGemini.backend.googleVertexAi.projectId",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "allMatch" : [ {
+        "property" : "provider.googleGemini.backend.type",
+        "equals" : "google-vertex-ai",
+        "type" : "simple"
+      }, {
+        "property" : "provider.type",
+        "equals" : "google-gemini",
+        "type" : "simple"
+      } ]
+    },
+    "type" : "String"
+  }, {
+    "id" : "provider.googleGemini.backend.googleVertexAi.region",
+    "label" : "Region",
+    "description" : "Specify the region where AI inference should take place",
+    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "provider",
+    "binding" : {
+      "name" : "provider.googleGemini.backend.googleVertexAi.region",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "allMatch" : [ {
+        "property" : "provider.googleGemini.backend.type",
+        "equals" : "google-vertex-ai",
+        "type" : "simple"
+      }, {
+        "property" : "provider.type",
+        "equals" : "google-gemini",
+        "type" : "simple"
+      } ]
+    },
+    "type" : "String"
+  }, {
+    "id" : "provider.googleGemini.backend.googleVertexAi.endpoint",
+    "label" : "API endpoint",
+    "optional" : true,
+    "group" : "provider",
+    "binding" : {
+      "name" : "provider.googleGemini.backend.googleVertexAi.endpoint",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "allMatch" : [ {
+        "property" : "provider.googleGemini.backend.type",
+        "equals" : "google-vertex-ai",
+        "type" : "simple"
+      }, {
+        "property" : "provider.type",
+        "equals" : "google-gemini",
+        "type" : "simple"
+      } ]
+    },
+    "type" : "Hidden"
+  }, {
+    "id" : "provider.googleGemini.backend.googleVertexAi.authentication.type",
+    "label" : "Authentication",
+    "description" : "Specify the Google Vertex AI authentication strategy.",
+    "value" : "serviceAccountCredentials",
+    "group" : "provider",
+    "binding" : {
+      "name" : "provider.googleGemini.backend.googleVertexAi.authentication.type",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "allMatch" : [ {
+        "property" : "provider.googleGemini.backend.type",
+        "equals" : "google-vertex-ai",
+        "type" : "simple"
+      }, {
+        "property" : "provider.type",
+        "equals" : "google-gemini",
+        "type" : "simple"
+      } ]
+    },
+    "type" : "Dropdown",
+    "choices" : [ {
+      "name" : "Service account credentials",
+      "value" : "serviceAccountCredentials"
+    }, {
+      "name" : "Application default credentials (Hybrid/Self-Managed only)",
+      "value" : "applicationDefaultCredentials"
+    } ]
+  }, {
+    "id" : "provider.googleGemini.backend.googleVertexAi.authentication.jsonKey",
+    "label" : "JSON key of the service account",
+    "description" : "This is the key of the service account in JSON format.",
+    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "provider",
+    "binding" : {
+      "name" : "provider.googleGemini.backend.googleVertexAi.authentication.jsonKey",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "allMatch" : [ {
+        "property" : "provider.googleGemini.backend.googleVertexAi.authentication.type",
+        "equals" : "serviceAccountCredentials",
+        "type" : "simple"
+      }, {
+        "property" : "provider.googleGemini.backend.type",
+        "equals" : "google-vertex-ai",
+        "type" : "simple"
+      }, {
+        "property" : "provider.type",
+        "equals" : "google-gemini",
+        "type" : "simple"
+      } ]
+    },
+    "type" : "String"
   }, {
     "id" : "provider.googleGemini.timeouts.timeout",
     "label" : "Timeout",

--- a/connectors/agentic-ai/connector-agentic-ai/element-templates/hybrid/agenticai-ai-agent-task.v2-hybrid.json
+++ b/connectors/agentic-ai/connector-agentic-ai/element-templates/hybrid/agenticai-ai-agent-task.v2-hybrid.json
@@ -1095,7 +1095,7 @@
   }, {
     "id" : "provider.googleGemini.backend.type",
     "label" : "Backend",
-    "description" : "Specify how the Gemini Developer API is reached.",
+    "description" : "Specify which Google backend serves the Gemini model.",
     "value" : "google-gemini-api",
     "group" : "provider",
     "binding" : {
@@ -1111,6 +1111,9 @@
     "choices" : [ {
       "name" : "Google Gemini API",
       "value" : "google-gemini-api"
+    }, {
+      "name" : "Google Vertex AI",
+      "value" : "google-vertex-ai"
     } ]
   }, {
     "id" : "provider.googleGemini.backend.googleGeminiApi.apiKey",
@@ -1158,6 +1161,138 @@
       } ]
     },
     "type" : "Hidden"
+  }, {
+    "id" : "provider.googleGemini.backend.googleVertexAi.projectId",
+    "label" : "Project ID",
+    "description" : "Specify Google Cloud project ID",
+    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "provider",
+    "binding" : {
+      "name" : "provider.googleGemini.backend.googleVertexAi.projectId",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "allMatch" : [ {
+        "property" : "provider.googleGemini.backend.type",
+        "equals" : "google-vertex-ai",
+        "type" : "simple"
+      }, {
+        "property" : "provider.type",
+        "equals" : "google-gemini",
+        "type" : "simple"
+      } ]
+    },
+    "type" : "String"
+  }, {
+    "id" : "provider.googleGemini.backend.googleVertexAi.region",
+    "label" : "Region",
+    "description" : "Specify the region where AI inference should take place",
+    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "provider",
+    "binding" : {
+      "name" : "provider.googleGemini.backend.googleVertexAi.region",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "allMatch" : [ {
+        "property" : "provider.googleGemini.backend.type",
+        "equals" : "google-vertex-ai",
+        "type" : "simple"
+      }, {
+        "property" : "provider.type",
+        "equals" : "google-gemini",
+        "type" : "simple"
+      } ]
+    },
+    "type" : "String"
+  }, {
+    "id" : "provider.googleGemini.backend.googleVertexAi.endpoint",
+    "label" : "API endpoint",
+    "optional" : true,
+    "group" : "provider",
+    "binding" : {
+      "name" : "provider.googleGemini.backend.googleVertexAi.endpoint",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "allMatch" : [ {
+        "property" : "provider.googleGemini.backend.type",
+        "equals" : "google-vertex-ai",
+        "type" : "simple"
+      }, {
+        "property" : "provider.type",
+        "equals" : "google-gemini",
+        "type" : "simple"
+      } ]
+    },
+    "type" : "Hidden"
+  }, {
+    "id" : "provider.googleGemini.backend.googleVertexAi.authentication.type",
+    "label" : "Authentication",
+    "description" : "Specify the Google Vertex AI authentication strategy.",
+    "value" : "serviceAccountCredentials",
+    "group" : "provider",
+    "binding" : {
+      "name" : "provider.googleGemini.backend.googleVertexAi.authentication.type",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "allMatch" : [ {
+        "property" : "provider.googleGemini.backend.type",
+        "equals" : "google-vertex-ai",
+        "type" : "simple"
+      }, {
+        "property" : "provider.type",
+        "equals" : "google-gemini",
+        "type" : "simple"
+      } ]
+    },
+    "type" : "Dropdown",
+    "choices" : [ {
+      "name" : "Service account credentials",
+      "value" : "serviceAccountCredentials"
+    }, {
+      "name" : "Application default credentials (Hybrid/Self-Managed only)",
+      "value" : "applicationDefaultCredentials"
+    } ]
+  }, {
+    "id" : "provider.googleGemini.backend.googleVertexAi.authentication.jsonKey",
+    "label" : "JSON key of the service account",
+    "description" : "This is the key of the service account in JSON format.",
+    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "provider",
+    "binding" : {
+      "name" : "provider.googleGemini.backend.googleVertexAi.authentication.jsonKey",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "allMatch" : [ {
+        "property" : "provider.googleGemini.backend.googleVertexAi.authentication.type",
+        "equals" : "serviceAccountCredentials",
+        "type" : "simple"
+      }, {
+        "property" : "provider.googleGemini.backend.type",
+        "equals" : "google-vertex-ai",
+        "type" : "simple"
+      }, {
+        "property" : "provider.type",
+        "equals" : "google-gemini",
+        "type" : "simple"
+      } ]
+    },
+    "type" : "String"
   }, {
     "id" : "provider.googleGemini.timeouts.timeout",
     "label" : "Timeout",

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/agent/AgentResponseHandlerImpl.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/agent/AgentResponseHandlerImpl.java
@@ -27,6 +27,7 @@ import io.camunda.connector.api.error.ConnectorException;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -75,19 +76,21 @@ public class AgentResponseHandlerImpl implements AgentResponseHandler {
       builder.responseMessage(assistantMessage);
     }
 
-    findFirstResponseText(assistantMessage)
+    deriveResponseText(assistantMessage)
         .ifPresent(
             responseText -> handleFirstResponseText(responseConfiguration, builder, responseText));
 
     return builder.build();
   }
 
-  private Optional<String> findFirstResponseText(AssistantMessage assistantMessage) {
-    return assistantMessage.content().stream()
-        .filter(c -> c instanceof TextContent)
-        .map(c -> ((TextContent) c).text())
-        .filter(StringUtils::isNotBlank)
-        .findFirst();
+  private Optional<String> deriveResponseText(AssistantMessage assistantMessage) {
+    return Optional.of(
+            assistantMessage.content().stream()
+                .filter(c -> c instanceof TextContent)
+                .map(c -> ((TextContent) c).text())
+                .filter(StringUtils::isNotBlank)
+                .collect(Collectors.joining()))
+        .filter(StringUtils::isNotBlank);
   }
 
   private void handleFirstResponseText(

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiChatModelFactory.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiChatModelFactory.java
@@ -6,7 +6,10 @@
  */
 package io.camunda.connector.agenticai.aiagent.chatmodel.provider.gemini;
 
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.auth.oauth2.ServiceAccountCredentials;
 import com.google.genai.Client;
+import com.google.genai.errors.GenAiIOException;
 import com.google.genai.types.ClientOptions;
 import com.google.genai.types.HttpOptions;
 import io.camunda.connector.agenticai.aiagent.chatmodel.ChatModel;
@@ -15,10 +18,16 @@ import io.camunda.connector.agenticai.aiagent.chatmodel.ChatModelFactory;
 import io.camunda.connector.agenticai.aiagent.model.request.v2.GeminiChatModelConfiguration;
 import io.camunda.connector.agenticai.aiagent.model.request.v2.GeminiChatModelConfiguration.GeminiBackend;
 import io.camunda.connector.agenticai.aiagent.model.request.v2.GeminiChatModelConfiguration.GeminiBackend.GeminiApiBackend;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.GeminiChatModelConfiguration.GeminiBackend.GeminiVertexAiBackend;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.GeminiChatModelConfiguration.GeminiBackend.GoogleVertexAiAuthentication.ServiceAccountCredentialsAuthentication;
 import io.camunda.connector.agenticai.common.AgenticAiHttpProxySupport;
 import io.camunda.connector.api.error.ConnectorInputException;
+import io.camunda.connector.http.client.proxy.NonProxyHosts;
 import io.camunda.connector.http.client.proxy.ProxyConfiguration;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.Optional;
 import okhttp3.Credentials;
@@ -55,6 +64,12 @@ public class GeminiChatModelFactory implements ChatModelFactory {
    * connect bounded and {@code callTimeout} governing the overall budget.
    */
   private static final Duration CONNECT_TIMEOUT = Duration.ofSeconds(10);
+
+  private static final String GOOGLE_CLOUD_PLATFORM_SCOPE =
+      "https://www.googleapis.com/auth/cloud-platform";
+
+  private static final String DEFAULT_GEMINI_API_BASE_URL =
+      "https://generativelanguage.googleapis.com";
 
   private final AgenticAiHttpProxySupport httpProxySupport;
   private final GeminiContentRequestConverter requestConverter;
@@ -94,20 +109,31 @@ public class GeminiChatModelFactory implements ChatModelFactory {
       GeminiBackend backend,
       @Nullable Duration timeout,
       AgenticAiHttpProxySupport httpProxySupport) {
-    // Only one backend variant exists today (google-gemini-api), so this cast is safe.
-    final var apiBackend = (GeminiApiBackend) backend;
-    final var googleGeminiApi = apiBackend.googleGeminiApi();
-    final String endpoint = googleGeminiApi.endpoint();
+    // the configured endpoint override, if any - only ever set for e2e tests (see the field's
+    // javadoc); when unset, the SDK derives its own production base URL for the backend at build
+    // time (which, for google-vertex-ai, is not always byte-identical to
+    // AgenticAiHttpProxySupport.defaultGoogleGenAiBaseUrl - e.g. the "us"/"eu" multi-region
+    // hosts), so it must not be pinned here.
+    final String endpointOverride = configuredEndpoint(backend);
 
     final var httpOptionsBuilder = HttpOptions.builder();
-    if (endpoint != null) {
-      httpOptionsBuilder.baseUrl(endpoint);
+    if (endpointOverride != null) {
+      httpOptionsBuilder.baseUrl(endpointOverride);
     }
     // Stored for introspection/consistency only -- because a customHttpClient is always supplied
     // below, the SDK never reads this value itself; okHttpClientBuilder.callTimeout is what
     // actually enforces the overall timeout.
     if (timeout != null) {
       httpOptionsBuilder.timeout(toGeminiTimeoutMillis(timeout));
+    }
+
+    final var clientBuilder = Client.builder().httpOptions(httpOptionsBuilder.build());
+
+    switch (backend) {
+      case GeminiApiBackend apiBackend ->
+          clientBuilder.apiKey(apiBackend.googleGeminiApi().apiKey());
+      case GeminiVertexAiBackend vertexAiBackend ->
+          applyVertexAiBackend(clientBuilder, vertexAiBackend);
     }
 
     final var okHttpClientBuilder =
@@ -119,18 +145,88 @@ public class GeminiChatModelFactory implements ChatModelFactory {
       okHttpClientBuilder.callTimeout(Duration.ofMillis(toGeminiTimeoutMillis(timeout)));
     }
 
+    // the proxy scheme is derived from the endpoint override, if any; when unset, the proxy
+    // configuration's default scheme (https) is used
     final String scheme =
-        Optional.ofNullable(endpoint).map(e -> URI.create(e).getScheme()).orElse(null);
-    httpProxySupport
-        .okHttpProxy(scheme != null ? scheme : ProxyConfiguration.SCHEME_HTTPS)
-        .ifPresent(proxy -> applyProxy(okHttpClientBuilder, proxy));
+        Optional.ofNullable(endpointOverride).map(url -> URI.create(url).getScheme()).orElse(null);
+    final String targetHost = resolveTargetHost(backend, endpointOverride);
+    if (!NonProxyHosts.isNonProxyHost(targetHost)) {
+      httpProxySupport
+          .okHttpProxy(scheme != null ? scheme : ProxyConfiguration.SCHEME_HTTPS)
+          .ifPresent(proxy -> applyProxy(okHttpClientBuilder, proxy));
+    }
 
-    return Client.builder()
-        .apiKey(googleGeminiApi.apiKey())
-        .httpOptions(httpOptionsBuilder.build())
-        .clientOptions(
-            ClientOptions.builder().customHttpClient(okHttpClientBuilder.build()).build())
-        .build();
+    clientBuilder.clientOptions(
+        ClientOptions.builder().customHttpClient(okHttpClientBuilder.build()).build());
+
+    try {
+      // for the google-vertex-ai backend with application default credentials, the credentials
+      // are resolved here, eagerly, by the SDK
+      return clientBuilder.build();
+    } catch (GenAiIOException | IllegalArgumentException e) {
+      throw new ConnectorInputException("Failed to create Google GenAI client", e);
+    }
+  }
+
+  private static @Nullable String configuredEndpoint(GeminiBackend backend) {
+    return switch (backend) {
+      case GeminiApiBackend apiBackend -> apiBackend.googleGeminiApi().endpoint();
+      case GeminiVertexAiBackend vertexAiBackend -> vertexAiBackend.googleVertexAi().endpoint();
+    };
+  }
+
+  /**
+   * Resolves the host the SDK will actually target, so the proxy can be skipped when it matches a
+   * configured non-proxy host pattern. {@code com.google.genai.types.ProxyOptions} -- the SDK's own
+   * proxy mechanism, which does understand a bypass list, see the v1 Vertex AI provider's {@code
+   * ChatModelHttpProxySupport#createGoogleGenAiProxyOptions} -- is never used here, because
+   * supplying a {@code customHttpClient} (required for the timeout/streaming behavior documented on
+   * {@link #CONNECT_TIMEOUT}) makes the SDK ignore it entirely, so the same bypass has to be
+   * reimplemented against the raw OkHttp client instead.
+   */
+  private static String resolveTargetHost(
+      GeminiBackend backend, @Nullable String endpointOverride) {
+    if (endpointOverride != null) {
+      return URI.create(endpointOverride).getHost();
+    }
+    return switch (backend) {
+      case GeminiApiBackend ignored -> URI.create(DEFAULT_GEMINI_API_BASE_URL).getHost();
+      case GeminiVertexAiBackend vertexAiBackend ->
+          URI.create(
+                  AgenticAiHttpProxySupport.defaultGoogleGenAiBaseUrl(
+                      vertexAiBackend.googleVertexAi().region()))
+              .getHost();
+    };
+  }
+
+  private static void applyVertexAiBackend(
+      Client.Builder clientBuilder, GeminiVertexAiBackend vertexAiBackend) {
+    final var googleVertexAi = vertexAiBackend.googleVertexAi();
+    clientBuilder
+        .vertexAI(true)
+        .project(googleVertexAi.projectId())
+        .location(googleVertexAi.region());
+
+    // application default credentials are left unset here - the SDK resolves them itself when
+    // the client is built
+    if (googleVertexAi.authentication() instanceof ServiceAccountCredentialsAuthentication sac) {
+      clientBuilder.credentials(createServiceAccountCredentials(sac));
+    }
+  }
+
+  private static GoogleCredentials createServiceAccountCredentials(
+      ServiceAccountCredentialsAuthentication sac) {
+    try {
+      // Credentials read from a key file carry no scopes. google-genai only scopes the
+      // application default credentials it resolves itself and passes these through verbatim,
+      // so without this the token request fails with invalid_scope.
+      return ServiceAccountCredentials.fromStream(
+              new ByteArrayInputStream(sac.jsonKey().getBytes(StandardCharsets.UTF_8)))
+          .createScoped(GOOGLE_CLOUD_PLATFORM_SCOPE);
+    } catch (IOException e) {
+      throw new ConnectorInputException(
+          "Authentication failed for provided service account credentials", e);
+    }
   }
 
   /**

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiChatModelFactory.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiChatModelFactory.java
@@ -109,20 +109,12 @@ public class GeminiChatModelFactory implements ChatModelFactory {
       GeminiBackend backend,
       @Nullable Duration timeout,
       AgenticAiHttpProxySupport httpProxySupport) {
-    // the configured endpoint override, if any - only ever set for e2e tests (see the field's
-    // javadoc); when unset, the SDK derives its own production base URL for the backend at build
-    // time (which, for google-vertex-ai, is not always byte-identical to
-    // AgenticAiHttpProxySupport.defaultGoogleGenAiBaseUrl - e.g. the "us"/"eu" multi-region
-    // hosts), so it must not be pinned here.
     final String endpointOverride = configuredEndpoint(backend);
 
     final var httpOptionsBuilder = HttpOptions.builder();
     if (endpointOverride != null) {
       httpOptionsBuilder.baseUrl(endpointOverride);
     }
-    // Stored for introspection/consistency only -- because a customHttpClient is always supplied
-    // below, the SDK never reads this value itself; okHttpClientBuilder.callTimeout is what
-    // actually enforces the overall timeout.
     if (timeout != null) {
       httpOptionsBuilder.timeout(toGeminiTimeoutMillis(timeout));
     }
@@ -145,8 +137,6 @@ public class GeminiChatModelFactory implements ChatModelFactory {
       okHttpClientBuilder.callTimeout(Duration.ofMillis(toGeminiTimeoutMillis(timeout)));
     }
 
-    // the proxy scheme is derived from the endpoint override, if any; when unset, the proxy
-    // configuration's default scheme (https) is used
     final String scheme =
         Optional.ofNullable(endpointOverride).map(url -> URI.create(url).getScheme()).orElse(null);
     final String targetHost = resolveTargetHost(backend, endpointOverride);

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/v2/GeminiChatModelConfiguration.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/v2/GeminiChatModelConfiguration.java
@@ -103,6 +103,103 @@ public record GeminiChatModelConfiguration(@Valid @NotNull GeminiConnection goog
         }
       }
     }
+
+    @TemplateSubType(id = GOOGLE_VERTEX_AI_ID, label = "Google Vertex AI")
+    record GeminiVertexAiBackend(@Valid @NotNull GoogleVertexAi googleVertexAi)
+        implements GeminiBackend {
+
+      @TemplateProperty(ignore = true)
+      public static final String GOOGLE_VERTEX_AI_ID = "google-vertex-ai";
+
+      @Override
+      public String type() {
+        return GOOGLE_VERTEX_AI_ID;
+      }
+
+      public record GoogleVertexAi(
+          @NotBlank
+              @TemplateProperty(
+                  group = "provider",
+                  label = "Project ID",
+                  description = "Specify Google Cloud project ID",
+                  type = TemplateProperty.PropertyType.String,
+                  feel = FeelMode.optional,
+                  constraints = @TemplateProperty.PropertyConstraints(notEmpty = true))
+              String projectId,
+          @NotBlank
+              @TemplateProperty(
+                  group = "provider",
+                  label = "Region",
+                  description = "Specify the region where AI inference should take place",
+                  type = TemplateProperty.PropertyType.String,
+                  feel = FeelMode.optional,
+                  constraints = @TemplateProperty.PropertyConstraints(notEmpty = true))
+              String region,
+          // Hidden: never shown in the modeler. Exists solely so e2e tests can point the client
+          // at a local WireMock server via HttpOptions.baseUrl(); real deployments never set it.
+          // Mirrors GoogleGeminiApi's own hidden endpoint field 1:1 (same rationale).
+          @HttpUrl
+              @TemplateProperty(
+                  group = "provider",
+                  label = "API endpoint",
+                  type = TemplateProperty.PropertyType.Hidden,
+                  feel = FeelMode.disabled,
+                  optional = true)
+              @Nullable String endpoint,
+          @Valid @NotNull GoogleVertexAiAuthentication authentication) {
+
+        @JsonIgnore
+        @AssertFalse(
+            message =
+                "Application default credentials for Google Vertex AI are not supported on SaaS")
+        public boolean isApplicationDefaultCredentialsUsedInSaaS() {
+          return ConnectorUtils.isSaaS()
+              && authentication
+                  instanceof
+                  GoogleVertexAiAuthentication.ApplicationDefaultCredentialsAuthentication;
+        }
+      }
+    }
+
+    @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+    @JsonSubTypes({
+      @JsonSubTypes.Type(
+          value = GoogleVertexAiAuthentication.ServiceAccountCredentialsAuthentication.class,
+          name = "serviceAccountCredentials"),
+      @JsonSubTypes.Type(
+          value = GoogleVertexAiAuthentication.ApplicationDefaultCredentialsAuthentication.class,
+          name = "applicationDefaultCredentials")
+    })
+    @TemplateDiscriminatorProperty(
+        label = "Authentication",
+        group = "provider",
+        name = "type",
+        defaultValue = "serviceAccountCredentials",
+        description = "Specify the Google Vertex AI authentication strategy.")
+    sealed interface GoogleVertexAiAuthentication {
+      @TemplateSubType(id = "serviceAccountCredentials", label = "Service account credentials")
+      record ServiceAccountCredentialsAuthentication(
+          @NotBlank
+              @TemplateProperty(
+                  group = "provider",
+                  label = "JSON key of the service account",
+                  description = "This is the key of the service account in JSON format.",
+                  feel = FeelMode.optional,
+                  constraints = @TemplateProperty.PropertyConstraints(notEmpty = true))
+              String jsonKey)
+          implements GoogleVertexAiAuthentication {
+        @Override
+        public String toString() {
+          return "ServiceAccountCredentialsAuthentication{jsonKey=[REDACTED]}";
+        }
+      }
+
+      @TemplateSubType(
+          id = "applicationDefaultCredentials",
+          label = "Application default credentials (Hybrid/Self-Managed only)")
+      record ApplicationDefaultCredentialsAuthentication()
+          implements GoogleVertexAiAuthentication {}
+    }
   }
 
   public record GeminiModel(

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/v2/GeminiChatModelConfiguration.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/v2/GeminiChatModelConfiguration.java
@@ -8,6 +8,7 @@ package io.camunda.connector.agenticai.aiagent.model.request.v2;
 
 import static io.camunda.connector.agenticai.aiagent.model.request.v2.GeminiChatModelConfiguration.GOOGLE_GEMINI_ID;
 import static io.camunda.connector.agenticai.aiagent.model.request.v2.GeminiChatModelConfiguration.GeminiBackend.GeminiApiBackend.GOOGLE_GEMINI_API_ID;
+import static io.camunda.connector.agenticai.aiagent.model.request.v2.GeminiChatModelConfiguration.GeminiBackend.GeminiVertexAiBackend.GOOGLE_VERTEX_AI_ID;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -15,6 +16,7 @@ import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import io.camunda.connector.agenticai.aiagent.model.request.v1.shared.HttpUrl;
 import io.camunda.connector.agenticai.aiagent.model.request.v1.shared.TimeoutConfiguration;
+import io.camunda.connector.agenticai.aiagent.util.ConnectorUtils;
 import io.camunda.connector.generator.java.annotation.FeelMode;
 import io.camunda.connector.generator.java.annotation.TemplateDiscriminatorProperty;
 import io.camunda.connector.generator.java.annotation.TemplateProperty;
@@ -54,14 +56,17 @@ public record GeminiChatModelConfiguration(@Valid @NotNull GeminiConnection goog
 
   @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
   @JsonSubTypes({
-    @JsonSubTypes.Type(value = GeminiBackend.GeminiApiBackend.class, name = GOOGLE_GEMINI_API_ID)
+    @JsonSubTypes.Type(value = GeminiBackend.GeminiApiBackend.class, name = GOOGLE_GEMINI_API_ID),
+    @JsonSubTypes.Type(
+        value = GeminiBackend.GeminiVertexAiBackend.class,
+        name = GOOGLE_VERTEX_AI_ID)
   })
   @TemplateDiscriminatorProperty(
       label = "Backend",
       group = "provider",
       name = "type",
       defaultValue = GOOGLE_GEMINI_API_ID,
-      description = "Specify how the Gemini Developer API is reached.")
+      description = "Specify which Google backend serves the Gemini model.")
   public sealed interface GeminiBackend {
 
     /** The backend discriminator string. */

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/common/AgenticAiHttpProxySupport.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/common/AgenticAiHttpProxySupport.java
@@ -13,7 +13,9 @@ import io.camunda.connector.http.client.proxy.ProxyConfiguration;
 import java.net.InetSocketAddress;
 import java.net.Proxy;
 import java.net.URI;
+import java.util.Locale;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
@@ -168,6 +170,9 @@ public class AgenticAiHttpProxySupport {
         proxyDetails.scheme() + "://" + proxyDetails.host() + ":" + proxyDetails.port());
   }
 
+  /** Vertex AI's two multi-regional locations, mirroring {@code com.google.genai.ApiClient}. */
+  private static final Set<String> MULTI_REGIONAL_LOCATIONS = Set.of("us", "eu");
+
   /**
    * Returns the {@link ProxyOptions} configured for the target scheme, if any, for azure-core/
    * azure-identity based clients (e.g. {@code ClientSecretCredentialBuilder}, {@code
@@ -197,5 +202,21 @@ public class AgenticAiHttpProxySupport {
               }
               return options;
             });
+  }
+
+  /**
+   * Resolves the default Google GenAI API host for the given Vertex AI region, mirroring {@code
+   * com.google.genai.ApiClient}'s own (package-private, unexported) resolution: the global endpoint
+   * host for {@code global}, the multi-regional host for {@code us}/{@code eu}, otherwise the
+   * regional endpoint host.
+   */
+  public static String defaultGoogleGenAiBaseUrl(String region) {
+    if ("global".equalsIgnoreCase(region)) {
+      return "https://aiplatform.googleapis.com";
+    }
+    if (MULTI_REGIONAL_LOCATIONS.contains(region.toLowerCase(Locale.ROOT))) {
+      return "https://aiplatform.%s.rep.googleapis.com".formatted(region.toLowerCase(Locale.ROOT));
+    }
+    return "https://%s-aiplatform.googleapis.com".formatted(region);
   }
 }

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/agent/AgentResponseHandlerTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/agent/AgentResponseHandlerTest.java
@@ -26,6 +26,7 @@ import io.camunda.connector.agenticai.aiagent.model.AgentState;
 import io.camunda.connector.agenticai.aiagent.model.TurnReconstructor;
 import io.camunda.connector.agenticai.aiagent.model.message.AssistantMessage;
 import io.camunda.connector.agenticai.aiagent.model.message.content.DocumentContent;
+import io.camunda.connector.agenticai.aiagent.model.message.content.TextContent;
 import io.camunda.connector.agenticai.aiagent.model.request.AgentTaskResponseConfiguration;
 import io.camunda.connector.agenticai.aiagent.model.request.ResponseConfiguration;
 import io.camunda.connector.agenticai.aiagent.model.request.ResponseFormatConfiguration.JsonResponseFormatConfiguration;
@@ -218,6 +219,25 @@ class AgentResponseHandlerTest {
       assertThat(response.responseMessage()).isNotNull().isEqualTo(assistantMessage);
       assertThat(response.responseText()).isEqualTo(HAIKU_TEXT);
       assertThat(response.responseJson()).isNull();
+    }
+
+    @Test
+    void joinsAllTextContentBlocksWhenAssistantMessageHasMultipleTextContentBlocks() {
+      // Gemini 2.5 models can return several TextContent blocks in one assistant message (e.g.
+      // split at a thoughtSignature boundary); the response text must not silently drop anything
+      // after the first block.
+      final var assistantMessage =
+          assistantMessage(
+              List.of(
+                  TextContent.textContent("First half. "),
+                  TextContent.textContent("Second half.")));
+
+      final var response =
+          createResponse(
+              new AgentTaskResponseConfiguration(new TextResponseFormatConfiguration(false), false),
+              assistantMessage);
+
+      assertThat(response.responseText()).isEqualTo("First half. Second half.");
     }
 
     static Stream<AssistantMessage> emptyAssistantMessages() {

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiChatModelFactoryTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiChatModelFactoryTest.java
@@ -230,6 +230,134 @@ class GeminiChatModelFactoryTest {
     model.close();
   }
 
+  @Test
+  void createBuildsVertexAiClientWithApplicationDefaultCredentials() {
+    noProxyConfigured();
+
+    final var clientBuilder =
+        createVertexAiChatModel(
+            vertexConfig(null, new ApplicationDefaultCredentialsAuthentication()));
+
+    verify(clientBuilder).vertexAI(true);
+    verify(clientBuilder).project(PROJECT_ID);
+    verify(clientBuilder).location(REGION);
+    verify(clientBuilder, never()).credentials(any());
+
+    // no endpoint override configured: the base URL is left for the SDK to derive itself at
+    // build time (its own per-region formula, e.g. for "us"/"eu" multi-region hosts, is not
+    // byte-identical to AgenticAiHttpProxySupport.defaultGoogleGenAiBaseUrl, which is why that
+    // function is never used to pin the base URL here)
+    verify(clientBuilder).httpOptions(httpOptionsCaptor.capture());
+    assertThat(httpOptionsCaptor.getValue().baseUrl()).isEmpty();
+
+    // .. and with no endpoint override configured, the proxy scheme falls back to the default
+    // https scheme
+    verify(httpProxySupport).okHttpProxy(ProxyConfiguration.SCHEME_HTTPS);
+  }
+
+  /**
+   * Service account credentials must be scoped explicitly. google-genai only scopes the application
+   * default credentials it resolves itself and passes user-supplied credentials through verbatim,
+   * so an unscoped credential would make the token request fail with {@code invalid_scope}.
+   */
+  @Test
+  void createBuildsVertexAiClientWithServiceAccountCredentials() {
+    noProxyConfigured();
+
+    try (MockedStatic<ServiceAccountCredentials> sacMock =
+        mockStatic(ServiceAccountCredentials.class)) {
+      final var mockedSac = mock(ServiceAccountCredentials.class);
+      final var scopedSac = mock(GoogleCredentials.class);
+      when(mockedSac.createScoped("https://www.googleapis.com/auth/cloud-platform"))
+          .thenReturn(scopedSac);
+      sacMock.when(() -> ServiceAccountCredentials.fromStream(any())).thenReturn(mockedSac);
+
+      final var clientBuilder =
+          createVertexAiChatModel(
+              vertexConfig(null, new ServiceAccountCredentialsAuthentication("{}")));
+
+      verify(clientBuilder).credentials(scopedSac);
+    }
+  }
+
+  @Test
+  void createAppliesVertexAiEndpointOverride() {
+    noProxyConfigured();
+    final String endpoint = "http://localhost:8888";
+
+    final var clientBuilder =
+        createVertexAiChatModel(
+            vertexConfig(endpoint, new ApplicationDefaultCredentialsAuthentication()));
+
+    verify(clientBuilder).httpOptions(httpOptionsCaptor.capture());
+    assertThat(httpOptionsCaptor.getValue().baseUrl()).contains(endpoint);
+
+    verify(httpProxySupport).okHttpProxy(ProxyConfiguration.SCHEME_HTTP);
+  }
+
+  @Test
+  void createWiresProxyOptionsForVertexAiBackendWhenProxyConfigured() {
+    when(httpProxySupport.okHttpProxy(any()))
+        .thenReturn(Optional.of(proxyOf("proxy.example.com", 8080, "proxy-user", "proxy-pass")));
+
+    final var clientBuilder =
+        createVertexAiChatModel(
+            vertexConfig(null, new ApplicationDefaultCredentialsAuthentication()));
+
+    // applied directly to the custom OkHttp client, not via ClientOptions.proxyOptions() - see
+    // GeminiChatModelFactory#buildClient's javadoc on CONNECT_TIMEOUT
+    verify(clientBuilder).clientOptions(clientOptionsCaptor.capture());
+    final var customHttpClient = clientOptionsCaptor.getValue().customHttpClient();
+    assertThat(customHttpClient).isPresent();
+    final var proxyAddress = (InetSocketAddress) customHttpClient.get().proxy().address();
+    assertThat(proxyAddress.getHostString()).isEqualTo("proxy.example.com");
+    assertThat(proxyAddress.getPort()).isEqualTo(8080);
+    assertThat(customHttpClient.get().proxyAuthenticator()).isNotEqualTo(Authenticator.NONE);
+
+    verify(httpProxySupport).okHttpProxy(ProxyConfiguration.SCHEME_HTTPS);
+  }
+
+  @Test
+  void createThrowsConnectorInputExceptionWhenVertexAiClientBuildFails() {
+    noProxyConfigured();
+
+    final var clientBuilder = spy(Client.builder());
+    doAnswer(
+            invocation -> {
+              throw new IllegalArgumentException("boom");
+            })
+        .when(clientBuilder)
+        .build();
+
+    try (MockedStatic<Client> clientMock = mockStatic(Client.class, Answers.CALLS_REAL_METHODS)) {
+      clientMock.when(Client::builder).thenReturn(clientBuilder);
+
+      assertThatThrownBy(
+              () ->
+                  factory.create(
+                      vertexConfig(null, new ApplicationDefaultCredentialsAuthentication())))
+          .isInstanceOf(ConnectorInputException.class)
+          .hasMessageContaining("Failed to create Google GenAI client");
+    }
+  }
+
+  @Test
+  void createThrowsConnectorInputExceptionWhenServiceAccountCredentialsAreInvalid() {
+    try (MockedStatic<ServiceAccountCredentials> sacMock =
+        mockStatic(ServiceAccountCredentials.class)) {
+      sacMock
+          .when(() -> ServiceAccountCredentials.fromStream(any()))
+          .thenThrow(new IOException("bad key"));
+
+      assertThatThrownBy(
+              () ->
+                  factory.create(
+                      vertexConfig(null, new ServiceAccountCredentialsAuthentication("{}"))))
+          .isInstanceOf(ConnectorInputException.class)
+          .hasMessageContaining("Authentication failed for provided service account credentials");
+    }
+  }
+
   private void noProxyConfigured() {
     when(httpProxySupport.okHttpProxy(any())).thenReturn(Optional.empty());
   }

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiChatModelFactoryTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiChatModelFactoryTest.java
@@ -114,7 +114,11 @@ class GeminiChatModelFactoryTest {
 
     final ChatModel model = factory.create(apiConfig(null, Duration.ofSeconds(30)));
 
+    // httpOptions().timeout() is stored for introspection/consistency only - the SDK never reads
+    // it once a customHttpClient is supplied; callTimeoutMillis() on that client is what actually
+    // enforces the overall timeout, see GeminiChatModelFactory#buildClient's javadoc.
     assertThat(httpOptionsOf(model).timeout()).contains(30_000);
+    assertThat(callTimeoutMillisOf(model)).isEqualTo(30_000);
 
     model.close();
   }
@@ -126,6 +130,7 @@ class GeminiChatModelFactoryTest {
     final ChatModel model = factory.create(apiConfig(null, Duration.ofNanos(500)));
 
     assertThat(httpOptionsOf(model).timeout()).contains(1);
+    assertThat(callTimeoutMillisOf(model)).isEqualTo(1);
 
     model.close();
   }
@@ -136,10 +141,12 @@ class GeminiChatModelFactoryTest {
 
     final ChatModel zeroTimeoutModel = factory.create(apiConfig(null, Duration.ZERO));
     assertThat(httpOptionsOf(zeroTimeoutModel).timeout()).isEmpty();
+    assertThat(callTimeoutMillisOf(zeroTimeoutModel)).isZero();
     zeroTimeoutModel.close();
 
     final ChatModel negativeTimeoutModel = factory.create(apiConfig(null, Duration.ofSeconds(-1)));
     assertThat(httpOptionsOf(negativeTimeoutModel).timeout()).isEmpty();
+    assertThat(callTimeoutMillisOf(negativeTimeoutModel)).isZero();
     negativeTimeoutModel.close();
   }
 
@@ -249,6 +256,14 @@ class GeminiChatModelFactoryTest {
   private static Optional<ClientOptions> clientOptionsOf(ChatModel model) {
     return (Optional<ClientOptions>)
         ReflectionTestUtils.getField(apiClientOf(model), "clientOptions");
+  }
+
+  private static int callTimeoutMillisOf(ChatModel model) {
+    return clientOptionsOf(model)
+        .orElseThrow()
+        .customHttpClient()
+        .orElseThrow()
+        .callTimeoutMillis();
   }
 
   private static GeminiChatModelConfiguration apiConfig(

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiChatModelFactoryTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiChatModelFactoryTest.java
@@ -9,10 +9,18 @@ package io.camunda.connector.agenticai.aiagent.chatmodel.provider.gemini;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.auth.oauth2.ServiceAccountCredentials;
 import com.google.genai.ApiClient;
 import com.google.genai.Client;
 import com.google.genai.types.ClientOptions;
@@ -24,11 +32,18 @@ import io.camunda.connector.agenticai.aiagent.model.request.v2.CustomProviderCon
 import io.camunda.connector.agenticai.aiagent.model.request.v2.GeminiChatModelConfiguration;
 import io.camunda.connector.agenticai.aiagent.model.request.v2.GeminiChatModelConfiguration.GeminiBackend.GeminiApiBackend;
 import io.camunda.connector.agenticai.aiagent.model.request.v2.GeminiChatModelConfiguration.GeminiBackend.GeminiApiBackend.GoogleGeminiApi;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.GeminiChatModelConfiguration.GeminiBackend.GeminiVertexAiBackend;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.GeminiChatModelConfiguration.GeminiBackend.GeminiVertexAiBackend.GoogleVertexAi;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.GeminiChatModelConfiguration.GeminiBackend.GoogleVertexAiAuthentication;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.GeminiChatModelConfiguration.GeminiBackend.GoogleVertexAiAuthentication.ApplicationDefaultCredentialsAuthentication;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.GeminiChatModelConfiguration.GeminiBackend.GoogleVertexAiAuthentication.ServiceAccountCredentialsAuthentication;
 import io.camunda.connector.agenticai.aiagent.model.request.v2.GeminiChatModelConfiguration.GeminiConnection;
 import io.camunda.connector.agenticai.aiagent.model.request.v2.GeminiChatModelConfiguration.GeminiModel;
 import io.camunda.connector.agenticai.common.AgenticAiHttpProxySupport;
 import io.camunda.connector.api.error.ConnectorInputException;
+import io.camunda.connector.http.client.proxy.NonProxyHosts;
 import io.camunda.connector.http.client.proxy.ProxyConfiguration;
+import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.Proxy;
 import java.time.Duration;
@@ -39,7 +54,11 @@ import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
@@ -48,8 +67,13 @@ class GeminiChatModelFactoryTest {
 
   private static final String MODEL_ID = "gemini-3-pro-preview";
   private static final String API_KEY = "test-api-key";
+  private static final String PROJECT_ID = "test-project";
+  private static final String REGION = "us-central1";
 
   @Mock private AgenticAiHttpProxySupport httpProxySupport;
+
+  @Captor private ArgumentCaptor<HttpOptions> httpOptionsCaptor;
+  @Captor private ArgumentCaptor<ClientOptions> clientOptionsCaptor;
 
   private GeminiChatModelFactory factory;
 
@@ -106,6 +130,35 @@ class GeminiChatModelFactoryTest {
     verify(httpProxySupport).okHttpProxy(ProxyConfiguration.SCHEME_HTTP);
 
     model.close();
+  }
+
+  @Test
+  void createSkipsProxyWhenDefaultGeminiApiHostIsNonProxyHost() {
+    try (MockedStatic<NonProxyHosts> nonProxyHostsMock = mockStatic(NonProxyHosts.class)) {
+      nonProxyHostsMock.when(() -> NonProxyHosts.isNonProxyHost(any())).thenReturn(true);
+
+      final ChatModel model = factory.create(apiConfig(null, null));
+
+      nonProxyHostsMock.verify(
+          () -> NonProxyHosts.isNonProxyHost("generativelanguage.googleapis.com"));
+      verify(httpProxySupport, never()).okHttpProxy(any());
+
+      model.close();
+    }
+  }
+
+  @Test
+  void createSkipsProxyWhenConfiguredEndpointHostIsNonProxyHost() {
+    try (MockedStatic<NonProxyHosts> nonProxyHostsMock = mockStatic(NonProxyHosts.class)) {
+      nonProxyHostsMock.when(() -> NonProxyHosts.isNonProxyHost(any())).thenReturn(true);
+
+      final ChatModel model = factory.create(apiConfig("http://localhost:8080", null));
+
+      nonProxyHostsMock.verify(() -> NonProxyHosts.isNonProxyHost("localhost"));
+      verify(httpProxySupport, never()).okHttpProxy(any());
+
+      model.close();
+    }
   }
 
   @Test
@@ -318,6 +371,20 @@ class GeminiChatModelFactoryTest {
   }
 
   @Test
+  void createSkipsProxyWhenDefaultVertexAiHostIsNonProxyHost() {
+    try (MockedStatic<NonProxyHosts> nonProxyHostsMock = mockStatic(NonProxyHosts.class)) {
+      nonProxyHostsMock.when(() -> NonProxyHosts.isNonProxyHost(any())).thenReturn(true);
+
+      createVertexAiChatModel(
+          vertexConfig(null, new ApplicationDefaultCredentialsAuthentication()));
+
+      nonProxyHostsMock.verify(
+          () -> NonProxyHosts.isNonProxyHost(REGION + "-aiplatform.googleapis.com"));
+      verify(httpProxySupport, never()).okHttpProxy(any());
+    }
+  }
+
+  @Test
   void createThrowsConnectorInputExceptionWhenVertexAiClientBuildFails() {
     noProxyConfigured();
 
@@ -366,6 +433,38 @@ class GeminiChatModelFactoryTest {
       String host, int port, @Nullable String username, @Nullable String password) {
     return new AgenticAiHttpProxySupport.OkHttpProxy(
         new Proxy(Proxy.Type.HTTP, new InetSocketAddress(host, port)), username, password);
+  }
+
+  /**
+   * Builds a {@link GeminiChatModel} for a Vertex AI backend with a statically mocked {@link
+   * Client.Builder} spy so no real client (and, for application default credentials, no real OAuth
+   * resolution) is ever built - only the wiring onto the builder is inspected.
+   */
+  private Client.Builder createVertexAiChatModel(GeminiChatModelConfiguration config) {
+    final var client = mock(Client.class);
+    final var clientBuilder = spy(Client.builder());
+    doReturn(client).when(clientBuilder).build();
+
+    try (MockedStatic<Client> clientMock = mockStatic(Client.class, Answers.CALLS_REAL_METHODS)) {
+      clientMock.when(Client::builder).thenReturn(clientBuilder);
+
+      final ChatModel model = factory.create(config);
+      assertThat(model).isNotNull().isInstanceOf(GeminiChatModel.class);
+      assertThat(ReflectionTestUtils.getField(model, "client")).isSameAs(client);
+      model.close();
+    }
+
+    return clientBuilder;
+  }
+
+  private static GeminiChatModelConfiguration vertexConfig(
+      @Nullable String endpoint, GoogleVertexAiAuthentication authentication) {
+    return new GeminiChatModelConfiguration(
+        new GeminiConnection(
+            new GeminiVertexAiBackend(
+                new GoogleVertexAi(PROJECT_ID, REGION, endpoint, authentication)),
+            new GeminiModel(MODEL_ID, null),
+            null));
   }
 
   private static Client clientOf(ChatModel model) {

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/model/request/v2/GeminiChatModelConfigurationTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/model/request/v2/GeminiChatModelConfigurationTest.java
@@ -10,28 +10,44 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.connector.agenticai.aiagent.model.request.v2.GeminiChatModelConfiguration.GeminiBackend.GeminiApiBackend;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.GeminiChatModelConfiguration.GeminiBackend.GeminiVertexAiBackend;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.GeminiChatModelConfiguration.GeminiBackend.GeminiVertexAiBackend.GoogleVertexAi;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.GeminiChatModelConfiguration.GeminiBackend.GoogleVertexAiAuthentication;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.GeminiChatModelConfiguration.GeminiBackend.GoogleVertexAiAuthentication.ApplicationDefaultCredentialsAuthentication;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.GeminiChatModelConfiguration.GeminiBackend.GoogleVertexAiAuthentication.ServiceAccountCredentialsAuthentication;
 import io.camunda.connector.agenticai.aiagent.model.request.v2.GeminiChatModelConfiguration.GeminiConnection;
 import io.camunda.connector.agenticai.aiagent.model.request.v2.GeminiChatModelConfiguration.GeminiModel;
 import io.camunda.connector.agenticai.aiagent.model.request.v2.GeminiChatModelConfiguration.GeminiModel.GeminiModelParameters;
 import io.camunda.connector.agenticai.aiagent.model.request.v2.GeminiChatModelConfiguration.GeminiModel.GeminiThinking;
 import io.camunda.connector.agenticai.aiagent.model.request.v2.GeminiChatModelConfiguration.GeminiModel.GeminiThinkingLevel;
+import io.camunda.connector.agenticai.aiagent.util.ConnectorUtils;
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.Validator;
 import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.validation.autoconfigure.ValidationAutoConfiguration;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
+import uk.org.webcompere.systemstubs.environment.EnvironmentVariables;
+import uk.org.webcompere.systemstubs.jupiter.SystemStub;
+import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
 
-@ExtendWith(SpringExtension.class)
+@ExtendWith({SpringExtension.class, SystemStubsExtension.class})
 @Import(ValidationAutoConfiguration.class)
 class GeminiChatModelConfigurationTest {
 
   private final ObjectMapper mapper = new ObjectMapper();
 
   @Autowired private Validator validator;
+  @SystemStub private EnvironmentVariables environment;
+
+  @BeforeEach
+  void setUp() {
+    environment.set(ConnectorUtils.CONNECTOR_RUNTIME_SAAS_ENV_VARIABLE, null);
+  }
 
   @Test
   void deserialisesGeminiApiBackendWithModelParametersAndRoundTrips() throws Exception {

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/model/request/v2/GeminiChatModelConfigurationTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/model/request/v2/GeminiChatModelConfigurationTest.java
@@ -246,4 +246,197 @@ class GeminiChatModelConfigurationTest {
               assertThat(v.getMessage()).isEqualTo("must not be blank");
             });
   }
+
+  @Test
+  void deserialisesVertexAiBackendWithServiceAccountCredentialsAndRoundTrips() throws Exception {
+    final String json =
+        """
+        {
+          "type": "google-gemini",
+          "googleGemini": {
+            "backend": {
+              "type": "google-vertex-ai",
+              "googleVertexAi": {
+                "projectId": "my-project",
+                "region": "us-central1",
+                "authentication": {
+                  "type": "serviceAccountCredentials",
+                  "jsonKey": "{\\"type\\":\\"service_account\\"}"
+                }
+              }
+            },
+            "model": { "model": "gemini-3-pro-preview" }
+          }
+        }
+        """;
+
+    final ProviderConfiguration parsed = mapper.readValue(json, ProviderConfiguration.class);
+
+    assertThat(parsed).isInstanceOf(GeminiChatModelConfiguration.class);
+    assertThat(parsed.provider()).isEqualTo("google-gemini");
+    assertThat(parsed.model()).isEqualTo("gemini-3-pro-preview");
+
+    final GeminiChatModelConfiguration gemini = (GeminiChatModelConfiguration) parsed;
+    assertThat(gemini.googleGemini().backend()).isInstanceOf(GeminiVertexAiBackend.class);
+
+    final GoogleVertexAi vertexAi =
+        ((GeminiVertexAiBackend) gemini.googleGemini().backend()).googleVertexAi();
+    assertThat(vertexAi.projectId()).isEqualTo("my-project");
+    assertThat(vertexAi.region()).isEqualTo("us-central1");
+    assertThat(vertexAi.endpoint()).isNull();
+    assertThat(vertexAi.authentication())
+        .isEqualTo(new ServiceAccountCredentialsAuthentication("{\"type\":\"service_account\"}"));
+
+    final String reserialised = mapper.writeValueAsString(parsed);
+    assertThat(mapper.readValue(reserialised, ProviderConfiguration.class)).isEqualTo(parsed);
+  }
+
+  @Test
+  void deserialisesVertexAiBackendWithApplicationDefaultCredentialsAndRoundTrips()
+      throws Exception {
+    final String json =
+        """
+        {
+          "type": "google-gemini",
+          "googleGemini": {
+            "backend": {
+              "type": "google-vertex-ai",
+              "googleVertexAi": {
+                "projectId": "my-project",
+                "region": "us-central1",
+                "endpoint": "https://example.com",
+                "authentication": { "type": "applicationDefaultCredentials" }
+              }
+            },
+            "model": { "model": "gemini-3-pro-preview" }
+          }
+        }
+        """;
+
+    final ProviderConfiguration parsed = mapper.readValue(json, ProviderConfiguration.class);
+    final GeminiChatModelConfiguration gemini = (GeminiChatModelConfiguration) parsed;
+    final GoogleVertexAi vertexAi =
+        ((GeminiVertexAiBackend) gemini.googleGemini().backend()).googleVertexAi();
+
+    assertThat(vertexAi.endpoint()).isEqualTo("https://example.com");
+    assertThat(vertexAi.authentication())
+        .isEqualTo(new ApplicationDefaultCredentialsAuthentication());
+
+    final String reserialised = mapper.writeValueAsString(parsed);
+    assertThat(mapper.readValue(reserialised, ProviderConfiguration.class)).isEqualTo(parsed);
+  }
+
+  @Test
+  void serviceAccountCredentialsAuthenticationRedactsJsonKeyInToString() {
+    final var authentication = new ServiceAccountCredentialsAuthentication("super-secret-key");
+
+    final String toString = authentication.toString();
+
+    assertThat(toString).doesNotContain("super-secret-key");
+    assertThat(toString).isEqualTo("ServiceAccountCredentialsAuthentication{jsonKey=[REDACTED]}");
+  }
+
+  @Test
+  void vertexAiBackendRejectsBlankProjectIdAndRegion() {
+    final var authentication = new ServiceAccountCredentialsAuthentication("key-json");
+    final var backendWithBlanks =
+        new GeminiVertexAiBackend(new GoogleVertexAi("  ", "  ", null, authentication));
+
+    final var violations =
+        validator.validate(
+            new GeminiChatModelConfiguration(
+                new GeminiConnection(
+                    backendWithBlanks, new GeminiModel("gemini-3-pro-preview", null), null)));
+
+    assertThat(violations)
+        .anySatisfy(
+            v -> {
+              assertThat(v.getPropertyPath().toString())
+                  .isEqualTo("googleGemini.backend.googleVertexAi.projectId");
+              assertThat(v.getMessage()).isEqualTo("must not be blank");
+            })
+        .anySatisfy(
+            v -> {
+              assertThat(v.getPropertyPath().toString())
+                  .isEqualTo("googleGemini.backend.googleVertexAi.region");
+              assertThat(v.getMessage()).isEqualTo("must not be blank");
+            });
+  }
+
+  @Test
+  void vertexAiServiceAccountCredentialsRejectsBlankJsonKey() {
+    final var config =
+        vertexAiChatModelConfiguration(new ServiceAccountCredentialsAuthentication("  "));
+
+    final var violations = validator.validate(config);
+
+    assertThat(violations)
+        .anySatisfy(
+            v -> {
+              assertThat(v.getPropertyPath().toString())
+                  .isEqualTo("googleGemini.backend.googleVertexAi.authentication.jsonKey");
+              assertThat(v.getMessage()).isEqualTo("must not be blank");
+            });
+  }
+
+  @Test
+  void vertexAiBackendRejectsMissingAuthentication() {
+    final var config =
+        new GeminiChatModelConfiguration(
+            new GeminiConnection(
+                new GeminiVertexAiBackend(
+                    new GoogleVertexAi("my-project", "us-central1", null, null)),
+                new GeminiModel("gemini-3-pro-preview", null),
+                null));
+
+    final var violations = validator.validate(config);
+
+    assertThat(violations)
+        .anySatisfy(
+            v -> {
+              assertThat(v.getPropertyPath().toString())
+                  .isEqualTo("googleGemini.backend.googleVertexAi.authentication");
+              assertThat(v.getMessage()).isEqualTo("must not be null");
+            });
+  }
+
+  @Test
+  void validVertexAiConfigurationHasNoViolations() {
+    final var config =
+        vertexAiChatModelConfiguration(new ServiceAccountCredentialsAuthentication("key-json"));
+
+    assertThat(validator.validate(config)).isEmpty();
+  }
+
+  @Test
+  void vertexAiApplicationDefaultCredentialsRejectedOnSaaS() {
+    environment.set(ConnectorUtils.CONNECTOR_RUNTIME_SAAS_ENV_VARIABLE, "true");
+    final var config =
+        vertexAiChatModelConfiguration(new ApplicationDefaultCredentialsAuthentication());
+
+    assertThat(validator.validate(config))
+        .extracting(ConstraintViolation::getMessage)
+        .contains("Application default credentials for Google Vertex AI are not supported on SaaS");
+  }
+
+  @Test
+  void vertexAiApplicationDefaultCredentialsAllowedWhenNotSaaS() {
+    final var config =
+        vertexAiChatModelConfiguration(new ApplicationDefaultCredentialsAuthentication());
+
+    assertThat(validator.validate(config)).isEmpty();
+  }
+
+  private static GoogleVertexAi vertexAiConfig(GoogleVertexAiAuthentication authentication) {
+    return new GoogleVertexAi("my-project", "us-central1", null, authentication);
+  }
+
+  private static GeminiChatModelConfiguration vertexAiChatModelConfiguration(
+      GoogleVertexAiAuthentication authentication) {
+    return new GeminiChatModelConfiguration(
+        new GeminiConnection(
+            new GeminiVertexAiBackend(vertexAiConfig(authentication)),
+            new GeminiModel("gemini-3-pro-preview", null),
+            null));
+  }
 }

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/common/AgenticAiHttpProxySupportTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/common/AgenticAiHttpProxySupportTest.java
@@ -258,6 +258,16 @@ class AgenticAiHttpProxySupportTest {
     }
   }
 
+  @Test
+  void shouldResolveMultiRegionalDefaultHost() {
+    assertThat(AgenticAiHttpProxySupport.defaultGoogleGenAiBaseUrl("us"))
+        .isEqualTo("https://aiplatform.us.rep.googleapis.com");
+    assertThat(AgenticAiHttpProxySupport.defaultGoogleGenAiBaseUrl("eu"))
+        .isEqualTo("https://aiplatform.eu.rep.googleapis.com");
+    assertThat(AgenticAiHttpProxySupport.defaultGoogleGenAiBaseUrl("EU"))
+        .isEqualTo("https://aiplatform.eu.rep.googleapis.com");
+  }
+
   private static ProxyConfiguration testProxyConfiguration(
       String host, int port, String user, String password) {
     return protocol -> {


### PR DESCRIPTION
## Description

- Adds Vertex AI as a second backend for the native Gemini provider (`GeminiVertexAiBackend`, backend id `google-vertex-ai`): project/region config, service-account and application-default-credentials auth.
- Extends `GeminiChatModelFactory.buildClient` with a per-backend switch to build the Vertex `com.google.genai.Client`; extracts Vertex default-host resolution into `AgenticAiHttpProxySupport`.
- Reuses `AgenticAiHttpProxySupport.okHttpProxy` (already used by the Anthropic/OpenAI factories) instead of hand-rolling proxy resolution, for parity and matching debug-log observability.
- Scopes the SaaS-only rejection message to name application-default credentials specifically - service-account authentication remains supported on SaaS.
- Regenerates v2 AI Agent element templates with the Vertex AI backend choice and field group.
- Adds unit tests (factory client-building), a real-proxy-wire test, a WireMock e2e tool-calling test, and a Vertex AI row in `RealProviderApiSmokeIT`.
- Documents both backends in `native-providers.md`.
- Known limitation: Vertex AI credential resolution (service-account token exchange, application-default-credentials lookup) does not go through the configured proxy yet - only model-call traffic does. Pre-existing in the langchain4j-based v1 Vertex AI path too, not a regression here; tracked in #8371.

## Related issues

Part of #7222, tracked as #8066

## Checklist

- [x] Backport labels are added if these code changes should be backported. No backport label is added to the latest
  release, as this branch will be rebased onto main before the next release. Example backport labels:
    - `backport stable/8.8`: for changes that should be included in the next 8.8.x release.
    - **or** `backport release-8.8.7`: for changes that should be included in the specific release 8.8.7, and this
      *release has already been created*. The release branch will be merged back into stable/8.8 later, so the change
      will be included in future 8.8.x releases as well.
- [x] Tests/Integration tests for the changes have been added if applicable.
- [x] If the change requires a documentation update, it has been added to the appropriate section in the documentation.
