### PR TITLE
fix(agentic-ai): keep response message ID example fixture stable

### DIFF
--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/AgentResponse.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/AgentResponse.java
@@ -11,6 +11,7 @@ import static io.camunda.connector.agenticai.aiagent.model.message.MessageUtil.s
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import io.camunda.connector.agenticai.aiagent.model.message.AssistantMessage;
+import io.camunda.connector.agenticai.aiagent.model.message.MessageId;
 import io.camunda.connector.agenticai.aiagent.model.tool.ToolCall;
 import io.camunda.connector.agenticai.aiagent.model.tool.ToolCallProcessVariable;
 import io.camunda.connector.agenticai.aiagent.model.tool.ToolDefinition;
@@ -86,6 +87,7 @@ public record AgentResponse(
   public static AgentResponse exampleResultWithAssistantMessageResponse() {
     final var assistantMessage =
         AssistantMessage.builder()
+            .id(MessageId.of("01a00023-829e-723b-8cae-8bd1bb11c25b"))
             .content(singleTextContent("This is a sample response text from the AI agent."))
             .metadata(
                 Map.of(


### PR DESCRIPTION
## Description

`AgentResponse`'s sample fixture (used to regenerate `AI_AGENT.md`'s example section) didn't pin a message ID, so `MessageId` generated a fresh UUID on every build. That turned every rebuild into an unrelated diff in `AI_AGENT.md`. Pins the ID so the generated doc is stable across rebuilds.

## Related issues

closes #

## Checklist

- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest
  release, as this branch will be rebased onto main before the next release. Example backport labels:
    - `backport stable/8.8`: for changes that should be included in the next 8.8.x release.
    - **or** `backport release-8.8.7`: for changes that should be included in the specific release 8.8.7, and this
      *release has already been created*. The release branch will be merged back into stable/8.8 later, so the change
      will be included in future 8.8.x releases as well.
- [x] Tests/Integration tests for the changes have been added if applicable.
- [x] If the change requires a documentation update, it has been added to the appropriate section in the documentation.