### PR TITLE
fix(agentic-ai): make sealed Content switches exhaustive, reuse OpenAI converter helpers

### DIFF
--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/anthropic/AnthropicContentConverter.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/anthropic/AnthropicContentConverter.java
@@ -156,10 +156,14 @@ public class AnthropicContentConverter {
                     TextBlockParam.builder().text(writeAsJson(doc.document())).build()));
         case ObjectContent obj ->
             blocks.add(ToolResultBlockParam.Content.Block.ofText(toTextBlockParam(obj)));
-        default ->
+        case ReasoningContent reasoning ->
             blocks.add(
                 ToolResultBlockParam.Content.Block.ofText(
-                    TextBlockParam.builder().text(writeAsJson(c)).build()));
+                    TextBlockParam.builder().text(writeAsJson(reasoning)).build()));
+        case ProviderContent providerContent ->
+            blocks.add(
+                ToolResultBlockParam.Content.Block.ofText(
+                    TextBlockParam.builder().text(writeAsJson(providerContent)).build()));
       }
     }
     return blocks;

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/openai/OpenAiContentConverter.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/openai/OpenAiContentConverter.java
@@ -105,10 +105,14 @@ public class OpenAiContentConverter {
             items.add(
                 ResponseFunctionCallOutputItem.ofInputText(
                     ResponseInputTextContent.builder().text(writeAsJson(obj.content())).build()));
-        default ->
+        case ReasoningContent reasoning ->
             items.add(
                 ResponseFunctionCallOutputItem.ofInputText(
-                    ResponseInputTextContent.builder().text(writeAsJson(c)).build()));
+                    ResponseInputTextContent.builder().text(writeAsJson(reasoning)).build()));
+        case ProviderContent providerContent ->
+            items.add(
+                ResponseFunctionCallOutputItem.ofInputText(
+                    ResponseInputTextContent.builder().text(writeAsJson(providerContent)).build()));
       }
     }
     return items;
@@ -129,10 +133,16 @@ public class OpenAiContentConverter {
                     ChatCompletionContentPartText.builder()
                         .text(writeAsJson(obj.content()))
                         .build()));
-        default ->
+        case ReasoningContent reasoning ->
             parts.add(
                 ChatCompletionContentPart.ofText(
-                    ChatCompletionContentPartText.builder().text(writeAsJson(c)).build()));
+                    ChatCompletionContentPartText.builder().text(writeAsJson(reasoning)).build()));
+        case ProviderContent providerContent ->
+            parts.add(
+                ChatCompletionContentPart.ofText(
+                    ChatCompletionContentPartText.builder()
+                        .text(writeAsJson(providerContent))
+                        .build()));
       }
     }
     return parts;
@@ -210,7 +220,7 @@ public class OpenAiContentConverter {
     return new String(document.asByteArray(), StandardCharsets.UTF_8);
   }
 
-  private String writeAsJson(Object value) {
+  public String writeAsJson(Object value) {
     try {
       return objectMapper.writeValueAsString(value);
     } catch (JsonProcessingException e) {

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/openai/family/completions/OpenAiCompletionsRequestConverter.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/openai/family/completions/OpenAiCompletionsRequestConverter.java
@@ -6,7 +6,6 @@
  */
 package io.camunda.connector.agenticai.aiagent.chatmodel.provider.openai.family.completions;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.openai.core.JsonValue;
 import com.openai.models.FunctionDefinition;
@@ -216,7 +215,7 @@ public class OpenAiCompletionsRequestConverter {
                   .function(
                       ChatCompletionMessageFunctionToolCall.Function.builder()
                           .name(toolCall.name())
-                          .arguments(writeAsJson(toolCall.arguments()))
+                          .arguments(contentConverter.writeAsJson(toolCall.arguments()))
                           .build())
                   .build()));
     }
@@ -254,11 +253,11 @@ public class OpenAiCompletionsRequestConverter {
               if (c instanceof TextContent text) {
                 return text.text();
               } else if (c instanceof ObjectContent obj) {
-                return writeAsJson(obj.content());
+                return contentConverter.writeAsJson(obj.content());
               } else if (c instanceof DocumentContent doc) {
-                return writeAsJson(doc.document());
+                return contentConverter.writeAsJson(doc.document());
               } else {
-                return writeAsJson(c);
+                return contentConverter.writeAsJson(c);
               }
             })
         .collect(Collectors.joining("\n"));
@@ -311,13 +310,5 @@ public class OpenAiCompletionsRequestConverter {
     customizations
         .bodyProperties()
         .forEach((k, v) -> builder.putAdditionalBodyProperty(k, JsonValue.from(v)));
-  }
-
-  private String writeAsJson(Object value) {
-    try {
-      return objectMapper.writeValueAsString(value);
-    } catch (JsonProcessingException e) {
-      throw new IllegalStateException("Failed to serialize content to JSON", e);
-    }
   }
 }

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/openai/family/completions/OpenAiCompletionsResponseConverter.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/openai/family/completions/OpenAiCompletionsResponseConverter.java
@@ -7,6 +7,7 @@
 package io.camunda.connector.agenticai.aiagent.chatmodel.provider.openai.family.completions;
 
 import static io.camunda.connector.agenticai.aiagent.agent.AgentErrorCodes.ERROR_CODE_FAILED_MODEL_CALL;
+import static io.camunda.connector.agenticai.aiagent.model.request.v2.OpenAiChatModelConfiguration.OPENAI_ID;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -53,8 +54,6 @@ import java.util.Map;
  * {@link ChatResult.Completed}.
  */
 public class OpenAiCompletionsResponseConverter {
-
-  private static final String OPENAI_PROVIDER = "openai";
 
   private final ObjectMapper objectMapper;
 
@@ -123,7 +122,7 @@ public class OpenAiCompletionsResponseConverter {
         .ifPresent(calls -> calls.forEach(call -> toToolCall(call, toolCalls, content)));
 
     final Map<String, Object> openAiMetadata =
-        Map.of(OPENAI_PROVIDER, Map.of("stopReason", choice.finishReason().asString()));
+        Map.of(OPENAI_ID, Map.of("stopReason", choice.finishReason().asString()));
 
     return AssistantMessage.builder()
         .content(content)
@@ -158,7 +157,7 @@ public class OpenAiCompletionsResponseConverter {
       // Only function tool calls have a provider-neutral representation; a custom tool call (see
       // the class Javadoc) is preserved losslessly as ProviderContent instead, so the agent loop
       // still sees the model's output even though it can't act on it as a tool call.
-      content.add(ProviderContent.providerContent(OPENAI_PROVIDER, toRawMap(call)));
+      content.add(ProviderContent.providerContent(OPENAI_ID, toRawMap(call)));
       return;
     }
 

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/openai/family/responses/OpenAiResponsesRequestConverter.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/openai/family/responses/OpenAiResponsesRequestConverter.java
@@ -8,7 +8,6 @@ package io.camunda.connector.agenticai.aiagent.chatmodel.provider.openai.family.
 
 import static io.camunda.connector.agenticai.aiagent.model.request.v2.OpenAiChatModelConfiguration.OPENAI_ID;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.openai.core.JsonValue;
 import com.openai.core.ObjectMappers;
@@ -233,7 +232,7 @@ public class OpenAiResponsesRequestConverter {
               ResponseFunctionToolCall.builder()
                   .callId(toolCall.id())
                   .name(toolCall.name())
-                  .arguments(writeAsJson(toolCall.arguments()))
+                  .arguments(contentConverter.writeAsJson(toolCall.arguments()))
                   .build()));
     }
     return items;
@@ -329,13 +328,5 @@ public class OpenAiResponsesRequestConverter {
     customizations
         .bodyProperties()
         .forEach((k, v) -> builder.putAdditionalBodyProperty(k, JsonValue.from(v)));
-  }
-
-  private String writeAsJson(Object value) {
-    try {
-      return objectMapper.writeValueAsString(value);
-    } catch (JsonProcessingException e) {
-      throw new IllegalStateException("Failed to serialize content to JSON", e);
-    }
   }
 }

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/openai/family/responses/OpenAiResponsesResponseConverter.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/openai/family/responses/OpenAiResponsesResponseConverter.java
@@ -7,6 +7,7 @@
 package io.camunda.connector.agenticai.aiagent.chatmodel.provider.openai.family.responses;
 
 import static io.camunda.connector.agenticai.aiagent.agent.AgentErrorCodes.ERROR_CODE_FAILED_MODEL_CALL;
+import static io.camunda.connector.agenticai.aiagent.model.request.v2.OpenAiChatModelConfiguration.OPENAI_ID;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -59,7 +60,6 @@ import org.springframework.util.StringUtils;
  */
 public class OpenAiResponsesResponseConverter {
 
-  private static final String OPENAI_PROVIDER = "openai";
   private static final String METADATA_RESPONSE_ID = "responseId";
   private static final String METADATA_STOP_REASON = "stopReason";
 
@@ -148,7 +148,7 @@ public class OpenAiResponsesResponseConverter {
         // original order as ProviderContent rather than silently dropping it; it is never a
         // client tool call (the caller is never expected to act on it), so it is kept out of
         // toolCalls.
-        content.add(ProviderContent.providerContent(OPENAI_PROVIDER, toRawMap(item)));
+        content.add(ProviderContent.providerContent(OPENAI_ID, toRawMap(item)));
       }
     }
 
@@ -201,7 +201,7 @@ public class OpenAiResponsesResponseConverter {
         .map(Response.IncompleteDetails.Reason::asString)
         .or(() -> response.status().map(ResponseStatus::asString))
         .ifPresent(sr -> metadata.put(METADATA_STOP_REASON, sr));
-    return Map.of(OPENAI_PROVIDER, Map.copyOf(metadata));
+    return Map.of(OPENAI_ID, Map.copyOf(metadata));
   }
 
   /**
@@ -252,12 +252,12 @@ public class OpenAiResponsesResponseConverter {
     final Optional<ResponseReasoningItem> reasoning = item.reasoning();
     final String text = reasoning.map(this::summaryText).orElse(null);
     if (text == null) {
-      return ReasoningContent.reasoningContent(OPENAI_PROVIDER, raw);
+      return ReasoningContent.reasoningContent(OPENAI_ID, raw);
     }
     if (reasoning.filter(this::canReconstructSummaryFromText).isPresent()) {
       raw.remove("summary");
     }
-    return new ReasoningContent(OPENAI_PROVIDER, raw, text, Map.of());
+    return new ReasoningContent(OPENAI_ID, raw, text, Map.of());
   }
 
   private @Nullable String summaryText(ResponseReasoningItem reasoning) {


### PR DESCRIPTION
## Description

Small follow-ups from a code review of the native OpenAI/Anthropic provider support (#8279):

- The `switch` over the sealed `Content` type in `OpenAiContentConverter` (`toResponsesToolResultOutputItems`, `toCompletionsContentParts`) and in `AnthropicContentConverter#toToolResultBlocks` fell back to a catch-all `default` for `ReasoningContent`/`ProviderContent`, even though sibling methods in the same classes already switch exhaustively. Made these exhaustive too, so a future `Content` subtype fails to compile here instead of silently landing in the generic branch. No behavior change — same JSON-serialization fallback as before.
- The two OpenAI request converters each kept their own copy of a `writeAsJson` helper that `OpenAiContentConverter` already provides; they now call the shared one. The two OpenAI response converters each declared their own `OPENAI_PROVIDER` constant instead of reusing the existing `OpenAiChatModelConfiguration.OPENAI_ID`; they now reuse it.

## Related issues

Code-review follow-up, no tracked issue.

## Checklist

- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest
  release, as this branch will be rebased onto main before the next release. Example backport labels:
    - `backport stable/8.8`: for changes that should be included in the next 8.8.x release.
    - **or** `backport release-8.8.7`: for changes that should be included in the specific release 8.8.7, and this
      *release has already been created*. The release branch will be merged back into stable/8.8 later, so the change
      will be included in future 8.8.x releases as well.
- [x] Tests/Integration tests for the changes have been added if applicable.
- [ ] If the change requires a documentation update, it has been added to the appropriate section in the documentation.
