### PR TITLE
fix(agentic-ai): replay OpenAI Responses assistant text without 400ing

### DIFF
--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/wiremock/ProviderWireFormatExpectedMessage.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/wiremock/ProviderWireFormatExpectedMessage.java
@@ -125,6 +125,19 @@ sealed interface ProviderWireFormatExpectedMessage {
     public void assertMatches(int index, RecordedMessage message) {
       assertRoleAndText(index, message, "assistant", text);
 
+      // Every wire format this suite covers reserves an "input_"-prefixed content-part kind for
+      // input-only roles (e.g. OpenAI Responses' input_text/input_image/input_file); none of them
+      // ever produce one for the model's own turn. Catches a role/type mismatch (e.g. an
+      // input_text part replayed on an assistant message) that a text-only comparison would miss.
+      final var inputTypedParts =
+          message.contentParts().stream()
+              .map(RecordedContentPart::kind)
+              .filter(kind -> kind.startsWith("input_"))
+              .toList();
+      assertThat(inputTypedParts)
+          .as("input-only content part kinds on assistant message %d", index)
+          .isEmpty();
+
       final var actualNames = message.toolCalls().stream().map(RecordedToolCall::name).toList();
       assertThat(actualNames)
           .as("tool call names of message %d", index)

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/wiremock/ProviderWireFormatExpectedMessage.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/wiremock/ProviderWireFormatExpectedMessage.java
@@ -23,6 +23,7 @@ import io.camunda.connector.e2e.agenticai.aiagent.wiremock.spi.RecordedContentPa
 import io.camunda.connector.e2e.agenticai.aiagent.wiremock.spi.RecordedMessage;
 import io.camunda.connector.e2e.agenticai.aiagent.wiremock.spi.RecordedToolCall;
 import java.util.List;
+import java.util.Set;
 
 /**
  * Provider-agnostic counterpart of {@code BaseAgentTest.ExpectedMessage}, asserting against the
@@ -35,6 +36,9 @@ import java.util.List;
  * assertions for multimodal tool-call turns without affecting the other roles.
  */
 sealed interface ProviderWireFormatExpectedMessage {
+
+  /** Content-part kinds valid only on input (user/tool) messages, never on the model's own turn. */
+  Set<String> INPUT_ONLY_CONTENT_KINDS = Set.of("input_text", "input_image", "input_file");
 
   void assertMatches(int index, RecordedMessage message);
 
@@ -125,16 +129,13 @@ sealed interface ProviderWireFormatExpectedMessage {
     public void assertMatches(int index, RecordedMessage message) {
       assertRoleAndText(index, message, "assistant", text);
 
-      // Every wire format this suite covers reserves an "input_"-prefixed content-part kind for
-      // input-only roles (e.g. OpenAI Responses' input_text/input_image/input_file); none of them
-      // ever produce one for the model's own turn. Catches a role/type mismatch (e.g. an
-      // input_text part replayed on an assistant message) that a text-only comparison would miss.
-      final var inputTypedParts =
+      // No wire format should put an input-only part on the model's own turn.
+      final var inputOnlyParts =
           message.contentParts().stream()
               .map(RecordedContentPart::kind)
-              .filter(kind -> kind.startsWith("input_"))
+              .filter(INPUT_ONLY_CONTENT_KINDS::contains)
               .toList();
-      assertThat(inputTypedParts)
+      assertThat(inputOnlyParts)
           .as("input-only content part kinds on assistant message %d", index)
           .isEmpty();
 

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/wiremock/openai/OpenAiResponsesV2RecordedChatRequestAdapter.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/wiremock/openai/OpenAiResponsesV2RecordedChatRequestAdapter.java
@@ -75,14 +75,15 @@ final class OpenAiResponsesV2RecordedChatRequestAdapter implements RecordedChatR
       return delegate.contentParts().stream()
           .map(
               part -> {
-                final var rawKind = part.path("type").asText();
-                // The Responses wire uses "input_text" for text parts (unlike Completions'/
-                // Anthropic's "text"); normalize so the shared RecordedContentPart#isText()/
-                // RecordedMessage#textContent() contract behaves the same across every provider
-                // fixture. Other kinds (input_image/input_file) are passed through verbatim.
-                final var kind = "input_text".equals(rawKind) ? "text" : rawKind;
+                // The raw wire kind (e.g. "input_text"/"input_image"/"input_file") is kept as-is,
+                // not normalized to a provider-neutral "text" - RecordedContentPart#isText()
+                // already recognizes "input_text" for RecordedMessage#textContent() to keep
+                // working, and keeping the raw kind is what lets ProviderWireFormatExpectedMessage
+                // catch an input_*-typed part landing on an assistant-role message (only
+                // output_text/refusal are valid there).
+                final var kind = part.path("type").asText();
                 return new RecordedContentPart(
-                    kind, "text".equals(kind) ? part.path("text").asText() : null);
+                    kind, "input_text".equals(kind) ? part.path("text").asText() : null);
               })
           .toList();
     }

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/wiremock/openai/OpenAiResponsesV2RecordedChatRequestAdapter.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/wiremock/openai/OpenAiResponsesV2RecordedChatRequestAdapter.java
@@ -75,15 +75,16 @@ final class OpenAiResponsesV2RecordedChatRequestAdapter implements RecordedChatR
       return delegate.contentParts().stream()
           .map(
               part -> {
-                // The raw wire kind (e.g. "input_text"/"input_image"/"input_file") is kept as-is,
-                // not normalized to a provider-neutral "text" - RecordedContentPart#isText()
-                // already recognizes "input_text" for RecordedMessage#textContent() to keep
-                // working, and keeping the raw kind is what lets ProviderWireFormatExpectedMessage
-                // catch an input_*-typed part landing on an assistant-role message (only
-                // output_text/refusal are valid there).
+                // The raw wire kind (e.g. "input_text"/"output_text"/"input_image"/"input_file")
+                // is kept as-is, not normalized to a provider-neutral "text" -
+                // RecordedContentPart#isText() already recognizes both "input_text" (user/tool
+                // messages) and "output_text" (assistant messages) for
+                // RecordedMessage#textContent() to keep working, and keeping the raw kind is what
+                // lets ProviderWireFormatExpectedMessage catch an input_*-typed part landing on an
+                // assistant-role message (only output_text/refusal are valid there).
                 final var kind = part.path("type").asText();
-                return new RecordedContentPart(
-                    kind, "input_text".equals(kind) ? part.path("text").asText() : null);
+                final var isText = "input_text".equals(kind) || "output_text".equals(kind);
+                return new RecordedContentPart(kind, isText ? part.path("text").asText() : null);
               })
           .toList();
     }

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/wiremock/spi/RecordedContentPart.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/wiremock/spi/RecordedContentPart.java
@@ -16,15 +16,27 @@
  */
 package io.camunda.connector.e2e.agenticai.aiagent.wiremock.spi;
 
+import java.util.Set;
+
 /**
  * A single content part of a {@link RecordedMessage}, in a provider-agnostic shape. {@code kind} is
- * the provider's own discriminator value (e.g. {@code "text"}, {@code "image"}/{@code "image_url"},
- * {@code "document"}) — not normalized across providers, since the point of this suite is to see
- * those differences, not paper over them. {@code text} is non-null only for {@code "text"} parts.
+ * the provider's own raw wire discriminator value (e.g. {@code "text"}, {@code "input_text"},
+ * {@code "image"}/{@code "image_url"}, {@code "document"}) — not normalized across providers, since
+ * the point of this suite is to see those differences, not paper over them; a fixture keeping the
+ * raw kind is also what lets a role/type mismatch (e.g. an {@code input_text} part on an
+ * assistant-role message) surface as an assertion failure instead of being erased. {@code text} is
+ * non-null only for text-carrying parts.
  */
 public record RecordedContentPart(String kind, String text) {
 
+  /**
+   * Recognizes every wire vocabulary this suite's fixtures use for a plain-text part, so {@link
+   * RecordedMessage#textContent()} joins correctly regardless of provider, even though {@link
+   * #kind()} itself stays unnormalized.
+   */
+  private static final Set<String> TEXT_KINDS = Set.of("text", "input_text", "output_text");
+
   public boolean isText() {
-    return "text".equals(kind);
+    return TEXT_KINDS.contains(kind);
   }
 }

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/e2e/RealProviderApiSmokeIT.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/e2e/RealProviderApiSmokeIT.java
@@ -30,7 +30,6 @@ import com.github.tomakehurst.wiremock.junit5.WireMockTest;
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.response.ProcessInstanceEvent;
 import io.camunda.connector.agenticai.aiagent.model.AgentSubProcessResponse;
-import io.camunda.connector.agenticai.aiagent.model.message.AssistantMessage;
 import io.camunda.connector.e2e.BpmnFile;
 import io.camunda.connector.e2e.ElementTemplate;
 import io.camunda.connector.e2e.ZeebeTest;
@@ -84,8 +83,6 @@ import org.springframework.core.io.ResourceLoader;
 class RealProviderApiSmokeIT {
 
   static final String BPMN_RESOURCE = "classpath:real-provider-api-smoke.bpmn";
-  // Reuses the same form AiAgentE2ETestIT's ai-agent-e2e-openai.bpmn deploys - same field keys
-  // (userSatisfied/followUpInput/followUpDocuments), so the same form fixture fits both BPMNs.
   static final String FORM_RESOURCE = "ai-agent-chat-user-feedback.form";
   static final String PROCESS_ID = "real_provider_api_smoke";
   static final String TOOL_JOB_TYPE = "lookup-classified-fact";
@@ -553,20 +550,7 @@ class RealProviderApiSmokeIT {
         });
   }
 
-  /**
-   * Regression test for a real production bug in the OpenAI Responses provider: replaying a
-   * completed assistant TEXT turn as conversation history sent {@code input_text} content on an
-   * assistant-role item, which the real API rejects with a 400 ({@code "Invalid value:
-   * 'input_text'. Supported values are: 'output_text' and 'refusal'."}) - see
-   * OpenAiResponsesRequestConverter#assistantContentInputItem. Tool-call turns replay as {@code
-   * function_call} items and never hit this, which is why no other scenario in this suite (or the
-   * unit/wire-format suites before this test was added) covered it.
-   *
-   * <p>Turn 1 gets a tool call followed by a completed text answer, so its {@link AssistantMessage}
-   * carries plain text content with no further tool call once persisted. The user-feedback loop's
-   * follow-up then forces a second model call whose request necessarily replays that turn 1
-   * assistant message - the exact shape that 400'd on the OpenAI Responses rows before the fix.
-   */
+  /** Re-entry test: catches a completed assistant text turn getting replayed incorrectly. */
   @ParameterizedTest(name = "{0}")
   @MethodSource("providers")
   void userFeedbackLoopReplaysAssistantTextOnFollowUp(Provider provider) {
@@ -717,9 +701,6 @@ class RealProviderApiSmokeIT {
       String systemPrompt,
       Map<String, Object> variables) {
     ZeebeTest.with(camundaClient).awaitCompleteTopology().deploy(model);
-    // Deployed unconditionally: only real-provider-api-smoke.bpmn's User_Feedback task references
-    // this form, but redeploying it for scenarios on a different BPMN (e.g. the document ones) is a
-    // harmless no-op - Zeebe deduplicates identical resource content under the same form id.
     camundaClient.newDeployResourceCommand().addResourceFromClasspath(FORM_RESOURCE).send().join();
     final var allVariables = new HashMap<>(variables);
     allVariables.put("systemPrompt", systemPrompt);

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/e2e/RealProviderApiSmokeIT.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/e2e/RealProviderApiSmokeIT.java
@@ -714,12 +714,10 @@ class RealProviderApiSmokeIT {
   }
 
   /**
-   * Completes the currently active {@code User_Feedback} user task with the given variables,
-   * mirroring {@code AiAgentE2ETestIT#shouldCompleteFeedbackLoop}'s raw {@code CamundaClient}
-   * completion for this suite's harness (no {@code ZeebeTest} response wrapper, no WireMock
-   * fixture). Picks the task with the highest key - user task keys are monotonically increasing, so
-   * this is always the most recently created (and only still-active) one for the instance, even
-   * after a prior feedback-loop iteration already completed an earlier task on the same instance.
+   * Completes the currently active {@code User_Feedback} user task with the given variables. Picks
+   * the task with the highest key - user task keys are monotonically increasing, so this is always
+   * the most recently created (and only still-active) one for the instance, even after a prior
+   * feedback-loop iteration already completed an earlier task on the same instance.
    */
   private void completeUserFeedback(ProcessInstanceEvent instance, Map<String, Object> variables) {
     assertThat(instance).withAssertionTimeout(PROCESS_TIMEOUT).hasActiveElements("User_Feedback");

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/e2e/RealProviderApiSmokeIT.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/e2e/RealProviderApiSmokeIT.java
@@ -30,6 +30,7 @@ import com.github.tomakehurst.wiremock.junit5.WireMockTest;
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.response.ProcessInstanceEvent;
 import io.camunda.connector.agenticai.aiagent.model.AgentSubProcessResponse;
+import io.camunda.connector.agenticai.aiagent.model.message.AssistantMessage;
 import io.camunda.connector.e2e.BpmnFile;
 import io.camunda.connector.e2e.ElementTemplate;
 import io.camunda.connector.e2e.ZeebeTest;
@@ -83,6 +84,9 @@ import org.springframework.core.io.ResourceLoader;
 class RealProviderApiSmokeIT {
 
   static final String BPMN_RESOURCE = "classpath:real-provider-api-smoke.bpmn";
+  // Reuses the same form AiAgentE2ETestIT's ai-agent-e2e-openai.bpmn deploys - same field keys
+  // (userSatisfied/followUpInput/followUpDocuments), so the same form fixture fits both BPMNs.
+  static final String FORM_RESOURCE = "ai-agent-chat-user-feedback.form";
   static final String PROCESS_ID = "real_provider_api_smoke";
   static final String TOOL_JOB_TYPE = "lookup-classified-fact";
   static final Duration PROCESS_TIMEOUT = Duration.ofMinutes(3);
@@ -416,6 +420,7 @@ class RealProviderApiSmokeIT {
             PROCESS_ID,
             DEFAULT_SYSTEM_PROMPT,
             Map.of("userPrompt", "What is the internal project code name? Use your lookup tool."));
+    completeUserFeedback(instance, Map.of("userSatisfied", true));
 
     assertAgentResponse(
         instance,
@@ -449,6 +454,7 @@ class RealProviderApiSmokeIT {
             Map.of(
                 "userPrompt",
                 "Look up the internal project code name and clearance level and return them."));
+    completeUserFeedback(instance, Map.of("userSatisfied", true));
 
     assertAgentResponse(
         instance,
@@ -487,6 +493,7 @@ class RealProviderApiSmokeIT {
                 "userPrompt",
                 "A farmer has chickens and rabbits. Together they have 35 heads and 94 legs. How "
                     + "many chickens are there? Reply with just the number."));
+    completeUserFeedback(instance, Map.of("userSatisfied", true));
 
     assertAgentResponse(
         instance,
@@ -521,6 +528,7 @@ class RealProviderApiSmokeIT {
                 "What is the internal project code name? Use your lookup tool.",
                 "longSystemPrompt",
                 LONG_SYSTEM_PROMPT));
+    completeUserFeedback(instance, Map.of("userSatisfied", true));
 
     // The tool call forces a second model call: turn 1 writes the cache, turn 2 reads it.
     assertAgentResponse(
@@ -543,6 +551,62 @@ class RealProviderApiSmokeIT {
               .hasResponseTextSatisfying(
                   text -> Assertions.assertThat(text).contains(NONCE_CODE_NAME));
         });
+  }
+
+  /**
+   * Regression test for a real production bug in the OpenAI Responses provider: replaying a
+   * completed assistant TEXT turn as conversation history sent {@code input_text} content on an
+   * assistant-role item, which the real API rejects with a 400 ({@code "Invalid value:
+   * 'input_text'. Supported values are: 'output_text' and 'refusal'."}) - see
+   * OpenAiResponsesRequestConverter#assistantContentInputItem. Tool-call turns replay as {@code
+   * function_call} items and never hit this, which is why no other scenario in this suite (or the
+   * unit/wire-format suites before this test was added) covered it.
+   *
+   * <p>Turn 1 gets a tool call followed by a completed text answer, so its {@link AssistantMessage}
+   * carries plain text content with no further tool call once persisted. The user-feedback loop's
+   * follow-up then forces a second model call whose request necessarily replays that turn 1
+   * assistant message - the exact shape that 400'd on the OpenAI Responses rows before the fix.
+   */
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("providers")
+  void userFeedbackLoopReplaysAssistantTextOnFollowUp(Provider provider) {
+    var model =
+        buildModel(
+            provider,
+            AI_AGENT_SUB_PROCESS_V2_ELEMENT_TEMPLATE_PATH,
+            BPMN_RESOURCE,
+            DEFAULT_SYSTEM_PROMPT,
+            template ->
+                template.property(
+                    "data.userPrompt.prompt",
+                    "=if (is defined(followUpInput)) then followUpInput else userPrompt"));
+
+    var instance =
+        startAgent(
+            model,
+            PROCESS_ID,
+            DEFAULT_SYSTEM_PROMPT,
+            Map.of("userPrompt", "What is the internal project code name? Use your lookup tool."));
+
+    // Turn 1 completes with a plain text answer - no follow-up tool call.
+    completeUserFeedback(
+        instance,
+        Map.of(
+            "userSatisfied",
+            false,
+            "followUpInput",
+            "Also tell me the clearance level you just found, in one short sentence."));
+
+    // Turn 2's request replays turn 1's completed assistant text message from history.
+    completeUserFeedback(instance, Map.of("userSatisfied", true));
+
+    assertAgentResponse(
+        instance,
+        response ->
+            AgentSubProcessResponseAssert.assertThat(response)
+                .isReady()
+                .hasResponseTextSatisfying(
+                    text -> Assertions.assertThat(text).contains(NONCE_CLEARANCE)));
   }
 
   @ParameterizedTest(name = "{0}")
@@ -653,6 +717,10 @@ class RealProviderApiSmokeIT {
       String systemPrompt,
       Map<String, Object> variables) {
     ZeebeTest.with(camundaClient).awaitCompleteTopology().deploy(model);
+    // Deployed unconditionally: only real-provider-api-smoke.bpmn's User_Feedback task references
+    // this form, but redeploying it for scenarios on a different BPMN (e.g. the document ones) is a
+    // harmless no-op - Zeebe deduplicates identical resource content under the same form id.
+    camundaClient.newDeployResourceCommand().addResourceFromClasspath(FORM_RESOURCE).send().join();
     final var allVariables = new HashMap<>(variables);
     allVariables.put("systemPrompt", systemPrompt);
     return camundaClient
@@ -662,6 +730,32 @@ class RealProviderApiSmokeIT {
         .variables(allVariables)
         .send()
         .join();
+  }
+
+  /**
+   * Completes the currently active {@code User_Feedback} user task with the given variables,
+   * mirroring {@code AiAgentE2ETestIT#shouldCompleteFeedbackLoop}'s raw {@code CamundaClient}
+   * completion for this suite's harness (no {@code ZeebeTest} response wrapper, no WireMock
+   * fixture). Picks the task with the highest key - user task keys are monotonically increasing, so
+   * this is always the most recently created (and only still-active) one for the instance, even
+   * after a prior feedback-loop iteration already completed an earlier task on the same instance.
+   */
+  private void completeUserFeedback(ProcessInstanceEvent instance, Map<String, Object> variables) {
+    assertThat(instance).withAssertionTimeout(PROCESS_TIMEOUT).hasActiveElements("User_Feedback");
+
+    final var tasks =
+        camundaClient
+            .newUserTaskSearchRequest()
+            .filter(f -> f.processInstanceKey(instance.getProcessInstanceKey()))
+            .send()
+            .join();
+    final var taskKey =
+        tasks.items().stream()
+            .max((a, b) -> Long.compare(a.getUserTaskKey(), b.getUserTaskKey()))
+            .orElseThrow()
+            .getUserTaskKey();
+
+    camundaClient.newCompleteUserTaskCommand(taskKey).variables(variables).send().join();
   }
 
   /**

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/resources/real-provider-api-smoke.bpmn
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/resources/real-provider-api-smoke.bpmn
@@ -1,17 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" id="Definitions_NativeAcceptance" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.42.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.9.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="Definitions_NativeAcceptance" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.42.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.9.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0">
   <bpmn:process id="real_provider_api_smoke" name="Real Provider API Smoke" isExecutable="true">
     <bpmn:startEvent id="StartEvent_1">
-      <bpmn:outgoing>Flow_Start_To_Agent</bpmn:outgoing>
+      <bpmn:outgoing>Flow_Start_To_Loop</bpmn:outgoing>
     </bpmn:startEvent>
-    <bpmn:sequenceFlow id="Flow_Start_To_Agent" sourceRef="StartEvent_1" targetRef="AI_Agent" />
+    <bpmn:sequenceFlow id="Flow_Start_To_Loop" sourceRef="StartEvent_1" targetRef="Gateway_Loop" />
+    <bpmn:exclusiveGateway id="Gateway_Loop">
+      <bpmn:incoming>Flow_Start_To_Loop</bpmn:incoming>
+      <bpmn:incoming>Flow_NotSatisfied_To_Loop</bpmn:incoming>
+      <bpmn:outgoing>Flow_Loop_To_Agent</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="Flow_Loop_To_Agent" sourceRef="Gateway_Loop" targetRef="AI_Agent" />
     <bpmn:adHocSubProcess id="AI_Agent" name="AI Agent">
       <bpmn:documentation>Real provider API smoke test agent</bpmn:documentation>
       <bpmn:extensionElements>
         <zeebe:taskDefinition type="dummy" retries="0" />
       </bpmn:extensionElements>
-      <bpmn:incoming>Flow_Start_To_Agent</bpmn:incoming>
-      <bpmn:outgoing>Flow_Agent_To_End</bpmn:outgoing>
+      <bpmn:incoming>Flow_Loop_To_Agent</bpmn:incoming>
+      <bpmn:outgoing>Flow_Agent_To_Feedback</bpmn:outgoing>
       <bpmn:serviceTask id="Lookup_Classified_Fact" name="Lookup Classified Fact">
         <bpmn:documentation>Looks up the classified internal fact sheet and returns the secret project code name and clearance level. Call this whenever the user asks for the internal/classified code name.</bpmn:documentation>
         <bpmn:extensionElements>
@@ -19,9 +25,32 @@
         </bpmn:extensionElements>
       </bpmn:serviceTask>
     </bpmn:adHocSubProcess>
-    <bpmn:sequenceFlow id="Flow_Agent_To_End" sourceRef="AI_Agent" targetRef="EndEvent_1" />
+    <bpmn:sequenceFlow id="Flow_Agent_To_Feedback" sourceRef="AI_Agent" targetRef="User_Feedback" />
+    <bpmn:userTask id="User_Feedback" name="User Feedback">
+      <bpmn:extensionElements>
+        <zeebe:userTask />
+        <zeebe:formDefinition formId="ai-agent-chat-user-feedback" />
+        <zeebe:ioMapping>
+          <zeebe:input source="=agent.responseText" target="responseText" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_Agent_To_Feedback</bpmn:incoming>
+      <bpmn:outgoing>Flow_Feedback_To_Satisfied</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:sequenceFlow id="Flow_Feedback_To_Satisfied" sourceRef="User_Feedback" targetRef="Gateway_Satisfied" />
+    <bpmn:exclusiveGateway id="Gateway_Satisfied" name="User satisfied?">
+      <bpmn:incoming>Flow_Feedback_To_Satisfied</bpmn:incoming>
+      <bpmn:outgoing>Flow_NotSatisfied_To_Loop</bpmn:outgoing>
+      <bpmn:outgoing>Flow_Satisfied_To_End</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="Flow_NotSatisfied_To_Loop" name="no - we follow up" sourceRef="Gateway_Satisfied" targetRef="Gateway_Loop">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=userSatisfied = null or userSatisfied = false</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_Satisfied_To_End" name="yes" sourceRef="Gateway_Satisfied" targetRef="EndEvent_1">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=userSatisfied</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
     <bpmn:endEvent id="EndEvent_1">
-      <bpmn:incoming>Flow_Agent_To_End</bpmn:incoming>
+      <bpmn:incoming>Flow_Satisfied_To_End</bpmn:incoming>
     </bpmn:endEvent>
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
@@ -29,22 +58,58 @@
       <bpmndi:BPMNShape id="StartEvent_1_di" bpmnElement="StartEvent_1">
         <dc:Bounds x="152" y="182" width="36" height="36" />
       </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_Loop_di" bpmnElement="Gateway_Loop" isMarkerVisible="true">
+        <dc:Bounds x="245" y="175" width="50" height="50" />
+      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_Agent_di" bpmnElement="AI_Agent" isExpanded="true">
-        <dc:Bounds x="260" y="100" width="360" height="200" />
+        <dc:Bounds x="360" y="100" width="360" height="200" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_Lookup_di" bpmnElement="Lookup_Classified_Fact">
-        <dc:Bounds x="320" y="150" width="100" height="80" />
+        <dc:Bounds x="420" y="150" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_Feedback_di" bpmnElement="User_Feedback">
+        <dc:Bounds x="790" y="160" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_Satisfied_di" bpmnElement="Gateway_Satisfied" isMarkerVisible="true">
+        <dc:Bounds x="945" y="175" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="934" y="232" width="73" height="14" />
+        </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="EndEvent_1_di" bpmnElement="EndEvent_1">
-        <dc:Bounds x="692" y="182" width="36" height="36" />
+        <dc:Bounds x="1052" y="182" width="36" height="36" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="Flow_Start_To_Agent_di" bpmnElement="Flow_Start_To_Agent">
+      <bpmndi:BPMNEdge id="Flow_Start_To_Loop_di" bpmnElement="Flow_Start_To_Loop">
         <di:waypoint x="188" y="200" />
-        <di:waypoint x="260" y="200" />
+        <di:waypoint x="245" y="200" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_Agent_To_End_di" bpmnElement="Flow_Agent_To_End">
-        <di:waypoint x="620" y="200" />
-        <di:waypoint x="692" y="200" />
+      <bpmndi:BPMNEdge id="Flow_Loop_To_Agent_di" bpmnElement="Flow_Loop_To_Agent">
+        <di:waypoint x="295" y="200" />
+        <di:waypoint x="360" y="200" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Agent_To_Feedback_di" bpmnElement="Flow_Agent_To_Feedback">
+        <di:waypoint x="720" y="200" />
+        <di:waypoint x="790" y="200" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Feedback_To_Satisfied_di" bpmnElement="Flow_Feedback_To_Satisfied">
+        <di:waypoint x="890" y="200" />
+        <di:waypoint x="945" y="200" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_NotSatisfied_To_Loop_di" bpmnElement="Flow_NotSatisfied_To_Loop">
+        <di:waypoint x="970" y="175" />
+        <di:waypoint x="970" y="90" />
+        <di:waypoint x="270" y="90" />
+        <di:waypoint x="270" y="175" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="878" y="73" width="83" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Satisfied_To_End_di" bpmnElement="Flow_Satisfied_To_End">
+        <di:waypoint x="995" y="200" />
+        <di:waypoint x="1052" y="200" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1015" y="182" width="18" height="14" />
+        </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/resources/real-provider-api-smoke.bpmn
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/resources/real-provider-api-smoke.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="Definitions_NativeAcceptance" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.42.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.9.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_NativeAcceptance" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.49.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.9.0">
   <bpmn:process id="real_provider_api_smoke" name="Real Provider API Smoke" isExecutable="true">
     <bpmn:startEvent id="StartEvent_1">
       <bpmn:outgoing>Flow_Start_To_Loop</bpmn:outgoing>
@@ -56,59 +56,59 @@
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="real_provider_api_smoke">
       <bpmndi:BPMNShape id="StartEvent_1_di" bpmnElement="StartEvent_1">
-        <dc:Bounds x="152" y="182" width="36" height="36" />
+        <dc:Bounds x="152" y="232" width="36" height="36" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Gateway_Loop_di" bpmnElement="Gateway_Loop" isMarkerVisible="true">
-        <dc:Bounds x="245" y="175" width="50" height="50" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_Agent_di" bpmnElement="AI_Agent" isExpanded="true">
-        <dc:Bounds x="360" y="100" width="360" height="200" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_Lookup_di" bpmnElement="Lookup_Classified_Fact">
-        <dc:Bounds x="420" y="150" width="100" height="80" />
+        <dc:Bounds x="245" y="225" width="50" height="50" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_Feedback_di" bpmnElement="User_Feedback">
-        <dc:Bounds x="790" y="160" width="100" height="80" />
+        <dc:Bounds x="790" y="210" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Gateway_Satisfied_di" bpmnElement="Gateway_Satisfied" isMarkerVisible="true">
-        <dc:Bounds x="945" y="175" width="50" height="50" />
+        <dc:Bounds x="945" y="225" width="50" height="50" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="934" y="232" width="73" height="14" />
+          <dc:Bounds x="934" y="282" width="73" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="EndEvent_1_di" bpmnElement="EndEvent_1">
-        <dc:Bounds x="1052" y="182" width="36" height="36" />
+        <dc:Bounds x="1052" y="232" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_Agent_di" bpmnElement="AI_Agent" isExpanded="true">
+        <dc:Bounds x="360" y="150" width="360" height="200" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_Lookup_di" bpmnElement="Lookup_Classified_Fact">
+        <dc:Bounds x="480" y="200" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNEdge id="Flow_Start_To_Loop_di" bpmnElement="Flow_Start_To_Loop">
-        <di:waypoint x="188" y="200" />
-        <di:waypoint x="245" y="200" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_Loop_To_Agent_di" bpmnElement="Flow_Loop_To_Agent">
-        <di:waypoint x="295" y="200" />
-        <di:waypoint x="360" y="200" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_Agent_To_Feedback_di" bpmnElement="Flow_Agent_To_Feedback">
-        <di:waypoint x="720" y="200" />
-        <di:waypoint x="790" y="200" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_Feedback_To_Satisfied_di" bpmnElement="Flow_Feedback_To_Satisfied">
-        <di:waypoint x="890" y="200" />
-        <di:waypoint x="945" y="200" />
+        <di:waypoint x="188" y="250" />
+        <di:waypoint x="245" y="250" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_NotSatisfied_To_Loop_di" bpmnElement="Flow_NotSatisfied_To_Loop">
-        <di:waypoint x="970" y="175" />
-        <di:waypoint x="970" y="90" />
-        <di:waypoint x="270" y="90" />
-        <di:waypoint x="270" y="175" />
+        <di:waypoint x="970" y="225" />
+        <di:waypoint x="970" y="100" />
+        <di:waypoint x="270" y="100" />
+        <di:waypoint x="270" y="225" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="878" y="73" width="83" height="14" />
+          <dc:Bounds x="878" y="83" width="83" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Loop_To_Agent_di" bpmnElement="Flow_Loop_To_Agent">
+        <di:waypoint x="295" y="250" />
+        <di:waypoint x="360" y="250" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Agent_To_Feedback_di" bpmnElement="Flow_Agent_To_Feedback">
+        <di:waypoint x="720" y="250" />
+        <di:waypoint x="790" y="250" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Feedback_To_Satisfied_di" bpmnElement="Flow_Feedback_To_Satisfied">
+        <di:waypoint x="890" y="250" />
+        <di:waypoint x="945" y="250" />
+      </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_Satisfied_To_End_di" bpmnElement="Flow_Satisfied_To_End">
-        <di:waypoint x="995" y="200" />
-        <di:waypoint x="1052" y="200" />
+        <di:waypoint x="995" y="250" />
+        <di:waypoint x="1052" y="250" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="1015" y="182" width="18" height="14" />
+          <dc:Bounds x="1015" y="232" width="18" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/openai/family/responses/OpenAiResponsesRequestConverter.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/openai/family/responses/OpenAiResponsesRequestConverter.java
@@ -35,6 +35,7 @@ import io.camunda.connector.agenticai.aiagent.model.message.UserMessage;
 import io.camunda.connector.agenticai.aiagent.model.message.content.Content;
 import io.camunda.connector.agenticai.aiagent.model.message.content.ProviderContent;
 import io.camunda.connector.agenticai.aiagent.model.message.content.ReasoningContent;
+import io.camunda.connector.agenticai.aiagent.model.message.content.TextContent;
 import io.camunda.connector.agenticai.aiagent.model.request.ResponseConfiguration;
 import io.camunda.connector.agenticai.aiagent.model.request.ResponseFormatConfiguration.JsonResponseFormatConfiguration;
 import io.camunda.connector.agenticai.aiagent.model.request.v2.OpenAiChatModelConfiguration;
@@ -51,6 +52,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.stream.Collectors;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -194,7 +196,8 @@ public class OpenAiResponsesRequestConverter {
    *
    * <p>Plain content is replayed via {@link EasyInputMessage} rather than the structured {@link
    * ResponseOutputMessage} shape, which requires a {@code msg_*}-namespaced {@code id} that {@link
-   * AssistantMessage#messageId()} isn't guaranteed to carry.
+   * AssistantMessage#messageId()} isn't guaranteed to carry. See {@link
+   * #assistantContentInputItem(List)} for the content shape used for the assistant role.
    */
   private List<ResponseInputItem> assistantInputItems(AssistantMessage assistant) {
     final List<ResponseInputItem> items = new ArrayList<>();
@@ -217,14 +220,7 @@ public class OpenAiResponsesRequestConverter {
       }
     }
     if (!plainContent.isEmpty()) {
-      items.add(
-          ResponseInputItem.ofEasyInputMessage(
-              EasyInputMessage.builder()
-                  .role(EasyInputMessage.Role.ASSISTANT)
-                  .content(
-                      EasyInputMessage.Content.ofResponseInputMessageContentList(
-                          contentConverter.toResponsesContentParts(plainContent)))
-                  .build()));
+      items.add(assistantContentInputItem(plainContent));
     }
     for (final ToolCall toolCall : assistant.toolCalls()) {
       items.add(
@@ -236,6 +232,48 @@ public class OpenAiResponsesRequestConverter {
                   .build()));
     }
     return items;
+  }
+
+  /**
+   * Builds the assistant-role input item for plain (text/document/object) content. The Responses
+   * API accepts only {@code output_text}/{@code refusal} content parts for the assistant role, so
+   * the part-list shape used for user messages (built from {@link
+   * OpenAiContentConverter#toResponsesContentParts}, whose parts are all {@code input_text}/{@code
+   * input_image}/{@code input_file}) is rejected here. {@link EasyInputMessage.Content#ofTextInput}
+   * serializes as a bare JSON string instead, which the API does accept for this role, so text
+   * content is joined into one string that way.
+   *
+   * <p>The domain only ever puts {@link TextContent} into an assistant message's plain content --
+   * LLM responses are translated to text/reasoning/tool-call content, never document or object
+   * content. If a non-text part does appear, this falls back to the part-list shape rather than
+   * inventing handling for a case the domain does not produce; that fallback is rejected by the API
+   * for the same reason plain text was, and stays that way until the domain actually produces it.
+   *
+   * <p>Multiple {@link TextContent} blocks are joined into the single string rather than replayed
+   * as separate {@code output_text} parts: {@link EasyInputMessage.Content} has no such array-of-
+   * output_text variant for the assistant role -- only the bare-string shape used here and the
+   * part-list shape of {@code input_text}/{@code input_image}/{@code input_file} parts, both
+   * rejected above. An array of {@code output_text}/{@code refusal} parts requires the {@link
+   * ResponseOutputMessage} shape this method deliberately avoids (see {@link
+   * #assistantInputItems}).
+   *
+   * <p>Refusals need no handling here: {@code OpenAiResponsesResponseConverter} has no domain
+   * content type for them and never turns one into {@link AssistantMessage} content -- a refusal
+   * response is surfaced as a thrown {@code ContentFilteredException} instead, so it never reaches
+   * conversation history to be replayed.
+   */
+  private ResponseInputItem assistantContentInputItem(List<Content> plainContent) {
+    final boolean textOnly = plainContent.stream().allMatch(TextContent.class::isInstance);
+    final EasyInputMessage.Content content =
+        textOnly
+            ? EasyInputMessage.Content.ofTextInput(
+                plainContent.stream()
+                    .map(c -> ((TextContent) c).text())
+                    .collect(Collectors.joining("\n")))
+            : EasyInputMessage.Content.ofResponseInputMessageContentList(
+                contentConverter.toResponsesContentParts(plainContent));
+    return ResponseInputItem.ofEasyInputMessage(
+        EasyInputMessage.builder().role(EasyInputMessage.Role.ASSISTANT).content(content).build());
   }
 
   /**

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/openai/family/responses/OpenAiResponsesRequestConverter.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/openai/family/responses/OpenAiResponsesRequestConverter.java
@@ -241,19 +241,11 @@ public class OpenAiResponsesRequestConverter {
   }
 
   /**
-   * Builds the assistant-role input item for plain (text/document/object) content, as a {@link
-   * ResponseOutputMessage} with one {@code output_text} part per {@link Content} block, preserving
-   * block boundaries rather than flattening them into one string. {@link DocumentContent}/{@link
-   * ObjectContent} -- content types the domain never actually puts into an assistant message's
-   * plain content, since LLM responses are translated to text/reasoning/tool-call content only --
-   * become an {@code output_text} part carrying their JSON serialization, the same "reference
-   * rather than lost" treatment {@link OpenAiContentConverter} gives out-of-place content
-   * elsewhere; {@code output_text} carries text only, so there is no native shape for either.
-   *
-   * <p>Refusals need no handling here: {@code OpenAiResponsesResponseConverter} has no domain
-   * content type for them and never turns one into {@link AssistantMessage} content -- a refusal
-   * response is surfaced as a thrown {@code ContentFilteredException} instead, so it never reaches
-   * conversation history to be replayed.
+   * Builds the assistant-role input item: a {@link ResponseOutputMessage} with one {@code
+   * output_text} part per {@link Content} block. {@link DocumentContent}/{@link ObjectContent}
+   * become an {@code output_text} part carrying their JSON serialization, since that part type
+   * carries text only. Refusals never reach here -- the response converter turns them into a thrown
+   * exception, not assistant content.
    */
   private ResponseInputItem assistantContentInputItem(
       AssistantMessage assistant, List<Content> plainContent) {

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/openai/family/responses/OpenAiResponsesRequestConverter.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/openai/family/responses/OpenAiResponsesRequestConverter.java
@@ -22,6 +22,7 @@ import com.openai.models.responses.ResponseFunctionToolCall;
 import com.openai.models.responses.ResponseIncludable;
 import com.openai.models.responses.ResponseInputItem;
 import com.openai.models.responses.ResponseOutputMessage;
+import com.openai.models.responses.ResponseOutputText;
 import com.openai.models.responses.ResponseTextConfig;
 import com.openai.models.responses.Tool;
 import io.camunda.connector.agenticai.aiagent.chatmodel.provider.openai.OpenAiContentConverter;
@@ -33,6 +34,8 @@ import io.camunda.connector.agenticai.aiagent.model.message.SystemMessage;
 import io.camunda.connector.agenticai.aiagent.model.message.ToolCallResultMessage;
 import io.camunda.connector.agenticai.aiagent.model.message.UserMessage;
 import io.camunda.connector.agenticai.aiagent.model.message.content.Content;
+import io.camunda.connector.agenticai.aiagent.model.message.content.DocumentContent;
+import io.camunda.connector.agenticai.aiagent.model.message.content.ObjectContent;
 import io.camunda.connector.agenticai.aiagent.model.message.content.ProviderContent;
 import io.camunda.connector.agenticai.aiagent.model.message.content.ReasoningContent;
 import io.camunda.connector.agenticai.aiagent.model.message.content.TextContent;
@@ -52,7 +55,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.stream.Collectors;
+import java.util.UUID;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -194,10 +197,13 @@ public class OpenAiResponsesRequestConverter {
    * provider is dropped rather than replayed, since its payload is shaped for that provider's SDK
    * and would either throw or produce garbage if converted here.
    *
-   * <p>Plain content is replayed via {@link EasyInputMessage} rather than the structured {@link
-   * ResponseOutputMessage} shape, which requires a {@code msg_*}-namespaced {@code id} that {@link
-   * AssistantMessage#messageId()} isn't guaranteed to carry. See {@link
-   * #assistantContentInputItem(List)} for the content shape used for the assistant role.
+   * <p>Plain content is replayed as a {@link ResponseOutputMessage}, not the {@link
+   * EasyInputMessage} shape used for user messages: the Responses API accepts only {@code
+   * output_text}/{@code refusal} content parts for the assistant role, and {@link
+   * EasyInputMessage}'s part-list shape (built from {@link
+   * OpenAiContentConverter#toResponsesContentParts}) is exclusively {@code input_text}/{@code
+   * input_image}/{@code input_file}, which the API rejects for that role. See {@link
+   * #assistantContentInputItem(AssistantMessage, List)} for the item's exact shape.
    */
   private List<ResponseInputItem> assistantInputItems(AssistantMessage assistant) {
     final List<ResponseInputItem> items = new ArrayList<>();
@@ -220,7 +226,7 @@ public class OpenAiResponsesRequestConverter {
       }
     }
     if (!plainContent.isEmpty()) {
-      items.add(assistantContentInputItem(plainContent));
+      items.add(assistantContentInputItem(assistant, plainContent));
     }
     for (final ToolCall toolCall : assistant.toolCalls()) {
       items.add(
@@ -235,45 +241,63 @@ public class OpenAiResponsesRequestConverter {
   }
 
   /**
-   * Builds the assistant-role input item for plain (text/document/object) content. The Responses
-   * API accepts only {@code output_text}/{@code refusal} content parts for the assistant role, so
-   * the part-list shape used for user messages (built from {@link
-   * OpenAiContentConverter#toResponsesContentParts}, whose parts are all {@code input_text}/{@code
-   * input_image}/{@code input_file}) is rejected here. {@link EasyInputMessage.Content#ofTextInput}
-   * serializes as a bare JSON string instead, which the API does accept for this role, so text
-   * content is joined into one string that way.
-   *
-   * <p>The domain only ever puts {@link TextContent} into an assistant message's plain content --
-   * LLM responses are translated to text/reasoning/tool-call content, never document or object
-   * content. If a non-text part does appear, this falls back to the part-list shape rather than
-   * inventing handling for a case the domain does not produce; that fallback is rejected by the API
-   * for the same reason plain text was, and stays that way until the domain actually produces it.
-   *
-   * <p>Multiple {@link TextContent} blocks are joined into the single string rather than replayed
-   * as separate {@code output_text} parts: {@link EasyInputMessage.Content} has no such array-of-
-   * output_text variant for the assistant role -- only the bare-string shape used here and the
-   * part-list shape of {@code input_text}/{@code input_image}/{@code input_file} parts, both
-   * rejected above. An array of {@code output_text}/{@code refusal} parts requires the {@link
-   * ResponseOutputMessage} shape this method deliberately avoids (see {@link
-   * #assistantInputItems}).
+   * Builds the assistant-role input item for plain (text/document/object) content, as a {@link
+   * ResponseOutputMessage} with one {@code output_text} part per {@link Content} block, preserving
+   * block boundaries rather than flattening them into one string. {@link DocumentContent}/{@link
+   * ObjectContent} -- content types the domain never actually puts into an assistant message's
+   * plain content, since LLM responses are translated to text/reasoning/tool-call content only --
+   * become an {@code output_text} part carrying their JSON serialization, the same "reference
+   * rather than lost" treatment {@link OpenAiContentConverter} gives out-of-place content
+   * elsewhere; {@code output_text} carries text only, so there is no native shape for either.
    *
    * <p>Refusals need no handling here: {@code OpenAiResponsesResponseConverter} has no domain
    * content type for them and never turns one into {@link AssistantMessage} content -- a refusal
    * response is surfaced as a thrown {@code ContentFilteredException} instead, so it never reaches
    * conversation history to be replayed.
    */
-  private ResponseInputItem assistantContentInputItem(List<Content> plainContent) {
-    final boolean textOnly = plainContent.stream().allMatch(TextContent.class::isInstance);
-    final EasyInputMessage.Content content =
-        textOnly
-            ? EasyInputMessage.Content.ofTextInput(
-                plainContent.stream()
-                    .map(c -> ((TextContent) c).text())
-                    .collect(Collectors.joining("\n")))
-            : EasyInputMessage.Content.ofResponseInputMessageContentList(
-                contentConverter.toResponsesContentParts(plainContent));
-    return ResponseInputItem.ofEasyInputMessage(
-        EasyInputMessage.builder().role(EasyInputMessage.Role.ASSISTANT).content(content).build());
+  private ResponseInputItem assistantContentInputItem(
+      AssistantMessage assistant, List<Content> plainContent) {
+    final List<ResponseOutputMessage.Content> parts =
+        plainContent.stream().map(this::outputTextPart).toList();
+    return ResponseInputItem.ofResponseOutputMessage(
+        ResponseOutputMessage.builder()
+            .id(assistantMessageId(assistant))
+            .status(ResponseOutputMessage.Status.COMPLETED)
+            .content(parts)
+            .build());
+  }
+
+  private ResponseOutputMessage.Content outputTextPart(Content content) {
+    final String text =
+        switch (content) {
+          case TextContent t -> t.text();
+          case ObjectContent obj -> contentConverter.writeAsJson(obj.content());
+          case DocumentContent doc -> contentConverter.writeAsJson(doc.document());
+          default ->
+              throw new IllegalStateException(
+                  "Reasoning/provider content is routed by assistantInputItems before reaching "
+                      + "plain-content handling and must never appear here: "
+                      + content.getClass().getSimpleName());
+        };
+    return ResponseOutputMessage.Content.ofOutputText(
+        ResponseOutputText.builder().text(text).annotations(List.of()).build());
+  }
+
+  /**
+   * The {@code id} to replay an assistant message under. A genuine Responses-origin turn's {@link
+   * AssistantMessage#messageId()} is the {@code msg_*} output-item id {@code
+   * OpenAiResponsesResponseConverter} captured from the real response, so it is passed through
+   * verbatim. Any other value -- absent (e.g. v1 LangChain4j-sourced history, a legacy record) or
+   * foreign-namespaced (e.g. Completions' {@code chatcmpl_*}, or another provider's own id scheme
+   * after a family/provider switch) -- is rejected by the API ({@code "Expected an ID that begins
+   * with msg"}), so a fresh {@code msg_}-namespaced id is synthesized instead; {@code id} is
+   * required to build a {@link ResponseOutputMessage} at all, so replay can't simply omit it here.
+   */
+  private String assistantMessageId(AssistantMessage assistant) {
+    final String messageId = assistant.messageId();
+    return messageId != null && messageId.startsWith("msg_")
+        ? messageId
+        : "msg_" + UUID.randomUUID().toString().replace("-", "");
   }
 
   /**

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/openai/family/responses/OpenAiResponsesRequestConverterTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/openai/family/responses/OpenAiResponsesRequestConverterTest.java
@@ -19,6 +19,7 @@ import com.openai.models.ReasoningEffort;
 import com.openai.models.responses.EasyInputMessage;
 import com.openai.models.responses.ResponseCreateParams;
 import com.openai.models.responses.ResponseIncludable;
+import com.openai.models.responses.ResponseInputContent;
 import io.camunda.connector.agenticai.aiagent.chatmodel.provider.openai.OpenAiContentConverter;
 import io.camunda.connector.agenticai.aiagent.memory.ConversationSnapshot;
 import io.camunda.connector.agenticai.aiagent.model.message.AssistantMessage;
@@ -266,7 +267,11 @@ class OpenAiResponsesRequestConverterTest {
   }
 
   @Test
-  void replaysAssistantTextContentAsAssistantMessageInputItem() {
+  void replaysAssistantTextContentAsBareAssistantMessageString() {
+    // Responses rejects input_text/input_image/input_file content parts for the assistant role
+    // (only output_text/refusal are valid there) - see
+    // OpenAiResponsesRequestConverter#assistantContentInputItem. Assistant text is therefore
+    // replayed as a bare string, not a content-part list.
     final var snapshot =
         new ConversationSnapshot(
             List.of(
@@ -283,10 +288,35 @@ class OpenAiResponsesRequestConverterTest {
 
     final var easy = items.get(0).easyInputMessage().orElseThrow();
     assertThat(easy.role()).isEqualTo(EasyInputMessage.Role.ASSISTANT);
+    assertThat(easy.content().textInput()).contains("here's the answer");
+    assertThat(easy.content().responseInputMessageContentList()).isEmpty();
+  }
 
-    final var parts = easy.content().asResponseInputMessageContentList();
-    assertThat(parts).hasSize(1);
-    assertThat(parts.get(0).inputText().orElseThrow().text()).isEqualTo("here's the answer");
+  @Test
+  void neverEmitsAnInputTextContentPartForAnAssistantMessage() {
+    // Regression test for the 400 the real Responses API returns for an assistant-role input_text
+    // part ("Invalid value: 'input_text'. Supported values are: 'output_text' and 'refusal'.") -
+    // this must fail if assistant content is ever emitted as a content-part list again.
+    final var snapshot =
+        new ConversationSnapshot(
+            List.of(
+                AssistantMessage.builder()
+                    .content(List.of(TextContent.textContent("here's the answer")))
+                    .build()),
+            List.of());
+
+    final var params = converter.toRequest(model(null), null, snapshot);
+
+    final var items = params.input().orElseThrow().asResponse();
+    final boolean anyAssistantInputTextPart =
+        items.stream()
+            .flatMap(item -> item.easyInputMessage().stream())
+            .filter(easy -> easy.role() == EasyInputMessage.Role.ASSISTANT)
+            .flatMap(easy -> easy.content().responseInputMessageContentList().stream())
+            .flatMap(List::stream)
+            .anyMatch(ResponseInputContent::isInputText);
+
+    assertThat(anyAssistantInputTextPart).isFalse();
   }
 
   @Test

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/openai/family/responses/OpenAiResponsesRequestConverterTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/openai/family/responses/OpenAiResponsesRequestConverterTest.java
@@ -19,7 +19,7 @@ import com.openai.models.ReasoningEffort;
 import com.openai.models.responses.EasyInputMessage;
 import com.openai.models.responses.ResponseCreateParams;
 import com.openai.models.responses.ResponseIncludable;
-import com.openai.models.responses.ResponseInputContent;
+import com.openai.models.responses.ResponseOutputMessage;
 import io.camunda.connector.agenticai.aiagent.chatmodel.provider.openai.OpenAiContentConverter;
 import io.camunda.connector.agenticai.aiagent.memory.ConversationSnapshot;
 import io.camunda.connector.agenticai.aiagent.model.message.AssistantMessage;
@@ -55,6 +55,7 @@ import io.camunda.connector.document.jackson.DocumentReferenceModel.ExternalDocu
 import io.camunda.connector.document.jackson.JacksonModuleDocumentSerializer;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
 import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
 
@@ -267,11 +268,12 @@ class OpenAiResponsesRequestConverterTest {
   }
 
   @Test
-  void replaysAssistantTextContentAsBareAssistantMessageString() {
+  void replaysAssistantTextContentAsOutputTextMessage() {
     // Responses rejects input_text/input_image/input_file content parts for the assistant role
     // (only output_text/refusal are valid there) - see
     // OpenAiResponsesRequestConverter#assistantContentInputItem. Assistant text is therefore
-    // replayed as a bare string, not a content-part list.
+    // replayed as a ResponseOutputMessage with an output_text part, not the EasyInputMessage
+    // content-part-list shape used for user messages.
     final var snapshot =
         new ConversationSnapshot(
             List.of(
@@ -286,17 +288,44 @@ class OpenAiResponsesRequestConverterTest {
     final var items = params.input().orElseThrow().asResponse();
     assertThat(items).hasSize(1);
 
-    final var easy = items.get(0).easyInputMessage().orElseThrow();
-    assertThat(easy.role()).isEqualTo(EasyInputMessage.Role.ASSISTANT);
-    assertThat(easy.content().textInput()).contains("here's the answer");
-    assertThat(easy.content().responseInputMessageContentList()).isEmpty();
+    final var message = items.get(0).responseOutputMessage().orElseThrow();
+    assertThat(message.id()).isEqualTo("msg_1");
+    assertThat(message.status()).isEqualTo(ResponseOutputMessage.Status.COMPLETED);
+    assertThat(message.content()).hasSize(1);
+    assertThat(message.content().get(0).asOutputText().text()).isEqualTo("here's the answer");
+  }
+
+  @Test
+  void replaysMultipleAssistantTextBlocksAsSeparateOutputTextParts() {
+    // Block boundaries are preserved rather than flattened into one joined string - see
+    // OpenAiResponsesRequestConverter#assistantContentInputItem.
+    final var snapshot =
+        new ConversationSnapshot(
+            List.of(
+                AssistantMessage.builder()
+                    .content(
+                        List.of(
+                            TextContent.textContent("first block"),
+                            TextContent.textContent("second block")))
+                    .messageId("msg_1")
+                    .build()),
+            List.of());
+
+    final var params = converter.toRequest(model(null), null, snapshot);
+
+    final var items = params.input().orElseThrow().asResponse();
+    final var message = items.get(0).responseOutputMessage().orElseThrow();
+    assertThat(message.content()).hasSize(2);
+    assertThat(message.content().get(0).asOutputText().text()).isEqualTo("first block");
+    assertThat(message.content().get(1).asOutputText().text()).isEqualTo("second block");
   }
 
   @Test
   void neverEmitsAnInputTextContentPartForAnAssistantMessage() {
     // Regression test for the 400 the real Responses API returns for an assistant-role input_text
     // part ("Invalid value: 'input_text'. Supported values are: 'output_text' and 'refusal'.") -
-    // this must fail if assistant content is ever emitted as a content-part list again.
+    // checked at the raw JSON level (not through a typed SDK accessor) so it fails on any
+    // reintroduction of the bug, typed or not.
     final var snapshot =
         new ConversationSnapshot(
             List.of(
@@ -307,24 +336,45 @@ class OpenAiResponsesRequestConverterTest {
 
     final var params = converter.toRequest(model(null), null, snapshot);
 
-    final var items = params.input().orElseThrow().asResponse();
-    final boolean anyAssistantInputTextPart =
-        items.stream()
-            .flatMap(item -> item.easyInputMessage().stream())
-            .filter(easy -> easy.role() == EasyInputMessage.Role.ASSISTANT)
-            .flatMap(easy -> easy.content().responseInputMessageContentList().stream())
-            .flatMap(List::stream)
-            .anyMatch(ResponseInputContent::isInputText);
+    final var assistantInputTextParts =
+        rawInputItems(params).stream()
+            .filter(item -> "assistant".equals(item.get("role")))
+            .flatMap(
+                item ->
+                    item.get("content") instanceof List<?> parts ? parts.stream() : Stream.empty())
+            .filter(part -> part instanceof Map<?, ?> map && "input_text".equals(map.get("type")))
+            .toList();
 
-    assertThat(anyAssistantInputTextPart).isFalse();
+    assertThat(assistantInputTextParts).isEmpty();
   }
 
   @Test
-  void replaysAssistantTextContentWithoutRequiringAValidResponsesMessageId() {
+  void replaysAssistantTextContentUnderItsOwnValidMessageId() {
+    // A genuine Responses-origin turn's messageId is the msg_* id OpenAiResponsesResponseConverter
+    // captured from the real response - replay passes it through verbatim.
+    final var snapshot =
+        new ConversationSnapshot(
+            List.of(
+                AssistantMessage.builder()
+                    .content(List.of(TextContent.textContent("here's the answer")))
+                    .messageId("msg_abc123")
+                    .build()),
+            List.of());
+
+    final var params = converter.toRequest(model(null), null, snapshot);
+
+    final var items = params.input().orElseThrow().asResponse();
+    final var message = items.get(0).responseOutputMessage().orElseThrow();
+    assertThat(message.id()).isEqualTo("msg_abc123");
+  }
+
+  @Test
+  void synthesizesAFreshMessageIdWhenNoneIsValid() {
     // messageId is null (e.g. v1 LangChain4j-sourced history, or a legacy record) or namespaced
     // for a different family/provider (e.g. OpenAI Completions' chatcmpl_*, or another provider's
-    // own id scheme, after a family/provider switch mid-conversation) -- EasyInputMessage has no
-    // id field, so replay must not depend on messageId being present or valid at all.
+    // own id scheme, after a family/provider switch mid-conversation) -- the API rejects any id
+    // that doesn't start with "msg_", so replay must synthesize a fresh one rather than passing
+    // the foreign id through or failing.
     for (final String messageId : new String[] {null, "chatcmpl_1", "some-other-provider-id"}) {
       final var snapshot =
           new ConversationSnapshot(
@@ -339,7 +389,8 @@ class OpenAiResponsesRequestConverterTest {
 
       final var items = params.input().orElseThrow().asResponse();
       assertThat(items).hasSize(1);
-      assertThat(items.get(0).easyInputMessage()).isPresent();
+      final var message = items.get(0).responseOutputMessage().orElseThrow();
+      assertThat(message.id()).startsWith("msg_").isNotEqualTo(messageId);
     }
   }
 
@@ -366,7 +417,7 @@ class OpenAiResponsesRequestConverterTest {
     final var items = params.input().orElseThrow().asResponse();
     assertThat(items).hasSize(2);
 
-    assertThat(items.get(0).easyInputMessage()).isPresent();
+    assertThat(items.get(0).responseOutputMessage()).isPresent();
 
     final var functionCall = items.get(1).functionCall().orElseThrow();
     assertThat(functionCall.callId()).isEqualTo("call_1");
@@ -401,7 +452,7 @@ class OpenAiResponsesRequestConverterTest {
     final var items = params.input().orElseThrow().asResponse();
     assertThat(items).hasSize(3);
     assertThat(items.get(0).reasoning()).isPresent();
-    assertThat(items.get(1).easyInputMessage()).isPresent();
+    assertThat(items.get(1).responseOutputMessage()).isPresent();
     assertThat(items.get(2).functionCall()).isPresent();
   }
 


### PR DESCRIPTION
## Description

The native OpenAI **Responses** provider crashed with a 400 (`Invalid value: 'input_text'. Supported values are: 'output_text' and 'refusal'.`) whenever a conversation replayed a completed assistant *text* turn — e.g. a second agent turn after the user gives feedback and asks a follow-up. Tool-call turns replay fine (`function_call` items), which is why this went unnoticed: the bug only surfaces once a turn ends in plain text and the conversation continues.

Assistant text is now replayed as a structured output message (`output_text` parts, one per text block, under a valid `msg_*` id), matching what the Responses API actually accepts for the assistant role.

Also hardens the coverage that let this ship:
- The wire-format e2e suite normalized away the very detail (`input_text` vs `output_text`) that would have caught this, and only compared joined text, never content-part *type*. It now keeps the raw wire encoding and asserts no assistant-role item ever carries an input-only part.
- The real-provider acceptance suite never exercised a multi-turn conversation with a completed text answer in the middle — every scenario was single-shot. It now includes a user-feedback loop that forces a text turn to be replayed, for every provider row.

## Related issues

closes #

## Checklist

- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest
  release, as this branch will be rebased onto main before the next release. Example backport labels:
    - `backport stable/8.8`: for changes that should be included in the next 8.8.x release.
    - **or** `backport release-8.8.7`: for changes that should be included in the specific release 8.8.7, and this
      *release has already been created*. The release branch will be merged back into stable/8.8 later, so the change
      will be included in future 8.8.x releases as well.
- [x] Tests/Integration tests for the changes have been added if applicable.
- [ ] If the change requires a documentation update, it has been added to the appropriate section in the documentation.
