### PR TITLE
fix(agentic-ai): auto-inject additionalProperties:false for OpenAI native strict schemas

### DIFF
--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/e2e/RealProviderApiSmokeIT.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/e2e/RealProviderApiSmokeIT.java
@@ -105,8 +105,7 @@ class RealProviderApiSmokeIT {
   private static final String RESPONSE_SCHEMA =
       "{\"type\":\"object\","
           + "\"properties\":{\"codeName\":{\"type\":\"string\"},\"clearanceLevel\":{\"type\":\"string\"}},"
-          + "\"required\":[\"codeName\",\"clearanceLevel\"],"
-          + "\"additionalProperties\":false}";
+          + "\"required\":[\"codeName\",\"clearanceLevel\"]}";
 
   // Repeated to clear Anthropic's minimum cacheable-prefix size (~1024 tokens for Sonnet-class
   // models); each repeat is ~65 tokens, so 24 repeats gives comfortable margin.

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/openai/OpenAiStrictJsonSchemas.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/openai/OpenAiStrictJsonSchemas.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.agenticai.aiagent.chatmodel.provider.openai;
+
+import static io.camunda.connector.agenticai.common.JsonSchemaConstants.PROPERTY_ADDITIONAL_PROPERTIES;
+import static io.camunda.connector.agenticai.common.JsonSchemaConstants.PROPERTY_ANYOF;
+import static io.camunda.connector.agenticai.common.JsonSchemaConstants.PROPERTY_DEFINITIONS;
+import static io.camunda.connector.agenticai.common.JsonSchemaConstants.PROPERTY_ITEMS;
+import static io.camunda.connector.agenticai.common.JsonSchemaConstants.PROPERTY_PROPERTIES;
+import static io.camunda.connector.agenticai.common.JsonSchemaConstants.PROPERTY_TYPE;
+import static io.camunda.connector.agenticai.common.JsonSchemaConstants.TYPE_OBJECT;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.util.Map;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Recursively injects {@code additionalProperties: false} into a JSON schema, overriding any
+ * explicit value already present at that level. OpenAI's strict structured-output mode requires
+ * this on every object schema in the tree, including the root; a schema that omits it anywhere is
+ * rejected with a 400 rather than defaulted.
+ *
+ * <p>Supports the same schema dialect subset as {@code JsonSchemaElementDeserializer} (in the
+ * {@code langchain4j.jsonschema} package): object {@code properties} and {@code $defs}, array
+ * {@code items}, and {@code anyOf} branches.
+ */
+public final class OpenAiStrictJsonSchemas {
+
+  private OpenAiStrictJsonSchemas() {}
+
+  public static JsonNode forStrictMode(Map<String, Object> schema, ObjectMapper objectMapper) {
+    final JsonNode root = objectMapper.valueToTree(schema);
+    enforceAdditionalPropertiesFalse(root);
+    return root;
+  }
+
+  private static void enforceAdditionalPropertiesFalse(@Nullable JsonNode node) {
+    if (!(node instanceof ObjectNode object)) {
+      return;
+    }
+
+    if (TYPE_OBJECT.equals(object.path(PROPERTY_TYPE).asText(null))) {
+      object.put(PROPERTY_ADDITIONAL_PROPERTIES, false);
+    }
+
+    if (object.get(PROPERTY_PROPERTIES) instanceof ObjectNode properties) {
+      properties.properties().forEach(entry -> enforceAdditionalPropertiesFalse(entry.getValue()));
+    }
+
+    enforceAdditionalPropertiesFalse(object.get(PROPERTY_ITEMS));
+
+    if (object.get(PROPERTY_ANYOF) instanceof ArrayNode anyOf) {
+      anyOf.forEach(OpenAiStrictJsonSchemas::enforceAdditionalPropertiesFalse);
+    }
+
+    if (object.get(PROPERTY_DEFINITIONS) instanceof ObjectNode definitions) {
+      definitions.properties().forEach(entry -> enforceAdditionalPropertiesFalse(entry.getValue()));
+    }
+  }
+}

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/openai/OpenAiStrictJsonSchemas.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/openai/OpenAiStrictJsonSchemas.java
@@ -18,18 +18,20 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.util.ArrayDeque;
+import java.util.Deque;
 import java.util.Map;
-import org.jspecify.annotations.Nullable;
 
 /**
- * Recursively injects {@code additionalProperties: false} into a JSON schema, overriding any
- * explicit value already present at that level. OpenAI's strict structured-output mode requires
- * this on every object schema in the tree, including the root; a schema that omits it anywhere is
- * rejected with a 400 rather than defaulted.
+ * Injects {@code additionalProperties: false} into a JSON schema at every object level, overriding
+ * any explicit value already present there. OpenAI's strict structured-output mode requires this on
+ * every object schema in the tree, including the root; a schema that omits it anywhere is rejected
+ * with a 400 rather than defaulted.
  *
  * <p>Supports the same schema dialect subset as {@code JsonSchemaElementDeserializer} (in the
  * {@code langchain4j.jsonschema} package): object {@code properties} and {@code $defs}, array
- * {@code items}, and {@code anyOf} branches.
+ * {@code items}, and {@code anyOf} branches. Traverses the tree iteratively via an explicit work
+ * stack rather than recursively, so depth is bounded only by available heap, not call-stack size.
  */
 public final class OpenAiStrictJsonSchemas {
 
@@ -41,27 +43,36 @@ public final class OpenAiStrictJsonSchemas {
     return root;
   }
 
-  private static void enforceAdditionalPropertiesFalse(@Nullable JsonNode node) {
-    if (!(node instanceof ObjectNode object)) {
-      return;
-    }
+  private static void enforceAdditionalPropertiesFalse(JsonNode root) {
+    final Deque<JsonNode> pending = new ArrayDeque<>();
+    pending.push(root);
 
-    if (TYPE_OBJECT.equals(object.path(PROPERTY_TYPE).asText(null))) {
-      object.put(PROPERTY_ADDITIONAL_PROPERTIES, false);
-    }
+    while (!pending.isEmpty()) {
+      final JsonNode current = pending.pop();
+      if (!(current instanceof ObjectNode object)) {
+        continue;
+      }
 
-    if (object.get(PROPERTY_PROPERTIES) instanceof ObjectNode properties) {
-      properties.properties().forEach(entry -> enforceAdditionalPropertiesFalse(entry.getValue()));
-    }
+      if (TYPE_OBJECT.equals(object.path(PROPERTY_TYPE).asText(null))) {
+        object.put(PROPERTY_ADDITIONAL_PROPERTIES, false);
+      }
 
-    enforceAdditionalPropertiesFalse(object.get(PROPERTY_ITEMS));
+      if (object.get(PROPERTY_PROPERTIES) instanceof ObjectNode properties) {
+        properties.properties().forEach(entry -> pending.push(entry.getValue()));
+      }
 
-    if (object.get(PROPERTY_ANYOF) instanceof ArrayNode anyOf) {
-      anyOf.forEach(OpenAiStrictJsonSchemas::enforceAdditionalPropertiesFalse);
-    }
+      final JsonNode items = object.get(PROPERTY_ITEMS);
+      if (items != null) {
+        pending.push(items);
+      }
 
-    if (object.get(PROPERTY_DEFINITIONS) instanceof ObjectNode definitions) {
-      definitions.properties().forEach(entry -> enforceAdditionalPropertiesFalse(entry.getValue()));
+      if (object.get(PROPERTY_ANYOF) instanceof ArrayNode anyOf) {
+        anyOf.forEach(pending::push);
+      }
+
+      if (object.get(PROPERTY_DEFINITIONS) instanceof ObjectNode definitions) {
+        definitions.properties().forEach(entry -> pending.push(entry.getValue()));
+      }
     }
   }
 }

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/openai/family/completions/OpenAiCompletionsRequestConverter.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/openai/family/completions/OpenAiCompletionsRequestConverter.java
@@ -24,6 +24,7 @@ import com.openai.models.chat.completions.ChatCompletionTool;
 import com.openai.models.chat.completions.ChatCompletionToolMessageParam;
 import com.openai.models.chat.completions.ChatCompletionUserMessageParam;
 import io.camunda.connector.agenticai.aiagent.chatmodel.provider.openai.OpenAiContentConverter;
+import io.camunda.connector.agenticai.aiagent.chatmodel.provider.openai.OpenAiStrictJsonSchemas;
 import io.camunda.connector.agenticai.aiagent.memory.ConversationSnapshot;
 import io.camunda.connector.agenticai.aiagent.model.message.AssistantMessage;
 import io.camunda.connector.agenticai.aiagent.model.message.Message;
@@ -292,7 +293,8 @@ public class OpenAiCompletionsRequestConverter {
                     .name(json.schemaName())
                     .schema(
                         objectMapper.convertValue(
-                            json.schema(), ResponseFormatJsonSchema.JsonSchema.Schema.class))
+                            OpenAiStrictJsonSchemas.forStrictMode(json.schema(), objectMapper),
+                            ResponseFormatJsonSchema.JsonSchema.Schema.class))
                     .strict(true)
                     .build())
             .build());

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/openai/family/responses/OpenAiResponsesRequestConverter.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/openai/family/responses/OpenAiResponsesRequestConverter.java
@@ -25,6 +25,7 @@ import com.openai.models.responses.ResponseOutputMessage;
 import com.openai.models.responses.ResponseTextConfig;
 import com.openai.models.responses.Tool;
 import io.camunda.connector.agenticai.aiagent.chatmodel.provider.openai.OpenAiContentConverter;
+import io.camunda.connector.agenticai.aiagent.chatmodel.provider.openai.OpenAiStrictJsonSchemas;
 import io.camunda.connector.agenticai.aiagent.memory.ConversationSnapshot;
 import io.camunda.connector.agenticai.aiagent.model.message.AssistantMessage;
 import io.camunda.connector.agenticai.aiagent.model.message.Message;
@@ -310,7 +311,8 @@ public class OpenAiResponsesRequestConverter {
                         .name(json.schemaName())
                         .schema(
                             objectMapper.convertValue(
-                                json.schema(), ResponseFormatTextJsonSchemaConfig.Schema.class))
+                                OpenAiStrictJsonSchemas.forStrictMode(json.schema(), objectMapper),
+                                ResponseFormatTextJsonSchemaConfig.Schema.class))
                         .strict(true)
                         .build()))
             .build());

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/openai/family/completions/OpenAiCompletionsRequestConverterTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/openai/family/completions/OpenAiCompletionsRequestConverterTest.java
@@ -340,7 +340,28 @@ class OpenAiCompletionsRequestConverterTest {
   @Test
   void configuresStructuredOutputFromJsonSchema() {
     final Map<String, Object> schema =
-        Map.of("type", "object", "properties", Map.of("answer", Map.of("type", "string")));
+        Map.of(
+            "type",
+            "object",
+            "properties",
+            Map.of(
+                "answer",
+                Map.of("type", "string"),
+                "details",
+                Map.of(
+                    "type",
+                    "object",
+                    "additionalProperties",
+                    true,
+                    "properties",
+                    Map.of("confidence", Map.of("type", "number"))),
+                "sources",
+                Map.of(
+                    "type",
+                    "array",
+                    "items",
+                    Map.of(
+                        "type", "object", "properties", Map.of("id", Map.of("type", "string"))))));
     final ResponseConfiguration response =
         new AgentTaskResponseConfiguration(
             new JsonResponseFormatConfiguration(schema, "Answer"), null);
@@ -354,17 +375,27 @@ class OpenAiCompletionsRequestConverterTest {
     assertThat(formatNode.path("type").asText()).isEqualTo("json_schema");
     assertThat(formatNode.path("json_schema").path("name").asText()).isEqualTo("Answer");
     assertThat(formatNode.path("json_schema").path("strict").asBoolean()).isTrue();
-    assertThat(formatNode.path("json_schema").path("schema").path("type").asText())
-        .isEqualTo("object");
-    assertThat(
-            formatNode
-                .path("json_schema")
-                .path("schema")
-                .path("properties")
-                .path("answer")
-                .path("type")
-                .asText())
+
+    final var schemaNode = formatNode.path("json_schema").path("schema");
+    assertThat(schemaNode.path("type").asText()).isEqualTo("object");
+    assertThat(schemaNode.path("properties").path("answer").path("type").asText())
         .isEqualTo("string");
+
+    // additionalProperties: false is required by OpenAI's strict mode on every object level, so
+    // it's auto-injected -- at the root, overriding an explicit `true` on a nested object, and on
+    // an object nested inside an array's items -- rather than left to the caller to get right.
+    assertThat(schemaNode.path("additionalProperties").asBoolean()).isFalse();
+    assertThat(
+            schemaNode.path("properties").path("details").path("additionalProperties").asBoolean())
+        .isFalse();
+    assertThat(
+            schemaNode
+                .path("properties")
+                .path("sources")
+                .path("items")
+                .path("additionalProperties")
+                .asBoolean())
+        .isFalse();
   }
 
   @Test

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/openai/family/responses/OpenAiResponsesRequestConverterTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/openai/family/responses/OpenAiResponsesRequestConverterTest.java
@@ -413,7 +413,28 @@ class OpenAiResponsesRequestConverterTest {
   @Test
   void configuresStructuredOutputFromJsonSchema() {
     final Map<String, Object> schema =
-        Map.of("type", "object", "properties", Map.of("answer", Map.of("type", "string")));
+        Map.of(
+            "type",
+            "object",
+            "properties",
+            Map.of(
+                "answer",
+                Map.of("type", "string"),
+                "details",
+                Map.of(
+                    "type",
+                    "object",
+                    "additionalProperties",
+                    true,
+                    "properties",
+                    Map.of("confidence", Map.of("type", "number"))),
+                "sources",
+                Map.of(
+                    "type",
+                    "array",
+                    "items",
+                    Map.of(
+                        "type", "object", "properties", Map.of("id", Map.of("type", "string"))))));
     final var response =
         new AgentTaskResponseConfiguration(
             new JsonResponseFormatConfiguration(schema, "Answer"), null);
@@ -427,9 +448,27 @@ class OpenAiResponsesRequestConverterTest {
     assertThat(textNode.path("type").asText()).isEqualTo("json_schema");
     assertThat(textNode.path("name").asText()).isEqualTo("Answer");
     assertThat(textNode.path("strict").asBoolean()).isTrue();
-    assertThat(textNode.path("schema").path("type").asText()).isEqualTo("object");
-    assertThat(textNode.path("schema").path("properties").path("answer").path("type").asText())
+
+    final var schemaNode = textNode.path("schema");
+    assertThat(schemaNode.path("type").asText()).isEqualTo("object");
+    assertThat(schemaNode.path("properties").path("answer").path("type").asText())
         .isEqualTo("string");
+
+    // additionalProperties: false is required by OpenAI's strict mode on every object level, so
+    // it's auto-injected -- at the root, overriding an explicit `true` on a nested object, and on
+    // an object nested inside an array's items -- rather than left to the caller to get right.
+    assertThat(schemaNode.path("additionalProperties").asBoolean()).isFalse();
+    assertThat(
+            schemaNode.path("properties").path("details").path("additionalProperties").asBoolean())
+        .isFalse();
+    assertThat(
+            schemaNode
+                .path("properties")
+                .path("sources")
+                .path("items")
+                .path("additionalProperties")
+                .asBoolean())
+        .isFalse();
   }
 
   // --- Reasoning / effort ------------------------------------------------------------------


### PR DESCRIPTION
## Description

Both native OpenAI converters (`OpenAiResponsesRequestConverter` and `OpenAiCompletionsRequestConverter`) set
`.strict(true)` on the user-supplied structured-output schema unconditionally, with no normalization. OpenAI's strict
mode requires `additionalProperties: false` on every object level, including the root, and 400s instead of
defaulting it when missing. Hit on live testing gpt-5.5 Responses:

```
Model call failed: 400: Invalid schema for response_format 'Response': In context=(), 'additionalProperties' is required to be supplied and to be false.
```

Fix: `OpenAiStrictJsonSchemas` recursively injects `additionalProperties: false` into the schema (root, `properties`,
array `items`, `anyOf`, `$defs`) before it's converted to the SDK's `Schema` type, overriding any explicit value.
This mirrors what `langchain4j`'s OpenAI/Anthropic clients already do for the v1 provider path — only the v2 native
converters were missing it, since they bypass `langchain4j` entirely.

Both converters' existing `configuresStructuredOutputFromJsonSchema` tests are extended with a nested object and an
array of objects to cover the recursion and override. `RealProviderApiSmokeIT#RESPONSE_SCHEMA` no longer hardcodes
`additionalProperties: false`, so it now exercises the fix against the real API.

## Related issues

<!-- Which issues are closed by this PR or are related -->

## Checklist

- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest
  release, as this branch will be rebased onto main before the next release. Example backport labels:
    - `backport stable/8.8`: for changes that should be included in the next 8.8.x release.
    - **or** `backport release-8.8.7`: for changes that should be included in the specific release 8.8.7, and this
      *release has already been created*. The release branch will be merged back into stable/8.8 later, so the change
      will be included in future 8.8.x releases as well.
- [x] Tests/Integration tests for the changes have been added if applicable.
- [ ] If the change requires a documentation update, it has been added to the appropriate section in the documentation.
