### PR TITLE
fix(github-connector): update Camunda engine version to ^8.10

### DIFF
--- a/connectors/github/element-templates/github-connector.json
+++ b/connectors/github/element-templates/github-connector.json
@@ -4,7 +4,7 @@
   "id": "io.camunda.connectors.GitHub.v1",
   "version": 13,
   "engines": {
-    "camunda": "^8.7"
+    "camunda": "^8.10"
   },
   "description": "Manage GitHub issues, branches, releases, and more",
   "keywords": [


### PR DESCRIPTION
This pull request makes a minor update to the `github-connector.json` file, raising the required Camunda engine version from `^8.7` to `^8.10`. This ensures compatibility with newer features or fixes in Camunda.