### PR TITLE
deps: Update dependency io.netty:netty-bom to v4.2.17.Final (stable/8.9)

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -104,7 +104,7 @@ limitations under the License.</license.inlineheader>
          Ref: https://github.com/rabbitmq/rabbitmq-java-client/security/advisories/GHSA-jh4v-gfqj-7rhx -->
     <version.amqp-client>5.34.0</version.amqp-client>
     <tomcat.version>11.0.24</tomcat.version>
-    <version.netty>4.2.16.Final</version.netty>
+    <version.netty>4.2.17.Final</version.netty>
     <version.spring-cloud-gcp-starter-logging>8.1.0</version.spring-cloud-gcp-starter-logging>
     <version.logback>1.6.1</version.logback>
 


### PR DESCRIPTION
## Summary

Bumps `io.netty:netty-bom` from `4.2.16.Final` to `4.2.17.Final`.

Security fix. Details in the internal tracking issue: camunda/team-connectors#1260