### PR TITLE
feat(agentic-ai): gate agent instance creation on agentDefinitionKey job header

### DIFF
--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/agent/AgentInitializerImpl.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/agent/AgentInitializerImpl.java
@@ -10,6 +10,7 @@ import io.camunda.connector.agenticai.aiagent.agent.AgentInitializationResult.De
 import io.camunda.connector.agenticai.aiagent.agent.AgentInitializationResult.DiscoverTools;
 import io.camunda.connector.agenticai.aiagent.agent.AgentInitializationResult.ReadyToConverse;
 import io.camunda.connector.agenticai.aiagent.agentinstance.AgentInstanceClient;
+import io.camunda.connector.agenticai.aiagent.agentinstance.AgentInstanceKey;
 import io.camunda.connector.agenticai.aiagent.model.AgentContext;
 import io.camunda.connector.agenticai.aiagent.model.AgentExecutionContext;
 import io.camunda.connector.agenticai.aiagent.model.AgentMetadata;
@@ -19,6 +20,7 @@ import io.camunda.connector.agenticai.aiagent.model.tool.ToolCall;
 import io.camunda.connector.agenticai.aiagent.model.tool.ToolCallResult;
 import io.camunda.connector.agenticai.aiagent.tool.GatewayToolDiscoveryInitiationResult;
 import io.camunda.connector.agenticai.aiagent.tool.GatewayToolHandlerRegistry;
+import io.camunda.connector.api.outbound.JobContext;
 import java.util.List;
 import java.util.Optional;
 import org.slf4j.Logger;
@@ -28,6 +30,9 @@ import org.springframework.util.CollectionUtils;
 public class AgentInitializerImpl implements AgentInitializer {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(AgentInitializerImpl.class);
+
+  private static final String AGENT_DEFINITION_KEY_HEADER_NAME =
+      "io.camunda.zeebe:agentDefinitionKey";
 
   private final AgentToolsResolver toolsResolver;
   private final GatewayToolHandlerRegistry gatewayToolHandlers;
@@ -49,7 +54,7 @@ public class AgentInitializerImpl implements AgentInitializer {
   public AgentInitializationResult initializeAgent(AgentExecutionContext executionContext) {
     AgentContext agentContext =
         Optional.ofNullable(executionContext.initialAgentContext())
-            .orElseGet(() -> provisionAgentInstance(executionContext));
+            .orElseGet(() -> createAgentContext(executionContext));
 
     List<ToolCallResult> initialToolCallResults =
         Optional.ofNullable(executionContext.initialToolCallResults()).orElseGet(List::of);
@@ -67,18 +72,41 @@ public class AgentInitializerImpl implements AgentInitializer {
   }
 
   /**
-   * Creates the initial agent context by first registering the agent instance on the engine. The
-   * returned key is embedded in the context metadata.
+   * Builds the initial agent context for a new agent, provisioning an agent instance on the engine
+   * when the job carries a non-blank {@code agentDefinitionKey} custom header.
+   */
+  private AgentContext createAgentContext(AgentExecutionContext executionContext) {
+    final var jobContext = executionContext.jobContext();
+    var metadata = AgentMetadata.of(jobContext);
+
+    if (hasAgentDefinitionKeyHeader(jobContext)) {
+      final var agentInstanceKey = provisionAgentInstance(executionContext);
+      metadata = metadata.withAgentInstanceKey(agentInstanceKey.value());
+    } else {
+      LOGGER.debug(
+          "Skipping agent instance creation: element was not marked with an agent definition");
+    }
+
+    return AgentContext.empty().withMetadata(metadata);
+  }
+
+  private boolean hasAgentDefinitionKeyHeader(JobContext jobContext) {
+    final var customHeaders = jobContext.getCustomHeaders();
+    if (customHeaders == null) {
+      return false;
+    }
+    final var agentDefinitionKey = customHeaders.get(AGENT_DEFINITION_KEY_HEADER_NAME);
+    return agentDefinitionKey != null && !agentDefinitionKey.isBlank();
+  }
+
+  /**
+   * Registers the agent instance on the engine.
    *
    * @throws io.camunda.connector.api.error.ConnectorException with code {@code
    *     AGENT_INSTANCE_CREATION_FAILED} when retries are exhausted or a non-retryable error occurs
    */
-  private AgentContext provisionAgentInstance(AgentExecutionContext executionContext) {
-    final var agentInstanceKey = agentInstanceClient.create(executionContext);
-    return AgentContext.empty()
-        .withMetadata(
-            AgentMetadata.of(executionContext.jobContext())
-                .withAgentInstanceKey(agentInstanceKey.value()));
+  private AgentInstanceKey provisionAgentInstance(AgentExecutionContext executionContext) {
+    return agentInstanceClient.create(executionContext);
   }
 
   private AgentInitializationResult resumeReadyAgent(

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/agent/AgentInitializerImpl.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/agent/AgentInitializerImpl.java
@@ -81,9 +81,10 @@ public class AgentInitializerImpl implements AgentInitializer {
 
     if (hasAgentDefinitionKeyHeader(jobContext)) {
       final var agentInstanceKey = provisionAgentInstance(executionContext);
+      LOGGER.debug("Created agent instance {}", agentInstanceKey.value());
       metadata = metadata.withAgentInstanceKey(agentInstanceKey.value());
     } else {
-      LOGGER.debug(
+      LOGGER.warn(
           "Skipping agent instance creation: element was not marked with an agent definition");
     }
 

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/agent/AgentInitializerTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/agent/AgentInitializerTest.java
@@ -41,6 +41,7 @@ import io.camunda.connector.api.error.ConnectorException;
 import io.camunda.connector.api.outbound.JobContext;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
@@ -50,6 +51,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -137,6 +139,8 @@ class AgentInitializerTest {
     void shouldHandleNullInitialAgentContext() {
       // When initialAgentContext is null, creates new context with INITIALIZING state
       // which triggers agent instance creation then initiateToolDiscovery flow
+      when(jobContext.getCustomHeaders())
+          .thenReturn(Map.of("io.camunda.zeebe:agentDefinitionKey", "6755399441055744"));
       when(agentInstanceClient.create(any())).thenReturn(AgentInstanceKey.of(12345L));
 
       when(toolsResolver.loadAdHocToolsSchema(
@@ -568,12 +572,16 @@ class AgentInitializerTest {
 
     private static final long PROCESS_DEFINITION_KEY = 100L;
     private static final long PROCESS_INSTANCE_KEY = 200L;
+    private static final String AGENT_DEFINITION_KEY_HEADER = "io.camunda.zeebe:agentDefinitionKey";
 
     @BeforeEach
     void setUp() {
       lenient().when(executionContext.jobContext()).thenReturn(jobContext);
       lenient().when(jobContext.getProcessDefinitionKey()).thenReturn(PROCESS_DEFINITION_KEY);
       lenient().when(jobContext.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
+      lenient()
+          .when(jobContext.getCustomHeaders())
+          .thenReturn(Map.of(AGENT_DEFINITION_KEY_HEADER, "6755399441055744"));
     }
 
     @Test
@@ -589,6 +597,49 @@ class AgentInitializerTest {
 
       verify(agentInstanceClient, times(1)).create(any(AgentExecutionContext.class));
       assertThat(result.agentContext().metadata().agentInstanceKey()).isEqualTo(12345L);
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = {" ", "\t"})
+    void shouldSkipAgentInstanceCreationWhenAgentDefinitionKeyHeaderIsBlank(String headerValue) {
+      final var headers = new HashMap<String, String>();
+      headers.put(AGENT_DEFINITION_KEY_HEADER, headerValue);
+      when(jobContext.getCustomHeaders()).thenReturn(headers);
+      when(toolsResolver.loadAdHocToolsSchema(
+              any(AgentExecutionContext.class), any(AgentContext.class)))
+          .thenReturn(new AdHocToolsSchemaResponse(List.of(), null));
+
+      final var result = (ReadyToConverse) agentInitializer.initializeAgent(executionContext);
+
+      verify(agentInstanceClient, never()).create(any());
+      assertThat(result.agentContext().metadata().agentInstanceKey()).isNull();
+    }
+
+    @Test
+    void shouldSkipAgentInstanceCreationWhenAgentDefinitionKeyHeaderMissing() {
+      when(jobContext.getCustomHeaders()).thenReturn(Map.of("some-other-header", "value"));
+      when(toolsResolver.loadAdHocToolsSchema(
+              any(AgentExecutionContext.class), any(AgentContext.class)))
+          .thenReturn(new AdHocToolsSchemaResponse(List.of(), null));
+
+      final var result = (ReadyToConverse) agentInitializer.initializeAgent(executionContext);
+
+      verify(agentInstanceClient, never()).create(any());
+      assertThat(result.agentContext().metadata().agentInstanceKey()).isNull();
+    }
+
+    @Test
+    void shouldSkipAgentInstanceCreationWhenCustomHeadersIsNull() {
+      when(jobContext.getCustomHeaders()).thenReturn(null);
+      when(toolsResolver.loadAdHocToolsSchema(
+              any(AgentExecutionContext.class), any(AgentContext.class)))
+          .thenReturn(new AdHocToolsSchemaResponse(List.of(), null));
+
+      final var result = (ReadyToConverse) agentInitializer.initializeAgent(executionContext);
+
+      verify(agentInstanceClient, never()).create(any());
+      assertThat(result.agentContext().metadata().agentInstanceKey()).isNull();
     }
 
     @Test


### PR DESCRIPTION
## Description

Jobs for `zeebe:agentDefinition`-marked service tasks and ad-hoc sub-processes now carry a reserved `io.camunda.zeebe:agentDefinitionKey` custom job header. The AI Agent connector now checks for this header and only creates an agent instance on the engine when it is present and non-blank. Jobs without it skip agent instance creation entirely, reusing the existing null-`agentInstanceKey` handling already in place for agents that pre-date the agent-instance feature.

## Related issues

closes #8372

## Checklist

- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest
  release, as this branch will be rebased onto main before the next release. Example backport labels:
    - `backport stable/8.8`: for changes that should be included in the next 8.8.x release.
    - **or** `backport release-8.8.7`: for changes that should be included in the specific release 8.8.7, and this
      *release has already been created*. The release branch will be merged back into stable/8.8 later, so the change
      will be included in future 8.8.x releases as well.
- [x] Tests/Integration tests for the changes have been added if applicable.
- [ ] If the change requires a documentation update, it has been added to the appropriate section in the documentation.
