### PR TITLE
fix(etg): isEmpty condition + credential-first field order for JDBC connector

### DIFF
--- a/connectors/jdbc/element-templates/hybrid/jdbc-outbound-connector-hybrid.json
+++ b/connectors/jdbc/element-templates/hybrid/jdbc-outbound-connector-hybrid.json
@@ -5,7 +5,7 @@
   "description" : "Read and write data from a Camunda process directly to a SQL database (e.g., Microsoft SQL Server, MySQL, PostgreSQL)",
   "keywords" : [ "relational", "database", "SQL", "query database", "execute SQL", "relational database", "MySQL", "PostgreSQL", "SQL Server", "Oracle", "MariaDB", "select", "insert", "update", "delete" ],
   "documentationRef" : "https://docs.camunda.io/docs/8.6/components/connectors/out-of-the-box-connectors/sql",
-  "version" : 5,
+  "version" : 6,
   "category" : {
     "id" : "connectors",
     "name" : "Connectors"
@@ -82,6 +82,18 @@
       "value" : "ORACLE"
     } ]
   }, {
+    "id" : "connectionConfiguration",
+    "label" : "Connection credential",
+    "description" : "Choose a reusable JDBC connection credential. When set, it is bound as a whole to the connector's 'configuration' input.",
+    "optional" : true,
+    "group" : "connection",
+    "binding" : {
+      "name" : "configuration",
+      "type" : "zeebe:input"
+    },
+    "type" : "Configuration",
+    "configurationTemplate" : "io.camunda.connectors:jdbc-connection:1"
+  }, {
     "id" : "connection.authType",
     "label" : "Connection type",
     "value" : "uri",
@@ -89,6 +101,11 @@
     "binding" : {
       "name" : "connection.authType",
       "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "connectionConfiguration",
+      "isEmpty" : true,
+      "type" : "simple"
     },
     "type" : "Dropdown",
     "choices" : [ {
@@ -116,9 +133,15 @@
       "type" : "zeebe:input"
     },
     "condition" : {
-      "property" : "connection.authType",
-      "equals" : "uri",
-      "type" : "simple"
+      "allMatch" : [ {
+        "property" : "connection.authType",
+        "equals" : "uri",
+        "type" : "simple"
+      }, {
+        "property" : "connectionConfiguration",
+        "isEmpty" : true,
+        "type" : "simple"
+      } ]
     },
     "tooltip" : "URI should contain JDBC driver, host name, and port number. See the <a href=\"https://docs.camunda.io/docs/8.6/components/connectors/out-of-the-box-connectors/sql/#uri-connection\" target=\"_blank\">URI connection</a> reference.",
     "type" : "String"
@@ -133,9 +156,15 @@
       "type" : "zeebe:input"
     },
     "condition" : {
-      "property" : "connection.authType",
-      "equals" : "uri",
-      "type" : "simple"
+      "allMatch" : [ {
+        "property" : "connection.authType",
+        "equals" : "uri",
+        "type" : "simple"
+      }, {
+        "property" : "connectionConfiguration",
+        "isEmpty" : true,
+        "type" : "simple"
+      } ]
     },
     "tooltip" : "Additional properties for the connection ('user' and 'password' for instance). See the <a href=\"https://docs.camunda.io/docs/8.6/components/connectors/out-of-the-box-connectors/sql/#connection\" target=\"_blank\">SQL connection properties</a> reference.",
     "type" : "String"
@@ -153,9 +182,15 @@
       "type" : "zeebe:input"
     },
     "condition" : {
-      "property" : "connection.authType",
-      "equals" : "detailed",
-      "type" : "simple"
+      "allMatch" : [ {
+        "property" : "connection.authType",
+        "equals" : "detailed",
+        "type" : "simple"
+      }, {
+        "property" : "connectionConfiguration",
+        "isEmpty" : true,
+        "type" : "simple"
+      } ]
     },
     "type" : "String"
   }, {
@@ -172,9 +207,15 @@
       "type" : "zeebe:input"
     },
     "condition" : {
-      "property" : "connection.authType",
-      "equals" : "detailed",
-      "type" : "simple"
+      "allMatch" : [ {
+        "property" : "connection.authType",
+        "equals" : "detailed",
+        "type" : "simple"
+      }, {
+        "property" : "connectionConfiguration",
+        "isEmpty" : true,
+        "type" : "simple"
+      } ]
     },
     "type" : "String"
   }, {
@@ -188,9 +229,15 @@
       "type" : "zeebe:input"
     },
     "condition" : {
-      "property" : "connection.authType",
-      "equals" : "detailed",
-      "type" : "simple"
+      "allMatch" : [ {
+        "property" : "connection.authType",
+        "equals" : "detailed",
+        "type" : "simple"
+      }, {
+        "property" : "connectionConfiguration",
+        "isEmpty" : true,
+        "type" : "simple"
+      } ]
     },
     "type" : "String"
   }, {
@@ -204,9 +251,15 @@
       "type" : "zeebe:input"
     },
     "condition" : {
-      "property" : "connection.authType",
-      "equals" : "detailed",
-      "type" : "simple"
+      "allMatch" : [ {
+        "property" : "connection.authType",
+        "equals" : "detailed",
+        "type" : "simple"
+      }, {
+        "property" : "connectionConfiguration",
+        "isEmpty" : true,
+        "type" : "simple"
+      } ]
     },
     "type" : "String"
   }, {
@@ -220,9 +273,15 @@
       "type" : "zeebe:input"
     },
     "condition" : {
-      "property" : "connection.authType",
-      "equals" : "detailed",
-      "type" : "simple"
+      "allMatch" : [ {
+        "property" : "connection.authType",
+        "equals" : "detailed",
+        "type" : "simple"
+      }, {
+        "property" : "connectionConfiguration",
+        "isEmpty" : true,
+        "type" : "simple"
+      } ]
     },
     "type" : "String"
   }, {
@@ -236,24 +295,18 @@
       "type" : "zeebe:input"
     },
     "condition" : {
-      "property" : "connection.authType",
-      "equals" : "detailed",
-      "type" : "simple"
+      "allMatch" : [ {
+        "property" : "connection.authType",
+        "equals" : "detailed",
+        "type" : "simple"
+      }, {
+        "property" : "connectionConfiguration",
+        "isEmpty" : true,
+        "type" : "simple"
+      } ]
     },
     "tooltip" : "Additional properties for the connection. See the <a href=\"https://docs.camunda.io/docs/8.6/components/connectors/out-of-the-box-connectors/sql/#connection\" target=\"_blank\">SQL connection properties</a> reference.",
     "type" : "String"
-  }, {
-    "id" : "connectionConfiguration",
-    "label" : "Connection credential",
-    "description" : "Choose a reusable JDBC connection credential. When set, it is bound as a whole to the connector's 'configuration' input.",
-    "optional" : true,
-    "group" : "connection",
-    "binding" : {
-      "name" : "configuration",
-      "type" : "zeebe:input"
-    },
-    "type" : "Configuration",
-    "configurationTemplate" : "io.camunda.connectors:jdbc-connection:1"
   }, {
     "id" : "data.returnResults",
     "label" : "Return results",
@@ -298,7 +351,7 @@
     "id" : "version",
     "label" : "Version",
     "description" : "Version of the element template",
-    "value" : "5",
+    "value" : "6",
     "group" : "connector",
     "binding" : {
       "key" : "elementTemplateVersion",

--- a/connectors/jdbc/element-templates/hybrid/jdbc-outbound-connector-hybrid.json
+++ b/connectors/jdbc/element-templates/hybrid/jdbc-outbound-connector-hybrid.json
@@ -21,9 +21,6 @@
     "id" : "taskDefinitionType",
     "label" : "Task definition type"
   }, {
-    "id" : "database",
-    "label" : "Database"
-  }, {
     "id" : "connection",
     "label" : "Connection"
   }, {
@@ -52,16 +49,34 @@
     },
     "type" : "String"
   }, {
+    "id" : "connectionConfiguration",
+    "label" : "Connection credential",
+    "description" : "Choose a reusable JDBC connection credential, or configure one-time connection parameters below.",
+    "optional" : true,
+    "group" : "connection",
+    "binding" : {
+      "name" : "configuration",
+      "type" : "zeebe:input"
+    },
+    "type" : "Configuration",
+    "configurationTemplate" : "io.camunda.connectors:jdbc-connection:1"
+  }, {
     "id" : "database",
     "label" : "Select a database",
     "optional" : false,
+    "value" : "POSTGRESQL",
     "constraints" : {
       "notEmpty" : true
     },
-    "group" : "database",
+    "group" : "connection",
     "binding" : {
       "name" : "database",
       "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "connectionConfiguration",
+      "isEmpty" : true,
+      "type" : "simple"
     },
     "tooltip" : "If you choose Oracle, make sure the Oracle JDBC driver is included. <a href=\"https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/sql/#database\">Oracle JDBC driver setup</a>.",
     "type" : "Dropdown",
@@ -81,18 +96,6 @@
       "name" : "Oracle",
       "value" : "ORACLE"
     } ]
-  }, {
-    "id" : "connectionConfiguration",
-    "label" : "Connection credential",
-    "description" : "Choose a reusable JDBC connection credential, or configure one-time connection parameters below.",
-    "optional" : true,
-    "group" : "connection",
-    "binding" : {
-      "name" : "configuration",
-      "type" : "zeebe:input"
-    },
-    "type" : "Configuration",
-    "configurationTemplate" : "io.camunda.connectors:jdbc-connection:1"
   }, {
     "id" : "connection.authType",
     "label" : "Connection type",
@@ -439,9 +442,38 @@
   "configurationTemplates" : [ {
     "id" : "io.camunda.connectors:jdbc-connection:1",
     "kind" : "CREDENTIAL",
-    "version" : 1,
+    "version" : 2,
     "name" : "JDBC Connection",
     "properties" : [ {
+      "id" : "database",
+      "label" : "Select a database",
+      "constraints" : {
+        "notEmpty" : true
+      },
+      "group" : "connection",
+      "binding" : {
+        "name" : "database",
+        "type" : "property"
+      },
+      "tooltip" : "If you choose Oracle, make sure the Oracle JDBC driver is included. <a href=\"https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/sql/#database\">Oracle JDBC driver setup</a>.",
+      "type" : "Dropdown",
+      "choices" : [ {
+        "name" : "MariaDB",
+        "value" : "MARIADB"
+      }, {
+        "name" : "Microsoft SQL Server",
+        "value" : "MSSQL"
+      }, {
+        "name" : "MySQL",
+        "value" : "MYSQL"
+      }, {
+        "name" : "PostgreSQL",
+        "value" : "POSTGRESQL"
+      }, {
+        "name" : "Oracle",
+        "value" : "ORACLE"
+      } ]
+    }, {
       "id" : "host",
       "label" : "Host",
       "constraints" : {

--- a/connectors/jdbc/element-templates/hybrid/jdbc-outbound-connector-hybrid.json
+++ b/connectors/jdbc/element-templates/hybrid/jdbc-outbound-connector-hybrid.json
@@ -84,7 +84,7 @@
   }, {
     "id" : "connectionConfiguration",
     "label" : "Connection credential",
-    "description" : "Choose a reusable JDBC connection credential. When set, it is bound as a whole to the connector's 'configuration' input.",
+    "description" : "Choose a reusable JDBC connection credential, or configure one-time connection parameters below.",
     "optional" : true,
     "group" : "connection",
     "binding" : {

--- a/connectors/jdbc/element-templates/jdbc-outbound-connector.json
+++ b/connectors/jdbc/element-templates/jdbc-outbound-connector.json
@@ -18,9 +18,6 @@
     "camunda" : "^8.10"
   },
   "groups" : [ {
-    "id" : "database",
-    "label" : "Database"
-  }, {
     "id" : "connection",
     "label" : "Connection"
   }, {
@@ -47,16 +44,34 @@
     },
     "type" : "Hidden"
   }, {
+    "id" : "connectionConfiguration",
+    "label" : "Connection credential",
+    "description" : "Choose a reusable JDBC connection credential, or configure one-time connection parameters below.",
+    "optional" : true,
+    "group" : "connection",
+    "binding" : {
+      "name" : "configuration",
+      "type" : "zeebe:input"
+    },
+    "type" : "Configuration",
+    "configurationTemplate" : "io.camunda.connectors:jdbc-connection:1"
+  }, {
     "id" : "database",
     "label" : "Select a database",
     "optional" : false,
+    "value" : "POSTGRESQL",
     "constraints" : {
       "notEmpty" : true
     },
-    "group" : "database",
+    "group" : "connection",
     "binding" : {
       "name" : "database",
       "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "connectionConfiguration",
+      "isEmpty" : true,
+      "type" : "simple"
     },
     "tooltip" : "If you choose Oracle, make sure the Oracle JDBC driver is included. <a href=\"https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/sql/#database\">Oracle JDBC driver setup</a>.",
     "type" : "Dropdown",
@@ -76,18 +91,6 @@
       "name" : "Oracle",
       "value" : "ORACLE"
     } ]
-  }, {
-    "id" : "connectionConfiguration",
-    "label" : "Connection credential",
-    "description" : "Choose a reusable JDBC connection credential, or configure one-time connection parameters below.",
-    "optional" : true,
-    "group" : "connection",
-    "binding" : {
-      "name" : "configuration",
-      "type" : "zeebe:input"
-    },
-    "type" : "Configuration",
-    "configurationTemplate" : "io.camunda.connectors:jdbc-connection:1"
   }, {
     "id" : "connection.authType",
     "label" : "Connection type",
@@ -434,9 +437,38 @@
   "configurationTemplates" : [ {
     "id" : "io.camunda.connectors:jdbc-connection:1",
     "kind" : "CREDENTIAL",
-    "version" : 1,
+    "version" : 2,
     "name" : "JDBC Connection",
     "properties" : [ {
+      "id" : "database",
+      "label" : "Select a database",
+      "constraints" : {
+        "notEmpty" : true
+      },
+      "group" : "connection",
+      "binding" : {
+        "name" : "database",
+        "type" : "property"
+      },
+      "tooltip" : "If you choose Oracle, make sure the Oracle JDBC driver is included. <a href=\"https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/sql/#database\">Oracle JDBC driver setup</a>.",
+      "type" : "Dropdown",
+      "choices" : [ {
+        "name" : "MariaDB",
+        "value" : "MARIADB"
+      }, {
+        "name" : "Microsoft SQL Server",
+        "value" : "MSSQL"
+      }, {
+        "name" : "MySQL",
+        "value" : "MYSQL"
+      }, {
+        "name" : "PostgreSQL",
+        "value" : "POSTGRESQL"
+      }, {
+        "name" : "Oracle",
+        "value" : "ORACLE"
+      } ]
+    }, {
       "id" : "host",
       "label" : "Host",
       "constraints" : {

--- a/connectors/jdbc/element-templates/jdbc-outbound-connector.json
+++ b/connectors/jdbc/element-templates/jdbc-outbound-connector.json
@@ -79,7 +79,7 @@
   }, {
     "id" : "connectionConfiguration",
     "label" : "Connection credential",
-    "description" : "Choose a reusable JDBC connection credential. When set, it is bound as a whole to the connector's 'configuration' input.",
+    "description" : "Choose a reusable JDBC connection credential, or configure one-time connection parameters below.",
     "optional" : true,
     "group" : "connection",
     "binding" : {

--- a/connectors/jdbc/element-templates/versioned/jdbc-outbound-connector-5.json
+++ b/connectors/jdbc/element-templates/versioned/jdbc-outbound-connector-5.json
@@ -5,7 +5,7 @@
   "description" : "Read and write data from a Camunda process directly to a SQL database (e.g., Microsoft SQL Server, MySQL, PostgreSQL)",
   "keywords" : [ "relational", "database", "SQL", "query database", "execute SQL", "relational database", "MySQL", "PostgreSQL", "SQL Server", "Oracle", "MariaDB", "select", "insert", "update", "delete" ],
   "documentationRef" : "https://docs.camunda.io/docs/8.6/components/connectors/out-of-the-box-connectors/sql",
-  "version" : 6,
+  "version" : 5,
   "category" : {
     "id" : "connectors",
     "name" : "Connectors"
@@ -77,18 +77,6 @@
       "value" : "ORACLE"
     } ]
   }, {
-    "id" : "connectionConfiguration",
-    "label" : "Connection credential",
-    "description" : "Choose a reusable JDBC connection credential. When set, it is bound as a whole to the connector's 'configuration' input.",
-    "optional" : true,
-    "group" : "connection",
-    "binding" : {
-      "name" : "configuration",
-      "type" : "zeebe:input"
-    },
-    "type" : "Configuration",
-    "configurationTemplate" : "io.camunda.connectors:jdbc-connection:1"
-  }, {
     "id" : "connection.authType",
     "label" : "Connection type",
     "value" : "uri",
@@ -96,11 +84,6 @@
     "binding" : {
       "name" : "connection.authType",
       "type" : "zeebe:input"
-    },
-    "condition" : {
-      "property" : "connectionConfiguration",
-      "isEmpty" : true,
-      "type" : "simple"
     },
     "type" : "Dropdown",
     "choices" : [ {
@@ -128,15 +111,9 @@
       "type" : "zeebe:input"
     },
     "condition" : {
-      "allMatch" : [ {
-        "property" : "connection.authType",
-        "equals" : "uri",
-        "type" : "simple"
-      }, {
-        "property" : "connectionConfiguration",
-        "isEmpty" : true,
-        "type" : "simple"
-      } ]
+      "property" : "connection.authType",
+      "equals" : "uri",
+      "type" : "simple"
     },
     "tooltip" : "URI should contain JDBC driver, host name, and port number. See the <a href=\"https://docs.camunda.io/docs/8.6/components/connectors/out-of-the-box-connectors/sql/#uri-connection\" target=\"_blank\">URI connection</a> reference.",
     "type" : "String"
@@ -151,15 +128,9 @@
       "type" : "zeebe:input"
     },
     "condition" : {
-      "allMatch" : [ {
-        "property" : "connection.authType",
-        "equals" : "uri",
-        "type" : "simple"
-      }, {
-        "property" : "connectionConfiguration",
-        "isEmpty" : true,
-        "type" : "simple"
-      } ]
+      "property" : "connection.authType",
+      "equals" : "uri",
+      "type" : "simple"
     },
     "tooltip" : "Additional properties for the connection ('user' and 'password' for instance). See the <a href=\"https://docs.camunda.io/docs/8.6/components/connectors/out-of-the-box-connectors/sql/#connection\" target=\"_blank\">SQL connection properties</a> reference.",
     "type" : "String"
@@ -177,15 +148,9 @@
       "type" : "zeebe:input"
     },
     "condition" : {
-      "allMatch" : [ {
-        "property" : "connection.authType",
-        "equals" : "detailed",
-        "type" : "simple"
-      }, {
-        "property" : "connectionConfiguration",
-        "isEmpty" : true,
-        "type" : "simple"
-      } ]
+      "property" : "connection.authType",
+      "equals" : "detailed",
+      "type" : "simple"
     },
     "type" : "String"
   }, {
@@ -202,15 +167,9 @@
       "type" : "zeebe:input"
     },
     "condition" : {
-      "allMatch" : [ {
-        "property" : "connection.authType",
-        "equals" : "detailed",
-        "type" : "simple"
-      }, {
-        "property" : "connectionConfiguration",
-        "isEmpty" : true,
-        "type" : "simple"
-      } ]
+      "property" : "connection.authType",
+      "equals" : "detailed",
+      "type" : "simple"
     },
     "type" : "String"
   }, {
@@ -224,15 +183,9 @@
       "type" : "zeebe:input"
     },
     "condition" : {
-      "allMatch" : [ {
-        "property" : "connection.authType",
-        "equals" : "detailed",
-        "type" : "simple"
-      }, {
-        "property" : "connectionConfiguration",
-        "isEmpty" : true,
-        "type" : "simple"
-      } ]
+      "property" : "connection.authType",
+      "equals" : "detailed",
+      "type" : "simple"
     },
     "type" : "String"
   }, {
@@ -246,15 +199,9 @@
       "type" : "zeebe:input"
     },
     "condition" : {
-      "allMatch" : [ {
-        "property" : "connection.authType",
-        "equals" : "detailed",
-        "type" : "simple"
-      }, {
-        "property" : "connectionConfiguration",
-        "isEmpty" : true,
-        "type" : "simple"
-      } ]
+      "property" : "connection.authType",
+      "equals" : "detailed",
+      "type" : "simple"
     },
     "type" : "String"
   }, {
@@ -268,15 +215,9 @@
       "type" : "zeebe:input"
     },
     "condition" : {
-      "allMatch" : [ {
-        "property" : "connection.authType",
-        "equals" : "detailed",
-        "type" : "simple"
-      }, {
-        "property" : "connectionConfiguration",
-        "isEmpty" : true,
-        "type" : "simple"
-      } ]
+      "property" : "connection.authType",
+      "equals" : "detailed",
+      "type" : "simple"
     },
     "type" : "String"
   }, {
@@ -290,18 +231,24 @@
       "type" : "zeebe:input"
     },
     "condition" : {
-      "allMatch" : [ {
-        "property" : "connection.authType",
-        "equals" : "detailed",
-        "type" : "simple"
-      }, {
-        "property" : "connectionConfiguration",
-        "isEmpty" : true,
-        "type" : "simple"
-      } ]
+      "property" : "connection.authType",
+      "equals" : "detailed",
+      "type" : "simple"
     },
     "tooltip" : "Additional properties for the connection. See the <a href=\"https://docs.camunda.io/docs/8.6/components/connectors/out-of-the-box-connectors/sql/#connection\" target=\"_blank\">SQL connection properties</a> reference.",
     "type" : "String"
+  }, {
+    "id" : "connectionConfiguration",
+    "label" : "Connection credential",
+    "description" : "Choose a reusable JDBC connection credential. When set, it is bound as a whole to the connector's 'configuration' input.",
+    "optional" : true,
+    "group" : "connection",
+    "binding" : {
+      "name" : "configuration",
+      "type" : "zeebe:input"
+    },
+    "type" : "Configuration",
+    "configurationTemplate" : "io.camunda.connectors:jdbc-connection:1"
   }, {
     "id" : "data.returnResults",
     "label" : "Return results",
@@ -346,7 +293,7 @@
     "id" : "version",
     "label" : "Version",
     "description" : "Version of the element template",
-    "value" : "6",
+    "value" : "5",
     "group" : "connector",
     "binding" : {
       "key" : "elementTemplateVersion",

--- a/connectors/jdbc/src/main/java/io/camunda/connector/jdbc/model/request/JdbcRequest.java
+++ b/connectors/jdbc/src/main/java/io/camunda/connector/jdbc/model/request/JdbcRequest.java
@@ -21,28 +21,9 @@ import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.NotNull;
 
 public record JdbcRequest(
-    @NotNull
-        @TemplateProperty(
-            id = "database",
-            label = "Select a database",
-            tooltip =
-                "If you choose Oracle, make sure the Oracle JDBC driver is included. "
-                    + "<a href=\"https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/sql/#database\">Oracle JDBC driver setup</a>.",
-            group = "database",
-            type = Dropdown,
-            constraints = @TemplateProperty.PropertyConstraints(notEmpty = true),
-            choices = {
-              @TemplateProperty.DropdownPropertyChoice(label = "MariaDB", value = "MARIADB"),
-              @TemplateProperty.DropdownPropertyChoice(
-                  label = "Microsoft SQL Server",
-                  value = "MSSQL"),
-              @TemplateProperty.DropdownPropertyChoice(label = "MySQL", value = "MYSQL"),
-              @TemplateProperty.DropdownPropertyChoice(label = "PostgreSQL", value = "POSTGRESQL"),
-              @TemplateProperty.DropdownPropertyChoice(label = "Oracle", value = "ORACLE"),
-            })
-        SupportedDatabase database,
-    // Declared before `connection` so it renders first and satisfies ConditionPropertyOrderRule
-    // for the isEmpty condition on `connection` below.
+    // Declared first so it renders (and is emitted in properties[]) before the fallback fields it
+    // gates below - required both for UX (pick a credential before falling back to inline fields)
+    // and by ConditionPropertyOrderRule (a condition's referenced property must appear earlier).
     @TemplateProperty(
             id = "connectionConfiguration",
             label = "Connection credential",
@@ -55,6 +36,36 @@ public record JdbcRequest(
                     + " parameters below.")
         @Valid
         JdbcConnectionConfiguration configuration,
+    // Only @NotNull moved off this field: the credential now carries its own mandatory database
+    // selection (JdbcConnectionConfiguration#database), so once one is bound this inline value is
+    // irrelevant and hidden - requiredness is asserted on the effective value in
+    // isDatabaseSourceProvided() below. defaultValue keeps Modeler writing a valid enum literal
+    // for the hidden input rather than an empty string, avoiding an unrelated deserialization
+    // failure on a value nothing reads once a credential is bound.
+    @TemplateProperty(
+            id = "database",
+            label = "Select a database",
+            tooltip =
+                "If you choose Oracle, make sure the Oracle JDBC driver is included. "
+                    + "<a href=\"https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/sql/#database\">Oracle JDBC driver setup</a>.",
+            group = "connection",
+            type = Dropdown,
+            defaultValue = "POSTGRESQL",
+            condition =
+                @PropertyCondition(
+                    property = "connectionConfiguration",
+                    isEmpty = NullableBoolean.TRUE),
+            constraints = @TemplateProperty.PropertyConstraints(notEmpty = true),
+            choices = {
+              @TemplateProperty.DropdownPropertyChoice(label = "MariaDB", value = "MARIADB"),
+              @TemplateProperty.DropdownPropertyChoice(
+                  label = "Microsoft SQL Server",
+                  value = "MSSQL"),
+              @TemplateProperty.DropdownPropertyChoice(label = "MySQL", value = "MYSQL"),
+              @TemplateProperty.DropdownPropertyChoice(label = "PostgreSQL", value = "POSTGRESQL"),
+              @TemplateProperty.DropdownPropertyChoice(label = "Oracle", value = "ORACLE"),
+            })
+        SupportedDatabase database,
     // Not @NotNull, and not @Valid: a bound connection credential (configuration) may substitute
     // for inline connection fields, and takes precedence when both are set (resolved in
     // ConnectionHelper). The raw field is validated conditionally via
@@ -72,7 +83,20 @@ public record JdbcRequest(
 
   /** Convenience constructor for the pre-configuration-chooser shape (no bound configuration). */
   public JdbcRequest(SupportedDatabase database, JdbcConnection connection, JdbcRequestData data) {
-    this(database, null, connection, data);
+    this(null, database, connection, data);
+  }
+
+  /**
+   * The database engine is required, but a bound credential now carries its own mandatory
+   * selection (see {@link JdbcConnectionConfiguration#database()}) that takes precedence over the
+   * inline field - the same shape as {@link #getInlineConnectionWhenNoCredentialBound()}. Named as
+   * a method override (not a synthetic {@code effectiveDatabase()}) so every existing caller of
+   * {@code database()} - {@link
+   * io.camunda.connector.jdbc.utils.ConnectionHelper#openConnection} included - automatically gets
+   * the effective value.
+   */
+  public SupportedDatabase database() {
+    return configuration != null ? configuration.database() : database;
   }
 
   /**
@@ -86,6 +110,19 @@ public record JdbcRequest(
   @JsonIgnore
   public boolean isConnectionSourceProvided() {
     return connection != null || configuration != null;
+  }
+
+  /**
+   * The database engine is required, but it may come from the bound credential instead of the
+   * inline field, so requiredness is asserted on the effective value (see {@link #database()}) -
+   * the same shape as {@link #isConnectionSourceProvided()}. A component-level {@code @NotNull}
+   * could not do this: the inline field is legitimately absent when the credential supplies the
+   * database.
+   */
+  @AssertTrue(message = "No database selected by the credential or the element template")
+  @JsonIgnore
+  public boolean isDatabaseSourceProvided() {
+    return database() != null;
   }
 
   /**

--- a/connectors/jdbc/src/main/java/io/camunda/connector/jdbc/model/request/JdbcRequest.java
+++ b/connectors/jdbc/src/main/java/io/camunda/connector/jdbc/model/request/JdbcRequest.java
@@ -87,6 +87,20 @@ public record JdbcRequest(
   }
 
   /**
+   * Delegates to the canonical constructor in the pre-{@code configuration}-first component order:
+   * {@code configuration} moved from last to first above so it renders (and appears in {@code
+   * properties[]}) before the fields it gates, per {@code ConditionPropertyOrderRule}. Retained so
+   * existing Java callers built against that order keep compiling.
+   */
+  public JdbcRequest(
+      SupportedDatabase database,
+      JdbcConnection connection,
+      JdbcRequestData data,
+      JdbcConnectionConfiguration configuration) {
+    this(configuration, database, connection, data);
+  }
+
+  /**
    * The database engine is required, but a bound credential now carries its own mandatory selection
    * (see {@link JdbcConnectionConfiguration#database()}) that takes precedence over the inline
    * field - the same shape as {@link #getInlineConnectionWhenNoCredentialBound()}. Named as a

--- a/connectors/jdbc/src/main/java/io/camunda/connector/jdbc/model/request/JdbcRequest.java
+++ b/connectors/jdbc/src/main/java/io/camunda/connector/jdbc/model/request/JdbcRequest.java
@@ -87,13 +87,12 @@ public record JdbcRequest(
   }
 
   /**
-   * The database engine is required, but a bound credential now carries its own mandatory
-   * selection (see {@link JdbcConnectionConfiguration#database()}) that takes precedence over the
-   * inline field - the same shape as {@link #getInlineConnectionWhenNoCredentialBound()}. Named as
-   * a method override (not a synthetic {@code effectiveDatabase()}) so every existing caller of
-   * {@code database()} - {@link
-   * io.camunda.connector.jdbc.utils.ConnectionHelper#openConnection} included - automatically gets
-   * the effective value.
+   * The database engine is required, but a bound credential now carries its own mandatory selection
+   * (see {@link JdbcConnectionConfiguration#database()}) that takes precedence over the inline
+   * field - the same shape as {@link #getInlineConnectionWhenNoCredentialBound()}. Named as a
+   * method override (not a synthetic {@code effectiveDatabase()}) so every existing caller of
+   * {@code database()} - {@link io.camunda.connector.jdbc.utils.ConnectionHelper#openConnection}
+   * included - automatically gets the effective value.
    */
   public SupportedDatabase database() {
     return configuration != null ? configuration.database() : database;

--- a/connectors/jdbc/src/main/java/io/camunda/connector/jdbc/model/request/JdbcRequest.java
+++ b/connectors/jdbc/src/main/java/io/camunda/connector/jdbc/model/request/JdbcRequest.java
@@ -10,7 +10,10 @@ import static io.camunda.connector.generator.java.annotation.TemplateProperty.Pr
 import static io.camunda.connector.generator.java.annotation.TemplateProperty.PropertyType.Dropdown;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import io.camunda.connector.generator.java.annotation.NestedProperties;
 import io.camunda.connector.generator.java.annotation.TemplateProperty;
+import io.camunda.connector.generator.java.annotation.TemplateProperty.NullableBoolean;
+import io.camunda.connector.generator.java.annotation.TemplateProperty.PropertyCondition;
 import io.camunda.connector.jdbc.model.request.connection.JdbcConnection;
 import io.camunda.connector.jdbc.model.request.connection.JdbcConnectionConfiguration;
 import jakarta.validation.Valid;
@@ -38,14 +41,8 @@ public record JdbcRequest(
               @TemplateProperty.DropdownPropertyChoice(label = "Oracle", value = "ORACLE"),
             })
         SupportedDatabase database,
-    // Not @NotNull, and not @Valid: a bound connection credential (configuration) may substitute
-    // for inline connection fields, and takes precedence when both are set (resolved in
-    // ConnectionHelper). The raw field is validated conditionally via
-    // getInlineConnectionWhenNoCredentialBound() below, so a Modeler-generated diagram that only
-    // sets a credential (and carries connection's unconditional default discriminator, e.g.
-    // authType=uri, with no uri set) doesn't fail validation on the losing inline path.
-    JdbcConnection connection,
-    @Valid @NotNull JdbcRequestData data,
+    // Declared before `connection` so it renders first and satisfies ConditionPropertyOrderRule
+    // for the isEmpty condition on `connection` below.
     @TemplateProperty(
             id = "connectionConfiguration",
             label = "Connection credential",
@@ -57,11 +54,25 @@ public record JdbcRequest(
                 "Choose a reusable JDBC connection credential. When set, it is bound as a whole to"
                     + " the connector's 'configuration' input.")
         @Valid
-        JdbcConnectionConfiguration configuration) {
+        JdbcConnectionConfiguration configuration,
+    // Not @NotNull, and not @Valid: a bound connection credential (configuration) may substitute
+    // for inline connection fields, and takes precedence when both are set (resolved in
+    // ConnectionHelper). The raw field is validated conditionally via
+    // getInlineConnectionWhenNoCredentialBound() below, so a Modeler-generated diagram that only
+    // sets a credential (and carries connection's unconditional default discriminator, e.g.
+    // authType=uri, with no uri set) doesn't fail validation on the losing inline path. Hidden and
+    // un-required (via the isEmpty condition) once a credential is bound above.
+    @NestedProperties(
+            condition =
+                @PropertyCondition(
+                    property = "connectionConfiguration",
+                    isEmpty = NullableBoolean.TRUE))
+        JdbcConnection connection,
+    @Valid @NotNull JdbcRequestData data) {
 
   /** Convenience constructor for the pre-configuration-chooser shape (no bound configuration). */
   public JdbcRequest(SupportedDatabase database, JdbcConnection connection, JdbcRequestData data) {
-    this(database, connection, data, null);
+    this(database, null, connection, data);
   }
 
   /**

--- a/connectors/jdbc/src/main/java/io/camunda/connector/jdbc/model/request/JdbcRequest.java
+++ b/connectors/jdbc/src/main/java/io/camunda/connector/jdbc/model/request/JdbcRequest.java
@@ -51,8 +51,8 @@ public record JdbcRequest(
             optional = true,
             binding = @TemplateProperty.PropertyBinding(name = "configuration"),
             description =
-                "Choose a reusable JDBC connection credential. When set, it is bound as a whole to"
-                    + " the connector's 'configuration' input.")
+                "Choose a reusable JDBC connection credential, or configure one-time connection"
+                    + " parameters below.")
         @Valid
         JdbcConnectionConfiguration configuration,
     // Not @NotNull, and not @Valid: a bound connection credential (configuration) may substitute

--- a/connectors/jdbc/src/main/java/io/camunda/connector/jdbc/model/request/connection/JdbcConnectionConfiguration.java
+++ b/connectors/jdbc/src/main/java/io/camunda/connector/jdbc/model/request/connection/JdbcConnectionConfiguration.java
@@ -22,8 +22,9 @@ import jakarta.validation.constraints.NotNull;
  * <p>{@code database} is mandatory here (unlike the connector's own inline field, which is only
  * required when no credential is bound) - the credential is a complete, standalone connection
  * description, and the driver/URL scheme it resolves to differs per database. Version bumped to 2
- * for this new required field (see CONFIGURATION_VERSIONING.md's floor-semantics compatibility): a
- * v1 instance predating this field would otherwise be silently invalid.
+ * for this new required field (see {@code version()}'s floor-semantics in ADR-0004, {@code
+ * docs/adr/ADR-0004-configuration-templates-in-element-templates.md}): a v1 instance predating this
+ * field would otherwise be silently invalid.
  */
 @Configuration(
     id = "io.camunda.connectors:jdbc-connection:1",

--- a/connectors/jdbc/src/main/java/io/camunda/connector/jdbc/model/request/connection/JdbcConnectionConfiguration.java
+++ b/connectors/jdbc/src/main/java/io/camunda/connector/jdbc/model/request/connection/JdbcConnectionConfiguration.java
@@ -8,19 +8,47 @@ package io.camunda.connector.jdbc.model.request.connection;
 
 import io.camunda.connector.api.annotation.Configuration;
 import io.camunda.connector.generator.java.annotation.TemplateProperty;
+import io.camunda.connector.generator.java.annotation.TemplateProperty.PropertyType;
+import io.camunda.connector.jdbc.model.request.SupportedDatabase;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 
 /**
  * Configuration (credential) template for a reusable JDBC connection. Demonstrates the whole-object
  * binding model: an element template embeds this template under {@code configurationTemplates} and
  * a {@code Configuration} chooser lets a Camunda developer pick a stored connection instead of
  * filling in the inline connection fields.
+ *
+ * <p>{@code database} is mandatory here (unlike the connector's own inline field, which is only
+ * required when no credential is bound) - the credential is a complete, standalone connection
+ * description, and the driver/URL scheme it resolves to differs per database. Version bumped to 2
+ * for this new required field (see CONFIGURATION_VERSIONING.md's floor-semantics compatibility): a
+ * v1 instance predating this field would otherwise be silently invalid.
  */
 @Configuration(
     id = "io.camunda.connectors:jdbc-connection:1",
-    version = 1,
+    version = 2,
     name = "JDBC Connection")
 public record JdbcConnectionConfiguration(
+    @NotNull
+        @TemplateProperty(
+            label = "Select a database",
+            tooltip =
+                "If you choose Oracle, make sure the Oracle JDBC driver is included. "
+                    + "<a href=\"https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/sql/#database\">Oracle JDBC driver setup</a>.",
+            group = "connection",
+            type = PropertyType.Dropdown,
+            constraints = @TemplateProperty.PropertyConstraints(notEmpty = true),
+            choices = {
+              @TemplateProperty.DropdownPropertyChoice(label = "MariaDB", value = "MARIADB"),
+              @TemplateProperty.DropdownPropertyChoice(
+                  label = "Microsoft SQL Server",
+                  value = "MSSQL"),
+              @TemplateProperty.DropdownPropertyChoice(label = "MySQL", value = "MYSQL"),
+              @TemplateProperty.DropdownPropertyChoice(label = "PostgreSQL", value = "POSTGRESQL"),
+              @TemplateProperty.DropdownPropertyChoice(label = "Oracle", value = "ORACLE"),
+            })
+        SupportedDatabase database,
     @NotBlank @TemplateProperty(group = "connection", label = "Host") String host,
     @NotBlank @TemplateProperty(group = "connection", label = "Port") String port,
     @TemplateProperty(group = "connection", label = "Database name") String databaseName,
@@ -36,7 +64,9 @@ public record JdbcConnectionConfiguration(
   @Override
   public String toString() {
     return "JdbcConnectionConfiguration{"
-        + "host="
+        + "database="
+        + database
+        + ", host="
         + host
         + ", port="
         + port

--- a/connectors/jdbc/src/main/java/io/camunda/connector/jdbc/model/request/connection/JdbcConnectionConfiguration.java
+++ b/connectors/jdbc/src/main/java/io/camunda/connector/jdbc/model/request/connection/JdbcConnectionConfiguration.java
@@ -57,6 +57,17 @@ public record JdbcConnectionConfiguration(
     @TemplateProperty(group = "authentication", label = "Password", secret = true)
         String password) {
 
+  /**
+   * Delegates to the canonical constructor for the pre-{@code database}-field shape (this
+   * credential's version 1, before the database engine became part of it). {@code database} is left
+   * {@code null} here, which the {@code @NotNull} constraint above then correctly rejects at
+   * validation time -- see this record's class javadoc on why a v1 instance must not silently pass.
+   */
+  public JdbcConnectionConfiguration(
+      String host, String port, String databaseName, String username, String password) {
+    this(null, host, port, databaseName, username, password);
+  }
+
   /** Adapts this credential to the connector's existing {@link DetailedConnection} shape. */
   public DetailedConnection toDetailedConnection() {
     return new DetailedConnection(host, port, username, password, databaseName, null);

--- a/connectors/jdbc/src/main/java/io/camunda/connector/jdbc/outbound/JdbcFunction.java
+++ b/connectors/jdbc/src/main/java/io/camunda/connector/jdbc/outbound/JdbcFunction.java
@@ -48,7 +48,6 @@ import io.camunda.connector.jdbc.model.response.JdbcResponse;
     documentationRef =
         "https://docs.camunda.io/docs/8.6/components/connectors/out-of-the-box-connectors/sql",
     propertyGroups = {
-      @ElementTemplate.PropertyGroup(id = JdbcFunction.DATABASE_GROUP_ID, label = "Database"),
       @ElementTemplate.PropertyGroup(id = JdbcFunction.CONNECTION_GROUP_ID, label = "Connection"),
       @ElementTemplate.PropertyGroup(id = JdbcFunction.QUERY_GROUP_ID, label = "Query"),
     },
@@ -56,7 +55,6 @@ import io.camunda.connector.jdbc.model.response.JdbcResponse;
     configurations = {JdbcConnectionConfiguration.class},
     outputDataClass = JdbcResponse.class)
 public class JdbcFunction implements OutboundConnectorFunction {
-  static final String DATABASE_GROUP_ID = "database";
   static final String CONNECTION_GROUP_ID = "connection";
   static final String QUERY_GROUP_ID = "query";
 

--- a/connectors/jdbc/src/main/java/io/camunda/connector/jdbc/outbound/JdbcFunction.java
+++ b/connectors/jdbc/src/main/java/io/camunda/connector/jdbc/outbound/JdbcFunction.java
@@ -24,7 +24,7 @@ import io.camunda.connector.jdbc.model.response.JdbcResponse;
     engineVersion = "^8.10",
     id = "io.camunda.connectors.Jdbc.v1",
     name = "Execute SQL Statement on Database",
-    version = 5,
+    version = 6,
     description =
         "Read and write data from a Camunda process directly to a SQL database (e.g., Microsoft SQL Server, MySQL, PostgreSQL)",
     keywords = {

--- a/connectors/jdbc/src/test/java/io/camunda/connector/jdbc/model/request/JdbcRequestTest.java
+++ b/connectors/jdbc/src/test/java/io/camunda/connector/jdbc/model/request/JdbcRequestTest.java
@@ -87,14 +87,16 @@ public class JdbcRequestTest extends BaseTest {
   /**
    * Exercises the full runtime path (JSON -> Jackson binding -> {@code @Valid} cascade), which
    * {@code ConnectionHelperTest} does not cover since it constructs {@code JdbcRequest} directly.
-   * Only the bound connection credential is present; no inline connection fields.
+   * Only the bound connection credential is present; no inline connection fields and no inline
+   * {@code database} either, proving moving {@code @NotNull} off that record component works. The
+   * conflicting-value case (both an inline {@code database} and a credential set) is covered
+   * separately in {@code ConnectionHelperTest}.
    */
   @Test
   void bindVariablesSucceedsWithOnlyConfigurationProvided() {
     String variables =
         """
         {
-          "database": "MYSQL",
           "configuration": {
             "database": "POSTGRESQL",
             "host": "cred-host",
@@ -113,7 +115,7 @@ public class JdbcRequestTest extends BaseTest {
     assertThat(request.connection()).isNull();
     assertThat(request.configuration()).isNotNull();
     assertThat(request.configuration().host()).isEqualTo("cred-host");
-    // The credential's mandatory database selection wins over the (hidden, ignored) inline value.
+    // The credential's mandatory database selection is the only source, and satisfies validation.
     assertThat(request.database()).isEqualTo(SupportedDatabase.POSTGRESQL);
   }
 

--- a/connectors/jdbc/src/test/java/io/camunda/connector/jdbc/model/request/JdbcRequestTest.java
+++ b/connectors/jdbc/src/test/java/io/camunda/connector/jdbc/model/request/JdbcRequestTest.java
@@ -94,8 +94,9 @@ public class JdbcRequestTest extends BaseTest {
     String variables =
         """
         {
-          "database": "POSTGRESQL",
+          "database": "MYSQL",
           "configuration": {
+            "database": "POSTGRESQL",
             "host": "cred-host",
             "port": "5432",
             "databaseName": "cred-db",
@@ -112,6 +113,8 @@ public class JdbcRequestTest extends BaseTest {
     assertThat(request.connection()).isNull();
     assertThat(request.configuration()).isNotNull();
     assertThat(request.configuration().host()).isEqualTo("cred-host");
+    // The credential's mandatory database selection wins over the (hidden, ignored) inline value.
+    assertThat(request.database()).isEqualTo(SupportedDatabase.POSTGRESQL);
   }
 
   /** Only inline connection fields are present; no bound configuration. */
@@ -174,6 +177,7 @@ public class JdbcRequestTest extends BaseTest {
           "database": "POSTGRESQL",
           "connection": { "authType": "uri" },
           "configuration": {
+            "database": "POSTGRESQL",
             "host": "cred-host",
             "port": "5432",
             "databaseName": "cred-db",

--- a/connectors/jdbc/src/test/java/io/camunda/connector/jdbc/utils/ConnectionHelperTest.java
+++ b/connectors/jdbc/src/test/java/io/camunda/connector/jdbc/utils/ConnectionHelperTest.java
@@ -24,7 +24,8 @@ class ConnectionHelperTest {
   private static final JdbcRequestData DATA = new JdbcRequestData(false, "SELECT 1");
 
   private static final JdbcConnectionConfiguration CREDENTIAL =
-      new JdbcConnectionConfiguration("cred-host", "5432", "cred-db", "cred-user", "cred-pass");
+      new JdbcConnectionConfiguration(
+          SupportedDatabase.POSTGRESQL, "cred-host", "5432", "cred-db", "cred-user", "cred-pass");
 
   private static final DetailedConnection INLINE =
       new DetailedConnection(
@@ -32,7 +33,7 @@ class ConnectionHelperTest {
 
   @Test
   void usesConfigurationWhenBound() {
-    var request = new JdbcRequest(SupportedDatabase.POSTGRESQL, CREDENTIAL, null, DATA);
+    var request = new JdbcRequest(CREDENTIAL, SupportedDatabase.POSTGRESQL, null, DATA);
 
     JdbcConnection resolved = ConnectionHelper.resolveConnection(request);
 
@@ -56,11 +57,28 @@ class ConnectionHelperTest {
 
   @Test
   void configurationTakesPrecedenceOverInline() {
-    var request = new JdbcRequest(SupportedDatabase.POSTGRESQL, CREDENTIAL, INLINE, DATA);
+    var request = new JdbcRequest(CREDENTIAL, SupportedDatabase.POSTGRESQL, INLINE, DATA);
 
     var resolved = (DetailedConnection) ConnectionHelper.resolveConnection(request);
 
     assertThat(resolved.host()).isEqualTo("cred-host");
+  }
+
+  @Test
+  void configurationDatabaseTakesPrecedenceOverInlineDatabase() {
+    var credentialWithMysql =
+        new JdbcConnectionConfiguration(
+            SupportedDatabase.MYSQL, "cred-host", "5432", "cred-db", "cred-user", "cred-pass");
+    var request = new JdbcRequest(credentialWithMysql, SupportedDatabase.ORACLE, null, DATA);
+
+    assertThat(request.database()).isEqualTo(SupportedDatabase.MYSQL);
+  }
+
+  @Test
+  void fallsBackToInlineDatabaseWhenNoConfiguration() {
+    var request = new JdbcRequest(SupportedDatabase.MYSQL, INLINE, DATA);
+
+    assertThat(request.database()).isEqualTo(SupportedDatabase.MYSQL);
   }
 
   @Test

--- a/connectors/jdbc/src/test/java/io/camunda/connector/jdbc/utils/ConnectionHelperTest.java
+++ b/connectors/jdbc/src/test/java/io/camunda/connector/jdbc/utils/ConnectionHelperTest.java
@@ -32,7 +32,7 @@ class ConnectionHelperTest {
 
   @Test
   void usesConfigurationWhenBound() {
-    var request = new JdbcRequest(SupportedDatabase.POSTGRESQL, null, DATA, CREDENTIAL);
+    var request = new JdbcRequest(SupportedDatabase.POSTGRESQL, CREDENTIAL, null, DATA);
 
     JdbcConnection resolved = ConnectionHelper.resolveConnection(request);
 
@@ -56,7 +56,7 @@ class ConnectionHelperTest {
 
   @Test
   void configurationTakesPrecedenceOverInline() {
-    var request = new JdbcRequest(SupportedDatabase.POSTGRESQL, INLINE, DATA, CREDENTIAL);
+    var request = new JdbcRequest(SupportedDatabase.POSTGRESQL, CREDENTIAL, INLINE, DATA);
 
     var resolved = (DetailedConnection) ConnectionHelper.resolveConnection(request);
 


### PR DESCRIPTION
## Summary
- Applies the isEmpty gate + chooser-first field ordering (generator support added in #8307) to the JDBC outbound connector

Stacked on the AWS connector family PR (3 of 3 in the stack).

## Test plan
- [ ] Existing unit tests pass for the JDBC connector module
- [ ] Regenerated element template renders credential chooser before fallback fields