### PR TITLE
feat(agentic-ai): emit zeebe:agentDefinition marker from v2 AI Agent templates

### DIFF
--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/BpmnUtil.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/BpmnUtil.java
@@ -84,30 +84,4 @@ public class BpmnUtil {
               return im;
             });
   }
-
-  /**
-   * TODO(camunda/camunda#59715): temporary workaround, remove once the v2 AI Agent element
-   * templates set {@code zeebe:agentDefinition} themselves. The engine rejects {@code
-   * AgentInstance} creation without that marker, but neither the v2 element templates nor
-   * element-templates-cli's bundled {@code zeebe-bpmn-moddle} support the element yet - the CLI
-   * strips it if added to the source BPMN. Needs element-templates-cli/library updates plus updated
-   * element templates; until then, add it here directly on the already-applied model.
-   */
-  public static BpmnModelInstance withAgentDefinitionMarker(
-      BpmnModelInstance model, String elementId, String agentType) {
-    final var element = model.getModelElementById(elementId);
-    assertThat(element)
-        .describedAs("Element with ID %s is expected to exist", elementId)
-        .isNotNull()
-        .describedAs(
-            "Element with ID %s is expected to be a child instance of BaseElement", elementId)
-        .isInstanceOf(BaseElement.class);
-
-    final var agentDefinition =
-        ((BaseElement) element)
-            .getExtensionElements()
-            .addExtensionElement("http://camunda.org/schema/zeebe/1.0", "agentDefinition");
-    agentDefinition.setAttributeValue("agentType", agentType);
-    return model;
-  }
 }

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/subprocess/BaseAgentSubProcessTest.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/subprocess/BaseAgentSubProcessTest.java
@@ -16,9 +16,7 @@
  */
 package io.camunda.connector.e2e.agenticai.aiagent.subprocess;
 
-import static io.camunda.connector.e2e.agenticai.BpmnUtil.withAgentDefinitionMarker;
 import static io.camunda.connector.e2e.agenticai.aiagent.AgentTestFixtures.AGENT_RESPONSE_VARIABLE;
-import static io.camunda.connector.e2e.agenticai.aiagent.AgentTestFixtures.AI_AGENT_ELEMENT_ID;
 import static io.camunda.connector.e2e.agenticai.aiagent.AgentTestFixtures.AI_AGENT_SUB_PROCESS_V1_ELEMENT_TEMPLATE_PATH;
 import static io.camunda.connector.e2e.agenticai.aiagent.AgentTestFixtures.AI_AGENT_SUB_PROCESS_V1_ELEMENT_TEMPLATE_PROPERTIES;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -29,7 +27,6 @@ import io.camunda.connector.agenticai.aiagent.model.AgentMetrics;
 import io.camunda.connector.agenticai.aiagent.model.AgentSubProcessResponse;
 import io.camunda.connector.e2e.ElementTemplate;
 import io.camunda.connector.e2e.ZeebeTest;
-import io.camunda.connector.e2e.agenticai.BpmnUtil;
 import io.camunda.connector.e2e.agenticai.aiagent.BaseAgentTest;
 import io.camunda.connector.e2e.agenticai.aiagent.task.BaseAgentTaskTest;
 import io.camunda.connector.e2e.agenticai.aiagent.wiremock.openai.OpenAiCompletionsChatModelStubs;
@@ -39,7 +36,6 @@ import io.camunda.connector.e2e.agenticai.aiagent.wiremock.openai.OpenAiCompleti
 import io.camunda.connector.e2e.agenticai.assertj.AgentSubProcessResponseAssert;
 import io.camunda.connector.test.utils.annotation.SlowTest;
 import io.camunda.process.test.api.CamundaAssert;
-import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.HashMap;
@@ -101,13 +97,6 @@ public abstract class BaseAgentSubProcessTest extends BaseAgentTest {
 
   protected Function<ElementTemplate, ElementTemplate> providerConfigurer() {
     return this::withOpenAiCompatibleProvider;
-  }
-
-  /** See {@link BpmnUtil#withAgentDefinitionMarker} for why this is needed. */
-  @Override
-  protected BpmnModelInstance customizeModel(BpmnModelInstance model) {
-    return super.customizeModel(
-        withAgentDefinitionMarker(model, AI_AGENT_ELEMENT_ID, "aiAgentSubProcess"));
   }
 
   @Override

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/task/BaseAgentTaskTest.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/task/BaseAgentTaskTest.java
@@ -16,9 +16,7 @@
  */
 package io.camunda.connector.e2e.agenticai.aiagent.task;
 
-import static io.camunda.connector.e2e.agenticai.BpmnUtil.withAgentDefinitionMarker;
 import static io.camunda.connector.e2e.agenticai.aiagent.AgentTestFixtures.AGENT_RESPONSE_VARIABLE;
-import static io.camunda.connector.e2e.agenticai.aiagent.AgentTestFixtures.AI_AGENT_ELEMENT_ID;
 import static io.camunda.connector.e2e.agenticai.aiagent.AgentTestFixtures.AI_AGENT_TASK_V1_ELEMENT_TEMPLATE_PATH;
 import static io.camunda.connector.e2e.agenticai.aiagent.AgentTestFixtures.AI_AGENT_TASK_V1_ELEMENT_TEMPLATE_PROPERTIES;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -28,7 +26,6 @@ import io.camunda.connector.agenticai.aiagent.model.AgentMetrics;
 import io.camunda.connector.agenticai.aiagent.model.AgentResponse;
 import io.camunda.connector.e2e.ElementTemplate;
 import io.camunda.connector.e2e.ZeebeTest;
-import io.camunda.connector.e2e.agenticai.BpmnUtil;
 import io.camunda.connector.e2e.agenticai.aiagent.BaseAgentTest;
 import io.camunda.connector.e2e.agenticai.aiagent.wiremock.openai.OpenAiCompletionsChatModelStubs;
 import io.camunda.connector.e2e.agenticai.aiagent.wiremock.openai.OpenAiCompletionsChatModelStubs.ToolCall;
@@ -37,7 +34,6 @@ import io.camunda.connector.e2e.agenticai.aiagent.wiremock.openai.OpenAiCompleti
 import io.camunda.connector.e2e.agenticai.assertj.AgentResponseAssert;
 import io.camunda.connector.test.utils.annotation.SlowTest;
 import io.camunda.process.test.api.CamundaAssert;
-import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
@@ -97,13 +93,6 @@ public abstract class BaseAgentTaskTest extends BaseAgentTest {
 
   protected Function<ElementTemplate, ElementTemplate> providerConfigurer() {
     return this::withOpenAiCompatibleProvider;
-  }
-
-  /** See {@link BpmnUtil#withAgentDefinitionMarker} for why this is needed. */
-  @Override
-  protected BpmnModelInstance customizeModel(BpmnModelInstance model) {
-    return super.customizeModel(
-        withAgentDefinitionMarker(model, AI_AGENT_ELEMENT_ID, "aiAgentTask"));
   }
 
   @Override

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/e2e/AiAgentE2ETestIT.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/e2e/AiAgentE2ETestIT.java
@@ -32,7 +32,6 @@ import io.camunda.client.api.search.response.UserTask;
 import io.camunda.connector.agenticai.aiagent.model.AgentResponse;
 import io.camunda.connector.e2e.BpmnFile;
 import io.camunda.connector.e2e.ElementTemplate;
-import io.camunda.connector.e2e.agenticai.BpmnUtil;
 import io.camunda.process.test.api.CamundaProcessTestContext;
 import io.camunda.process.test.api.CamundaProcessTestExtension;
 import io.camunda.process.test.api.CamundaProcessTestRuntimeMode;
@@ -676,9 +675,8 @@ public class AiAgentE2ETestIT {
       var templateFile = template.writeTo(new File(tempDir, "template.json"));
       var bpmnFile =
           new File(AiAgentE2ETestIT.class.getClassLoader().getResource(BPMN_RESOURCE).toURI());
-      var model =
-          new BpmnFile(bpmnFile).apply(templateFile, "AI_Agent", new File(tempDir, "applied.bpmn"));
-      return BpmnUtil.withAgentDefinitionMarker(model, "AI_Agent", "aiAgentSubProcess");
+      return new BpmnFile(bpmnFile)
+          .apply(templateFile, "AI_Agent", new File(tempDir, "applied.bpmn"));
     } catch (Exception e) {
       throw new RuntimeException("Failed to build BPMN model for " + provider.label(), e);
     }

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/e2e/DocumentToolCallResultsIT.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/e2e/DocumentToolCallResultsIT.java
@@ -31,7 +31,6 @@ import io.camunda.client.api.response.ProcessInstanceEvent;
 import io.camunda.connector.e2e.BpmnFile;
 import io.camunda.connector.e2e.ElementTemplate;
 import io.camunda.connector.e2e.ZeebeTest;
-import io.camunda.connector.e2e.agenticai.BpmnUtil;
 import io.camunda.connector.e2e.agenticai.CamundaDocumentTestConfiguration;
 import io.camunda.connector.e2e.app.TestConnectorRuntimeApplication;
 import io.camunda.connector.runtime.core.document.store.InMemoryDocumentStore;
@@ -551,9 +550,8 @@ class DocumentToolCallResultsIT {
     try {
       var templateFile = template.writeTo(new File(tempDir, "template.json"));
       var bpmnFile = resourceLoader.getResource(BPMN_RESOURCE).getFile();
-      var modelInstance =
-          new BpmnFile(bpmnFile).apply(templateFile, "AI_Agent", new File(tempDir, "applied.bpmn"));
-      return BpmnUtil.withAgentDefinitionMarker(modelInstance, "AI_Agent", "aiAgentSubProcess");
+      return new BpmnFile(bpmnFile)
+          .apply(templateFile, "AI_Agent", new File(tempDir, "applied.bpmn"));
     } catch (Exception e) {
       throw new RuntimeException("Failed to build BPMN model for " + provider.label(), e);
     }

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/e2e/RealProviderApiSmokeIT.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/e2e/RealProviderApiSmokeIT.java
@@ -33,7 +33,6 @@ import io.camunda.connector.agenticai.aiagent.model.AgentSubProcessResponse;
 import io.camunda.connector.e2e.BpmnFile;
 import io.camunda.connector.e2e.ElementTemplate;
 import io.camunda.connector.e2e.ZeebeTest;
-import io.camunda.connector.e2e.agenticai.BpmnUtil;
 import io.camunda.connector.e2e.agenticai.CamundaDocumentTestConfiguration;
 import io.camunda.connector.e2e.agenticai.assertj.AgentSubProcessResponseAssert;
 import io.camunda.connector.e2e.app.TestConnectorRuntimeApplication;
@@ -917,9 +916,8 @@ class RealProviderApiSmokeIT {
     try {
       var templateFile = template.writeTo(new File(tempDir, "template.json"));
       var bpmnFile = resourceLoader.getResource(bpmnResource).getFile();
-      var modelInstance =
-          new BpmnFile(bpmnFile).apply(templateFile, "AI_Agent", new File(tempDir, "applied.bpmn"));
-      return BpmnUtil.withAgentDefinitionMarker(modelInstance, "AI_Agent", "aiAgentSubProcess");
+      return new BpmnFile(bpmnFile)
+          .apply(templateFile, "AI_Agent", new File(tempDir, "applied.bpmn"));
     } catch (Exception e) {
       throw new RuntimeException("Failed to build BPMN model for " + provider.label(), e);
     }

--- a/connectors/agentic-ai/AGENTS.md
+++ b/connectors/agentic-ai/AGENTS.md
@@ -273,6 +273,15 @@ When a version is bumped, a template moves into `versioned/`, or a connector is 
 
 Do not list `hybrid/` templates in the README. They are intentionally omitted.
 
+### Agent definition marker
+
+The v2 AI Agent Task and Sub-process templates (all flavors, including hybrid) carry a hidden
+`zeebe:agentDefinition` property so the engine detects a native agent at deploy time
+(camunda/connectors#8176). `transform-ai-agent-task-template.groovy` adds it to the task template
+(`agentType=aiAgentTask`); `transform-ai-agent-sub-process-template.groovy` adds its own
+(`agentType=aiAgentSubProcess`) to the derived sub-process template. Both take `agentType` as a
+Maven property; it's left unset for the v1 job-worker template, so that one gets no marker.
+
 ## Key entry points
 
 | File                                        | Purpose                                    |

--- a/connectors/agentic-ai/AGENTS.md
+++ b/connectors/agentic-ai/AGENTS.md
@@ -280,8 +280,9 @@ hidden `zeebe:agentDefinition` property so the engine detects a native agent at 
 (camunda/connectors#8176). `transform-ai-agent-task-template.groovy` adds it to each task template
 (`agentType=aiAgentTask`); `transform-ai-agent-sub-process-template.groovy` adds its own
 (`agentType=aiAgentSubProcess`) to the derived sub-process template. Both take `agentType` as a
-Maven property. The task-marker script must run after the sub-process template is derived from that
-same task template file, otherwise the marker gets carried into the derived template too.
+Maven property. Both scripts drop any incoming `zeebe:agentDefinition` before adding their own, so
+execution order does not matter — the sub-process transformer cannot carry the task marker into the
+derived template regardless of when the task-marker script runs.
 
 ## Key entry points
 

--- a/connectors/agentic-ai/AGENTS.md
+++ b/connectors/agentic-ai/AGENTS.md
@@ -275,12 +275,13 @@ Do not list `hybrid/` templates in the README. They are intentionally omitted.
 
 ### Agent definition marker
 
-The v2 AI Agent Task and Sub-process templates (all flavors, including hybrid) carry a hidden
-`zeebe:agentDefinition` property so the engine detects a native agent at deploy time
-(camunda/connectors#8176). `transform-ai-agent-task-template.groovy` adds it to the task template
+All AI Agent Task and Sub-process templates (v1 and v2, all flavors, including hybrid) carry a
+hidden `zeebe:agentDefinition` property so the engine detects a native agent at deploy time
+(camunda/connectors#8176). `transform-ai-agent-task-template.groovy` adds it to each task template
 (`agentType=aiAgentTask`); `transform-ai-agent-sub-process-template.groovy` adds its own
 (`agentType=aiAgentSubProcess`) to the derived sub-process template. Both take `agentType` as a
-Maven property; it's left unset for the v1 job-worker template, so that one gets no marker.
+Maven property. The task-marker script must run after the sub-process template is derived from that
+same task template file, otherwise the marker gets carried into the derived template too.
 
 ## Key entry points
 

--- a/connectors/agentic-ai/connector-agentic-ai/AI_AGENT.md
+++ b/connectors/agentic-ai/connector-agentic-ai/AI_AGENT.md
@@ -241,6 +241,6 @@ leading to the following result
 | Connector Info            |                                                                       |
 | ---                       | ---                                                                   |
 | Type                      | io.camunda.agenticai:aiagent:1                                                            |
-| Version                   | 12                                                         |
+| Version                   | 13                                                         |
 | Supported element types   |     |
 

--- a/connectors/agentic-ai/connector-agentic-ai/bin/transform-ai-agent-sub-process-template.groovy
+++ b/connectors/agentic-ai/connector-agentic-ai/bin/transform-ai-agent-sub-process-template.groovy
@@ -38,6 +38,9 @@ if (!connectorType) {
     System.exit(1)
 }
 
+// optional: agentType for the zeebe:agentDefinition marker; unset means no marker is added
+def agentType = binding.hasVariable('agentType') ? agentType : null
+
 def file = new File((String) sourceFile)
 if (!file.exists()) {
     System.err.println("Error: Source file ${sourceFile} not found")
@@ -162,6 +165,19 @@ def updatedProperties = []
             ],
             type: "Hidden"
         ])
+
+        // Mark the element as a native agent definition so the engine creates an agent-definition
+        // record at deploy time.
+        if (agentType) {
+            updatedProperties.add([
+                value: (String) agentType,
+                binding: [
+                    type: "zeebe:agentDefinition",
+                    property: "agentType"
+                ],
+                type: "Hidden"
+            ])
+        }
     } else if (property.id == "id") {
         property.value = (String) templateId
         updatedProperties.add(property)

--- a/connectors/agentic-ai/connector-agentic-ai/bin/transform-ai-agent-sub-process-template.groovy
+++ b/connectors/agentic-ai/connector-agentic-ai/bin/transform-ai-agent-sub-process-template.groovy
@@ -120,6 +120,11 @@ def updatedProperties = []
         return
     }
 
+    // never carry over a marker from the source template; this script adds its own below
+    if (property.binding?.type == "zeebe:agentDefinition") {
+        return
+    }
+
     if (property.description) {
         property.description = replaceDocumentationLinks(property.description)
     }

--- a/connectors/agentic-ai/connector-agentic-ai/bin/transform-ai-agent-task-template.groovy
+++ b/connectors/agentic-ai/connector-agentic-ai/bin/transform-ai-agent-task-template.groovy
@@ -1,0 +1,52 @@
+#!/usr/bin/env groovy
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.SerializationFeature
+
+def sourceFile = sourceFile
+if (!sourceFile) {
+    System.err.println("Error: Source file path required as property")
+    System.exit(1)
+}
+
+def outputFile = outputFile
+if (!outputFile) {
+    System.err.println("Error: Output file path required as property")
+    System.exit(1)
+}
+
+// optional: agentType for the zeebe:agentDefinition marker; unset means no marker is added
+def agentType = binding.hasVariable('agentType') ? agentType : null
+
+def file = new File((String) sourceFile)
+if (!file.exists()) {
+    System.err.println("Error: Source file ${sourceFile} not found")
+    System.exit(1)
+}
+
+def mapper = new ObjectMapper()
+mapper.enable(SerializationFeature.INDENT_OUTPUT)
+
+def json = mapper.readValue(file, Map.class)
+
+def updatedProperties = []
+
+((List) json.get('properties')).each { property ->
+    updatedProperties.add(property)
+
+    // Mark the element as a native agent definition so the engine creates an agent-definition
+    // record at deploy time.
+    if (agentType && property.binding?.type == "zeebe:taskDefinition" && property.binding?.property == "type") {
+        updatedProperties.add([
+            value: (String) agentType,
+            binding: [
+                type: "zeebe:agentDefinition",
+                property: "agentType"
+            ],
+            type: "Hidden"
+        ])
+    }
+}
+
+json.put('properties', updatedProperties)
+mapper.writeValue(new File((String) outputFile), json)

--- a/connectors/agentic-ai/connector-agentic-ai/bin/transform-ai-agent-task-template.groovy
+++ b/connectors/agentic-ai/connector-agentic-ai/bin/transform-ai-agent-task-template.groovy
@@ -32,6 +32,11 @@ def json = mapper.readValue(file, Map.class)
 def updatedProperties = []
 
 ((List) json.get('properties')).each { property ->
+    // never carry over a marker from the source template; this script adds its own below
+    if (property.binding?.type == "zeebe:agentDefinition") {
+        return
+    }
+
     updatedProperties.add(property)
 
     // Mark the element as a native agent definition so the engine creates an agent-definition

--- a/connectors/agentic-ai/connector-agentic-ai/element-templates/README.md
+++ b/connectors/agentic-ai/connector-agentic-ai/element-templates/README.md
@@ -30,7 +30,7 @@ running on the new chat-model provider SPI; it does not supersede the v1 templat
 | Connector         | Minimum Camunda version | Template version | File |
 | --- | --- | --- | --- |
 | AI Agent Task v2  | 8.10 | 1  | [`agenticai-ai-agent-task.v2.json`](./agenticai-ai-agent-task.v2.json) |
-| AI Agent Task     | 8.10 | 12 | [`agenticai-aiagent-outbound-connector.json`](./agenticai-aiagent-outbound-connector.json) |
+| AI Agent Task     | 8.10 | 13 | [`agenticai-aiagent-outbound-connector.json`](./agenticai-aiagent-outbound-connector.json) |
 | AI Agent Task     | 8.9  | 7  | [`versioned/agenticai-aiagent-outbound-connector-7.json`](./versioned/agenticai-aiagent-outbound-connector-7.json) |
 | AI Agent Task     | 8.8  | 5  | [`versioned/agenticai-aiagent-outbound-connector-5.json`](./versioned/agenticai-aiagent-outbound-connector-5.json) |
 
@@ -42,7 +42,7 @@ running on the new chat-model provider SPI; it does not supersede the v1 templat
 | Connector                | Minimum Camunda version | Template version | File |
 | --- | --- | --- | --- |
 | AI Agent Sub-process v2  | 8.10 | 1  | [`agenticai-ai-agent-subprocess.v2.json`](./agenticai-ai-agent-subprocess.v2.json) |
-| AI Agent Sub-process     | 8.10 | 12 | [`agenticai-aiagent-job-worker.json`](./agenticai-aiagent-job-worker.json) |
+| AI Agent Sub-process     | 8.10 | 13 | [`agenticai-aiagent-job-worker.json`](./agenticai-aiagent-job-worker.json) |
 | AI Agent Sub-process     | 8.9  | 7  | [`versioned/agenticai-aiagent-job-worker-7.json`](./versioned/agenticai-aiagent-job-worker-7.json) |
 | AI Agent Sub-process     | 8.8  | 5  | [`versioned/agenticai-aiagent-job-worker-5.json`](./versioned/agenticai-aiagent-job-worker-5.json) |
 

--- a/connectors/agentic-ai/connector-agentic-ai/element-templates/agenticai-ai-agent-subprocess.v2.json
+++ b/connectors/agentic-ai/connector-agentic-ai/element-templates/agenticai-ai-agent-subprocess.v2.json
@@ -112,6 +112,13 @@
     },
     "type" : "Hidden"
   }, {
+    "value" : "aiAgentSubProcess",
+    "binding" : {
+      "type" : "zeebe:agentDefinition",
+      "property" : "agentType"
+    },
+    "type" : "Hidden"
+  }, {
     "id" : "provider.type",
     "label" : "Provider",
     "description" : "Specify the LLM provider to use.",

--- a/connectors/agentic-ai/connector-agentic-ai/element-templates/agenticai-ai-agent-task.v2.json
+++ b/connectors/agentic-ai/connector-agentic-ai/element-templates/agenticai-ai-agent-task.v2.json
@@ -84,6 +84,13 @@
     },
     "type" : "Hidden"
   }, {
+    "value" : "aiAgentTask",
+    "binding" : {
+      "type" : "zeebe:agentDefinition",
+      "property" : "agentType"
+    },
+    "type" : "Hidden"
+  }, {
     "id" : "provider.type",
     "label" : "Provider",
     "description" : "Specify the LLM provider to use.",

--- a/connectors/agentic-ai/connector-agentic-ai/element-templates/agenticai-aiagent-job-worker.json
+++ b/connectors/agentic-ai/connector-agentic-ai/element-templates/agenticai-aiagent-job-worker.json
@@ -103,6 +103,13 @@
     },
     "type" : "Hidden"
   }, {
+    "value" : "aiAgentSubProcess",
+    "binding" : {
+      "type" : "zeebe:agentDefinition",
+      "property" : "agentType"
+    },
+    "type" : "Hidden"
+  }, {
     "id" : "provider.type",
     "label" : "Provider",
     "description" : "Specify the LLM provider to use.",

--- a/connectors/agentic-ai/connector-agentic-ai/element-templates/agenticai-aiagent-job-worker.json
+++ b/connectors/agentic-ai/connector-agentic-ai/element-templates/agenticai-aiagent-job-worker.json
@@ -5,7 +5,7 @@
   "description" : "Run a multi-step AI reasoning loop with dynamic tool selection",
   "keywords" : [ "AI", "AI Agent", "agentic orchestration" ],
   "documentationRef" : "https://docs.camunda.io/docs/8.10/components/connectors/out-of-the-box-connectors/agentic-ai-aiagent-subprocess/",
-  "version" : 12,
+  "version" : 13,
   "category" : {
     "id" : "aiTools",
     "name" : "AI Tools"
@@ -1746,7 +1746,7 @@
     "id" : "version",
     "label" : "Version",
     "description" : "Version of the element template",
-    "value" : "12",
+    "value" : "13",
     "group" : "connector",
     "binding" : {
       "key" : "elementTemplateVersion",

--- a/connectors/agentic-ai/connector-agentic-ai/element-templates/agenticai-aiagent-outbound-connector.json
+++ b/connectors/agentic-ai/connector-agentic-ai/element-templates/agenticai-aiagent-outbound-connector.json
@@ -5,7 +5,7 @@
   "description" : "Execute a single AI-powered action with tool calling capabilities",
   "keywords" : [ "AI", "AI Agent", "agentic orchestration" ],
   "documentationRef" : "https://docs.camunda.io/docs/8.10/components/connectors/out-of-the-box-connectors/agentic-ai-aiagent-task/",
-  "version" : 12,
+  "version" : 13,
   "category" : {
     "id" : "aiTools",
     "name" : "AI Tools"
@@ -1713,7 +1713,7 @@
     "id" : "version",
     "label" : "Version",
     "description" : "Version of the element template",
-    "value" : "12",
+    "value" : "13",
     "group" : "connector",
     "binding" : {
       "key" : "elementTemplateVersion",

--- a/connectors/agentic-ai/connector-agentic-ai/element-templates/agenticai-aiagent-outbound-connector.json
+++ b/connectors/agentic-ai/connector-agentic-ai/element-templates/agenticai-aiagent-outbound-connector.json
@@ -75,6 +75,13 @@
     },
     "type" : "Hidden"
   }, {
+    "value" : "aiAgentTask",
+    "binding" : {
+      "type" : "zeebe:agentDefinition",
+      "property" : "agentType"
+    },
+    "type" : "Hidden"
+  }, {
     "id" : "provider.type",
     "label" : "Provider",
     "description" : "Specify the LLM provider to use.",

--- a/connectors/agentic-ai/connector-agentic-ai/element-templates/hybrid/agenticai-ai-agent-subprocess.v2-hybrid.json
+++ b/connectors/agentic-ai/connector-agentic-ai/element-templates/hybrid/agenticai-ai-agent-subprocess.v2-hybrid.json
@@ -117,6 +117,13 @@
     },
     "type" : "Hidden"
   }, {
+    "value" : "aiAgentSubProcess",
+    "binding" : {
+      "type" : "zeebe:agentDefinition",
+      "property" : "agentType"
+    },
+    "type" : "Hidden"
+  }, {
     "id" : "provider.type",
     "label" : "Provider",
     "description" : "Specify the LLM provider to use.",

--- a/connectors/agentic-ai/connector-agentic-ai/element-templates/hybrid/agenticai-ai-agent-task.v2-hybrid.json
+++ b/connectors/agentic-ai/connector-agentic-ai/element-templates/hybrid/agenticai-ai-agent-task.v2-hybrid.json
@@ -89,6 +89,13 @@
     },
     "type" : "String"
   }, {
+    "value" : "aiAgentTask",
+    "binding" : {
+      "type" : "zeebe:agentDefinition",
+      "property" : "agentType"
+    },
+    "type" : "Hidden"
+  }, {
     "id" : "provider.type",
     "label" : "Provider",
     "description" : "Specify the LLM provider to use.",

--- a/connectors/agentic-ai/connector-agentic-ai/element-templates/hybrid/agenticai-aiagent-job-worker-hybrid.json
+++ b/connectors/agentic-ai/connector-agentic-ai/element-templates/hybrid/agenticai-aiagent-job-worker-hybrid.json
@@ -108,6 +108,13 @@
     },
     "type" : "Hidden"
   }, {
+    "value" : "aiAgentSubProcess",
+    "binding" : {
+      "type" : "zeebe:agentDefinition",
+      "property" : "agentType"
+    },
+    "type" : "Hidden"
+  }, {
     "id" : "provider.type",
     "label" : "Provider",
     "description" : "Specify the LLM provider to use.",

--- a/connectors/agentic-ai/connector-agentic-ai/element-templates/hybrid/agenticai-aiagent-outbound-connector-hybrid.json
+++ b/connectors/agentic-ai/connector-agentic-ai/element-templates/hybrid/agenticai-aiagent-outbound-connector-hybrid.json
@@ -80,6 +80,13 @@
     },
     "type" : "String"
   }, {
+    "value" : "aiAgentTask",
+    "binding" : {
+      "type" : "zeebe:agentDefinition",
+      "property" : "agentType"
+    },
+    "type" : "Hidden"
+  }, {
     "id" : "provider.type",
     "label" : "Provider",
     "description" : "Specify the LLM provider to use.",

--- a/connectors/agentic-ai/connector-agentic-ai/element-templates/hybrid/agenticai-aiagent-outbound-connector-hybrid.json
+++ b/connectors/agentic-ai/connector-agentic-ai/element-templates/hybrid/agenticai-aiagent-outbound-connector-hybrid.json
@@ -5,7 +5,7 @@
   "description" : "Execute a single AI-powered action with tool calling capabilities",
   "keywords" : [ "AI", "AI Agent", "agentic orchestration" ],
   "documentationRef" : "https://docs.camunda.io/docs/8.10/components/connectors/out-of-the-box-connectors/agentic-ai-aiagent-task/",
-  "version" : 12,
+  "version" : 13,
   "category" : {
     "id" : "aiTools",
     "name" : "AI Tools"
@@ -1718,7 +1718,7 @@
     "id" : "version",
     "label" : "Version",
     "description" : "Version of the element template",
-    "value" : "12",
+    "value" : "13",
     "group" : "connector",
     "binding" : {
       "key" : "elementTemplateVersion",

--- a/connectors/agentic-ai/connector-agentic-ai/element-templates/versioned/agenticai-aiagent-job-worker-12.json
+++ b/connectors/agentic-ai/connector-agentic-ai/element-templates/versioned/agenticai-aiagent-job-worker-12.json
@@ -1,11 +1,11 @@
 {
   "$schema" : "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
-  "name" : "Hybrid AI Agent Sub-process",
-  "id" : "io.camunda.connectors.agenticai.aiagent.jobworker.v1-hybrid",
+  "name" : "AI Agent Sub-process",
+  "id" : "io.camunda.connectors.agenticai.aiagent.jobworker.v1",
   "description" : "Run a multi-step AI reasoning loop with dynamic tool selection",
   "keywords" : [ "AI", "AI Agent", "agentic orchestration" ],
   "documentationRef" : "https://docs.camunda.io/docs/8.10/components/connectors/out-of-the-box-connectors/agentic-ai-aiagent-subprocess/",
-  "version" : 13,
+  "version" : 12,
   "category" : {
     "id" : "aiTools",
     "name" : "AI Tools"
@@ -18,9 +18,6 @@
     "camunda" : "^8.10"
   },
   "groups" : [ {
-    "id" : "taskDefinitionType",
-    "label" : "Task definition type"
-  }, {
     "id" : "provider",
     "label" : "Model provider",
     "openByDefault" : false
@@ -76,14 +73,12 @@
     "label" : "Retries"
   } ],
   "properties" : [ {
-    "id" : "taskDefinitionType",
     "value" : "io.camunda.agenticai:aiagent-job-worker:1",
-    "group" : "taskDefinitionType",
     "binding" : {
       "property" : "type",
       "type" : "zeebe:taskDefinition"
     },
-    "type" : "String"
+    "type" : "Hidden"
   }, {
     "id" : "outputCollection",
     "binding" : {
@@ -1751,7 +1746,7 @@
     "id" : "version",
     "label" : "Version",
     "description" : "Version of the element template",
-    "value" : "13",
+    "value" : "12",
     "group" : "connector",
     "binding" : {
       "key" : "elementTemplateVersion",

--- a/connectors/agentic-ai/connector-agentic-ai/element-templates/versioned/agenticai-aiagent-outbound-connector-12.json
+++ b/connectors/agentic-ai/connector-agentic-ai/element-templates/versioned/agenticai-aiagent-outbound-connector-12.json
@@ -1,26 +1,23 @@
 {
   "$schema" : "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
-  "name" : "Hybrid AI Agent Sub-process",
-  "id" : "io.camunda.connectors.agenticai.aiagent.jobworker.v1-hybrid",
-  "description" : "Run a multi-step AI reasoning loop with dynamic tool selection",
+  "name" : "AI Agent Task",
+  "id" : "io.camunda.connectors.agenticai.aiagent.v1",
+  "description" : "Execute a single AI-powered action with tool calling capabilities",
   "keywords" : [ "AI", "AI Agent", "agentic orchestration" ],
-  "documentationRef" : "https://docs.camunda.io/docs/8.10/components/connectors/out-of-the-box-connectors/agentic-ai-aiagent-subprocess/",
-  "version" : 13,
+  "documentationRef" : "https://docs.camunda.io/docs/8.10/components/connectors/out-of-the-box-connectors/agentic-ai-aiagent-task/",
+  "version" : 12,
   "category" : {
     "id" : "aiTools",
     "name" : "AI Tools"
   },
-  "appliesTo" : [ "bpmn:SubProcess" ],
+  "appliesTo" : [ "bpmn:Task" ],
   "elementType" : {
-    "value" : "bpmn:AdHocSubProcess"
+    "value" : "bpmn:ServiceTask"
   },
   "engines" : {
     "camunda" : "^8.10"
   },
   "groups" : [ {
-    "id" : "taskDefinitionType",
-    "label" : "Task definition type"
-  }, {
     "id" : "provider",
     "label" : "Model provider",
     "openByDefault" : false
@@ -53,14 +50,9 @@
     "label" : "Limits",
     "openByDefault" : false
   }, {
-    "id" : "events",
-    "label" : "Event handling",
-    "tooltip" : "Configure how event sub-process results are handled. Results are added as user messages to the running agent.",
-    "openByDefault" : false
-  }, {
     "id" : "response",
     "label" : "Response",
-    "tooltip" : "Configuration of the model response format and how to map the model response to the connector result.<br><br>Depending on the selection, the model response will be available as <code>response.responseText</code> or <code>response.responseJson</code>.<br><br>See <a href=\"https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/agentic-ai-aiagent-subprocess/#response\">documentation</a> for details.",
+    "tooltip" : "Configuration of the model response format and how to map the model response to the connector result.<br><br>Depending on the selection, the model response will be available as <code>response.responseText</code> or <code>response.responseJson</code>.<br><br>See <a href=\"https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/agentic-ai-aiagent-task/#response\">documentation</a> for details.",
     "openByDefault" : false
   }, {
     "id" : "connector",
@@ -76,35 +68,10 @@
     "label" : "Retries"
   } ],
   "properties" : [ {
-    "id" : "taskDefinitionType",
-    "value" : "io.camunda.agenticai:aiagent-job-worker:1",
-    "group" : "taskDefinitionType",
+    "value" : "io.camunda.agenticai:aiagent:1",
     "binding" : {
       "property" : "type",
       "type" : "zeebe:taskDefinition"
-    },
-    "type" : "String"
-  }, {
-    "id" : "outputCollection",
-    "binding" : {
-      "property" : "outputCollection",
-      "type" : "zeebe:adHoc"
-    },
-    "value" : "toolCallResults",
-    "type" : "Hidden"
-  }, {
-    "id" : "outputElement",
-    "binding" : {
-      "property" : "outputElement",
-      "type" : "zeebe:adHoc"
-    },
-    "value" : "={\n  id: toolCall._meta.id,\n  name: toolCall._meta.name,\n  content: toolCallResult,\n  completedAt: now()\n}",
-    "type" : "Hidden"
-  }, {
-    "value" : "true",
-    "binding" : {
-      "name" : "io.camunda.agenticai.toolContainer",
-      "type" : "zeebe:property"
     },
     "type" : "Hidden"
   }, {
@@ -1336,20 +1303,50 @@
       "name" : "data.userPrompt.documents",
       "type" : "zeebe:input"
     },
-    "tooltip" : "Referenced documents will be automatically added to the user prompt. <a href=\"https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/agentic-ai-aiagent-subprocess/\" target=\"_blank\">See documentation</a> for details and supported file types.",
+    "tooltip" : "Referenced documents will be automatically added to the user prompt. <a href=\"https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/agentic-ai-aiagent-task/\" target=\"_blank\">See documentation</a> for details and supported file types.",
     "type" : "String"
   }, {
-    "id" : "agentContext",
+    "id" : "data.tools.containerElementId",
+    "label" : "Ad-hoc sub-process ID",
+    "description" : "ID of the sub-process that contains the tools the AI agent can use.",
+    "optional" : true,
+    "feel" : "optional",
+    "group" : "tools",
+    "binding" : {
+      "name" : "data.tools.containerElementId",
+      "type" : "zeebe:input"
+    },
+    "tooltip" : "Add an ad-hoc sub-process ID to attach the AI agent to the tools. Ensure your process includes a tools feedback loop routing into the ad-hoc sub-process and back to the AI agent connector. <a href=\"https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/agentic-ai-aiagent-task/\" target=\"_blank\">See documentation</a> for details.",
+    "type" : "String"
+  }, {
+    "id" : "data.tools.toolCallResults",
+    "label" : "Tool call results",
+    "description" : "Tool call results as returned by the sub-process.",
+    "optional" : true,
+    "feel" : "required",
+    "group" : "tools",
+    "binding" : {
+      "name" : "data.tools.toolCallResults",
+      "type" : "zeebe:input"
+    },
+    "tooltip" : "This defines where to handle tool call results returned by the ad-hoc sub-process. Model this as part of your process and route it into the tools feedback loop. <a href=\"https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/agentic-ai-aiagent-task/\" target=\"_blank\">See documentation</a> for details.",
+    "type" : "Text"
+  }, {
+    "id" : "data.agentContext",
     "label" : "Agent context",
-    "description" : "Initial agent context from previous interactions. Avoid reusing context variables across agents to prevent issues with stale data or tool access.",
+    "description" : "Avoid reusing context variables across agents to prevent issues with stale data or tool access.",
     "optional" : false,
+    "value" : "=agent.context",
+    "constraints" : {
+      "notEmpty" : true
+    },
     "feel" : "required",
     "group" : "memory",
     "binding" : {
-      "name" : "agentContext",
+      "name" : "data.context",
       "type" : "zeebe:input"
     },
-    "tooltip" : "The agent context variable containing all relevant data for the agent to support the feedback loop between user requests, tool calls and LLM responses. Make sure this variable points to the <code>context</code> variable which is returned from the agent response. <a href=\"https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/agentic-ai-aiagent-subprocess/\" target=\"_blank\">See documentation</a> for details.",
+    "tooltip" : "The agent context variable containing all relevant data for the agent to support the feedback loop between user requests, tool calls and LLM responses. Make sure this variable points to the <code>context</code> variable which is returned from the agent response. <a href=\"https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/agentic-ai-aiagent-task/\" target=\"_blank\">See documentation</a> for details.",
     "type" : "Text"
   }, {
     "id" : "data.memory.storage.type",
@@ -1612,7 +1609,7 @@
       "name" : "data.memory.contextWindowSize",
       "type" : "zeebe:input"
     },
-    "tooltip" : "Use this to limit the number of messages which are sent to the model. The agent will only send the most recent messages up to the configured limit to the LLM. Older messages will be kept in the conversation store, but not sent to the model. <a href=\"https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/agentic-ai-aiagent-subprocess/\" target=\"_blank\">See documentation</a> for details.",
+    "tooltip" : "Use this to limit the number of messages which are sent to the model. The agent will only send the most recent messages up to the configured limit to the LLM. Older messages will be kept in the conversation store, but not sent to the model. <a href=\"https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/agentic-ai-aiagent-task/\" target=\"_blank\">See documentation</a> for details.",
     "type" : "Number"
   }, {
     "id" : "data.limits.maxModelCalls",
@@ -1627,28 +1624,6 @@
       "type" : "zeebe:input"
     },
     "type" : "Number"
-  }, {
-    "id" : "data.events.behavior",
-    "label" : "Event handling behavior",
-    "description" : "Behavior on completing an event sub-process.",
-    "optional" : false,
-    "value" : "WAIT_FOR_TOOL_CALL_RESULTS",
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "group" : "events",
-    "binding" : {
-      "name" : "data.events.behavior",
-      "type" : "zeebe:input"
-    },
-    "type" : "Dropdown",
-    "choices" : [ {
-      "name" : "Wait for tool call results",
-      "value" : "WAIT_FOR_TOOL_CALL_RESULTS"
-    }, {
-      "name" : "Cancel tool calls",
-      "value" : "INTERRUPT_TOOL_CALLS"
-    } ]
   }, {
     "id" : "data.response.format.type",
     "label" : "Response format",
@@ -1735,23 +1710,10 @@
     "tooltip" : "In addition to the text content, the assistant message may include multiple additional content blocks and metadata (such as token usage). The message will be available as <code>response.responseMessage</code>.",
     "type" : "Boolean"
   }, {
-    "id" : "data.response.includeAgentContext",
-    "label" : "Include agent context",
-    "description" : "Include the agent context as part of the result object.",
-    "optional" : true,
-    "feel" : "static",
-    "group" : "response",
-    "binding" : {
-      "name" : "data.response.includeAgentContext",
-      "type" : "zeebe:input"
-    },
-    "tooltip" : "Use this option if you need to re-inject the previous agent context into a future agent execution, for example when modeling a user feedback loop between an agent and a user task.",
-    "type" : "Boolean"
-  }, {
     "id" : "version",
     "label" : "Version",
     "description" : "Version of the element template",
-    "value" : "13",
+    "value" : "12",
     "group" : "connector",
     "binding" : {
       "key" : "elementTemplateVersion",
@@ -1762,7 +1724,7 @@
     "id" : "id",
     "label" : "ID",
     "description" : "ID of the element template",
-    "value" : "io.camunda.connectors.agenticai.aiagent.jobworker.v1",
+    "value" : "io.camunda.connectors.agenticai.aiagent.v1",
     "group" : "connector",
     "binding" : {
       "key" : "elementTemplateId",
@@ -1776,10 +1738,22 @@
     "value" : "agent",
     "group" : "output",
     "binding" : {
-      "source" : "=agent",
-      "type" : "zeebe:output"
+      "key" : "resultVariable",
+      "type" : "zeebe:taskHeader"
     },
     "type" : "String"
+  }, {
+    "id" : "resultExpression",
+    "label" : "Result expression",
+    "description" : "Expression to map the response into process variables. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-expression\" target=\"_blank\">documentation</a>.",
+    "feel" : "required",
+    "group" : "output",
+    "binding" : {
+      "key" : "resultExpression",
+      "type" : "zeebe:taskHeader"
+    },
+    "tooltip" : "<div><p>Example response:</p><code>{\"context\":{\"metrics\":{\"modelCalls\":3,\"tokenUsage\":{\"inputTokenCount\":10,\"outputTokenCount\":20},\"toolCalls\":0},\"schemaVersion\":1,\"state\":\"READY\",\"toolDefinitions\":[{\"description\":\"A sample tool for demonstration purposes.\",\"inputSchema\":{\"properties\":{\"input1\":{\"type\":\"string\"},\"input2\":{\"type\":\"number\"}},\"required\":[\"input1\",\"input2\"],\"type\":\"object\"},\"name\":\"sampleTool\"}]},\"responseText\":\"This is a sample response text from the AI agent.\",\"toolCalls\":[]}</code><p>Example FEEL expression: <code>={ responseText: responseText }</code> -&gt; <code>{\"responseText\":\"This is a sample response text from the AI agent.\"}</code></p></div>",
+    "type" : "Text"
   }, {
     "id" : "errorExpression",
     "label" : "Error expression",
@@ -1825,12 +1799,6 @@
       "type" : "zeebe:taskHeader"
     },
     "type" : "String"
-  }, {
-    "binding" : {
-      "name" : "agent",
-      "type" : "zeebe:input"
-    },
-    "type" : "Hidden"
   } ],
   "icon" : {
     "contents" : "data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMzIiIGhlaWdodD0iMzIiIHZpZXdCb3g9IjAgMCAzMiAzMiIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPGNpcmNsZSBjeD0iMTYiIGN5PSIxNiIgcj0iMTYiIGZpbGw9IiNBNTZFRkYiLz4KPG1hc2sgaWQ9InBhdGgtMi1vdXRzaWRlLTFfMTg1XzYiIG1hc2tVbml0cz0idXNlclNwYWNlT25Vc2UiIHg9IjQiIHk9IjQiIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgZmlsbD0iYmxhY2siPgo8cmVjdCBmaWxsPSJ3aGl0ZSIgeD0iNCIgeT0iNCIgd2lkdGg9IjI0IiBoZWlnaHQ9IjI0Ii8+CjxwYXRoIGZpbGwtcnVsZT0iZXZlbm9kZCIgY2xpcC1ydWxlPSJldmVub2RkIiBkPSJNMjAuMDEwNSAxMi4wOTg3QzE4LjQ5IDEwLjU4OTQgMTcuMTU5NCA4LjEwODE0IDE2LjE3OTkgNi4wMTEwM0MxNi4xNTIgNi4wMDQ1MSAxNi4xMTc2IDYgMTYuMDc5NCA2QzE2LjA0MTEgNiAxNi4wMDY2IDYuMDA0NTEgMTUuOTc4OCA2LjAxMTA0QzE0Ljk5OTQgOC4xMDgxNCAxMy42Njk3IDEwLjU4ODkgMTIuMTQ4MSAxMi4wOTgxQzEwLjYyNjkgMTMuNjA3MSA4LjEyNTY4IDE0LjkyNjQgNi4wMTE1NyAxNS44OTgxQzYuMDA0NzQgMTUuOTI2MSA2IDE1Ljk2MTEgNiAxNkM2IDE2LjAzODcgNi4wMDQ2OCAxNi4wNzM2IDYuMDExNDQgMTYuMTAxNEM4LjEyNTE5IDE3LjA3MjkgMTAuNjI2MiAxOC4zOTE5IDEyLjE0NzcgMTkuOTAxNkMxMy42Njk3IDIxLjQxMDcgMTQuOTk5NiAyMy44OTIgMTUuOTc5MSAyNS45ODlDMTYuMDA2OCAyNS45OTU2IDE2LjA0MTEgMjYgMTYuMDc5MyAyNkMxNi4xMTc1IDI2IDE2LjE1MTkgMjUuOTk1NCAxNi4xNzk2IDI1Ljk4OUMxNy4xNTkxIDIzLjg5MiAxOC40ODg4IDIxLjQxMSAyMC4wMDk5IDE5LjkwMjFNMjAuMDA5OSAxOS45MDIxQzIxLjUyNTMgMTguMzk4NyAyMy45NDY1IDE3LjA2NjkgMjUuOTkxNSAxNi4wODI0QzI1Ljk5NjUgMTYuMDU5MyAyNiAxNi4wMzEgMjYgMTUuOTk5N0MyNiAxNS45Njg0IDI1Ljk5NjUgMTUuOTQwMyAyNS45OTE1IDE1LjkxNzFDMjMuOTQ3NCAxNC45MzI3IDIxLjUyNTkgMTMuNjAxIDIwLjAxMDUgMTIuMDk4NyIvPgo8L21hc2s+CjxwYXRoIGZpbGwtcnVsZT0iZXZlbm9kZCIgY2xpcC1ydWxlPSJldmVub2RkIiBkPSJNMjAuMDEwNSAxMi4wOTg3QzE4LjQ5IDEwLjU4OTQgMTcuMTU5NCA4LjEwODE0IDE2LjE3OTkgNi4wMTEwM0MxNi4xNTIgNi4wMDQ1MSAxNi4xMTc2IDYgMTYuMDc5NCA2QzE2LjA0MTEgNiAxNi4wMDY2IDYuMDA0NTEgMTUuOTc4OCA2LjAxMTA0QzE0Ljk5OTQgOC4xMDgxNCAxMy42Njk3IDEwLjU4ODkgMTIuMTQ4MSAxMi4wOTgxQzEwLjYyNjkgMTMuNjA3MSA4LjEyNTY4IDE0LjkyNjQgNi4wMTE1NyAxNS44OTgxQzYuMDA0NzQgMTUuOTI2MSA2IDE1Ljk2MTEgNiAxNkM2IDE2LjAzODcgNi4wMDQ2OCAxNi4wNzM2IDYuMDExNDQgMTYuMTAxNEM4LjEyNTE5IDE3LjA3MjkgMTAuNjI2MiAxOC4zOTE5IDEyLjE0NzcgMTkuOTAxNkMxMy42Njk3IDIxLjQxMDcgMTQuOTk5NiAyMy44OTIgMTUuOTc5MSAyNS45ODlDMTYuMDA2OCAyNS45OTU2IDE2LjA0MTEgMjYgMTYuMDc5MyAyNkMxNi4xMTc1IDI2IDE2LjE1MTkgMjUuOTk1NCAxNi4xNzk2IDI1Ljk4OUMxNy4xNTkxIDIzLjg5MiAxOC40ODg4IDIxLjQxMSAyMC4wMDk5IDE5LjkwMjFNMjAuMDA5OSAxOS45MDIxQzIxLjUyNTMgMTguMzk4NyAyMy45NDY1IDE3LjA2NjkgMjUuOTkxNSAxNi4wODI0QzI1Ljk5NjUgMTYuMDU5MyAyNiAxNi4wMzEgMjYgMTUuOTk5N0MyNiAxNS45Njg0IDI1Ljk5NjUgMTUuOTQwMyAyNS45OTE1IDE1LjkxNzFDMjMuOTQ3NCAxNC45MzI3IDIxLjUyNTkgMTMuNjAxIDIwLjAxMDUgMTIuMDk4NyIgZmlsbD0id2hpdGUiLz4KPHBhdGggZmlsbC1ydWxlPSJldmVub2RkIiBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGQ9Ik0yMC4wMTA1IDEyLjA5ODdDMTguNDkgMTAuNTg5NCAxNy4xNTk0IDguMTA4MTQgMTYuMTc5OSA2LjAxMTAzQzE2LjE1MiA2LjAwNDUxIDE2LjExNzYgNiAxNi4wNzk0IDZDMTYuMDQxMSA2IDE2LjAwNjYgNi4wMDQ1MSAxNS45Nzg4IDYuMDExMDRDMTQuOTk5NCA4LjEwODE0IDEzLjY2OTcgMTAuNTg4OSAxMi4xNDgxIDEyLjA5ODFDMTAuNjI2OSAxMy42MDcxIDguMTI1NjggMTQuOTI2NCA2LjAxMTU3IDE1Ljg5ODFDNi4wMDQ3NCAxNS45MjYxIDYgMTUuOTYxMSA2IDE2QzYgMTYuMDM4NyA2LjAwNDY4IDE2LjA3MzYgNi4wMTE0NCAxNi4xMDE0QzguMTI1MTkgMTcuMDcyOSAxMC42MjYyIDE4LjM5MTkgMTIuMTQ3NyAxOS45MDE2QzEzLjY2OTcgMjEuNDEwNyAxNC45OTk2IDIzLjg5MiAxNS45NzkxIDI1Ljk4OUMxNi4wMDY4IDI1Ljk5NTYgMTYuMDQxMSAyNiAxNi4wNzkzIDI2QzE2LjExNzUgMjYgMTYuMTUxOSAyNS45OTU0IDE2LjE3OTYgMjUuOTg5QzE3LjE1OTEgMjMuODkyIDE4LjQ4ODggMjEuNDExIDIwLjAwOTkgMTkuOTAyMU0yMC4wMDk5IDE5LjkwMjFDMjEuNTI1MyAxOC4zOTg3IDIzLjk0NjUgMTcuMDY2OSAyNS45OTE1IDE2LjA4MjRDMjUuOTk2NSAxNi4wNTkzIDI2IDE2LjAzMSAyNiAxNS45OTk3QzI2IDE1Ljk2ODQgMjUuOTk2NSAxNS45NDAzIDI1Ljk5MTUgMTUuOTE3MUMyMy45NDc0IDE0LjkzMjcgMjEuNTI1OSAxMy42MDEgMjAuMDEwNSAxMi4wOTg3IiBzdHJva2U9IiM0OTFEOEIiIHN0cm9rZS13aWR0aD0iNCIgc3Ryb2tlLWxpbmVqb2luPSJyb3VuZCIgbWFzaz0idXJsKCNwYXRoLTItb3V0c2lkZS0xXzE4NV82KSIvPgo8L3N2Zz4K"

--- a/connectors/agentic-ai/connector-agentic-ai/pom.xml
+++ b/connectors/agentic-ai/connector-agentic-ai/pom.xml
@@ -724,6 +724,10 @@
                   <name>connectorType</name>
                   <value>io.camunda.agenticai:aiagent:subprocess:2</value>
                 </property>
+                <property>
+                  <name>agentType</name>
+                  <value>aiAgentSubProcess</value>
+                </property>
               </properties>
             </configuration>
           </execution>
@@ -757,6 +761,66 @@
                 <property>
                   <name>connectorType</name>
                   <value>io.camunda.agenticai:aiagent:subprocess:2</value>
+                </property>
+                <property>
+                  <name>agentType</name>
+                  <value>aiAgentSubProcess</value>
+                </property>
+              </properties>
+            </configuration>
+          </execution>
+          <execution>
+            <id>add-agent-definition-marker-task-v2</id>
+            <phase>process-classes</phase>
+            <goals>
+              <goal>execute</goal>
+            </goals>
+            <configuration>
+              <scripts>
+                <script>file:///${project.basedir}/bin/transform-ai-agent-task-template.groovy</script>
+              </scripts>
+              <properties>
+                <property>
+                  <name>sourceFile</name>
+                  <value>${project.basedir}/element-templates/agenticai-ai-agent-task.v2.json</value>
+                </property>
+                <property>
+                  <name>outputFile</name>
+                  <value>${project.basedir}/element-templates/agenticai-ai-agent-task.v2.json</value>
+                </property>
+                <property>
+                  <name>agentType</name>
+                  <value>aiAgentTask</value>
+                </property>
+              </properties>
+            </configuration>
+          </execution>
+          <execution>
+            <id>add-agent-definition-marker-task-v2-hybrid</id>
+            <phase>process-classes</phase>
+            <goals>
+              <goal>execute</goal>
+            </goals>
+            <configuration>
+              <scripts>
+                <script>file:///${project.basedir}/bin/transform-ai-agent-task-template.groovy</script>
+              </scripts>
+              <properties>
+                <property>
+                  <name>sourceFile</name>
+                  <value>
+                    ${project.basedir}/element-templates/hybrid/agenticai-ai-agent-task.v2-hybrid.json
+                  </value>
+                </property>
+                <property>
+                  <name>outputFile</name>
+                  <value>
+                    ${project.basedir}/element-templates/hybrid/agenticai-ai-agent-task.v2-hybrid.json
+                  </value>
+                </property>
+                <property>
+                  <name>agentType</name>
+                  <value>aiAgentTask</value>
                 </property>
               </properties>
             </configuration>

--- a/connectors/agentic-ai/connector-agentic-ai/pom.xml
+++ b/connectors/agentic-ai/connector-agentic-ai/pom.xml
@@ -660,6 +660,10 @@
                   <name>connectorType</name>
                   <value>io.camunda.agenticai:aiagent-job-worker:1</value>
                 </property>
+                <property>
+                  <name>agentType</name>
+                  <value>aiAgentSubProcess</value>
+                </property>
               </properties>
             </configuration>
           </execution>
@@ -693,6 +697,66 @@
                 <property>
                   <name>connectorType</name>
                   <value>io.camunda.agenticai:aiagent-job-worker:1</value>
+                </property>
+                <property>
+                  <name>agentType</name>
+                  <value>aiAgentSubProcess</value>
+                </property>
+              </properties>
+            </configuration>
+          </execution>
+          <execution>
+            <id>add-agent-definition-marker-task-v1</id>
+            <phase>process-classes</phase>
+            <goals>
+              <goal>execute</goal>
+            </goals>
+            <configuration>
+              <scripts>
+                <script>file:///${project.basedir}/bin/transform-ai-agent-task-template.groovy</script>
+              </scripts>
+              <properties>
+                <property>
+                  <name>sourceFile</name>
+                  <value>${project.basedir}/element-templates/agenticai-aiagent-outbound-connector.json</value>
+                </property>
+                <property>
+                  <name>outputFile</name>
+                  <value>${project.basedir}/element-templates/agenticai-aiagent-outbound-connector.json</value>
+                </property>
+                <property>
+                  <name>agentType</name>
+                  <value>aiAgentTask</value>
+                </property>
+              </properties>
+            </configuration>
+          </execution>
+          <execution>
+            <id>add-agent-definition-marker-task-v1-hybrid</id>
+            <phase>process-classes</phase>
+            <goals>
+              <goal>execute</goal>
+            </goals>
+            <configuration>
+              <scripts>
+                <script>file:///${project.basedir}/bin/transform-ai-agent-task-template.groovy</script>
+              </scripts>
+              <properties>
+                <property>
+                  <name>sourceFile</name>
+                  <value>
+                    ${project.basedir}/element-templates/hybrid/agenticai-aiagent-outbound-connector-hybrid.json
+                  </value>
+                </property>
+                <property>
+                  <name>outputFile</name>
+                  <value>
+                    ${project.basedir}/element-templates/hybrid/agenticai-aiagent-outbound-connector-hybrid.json
+                  </value>
+                </property>
+                <property>
+                  <name>agentType</name>
+                  <value>aiAgentTask</value>
                 </property>
               </properties>
             </configuration>

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/AgentTaskV1Function.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/AgentTaskV1Function.java
@@ -39,7 +39,7 @@ import io.camunda.connector.generator.java.annotation.ElementTemplate.PropertyGr
     documentationRef =
         "https://docs.camunda.io/docs/8.10/components/connectors/out-of-the-box-connectors/agentic-ai-aiagent-task/",
     engineVersion = "^8.10",
-    version = 12,
+    version = 13,
     category = @ElementTemplate.Category(id = "aiTools", name = "AI Tools"),
     inputDataClass = AgentTaskV1Request.class,
     outputDataClass = AgentResponse.class,


### PR DESCRIPTION
## Description

Adds a hidden `zeebe:agentDefinition` property to both the v1 and v2 AI Agent Task and AI Agent Sub-process element templates (all flavors, including hybrid), so the engine can detect a native agent at deploy time and create an agent-definition record for it.

`transform-ai-agent-task-template.groovy` adds the marker to each task template (`agentType=aiAgentTask`). `transform-ai-agent-sub-process-template.groovy` adds its own (`agentType=aiAgentSubProcess`) to the derived sub-process template. Both take `agentType` as an optional Maven property, and both drop any incoming `zeebe:agentDefinition` property before adding their own, so a stale marker can never be carried over regardless of pom execution order. The v1 templates are bumped to version 13 (existing version 12 backed up under `versioned/`).

With the marker now applied straight from the template, `element-templates-cli` is bumped to 0.7.0 (which can apply it), and the `BpmnUtil.withAgentDefinitionMarker` e2e workaround — which manually injected the marker onto the model after template application — is removed, along with its call sites in `BaseAgentSubProcessTest`/`BaseAgentTaskTest`/`DocumentToolCallResultsIT`/`RealProviderApiSmokeIT`.

## Related issues

closes #8176
closes #8380

## Checklist

- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest
  release, as this branch will be rebased onto main before the next release. Example backport labels:
    - `backport stable/8.8`: for changes that should be included in the next 8.8.x release.
    - **or** `backport release-8.8.7`: for changes that should be included in the specific release 8.8.7, and this
      *release has already been created*. The release branch will be merged back into stable/8.8 later, so the change
      will be included in future 8.8.x releases as well.
- [x] Tests/Integration tests for the changes have been added if applicable.
- [ ] If the change requires a documentation update, it has been added to the appropriate section in the documentation.