### PR TITLE
fix(agentic-ai): align agent instance API usage with camunda-client 8.10

### DIFF
--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/agentinstance/AgentInstanceToolMapper.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/agentinstance/AgentInstanceToolMapper.java
@@ -6,7 +6,7 @@
  */
 package io.camunda.connector.agenticai.aiagent.agentinstance;
 
-import io.camunda.client.api.command.UpdateAgentInstanceCommandStep1.AgentTool;
+import io.camunda.client.api.command.AgentTool;
 import io.camunda.connector.agenticai.aiagent.model.tool.ToolDefinition;
 import io.camunda.connector.agenticai.aiagent.tool.GatewayToolHandlerRegistry;
 import java.util.List;

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/agentinstance/CamundaAgentInstanceClientTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/agentinstance/CamundaAgentInstanceClientTest.java
@@ -27,12 +27,12 @@ import io.camunda.client.api.command.AgentInstanceHistoryContent;
 import io.camunda.client.api.command.AgentInstanceHistoryMetrics;
 import io.camunda.client.api.command.AgentInstanceHistoryToolCall;
 import io.camunda.client.api.command.AgentInstanceUpdateStatus;
+import io.camunda.client.api.command.AgentTool;
 import io.camunda.client.api.command.ClientHttpException;
 import io.camunda.client.api.command.CreateAgentInstanceCommandStep1;
-import io.camunda.client.api.command.CreateAgentInstanceCommandStep1.CreateAgentInstanceCommandStep5;
+import io.camunda.client.api.command.CreateAgentInstanceCommandStep1.CreateAgentInstanceCommandStep2;
 import io.camunda.client.api.command.ProblemException;
 import io.camunda.client.api.command.UpdateAgentInstanceCommandStep1;
-import io.camunda.client.api.command.UpdateAgentInstanceCommandStep1.AgentTool;
 import io.camunda.client.api.command.UpdateAgentInstanceCommandStep1.UpdateAgentInstanceCommandStep2;
 import io.camunda.client.api.response.CreateAgentInstanceResponse;
 import io.camunda.client.api.search.enums.AgentInstanceHistoryRole;
@@ -116,7 +116,7 @@ class CamundaAgentInstanceClientTest {
   @Mock(answer = Answers.RETURNS_SELF)
   private CreateAgentHistoryItemCommandImpl historyCommand;
 
-  private CreateAgentInstanceCommandStep5 step5;
+  private CreateAgentInstanceCommandStep2 step5;
 
   @Mock private GatewayToolHandlerRegistry gatewayToolHandlers;
 


### PR DESCRIPTION
## Description

`camunda-client` 8.10 moved `AgentTool` to the top-level `io.camunda.client.api.command` package and collapsed the create-agent-instance command chain into a self-returning `Step2`. Update `AgentInstanceToolMapper` to the new `AgentTool` import and fix the stale `AgentTool` / `CreateAgentInstanceCommandStep5` references in its client test. Production wiring already used the new API; only these two files lagged.

## Related issues

None.

## Checklist

- [ ] Backport labels are added if these code changes should be backported.
- [x] Tests/Integration tests for the changes have been added if applicable.
- [ ] If the change requires a documentation update, it has been added to the appropriate section in the documentation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
