### PR TITLE
fix(agentic-ai): normalize Foundry endpoints onto the unified OpenAI/v1 API surface

### DIFF
--- a/connectors/agentic-ai/connector-agentic-ai/element-templates/agenticai-ai-agent-subprocess.v2.json
+++ b/connectors/agentic-ai/connector-agentic-ai/element-templates/agenticai-ai-agent-subprocess.v2.json
@@ -990,14 +990,40 @@
     },
     "type" : "String"
   }, {
-    "id" : "provider.openai.backend.foundry.authentication.managedIdentityClientId",
+    "id" : "provider.openai.backend.foundry.authentication.entraIdScope",
+    "label" : "Entra ID scope",
+    "description" : "Overrides the Microsoft Entra ID token scope requested for this authentication flow. Leave unset to let the automatically detected Azure cloud pick its own default.",
+    "optional" : true,
+    "group" : "provider",
+    "binding" : {
+      "name" : "provider.openai.backend.foundry.authentication.entraIdScope",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "allMatch" : [ {
+        "property" : "provider.openai.backend.foundry.authentication.type",
+        "equals" : "clientCredentials",
+        "type" : "simple"
+      }, {
+        "property" : "provider.openai.backend.type",
+        "equals" : "foundry",
+        "type" : "simple"
+      }, {
+        "property" : "provider.type",
+        "equals" : "openai",
+        "type" : "simple"
+      } ]
+    },
+    "type" : "Hidden"
+  }, {
+    "id" : "provider.openai.backend.foundry.authentication.managedIdentity.clientId",
     "label" : "Client ID",
     "description" : "Client ID of a user-assigned managed identity. Leave unset to use the system-assigned managed identity.",
     "optional" : true,
     "feel" : "optional",
     "group" : "provider",
     "binding" : {
-      "name" : "provider.openai.backend.foundry.authentication.managedIdentityClientId",
+      "name" : "provider.openai.backend.foundry.authentication.clientId",
       "type" : "zeebe:input"
     },
     "condition" : {
@@ -1016,6 +1042,32 @@
       } ]
     },
     "type" : "String"
+  }, {
+    "id" : "provider.openai.backend.foundry.authentication.managedIdentity.entraIdScope",
+    "label" : "Entra ID scope",
+    "description" : "Overrides the Microsoft Entra ID token scope requested for this authentication flow. Leave unset to let the automatically detected Azure cloud pick its own default.",
+    "optional" : true,
+    "group" : "provider",
+    "binding" : {
+      "name" : "provider.openai.backend.foundry.authentication.entraIdScope",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "allMatch" : [ {
+        "property" : "provider.openai.backend.foundry.authentication.type",
+        "equals" : "managedIdentity",
+        "type" : "simple"
+      }, {
+        "property" : "provider.openai.backend.type",
+        "equals" : "foundry",
+        "type" : "simple"
+      }, {
+        "property" : "provider.type",
+        "equals" : "openai",
+        "type" : "simple"
+      } ]
+    },
+    "type" : "Hidden"
   }, {
     "id" : "provider.openai.backend.custom.endpoint",
     "label" : "API endpoint",

--- a/connectors/agentic-ai/connector-agentic-ai/element-templates/agenticai-ai-agent-task.v2.json
+++ b/connectors/agentic-ai/connector-agentic-ai/element-templates/agenticai-ai-agent-task.v2.json
@@ -962,14 +962,40 @@
     },
     "type" : "String"
   }, {
-    "id" : "provider.openai.backend.foundry.authentication.managedIdentityClientId",
+    "id" : "provider.openai.backend.foundry.authentication.entraIdScope",
+    "label" : "Entra ID scope",
+    "description" : "Overrides the Microsoft Entra ID token scope requested for this authentication flow. Leave unset to let the automatically detected Azure cloud pick its own default.",
+    "optional" : true,
+    "group" : "provider",
+    "binding" : {
+      "name" : "provider.openai.backend.foundry.authentication.entraIdScope",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "allMatch" : [ {
+        "property" : "provider.openai.backend.foundry.authentication.type",
+        "equals" : "clientCredentials",
+        "type" : "simple"
+      }, {
+        "property" : "provider.openai.backend.type",
+        "equals" : "foundry",
+        "type" : "simple"
+      }, {
+        "property" : "provider.type",
+        "equals" : "openai",
+        "type" : "simple"
+      } ]
+    },
+    "type" : "Hidden"
+  }, {
+    "id" : "provider.openai.backend.foundry.authentication.managedIdentity.clientId",
     "label" : "Client ID",
     "description" : "Client ID of a user-assigned managed identity. Leave unset to use the system-assigned managed identity.",
     "optional" : true,
     "feel" : "optional",
     "group" : "provider",
     "binding" : {
-      "name" : "provider.openai.backend.foundry.authentication.managedIdentityClientId",
+      "name" : "provider.openai.backend.foundry.authentication.clientId",
       "type" : "zeebe:input"
     },
     "condition" : {
@@ -988,6 +1014,32 @@
       } ]
     },
     "type" : "String"
+  }, {
+    "id" : "provider.openai.backend.foundry.authentication.managedIdentity.entraIdScope",
+    "label" : "Entra ID scope",
+    "description" : "Overrides the Microsoft Entra ID token scope requested for this authentication flow. Leave unset to let the automatically detected Azure cloud pick its own default.",
+    "optional" : true,
+    "group" : "provider",
+    "binding" : {
+      "name" : "provider.openai.backend.foundry.authentication.entraIdScope",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "allMatch" : [ {
+        "property" : "provider.openai.backend.foundry.authentication.type",
+        "equals" : "managedIdentity",
+        "type" : "simple"
+      }, {
+        "property" : "provider.openai.backend.type",
+        "equals" : "foundry",
+        "type" : "simple"
+      }, {
+        "property" : "provider.type",
+        "equals" : "openai",
+        "type" : "simple"
+      } ]
+    },
+    "type" : "Hidden"
   }, {
     "id" : "provider.openai.backend.custom.endpoint",
     "label" : "API endpoint",

--- a/connectors/agentic-ai/connector-agentic-ai/element-templates/hybrid/agenticai-ai-agent-subprocess.v2-hybrid.json
+++ b/connectors/agentic-ai/connector-agentic-ai/element-templates/hybrid/agenticai-ai-agent-subprocess.v2-hybrid.json
@@ -995,14 +995,40 @@
     },
     "type" : "String"
   }, {
-    "id" : "provider.openai.backend.foundry.authentication.managedIdentityClientId",
+    "id" : "provider.openai.backend.foundry.authentication.entraIdScope",
+    "label" : "Entra ID scope",
+    "description" : "Overrides the Microsoft Entra ID token scope requested for this authentication flow. Leave unset to let the automatically detected Azure cloud pick its own default.",
+    "optional" : true,
+    "group" : "provider",
+    "binding" : {
+      "name" : "provider.openai.backend.foundry.authentication.entraIdScope",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "allMatch" : [ {
+        "property" : "provider.openai.backend.foundry.authentication.type",
+        "equals" : "clientCredentials",
+        "type" : "simple"
+      }, {
+        "property" : "provider.openai.backend.type",
+        "equals" : "foundry",
+        "type" : "simple"
+      }, {
+        "property" : "provider.type",
+        "equals" : "openai",
+        "type" : "simple"
+      } ]
+    },
+    "type" : "Hidden"
+  }, {
+    "id" : "provider.openai.backend.foundry.authentication.managedIdentity.clientId",
     "label" : "Client ID",
     "description" : "Client ID of a user-assigned managed identity. Leave unset to use the system-assigned managed identity.",
     "optional" : true,
     "feel" : "optional",
     "group" : "provider",
     "binding" : {
-      "name" : "provider.openai.backend.foundry.authentication.managedIdentityClientId",
+      "name" : "provider.openai.backend.foundry.authentication.clientId",
       "type" : "zeebe:input"
     },
     "condition" : {
@@ -1021,6 +1047,32 @@
       } ]
     },
     "type" : "String"
+  }, {
+    "id" : "provider.openai.backend.foundry.authentication.managedIdentity.entraIdScope",
+    "label" : "Entra ID scope",
+    "description" : "Overrides the Microsoft Entra ID token scope requested for this authentication flow. Leave unset to let the automatically detected Azure cloud pick its own default.",
+    "optional" : true,
+    "group" : "provider",
+    "binding" : {
+      "name" : "provider.openai.backend.foundry.authentication.entraIdScope",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "allMatch" : [ {
+        "property" : "provider.openai.backend.foundry.authentication.type",
+        "equals" : "managedIdentity",
+        "type" : "simple"
+      }, {
+        "property" : "provider.openai.backend.type",
+        "equals" : "foundry",
+        "type" : "simple"
+      }, {
+        "property" : "provider.type",
+        "equals" : "openai",
+        "type" : "simple"
+      } ]
+    },
+    "type" : "Hidden"
   }, {
     "id" : "provider.openai.backend.custom.endpoint",
     "label" : "API endpoint",

--- a/connectors/agentic-ai/connector-agentic-ai/element-templates/hybrid/agenticai-ai-agent-task.v2-hybrid.json
+++ b/connectors/agentic-ai/connector-agentic-ai/element-templates/hybrid/agenticai-ai-agent-task.v2-hybrid.json
@@ -967,14 +967,40 @@
     },
     "type" : "String"
   }, {
-    "id" : "provider.openai.backend.foundry.authentication.managedIdentityClientId",
+    "id" : "provider.openai.backend.foundry.authentication.entraIdScope",
+    "label" : "Entra ID scope",
+    "description" : "Overrides the Microsoft Entra ID token scope requested for this authentication flow. Leave unset to let the automatically detected Azure cloud pick its own default.",
+    "optional" : true,
+    "group" : "provider",
+    "binding" : {
+      "name" : "provider.openai.backend.foundry.authentication.entraIdScope",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "allMatch" : [ {
+        "property" : "provider.openai.backend.foundry.authentication.type",
+        "equals" : "clientCredentials",
+        "type" : "simple"
+      }, {
+        "property" : "provider.openai.backend.type",
+        "equals" : "foundry",
+        "type" : "simple"
+      }, {
+        "property" : "provider.type",
+        "equals" : "openai",
+        "type" : "simple"
+      } ]
+    },
+    "type" : "Hidden"
+  }, {
+    "id" : "provider.openai.backend.foundry.authentication.managedIdentity.clientId",
     "label" : "Client ID",
     "description" : "Client ID of a user-assigned managed identity. Leave unset to use the system-assigned managed identity.",
     "optional" : true,
     "feel" : "optional",
     "group" : "provider",
     "binding" : {
-      "name" : "provider.openai.backend.foundry.authentication.managedIdentityClientId",
+      "name" : "provider.openai.backend.foundry.authentication.clientId",
       "type" : "zeebe:input"
     },
     "condition" : {
@@ -993,6 +1019,32 @@
       } ]
     },
     "type" : "String"
+  }, {
+    "id" : "provider.openai.backend.foundry.authentication.managedIdentity.entraIdScope",
+    "label" : "Entra ID scope",
+    "description" : "Overrides the Microsoft Entra ID token scope requested for this authentication flow. Leave unset to let the automatically detected Azure cloud pick its own default.",
+    "optional" : true,
+    "group" : "provider",
+    "binding" : {
+      "name" : "provider.openai.backend.foundry.authentication.entraIdScope",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "allMatch" : [ {
+        "property" : "provider.openai.backend.foundry.authentication.type",
+        "equals" : "managedIdentity",
+        "type" : "simple"
+      }, {
+        "property" : "provider.openai.backend.type",
+        "equals" : "foundry",
+        "type" : "simple"
+      }, {
+        "property" : "provider.type",
+        "equals" : "openai",
+        "type" : "simple"
+      } ]
+    },
+    "type" : "Hidden"
   }, {
     "id" : "provider.openai.backend.custom.endpoint",
     "label" : "API endpoint",

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/openai/OpenAiChatModelFactory.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/openai/OpenAiChatModelFactory.java
@@ -24,8 +24,10 @@ import io.camunda.connector.agenticai.aiagent.model.request.v2.OpenAiChatModelCo
 import io.camunda.connector.agenticai.aiagent.model.request.v2.OpenAiChatModelConfiguration.OpenAiBackend.OpenAiFoundryBackend;
 import io.camunda.connector.agenticai.aiagent.model.request.v2.OpenAiCustomEndpointAuthentication.ApiKeyAuthentication;
 import io.camunda.connector.agenticai.common.AgenticAiHttpProxySupport;
+import io.camunda.connector.api.error.ConnectorInputException;
 import io.camunda.connector.http.client.proxy.ProxyConfiguration;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.time.Duration;
 import java.util.Optional;
 import org.jspecify.annotations.Nullable;
@@ -175,18 +177,43 @@ public class OpenAiChatModelFactory implements ChatModelFactory {
    * currently recommends for both classic Azure OpenAI ({@code *.openai.azure.com}) and Foundry
    * ({@code *.services.ai.azure.com}) resources alike (see the <a
    * href="https://learn.microsoft.com/en-us/azure/foundry/foundry-models/concepts/endpoints">Microsoft
-   * Foundry endpoints documentation</a>) by appending {@code /openai/v1} if the configured endpoint
-   * doesn't already end with it. Without this, a bare resource endpoint -- exactly what this
+   * Foundry endpoints documentation</a>) by appending {@code /openai/v1} to the URI's <em>path</em>
+   * if it doesn't already end with it. Without this, a bare resource endpoint -- exactly what this
    * backend's own template field asks for -- gets routed by the SDK's default {@code
    * AzureUrlPathMode.AUTO} detection as the legacy, deployments-based API instead.
+   *
+   * <p>A query string or fragment on the endpoint is rejected rather than carried through: the
+   * openai-java SDK builds each request URL by appending the service path directly onto the base
+   * URL string (see {@code com.openai.core.http.HttpRequest#url()}), so anything after a {@code ?}
+   * or {@code #} would leave the {@code /responses} (etc.) path segment stranded inside the query
+   * or fragment. A Foundry/Azure OpenAI resource endpoint never legitimately carries either; the
+   * backend's dedicated {@code queryParameters} field is the correct place for request query
+   * parameters. All trailing slashes are stripped, not just one, so a doubled slash (accidental or
+   * already ending in {@code /openai/v1//}) doesn't produce a broken or duplicated suffix.
+   *
+   * @throws ConnectorInputException if the endpoint is malformed or carries a query/fragment
    */
   static String unifiedEndpoint(String endpoint) {
-    final var trimmed = endpoint.strip();
-    final var withoutTrailingSlash =
-        trimmed.endsWith("/") ? trimmed.substring(0, trimmed.length() - 1) : trimmed;
-    return withoutTrailingSlash.endsWith("/openai/v1")
-        ? withoutTrailingSlash
-        : withoutTrailingSlash + "/openai/v1";
+    final URI uri;
+    try {
+      uri = new URI(endpoint.strip());
+    } catch (URISyntaxException e) {
+      throw new ConnectorInputException("Invalid Foundry endpoint: " + endpoint, e);
+    }
+    if (uri.getRawQuery() != null || uri.getRawFragment() != null) {
+      throw new ConnectorInputException(
+          "The Foundry endpoint must not contain a query string or fragment: " + endpoint);
+    }
+
+    var path = uri.getRawPath() == null ? "" : uri.getRawPath();
+    while (path.endsWith("/")) {
+      path = path.substring(0, path.length() - 1);
+    }
+    if (!path.endsWith("/openai/v1")) {
+      path = path + "/openai/v1";
+    }
+
+    return uri.getScheme() + "://" + uri.getRawAuthority() + path;
   }
 
   /**

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/openai/OpenAiChatModelFactory.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/openai/OpenAiChatModelFactory.java
@@ -7,6 +7,7 @@
 package io.camunda.connector.agenticai.aiagent.chatmodel.provider.openai;
 
 import com.openai.azure.AzureOpenAIServiceVersion;
+import com.openai.azure.AzureUrlPathMode;
 import com.openai.client.OpenAIClient;
 import com.openai.client.okhttp.OpenAIOkHttpClient;
 import com.openai.core.http.ProxyAuthenticator;
@@ -146,6 +147,13 @@ public class OpenAiChatModelFactory implements ChatModelFactory {
    * credential itself. {@code apiVersion} is only wired when explicitly set: the unified surface
    * uses implicit versioning, so it's an escape hatch for pinning a specific version rather than
    * something every request needs.
+   *
+   * <p>{@code azureUrlPathMode} is forced to {@link AzureUrlPathMode#UNIFIED} rather than left on
+   * the SDK's default {@code AUTO} host-sniffing: the endpoint is already unconditionally
+   * normalized onto {@code /openai/v1} above, and {@code AUTO}'s host allowlist doesn't recognize
+   * Azure Government ({@code *.azure.us}) hosts as Azure at all, which would silently classify
+   * those requests as non-Azure and skip the {@code apiVersion} escape hatch (and other
+   * Azure-specific handling) regardless of path.
    */
   private static void applyFoundryBackend(
       OpenAIOkHttpClient.Builder builder,
@@ -153,6 +161,7 @@ public class OpenAiChatModelFactory implements ChatModelFactory {
       OpenAiFoundryCredentialResolver openAiFoundryCredentialResolver) {
     final var foundry = foundryBackend.foundry();
     builder.baseUrl(unifiedEndpoint(foundry.endpoint()));
+    builder.azureUrlPathMode(AzureUrlPathMode.UNIFIED);
 
     if (foundry.apiVersion() != null && !foundry.apiVersion().isBlank()) {
       builder.azureServiceVersion(AzureOpenAIServiceVersion.fromString(foundry.apiVersion()));

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/openai/OpenAiChatModelFactory.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/openai/OpenAiChatModelFactory.java
@@ -139,26 +139,45 @@ public class OpenAiChatModelFactory implements ChatModelFactory {
   }
 
   /**
-   * Applies the {@code foundry} backend: base URL, an optional {@code apiVersion} pin, and the
+   * Applies the {@code foundry} backend: base URL (normalized onto the unified OpenAI/v1 API
+   * surface, see {@link #unifiedEndpoint(String)}), an optional {@code apiVersion} pin, and the
    * {@link com.openai.credential.Credential} resolved by {@link OpenAiFoundryCredentialResolver}
    * for the configured authentication variant -- this class never builds or inspects that
-   * credential itself. The SDK detects the Azure API surface (legacy vs. unified) automatically
-   * from the endpoint's hostname; {@code apiVersion} is only wired when explicitly set, as an
-   * escape hatch for pinning a specific legacy-style API version.
+   * credential itself. {@code apiVersion} is only wired when explicitly set: the unified surface
+   * uses implicit versioning, so it's an escape hatch for pinning a specific version rather than
+   * something every request needs.
    */
   private static void applyFoundryBackend(
       OpenAIOkHttpClient.Builder builder,
       OpenAiFoundryBackend foundryBackend,
       OpenAiFoundryCredentialResolver openAiFoundryCredentialResolver) {
     final var foundry = foundryBackend.foundry();
-    builder.baseUrl(foundry.endpoint());
+    builder.baseUrl(unifiedEndpoint(foundry.endpoint()));
 
     if (foundry.apiVersion() != null && !foundry.apiVersion().isBlank()) {
       builder.azureServiceVersion(AzureOpenAIServiceVersion.fromString(foundry.apiVersion()));
     }
 
-    builder.credential(
-        openAiFoundryCredentialResolver.credential(foundry.endpoint(), foundry.authentication()));
+    builder.credential(openAiFoundryCredentialResolver.credential(foundry.authentication()));
+  }
+
+  /**
+   * Normalizes a Foundry {@code endpoint} onto the unified OpenAI/v1 API surface Microsoft
+   * currently recommends for both classic Azure OpenAI ({@code *.openai.azure.com}) and Foundry
+   * ({@code *.services.ai.azure.com}) resources alike (see the <a
+   * href="https://learn.microsoft.com/en-us/azure/foundry/foundry-models/concepts/endpoints">Microsoft
+   * Foundry endpoints documentation</a>) by appending {@code /openai/v1} if the configured endpoint
+   * doesn't already end with it. Without this, a bare resource endpoint -- exactly what this
+   * backend's own template field asks for -- gets routed by the SDK's default {@code
+   * AzureUrlPathMode.AUTO} detection as the legacy, deployments-based API instead.
+   */
+  static String unifiedEndpoint(String endpoint) {
+    final var trimmed = endpoint.strip();
+    final var withoutTrailingSlash =
+        trimmed.endsWith("/") ? trimmed.substring(0, trimmed.length() - 1) : trimmed;
+    return withoutTrailingSlash.endsWith("/openai/v1")
+        ? withoutTrailingSlash
+        : withoutTrailingSlash + "/openai/v1";
   }
 
   /**

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/openai/OpenAiFoundryCredentialResolver.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/openai/OpenAiFoundryCredentialResolver.java
@@ -8,11 +8,14 @@ package io.camunda.connector.agenticai.aiagent.chatmodel.provider.openai;
 
 import com.azure.core.credential.TokenCredential;
 import com.azure.identity.AuthenticationUtil;
+import com.azure.identity.AzureAuthorityHosts;
 import com.openai.azure.credential.AzureApiKeyCredential;
 import com.openai.credential.BearerTokenCredential;
 import com.openai.credential.Credential;
 import io.camunda.connector.agenticai.aiagent.chatmodel.provider.azure.EntraIdTokenCredentialFactory;
 import io.camunda.connector.agenticai.aiagent.model.request.v2.OpenAiChatModelConfiguration.OpenAiBackend.FoundryAuthentication;
+import java.util.Locale;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Resolves the openai-java {@link Credential} for the {@code foundry} backend's {@link
@@ -26,14 +29,22 @@ import io.camunda.connector.agenticai.aiagent.model.request.v2.OpenAiChatModelCo
 public class OpenAiFoundryCredentialResolver {
 
   /**
-   * Scope requested when acquiring a Microsoft Entra ID token, per the <a
+   * Scope requested for tenants in the Azure Public Cloud, per the <a
    * href="https://learn.microsoft.com/en-us/azure/foundry/foundry-models/concepts/endpoints">Microsoft
    * Foundry endpoints documentation</a>: the unified OpenAI/v1 API surface -- which {@link
    * OpenAiChatModelFactory} always targets, for both classic Azure OpenAI ({@code
    * *.openai.azure.com}) and Foundry ({@code *.services.ai.azure.com}) resources alike -- uses this
-   * one scope regardless of host.
+   * one scope regardless of host, within a given cloud.
    */
-  private static final String AZURE_AI_FOUNDRY_SCOPE = "https://ai.azure.com/.default";
+  private static final String AZURE_PUBLIC_CLOUD_SCOPE = "https://ai.azure.com/.default";
+
+  /**
+   * Scope for tenants in the Azure US Government Cloud, per <a
+   * href="https://learn.microsoft.com/en-us/azure/foundry/concepts/foundry-azure-government">Microsoft
+   * Foundry in Azure Government</a> (portal/endpoints under {@code *.azure.us}) -- the only other
+   * sovereign cloud Foundry supports today.
+   */
+  private static final String AZURE_GOVERNMENT_SCOPE = "https://ai.azure.us/.default";
 
   private final EntraIdTokenCredentialFactory entraIdTokenCredentialFactory;
 
@@ -50,11 +61,35 @@ public class OpenAiFoundryCredentialResolver {
       case FoundryAuthentication.ClientCredentialsAuthentication auth ->
           entraIdBearerTokenCredential(
               entraIdTokenCredentialFactory.clientCredentials(
-                  auth.tenantId(), auth.clientId(), auth.clientSecret(), auth.authorityHost()));
+                  auth.tenantId(), auth.clientId(), auth.clientSecret(), auth.authorityHost()),
+              scopeFor(auth.authorityHost()));
+      // No authorityHost field to key off for managed identity -- Azure Public Cloud only for now.
       case FoundryAuthentication.ManagedIdentityAuthentication auth ->
           entraIdBearerTokenCredential(
-              entraIdTokenCredentialFactory.managedIdentity(auth.managedIdentityClientId()));
+              entraIdTokenCredentialFactory.managedIdentity(auth.managedIdentityClientId()),
+              AZURE_PUBLIC_CLOUD_SCOPE);
     };
+  }
+
+  /**
+   * Maps an (optional) Microsoft Entra ID {@code authorityHost} override to the matching Foundry
+   * scope: an unset/blank host, or one that doesn't match a known sovereign cloud, is Azure Public
+   * Cloud; {@link AzureAuthorityHosts#AZURE_GOVERNMENT} is the one other cloud Foundry ships in.
+   */
+  private static String scopeFor(@Nullable String authorityHost) {
+    if (authorityHost == null || authorityHost.isBlank()) {
+      return AZURE_PUBLIC_CLOUD_SCOPE;
+    }
+
+    final var isGovernmentCloud =
+        normalizeAuthorityHost(authorityHost)
+            .equals(normalizeAuthorityHost(AzureAuthorityHosts.AZURE_GOVERNMENT));
+    return isGovernmentCloud ? AZURE_GOVERNMENT_SCOPE : AZURE_PUBLIC_CLOUD_SCOPE;
+  }
+
+  private static String normalizeAuthorityHost(String authorityHost) {
+    final var lowerCased = authorityHost.strip().toLowerCase(Locale.ROOT);
+    return lowerCased.endsWith("/") ? lowerCased : lowerCased + "/";
   }
 
   /**
@@ -63,8 +98,9 @@ public class OpenAiFoundryCredentialResolver {
    * request, so this never caches a token itself, relying entirely on the wrapped credential's own
    * token cache and refresh logic.
    */
-  private static Credential entraIdBearerTokenCredential(TokenCredential tokenCredential) {
+  private static Credential entraIdBearerTokenCredential(
+      TokenCredential tokenCredential, String scope) {
     return BearerTokenCredential.create(
-        AuthenticationUtil.getBearerTokenSupplier(tokenCredential, AZURE_AI_FOUNDRY_SCOPE));
+        AuthenticationUtil.getBearerTokenSupplier(tokenCredential, scope));
   }
 }

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/openai/OpenAiFoundryCredentialResolver.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/openai/OpenAiFoundryCredentialResolver.java
@@ -53,7 +53,11 @@ public class OpenAiFoundryCredentialResolver {
     this.entraIdTokenCredentialFactory = entraIdTokenCredentialFactory;
   }
 
-  /** Resolves the openai-java {@link Credential} to apply for the given authentication variant. */
+  /**
+   * Resolves the openai-java {@link Credential} to apply for the given authentication variant. For
+   * either Entra ID flow, that variant's own {@code entraIdScope} escape hatch, when set, wins over
+   * the scope this class would otherwise derive.
+   */
   public Credential credential(FoundryAuthentication authentication) {
     return switch (authentication) {
       case FoundryAuthentication.ApiKeyAuthentication auth ->
@@ -62,12 +66,13 @@ public class OpenAiFoundryCredentialResolver {
           entraIdBearerTokenCredential(
               entraIdTokenCredentialFactory.clientCredentials(
                   auth.tenantId(), auth.clientId(), auth.clientSecret(), auth.authorityHost()),
-              scopeFor(auth.authorityHost()));
-      // No authorityHost field to key off for managed identity -- Azure Public Cloud only for now.
+              resolveScope(scopeFor(auth.authorityHost()), auth.entraIdScope()));
+      // No authorityHost field to key off for managed identity -- Azure Public Cloud only for now,
+      // unless entraIdScope steps in.
       case FoundryAuthentication.ManagedIdentityAuthentication auth ->
           entraIdBearerTokenCredential(
-              entraIdTokenCredentialFactory.managedIdentity(auth.managedIdentityClientId()),
-              AZURE_PUBLIC_CLOUD_SCOPE);
+              entraIdTokenCredentialFactory.managedIdentity(auth.clientId()),
+              resolveScope(AZURE_PUBLIC_CLOUD_SCOPE, auth.entraIdScope()));
     };
   }
 
@@ -85,6 +90,10 @@ public class OpenAiFoundryCredentialResolver {
         normalizeAuthorityHost(authorityHost)
             .equals(normalizeAuthorityHost(AzureAuthorityHosts.AZURE_GOVERNMENT));
     return isGovernmentCloud ? AZURE_GOVERNMENT_SCOPE : AZURE_PUBLIC_CLOUD_SCOPE;
+  }
+
+  private static String resolveScope(String derivedScope, @Nullable String scopeOverride) {
+    return scopeOverride != null && !scopeOverride.isBlank() ? scopeOverride : derivedScope;
   }
 
   private static String normalizeAuthorityHost(String authorityHost) {

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/openai/OpenAiFoundryCredentialResolver.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/openai/OpenAiFoundryCredentialResolver.java
@@ -13,39 +13,25 @@ import com.openai.credential.BearerTokenCredential;
 import com.openai.credential.Credential;
 import io.camunda.connector.agenticai.aiagent.chatmodel.provider.azure.EntraIdTokenCredentialFactory;
 import io.camunda.connector.agenticai.aiagent.model.request.v2.OpenAiChatModelConfiguration.OpenAiBackend.FoundryAuthentication;
-import java.net.URI;
 
 /**
  * Resolves the openai-java {@link Credential} for the {@code foundry} backend's {@link
  * FoundryAuthentication}: maps API-key auth directly to {@link AzureApiKeyCredential}, and wraps
  * the {@link TokenCredential} resolved by the shared, provider-agnostic {@link
  * EntraIdTokenCredentialFactory} as a {@link BearerTokenCredential} for the two Microsoft Entra ID
- * flows. {@link OpenAiChatModelFactory} only ever calls {@link #credential(String,
- * FoundryAuthentication)}; it never sees a raw {@link TokenCredential}, a cache key, or any secret
- * material one is derived from -- all of that lives in {@link EntraIdTokenCredentialFactory}.
- *
- * <p>The Entra ID token scope depends on which Azure API surface the configured endpoint targets:
- * classic Azure OpenAI ({@code *.openai.azure.com}) and unified Microsoft Foundry ({@code
- * *.services.ai.azure.com}) resources require different token audiences. This is a different axis
- * than the openai-java SDK's own {@code AzureUrlCategory} (legacy vs. unified <em>REST path
- * style</em>, driven by whether the base URL's path ends in {@code /openai/v1}, not by host) --
- * that classification can't be reused here, so the host is inspected directly.
+ * flows. {@link OpenAiChatModelFactory} only ever calls {@link #credential(FoundryAuthentication)};
+ * it never sees a raw {@link TokenCredential}, a cache key, or any secret material one is derived
+ * from -- all of that lives in {@link EntraIdTokenCredentialFactory}.
  */
 public class OpenAiFoundryCredentialResolver {
 
   /**
-   * Scope for the classic Azure OpenAI API surface ({@code *.openai.azure.com}), per the <a
-   * href="https://learn.microsoft.com/en-us/azure/ai-services/openai/how-to/managed-identity">Azure
-   * OpenAI managed identity documentation</a>.
-   */
-  private static final String AZURE_OPENAI_SCOPE = "https://cognitiveservices.azure.com/.default";
-
-  /**
-   * Scope for the unified Microsoft Foundry Models API surface ({@code *.services.ai.azure.com}),
-   * per the <a
-   * href="https://learn.microsoft.com/en-us/azure/ai-foundry/foundry-models/how-to/configure-entra-id">
-   * Microsoft Foundry Entra ID documentation</a> (the openai-java code sample there uses this exact
-   * scope with {@link AuthenticationUtil#getBearerTokenSupplier}).
+   * Scope requested when acquiring a Microsoft Entra ID token, per the <a
+   * href="https://learn.microsoft.com/en-us/azure/foundry/foundry-models/concepts/endpoints">Microsoft
+   * Foundry endpoints documentation</a>: the unified OpenAI/v1 API surface -- which {@link
+   * OpenAiChatModelFactory} always targets, for both classic Azure OpenAI ({@code
+   * *.openai.azure.com}) and Foundry ({@code *.services.ai.azure.com}) resources alike -- uses this
+   * one scope regardless of host.
    */
   private static final String AZURE_AI_FOUNDRY_SCOPE = "https://ai.azure.com/.default";
 
@@ -56,24 +42,18 @@ public class OpenAiFoundryCredentialResolver {
     this.entraIdTokenCredentialFactory = entraIdTokenCredentialFactory;
   }
 
-  /**
-   * Resolves the openai-java {@link Credential} to apply for the given authentication variant,
-   * requesting the Entra ID token scope appropriate for the given Foundry {@code endpoint} where
-   * applicable.
-   */
-  public Credential credential(String endpoint, FoundryAuthentication authentication) {
+  /** Resolves the openai-java {@link Credential} to apply for the given authentication variant. */
+  public Credential credential(FoundryAuthentication authentication) {
     return switch (authentication) {
       case FoundryAuthentication.ApiKeyAuthentication auth ->
           AzureApiKeyCredential.create(auth.apiKey());
       case FoundryAuthentication.ClientCredentialsAuthentication auth ->
           entraIdBearerTokenCredential(
               entraIdTokenCredentialFactory.clientCredentials(
-                  auth.tenantId(), auth.clientId(), auth.clientSecret(), auth.authorityHost()),
-              endpoint);
+                  auth.tenantId(), auth.clientId(), auth.clientSecret(), auth.authorityHost()));
       case FoundryAuthentication.ManagedIdentityAuthentication auth ->
           entraIdBearerTokenCredential(
-              entraIdTokenCredentialFactory.managedIdentity(auth.managedIdentityClientId()),
-              endpoint);
+              entraIdTokenCredentialFactory.managedIdentity(auth.managedIdentityClientId()));
     };
   }
 
@@ -83,22 +63,8 @@ public class OpenAiFoundryCredentialResolver {
    * request, so this never caches a token itself, relying entirely on the wrapped credential's own
    * token cache and refresh logic.
    */
-  private static Credential entraIdBearerTokenCredential(
-      TokenCredential tokenCredential, String endpoint) {
+  private static Credential entraIdBearerTokenCredential(TokenCredential tokenCredential) {
     return BearerTokenCredential.create(
-        AuthenticationUtil.getBearerTokenSupplier(tokenCredential, scopeFor(endpoint)));
-  }
-
-  /**
-   * The unified Microsoft Foundry Models API surface is reached through a {@code
-   * *.services.ai.azure.com} resource hostname; every other Foundry-backend endpoint (classic
-   * {@code *.openai.azure.com} resources, or anything else the user points the {@code foundry}
-   * backend at) is treated as the classic Azure OpenAI surface, its scope's documented default.
-   */
-  static String scopeFor(String endpoint) {
-    final var host = URI.create(endpoint).getHost();
-    return host != null && host.endsWith(".services.ai.azure.com")
-        ? AZURE_AI_FOUNDRY_SCOPE
-        : AZURE_OPENAI_SCOPE;
+        AuthenticationUtil.getBearerTokenSupplier(tokenCredential, AZURE_AI_FOUNDRY_SCOPE));
   }
 }

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/v2/OpenAiChatModelConfiguration.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/v2/OpenAiChatModelConfiguration.java
@@ -500,7 +500,18 @@ public record OpenAiChatModelConfiguration(@Valid @NotNull OpenAiConnection open
                   type = TemplateProperty.PropertyType.String,
                   feel = FeelMode.optional,
                   optional = true)
-              @Nullable String authorityHost)
+              @Nullable String authorityHost,
+          @TemplateProperty(
+                  group = "provider",
+                  label = "Entra ID scope",
+                  description =
+                      "Overrides the Microsoft Entra ID token scope requested for this "
+                          + "authentication flow. Leave unset to let the automatically detected "
+                          + "Azure cloud pick its own default.",
+                  type = TemplateProperty.PropertyType.Hidden,
+                  feel = FeelMode.disabled,
+                  optional = true)
+              @Nullable String entraIdScope)
           implements FoundryAuthentication {
 
         @Override
@@ -511,6 +522,8 @@ public record OpenAiChatModelConfiguration(@Valid @NotNull OpenAiConnection open
               + tenantId
               + ", authorityHost="
               + authorityHost
+              + ", entraIdScope="
+              + entraIdScope
               + "}";
         }
       }
@@ -520,6 +533,7 @@ public record OpenAiChatModelConfiguration(@Valid @NotNull OpenAiConnection open
           label = "Entra ID: Managed identity (Hybrid/Self-Managed only)")
       record ManagedIdentityAuthentication(
           @TemplateProperty(
+                  id = "managedIdentity.clientId",
                   group = "provider",
                   label = "Client ID",
                   description =
@@ -528,7 +542,19 @@ public record OpenAiChatModelConfiguration(@Valid @NotNull OpenAiConnection open
                   type = TemplateProperty.PropertyType.String,
                   feel = FeelMode.optional,
                   optional = true)
-              @Nullable String managedIdentityClientId)
+              @Nullable String clientId,
+          @TemplateProperty(
+                  id = "managedIdentity.entraIdScope",
+                  group = "provider",
+                  label = "Entra ID scope",
+                  description =
+                      "Overrides the Microsoft Entra ID token scope requested for this "
+                          + "authentication flow. Leave unset to let the automatically detected "
+                          + "Azure cloud pick its own default.",
+                  type = TemplateProperty.PropertyType.Hidden,
+                  feel = FeelMode.disabled,
+                  optional = true)
+              @Nullable String entraIdScope)
           implements FoundryAuthentication {
 
         @JsonIgnore

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/openai/OpenAiChatModelFactoryClientTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/openai/OpenAiChatModelFactoryClientTest.java
@@ -192,8 +192,10 @@ class OpenAiChatModelFactoryClientTest {
                 null)));
 
     // Azure wants the API key on a dedicated `api-key` header, never `Authorization: Bearer`.
+    // The endpoint is normalized onto the unified OpenAI/v1 API surface, so the request lands on
+    // /openai/v1/responses rather than the bare /responses path.
     verify(
-        postRequestedFor(urlPathEqualTo("/responses"))
+        postRequestedFor(urlPathEqualTo("/openai/v1/responses"))
             .withHeader("api-key", equalTo("foundry-secret-key")));
   }
 
@@ -210,7 +212,7 @@ class OpenAiChatModelFactoryClientTest {
                 null)));
 
     verify(
-        postRequestedFor(urlPathEqualTo("/responses"))
+        postRequestedFor(urlPathEqualTo("/openai/v1/responses"))
             .withHeader("X-Custom-Header", equalTo("header-value"))
             .withQueryParam("custom-query-param", equalTo("query-value")));
   }

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/openai/OpenAiChatModelFactoryClientTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/openai/OpenAiChatModelFactoryClientTest.java
@@ -218,6 +218,27 @@ class OpenAiChatModelFactoryClientTest {
   }
 
   @Test
+  void appliesApiVersionForFoundryBackendRegardlessOfHost(WireMockRuntimeInfo wireMock) {
+    // WireMock's host (127.0.0.1) is not on the openai-java SDK's AzureUrlPathMode.AUTO host
+    // allowlist -- same as a real Azure Government (*.azure.us) endpoint. Without explicitly
+    // forcing AzureUrlPathMode.UNIFIED, AUTO would classify this as NON_AZURE and silently drop
+    // the apiVersion escape hatch below.
+    executeAgainst(
+        new OpenAiFoundryBackend(
+            new FoundryBackend(
+                wireMock.getHttpBaseUrl(),
+                "2025-03-01-preview",
+                new FoundryAuthentication.ApiKeyAuthentication("foundry-secret-key"),
+                null,
+                null,
+                null)));
+
+    verify(
+        postRequestedFor(urlPathEqualTo("/openai/v1/responses"))
+            .withQueryParam("api-version", equalTo("2025-03-01-preview")));
+  }
+
+  @Test
   void usesConfiguredBaseUrlForCustomBackend(WireMockRuntimeInfo wireMock) {
     executeAgainst(
         new OpenAiCustomBackend(

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/openai/OpenAiChatModelFactoryTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/openai/OpenAiChatModelFactoryTest.java
@@ -47,6 +47,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -178,5 +179,30 @@ class OpenAiChatModelFactoryTest {
                     null)),
             new OpenAiModel(modelId),
             null));
+  }
+
+  @ParameterizedTest
+  @MethodSource("endpointsToNormalize")
+  void unifiedEndpointAppendsOpenaiV1WhenMissing(String endpoint, String expected) {
+    assertThat(OpenAiChatModelFactory.unifiedEndpoint(endpoint)).isEqualTo(expected);
+  }
+
+  static Stream<Arguments> endpointsToNormalize() {
+    return Stream.of(
+        Arguments.of(
+            "https://my-resource.openai.azure.com",
+            "https://my-resource.openai.azure.com/openai/v1"),
+        Arguments.of(
+            "https://my-resource.services.ai.azure.com",
+            "https://my-resource.services.ai.azure.com/openai/v1"),
+        Arguments.of(
+            "https://my-resource.openai.azure.com/",
+            "https://my-resource.openai.azure.com/openai/v1"),
+        Arguments.of(
+            "https://my-resource.openai.azure.com/openai/v1",
+            "https://my-resource.openai.azure.com/openai/v1"),
+        Arguments.of(
+            "https://my-resource.openai.azure.com/openai/v1/",
+            "https://my-resource.openai.azure.com/openai/v1"));
   }
 }

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/openai/OpenAiChatModelFactoryTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/openai/OpenAiChatModelFactoryTest.java
@@ -7,6 +7,7 @@
 package io.camunda.connector.agenticai.aiagent.chatmodel.provider.openai;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
@@ -39,6 +40,7 @@ import io.camunda.connector.agenticai.aiagent.model.request.v2.OpenAiChatModelCo
 import io.camunda.connector.agenticai.aiagent.model.request.v2.OpenAiCustomEndpointAuthentication.ApiKeyAuthentication;
 import io.camunda.connector.agenticai.autoconfigure.AgenticAiConnectorsConfigurationProperties.ChatModelProperties.AzureProperties.CredentialCacheProperties;
 import io.camunda.connector.agenticai.common.AgenticAiHttpProxySupport;
+import io.camunda.connector.api.error.ConnectorInputException;
 import java.time.Duration;
 import java.util.Map;
 import java.util.Optional;
@@ -49,6 +51,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -203,7 +206,30 @@ class OpenAiChatModelFactoryTest {
             "https://my-resource.openai.azure.com/openai/v1",
             "https://my-resource.openai.azure.com/openai/v1"),
         Arguments.of(
+            "https://my-resource.openai.azure.com//",
+            "https://my-resource.openai.azure.com/openai/v1"),
+        Arguments.of(
+            "https://my-resource.openai.azure.com/openai/v1//",
+            "https://my-resource.openai.azure.com/openai/v1"),
+        Arguments.of(
             "https://my-resource.openai.azure.com/openai/v1/",
             "https://my-resource.openai.azure.com/openai/v1"));
+  }
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "https://my-resource.openai.azure.com?api-version=2025-03-01-preview",
+        "https://my-resource.openai.azure.com/openai/v1?token=a%26b",
+        "https://my-resource.openai.azure.com#fragment",
+        "https://my-resource.openai.azure.com/openai/v1?foo=bar#frag"
+      })
+  void unifiedEndpointRejectsQueryOrFragment(String endpoint) {
+    // The openai-java SDK appends the service path directly onto the base URL string, so a query or
+    // fragment on the endpoint would strand the path segment inside it -- reject rather than carry
+    // it through. Request query parameters belong on the backend's dedicated queryParameters field.
+    assertThatThrownBy(() -> OpenAiChatModelFactory.unifiedEndpoint(endpoint))
+        .isInstanceOf(ConnectorInputException.class)
+        .hasMessageContaining("query string or fragment");
   }
 }

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/openai/OpenAiChatModelFactoryTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/openai/OpenAiChatModelFactoryTest.java
@@ -157,11 +157,12 @@ class OpenAiChatModelFactoryTest {
     return foundryConfig(
         modelId,
         new FoundryAuthentication.ClientCredentialsAuthentication(
-            "client-test", "secret-test", "tenant-test", null));
+            "client-test", "secret-test", "tenant-test", null, null));
   }
 
   private static OpenAiChatModelConfiguration foundryManagedIdentityConfig(String modelId) {
-    return foundryConfig(modelId, new FoundryAuthentication.ManagedIdentityAuthentication(null));
+    return foundryConfig(
+        modelId, new FoundryAuthentication.ManagedIdentityAuthentication(null, null));
   }
 
   private static OpenAiChatModelConfiguration foundryConfig(

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/openai/OpenAiFoundryCredentialResolverTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/openai/OpenAiFoundryCredentialResolverTest.java
@@ -7,14 +7,20 @@
 package io.camunda.connector.agenticai.aiagent.chatmodel.provider.openai;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
 
+import com.azure.identity.AuthenticationUtil;
 import io.camunda.connector.agenticai.aiagent.chatmodel.provider.azure.EntraIdTokenCredentialFactory;
 import io.camunda.connector.agenticai.aiagent.model.request.v2.OpenAiChatModelConfiguration.OpenAiBackend.FoundryAuthentication;
 import io.camunda.connector.agenticai.autoconfigure.AgenticAiConnectorsConfigurationProperties.ChatModelProperties.AzureProperties.CredentialCacheProperties;
 import io.camunda.connector.agenticai.common.AgenticAiHttpProxySupport;
 import java.time.Duration;
+import java.util.function.Supplier;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
 
 /**
  * Credential-object reuse/distinctness is covered by {@code EntraIdTokenCredentialFactoryTest};
@@ -49,5 +55,41 @@ class OpenAiFoundryCredentialResolverTest {
 
     assertThat(clientCredentials).isNotNull();
     assertThat(managedIdentity).isNotNull();
+  }
+
+  @Test
+  void requestsTheFoundryScopeForClientCredentials() {
+    try (MockedStatic<AuthenticationUtil> authenticationUtil =
+        mockStatic(AuthenticationUtil.class)) {
+      final Supplier<String> tokenSupplier = () -> "test-token";
+      authenticationUtil
+          .when(() -> AuthenticationUtil.getBearerTokenSupplier(any(), any()))
+          .thenReturn(tokenSupplier);
+      resolver.credential(
+          new FoundryAuthentication.ClientCredentialsAuthentication(
+              "client-id", "client-secret", "tenant-id", null));
+
+      authenticationUtil.verify(
+          () ->
+              AuthenticationUtil.getBearerTokenSupplier(
+                  any(), eq("https://ai.azure.com/.default")));
+    }
+  }
+
+  @Test
+  void requestsTheFoundryScopeForManagedIdentity() {
+    try (MockedStatic<AuthenticationUtil> authenticationUtil =
+        mockStatic(AuthenticationUtil.class)) {
+      final Supplier<String> tokenSupplier = () -> "test-token";
+      authenticationUtil
+          .when(() -> AuthenticationUtil.getBearerTokenSupplier(any(), any()))
+          .thenReturn(tokenSupplier);
+      resolver.credential(new FoundryAuthentication.ManagedIdentityAuthentication(null));
+
+      authenticationUtil.verify(
+          () ->
+              AuthenticationUtil.getBearerTokenSupplier(
+                  any(), eq("https://ai.azure.com/.default")));
+    }
   }
 }

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/openai/OpenAiFoundryCredentialResolverTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/openai/OpenAiFoundryCredentialResolverTest.java
@@ -92,4 +92,46 @@ class OpenAiFoundryCredentialResolverTest {
                   any(), eq("https://ai.azure.com/.default")));
     }
   }
+
+  @Test
+  void requestsTheGovernmentCloudScopeForMatchingAuthorityHost() {
+    try (MockedStatic<AuthenticationUtil> authenticationUtil =
+        mockStatic(AuthenticationUtil.class)) {
+      final Supplier<String> tokenSupplier = () -> "test-token";
+      authenticationUtil
+          .when(() -> AuthenticationUtil.getBearerTokenSupplier(any(), any()))
+          .thenReturn(tokenSupplier);
+
+      resolver.credential(
+          new FoundryAuthentication.ClientCredentialsAuthentication(
+              "client-id", "client-secret", "tenant-id", "https://login.microsoftonline.us/"));
+
+      authenticationUtil.verify(
+          () ->
+              AuthenticationUtil.getBearerTokenSupplier(any(), eq("https://ai.azure.us/.default")));
+    }
+  }
+
+  @Test
+  void requestsThePublicCloudScopeForUnknownAuthorityHost() {
+    try (MockedStatic<AuthenticationUtil> authenticationUtil =
+        mockStatic(AuthenticationUtil.class)) {
+      final Supplier<String> tokenSupplier = () -> "test-token";
+      authenticationUtil
+          .when(() -> AuthenticationUtil.getBearerTokenSupplier(any(), any()))
+          .thenReturn(tokenSupplier);
+
+      resolver.credential(
+          new FoundryAuthentication.ClientCredentialsAuthentication(
+              "client-id",
+              "client-secret",
+              "tenant-id",
+              "https://login.someprivatecloud.example/"));
+
+      authenticationUtil.verify(
+          () ->
+              AuthenticationUtil.getBearerTokenSupplier(
+                  any(), eq("https://ai.azure.com/.default")));
+    }
+  }
 }

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/openai/OpenAiFoundryCredentialResolverTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/openai/OpenAiFoundryCredentialResolverTest.java
@@ -31,9 +31,7 @@ class OpenAiFoundryCredentialResolverTest {
   @Test
   void resolvesApiKeyCredential() {
     final var credential =
-        resolver.credential(
-            "https://my-resource.openai.azure.com",
-            new FoundryAuthentication.ApiKeyAuthentication("foundry-secret"));
+        resolver.credential(new FoundryAuthentication.ApiKeyAuthentication("foundry-secret"));
 
     assertThat(credential).isNotNull();
   }
@@ -44,34 +42,12 @@ class OpenAiFoundryCredentialResolverTest {
     // token supplier (i.e. issuing a real request) would.
     final var clientCredentials =
         resolver.credential(
-            "https://my-resource.openai.azure.com",
             new FoundryAuthentication.ClientCredentialsAuthentication(
                 "client-id", "client-secret", "tenant-id", null));
     final var managedIdentity =
-        resolver.credential(
-            "https://my-resource.openai.azure.com",
-            new FoundryAuthentication.ManagedIdentityAuthentication(null));
+        resolver.credential(new FoundryAuthentication.ManagedIdentityAuthentication(null));
 
     assertThat(clientCredentials).isNotNull();
     assertThat(managedIdentity).isNotNull();
-  }
-
-  @Test
-  void resolvesClassicAzureOpenAiScope() {
-    assertThat(OpenAiFoundryCredentialResolver.scopeFor("https://my-resource.openai.azure.com"))
-        .isEqualTo("https://cognitiveservices.azure.com/.default");
-  }
-
-  @Test
-  void resolvesUnifiedFoundryScope() {
-    assertThat(
-            OpenAiFoundryCredentialResolver.scopeFor("https://my-resource.services.ai.azure.com"))
-        .isEqualTo("https://ai.azure.com/.default");
-  }
-
-  @Test
-  void defaultsToClassicScopeForNonFoundryHost() {
-    assertThat(OpenAiFoundryCredentialResolver.scopeFor("https://example.com"))
-        .isEqualTo("https://cognitiveservices.azure.com/.default");
   }
 }

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/openai/OpenAiFoundryCredentialResolverTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/openai/OpenAiFoundryCredentialResolverTest.java
@@ -49,9 +49,9 @@ class OpenAiFoundryCredentialResolverTest {
     final var clientCredentials =
         resolver.credential(
             new FoundryAuthentication.ClientCredentialsAuthentication(
-                "client-id", "client-secret", "tenant-id", null));
+                "client-id", "client-secret", "tenant-id", null, null));
     final var managedIdentity =
-        resolver.credential(new FoundryAuthentication.ManagedIdentityAuthentication(null));
+        resolver.credential(new FoundryAuthentication.ManagedIdentityAuthentication(null, null));
 
     assertThat(clientCredentials).isNotNull();
     assertThat(managedIdentity).isNotNull();
@@ -67,7 +67,7 @@ class OpenAiFoundryCredentialResolverTest {
           .thenReturn(tokenSupplier);
       resolver.credential(
           new FoundryAuthentication.ClientCredentialsAuthentication(
-              "client-id", "client-secret", "tenant-id", null));
+              "client-id", "client-secret", "tenant-id", null, null));
 
       authenticationUtil.verify(
           () ->
@@ -84,7 +84,7 @@ class OpenAiFoundryCredentialResolverTest {
       authenticationUtil
           .when(() -> AuthenticationUtil.getBearerTokenSupplier(any(), any()))
           .thenReturn(tokenSupplier);
-      resolver.credential(new FoundryAuthentication.ManagedIdentityAuthentication(null));
+      resolver.credential(new FoundryAuthentication.ManagedIdentityAuthentication(null, null));
 
       authenticationUtil.verify(
           () ->
@@ -104,7 +104,11 @@ class OpenAiFoundryCredentialResolverTest {
 
       resolver.credential(
           new FoundryAuthentication.ClientCredentialsAuthentication(
-              "client-id", "client-secret", "tenant-id", "https://login.microsoftonline.us/"));
+              "client-id",
+              "client-secret",
+              "tenant-id",
+              "https://login.microsoftonline.us/",
+              null));
 
       authenticationUtil.verify(
           () ->
@@ -126,7 +130,71 @@ class OpenAiFoundryCredentialResolverTest {
               "client-id",
               "client-secret",
               "tenant-id",
-              "https://login.someprivatecloud.example/"));
+              "https://login.someprivatecloud.example/",
+              null));
+
+      authenticationUtil.verify(
+          () ->
+              AuthenticationUtil.getBearerTokenSupplier(
+                  any(), eq("https://ai.azure.com/.default")));
+    }
+  }
+
+  @Test
+  void scopeOverrideWinsOverDerivedScopeForClientCredentials() {
+    try (MockedStatic<AuthenticationUtil> authenticationUtil =
+        mockStatic(AuthenticationUtil.class)) {
+      final Supplier<String> tokenSupplier = () -> "test-token";
+      authenticationUtil
+          .when(() -> AuthenticationUtil.getBearerTokenSupplier(any(), any()))
+          .thenReturn(tokenSupplier);
+
+      resolver.credential(
+          new FoundryAuthentication.ClientCredentialsAuthentication(
+              "client-id",
+              "client-secret",
+              "tenant-id",
+              "https://login.microsoftonline.us/",
+              "https://custom.scope/.default"));
+
+      authenticationUtil.verify(
+          () ->
+              AuthenticationUtil.getBearerTokenSupplier(
+                  any(), eq("https://custom.scope/.default")));
+    }
+  }
+
+  @Test
+  void scopeOverrideWinsOverDefaultScopeForManagedIdentity() {
+    try (MockedStatic<AuthenticationUtil> authenticationUtil =
+        mockStatic(AuthenticationUtil.class)) {
+      final Supplier<String> tokenSupplier = () -> "test-token";
+      authenticationUtil
+          .when(() -> AuthenticationUtil.getBearerTokenSupplier(any(), any()))
+          .thenReturn(tokenSupplier);
+
+      resolver.credential(
+          new FoundryAuthentication.ManagedIdentityAuthentication(
+              null, "https://ai.azure.us/.default"));
+
+      authenticationUtil.verify(
+          () ->
+              AuthenticationUtil.getBearerTokenSupplier(any(), eq("https://ai.azure.us/.default")));
+    }
+  }
+
+  @Test
+  void blankScopeOverrideIsIgnored() {
+    try (MockedStatic<AuthenticationUtil> authenticationUtil =
+        mockStatic(AuthenticationUtil.class)) {
+      final Supplier<String> tokenSupplier = () -> "test-token";
+      authenticationUtil
+          .when(() -> AuthenticationUtil.getBearerTokenSupplier(any(), any()))
+          .thenReturn(tokenSupplier);
+
+      resolver.credential(
+          new FoundryAuthentication.ClientCredentialsAuthentication(
+              "client-id", "client-secret", "tenant-id", null, "   "));
 
       authenticationUtil.verify(
           () ->

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/model/request/v2/OpenAiChatModelConfigurationTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/model/request/v2/OpenAiChatModelConfigurationTest.java
@@ -373,7 +373,7 @@ class OpenAiChatModelConfigurationTest {
     assertThat(foundry.foundry().authentication())
         .isEqualTo(
             new FoundryAuthentication.ClientCredentialsAuthentication(
-                "client-123", "secret-123", "tenant-123", null));
+                "client-123", "secret-123", "tenant-123", null, null));
 
     final String reserialised = mapper.writeValueAsString(parsed);
     assertThat(mapper.readValue(reserialised, ProviderConfiguration.class)).isEqualTo(parsed);
@@ -387,7 +387,7 @@ class OpenAiChatModelConfigurationTest {
                 "https://my-resource.openai.azure.com",
                 null,
                 new FoundryAuthentication.ClientCredentialsAuthentication(
-                    "client-123", "secret-super-secret", "tenant-123", null),
+                    "client-123", "secret-super-secret", "tenant-123", null, null),
                 Map.of("Authorization", "Bearer secret"),
                 Map.of("api-version", "2026-01-01"),
                 Map.of("large_field", "large_value")));
@@ -439,7 +439,8 @@ class OpenAiChatModelConfigurationTest {
   @Test
   void foundryManagedIdentityRejectedOnSaaS() {
     environment.set(ConnectorUtils.CONNECTOR_RUNTIME_SAAS_ENV_VARIABLE, "true");
-    final var config = foundryConfig(new FoundryAuthentication.ManagedIdentityAuthentication(null));
+    final var config =
+        foundryConfig(new FoundryAuthentication.ManagedIdentityAuthentication(null, null));
 
     assertThat(validator.validate(config))
         .extracting(ConstraintViolation::getMessage)
@@ -448,7 +449,8 @@ class OpenAiChatModelConfigurationTest {
 
   @Test
   void foundryManagedIdentityAllowedWhenNotSaaS() {
-    final var config = foundryConfig(new FoundryAuthentication.ManagedIdentityAuthentication(null));
+    final var config =
+        foundryConfig(new FoundryAuthentication.ManagedIdentityAuthentication(null, null));
 
     assertThat(validator.validate(config)).isEmpty();
   }

--- a/connectors/agentic-ai/docs/reference/native-providers.md
+++ b/connectors/agentic-ai/docs/reference/native-providers.md
@@ -186,10 +186,20 @@ for Azure Public Cloud, `https://ai.azure.us/.default` for Azure US Government �
 sovereign cloud Foundry supports today. `ClientCredentialsAuthentication`'s `authorityHost` field
 selects between them (matched against `com.azure.identity.AzureAuthorityHosts.AZURE_GOVERNMENT`;
 anything else, including an unset host, is Azure Public Cloud); `ManagedIdentityAuthentication` has no
-such field — its scope is always Azure Public Cloud, since IMDS-based managed identity is inherently
-tied to the cloud the identity already runs in and there's currently no field to signal otherwise. `apiVersion` exists only as a hidden,
-optional escape hatch for pinning a specific version, wired through the SDK's dedicated
-`azureServiceVersion(...)` builder method — the unified surface otherwise uses implicit versioning.
+such field — its derived scope is always Azure Public Cloud, since IMDS-based managed identity is
+inherently tied to the cloud the identity already runs in and there's currently no field to signal
+otherwise. Each Entra ID variant carries its own hidden `entraIdScope` escape hatch for a wrong guess:
+a custom `authorityHost` this resolver doesn't recognize, or a managed identity that does need a
+non-default scope. `ManagedIdentityAuthentication.clientId` (the identity's own client ID field) and
+`entraIdScope` share their field names with `ClientCredentialsAuthentication`'s fields of the same
+name rather than being disambiguated in Java, since the generator only requires distinct *template
+property IDs*, not distinct field names or binding paths — sibling sealed variants never coexist in
+one config, so both variants safely reusing the same runtime binding path is fine. Only
+`ManagedIdentityAuthentication`'s two fields set an explicit, path-relative `@TemplateProperty(id =
+...)` (e.g. `"managedIdentity.clientId"`) to break the tie; giving both sides an explicit id isn't
+needed once one side diverges from its default. This mirrors `apiVersion`, which exists only as a
+hidden, optional escape hatch for pinning a specific version, wired through the SDK's dedicated
+`azureServiceVersion(...)` builder method; the unified surface otherwise uses implicit versioning.
 
 Since a `ChatModel` (and the underlying `OpenAIClient`) is rebuilt on every agent turn, azure-identity
 `TokenCredential` instances (`ClientSecretCredential`, `ManagedIdentityCredential`) are cached and

--- a/connectors/agentic-ai/docs/reference/native-providers.md
+++ b/connectors/agentic-ai/docs/reference/native-providers.md
@@ -173,13 +173,18 @@ credential type each variant maps to and the Entra ID token scope — is encapsu
 and never sees a raw `TokenCredential` or any secret material. The credential caching itself (see
 below) lives one layer further down, in the provider-agnostic `EntraIdTokenCredentialFactory`.
 
-The openai-java SDK detects the Azure API surface (legacy dated `api-version` + deployment-in-path vs.
-the newer unified `/openai/v1` GA API) automatically from the endpoint hostname, so neither an
-api-version nor a URL-path-mode field is exposed as a normal config property. `apiVersion` exists only
-as a hidden, optional escape hatch for pinning a specific legacy-style API version, wired through the
-SDK's dedicated `azureServiceVersion(...)` builder method rather than the generic hidden
-`queryParameters` map — a manually-set `api-version` query parameter is silently dropped by the SDK
-when combined with Entra ID auth on a legacy-style endpoint.
+`OpenAiChatModelFactory` normalizes the configured `endpoint` onto the unified `/openai/v1` API surface
+(appending it if missing) for both classic Azure OpenAI (`*.openai.azure.com`) and Foundry
+(`*.services.ai.azure.com`) hosts alike, per
+[Microsoft's current Foundry endpoints guidance](https://learn.microsoft.com/en-us/azure/foundry/foundry-models/concepts/endpoints).
+This isn't optional: the openai-java SDK's own Azure-surface detection (`AzureUrlPathMode.AUTO`) only
+classifies a base URL as unified if its *path* already ends in `/openai/v1` — a bare resource endpoint,
+which is exactly what this backend's own `endpoint` field asks for, would otherwise be routed as the
+legacy, deployments-based API regardless of host. Since every request now targets the unified surface,
+the Entra ID token scope is a single constant (`https://ai.azure.com/.default`), not something derived
+per endpoint. `apiVersion` exists only as a hidden, optional escape hatch for pinning a specific
+version, wired through the SDK's dedicated `azureServiceVersion(...)` builder method — the unified
+surface otherwise uses implicit versioning.
 
 Since a `ChatModel` (and the underlying `OpenAIClient`) is rebuilt on every agent turn, azure-identity
 `TokenCredential` instances (`ClientSecretCredential`, `ManagedIdentityCredential`) are cached and

--- a/connectors/agentic-ai/docs/reference/native-providers.md
+++ b/connectors/agentic-ai/docs/reference/native-providers.md
@@ -181,10 +181,15 @@ This isn't optional: the openai-java SDK's own Azure-surface detection (`AzureUr
 classifies a base URL as unified if its *path* already ends in `/openai/v1` — a bare resource endpoint,
 which is exactly what this backend's own `endpoint` field asks for, would otherwise be routed as the
 legacy, deployments-based API regardless of host. Since every request now targets the unified surface,
-the Entra ID token scope is a single constant (`https://ai.azure.com/.default`), not something derived
-per endpoint. `apiVersion` exists only as a hidden, optional escape hatch for pinning a specific
-version, wired through the SDK's dedicated `azureServiceVersion(...)` builder method — the unified
-surface otherwise uses implicit versioning.
+the Entra ID token scope is fixed per Azure cloud rather than derived per endpoint: `https://ai.azure.com/.default`
+for Azure Public Cloud, `https://ai.azure.us/.default` for Azure US Government — the only other
+sovereign cloud Foundry supports today. `ClientCredentialsAuthentication`'s `authorityHost` field
+selects between them (matched against `com.azure.identity.AzureAuthorityHosts.AZURE_GOVERNMENT`;
+anything else, including an unset host, is Azure Public Cloud); `ManagedIdentityAuthentication` has no
+such field — its scope is always Azure Public Cloud, since IMDS-based managed identity is inherently
+tied to the cloud the identity already runs in and there's currently no field to signal otherwise. `apiVersion` exists only as a hidden,
+optional escape hatch for pinning a specific version, wired through the SDK's dedicated
+`azureServiceVersion(...)` builder method — the unified surface otherwise uses implicit versioning.
 
 Since a `ChatModel` (and the underlying `OpenAIClient`) is rebuilt on every agent turn, azure-identity
 `TokenCredential` instances (`ClientSecretCredential`, `ManagedIdentityCredential`) are cached and


### PR DESCRIPTION
Follow-up to #8361, which merged as `ea92383081` before this fix landed.

## Problem

The openai-java SDK's `AzureUrlPathMode.AUTO` only classifies a base URL as unified if its **path** already ends in `/openai/v1` — otherwise it's routed as the legacy, deployments-based API (`/openai/deployments/{model}/...` + forced `api-version` query param) regardless of host. A bare resource endpoint — exactly what the `foundry` backend's `endpoint` field asks for, and what the template placeholder shows — was therefore always classified legacy, for both classic Azure OpenAI (`*.openai.azure.com`) and Foundry (`*.services.ai.azure.com`) hosts.

Per [Microsoft's current Foundry endpoints guidance](https://learn.microsoft.com/en-us/azure/foundry/foundry-models/concepts/endpoints), both host families are meant to target `/openai/v1` unconditionally — the docs' own SDK examples append it even for classic `*.openai.azure.com` resources, and the base URL accepts both host forms with that suffix under one Entra ID scope.

## Fix

- `OpenAiChatModelFactory` now normalizes the configured endpoint onto `/openai/v1` (appending it if missing) instead of leaving Azure-surface detection to the SDK's hostname-based `AUTO` mode.
- `OpenAiFoundryCredentialResolver` requests the Entra ID token scope per Azure cloud rather than per endpoint: `https://ai.azure.com/.default` for Azure Public Cloud, `https://ai.azure.us/.default` for Azure US Government — the only other sovereign cloud Foundry supports today. `ClientCredentialsAuthentication`'s existing `authorityHost` field selects between the two; `ManagedIdentityAuthentication` has no such field, so it stays Azure Public Cloud only.
- Both Entra ID auth variants also get a hidden `entraIdScope` escape hatch (mirroring the existing hidden `apiVersion` field) for a wrong guess — a custom `authorityHost` this resolver doesn't recognize, or a managed identity that does need a non-default scope.
- `OpenAiChatModelFactory` also forces `builder.azureUrlPathMode(AzureUrlPathMode.UNIFIED)` explicitly rather than leaving it to `AUTO`: `AUTO`'s own host allowlist doesn't include Azure Government's `*.azure.us` hosts at all, so those endpoints were classified `NON_AZURE` regardless of path, silently dropping the `apiVersion` escape hatch and other Azure-specific request handling. Since the endpoint is already unconditionally normalized onto `/openai/v1`, there's no remaining case where `AUTO`'s guessing is needed.

Caught via Copilot's automated review as a suppressed low-confidence comment on #8361, then confirmed against openai-java 4.52.0 sources and Microsoft's current docs. The scope-per-cloud, escape-hatch and `azureUrlPathMode` pieces are follow-on refinements from review discussion on this PR itself, each caught by Copilot's review of the previous fix in turn.

Note: branch `8064-openai-foundry` (the original PR's branch name) got deleted+recreated as an orphan when this PR's predecessor merged mid-session; this is a fresh branch off `main` for that reason.
