### PR TITLE
feat(agentic-ai): send configuration as CONFIGURATION item on create

### DIFF
--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/BaseAgentTest.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/BaseAgentTest.java
@@ -24,7 +24,6 @@ import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options
 import static io.camunda.connector.e2e.agenticai.aiagent.AgentTestFixtures.AI_AGENT_ELEMENT_ID;
 import static io.camunda.connector.e2e.agenticai.aiagent.AgentToolSpecifications.EXPECTED_TOOL_SPECIFICATIONS;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.awaitility.Awaitility.await;
 
 import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.common.ConsoleNotifier;
@@ -260,26 +259,6 @@ public abstract class BaseAgentTest extends BaseAgenticAiTest {
     for (int i = 0; i < expectedMessages.length; i++) {
       expectedMessages[i].assertMatches(i, messages.get(i));
     }
-  }
-
-  /**
-   * Verifies on the engine that the agent instance is retrievable by key from secondary storage
-   * (RDBMS, eventually consistent) with its create-time definition, proving the {@code create}
-   * command landed on the broker and was indexed. Accumulated metrics / final status are verified
-   * via the {@code agentInstanceClient} spy, not here.
-   */
-  protected void assertAgentInstanceCreatedOnEngine(long agentInstanceKey, String expectedModel) {
-    await()
-        .alias("agent instance via REST get-by-key")
-        .atMost(Duration.ofSeconds(30))
-        .untilAsserted(
-            () -> {
-              final var agentInstance =
-                  camundaClient.newAgentInstanceGetRequest(agentInstanceKey).execute();
-              assertThat(agentInstance.getAgentInstanceKey()).isEqualTo(agentInstanceKey);
-              assertThat(agentInstance.getDefinition().getModel()).isEqualTo(expectedModel);
-              assertThat(agentInstance.getStatus()).isNotNull();
-            });
   }
 
   // ---------------------------------------------------------------------------

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/subprocess/AgentSubProcessAgentInstanceTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/subprocess/AgentSubProcessAgentInstanceTests.java
@@ -103,9 +103,6 @@ class AgentSubProcessAgentInstanceTests extends BaseAgentSubProcessTest {
                     .answering("The superflux calculation of 5 and 3 is complete."))
         .noMoreInteractions();
 
-    // Read the persisted state back through the query API and assert what actually landed on the
-    // broker: the accumulated metrics (which the spy above cannot prove committed), the create-time
-    // CONFIGURATION item, and the full committed history sequence.
     AgentInstanceEngineVerifier.verify(camundaClient, agentInstanceKey.get())
         .hasStatus(AgentInstanceStatus.COMPLETED)
         .hasMetrics(new AgentMetrics(2, new AgentMetrics.TokenUsage(25, 45), 1))
@@ -182,7 +179,6 @@ class AgentSubProcessAgentInstanceTests extends BaseAgentSubProcessTest {
                     .answering("The superflux calculation of 5 and 3 is complete."))
         .noMoreInteractions();
 
-    // Two tool-call rounds → one extra TOOL_RESULT + ASSISTANT pair in the persisted history.
     AgentInstanceEngineVerifier.verify(camundaClient, agentInstanceKey.get())
         .hasStatus(AgentInstanceStatus.COMPLETED)
         .hasMetrics(new AgentMetrics(3, new AgentMetrics.TokenUsage(35, 65), 2))
@@ -274,9 +270,7 @@ class AgentSubProcessAgentInstanceTests extends BaseAgentSubProcessTest {
 
     verifier.noMoreInteractions();
 
-    // Both tool results must be persisted on the engine, regardless of completion order. Roles are
-    // asserted loosely here (not the exact sequence) because the staggered early-report path can
-    // write a TOOL_RESULT row twice until per-item dedup lands (ADR 013, "Deferred").
+    // Loose role check: the staggered early-report path can write a TOOL_RESULT row twice.
     AgentInstanceEngineVerifier.verify(camundaClient, agentInstanceKey.get())
         .hasStatus(AgentInstanceStatus.COMPLETED)
         .hasToolResultsFor("SuperfluxProduct", "Download_A_File")

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/subprocess/AgentSubProcessAgentInstanceTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/subprocess/AgentSubProcessAgentInstanceTests.java
@@ -25,6 +25,8 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.verify;
 
+import io.camunda.client.api.search.enums.AgentInstanceHistoryRole;
+import io.camunda.client.api.search.enums.AgentInstanceStatus;
 import io.camunda.connector.agenticai.aiagent.agentinstance.AgentInstanceClient;
 import io.camunda.connector.agenticai.aiagent.agentinstance.AgentInstanceKey;
 import io.camunda.connector.agenticai.aiagent.model.AgentConversationTurn;
@@ -35,6 +37,7 @@ import io.camunda.connector.e2e.agenticai.aiagent.wiremock.openai.OpenAiCompleti
 import io.camunda.connector.e2e.agenticai.aiagent.wiremock.openai.OpenAiCompletionsChatModelStubs.ToolCall;
 import io.camunda.connector.e2e.agenticai.aiagent.wiremock.openai.OpenAiCompletionsChatModelStubs.Turn;
 import io.camunda.connector.e2e.agenticai.assertj.AgentInstanceClientVerifier;
+import io.camunda.connector.e2e.agenticai.assertj.AgentInstanceEngineVerifier;
 import io.camunda.connector.e2e.agenticai.assertj.AgentSubProcessResponseAssert;
 import io.camunda.connector.test.utils.annotation.SlowTest;
 import java.time.Duration;
@@ -100,9 +103,22 @@ class AgentSubProcessAgentInstanceTests extends BaseAgentSubProcessTest {
                     .answering("The superflux calculation of 5 and 3 is complete."))
         .noMoreInteractions();
 
-    // Verify on the engine that the agent instance the connector created actually landed on the
-    // broker and is queryable from secondary storage.
-    assertAgentInstanceCreatedOnEngine(agentInstanceKey.get(), "test-model");
+    // Read the persisted state back through the query API and assert what actually landed on the
+    // broker: the accumulated metrics (which the spy above cannot prove committed), the create-time
+    // CONFIGURATION item, and the full committed history sequence.
+    AgentInstanceEngineVerifier.verify(camundaClient, agentInstanceKey.get())
+        .hasStatus(AgentInstanceStatus.COMPLETED)
+        .hasMetrics(new AgentMetrics(2, new AgentMetrics.TokenUsage(25, 45), 1))
+        .hasDefinition("test-model", "openaiCompatible")
+        .hasToolsContaining("SuperfluxProduct")
+        .createdWithConfigurationItem("test-model", "openaiCompatible")
+        .hasConfigurationItemsAtLeast(2)
+        .hasConversationRoles(
+            AgentInstanceHistoryRole.USER,
+            AgentInstanceHistoryRole.ASSISTANT,
+            AgentInstanceHistoryRole.TOOL_RESULT,
+            AgentInstanceHistoryRole.ASSISTANT)
+        .verify();
   }
 
   /**
@@ -166,7 +182,22 @@ class AgentSubProcessAgentInstanceTests extends BaseAgentSubProcessTest {
                     .answering("The superflux calculation of 5 and 3 is complete."))
         .noMoreInteractions();
 
-    assertAgentInstanceCreatedOnEngine(agentInstanceKey.get(), "test-model");
+    // Two tool-call rounds → one extra TOOL_RESULT + ASSISTANT pair in the persisted history.
+    AgentInstanceEngineVerifier.verify(camundaClient, agentInstanceKey.get())
+        .hasStatus(AgentInstanceStatus.COMPLETED)
+        .hasMetrics(new AgentMetrics(3, new AgentMetrics.TokenUsage(35, 65), 2))
+        .hasDefinition("test-model", "openaiCompatible")
+        .hasToolsContaining("SuperfluxProduct")
+        .createdWithConfigurationItem("test-model", "openaiCompatible")
+        .hasConfigurationItemsAtLeast(2)
+        .hasConversationRoles(
+            AgentInstanceHistoryRole.USER,
+            AgentInstanceHistoryRole.ASSISTANT,
+            AgentInstanceHistoryRole.TOOL_RESULT,
+            AgentInstanceHistoryRole.ASSISTANT,
+            AgentInstanceHistoryRole.TOOL_RESULT,
+            AgentInstanceHistoryRole.ASSISTANT)
+        .verify();
   }
 
   /**
@@ -202,12 +233,15 @@ class AgentSubProcessAgentInstanceTests extends BaseAgentSubProcessTest {
             createProcessInstance(
                 Map.of("userPrompt", "Calculate the superflux product and download a file")));
 
+    final var agentInstanceKey = new AtomicLong();
     assertAgentResponse(
         zeebeTest,
-        agentResponse ->
-            AgentSubProcessResponseAssert.assertThat(agentResponse)
-                .isReady()
-                .hasMetrics(new AgentMetrics(2, new AgentMetrics.TokenUsage(25, 45), 2)));
+        agentResponse -> {
+          AgentSubProcessResponseAssert.assertThat(agentResponse)
+              .isReady()
+              .hasMetrics(new AgentMetrics(2, new AgentMetrics.TokenUsage(25, 45), 2));
+          agentInstanceKey.set(agentResponse.context().metadata().agentInstanceKey());
+        });
 
     final var verifier =
         AgentInstanceClientVerifier.verify(agentInstanceClient)
@@ -239,6 +273,14 @@ class AgentSubProcessAgentInstanceTests extends BaseAgentSubProcessTest {
             any(AgentConversationTurn.class));
 
     verifier.noMoreInteractions();
+
+    // Both tool results must be persisted on the engine, regardless of completion order. Roles are
+    // asserted loosely here (not the exact sequence) because the staggered early-report path can
+    // write a TOOL_RESULT row twice until per-item dedup lands (ADR 013, "Deferred").
+    AgentInstanceEngineVerifier.verify(camundaClient, agentInstanceKey.get())
+        .hasStatus(AgentInstanceStatus.COMPLETED)
+        .hasToolResultsFor("SuperfluxProduct", "Download_A_File")
+        .verify();
   }
 
   /**

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/task/AgentTaskAgentInstanceTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/task/AgentTaskAgentInstanceTests.java
@@ -98,9 +98,6 @@ class AgentTaskAgentInstanceTests extends BaseAgentTaskTest {
                     .answering("The superflux calculation of 5 and 3 is complete."))
         .noMoreInteractions();
 
-    // Read the persisted state back through the query API and assert what actually landed on the
-    // broker: the accumulated metrics (which the spy above cannot prove committed), the create-time
-    // CONFIGURATION item, and the full committed history sequence.
     AgentInstanceEngineVerifier.verify(camundaClient, agentInstanceKey.get())
         .hasStatus(AgentInstanceStatus.COMPLETED)
         .hasMetrics(new AgentMetrics(2, new AgentMetrics.TokenUsage(25, 45), 1))
@@ -182,7 +179,6 @@ class AgentTaskAgentInstanceTests extends BaseAgentTaskTest {
                     .answering("The superflux calculation of 5 and 3 is complete."))
         .noMoreInteractions();
 
-    // Two tool-call rounds → one extra TOOL_RESULT + ASSISTANT pair in the persisted history.
     AgentInstanceEngineVerifier.verify(camundaClient, agentInstanceKey.get())
         .hasStatus(AgentInstanceStatus.COMPLETED)
         .hasMetrics(new AgentMetrics(3, new AgentMetrics.TokenUsage(35, 65), 2))

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/task/AgentTaskAgentInstanceTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/task/AgentTaskAgentInstanceTests.java
@@ -16,12 +16,15 @@
  */
 package io.camunda.connector.e2e.agenticai.aiagent.task;
 
+import io.camunda.client.api.search.enums.AgentInstanceHistoryRole;
+import io.camunda.client.api.search.enums.AgentInstanceStatus;
 import io.camunda.connector.agenticai.aiagent.agentinstance.AgentInstanceClient;
 import io.camunda.connector.agenticai.aiagent.model.AgentMetrics;
 import io.camunda.connector.e2e.agenticai.aiagent.wiremock.openai.OpenAiCompletionsChatModelStubs;
 import io.camunda.connector.e2e.agenticai.aiagent.wiremock.openai.OpenAiCompletionsChatModelStubs.ToolCall;
 import io.camunda.connector.e2e.agenticai.aiagent.wiremock.openai.OpenAiCompletionsChatModelStubs.Turn;
 import io.camunda.connector.e2e.agenticai.assertj.AgentInstanceClientVerifier;
+import io.camunda.connector.e2e.agenticai.assertj.AgentInstanceEngineVerifier;
 import io.camunda.connector.e2e.agenticai.assertj.AgentResponseAssert;
 import io.camunda.connector.test.utils.annotation.SlowTest;
 import java.util.Map;
@@ -95,9 +98,22 @@ class AgentTaskAgentInstanceTests extends BaseAgentTaskTest {
                     .answering("The superflux calculation of 5 and 3 is complete."))
         .noMoreInteractions();
 
-    // Verify on the engine that the agent instance the connector created actually landed on the
-    // broker and is queryable from secondary storage.
-    assertAgentInstanceCreatedOnEngine(agentInstanceKey.get(), "gpt-4o");
+    // Read the persisted state back through the query API and assert what actually landed on the
+    // broker: the accumulated metrics (which the spy above cannot prove committed), the create-time
+    // CONFIGURATION item, and the full committed history sequence.
+    AgentInstanceEngineVerifier.verify(camundaClient, agentInstanceKey.get())
+        .hasStatus(AgentInstanceStatus.COMPLETED)
+        .hasMetrics(new AgentMetrics(2, new AgentMetrics.TokenUsage(25, 45), 1))
+        .hasDefinition("gpt-4o", "openaiCompatible")
+        .hasToolsContaining("SuperfluxProduct")
+        .createdWithConfigurationItem("gpt-4o", "openaiCompatible")
+        .hasConfigurationItemsAtLeast(2)
+        .hasConversationRoles(
+            AgentInstanceHistoryRole.USER,
+            AgentInstanceHistoryRole.ASSISTANT,
+            AgentInstanceHistoryRole.TOOL_RESULT,
+            AgentInstanceHistoryRole.ASSISTANT)
+        .verify();
   }
 
   /**
@@ -166,6 +182,21 @@ class AgentTaskAgentInstanceTests extends BaseAgentTaskTest {
                     .answering("The superflux calculation of 5 and 3 is complete."))
         .noMoreInteractions();
 
-    assertAgentInstanceCreatedOnEngine(agentInstanceKey.get(), "gpt-4o");
+    // Two tool-call rounds → one extra TOOL_RESULT + ASSISTANT pair in the persisted history.
+    AgentInstanceEngineVerifier.verify(camundaClient, agentInstanceKey.get())
+        .hasStatus(AgentInstanceStatus.COMPLETED)
+        .hasMetrics(new AgentMetrics(3, new AgentMetrics.TokenUsage(35, 65), 2))
+        .hasDefinition("gpt-4o", "openaiCompatible")
+        .hasToolsContaining("SuperfluxProduct")
+        .createdWithConfigurationItem("gpt-4o", "openaiCompatible")
+        .hasConfigurationItemsAtLeast(2)
+        .hasConversationRoles(
+            AgentInstanceHistoryRole.USER,
+            AgentInstanceHistoryRole.ASSISTANT,
+            AgentInstanceHistoryRole.TOOL_RESULT,
+            AgentInstanceHistoryRole.ASSISTANT,
+            AgentInstanceHistoryRole.TOOL_RESULT,
+            AgentInstanceHistoryRole.ASSISTANT)
+        .verify();
   }
 }

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/assertj/AgentInstanceEngineVerifier.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/assertj/AgentInstanceEngineVerifier.java
@@ -1,0 +1,224 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.e2e.agenticai.assertj;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.search.enums.AgentInstanceHistoryCommitStatus;
+import io.camunda.client.api.search.enums.AgentInstanceHistoryRole;
+import io.camunda.client.api.search.enums.AgentInstanceStatus;
+import io.camunda.client.api.search.response.AgentInstance;
+import io.camunda.client.api.search.response.AgentInstanceHistory;
+import io.camunda.connector.agenticai.aiagent.model.AgentMetrics;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+
+/**
+ * Verifies the agent instance state the connector actually persisted on the engine, read back
+ * through the query API (get-by-key + history search) from secondary storage.
+ *
+ * <p>Complements {@link AgentInstanceClientVerifier}: that one proves the ordered sequence of
+ * client <em>calls</em> the connector made (a Mockito spy); this one proves those calls committed
+ * and accumulated on the broker, which the spy fundamentally cannot show.
+ *
+ * <p>Secondary storage is eventually consistent, so every assertion is collected up front and
+ * evaluated together inside a single {@link org.awaitility.Awaitility} block — instance-level and
+ * history-level rows propagate independently, so splitting the await would flake. History reads are
+ * filtered to {@link AgentInstanceHistoryCommitStatus#COMMITTED} (what "correctly stored" means)
+ * and sorted by the engine-assigned, monotonic {@code historyItemKey} (items in one batched update
+ * carry near-identical connector timestamps and would tie on {@code producedAt}).
+ */
+public class AgentInstanceEngineVerifier {
+
+  private final CamundaClient client;
+  private final long agentInstanceKey;
+  private final List<Consumer<AgentInstance>> instanceChecks = new ArrayList<>();
+  private final List<Consumer<List<AgentInstanceHistory>>> historyChecks = new ArrayList<>();
+
+  private AgentInstanceEngineVerifier(CamundaClient client, long agentInstanceKey) {
+    this.client = client;
+    this.agentInstanceKey = agentInstanceKey;
+  }
+
+  public static AgentInstanceEngineVerifier verify(CamundaClient client, long agentInstanceKey) {
+    return new AgentInstanceEngineVerifier(client, agentInstanceKey);
+  }
+
+  /** The instance reached its terminal status (the engine transitions to COMPLETED on close). */
+  public AgentInstanceEngineVerifier hasStatus(AgentInstanceStatus status) {
+    instanceChecks.add(
+        instance -> assertThat(instance.getStatus()).as("agent instance status").isEqualTo(status));
+    return this;
+  }
+
+  /**
+   * The accumulated counter metrics stored on the instance equal {@code expected} — the batched
+   * turn updates committed and summed on the broker. {@code executionTime} is per-turn and not
+   * accumulated, so it is ignored here.
+   */
+  public AgentInstanceEngineVerifier hasMetrics(AgentMetrics expected) {
+    instanceChecks.add(
+        instance -> {
+          final var metrics = instance.getMetrics();
+          assertThat(metrics.getModelCalls()).as("modelCalls").isEqualTo(expected.modelCalls());
+          assertThat(metrics.getInputTokens())
+              .as("inputTokens")
+              .isEqualTo(expected.tokenUsage().inputTokenCount());
+          assertThat(metrics.getOutputTokens())
+              .as("outputTokens")
+              .isEqualTo(expected.tokenUsage().outputTokenCount());
+          assertThat(metrics.getToolCalls()).as("toolCalls").isEqualTo(expected.toolCalls());
+        });
+    return this;
+  }
+
+  /**
+   * The instance definition carries the configured model/provider and a non-empty system prompt.
+   */
+  public AgentInstanceEngineVerifier hasDefinition(String model, String provider) {
+    instanceChecks.add(
+        instance -> {
+          final var definition = instance.getDefinition();
+          assertThat(definition.getModel()).as("definition model").isEqualTo(model);
+          assertThat(definition.getProvider()).as("definition provider").isEqualTo(provider);
+          assertThat(definition.getSystemPrompt()).as("definition system prompt").isNotEmpty();
+        });
+    return this;
+  }
+
+  /** The instance advertises (at least) the given resolved tool names. */
+  public AgentInstanceEngineVerifier hasToolsContaining(String... toolNames) {
+    instanceChecks.add(
+        instance ->
+            assertThat(instance.getTools())
+                .as("resolved tools")
+                .extracting(AgentInstance.Tool::getName)
+                .contains(toolNames));
+    return this;
+  }
+
+  /**
+   * The create-time CONFIGURATION history item is present with the configuration the connector sent
+   * on {@code create}: model, provider, a non-empty system prompt, the create job's key and lease,
+   * and the 1-based first loop iteration. This is the end-to-end proof of issue #8390
+   * (configuration sent as a CONFIGURATION item, lease-fenced via jobKey/jobLease) — previously
+   * covered only at the Mockito level.
+   *
+   * <p>The lowest-keyed CONFIGURATION item is the create-time one; further CONFIGURATION items from
+   * each {@code applyTurnStart} follow (see {@link #hasConfigurationItemsAtLeast}).
+   */
+  public AgentInstanceEngineVerifier createdWithConfigurationItem(String model, String provider) {
+    historyChecks.add(
+        history -> {
+          final var configItem =
+              history.stream()
+                  .filter(item -> item.getRole() == AgentInstanceHistoryRole.CONFIGURATION)
+                  .findFirst()
+                  .orElseThrow(
+                      () -> new AssertionError("no CONFIGURATION history item on the instance"));
+          assertThat(configItem.getModel()).as("config item model").isEqualTo(model);
+          assertThat(configItem.getProvider()).as("config item provider").isEqualTo(provider);
+          assertThat(configItem.getSystemPrompt()).as("config item system prompt").isNotEmpty();
+          assertThat(configItem.getLoopIteration()).as("config item loop iteration").isEqualTo(1);
+          assertThat(configItem.getJobKey()).as("config item job key").isPositive();
+          assertThat(configItem.getJobLease()).as("config item job lease").isNotBlank();
+        });
+    return this;
+  }
+
+  /**
+   * The committed non-CONFIGURATION history items carry exactly these roles in {@code
+   * historyItemKey} order — the conversation backbone (USER prompt, ASSISTANT responses,
+   * TOOL_RESULT inputs).
+   *
+   * <p>CONFIGURATION items are filtered out first because their count is not stable: {@code create}
+   * emits one, and every turn-start re-emits one (the previous turn's configuration fingerprint is
+   * not retained across job activations, so the change-detection in {@code
+   * CamundaAgentInstanceClient} treats each turn as a change). Surplus CONFIGURATION rows are
+   * tolerated per ADR 013 pending per-item dedup (camunda/camunda#58792); their presence is
+   * asserted separately via {@link #hasConfigurationItemsAtLeast}.
+   */
+  public AgentInstanceEngineVerifier hasConversationRoles(AgentInstanceHistoryRole... roles) {
+    historyChecks.add(
+        history ->
+            assertThat(history)
+                .as("committed conversation-backbone roles (CONFIGURATION filtered out)")
+                .filteredOn(item -> item.getRole() != AgentInstanceHistoryRole.CONFIGURATION)
+                .extracting(AgentInstanceHistory::getRole)
+                .containsExactly(roles));
+    return this;
+  }
+
+  /**
+   * At least {@code min} committed CONFIGURATION items are present: the create-time one plus at
+   * least the first turn-start's. See {@link #hasConversationRoles} for why the exact count is not
+   * pinned.
+   */
+  public AgentInstanceEngineVerifier hasConfigurationItemsAtLeast(int min) {
+    historyChecks.add(
+        history ->
+            assertThat(history)
+                .as("committed CONFIGURATION history items")
+                .filteredOn(item -> item.getRole() == AgentInstanceHistoryRole.CONFIGURATION)
+                .hasSizeGreaterThanOrEqualTo(min));
+    return this;
+  }
+
+  /**
+   * A committed TOOL_RESULT history item exists for each of the given tool names (matched on the
+   * originating tool call). Order-agnostic and tolerant of the streamed-early duplicate rows ADR
+   * 013 documents, so it fits the staggered-tool cases.
+   */
+  public AgentInstanceEngineVerifier hasToolResultsFor(String... toolNames) {
+    historyChecks.add(
+        history -> {
+          final var resultToolNames =
+              history.stream()
+                  .filter(item -> item.getRole() == AgentInstanceHistoryRole.TOOL_RESULT)
+                  .flatMap(item -> item.getToolCalls().stream())
+                  .map(toolCall -> toolCall.getToolName())
+                  .toList();
+          assertThat(resultToolNames).as("tool result tool names").contains(toolNames);
+        });
+    return this;
+  }
+
+  /** Runs every collected assertion together, awaiting eventual-consistency propagation. */
+  public void verify() {
+    await()
+        .alias("agent instance state via query API")
+        .atMost(Duration.ofSeconds(30))
+        .ignoreExceptions()
+        .untilAsserted(
+            () -> {
+              final var instance = client.newAgentInstanceGetRequest(agentInstanceKey).execute();
+              final var history =
+                  client
+                      .newAgentInstanceHistorySearchRequest(agentInstanceKey)
+                      .filter(f -> f.commitStatus(AgentInstanceHistoryCommitStatus.COMMITTED))
+                      .sort(s -> s.historyItemKey().asc())
+                      .execute()
+                      .items();
+              instanceChecks.forEach(check -> check.accept(instance));
+              historyChecks.forEach(check -> check.accept(history));
+            });
+  }
+}

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/assertj/AgentInstanceEngineVerifier.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/assertj/AgentInstanceEngineVerifier.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
 import io.camunda.client.CamundaClient;
+import io.camunda.client.api.command.AgentInstanceHistoryToolCall;
 import io.camunda.client.api.search.enums.AgentInstanceHistoryCommitStatus;
 import io.camunda.client.api.search.enums.AgentInstanceHistoryRole;
 import io.camunda.client.api.search.enums.AgentInstanceStatus;
@@ -31,21 +32,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Consumer;
 
-/**
- * Verifies the agent instance state the connector actually persisted on the engine, read back
- * through the query API (get-by-key + history search) from secondary storage.
- *
- * <p>Complements {@link AgentInstanceClientVerifier}: that one proves the ordered sequence of
- * client <em>calls</em> the connector made (a Mockito spy); this one proves those calls committed
- * and accumulated on the broker, which the spy fundamentally cannot show.
- *
- * <p>Secondary storage is eventually consistent, so every assertion is collected up front and
- * evaluated together inside a single {@link org.awaitility.Awaitility} block — instance-level and
- * history-level rows propagate independently, so splitting the await would flake. History reads are
- * filtered to {@link AgentInstanceHistoryCommitStatus#COMMITTED} (what "correctly stored" means)
- * and sorted by the engine-assigned, monotonic {@code historyItemKey} (items in one batched update
- * carry near-identical connector timestamps and would tie on {@code producedAt}).
- */
+/** Reads an agent instance back through the query API and asserts its persisted state. */
 public class AgentInstanceEngineVerifier {
 
   private final CamundaClient client;
@@ -62,18 +49,12 @@ public class AgentInstanceEngineVerifier {
     return new AgentInstanceEngineVerifier(client, agentInstanceKey);
   }
 
-  /** The instance reached its terminal status (the engine transitions to COMPLETED on close). */
   public AgentInstanceEngineVerifier hasStatus(AgentInstanceStatus status) {
     instanceChecks.add(
         instance -> assertThat(instance.getStatus()).as("agent instance status").isEqualTo(status));
     return this;
   }
 
-  /**
-   * The accumulated counter metrics stored on the instance equal {@code expected} — the batched
-   * turn updates committed and summed on the broker. {@code executionTime} is per-turn and not
-   * accumulated, so it is ignored here.
-   */
   public AgentInstanceEngineVerifier hasMetrics(AgentMetrics expected) {
     instanceChecks.add(
         instance -> {
@@ -90,9 +71,6 @@ public class AgentInstanceEngineVerifier {
     return this;
   }
 
-  /**
-   * The instance definition carries the configured model/provider and a non-empty system prompt.
-   */
   public AgentInstanceEngineVerifier hasDefinition(String model, String provider) {
     instanceChecks.add(
         instance -> {
@@ -104,7 +82,6 @@ public class AgentInstanceEngineVerifier {
     return this;
   }
 
-  /** The instance advertises (at least) the given resolved tool names. */
   public AgentInstanceEngineVerifier hasToolsContaining(String... toolNames) {
     instanceChecks.add(
         instance ->
@@ -115,16 +92,7 @@ public class AgentInstanceEngineVerifier {
     return this;
   }
 
-  /**
-   * The create-time CONFIGURATION history item is present with the configuration the connector sent
-   * on {@code create}: model, provider, a non-empty system prompt, the create job's key and lease,
-   * and the 1-based first loop iteration. This is the end-to-end proof of issue #8390
-   * (configuration sent as a CONFIGURATION item, lease-fenced via jobKey/jobLease) — previously
-   * covered only at the Mockito level.
-   *
-   * <p>The lowest-keyed CONFIGURATION item is the create-time one; further CONFIGURATION items from
-   * each {@code applyTurnStart} follow (see {@link #hasConfigurationItemsAtLeast}).
-   */
+  /** Asserts the create-time CONFIGURATION item, i.e. the lowest-keyed one. */
   public AgentInstanceEngineVerifier createdWithConfigurationItem(String model, String provider) {
     historyChecks.add(
         history -> {
@@ -145,16 +113,8 @@ public class AgentInstanceEngineVerifier {
   }
 
   /**
-   * The committed non-CONFIGURATION history items carry exactly these roles in {@code
-   * historyItemKey} order — the conversation backbone (USER prompt, ASSISTANT responses,
-   * TOOL_RESULT inputs).
-   *
-   * <p>CONFIGURATION items are filtered out first because their count is not stable: {@code create}
-   * emits one, and every turn-start re-emits one (the previous turn's configuration fingerprint is
-   * not retained across job activations, so the change-detection in {@code
-   * CamundaAgentInstanceClient} treats each turn as a change). Surplus CONFIGURATION rows are
-   * tolerated per ADR 013 pending per-item dedup (camunda/camunda#58792); their presence is
-   * asserted separately via {@link #hasConfigurationItemsAtLeast}.
+   * Asserts the non-CONFIGURATION roles in {@code historyItemKey} order. CONFIGURATION items are
+   * excluded because one is emitted per turn-start, not only on configuration change.
    */
   public AgentInstanceEngineVerifier hasConversationRoles(AgentInstanceHistoryRole... roles) {
     historyChecks.add(
@@ -167,11 +127,6 @@ public class AgentInstanceEngineVerifier {
     return this;
   }
 
-  /**
-   * At least {@code min} committed CONFIGURATION items are present: the create-time one plus at
-   * least the first turn-start's. See {@link #hasConversationRoles} for why the exact count is not
-   * pinned.
-   */
   public AgentInstanceEngineVerifier hasConfigurationItemsAtLeast(int min) {
     historyChecks.add(
         history ->
@@ -182,11 +137,7 @@ public class AgentInstanceEngineVerifier {
     return this;
   }
 
-  /**
-   * A committed TOOL_RESULT history item exists for each of the given tool names (matched on the
-   * originating tool call). Order-agnostic and tolerant of the streamed-early duplicate rows ADR
-   * 013 documents, so it fits the staggered-tool cases.
-   */
+  /** Asserts a committed TOOL_RESULT exists for each named tool, order-agnostic. */
   public AgentInstanceEngineVerifier hasToolResultsFor(String... toolNames) {
     historyChecks.add(
         history -> {
@@ -194,14 +145,14 @@ public class AgentInstanceEngineVerifier {
               history.stream()
                   .filter(item -> item.getRole() == AgentInstanceHistoryRole.TOOL_RESULT)
                   .flatMap(item -> item.getToolCalls().stream())
-                  .map(toolCall -> toolCall.getToolName())
+                  .map(AgentInstanceHistoryToolCall::getToolName)
                   .toList();
           assertThat(resultToolNames).as("tool result tool names").contains(toolNames);
         });
     return this;
   }
 
-  /** Runs every collected assertion together, awaiting eventual-consistency propagation. */
+  /** Awaits eventual consistency and evaluates all collected checks together. */
   public void verify() {
     await()
         .alias("agent instance state via query API")

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/assertj/AgentInstanceEngineVerifier.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/assertj/AgentInstanceEngineVerifier.java
@@ -114,7 +114,8 @@ public class AgentInstanceEngineVerifier {
 
   /**
    * Asserts the non-CONFIGURATION roles in {@code historyItemKey} order. CONFIGURATION items are
-   * excluded because one is emitted per turn-start, not only on configuration change.
+   * excluded because {@code applyTurnStart} emits one only for the first turn or when the
+   * configuration changed since the previous turn, not on every turn-start.
    */
   public AgentInstanceEngineVerifier hasConversationRoles(AgentInstanceHistoryRole... roles) {
     historyChecks.add(

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/agentinstance/AgentInstanceClient.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/agentinstance/AgentInstanceClient.java
@@ -22,7 +22,10 @@ public interface AgentInstanceClient {
 
   /**
    * Creates an agent instance on the engine, or returns the key of the existing one. The engine
-   * command is idempotent by {@code elementInstanceKey}.
+   * command is idempotent by {@code elementInstanceKey}. The instance's configuration (model,
+   * provider, system prompt, tools) is sent as a {@code CONFIGURATION} history item rather than as
+   * direct command fields, and {@code jobKey}/{@code jobLease} are forwarded to fence the batched
+   * history against a superseded activation.
    *
    * @throws ConnectorException with code AGENT_INSTANCE_CREATION_FAILED when retries are exhausted
    *     or a non-retryable error occurs

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/agentinstance/CamundaAgentInstanceClient.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/agentinstance/CamundaAgentInstanceClient.java
@@ -110,9 +110,11 @@ public class CamundaAgentInstanceClient implements AgentInstanceClient {
         configuration.chatModel().provider());
 
     // Establish the instance definition (model/provider/systemPrompt) and tools as a CONFIGURATION
-    // history item rather than direct command fields, matching how every subsequent turn update
-    // records configuration. The first turn's applyTurnStart still emits its own CONFIGURATION item
-    // once tools are resolved -- that redundancy is accepted (ADR 013).
+    // history item rather than direct command fields. model/provider are fixed at create time and
+    // not re-pushed by later CONFIGURATION items (ai-agent.md §23); systemPrompt/tools are shared
+    // with configurationHistoryItem, which turn updates reuse. The first turn's applyTurnStart
+    // still emits its own CONFIGURATION item once tools are resolved -- that redundancy is
+    // accepted (ADR 013).
     // The engine rejects top-level limits (maxModelCalls etc.) alongside a history batch; the
     // model-call limit lives on the connector side and is recorded on the CONFIGURATION item's
     // fingerprint, consistent with how turn updates carry configuration.
@@ -123,8 +125,9 @@ public class CamundaAgentInstanceClient implements AgentInstanceClient {
             .jobKey(jobContext.getJobKey())
             .history(
                 List.of(
-                    configurationHistoryItem(
-                        configuration, FIRST_ITERATION, OffsetDateTime.now())));
+                    configurationHistoryItem(configuration, FIRST_ITERATION, OffsetDateTime.now())
+                        .model(configuration.chatModel().model())
+                        .provider(configuration.chatModel().provider())));
 
     final String leaseToken = jobContext.getLeaseToken();
     if (leaseToken != null && !leaseToken.isBlank()) {
@@ -291,8 +294,6 @@ public class CamundaAgentInstanceClient implements AgentInstanceClient {
         .content(List.of())
         .loopIteration(iterationKey)
         .producedAt(producedAt)
-        .model(configuration.chatModel().model())
-        .provider(configuration.chatModel().provider())
         .systemPrompt(
             List.of(AgentInstanceHistoryContent.text(configuration.systemPrompt().prompt())))
         .tools(toolMapper.mapTools(configuration.toolDefinitions()));

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/agentinstance/CamundaAgentInstanceClient.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/agentinstance/CamundaAgentInstanceClient.java
@@ -49,6 +49,9 @@ public class CamundaAgentInstanceClient implements AgentInstanceClient {
 
   private static final int HTTP_STATUS_CONFLICT = 409;
 
+  // Loop iterations are 1-based; the create-time CONFIGURATION item belongs to the first turn.
+  private static final int FIRST_ITERATION = 1;
+
   /**
    * Matches the {@code detail} message of a {@code 409 ALREADY_EXISTS} response from {@code POST
    * /agent-instances}, capturing the existing agent instance key.
@@ -97,7 +100,8 @@ public class CamundaAgentInstanceClient implements AgentInstanceClient {
   }
 
   private AgentInstanceKey executeCreate(AgentExecutionContext agentExecutionContext) {
-    final long elementInstanceKey = agentExecutionContext.jobContext().getElementInstanceKey();
+    final var jobContext = agentExecutionContext.jobContext();
+    final long elementInstanceKey = jobContext.getElementInstanceKey();
     final var configuration = agentExecutionContext.configuration();
     LOGGER.debug(
         "Creating agent instance for element instance {}: model={}, provider={}",
@@ -105,17 +109,26 @@ public class CamundaAgentInstanceClient implements AgentInstanceClient {
         configuration.chatModel().model(),
         configuration.chatModel().provider());
 
+    // Establish the instance definition (model/provider/systemPrompt) and tools as a CONFIGURATION
+    // history item rather than direct command fields, matching how every subsequent turn update
+    // records configuration. The first turn's applyTurnStart still emits its own CONFIGURATION item
+    // once tools are resolved -- that redundancy is accepted (ADR 013).
+    // The engine rejects top-level limits (maxModelCalls etc.) alongside a history batch; the
+    // model-call limit lives on the connector side and is recorded on the CONFIGURATION item's
+    // fingerprint, consistent with how turn updates carry configuration.
     var command =
         camundaClient
             .newCreateAgentInstanceCommand()
             .elementInstanceKey(elementInstanceKey)
-            .model(configuration.chatModel().model())
-            .provider(configuration.chatModel().provider())
-            .systemPrompt(configuration.systemPrompt().prompt());
+            .jobKey(jobContext.getJobKey())
+            .history(
+                List.of(
+                    configurationHistoryItem(
+                        configuration, FIRST_ITERATION, OffsetDateTime.now())));
 
-    final var limits = configuration.limits();
-    if (limits != null && limits.maxModelCalls() != null) {
-      command = command.maxModelCalls(limits.maxModelCalls());
+    final String leaseToken = jobContext.getLeaseToken();
+    if (leaseToken != null && !leaseToken.isBlank()) {
+      command = command.jobLease(leaseToken);
     }
 
     try {
@@ -278,6 +291,8 @@ public class CamundaAgentInstanceClient implements AgentInstanceClient {
         .content(List.of())
         .loopIteration(iterationKey)
         .producedAt(producedAt)
+        .model(configuration.chatModel().model())
+        .provider(configuration.chatModel().provider())
         .systemPrompt(
             List.of(AgentInstanceHistoryContent.text(configuration.systemPrompt().prompt())))
         .tools(toolMapper.mapTools(configuration.toolDefinitions()));

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/agentinstance/CamundaAgentInstanceClientTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/agentinstance/CamundaAgentInstanceClientTest.java
@@ -95,8 +95,10 @@ class CamundaAgentInstanceClientTest {
 
   @Mock private CamundaClient camundaClient;
 
-  @Mock(answer = Answers.RETURNS_DEEP_STUBS)
-  private CreateAgentInstanceCommandStep1 commandChain;
+  @Mock private CreateAgentInstanceCommandStep1 createCommandStep1;
+
+  @Mock(answer = Answers.RETURNS_SELF)
+  private CreateAgentInstanceCommandStep2 createCommandStep2;
 
   @Mock private CreateAgentInstanceResponse response;
 
@@ -104,8 +106,6 @@ class CamundaAgentInstanceClientTest {
 
   @Mock(answer = Answers.RETURNS_SELF)
   private UpdateAgentInstanceCommandStep2 updateCommandStep2;
-
-  private CreateAgentInstanceCommandStep2 step5;
 
   @Mock private GatewayToolHandlerRegistry gatewayToolHandlers;
 
@@ -123,18 +123,9 @@ class CamundaAgentInstanceClientTest {
   }
 
   private void givenCreateCommand() {
-    when(camundaClient.newCreateAgentInstanceCommand()).thenReturn(commandChain);
-    step5 =
-        commandChain
-            .elementInstanceKey(ELEMENT_INSTANCE_KEY)
-            .model("gpt-4o")
-            .provider(OpenAiProviderConfiguration.OPENAI_ID)
-            .systemPrompt("system prompt");
-  }
-
-  private void givenCreateCommandWithMaxModelCalls() {
-    givenCreateCommand();
-    when(step5.maxModelCalls(10)).thenReturn(step5);
+    when(camundaClient.newCreateAgentInstanceCommand()).thenReturn(createCommandStep1);
+    when(createCommandStep1.elementInstanceKey(ELEMENT_INSTANCE_KEY))
+        .thenReturn(createCommandStep2);
   }
 
   private void givenUpdateCommand() {
@@ -147,23 +138,53 @@ class CamundaAgentInstanceClientTest {
   @Nested
   class Create {
 
+    @SuppressWarnings("unchecked")
     @Test
     void shouldReturnAgentInstanceKeyOnFirstSuccessfulAttempt() {
-      givenCreateCommandWithMaxModelCalls();
-      when(step5.execute()).thenReturn(response);
+      givenCreateCommand();
+      when(createCommandStep2.execute()).thenReturn(response);
       when(response.getAgentInstanceKey()).thenReturn(12345L);
 
-      final AgentInstanceKey key = client.create(TestAgentExecutionContext.withLimits());
+      final var executionContext = TestAgentExecutionContext.withLimits();
+      final AgentInstanceKey key = client.create(executionContext);
 
       assertThat(key).isEqualTo(AgentInstanceKey.of(12345L));
       assertThat(recordedSleeps).isEmpty();
       verify(camundaClient, times(1)).newCreateAgentInstanceCommand();
+
+      // definition and tools are established as a CONFIGURATION history item, not direct fields
+      final ArgumentCaptor<List<AgentInstanceHistoryItem>> historyCaptor =
+          ArgumentCaptor.forClass(List.class);
+      verify(createCommandStep1).elementInstanceKey(ELEMENT_INSTANCE_KEY);
+      verify(createCommandStep2).jobKey(JOB_KEY);
+      // top-level limits are forbidden alongside a history batch
+      verify(createCommandStep2, never()).maxModelCalls(anyInt());
+      verify(createCommandStep2, never()).jobLease(any());
+      verify(createCommandStep2).history(historyCaptor.capture());
+
+      assertThat(historyCaptor.getValue())
+          .singleElement()
+          .satisfies(
+              item -> {
+                assertThat(item.getRole()).isEqualTo(AgentInstanceHistoryRole.CONFIGURATION);
+                assertThat(item.getHistoryItemId())
+                    .isEqualTo(executionContext.configuration().fingerprint());
+                assertThat(item.getLoopIteration()).isEqualTo(1);
+                assertThat(item.getModel()).isEqualTo("gpt-4o");
+                assertThat(item.getProvider()).isEqualTo(OpenAiProviderConfiguration.OPENAI_ID);
+                assertThat(item.getSystemPrompt())
+                    .singleElement()
+                    .isInstanceOfSatisfying(
+                        AgentInstanceHistoryContent.TextContent.class,
+                        text -> assertThat(text.getText()).isEqualTo("system prompt"));
+                assertThat(item.getTools()).isEmpty();
+              });
     }
 
     @Test
     void shouldReturnAgentInstanceKeyOnFirstAttemptWhenMaxModelCallsIsNull() {
       givenCreateCommand();
-      when(step5.execute()).thenReturn(response);
+      when(createCommandStep2.execute()).thenReturn(response);
       when(response.getAgentInstanceKey()).thenReturn(67890L);
 
       final AgentInstanceKey key = client.create(TestAgentExecutionContext.withoutLimits());
@@ -171,12 +192,26 @@ class CamundaAgentInstanceClientTest {
       assertThat(key).isEqualTo(AgentInstanceKey.of(67890L));
       assertThat(recordedSleeps).isEmpty();
       verify(camundaClient, times(1)).newCreateAgentInstanceCommand();
+      verify(createCommandStep2).jobKey(JOB_KEY);
+      verify(createCommandStep2).history(any());
+      verify(createCommandStep2, never()).maxModelCalls(anyInt());
+    }
+
+    @Test
+    void shouldForwardLeaseTokenWhenActivationIsLeased() {
+      givenCreateCommand();
+      when(createCommandStep2.execute()).thenReturn(response);
+      when(response.getAgentInstanceKey()).thenReturn(12345L);
+
+      client.create(TestAgentExecutionContext.withLeaseToken("lease-token-abc"));
+
+      verify(createCommandStep2).jobLease("lease-token-abc");
     }
 
     @Test
     void shouldThrowConnectorExceptionImmediatelyForHttp400PermanentError() {
-      givenCreateCommandWithMaxModelCalls();
-      when(step5.execute()).thenThrow(new ClientHttpException(400, "Bad Request"));
+      givenCreateCommand();
+      when(createCommandStep2.execute()).thenThrow(new ClientHttpException(400, "Bad Request"));
 
       assertThatThrownBy(() -> client.create(TestAgentExecutionContext.withLimits()))
           .isInstanceOfSatisfying(
@@ -192,8 +227,8 @@ class CamundaAgentInstanceClientTest {
 
     @Test
     void shouldReturnKeyAndRecordOneSleepWhenRetryableErrorPrecedesSuccess() {
-      givenCreateCommandWithMaxModelCalls();
-      when(step5.execute())
+      givenCreateCommand();
+      when(createCommandStep2.execute())
           .thenThrow(new ClientHttpException(503, "Service Unavailable"))
           .thenReturn(response);
       when(response.getAgentInstanceKey()).thenReturn(999L);
@@ -210,8 +245,8 @@ class CamundaAgentInstanceClientTest {
     void shouldThrowConnectorExceptionImmediatelyForHttp404PermanentError() {
       // given: a 404 from the create endpoint (x-eventually-consistent: false) means the
       // referenced element instance genuinely doesn't exist, not a not-yet-visible record
-      givenCreateCommandWithMaxModelCalls();
-      when(step5.execute()).thenThrow(new ClientHttpException(404, "Not Found"));
+      givenCreateCommand();
+      when(createCommandStep2.execute()).thenThrow(new ClientHttpException(404, "Not Found"));
 
       assertThatThrownBy(() -> client.create(TestAgentExecutionContext.withLimits()))
           .isInstanceOfSatisfying(
@@ -227,8 +262,9 @@ class CamundaAgentInstanceClientTest {
 
     @Test
     void shouldThrowConnectorExceptionWithAttemptCountWhenAllRetriesAreExhausted() {
-      givenCreateCommandWithMaxModelCalls();
-      when(step5.execute()).thenThrow(new ClientHttpException(500, "Internal Server Error"));
+      givenCreateCommand();
+      when(createCommandStep2.execute())
+          .thenThrow(new ClientHttpException(500, "Internal Server Error"));
 
       assertThatThrownBy(() -> client.create(TestAgentExecutionContext.withLimits()))
           .isInstanceOfSatisfying(
@@ -252,12 +288,12 @@ class CamundaAgentInstanceClientTest {
     @Test
     void shouldReturnExistingAgentInstanceKeyOnConflictWithParseableDetail() {
       // given: a 409 ALREADY_EXISTS response whose detail embeds the existing agent instance key
-      givenCreateCommandWithMaxModelCalls();
+      givenCreateCommand();
       final var detail =
           "Command 'CREATE' rejected with code 'ALREADY_EXISTS': Expected to associate element "
               + "instance with key '77' with an agent instance, but it is already associated with "
               + "agent instance with key '999'.";
-      when(step5.execute()).thenThrow(conflictException(detail));
+      when(createCommandStep2.execute()).thenThrow(conflictException(detail));
 
       // when
       final AgentInstanceKey key = client.create(TestAgentExecutionContext.withLimits());
@@ -287,8 +323,8 @@ class CamundaAgentInstanceClientTest {
     void shouldThrowConnectorExceptionImmediatelyOnUnparseableConflictDetail(
         @Nullable String detail) {
       // given: a 409 ALREADY_EXISTS response whose detail doesn't match the expected contract
-      givenCreateCommandWithMaxModelCalls();
-      when(step5.execute()).thenThrow(conflictException(detail));
+      givenCreateCommand();
+      when(createCommandStep2.execute()).thenThrow(conflictException(detail));
 
       // when / then: the conflict cannot be resolved, so it fails permanently, no retry
       assertThatThrownBy(() -> client.create(TestAgentExecutionContext.withLimits()))
@@ -743,6 +779,8 @@ class CamundaAgentInstanceClientTest {
       assertThat(configurationItem.getLoopIteration()).isEqualTo(1);
       // a CONFIGURATION item has no natural content of its own
       assertThat(configurationItem.getContent()).isEmpty();
+      assertThat(configurationItem.getModel()).isEqualTo("gpt-4o");
+      assertThat(configurationItem.getProvider()).isEqualTo(OpenAiProviderConfiguration.OPENAI_ID);
       assertThat(configurationItem.getSystemPrompt())
           .singleElement()
           .isInstanceOfSatisfying(

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/agentinstance/CamundaAgentInstanceClientTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/agentinstance/CamundaAgentInstanceClientTest.java
@@ -779,8 +779,9 @@ class CamundaAgentInstanceClientTest {
       assertThat(configurationItem.getLoopIteration()).isEqualTo(1);
       // a CONFIGURATION item has no natural content of its own
       assertThat(configurationItem.getContent()).isEmpty();
-      assertThat(configurationItem.getModel()).isEqualTo("gpt-4o");
-      assertThat(configurationItem.getProvider()).isEqualTo(OpenAiProviderConfiguration.OPENAI_ID);
+      // model/provider are fixed at create time only, not re-pushed by turn-start items
+      assertThat(configurationItem.getModel()).isNull();
+      assertThat(configurationItem.getProvider()).isNull();
       assertThat(configurationItem.getSystemPrompt())
           .singleElement()
           .isInstanceOfSatisfying(

--- a/connectors/agentic-ai/docs/adr/013-unified-agent-instance-turn-updates.md
+++ b/connectors/agentic-ai/docs/adr/013-unified-agent-instance-turn-updates.md
@@ -104,9 +104,11 @@ configuration as a `CONFIGURATION` history item (model/provider/system prompt/to
 call, though: it is not folded into the first turn's `applyTurnStart`. `AgentMetadata` starts with
 an empty `configurationFingerprintHistory`, so the first turn's `applyTurnStart` finds no previous
 fingerprint and emits its own `CONFIGURATION` item — redundant with what `create()` sent moments
-earlier, but harmless, and the two items carry different `historyItemId`s (create runs before tools
-are resolved, so its fingerprint differs). Folding creation into the first turn to remove the
-redundancy was declined to keep the change low-risk.
+earlier, but harmless. The two items usually carry different `historyItemId`s, since `create()` runs
+before tools are resolved and the fingerprint folds in the tool list; for a tool-less agent, both
+items see an empty tool list and the fingerprints (and thus `historyItemId`s) coincide, which is
+still harmless since it's an idempotent dedup key over identical content. Folding creation into the
+first turn to remove the redundancy was declined to keep the change low-risk.
 
 **Per-item dedup.** camunda/camunda#58792 (engine) has no PR yet. `historyItemId` values are already chosen so
 dedup works transparently once it lands; until then, the ADR 011 streamed-early duplicate row (one from

--- a/connectors/agentic-ai/docs/adr/013-unified-agent-instance-turn-updates.md
+++ b/connectors/agentic-ai/docs/adr/013-unified-agent-instance-turn-updates.md
@@ -91,20 +91,22 @@ rejected before any model tokens are spent.
 * `model`/`provider`/`limits` changes are not currently re-pushed via a `CONFIGURATION` item (see
   Deferred below) even though the engine allows it, since only system prompt and tool list are tracked
   by the change-detection fingerprint today.
-* The engine's create-agent-instance command still carries a single history-item write, not a batch
-  (Req 1, deferred — see below), so the first turn's create is not yet lease-fenced the same way.
+* `create()` sends its configuration as a `CONFIGURATION` history item and is lease-fenced via
+  `jobKey`/`jobLease`, consistent with the turn updates. The separate create call still precedes the
+  first turn's `applyTurnStart`, so that turn's `CONFIGURATION` item remains (see Deferred below).
 
 ## Deferred
 
-**History batch on create (Req 1).** `create()` still sends its mandatory `model`/`provider`/
-`systemPrompt` (+ `limits`) fields directly on the create command rather than as a `CONFIGURATION`
-history item — the engine's create-instance API does not yet accept the `jobKey`/`jobLease`/
-`history[]` batch that `update()` does (camunda/camunda#59784). No fingerprint seeding happens to compensate:
-`AgentMetadata` starts with an empty `configurationFingerprintHistory`, so the first turn's
-`applyTurnStart` always finds no previous fingerprint and always emits a `CONFIGURATION` item —
-redundant with what `create()` already sent moments earlier, but harmless. Once the engine's create
-command accepts a history batch, `create()` should send a `CONFIGURATION` item instead of the direct
-fields, and this first-turn redundancy can be removed.
+**First-turn configuration redundancy (Req 1, partly closed).** `create()` now sends its
+configuration as a `CONFIGURATION` history item (model/provider/system prompt/tools) and forwards
+`jobKey`/`jobLease`, using the `history[]` batch the engine's create-instance API accepts
+(camunda/camunda#59784) — the direct-fields create path is gone. Creation is kept as a standalone
+call, though: it is not folded into the first turn's `applyTurnStart`. `AgentMetadata` starts with
+an empty `configurationFingerprintHistory`, so the first turn's `applyTurnStart` finds no previous
+fingerprint and emits its own `CONFIGURATION` item — redundant with what `create()` sent moments
+earlier, but harmless, and the two items carry different `historyItemId`s (create runs before tools
+are resolved, so its fingerprint differs). Folding creation into the first turn to remove the
+redundancy was declined to keep the change low-risk.
 
 **Per-item dedup.** camunda/camunda#58792 (engine) has no PR yet. `historyItemId` values are already chosen so
 dedup works transparently once it lands; until then, the ADR 011 streamed-early duplicate row (one from


### PR DESCRIPTION
## Description

Two changes, one per commit.

**`feat`: send configuration as a `CONFIGURATION` item on create.**
`CamundaAgentInstanceClient.create()` sent the agent instance's configuration as direct
`model`/`provider`/`systemPrompt` fields. The engine now accepts a `history[]` batch on the
create command (camunda/camunda#59784), and everywhere else in the agent-instance API configuration
is a `CONFIGURATION` history item. `create()` now sends a single `CONFIGURATION` item
(model/provider/system prompt/tools) and forwards `jobKey`/`jobLease` for lease fencing, consistent
with the turn updates. Top-level limits are dropped (the engine forbids them alongside history; the
connector enforces the limit itself). Creation stays a standalone call; the first turn's
`applyTurnStart` still emits its own `CONFIGURATION` item, an accepted redundancy already documented
in ADR 013.

Scope is narrowed by design to the create-command shape (issue reqs 2/6/7). Folding creation into
the first turn, reordering the initializer, and the 409-path changes (reqs 1/3/4/5) are out of scope.

**`test`: verify agent instance state on the engine via the query API.**
The `AgentInstance` e2e tests only verified the connector's client calls (a Mockito spy). They now
also read the instance back through the query API (`get-by-key` + history search) and assert what
actually landed on the broker: terminal status, accumulated metrics (which the spy cannot prove
committed), definition, resolved tools, the create-time `CONFIGURATION` item (end-to-end proof of the
`feat` above), and the committed conversation backbone. New `AgentInstanceEngineVerifier` collects its
assertions and evaluates them in one Awaitility block (secondary storage is eventually consistent),
filtering to `COMMITTED` and sorting by the monotonic `historyItemKey`. `assertAgentInstanceCreatedOnEngine`
is subsumed and removed.

## Related issues

closes to #8390

## Checklist

- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest
  release, as this branch will be rebased onto main before the next release. Example backport labels:
    - `backport stable/8.8`: for changes that should be included in the next 8.8.x release.
    - **or** `backport release-8.8.7`: for changes that should be included in the specific release 8.8.7, and this
      *release has already been created*. The release branch will be merged back into stable/8.8 later, so the change
      will be included in future 8.8.x releases as well.
- [x] Tests/Integration tests for the changes have been added if applicable.
- [ ] If the change requires a documentation update, it has been added to the appropriate section in the documentation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
