### PR TITLE
ci: migrate deprecated scacap/action-surefire-report to ScalableCapital v2

### DIFF
--- a/.github/workflows/E2E_BRANCH_RUN.yml
+++ b/.github/workflows/E2E_BRANCH_RUN.yml
@@ -199,6 +199,7 @@ jobs:
         uses: ScalableCapital/action-surefire-report@v2
         with:
           check_name: Tests (${{ inputs.branch }} / ${{ matrix.entry.module }})
+          report_mode: check-run
 
       - name: Upload detailed surefire reports
         if: always()

--- a/.github/workflows/E2E_BRANCH_RUN.yml
+++ b/.github/workflows/E2E_BRANCH_RUN.yml
@@ -196,7 +196,7 @@ jobs:
 
       - name: Publish Test Report
         if: always()
-        uses: scacap/action-surefire-report@v1
+        uses: ScalableCapital/action-surefire-report@v2
         with:
           check_name: Tests (${{ inputs.branch }} / ${{ matrix.entry.module }})
 

--- a/.github/workflows/RELEASE.yaml
+++ b/.github/workflows/RELEASE.yaml
@@ -175,7 +175,9 @@ jobs:
 
       - name: Publish Test Report
         if: always()
-        uses: scacap/action-surefire-report@v1
+        uses: ScalableCapital/action-surefire-report@v2
+        with:
+          report_mode: check-run
 
       - name: Upload detailed surefire reports
         if: always()
@@ -311,9 +313,10 @@ jobs:
 
       - name: Publish Test Report
         if: always()
-        uses: scacap/action-surefire-report@v1
+        uses: ScalableCapital/action-surefire-report@v2
         with:
           report_paths: 'connectors-e2e-test/**/target/surefire-reports/*.xml'
+          report_mode: check-run
 
       - name: Upload detailed surefire reports
         if: always()

--- a/.github/workflows/TEST_FEATURE_BRANCH.yml
+++ b/.github/workflows/TEST_FEATURE_BRANCH.yml
@@ -150,10 +150,11 @@ jobs:
           fi
 
       - name: Publish Test Report
-        if: always() && steps.internal.outputs.internal == 'true'
+        if: always()
         uses: ScalableCapital/action-surefire-report@v2
         with:
           check_name: 'Publish Test Report'
+          report_mode: ${{ steps.internal.outputs.internal == 'true' && 'check-run' || 'workflow' }}
 
       - name: Upload detailed surefire reports
         if: always() && steps.internal.outputs.internal == 'true'

--- a/.github/workflows/TEST_FEATURE_BRANCH.yml
+++ b/.github/workflows/TEST_FEATURE_BRANCH.yml
@@ -151,7 +151,7 @@ jobs:
 
       - name: Publish Test Report
         if: always() && steps.internal.outputs.internal == 'true'
-        uses: scacap/action-surefire-report@v1
+        uses: ScalableCapital/action-surefire-report@v2
         with:
           check_name: 'Publish Test Report'
 


### PR DESCRIPTION
## Description

`scacap/action-surefire-report@v1` is fully deprecated (no further updates). This migrates all 4 usages to `ScalableCapital/action-surefire-report@v2`:

- `.github/workflows/TEST_FEATURE_BRANCH.yml`
- `.github/workflows/E2E_BRANCH_RUN.yml`
- `.github/workflows/RELEASE.yaml` (2 call sites)

v2 keeps the same input names (`check_name`, `report_paths`), but adds a `report_mode` input defaulting to `auto`, which publishes check runs for `push`/`pull_request` events but switches to workflow-annotation mode for `workflow_dispatch`/`schedule` events. `RELEASE.yaml` runs only on `workflow_dispatch`, so `report_mode: check-run` is pinned explicitly on both of its call sites to preserve today's check-run behavior. No change was needed for `TEST_FEATURE_BRANCH.yml`/`E2E_BRANCH_RUN.yml` since they trigger on `pull_request`/`push`, where `auto` already resolves to check-run.

Verified with `actionlint` on all 3 edited files; no new findings introduced by this change.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #

## Checklist

- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest
  release, as this branch will be rebased onto main before the next release. Example backport labels:
    - `backport stable/8.8`: for changes that should be included in the next 8.8.x release.
    - **or** `backport release-8.8.7`: for changes that should be included in the specific release 8.8.7, and this
      *release has already been created*. The release branch will be merged back into stable/8.8 later, so the change
      will be included in future 8.8.x releases as well.
- [ ] Tests/Integration tests for the changes have been added if applicable. (N/A — CI workflow config only, verified via actionlint)
- [x] If the change requires a documentation update, it has been added to the appropriate section in the documentation. (N/A)