### PR TITLE
fix(agentic-ai): support schema-less JSON response format on native providers

### DIFF
--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/bedrock/BedrockConverseRequestConverter.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/bedrock/BedrockConverseRequestConverter.java
@@ -323,9 +323,9 @@ public class BedrockConverseRequestConverter {
       return;
     }
 
-    if (json.schema() == null) {
-      // Converse structured output is schema-only: with no schema there is nothing to constrain,
-      // so emit no output config and leave JSON handling to client-side parsing.
+    if (!json.hasSchema()) {
+      // Converse structured output is schema-only: with no (or an empty) schema there is nothing
+      // to constrain, so emit no output config and leave JSON handling to client-side parsing.
       return;
     }
 

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/bedrock/BedrockConverseRequestConverter.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/bedrock/BedrockConverseRequestConverter.java
@@ -314,11 +314,18 @@ public class BedrockConverseRequestConverter {
    * Maps a {@link JsonResponseFormatConfiguration} onto Converse's native structured-output
    * mechanism. {@link
    * io.camunda.connector.agenticai.aiagent.model.request.ResponseFormatConfiguration.TextResponseFormatConfiguration}
-   * (and a null {@code response}) emits nothing - {@code parseJson} is client-side.
+   * (and a null {@code response}) emits nothing - {@code parseJson} is client-side. A JSON response
+   * format without a schema also emits nothing, as Converse structured output is schema-only.
    */
   private void applyOutputConfig(
       ConverseStreamRequest.Builder builder, @Nullable ResponseConfiguration response) {
     if (!(response != null && response.format() instanceof JsonResponseFormatConfiguration json)) {
+      return;
+    }
+
+    if (json.schema() == null) {
+      // Converse structured output is schema-only: with no schema there is nothing to constrain,
+      // so emit no output config and leave JSON handling to client-side parsing.
       return;
     }
 

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/openai/family/completions/OpenAiCompletionsRequestConverter.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/openai/family/completions/OpenAiCompletionsRequestConverter.java
@@ -11,6 +11,7 @@ import com.openai.core.JsonValue;
 import com.openai.models.FunctionDefinition;
 import com.openai.models.FunctionParameters;
 import com.openai.models.ReasoningEffort;
+import com.openai.models.ResponseFormatJsonObject;
 import com.openai.models.ResponseFormatJsonSchema;
 import com.openai.models.chat.completions.ChatCompletionAssistantMessageParam;
 import com.openai.models.chat.completions.ChatCompletionCreateParams;
@@ -284,6 +285,11 @@ public class OpenAiCompletionsRequestConverter {
   private void applyStructuredOutput(
       ChatCompletionCreateParams.Builder builder, @Nullable ResponseConfiguration response) {
     if (!(response != null && response.format() instanceof JsonResponseFormatConfiguration json)) {
+      return;
+    }
+    if (json.schema() == null) {
+      // JSON mode without a schema: constrain the model to valid JSON without a structure.
+      builder.responseFormat(ResponseFormatJsonObject.builder().build());
       return;
     }
     builder.responseFormat(

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/openai/family/completions/OpenAiCompletionsRequestConverter.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/openai/family/completions/OpenAiCompletionsRequestConverter.java
@@ -287,7 +287,7 @@ public class OpenAiCompletionsRequestConverter {
     if (!(response != null && response.format() instanceof JsonResponseFormatConfiguration json)) {
       return;
     }
-    if (json.schema() == null) {
+    if (!json.hasSchema()) {
       // JSON mode without a schema: constrain the model to valid JSON without a structure.
       builder.responseFormat(ResponseFormatJsonObject.builder().build());
       return;

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/openai/family/responses/OpenAiResponsesRequestConverter.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/openai/family/responses/OpenAiResponsesRequestConverter.java
@@ -358,7 +358,7 @@ public class OpenAiResponsesRequestConverter {
     if (!(response != null && response.format() instanceof JsonResponseFormatConfiguration json)) {
       return;
     }
-    if (json.schema() == null) {
+    if (!json.hasSchema()) {
       // JSON mode without a schema: constrain the model to valid JSON without a structure.
       builder.text(
           ResponseTextConfig.builder()

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/openai/family/responses/OpenAiResponsesRequestConverter.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/openai/family/responses/OpenAiResponsesRequestConverter.java
@@ -13,6 +13,7 @@ import com.openai.core.JsonValue;
 import com.openai.core.ObjectMappers;
 import com.openai.models.Reasoning;
 import com.openai.models.ReasoningEffort;
+import com.openai.models.ResponseFormatJsonObject;
 import com.openai.models.responses.EasyInputMessage;
 import com.openai.models.responses.FunctionTool;
 import com.openai.models.responses.ResponseCreateParams;
@@ -355,6 +356,15 @@ public class OpenAiResponsesRequestConverter {
   private void applyStructuredOutput(
       ResponseCreateParams.Builder builder, @Nullable ResponseConfiguration response) {
     if (!(response != null && response.format() instanceof JsonResponseFormatConfiguration json)) {
+      return;
+    }
+    if (json.schema() == null) {
+      // JSON mode without a schema: constrain the model to valid JSON without a structure.
+      builder.text(
+          ResponseTextConfig.builder()
+              .format(
+                  ResponseFormatTextConfig.ofJsonObject(ResponseFormatJsonObject.builder().build()))
+              .build());
       return;
     }
     builder.text(

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/ResponseFormatConfiguration.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/ResponseFormatConfiguration.java
@@ -73,5 +73,15 @@ public sealed interface ResponseFormatConfiguration {
               defaultValue = "Response",
               optional = true)
           String schemaName)
-      implements ResponseFormatConfiguration {}
+      implements ResponseFormatConfiguration {
+
+    /**
+     * {@code false} both when no schema was configured ({@code null}) and when one was configured
+     * as an empty object ({@code ={}} via FEEL) -- an empty schema constrains nothing, so it's
+     * treated the same as no schema at all.
+     */
+    public boolean hasSchema() {
+      return schema != null && !schema.isEmpty();
+    }
+  }
 }

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/bedrock/BedrockConverseRequestConverterTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/bedrock/BedrockConverseRequestConverterTest.java
@@ -427,6 +427,17 @@ class BedrockConverseRequestConverterTest {
     }
 
     @Test
+    void jsonResponseFormatWithoutSchemaEmitsNoOutputConfig() {
+      final var response =
+          new AgentTaskResponseConfiguration(new JsonResponseFormatConfiguration(null, null), null);
+      final var snapshot = new ConversationSnapshot(List.of(), List.of());
+
+      final var request = converter.toConverseStreamRequest(model(null), response, snapshot);
+
+      assertThat(request.outputConfig()).isNull();
+    }
+
+    @Test
     void textResponseFormatEmitsNoOutputConfig() {
       final var response =
           new AgentTaskResponseConfiguration(new TextResponseFormatConfiguration(true), null);

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/bedrock/BedrockConverseRequestConverterTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/bedrock/BedrockConverseRequestConverterTest.java
@@ -438,6 +438,18 @@ class BedrockConverseRequestConverterTest {
     }
 
     @Test
+    void jsonResponseFormatWithEmptySchemaEmitsNoOutputConfig() {
+      final var response =
+          new AgentTaskResponseConfiguration(
+              new JsonResponseFormatConfiguration(Map.of(), null), null);
+      final var snapshot = new ConversationSnapshot(List.of(), List.of());
+
+      final var request = converter.toConverseStreamRequest(model(null), response, snapshot);
+
+      assertThat(request.outputConfig()).isNull();
+    }
+
+    @Test
     void textResponseFormatEmitsNoOutputConfig() {
       final var response =
           new AgentTaskResponseConfiguration(new TextResponseFormatConfiguration(true), null);

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/openai/family/completions/OpenAiCompletionsRequestConverterTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/openai/family/completions/OpenAiCompletionsRequestConverterTest.java
@@ -399,6 +399,20 @@ class OpenAiCompletionsRequestConverterTest {
   }
 
   @Test
+  void configuresJsonObjectResponseFormatWhenNoSchema() {
+    final ResponseConfiguration response =
+        new AgentTaskResponseConfiguration(new JsonResponseFormatConfiguration(null, null), null);
+    final var snapshot = new ConversationSnapshot(List.of(), List.of());
+
+    final var params = converter.toRequest(model(null), response, snapshot);
+
+    assertThat(params.responseFormat()).isPresent();
+    final var formatNode = requestBodyAsJson(params).path("response_format");
+    assertThat(formatNode.path("type").asText()).isEqualTo("json_object");
+    assertThat(formatNode.has("json_schema")).isFalse();
+  }
+
+  @Test
   void mapsConfiguredEffortToReasoningEffort() {
     final var parameters = new CompletionsParameters(null, OpenAiEffort.HIGH, null, null);
     final var snapshot = new ConversationSnapshot(List.of(), List.of());

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/openai/family/completions/OpenAiCompletionsRequestConverterTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/openai/family/completions/OpenAiCompletionsRequestConverterTest.java
@@ -413,6 +413,21 @@ class OpenAiCompletionsRequestConverterTest {
   }
 
   @Test
+  void configuresJsonObjectResponseFormatWhenEmptySchema() {
+    final ResponseConfiguration response =
+        new AgentTaskResponseConfiguration(
+            new JsonResponseFormatConfiguration(Map.of(), null), null);
+    final var snapshot = new ConversationSnapshot(List.of(), List.of());
+
+    final var params = converter.toRequest(model(null), response, snapshot);
+
+    assertThat(params.responseFormat()).isPresent();
+    final var formatNode = requestBodyAsJson(params).path("response_format");
+    assertThat(formatNode.path("type").asText()).isEqualTo("json_object");
+    assertThat(formatNode.has("json_schema")).isFalse();
+  }
+
+  @Test
   void mapsConfiguredEffortToReasoningEffort() {
     final var parameters = new CompletionsParameters(null, OpenAiEffort.HIGH, null, null);
     final var snapshot = new ConversationSnapshot(List.of(), List.of());

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/openai/family/responses/OpenAiResponsesRequestConverterTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/openai/family/responses/OpenAiResponsesRequestConverterTest.java
@@ -566,6 +566,21 @@ class OpenAiResponsesRequestConverterTest {
     assertThat(textNode.has("schema")).isFalse();
   }
 
+  @Test
+  void configuresJsonObjectResponseFormatWhenEmptySchema() {
+    final var response =
+        new AgentTaskResponseConfiguration(
+            new JsonResponseFormatConfiguration(Map.of(), null), null);
+    final var snapshot = new ConversationSnapshot(List.of(), List.of());
+
+    final var params = converter.toRequest(model(null), response, snapshot);
+
+    assertThat(params.text()).isPresent();
+    final var textNode = requestBodyAsJson(params).path("text").path("format");
+    assertThat(textNode.path("type").asText()).isEqualTo("json_object");
+    assertThat(textNode.has("schema")).isFalse();
+  }
+
   // --- Reasoning / effort ------------------------------------------------------------------
 
   @Test

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/openai/family/responses/OpenAiResponsesRequestConverterTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/openai/family/responses/OpenAiResponsesRequestConverterTest.java
@@ -552,6 +552,20 @@ class OpenAiResponsesRequestConverterTest {
         .isFalse();
   }
 
+  @Test
+  void configuresJsonObjectResponseFormatWhenNoSchema() {
+    final var response =
+        new AgentTaskResponseConfiguration(new JsonResponseFormatConfiguration(null, null), null);
+    final var snapshot = new ConversationSnapshot(List.of(), List.of());
+
+    final var params = converter.toRequest(model(null), response, snapshot);
+
+    assertThat(params.text()).isPresent();
+    final var textNode = requestBodyAsJson(params).path("text").path("format");
+    assertThat(textNode.path("type").asText()).isEqualTo("json_object");
+    assertThat(textNode.has("schema")).isFalse();
+  }
+
   // --- Reasoning / effort ------------------------------------------------------------------
 
   @Test


### PR DESCRIPTION
## Description

The native v2 providers rejected a JSON response format configured **without a schema** (the schema is optional on the JSON response-format config). OpenAI Completions and Responses tried to build a strict `json_schema` from a null schema and threw; Bedrock Converse serialized a literal `null` schema and was rejected with an AWS 400.

This restores parity with the legacy LangChain4j behavior:

- OpenAI (Completions + Responses) now uses plain JSON-object mode when no schema is given.
- Bedrock Converse (schema-only) emits no output config and leaves JSON handling to client-side parsing.

Gemini and Anthropic already handled this case correctly.

## Related issues

Relates to #8407 (the deeper schema-less gap: the model is neither constrained by a schema nor instructed to emit JSON). No closing issue.

## Checklist

- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest
  release, as this branch will be rebased onto main before the next release. Example backport labels:
    - `backport stable/8.8`: for changes that should be included in the next 8.8.x release.
    - **or** `backport release-8.8.7`: for changes that should be included in the specific release 8.8.7, and this
      *release has already been created*. The release branch will be merged back into stable/8.8 later, so the change
      will be included in future 8.8.x releases as well.
- [ ] Tests/Integration tests for the changes have been added if applicable.
- [ ] If the change requires a documentation update, it has been added to the appropriate section in the documentation.
