### PR TITLE
feat(agentic-ai): route legacy v1 provider config through native v2 providers

### DIFF
--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/resources/application.yml
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/resources/application.yml
@@ -1,3 +1,11 @@
 camunda:
   process-test:
     runtime-mode: shared
+  connector:
+    agenticai:
+      aiagent:
+        # The product default is ON (v1 provider config is rewritten to the native v2 providers).
+        # It is pinned OFF here so the existing v1 e2e suites keep exercising the LangChain4j
+        # implementations they were written against (buffered, non-streaming wire format).
+        # Migrating the suite to run over the native providers (switch ON) is a dedicated follow-up.
+        rewrite-v1-provider-config-to-v2: false

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/resources/application.yml
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/resources/application.yml
@@ -7,5 +7,4 @@ camunda:
         # The product default is ON (v1 provider config is rewritten to the native v2 providers).
         # It is pinned OFF here so the existing v1 e2e suites keep exercising the LangChain4j
         # implementations they were written against (buffered, non-streaming wire format).
-        # Migrating the suite to run over the native providers (switch ON) is a dedicated follow-up.
         rewrite-v1-provider-config-to-v2: false

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/resources/application.yml
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/resources/application.yml
@@ -4,7 +4,5 @@ camunda:
   connector:
     agenticai:
       aiagent:
-        # The product default is ON (v1 provider config is rewritten to the native v2 providers).
-        # It is pinned OFF here so the existing v1 e2e suites keep exercising the LangChain4j
-        # implementations they were written against (buffered, non-streaming wire format).
+        # Pinned OFF (product default is ON) until the v1 e2e suites are rewritten against the native providers.
         rewrite-v1-provider-config-to-v2: false

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/AgentProcessVariables.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/AgentProcessVariables.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.agenticai.aiagent;
+
+/** Well-known process variable names used by the AI Agent connectors. */
+public final class AgentProcessVariables {
+
+  /** Input mapping: the LLM provider/model configuration. */
+  public static final String PROVIDER = "provider";
+
+  /** Input mapping: the agent request data (prompts, tools, memory, limits, response config). */
+  public static final String DATA = "data";
+
+  /** Output: the agent response result variable. */
+  public static final String AGENT_RESPONSE = "agent";
+
+  /** Persisted agent state carried across agent iterations. */
+  public static final String AGENT_CONTEXT = "agentContext";
+
+  /** Sub-process only: the resolved ad-hoc sub-process tool elements. */
+  public static final String AD_HOC_SUB_PROCESS_ELEMENTS = "adHocSubProcessElements";
+
+  /** Sub-process only: tool-call results accumulated for the current iteration. */
+  public static final String TOOL_CALL_RESULTS = "toolCallResults";
+
+  /** Sub-process only: the tool call passed into an activated ad-hoc element. */
+  public static final String TOOL_CALL = "toolCall";
+
+  /** Sub-process only: the local result variable of an activated ad-hoc element. */
+  public static final String TOOL_CALL_RESULT = "toolCallResult";
+
+  private AgentProcessVariables() {}
+}

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/AgentSubProcessV1Function.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/AgentSubProcessV1Function.java
@@ -9,7 +9,9 @@ package io.camunda.connector.agenticai.aiagent;
 import io.camunda.connector.agenticai.aiagent.agent.AgentSubProcessRequestHandler;
 import io.camunda.connector.agenticai.aiagent.model.AgentSubProcessExecutionContext;
 import io.camunda.connector.agenticai.aiagent.model.request.AgentSubProcessV1Request;
+import io.camunda.connector.agenticai.aiagent.model.request.V1ToV2ProviderConfigurationMapper;
 import io.camunda.connector.api.annotation.OutboundConnector;
+import io.camunda.connector.api.outbound.JobContext;
 import io.camunda.connector.api.outbound.OutboundConnectorContext;
 
 /**
@@ -21,16 +23,20 @@ import io.camunda.connector.api.outbound.OutboundConnectorContext;
  *   <li>CONNECTOR_AI_AGENT_JOB_WORKER_TYPE
  *   <li>CONNECTOR_AI_AGENT_JOB_WORKER_TIMEOUT
  * </ul>
+ *
+ * @deprecated Retained only as a backward-compatibility shim for existing v1 process models; new
+ *     process models should use the v2 AI Agent connector.
  */
+@Deprecated
 @OutboundConnector(
     name = AgentSubProcessV1Function.JOB_WORKER_NAME,
     type = AgentSubProcessV1Function.JOB_WORKER_TYPE,
     inputVariables = {
-      AgentSubProcessV1Function.AD_HOC_SUB_PROCESS_ELEMENT_VARIABLE,
-      AgentSubProcessV1Function.AGENT_CONTEXT_VARIABLE,
-      AgentSubProcessV1Function.TOOL_CALL_RESULTS_VARIABLE,
-      AgentSubProcessV1Function.PROVIDER_VARIABLE,
-      AgentSubProcessV1Function.DATA_VARIABLE
+      AgentProcessVariables.AD_HOC_SUB_PROCESS_ELEMENTS,
+      AgentProcessVariables.AGENT_CONTEXT,
+      AgentProcessVariables.TOOL_CALL_RESULTS,
+      AgentProcessVariables.PROVIDER,
+      AgentProcessVariables.DATA
     },
     withLease = true)
 public class AgentSubProcessV1Function implements AgentConnectorFunction {
@@ -38,26 +44,40 @@ public class AgentSubProcessV1Function implements AgentConnectorFunction {
   public static final String JOB_WORKER_NAME = "AI Agent Job Worker";
   public static final String JOB_WORKER_TYPE = "io.camunda.agenticai:aiagent-job-worker:1";
 
-  public static final String AD_HOC_SUB_PROCESS_ELEMENT_VARIABLE = "adHocSubProcessElements";
-  public static final String AGENT_CONTEXT_VARIABLE = "agentContext";
-  public static final String AGENT_RESPONSE_VARIABLE = "agent";
-  public static final String TOOL_CALL_RESULT_VARIABLE = "toolCallResult";
-  public static final String TOOL_CALL_RESULTS_VARIABLE = "toolCallResults";
-  public static final String PROVIDER_VARIABLE = "provider";
-  public static final String DATA_VARIABLE = "data";
-  public static final String TOOL_CALL_VARIABLE = "toolCall";
-
   private final AgentSubProcessRequestHandler agentRequestHandler;
+  private final V1ToV2ProviderConfigurationMapper providerConfigurationMapper;
+  private final boolean rewriteV1ProviderConfigToV2;
 
-  public AgentSubProcessV1Function(AgentSubProcessRequestHandler agentRequestHandler) {
+  public AgentSubProcessV1Function(
+      AgentSubProcessRequestHandler agentRequestHandler,
+      V1ToV2ProviderConfigurationMapper providerConfigurationMapper,
+      boolean rewriteV1ProviderConfigToV2) {
     this.agentRequestHandler = agentRequestHandler;
+    this.providerConfigurationMapper = providerConfigurationMapper;
+    this.rewriteV1ProviderConfigToV2 = rewriteV1ProviderConfigToV2;
   }
 
   @Override
   public AgentSubProcessConnectorResponse execute(OutboundConnectorContext context)
       throws Exception {
     var request = context.bindVariables(AgentSubProcessV1Request.class);
-    var executionContext = new AgentSubProcessExecutionContext(context.getJobContext(), request);
+    var executionContext = buildExecutionContext(context.getJobContext(), request);
     return agentRequestHandler.handleRequest(executionContext);
+  }
+
+  private AgentSubProcessExecutionContext buildExecutionContext(
+      JobContext jobContext, AgentSubProcessV1Request request) {
+    if (rewriteV1ProviderConfigToV2) {
+      var nativeConfig = providerConfigurationMapper.map(request.provider());
+      return new AgentSubProcessExecutionContext(
+          jobContext,
+          request.data(),
+          request.agentContext(),
+          request.toolCallResults(),
+          request.toolElements(),
+          nativeConfig);
+    }
+
+    return new AgentSubProcessExecutionContext(jobContext, request);
   }
 }

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/AgentSubProcessV2Function.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/AgentSubProcessV2Function.java
@@ -17,23 +17,17 @@ import io.camunda.connector.api.outbound.OutboundConnectorContext;
     name = AgentSubProcessV2Function.JOB_WORKER_NAME,
     type = AgentSubProcessV2Function.JOB_WORKER_TYPE,
     inputVariables = {
-      AgentSubProcessV2Function.AD_HOC_SUB_PROCESS_ELEMENT_VARIABLE,
-      AgentSubProcessV2Function.AGENT_CONTEXT_VARIABLE,
-      AgentSubProcessV2Function.TOOL_CALL_RESULTS_VARIABLE,
-      AgentSubProcessV2Function.PROVIDER_VARIABLE,
-      AgentSubProcessV2Function.DATA_VARIABLE
+      AgentProcessVariables.AD_HOC_SUB_PROCESS_ELEMENTS,
+      AgentProcessVariables.AGENT_CONTEXT,
+      AgentProcessVariables.TOOL_CALL_RESULTS,
+      AgentProcessVariables.PROVIDER,
+      AgentProcessVariables.DATA
     },
     withLease = true)
 public class AgentSubProcessV2Function implements AgentConnectorFunction {
 
   public static final String JOB_WORKER_NAME = "AI Agent Sub-process";
   public static final String JOB_WORKER_TYPE = "io.camunda.agenticai:aiagent:subprocess:2";
-
-  public static final String AD_HOC_SUB_PROCESS_ELEMENT_VARIABLE = "adHocSubProcessElements";
-  public static final String AGENT_CONTEXT_VARIABLE = "agentContext";
-  public static final String TOOL_CALL_RESULTS_VARIABLE = "toolCallResults";
-  public static final String PROVIDER_VARIABLE = "provider";
-  public static final String DATA_VARIABLE = "data";
 
   private final AgentSubProcessRequestHandler agentRequestHandler;
 

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/AgentTaskV1Function.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/AgentTaskV1Function.java
@@ -11,7 +11,9 @@ import io.camunda.connector.agenticai.aiagent.agent.AgentTaskRequestHandler;
 import io.camunda.connector.agenticai.aiagent.model.AgentResponse;
 import io.camunda.connector.agenticai.aiagent.model.AgentTaskExecutionContext;
 import io.camunda.connector.agenticai.aiagent.model.request.AgentTaskV1Request;
+import io.camunda.connector.agenticai.aiagent.model.request.V1ToV2ProviderConfigurationMapper;
 import io.camunda.connector.api.annotation.OutboundConnector;
+import io.camunda.connector.api.outbound.JobContext;
 import io.camunda.connector.api.outbound.OutboundConnectorContext;
 import io.camunda.connector.generator.java.annotation.ElementTemplate;
 import io.camunda.connector.generator.java.annotation.ElementTemplate.PropertyGroup;
@@ -25,10 +27,14 @@ import io.camunda.connector.generator.java.annotation.ElementTemplate.PropertyGr
  *   <li>CONNECTOR_AI_AGENT_TYPE
  *   <li>CONNECTOR_AI_AGENT_TIMEOUT
  * </ul>
+ *
+ * @deprecated Retained only as a backward-compatibility shim for existing v1 process models; new
+ *     process models should use the v2 AI Agent connector.
  */
+@Deprecated
 @OutboundConnector(
     name = "AI Agent",
-    inputVariables = {"provider", "data"},
+    inputVariables = {AgentProcessVariables.PROVIDER, AgentProcessVariables.DATA},
     type = "io.camunda.agenticai:aiagent:1",
     withLease = true)
 @ElementTemplate(
@@ -43,7 +49,7 @@ import io.camunda.connector.generator.java.annotation.ElementTemplate.PropertyGr
     category = @ElementTemplate.Category(id = "aiTools", name = "AI Tools"),
     inputDataClass = AgentTaskV1Request.class,
     outputDataClass = AgentResponse.class,
-    defaultResultVariable = "agent",
+    defaultResultVariable = AgentProcessVariables.AGENT_RESPONSE,
     propertyGroups = {
       @PropertyGroup(id = "provider", label = "Model provider", openByDefault = false),
       @PropertyGroup(id = "model", label = "Model", openByDefault = false),
@@ -87,19 +93,35 @@ import io.camunda.connector.generator.java.annotation.ElementTemplate.PropertyGr
 public class AgentTaskV1Function implements AgentConnectorFunction {
   private final ProcessDefinitionAdHocToolElementsResolver toolElementsResolver;
   private final AgentTaskRequestHandler agentRequestHandler;
+  private final V1ToV2ProviderConfigurationMapper providerConfigurationMapper;
+  private final boolean rewriteV1ProviderConfigToV2;
 
   public AgentTaskV1Function(
       ProcessDefinitionAdHocToolElementsResolver toolElementsResolver,
-      AgentTaskRequestHandler agentRequestHandler) {
+      AgentTaskRequestHandler agentRequestHandler,
+      V1ToV2ProviderConfigurationMapper providerConfigurationMapper,
+      boolean rewriteV1ProviderConfigToV2) {
     this.toolElementsResolver = toolElementsResolver;
     this.agentRequestHandler = agentRequestHandler;
+    this.providerConfigurationMapper = providerConfigurationMapper;
+    this.rewriteV1ProviderConfigToV2 = rewriteV1ProviderConfigToV2;
   }
 
   @Override
   public AgentTaskConnectorResponse execute(OutboundConnectorContext context) {
     var request = context.bindVariables(AgentTaskV1Request.class);
-    var executionContext =
-        new AgentTaskExecutionContext(context.getJobContext(), request, toolElementsResolver);
+    var executionContext = buildExecutionContext(context.getJobContext(), request);
     return agentRequestHandler.handleRequest(executionContext);
+  }
+
+  private AgentTaskExecutionContext buildExecutionContext(
+      JobContext jobContext, AgentTaskV1Request request) {
+    if (rewriteV1ProviderConfigToV2) {
+      var nativeConfig = providerConfigurationMapper.map(request.provider());
+      return new AgentTaskExecutionContext(
+          jobContext, request.data(), nativeConfig, toolElementsResolver);
+    }
+
+    return new AgentTaskExecutionContext(jobContext, request, toolElementsResolver);
   }
 }

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/AgentTaskV2Function.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/AgentTaskV2Function.java
@@ -21,7 +21,7 @@ import io.camunda.connector.generator.java.annotation.ElementTemplate.PropertyGr
  */
 @OutboundConnector(
     name = "AI Agent Task",
-    inputVariables = {"provider", "data"},
+    inputVariables = {AgentProcessVariables.PROVIDER, AgentProcessVariables.DATA},
     type = "io.camunda.agenticai:aiagent:task:2",
     withLease = true)
 @ElementTemplate(
@@ -36,7 +36,7 @@ import io.camunda.connector.generator.java.annotation.ElementTemplate.PropertyGr
     category = @ElementTemplate.Category(id = "aiTools", name = "AI Tools"),
     inputDataClass = AgentTaskV2Request.class,
     outputDataClass = AgentResponse.class,
-    defaultResultVariable = "agent",
+    defaultResultVariable = AgentProcessVariables.AGENT_RESPONSE,
     propertyGroups = {
       @PropertyGroup(id = "provider", label = "Model provider", openByDefault = false),
       @PropertyGroup(

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/agent/AgentSubProcessRequestHandler.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/agent/AgentSubProcessRequestHandler.java
@@ -6,9 +6,9 @@
  */
 package io.camunda.connector.agenticai.aiagent.agent;
 
+import io.camunda.connector.agenticai.aiagent.AgentProcessVariables;
 import io.camunda.connector.agenticai.aiagent.AgentSubProcessConnectorResponse;
 import io.camunda.connector.agenticai.aiagent.AgentSubProcessConnectorResponse.ToolCallElementActivation;
-import io.camunda.connector.agenticai.aiagent.AgentSubProcessV1Function;
 import io.camunda.connector.agenticai.aiagent.agentinstance.AgentInstanceClient;
 import io.camunda.connector.agenticai.aiagent.chatmodel.ChatModelRegistry;
 import io.camunda.connector.agenticai.aiagent.memory.conversation.ConversationStoreRegistry;
@@ -103,17 +103,17 @@ public class AgentSubProcessRequestHandler
         cancelRemainingInstances);
 
     final var variables = new LinkedHashMap<String, Object>();
-    variables.put(AgentSubProcessV1Function.AGENT_CONTEXT_VARIABLE, agentResponse.context());
+    variables.put(AgentProcessVariables.AGENT_CONTEXT, agentResponse.context());
 
     if (completionConditionFulfilled) {
       LOGGER.debug("Completion condition fulfilled, creating agent response variable");
       variables.put(
-          AgentSubProcessV1Function.AGENT_RESPONSE_VARIABLE,
+          AgentProcessVariables.AGENT_RESPONSE,
           createAgentResponseVariable(executionContext, agentResponse));
     } else {
       LOGGER.debug(
           "Completion condition not fulfilled, clearing tool call results for next tool call iteration");
-      variables.put(AgentSubProcessV1Function.TOOL_CALL_RESULTS_VARIABLE, List.of());
+      variables.put(AgentProcessVariables.TOOL_CALL_RESULTS, List.of());
     }
 
     return AgentSubProcessConnectorResponse.builder()
@@ -157,11 +157,11 @@ public class AgentSubProcessRequestHandler
                   new ToolCallElementActivation(
                       toolCall.metadata().name(),
                       Map.ofEntries(
-                          Map.entry(AgentSubProcessV1Function.TOOL_CALL_VARIABLE, toolCall),
+                          Map.entry(AgentProcessVariables.TOOL_CALL, toolCall),
                           // Creating empty toolCallResult variable to avoid variable
                           // to bubble up in the upper scopes while merging variables on
                           // ad-hoc sub-process inner instance completion.
-                          Map.entry(AgentSubProcessV1Function.TOOL_CALL_RESULT_VARIABLE, "")));
+                          Map.entry(AgentProcessVariables.TOOL_CALL_RESULT, "")));
             })
         .toList();
   }

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/V1ToV2ProviderConfigurationMapper.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/V1ToV2ProviderConfigurationMapper.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.agenticai.aiagent.model.request;
+
+/**
+ * Maps a v1 {@code ProviderConfiguration} to the equivalent native v2 {@code
+ * ProviderConfiguration}, so v1 agent jobs can run against the native providers.
+ */
+public interface V1ToV2ProviderConfigurationMapper {
+
+  io.camunda.connector.agenticai.aiagent.model.request.v2.ProviderConfiguration map(
+      io.camunda.connector.agenticai.aiagent.model.request.v1.ProviderConfiguration source);
+}

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/V1ToV2ProviderConfigurationMapperImpl.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/V1ToV2ProviderConfigurationMapperImpl.java
@@ -1,0 +1,325 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.agenticai.aiagent.model.request;
+
+import io.camunda.connector.agenticai.aiagent.model.request.v1.AnthropicProviderConfiguration;
+import io.camunda.connector.agenticai.aiagent.model.request.v1.AzureOpenAiProviderConfiguration;
+import io.camunda.connector.agenticai.aiagent.model.request.v1.BedrockProviderConfiguration;
+import io.camunda.connector.agenticai.aiagent.model.request.v1.GoogleVertexAiProviderConfiguration;
+import io.camunda.connector.agenticai.aiagent.model.request.v1.OpenAiCompatibleProviderConfiguration;
+import io.camunda.connector.agenticai.aiagent.model.request.v1.OpenAiProviderConfiguration;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.AnthropicChatModelConfiguration;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.AnthropicChatModelConfiguration.AnthropicBackend.AnthropicApiBackend;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.AnthropicChatModelConfiguration.AnthropicBackend.AnthropicApiBackend.AnthropicApi;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.AwsAuthentication;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.BedrockConverseChatModelConfiguration;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.BedrockConverseChatModelConfiguration.BedrockConverseConnection;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.BedrockConverseChatModelConfiguration.BedrockConverseModel;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.BedrockConverseChatModelConfiguration.BedrockConverseModel.BedrockConverseModelParameters;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.GeminiChatModelConfiguration;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.GeminiChatModelConfiguration.GeminiBackend.GeminiVertexAiBackend;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.GeminiChatModelConfiguration.GeminiBackend.GeminiVertexAiBackend.GoogleVertexAi;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.GeminiChatModelConfiguration.GeminiBackend.GoogleVertexAiAuthentication;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.GeminiChatModelConfiguration.GeminiConnection;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.GeminiChatModelConfiguration.GeminiModel;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.GeminiChatModelConfiguration.GeminiModel.GeminiModelParameters;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.OpenAiChatModelConfiguration;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.OpenAiChatModelConfiguration.OpenAiApi.OpenAiCompletionsApi;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.OpenAiChatModelConfiguration.OpenAiApi.OpenAiCompletionsApi.CompletionsParameters;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.OpenAiChatModelConfiguration.OpenAiBackend.FoundryAuthentication;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.OpenAiChatModelConfiguration.OpenAiBackend.OpenAiApiBackend;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.OpenAiChatModelConfiguration.OpenAiBackend.OpenAiApiBackend.OpenAiApiConnection;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.OpenAiChatModelConfiguration.OpenAiBackend.OpenAiCustomBackend;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.OpenAiChatModelConfiguration.OpenAiBackend.OpenAiCustomBackend.CustomBackend;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.OpenAiChatModelConfiguration.OpenAiBackend.OpenAiFoundryBackend;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.OpenAiChatModelConfiguration.OpenAiBackend.OpenAiFoundryBackend.FoundryBackend;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.OpenAiChatModelConfiguration.OpenAiConnection;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.OpenAiChatModelConfiguration.OpenAiModel;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.OpenAiCustomEndpointAuthentication.ApiKeyAuthentication;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Maps a v1 {@code ProviderConfiguration} to the equivalent native v2 {@code
+ * ProviderConfiguration}, so v1 agent jobs can run against the native providers.
+ */
+public class V1ToV2ProviderConfigurationMapperImpl implements V1ToV2ProviderConfigurationMapper {
+
+  /**
+   * Placeholder API key used for the OpenAI-compatible custom backend when the v1 configuration
+   * supplies neither an {@code apiKey} nor a lift-able {@code Authorization: Bearer} header. The
+   * native OpenAI SDK requires a credential to build a client at all.
+   */
+  public static final String MISSING_API_KEY_PLACEHOLDER = "not-required";
+
+  private static final String AUTHORIZATION_HEADER = "Authorization";
+  private static final String BEARER_PREFIX = "Bearer ";
+
+  @Override
+  public io.camunda.connector.agenticai.aiagent.model.request.v2.ProviderConfiguration map(
+      io.camunda.connector.agenticai.aiagent.model.request.v1.ProviderConfiguration source) {
+    return switch (source) {
+      case AnthropicProviderConfiguration anthropic -> mapAnthropic(anthropic);
+      case OpenAiProviderConfiguration openAi -> mapOpenAi(openAi);
+      case OpenAiCompatibleProviderConfiguration openAiCompatible ->
+          mapOpenAiCompatible(openAiCompatible);
+      case BedrockProviderConfiguration bedrock -> mapBedrock(bedrock);
+      case AzureOpenAiProviderConfiguration azureOpenAi -> mapAzureOpenAi(azureOpenAi);
+      case GoogleVertexAiProviderConfiguration googleVertexAi -> mapGoogleVertexAi(googleVertexAi);
+    };
+  }
+
+  private OpenAiChatModelConfiguration mapAzureOpenAi(AzureOpenAiProviderConfiguration source) {
+    final var connection = source.azureOpenAi();
+    final var model = connection.model();
+    final var parameters = model.parameters();
+
+    final var v2Parameters =
+        parameters == null
+            ? null
+            : new CompletionsParameters(
+                parameters.maxTokens(), null, parameters.temperature(), parameters.topP());
+
+    return new OpenAiChatModelConfiguration(
+        new OpenAiConnection(
+            new OpenAiCompletionsApi(v2Parameters),
+            new OpenAiFoundryBackend(
+                new FoundryBackend(
+                    connection.endpoint(),
+                    null,
+                    mapAzureAuthentication(connection.authentication()),
+                    null,
+                    null,
+                    null)),
+            new OpenAiModel(model.deploymentName()),
+            connection.timeouts()));
+  }
+
+  private FoundryAuthentication mapAzureAuthentication(
+      AzureOpenAiProviderConfiguration.AzureAuthentication authentication) {
+    return switch (authentication) {
+      case AzureOpenAiProviderConfiguration.AzureAuthentication.AzureApiKeyAuthentication apiKey ->
+          new FoundryAuthentication.ApiKeyAuthentication(apiKey.apiKey());
+      case AzureOpenAiProviderConfiguration.AzureAuthentication.AzureClientCredentialsAuthentication
+              clientCredentials ->
+          new FoundryAuthentication.ClientCredentialsAuthentication(
+              clientCredentials.clientId(),
+              clientCredentials.clientSecret(),
+              clientCredentials.tenantId(),
+              clientCredentials.authorityHost(),
+              null);
+    };
+  }
+
+  private GeminiChatModelConfiguration mapGoogleVertexAi(
+      GoogleVertexAiProviderConfiguration source) {
+    final var connection = source.googleVertexAi();
+    final var model = connection.model();
+    final var parameters = model.parameters();
+
+    final var v2Parameters =
+        parameters == null
+            ? null
+            : new GeminiModelParameters(
+                parameters.maxOutputTokens(),
+                toDouble(parameters.temperature()),
+                toDouble(parameters.topP()),
+                parameters.topK(),
+                null);
+
+    return new GeminiChatModelConfiguration(
+        new GeminiConnection(
+            new GeminiVertexAiBackend(
+                new GoogleVertexAi(
+                    connection.projectId(),
+                    connection.region(),
+                    connection.endpoint(),
+                    mapGoogleVertexAiAuthentication(connection.authentication()))),
+            new GeminiModel(model.model(), v2Parameters),
+            connection.timeouts()));
+  }
+
+  private GoogleVertexAiAuthentication mapGoogleVertexAiAuthentication(
+      GoogleVertexAiProviderConfiguration.GoogleVertexAiAuthentication authentication) {
+    return switch (authentication) {
+      case GoogleVertexAiProviderConfiguration.GoogleVertexAiAuthentication
+                  .ServiceAccountCredentialsAuthentication
+              serviceAccount ->
+          new GoogleVertexAiAuthentication.ServiceAccountCredentialsAuthentication(
+              serviceAccount.jsonKey());
+      case GoogleVertexAiProviderConfiguration.GoogleVertexAiAuthentication
+                  .ApplicationDefaultCredentialsAuthentication
+              ignored ->
+          new GoogleVertexAiAuthentication.ApplicationDefaultCredentialsAuthentication();
+    };
+  }
+
+  private static @Nullable Double toDouble(@Nullable Float value) {
+    return value == null ? null : value.doubleValue();
+  }
+
+  private AnthropicChatModelConfiguration mapAnthropic(AnthropicProviderConfiguration source) {
+    final var connection = source.anthropic();
+    final var model = connection.model();
+    final var parameters = model.parameters();
+
+    final var v2Parameters =
+        parameters == null
+            ? null
+            : new AnthropicChatModelConfiguration.AnthropicModel.AnthropicModelParameters(
+                null,
+                null,
+                null,
+                parameters.maxTokens(),
+                parameters.temperature(),
+                parameters.topP(),
+                parameters.topK());
+
+    return new AnthropicChatModelConfiguration(
+        new AnthropicChatModelConfiguration.AnthropicConnection(
+            new AnthropicApiBackend(
+                new AnthropicApi(
+                    connection.authentication().apiKey(), connection.endpoint(), null, null, null)),
+            new AnthropicChatModelConfiguration.AnthropicModel(model.model(), v2Parameters),
+            connection.timeouts()));
+  }
+
+  private OpenAiChatModelConfiguration mapOpenAi(OpenAiProviderConfiguration source) {
+    final var connection = source.openai();
+    final var authentication = connection.authentication();
+    final var model = connection.model();
+
+    return new OpenAiChatModelConfiguration(
+        new OpenAiConnection(
+            new OpenAiCompletionsApi(completionsParametersOf(model.parameters())),
+            new OpenAiApiBackend(
+                new OpenAiApiConnection(
+                    authentication.apiKey(),
+                    authentication.organizationId(),
+                    authentication.projectId(),
+                    null,
+                    null,
+                    null,
+                    null)),
+            new OpenAiModel(model.model()),
+            connection.timeouts()));
+  }
+
+  private OpenAiChatModelConfiguration mapOpenAiCompatible(
+      OpenAiCompatibleProviderConfiguration source) {
+    final var connection = source.openaiCompatible();
+    final var model = connection.model();
+    final var parameters = model.parameters();
+
+    final var resolvedAuthentication =
+        resolveOpenAiCompatibleAuthentication(connection.authentication(), connection.headers());
+
+    return new OpenAiChatModelConfiguration(
+        new OpenAiConnection(
+            new OpenAiCompletionsApi(completionsParametersOf(parameters)),
+            new OpenAiCustomBackend(
+                new CustomBackend(
+                    connection.endpoint(),
+                    resolvedAuthentication.headers(),
+                    connection.queryParameters(),
+                    parameters == null ? null : parameters.customParameters(),
+                    new ApiKeyAuthentication(resolvedAuthentication.apiKey()))),
+            new OpenAiModel(model.model()),
+            connection.timeouts()));
+  }
+
+  /**
+   * Resolves the effective API key for the OpenAI-compatible custom backend and the headers that
+   * should pass through alongside it, per the v1-to-v2 auth-lift algorithm: a non-blank {@code
+   * authentication.apiKey} wins outright; otherwise a case-insensitive {@code Authorization: Bearer
+   * <token>} header is lifted into the key and removed from the passthrough headers; otherwise the
+   * placeholder key is used and headers pass through unchanged.
+   */
+  private ResolvedOpenAiCompatibleAuthentication resolveOpenAiCompatibleAuthentication(
+      OpenAiCompatibleProviderConfiguration.OpenAiCompatibleAuthentication authentication,
+      @Nullable Map<String, String> headers) {
+    final var apiKey = authentication == null ? null : authentication.apiKey();
+    if (apiKey != null && !apiKey.isBlank()) {
+      return new ResolvedOpenAiCompatibleAuthentication(apiKey, headers);
+    }
+
+    if (headers != null) {
+      for (final var entry : headers.entrySet()) {
+        if (AUTHORIZATION_HEADER.equalsIgnoreCase(entry.getKey())
+            && entry.getValue() != null
+            && entry.getValue().regionMatches(true, 0, BEARER_PREFIX, 0, BEARER_PREFIX.length())) {
+          final var token = entry.getValue().substring(BEARER_PREFIX.length());
+          final var remainingHeaders = new LinkedHashMap<>(headers);
+          remainingHeaders.remove(entry.getKey());
+          return new ResolvedOpenAiCompatibleAuthentication(token, remainingHeaders);
+        }
+      }
+    }
+
+    return new ResolvedOpenAiCompatibleAuthentication(MISSING_API_KEY_PLACEHOLDER, headers);
+  }
+
+  private record ResolvedOpenAiCompatibleAuthentication(
+      String apiKey, @Nullable Map<String, String> headers) {}
+
+  private @Nullable CompletionsParameters completionsParametersOf(
+      OpenAiProviderConfiguration.OpenAiModel.@Nullable OpenAiModelParameters parameters) {
+    return parameters == null
+        ? null
+        : new CompletionsParameters(
+            parameters.maxCompletionTokens(), null, parameters.temperature(), parameters.topP());
+  }
+
+  private @Nullable CompletionsParameters completionsParametersOf(
+      OpenAiCompatibleProviderConfiguration.OpenAiCompatibleModel.@Nullable
+          OpenAiCompatibleModelParameters
+          parameters) {
+    return parameters == null
+        ? null
+        : new CompletionsParameters(
+            parameters.maxCompletionTokens(), null, parameters.temperature(), parameters.topP());
+  }
+
+  private BedrockConverseChatModelConfiguration mapBedrock(BedrockProviderConfiguration source) {
+    final var connection = source.bedrock();
+    final var model = connection.model();
+    final var parameters = model.parameters();
+
+    final var v2Parameters =
+        parameters == null
+            ? null
+            : new BedrockConverseModelParameters(
+                null, parameters.maxTokens(), parameters.temperature(), parameters.topP());
+
+    return new BedrockConverseChatModelConfiguration(
+        new BedrockConverseConnection(
+            connection.region(),
+            connection.endpoint(),
+            mapAwsAuthentication(connection.authentication()),
+            null,
+            null,
+            null,
+            connection.timeouts(),
+            new BedrockConverseModel(model.model(), v2Parameters)));
+  }
+
+  private AwsAuthentication mapAwsAuthentication(
+      BedrockProviderConfiguration.AwsAuthentication authentication) {
+    return switch (authentication) {
+      case BedrockProviderConfiguration.AwsAuthentication.AwsStaticCredentialsAuthentication
+              staticCredentials ->
+          new AwsAuthentication.AwsStaticCredentialsAuthentication(
+              staticCredentials.accessKey(), staticCredentials.secretKey());
+      case BedrockProviderConfiguration.AwsAuthentication.AwsApiKeyAuthentication apiKey ->
+          new AwsAuthentication.AwsApiKeyAuthentication(apiKey.apiKey());
+      case BedrockProviderConfiguration.AwsAuthentication.AwsDefaultCredentialsChainAuthentication
+              ignored ->
+          new AwsAuthentication.AwsDefaultCredentialsChainAuthentication();
+    };
+  }
+}

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/V1ToV2ProviderConfigurationMapperImpl.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/V1ToV2ProviderConfigurationMapperImpl.java
@@ -184,9 +184,32 @@ public class V1ToV2ProviderConfigurationMapperImpl implements V1ToV2ProviderConf
         new AnthropicChatModelConfiguration.AnthropicConnection(
             new AnthropicApiBackend(
                 new AnthropicApi(
-                    connection.authentication().apiKey(), connection.endpoint(), null, null, null)),
+                    connection.authentication().apiKey(),
+                    toNativeAnthropicEndpoint(connection.endpoint()),
+                    null,
+                    null,
+                    null)),
             new AnthropicChatModelConfiguration.AnthropicModel(model.model(), v2Parameters),
             connection.timeouts()));
+  }
+
+  /**
+   * Normalizes a v1 Anthropic endpoint to the base URL the native Anthropic SDK expects. The v1
+   * endpoint carries the {@code /v1} API-version segment, whereas the native SDK appends {@code
+   * /v1/messages} to the configured base itself; the segment is stripped here so the two do not
+   * combine into a doubled {@code /v1/v1}.
+   */
+  private static @Nullable String toNativeAnthropicEndpoint(@Nullable String endpoint) {
+    if (endpoint == null) {
+      return null;
+    }
+    var trimmed = endpoint;
+    while (trimmed.endsWith("/")) {
+      trimmed = trimmed.substring(0, trimmed.length() - 1);
+    }
+    return trimmed.endsWith("/v1")
+        ? trimmed.substring(0, trimmed.length() - "/v1".length())
+        : endpoint;
   }
 
   private OpenAiChatModelConfiguration mapOpenAi(OpenAiProviderConfiguration source) {

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/V1ToV2ProviderConfigurationMapperImpl.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/V1ToV2ProviderConfigurationMapperImpl.java
@@ -6,12 +6,15 @@
  */
 package io.camunda.connector.agenticai.aiagent.model.request;
 
+import static io.camunda.connector.agenticai.aiagent.chatmodel.provider.ChatModelProviderSupport.deriveTimeoutSetting;
+
 import io.camunda.connector.agenticai.aiagent.model.request.v1.AnthropicProviderConfiguration;
 import io.camunda.connector.agenticai.aiagent.model.request.v1.AzureOpenAiProviderConfiguration;
 import io.camunda.connector.agenticai.aiagent.model.request.v1.BedrockProviderConfiguration;
 import io.camunda.connector.agenticai.aiagent.model.request.v1.GoogleVertexAiProviderConfiguration;
 import io.camunda.connector.agenticai.aiagent.model.request.v1.OpenAiCompatibleProviderConfiguration;
 import io.camunda.connector.agenticai.aiagent.model.request.v1.OpenAiProviderConfiguration;
+import io.camunda.connector.agenticai.aiagent.model.request.v1.shared.TimeoutConfiguration;
 import io.camunda.connector.agenticai.aiagent.model.request.v2.AnthropicChatModelConfiguration;
 import io.camunda.connector.agenticai.aiagent.model.request.v2.AnthropicChatModelConfiguration.AnthropicBackend.AnthropicApiBackend;
 import io.camunda.connector.agenticai.aiagent.model.request.v2.AnthropicChatModelConfiguration.AnthropicBackend.AnthropicApiBackend.AnthropicApi;
@@ -40,9 +43,13 @@ import io.camunda.connector.agenticai.aiagent.model.request.v2.OpenAiChatModelCo
 import io.camunda.connector.agenticai.aiagent.model.request.v2.OpenAiChatModelConfiguration.OpenAiConnection;
 import io.camunda.connector.agenticai.aiagent.model.request.v2.OpenAiChatModelConfiguration.OpenAiModel;
 import io.camunda.connector.agenticai.aiagent.model.request.v2.OpenAiCustomEndpointAuthentication.ApiKeyAuthentication;
+import io.camunda.connector.agenticai.autoconfigure.AgenticAiConnectorsConfigurationProperties.ChatModelProperties;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import org.apache.commons.lang3.StringUtils;
 import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Maps a v1 {@code ProviderConfiguration} to the equivalent native v2 {@code
@@ -57,8 +64,16 @@ public class V1ToV2ProviderConfigurationMapperImpl implements V1ToV2ProviderConf
    */
   public static final String MISSING_API_KEY_PLACEHOLDER = "not-required";
 
+  private static final Logger LOGGER =
+      LoggerFactory.getLogger(V1ToV2ProviderConfigurationMapperImpl.class);
   private static final String AUTHORIZATION_HEADER = "Authorization";
   private static final String BEARER_PREFIX = "Bearer ";
+
+  private final ChatModelProperties chatModelProperties;
+
+  public V1ToV2ProviderConfigurationMapperImpl(ChatModelProperties chatModelProperties) {
+    this.chatModelProperties = chatModelProperties;
+  }
 
   @Override
   public io.camunda.connector.agenticai.aiagent.model.request.v2.ProviderConfiguration map(
@@ -71,6 +86,153 @@ public class V1ToV2ProviderConfigurationMapperImpl implements V1ToV2ProviderConf
       case BedrockProviderConfiguration bedrock -> mapBedrock(bedrock);
       case AzureOpenAiProviderConfiguration azureOpenAi -> mapAzureOpenAi(azureOpenAi);
       case GoogleVertexAiProviderConfiguration googleVertexAi -> mapGoogleVertexAi(googleVertexAi);
+    };
+  }
+
+  private AnthropicChatModelConfiguration mapAnthropic(AnthropicProviderConfiguration source) {
+    final var connection = source.anthropic();
+    final var model = connection.model();
+    final var parameters = model.parameters();
+
+    final var v2Parameters =
+        parameters == null
+            ? null
+            : new AnthropicChatModelConfiguration.AnthropicModel.AnthropicModelParameters(
+                null,
+                null,
+                null,
+                parameters.maxTokens(),
+                parameters.temperature(),
+                parameters.topP(),
+                parameters.topK());
+
+    return new AnthropicChatModelConfiguration(
+        new AnthropicChatModelConfiguration.AnthropicConnection(
+            new AnthropicApiBackend(
+                new AnthropicApi(
+                    connection.authentication().apiKey(),
+                    toNativeAnthropicEndpoint(connection.endpoint()),
+                    null,
+                    null,
+                    null)),
+            new AnthropicChatModelConfiguration.AnthropicModel(model.model(), v2Parameters),
+            resolveTimeouts(connection.timeouts())));
+  }
+
+  private OpenAiChatModelConfiguration mapOpenAi(OpenAiProviderConfiguration source) {
+    final var connection = source.openai();
+    final var authentication = connection.authentication();
+    final var model = connection.model();
+
+    return new OpenAiChatModelConfiguration(
+        new OpenAiConnection(
+            new OpenAiCompletionsApi(completionsParametersOf(model.parameters())),
+            new OpenAiApiBackend(
+                new OpenAiApiConnection(
+                    authentication.apiKey(),
+                    authentication.organizationId(),
+                    authentication.projectId(),
+                    null,
+                    null,
+                    null,
+                    null)),
+            new OpenAiModel(model.model()),
+            resolveTimeouts(connection.timeouts())));
+  }
+
+  private OpenAiChatModelConfiguration mapOpenAiCompatible(
+      OpenAiCompatibleProviderConfiguration source) {
+    final var connection = source.openaiCompatible();
+    final var model = connection.model();
+    final var parameters = model.parameters();
+
+    final var resolvedAuthentication =
+        resolveOpenAiCompatibleAuthentication(connection.authentication(), connection.headers());
+
+    return new OpenAiChatModelConfiguration(
+        new OpenAiConnection(
+            new OpenAiCompletionsApi(completionsParametersOf(parameters)),
+            new OpenAiCustomBackend(
+                new CustomBackend(
+                    connection.endpoint(),
+                    resolvedAuthentication.headers(),
+                    connection.queryParameters(),
+                    parameters == null ? null : parameters.customParameters(),
+                    new ApiKeyAuthentication(resolvedAuthentication.apiKey()))),
+            new OpenAiModel(model.model()),
+            resolveTimeouts(connection.timeouts())));
+  }
+
+  /**
+   * Resolves the effective custom-backend credential and pass-through headers per the v1 contract:
+   * an {@code Authorization} header wins over a configured API key (the legacy factory clears the
+   * key whenever both are present). A {@code Bearer} token is lifted into the native API key and
+   * its header dropped; any other {@code Authorization} scheme passes through with the placeholder
+   * key. With no {@code Authorization} header, a non-blank API key is used, else the placeholder.
+   */
+  private ResolvedOpenAiCompatibleAuthentication resolveOpenAiCompatibleAuthentication(
+      OpenAiCompatibleProviderConfiguration.@Nullable OpenAiCompatibleAuthentication authentication,
+      @Nullable Map<String, String> headers) {
+    if (headers != null) {
+      for (final var entry : headers.entrySet()) {
+        if (AUTHORIZATION_HEADER.equalsIgnoreCase(entry.getKey()) && entry.getValue() != null) {
+          final var value = entry.getValue();
+          if (value.regionMatches(true, 0, BEARER_PREFIX, 0, BEARER_PREFIX.length())) {
+            final var remainingHeaders = new LinkedHashMap<>(headers);
+            remainingHeaders.remove(entry.getKey());
+            return new ResolvedOpenAiCompatibleAuthentication(
+                value.substring(BEARER_PREFIX.length()), remainingHeaders);
+          }
+          return new ResolvedOpenAiCompatibleAuthentication(MISSING_API_KEY_PLACEHOLDER, headers);
+        }
+      }
+    }
+
+    final var apiKey = authentication == null ? null : authentication.apiKey();
+    if (apiKey != null && !apiKey.isBlank()) {
+      return new ResolvedOpenAiCompatibleAuthentication(apiKey, headers);
+    }
+    return new ResolvedOpenAiCompatibleAuthentication(MISSING_API_KEY_PLACEHOLDER, headers);
+  }
+
+  private record ResolvedOpenAiCompatibleAuthentication(
+      String apiKey, @Nullable Map<String, String> headers) {}
+
+  private BedrockConverseChatModelConfiguration mapBedrock(BedrockProviderConfiguration source) {
+    final var connection = source.bedrock();
+    final var model = connection.model();
+    final var parameters = model.parameters();
+
+    final var v2Parameters =
+        parameters == null
+            ? null
+            : new BedrockConverseModelParameters(
+                null, parameters.maxTokens(), parameters.temperature(), parameters.topP());
+
+    return new BedrockConverseChatModelConfiguration(
+        new BedrockConverseConnection(
+            connection.region(),
+            connection.endpoint(),
+            mapAwsAuthentication(connection.authentication()),
+            null,
+            null,
+            null,
+            resolveTimeouts(connection.timeouts()),
+            new BedrockConverseModel(model.model(), v2Parameters)));
+  }
+
+  private AwsAuthentication mapAwsAuthentication(
+      BedrockProviderConfiguration.AwsAuthentication authentication) {
+    return switch (authentication) {
+      case BedrockProviderConfiguration.AwsAuthentication.AwsStaticCredentialsAuthentication
+              staticCredentials ->
+          new AwsAuthentication.AwsStaticCredentialsAuthentication(
+              staticCredentials.accessKey(), staticCredentials.secretKey());
+      case BedrockProviderConfiguration.AwsAuthentication.AwsApiKeyAuthentication apiKey ->
+          new AwsAuthentication.AwsApiKeyAuthentication(apiKey.apiKey());
+      case BedrockProviderConfiguration.AwsAuthentication.AwsDefaultCredentialsChainAuthentication
+              ignored ->
+          new AwsAuthentication.AwsDefaultCredentialsChainAuthentication();
     };
   }
 
@@ -97,7 +259,7 @@ public class V1ToV2ProviderConfigurationMapperImpl implements V1ToV2ProviderConf
                     null,
                     null)),
             new OpenAiModel(model.deploymentName()),
-            connection.timeouts()));
+            resolveTimeouts(connection.timeouts())));
   }
 
   private FoundryAuthentication mapAzureAuthentication(
@@ -141,7 +303,7 @@ public class V1ToV2ProviderConfigurationMapperImpl implements V1ToV2ProviderConf
                     connection.endpoint(),
                     mapGoogleVertexAiAuthentication(connection.authentication()))),
             new GeminiModel(model.model(), v2Parameters),
-            connection.timeouts()));
+            resolveTimeouts(connection.timeouts())));
   }
 
   private GoogleVertexAiAuthentication mapGoogleVertexAiAuthentication(
@@ -158,137 +320,6 @@ public class V1ToV2ProviderConfigurationMapperImpl implements V1ToV2ProviderConf
           new GoogleVertexAiAuthentication.ApplicationDefaultCredentialsAuthentication();
     };
   }
-
-  private static @Nullable Double toDouble(@Nullable Float value) {
-    return value == null ? null : value.doubleValue();
-  }
-
-  private AnthropicChatModelConfiguration mapAnthropic(AnthropicProviderConfiguration source) {
-    final var connection = source.anthropic();
-    final var model = connection.model();
-    final var parameters = model.parameters();
-
-    final var v2Parameters =
-        parameters == null
-            ? null
-            : new AnthropicChatModelConfiguration.AnthropicModel.AnthropicModelParameters(
-                null,
-                null,
-                null,
-                parameters.maxTokens(),
-                parameters.temperature(),
-                parameters.topP(),
-                parameters.topK());
-
-    return new AnthropicChatModelConfiguration(
-        new AnthropicChatModelConfiguration.AnthropicConnection(
-            new AnthropicApiBackend(
-                new AnthropicApi(
-                    connection.authentication().apiKey(),
-                    toNativeAnthropicEndpoint(connection.endpoint()),
-                    null,
-                    null,
-                    null)),
-            new AnthropicChatModelConfiguration.AnthropicModel(model.model(), v2Parameters),
-            connection.timeouts()));
-  }
-
-  /**
-   * Normalizes a v1 Anthropic endpoint to the base URL the native Anthropic SDK expects. The v1
-   * endpoint carries the {@code /v1} API-version segment, whereas the native SDK appends {@code
-   * /v1/messages} to the configured base itself; the segment is stripped here so the two do not
-   * combine into a doubled {@code /v1/v1}.
-   */
-  private static @Nullable String toNativeAnthropicEndpoint(@Nullable String endpoint) {
-    if (endpoint == null) {
-      return null;
-    }
-    var trimmed = endpoint;
-    while (trimmed.endsWith("/")) {
-      trimmed = trimmed.substring(0, trimmed.length() - 1);
-    }
-    return trimmed.endsWith("/v1")
-        ? trimmed.substring(0, trimmed.length() - "/v1".length())
-        : endpoint;
-  }
-
-  private OpenAiChatModelConfiguration mapOpenAi(OpenAiProviderConfiguration source) {
-    final var connection = source.openai();
-    final var authentication = connection.authentication();
-    final var model = connection.model();
-
-    return new OpenAiChatModelConfiguration(
-        new OpenAiConnection(
-            new OpenAiCompletionsApi(completionsParametersOf(model.parameters())),
-            new OpenAiApiBackend(
-                new OpenAiApiConnection(
-                    authentication.apiKey(),
-                    authentication.organizationId(),
-                    authentication.projectId(),
-                    null,
-                    null,
-                    null,
-                    null)),
-            new OpenAiModel(model.model()),
-            connection.timeouts()));
-  }
-
-  private OpenAiChatModelConfiguration mapOpenAiCompatible(
-      OpenAiCompatibleProviderConfiguration source) {
-    final var connection = source.openaiCompatible();
-    final var model = connection.model();
-    final var parameters = model.parameters();
-
-    final var resolvedAuthentication =
-        resolveOpenAiCompatibleAuthentication(connection.authentication(), connection.headers());
-
-    return new OpenAiChatModelConfiguration(
-        new OpenAiConnection(
-            new OpenAiCompletionsApi(completionsParametersOf(parameters)),
-            new OpenAiCustomBackend(
-                new CustomBackend(
-                    connection.endpoint(),
-                    resolvedAuthentication.headers(),
-                    connection.queryParameters(),
-                    parameters == null ? null : parameters.customParameters(),
-                    new ApiKeyAuthentication(resolvedAuthentication.apiKey()))),
-            new OpenAiModel(model.model()),
-            connection.timeouts()));
-  }
-
-  /**
-   * Resolves the effective API key for the OpenAI-compatible custom backend and the headers that
-   * should pass through alongside it, per the v1-to-v2 auth-lift algorithm: a non-blank {@code
-   * authentication.apiKey} wins outright; otherwise a case-insensitive {@code Authorization: Bearer
-   * <token>} header is lifted into the key and removed from the passthrough headers; otherwise the
-   * placeholder key is used and headers pass through unchanged.
-   */
-  private ResolvedOpenAiCompatibleAuthentication resolveOpenAiCompatibleAuthentication(
-      OpenAiCompatibleProviderConfiguration.OpenAiCompatibleAuthentication authentication,
-      @Nullable Map<String, String> headers) {
-    final var apiKey = authentication == null ? null : authentication.apiKey();
-    if (apiKey != null && !apiKey.isBlank()) {
-      return new ResolvedOpenAiCompatibleAuthentication(apiKey, headers);
-    }
-
-    if (headers != null) {
-      for (final var entry : headers.entrySet()) {
-        if (AUTHORIZATION_HEADER.equalsIgnoreCase(entry.getKey())
-            && entry.getValue() != null
-            && entry.getValue().regionMatches(true, 0, BEARER_PREFIX, 0, BEARER_PREFIX.length())) {
-          final var token = entry.getValue().substring(BEARER_PREFIX.length());
-          final var remainingHeaders = new LinkedHashMap<>(headers);
-          remainingHeaders.remove(entry.getKey());
-          return new ResolvedOpenAiCompatibleAuthentication(token, remainingHeaders);
-        }
-      }
-    }
-
-    return new ResolvedOpenAiCompatibleAuthentication(MISSING_API_KEY_PLACEHOLDER, headers);
-  }
-
-  private record ResolvedOpenAiCompatibleAuthentication(
-      String apiKey, @Nullable Map<String, String> headers) {}
 
   private @Nullable CompletionsParameters completionsParametersOf(
       OpenAiProviderConfiguration.OpenAiModel.@Nullable OpenAiModelParameters parameters) {
@@ -308,41 +339,33 @@ public class V1ToV2ProviderConfigurationMapperImpl implements V1ToV2ProviderConf
             parameters.maxCompletionTokens(), null, parameters.temperature(), parameters.topP());
   }
 
-  private BedrockConverseChatModelConfiguration mapBedrock(BedrockProviderConfiguration source) {
-    final var connection = source.bedrock();
-    final var model = connection.model();
-    final var parameters = model.parameters();
-
-    final var v2Parameters =
-        parameters == null
-            ? null
-            : new BedrockConverseModelParameters(
-                null, parameters.maxTokens(), parameters.temperature(), parameters.topP());
-
-    return new BedrockConverseChatModelConfiguration(
-        new BedrockConverseConnection(
-            connection.region(),
-            connection.endpoint(),
-            mapAwsAuthentication(connection.authentication()),
-            null,
-            null,
-            null,
-            connection.timeouts(),
-            new BedrockConverseModel(model.model(), v2Parameters)));
+  /**
+   * Normalizes a v1 Anthropic endpoint to the base URL the native Anthropic SDK expects. The v1
+   * endpoint carries the {@code /v1} API-version segment, whereas the native SDK appends {@code
+   * /v1/messages} to the configured base itself; the segment is stripped here so the two do not
+   * combine into a doubled {@code /v1/v1}.
+   */
+  private static @Nullable String toNativeAnthropicEndpoint(@Nullable String endpoint) {
+    if (endpoint == null) {
+      return null;
+    }
+    final var trimmed = StringUtils.stripEnd(endpoint, "/");
+    return trimmed.endsWith("/v1")
+        ? trimmed.substring(0, trimmed.length() - "/v1".length())
+        : endpoint;
   }
 
-  private AwsAuthentication mapAwsAuthentication(
-      BedrockProviderConfiguration.AwsAuthentication authentication) {
-    return switch (authentication) {
-      case BedrockProviderConfiguration.AwsAuthentication.AwsStaticCredentialsAuthentication
-              staticCredentials ->
-          new AwsAuthentication.AwsStaticCredentialsAuthentication(
-              staticCredentials.accessKey(), staticCredentials.secretKey());
-      case BedrockProviderConfiguration.AwsAuthentication.AwsApiKeyAuthentication apiKey ->
-          new AwsAuthentication.AwsApiKeyAuthentication(apiKey.apiKey());
-      case BedrockProviderConfiguration.AwsAuthentication.AwsDefaultCredentialsChainAuthentication
-              ignored ->
-          new AwsAuthentication.AwsDefaultCredentialsChainAuthentication();
-    };
+  /**
+   * Resolves the timeout the way the legacy factories did: the v1 timeout when positive, otherwise
+   * the configured {@code chat-model.api.default-timeout}. Native providers otherwise fall back to
+   * their SDK default, which would silently change legacy timeout behavior on a rewritten job.
+   */
+  private TimeoutConfiguration resolveTimeouts(@Nullable TimeoutConfiguration timeouts) {
+    return new TimeoutConfiguration(
+        deriveTimeoutSetting("v1 provider configuration", chatModelProperties, timeouts, LOGGER));
+  }
+
+  private static @Nullable Double toDouble(@Nullable Float value) {
+    return value == null ? null : value.doubleValue();
   }
 }

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/autoconfigure/AgenticAiConnectorsAutoConfiguration.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/autoconfigure/AgenticAiConnectorsAutoConfiguration.java
@@ -77,6 +77,7 @@ import io.camunda.connector.runtime.annotation.ConnectorsObjectMapper;
 import io.camunda.connector.runtime.core.document.store.CamundaDocumentStore;
 import io.camunda.zeebe.feel.tagged.impl.TaggedParameterExtractor;
 import java.util.List;
+import org.springframework.beans.factory.config.ConfigurableBeanFactory;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBooleanProperty;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -84,6 +85,7 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Scope;
 
 @Configuration
 @ConditionalOnBooleanProperty(value = "camunda.connector.agenticai.enabled", matchIfMissing = true)
@@ -330,6 +332,7 @@ public class AgenticAiConnectorsAutoConfiguration {
   }
 
   @Bean
+  @Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
   @ConditionalOnMissingBean
   @ConditionalOnBooleanProperty(
       value = "camunda.connector.agenticai.aiagent.outbound-connector.enabled",
@@ -371,6 +374,7 @@ public class AgenticAiConnectorsAutoConfiguration {
   }
 
   @Bean
+  @Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
   @ConditionalOnMissingBean
   @ConditionalOnBooleanProperty(
       value = "camunda.connector.agenticai.aiagent.job-worker.enabled",
@@ -387,6 +391,7 @@ public class AgenticAiConnectorsAutoConfiguration {
   }
 
   @Bean
+  @Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
   @ConditionalOnMissingBean
   @ConditionalOnBean(AgentTaskRequestHandler.class)
   @ConditionalOnBooleanProperty(
@@ -399,6 +404,7 @@ public class AgenticAiConnectorsAutoConfiguration {
   }
 
   @Bean
+  @Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
   @ConditionalOnMissingBean
   @ConditionalOnBean(AgentSubProcessRequestHandler.class)
   @ConditionalOnBooleanProperty(

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/autoconfigure/AgenticAiConnectorsAutoConfiguration.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/autoconfigure/AgenticAiConnectorsAutoConfiguration.java
@@ -57,6 +57,8 @@ import io.camunda.connector.agenticai.aiagent.memory.conversation.awsagentcore.D
 import io.camunda.connector.agenticai.aiagent.memory.conversation.awsagentcore.mapping.AwsAgentCoreConversationMapper;
 import io.camunda.connector.agenticai.aiagent.memory.conversation.document.CamundaDocumentConversationStore;
 import io.camunda.connector.agenticai.aiagent.memory.conversation.inprocess.InProcessConversationStore;
+import io.camunda.connector.agenticai.aiagent.model.request.V1ToV2ProviderConfigurationMapper;
+import io.camunda.connector.agenticai.aiagent.model.request.V1ToV2ProviderConfigurationMapperImpl;
 import io.camunda.connector.agenticai.aiagent.systemprompt.SystemPromptComposer;
 import io.camunda.connector.agenticai.aiagent.systemprompt.SystemPromptComposerImpl;
 import io.camunda.connector.agenticai.aiagent.systemprompt.SystemPromptContributor;
@@ -300,6 +302,12 @@ public class AgenticAiConnectorsAutoConfiguration {
 
   @Bean
   @ConditionalOnMissingBean
+  public V1ToV2ProviderConfigurationMapper aiAgentV1ToV2ProviderConfigurationMapper() {
+    return new V1ToV2ProviderConfigurationMapperImpl();
+  }
+
+  @Bean
+  @ConditionalOnMissingBean
   @ConditionalOnBooleanProperty(
       value = "camunda.connector.agenticai.aiagent.outbound-connector.enabled",
       matchIfMissing = true)
@@ -326,10 +334,17 @@ public class AgenticAiConnectorsAutoConfiguration {
   @ConditionalOnBooleanProperty(
       value = "camunda.connector.agenticai.aiagent.outbound-connector.enabled",
       matchIfMissing = true)
+  @SuppressWarnings("deprecation")
   public AgentTaskV1Function aiAgentTaskV1Function(
       ProcessDefinitionAdHocToolElementsResolver toolElementsResolver,
-      AgentTaskRequestHandler agentRequestHandler) {
-    return new AgentTaskV1Function(toolElementsResolver, agentRequestHandler);
+      AgentTaskRequestHandler agentRequestHandler,
+      V1ToV2ProviderConfigurationMapper v1ProviderConfigurationMapper,
+      AgenticAiConnectorsConfigurationProperties configuration) {
+    return new AgentTaskV1Function(
+        toolElementsResolver,
+        agentRequestHandler,
+        v1ProviderConfigurationMapper,
+        configuration.aiagent().rewriteV1ProviderConfigToV2());
   }
 
   @Bean
@@ -360,9 +375,15 @@ public class AgenticAiConnectorsAutoConfiguration {
   @ConditionalOnBooleanProperty(
       value = "camunda.connector.agenticai.aiagent.job-worker.enabled",
       matchIfMissing = true)
+  @SuppressWarnings("deprecation")
   public AgentSubProcessV1Function aiAgentSubProcessV1Function(
-      AgentSubProcessRequestHandler agentRequestHandler) {
-    return new AgentSubProcessV1Function(agentRequestHandler);
+      AgentSubProcessRequestHandler agentRequestHandler,
+      V1ToV2ProviderConfigurationMapper v1ProviderConfigurationMapper,
+      AgenticAiConnectorsConfigurationProperties configuration) {
+    return new AgentSubProcessV1Function(
+        agentRequestHandler,
+        v1ProviderConfigurationMapper,
+        configuration.aiagent().rewriteV1ProviderConfigToV2());
   }
 
   @Bean

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/autoconfigure/AgenticAiConnectorsAutoConfiguration.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/autoconfigure/AgenticAiConnectorsAutoConfiguration.java
@@ -304,8 +304,9 @@ public class AgenticAiConnectorsAutoConfiguration {
 
   @Bean
   @ConditionalOnMissingBean
-  public V1ToV2ProviderConfigurationMapper aiAgentV1ToV2ProviderConfigurationMapper() {
-    return new V1ToV2ProviderConfigurationMapperImpl();
+  public V1ToV2ProviderConfigurationMapper aiAgentV1ToV2ProviderConfigurationMapper(
+      AgenticAiConnectorsConfigurationProperties configuration) {
+    return new V1ToV2ProviderConfigurationMapperImpl(configuration.aiagent().chatModel());
   }
 
   @Bean

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/autoconfigure/AgenticAiConnectorsConfigurationProperties.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/autoconfigure/AgenticAiConnectorsConfigurationProperties.java
@@ -27,7 +27,13 @@ public record AgenticAiConnectorsConfigurationProperties(
 
   public record AiAgentProperties(
       @Valid @DefaultValue ChatModelProperties chatModel,
-      @Valid @DefaultValue AgentInstanceProperties agentInstance) {
+      @Valid @DefaultValue AgentInstanceProperties agentInstance,
+      /**
+       * When {@code true} (the default), v1 provider configurations are rewritten to their v2
+       * equivalent and executed through the v2 provider path. When {@code false}, the original v1
+       * path is used. This is a temporary switch, removed when the v1 path is dropped.
+       */
+      @DefaultValue("true") boolean rewriteV1ProviderConfigToV2) {
 
     public record AgentInstanceProperties(@Valid @DefaultValue RetriesProperties retries) {}
   }

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/AgentJobCompletionListenerDelegationTests.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/AgentJobCompletionListenerDelegationTests.java
@@ -124,7 +124,7 @@ class AgentJobCompletionListenerDelegationTests {
     @Test
     void onJobCompleted_invokesAgentListenerCarriedByResponse() {
       var listener = mock(AgentJobCompletionListener.class);
-      var function = new AgentTaskV1Function(null, null);
+      var function = new AgentTaskV1Function(null, null, null, false);
       var response = new AgentTaskConnectorResponse(null, listener);
 
       function.onJobCompleted(mock(OutboundConnectorContext.class), response);
@@ -135,7 +135,7 @@ class AgentJobCompletionListenerDelegationTests {
     @Test
     void onJobCompletionFailed_invokesAgentListenerCarriedByResponse() {
       var listener = mock(AgentJobCompletionListener.class);
-      var function = new AgentTaskV1Function(null, null);
+      var function = new AgentTaskV1Function(null, null, null, false);
       var response = new AgentTaskConnectorResponse(null, listener);
       var failure =
           new JobCompletionFailure.CommandFailure.CommandFailed(new RuntimeException("test"));
@@ -147,7 +147,7 @@ class AgentJobCompletionListenerDelegationTests {
 
     @Test
     void onJobCompletionFailed_noOpWhenResponseIsNull() {
-      var function = new AgentTaskV1Function(null, null);
+      var function = new AgentTaskV1Function(null, null, null, false);
 
       // pre-response failure (e.g. execute() threw): no response to delegate to
       function.onJobCompletionFailed(
@@ -158,7 +158,7 @@ class AgentJobCompletionListenerDelegationTests {
 
     @Test
     void onJobCompletionFailed_noOpWhenResponseIsNotAgentResponse() {
-      var function = new AgentTaskV1Function(null, null);
+      var function = new AgentTaskV1Function(null, null, null, false);
       var foreignResponse = StandardConnectorResponse.of(Map.of("foo", "bar"));
 
       // should not throw
@@ -175,7 +175,7 @@ class AgentJobCompletionListenerDelegationTests {
     @Test
     void onJobCompleted_invokesAgentListenerCarriedByResponse() {
       var listener = mock(AgentJobCompletionListener.class);
-      var function = new AgentSubProcessV1Function(null);
+      var function = new AgentSubProcessV1Function(null, null, false);
       var response =
           AgentSubProcessConnectorResponse.builder()
               .variables(Map.of())
@@ -193,7 +193,7 @@ class AgentJobCompletionListenerDelegationTests {
     @Test
     void onJobCompletionFailed_invokesAgentListenerCarriedByResponse() {
       var listener = mock(AgentJobCompletionListener.class);
-      var function = new AgentSubProcessV1Function(null);
+      var function = new AgentSubProcessV1Function(null, null, false);
       var response =
           AgentSubProcessConnectorResponse.builder()
               .variables(Map.of())
@@ -212,7 +212,7 @@ class AgentJobCompletionListenerDelegationTests {
 
     @Test
     void onJobCompletionFailed_noOpWhenResponseIsNull() {
-      var function = new AgentSubProcessV1Function(null);
+      var function = new AgentSubProcessV1Function(null, null, false);
       var listener = mock(AgentJobCompletionListener.class);
 
       function.onJobCompletionFailed(

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/AgentSubProcessV1FunctionTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/AgentSubProcessV1FunctionTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.agenticai.aiagent;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import io.camunda.connector.agenticai.aiagent.agent.AgentSubProcessRequestHandler;
+import io.camunda.connector.agenticai.aiagent.model.AgentSubProcessExecutionContext;
+import io.camunda.connector.agenticai.aiagent.model.request.AgentSubProcessRequestData;
+import io.camunda.connector.agenticai.aiagent.model.request.AgentSubProcessV1Request;
+import io.camunda.connector.agenticai.aiagent.model.request.PromptConfiguration.SystemPromptConfiguration;
+import io.camunda.connector.agenticai.aiagent.model.request.PromptConfiguration.UserPromptConfiguration;
+import io.camunda.connector.agenticai.aiagent.model.request.V1ToV2ProviderConfigurationMapper;
+import io.camunda.connector.agenticai.aiagent.model.request.v1.AnthropicProviderConfiguration;
+import io.camunda.connector.agenticai.aiagent.model.request.v1.AnthropicProviderConfiguration.AnthropicAuthentication;
+import io.camunda.connector.agenticai.aiagent.model.request.v1.AnthropicProviderConfiguration.AnthropicConnection;
+import io.camunda.connector.agenticai.aiagent.model.request.v1.AnthropicProviderConfiguration.AnthropicModel;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.AnthropicChatModelConfiguration;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.AnthropicChatModelConfiguration.AnthropicBackend.AnthropicApiBackend;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.AnthropicChatModelConfiguration.AnthropicBackend.AnthropicApiBackend.AnthropicApi;
+import io.camunda.connector.api.outbound.JobContext;
+import io.camunda.connector.api.outbound.OutboundConnectorContext;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class AgentSubProcessV1FunctionTest {
+
+  private static final AnthropicProviderConfiguration V1_PROVIDER =
+      new AnthropicProviderConfiguration(
+          new AnthropicConnection(
+              null,
+              new AnthropicAuthentication("anthropic-api-key"),
+              null,
+              new AnthropicModel("claude-sonnet-4-6", null)));
+
+  private static final AnthropicChatModelConfiguration V2_PROVIDER =
+      new AnthropicChatModelConfiguration(
+          new AnthropicChatModelConfiguration.AnthropicConnection(
+              new AnthropicApiBackend(
+                  new AnthropicApi("anthropic-api-key", null, null, null, null)),
+              new AnthropicChatModelConfiguration.AnthropicModel("claude-sonnet-4-6", null),
+              null));
+
+  private static final AgentSubProcessRequestData DATA =
+      new AgentSubProcessRequestData(
+          new SystemPromptConfiguration("system prompt"),
+          new UserPromptConfiguration("user prompt", null),
+          null,
+          null,
+          null,
+          null);
+
+  private static final AgentSubProcessV1Request REQUEST =
+      new AgentSubProcessV1Request(List.of(), null, List.of(), V1_PROVIDER, DATA);
+
+  @Mock private AgentSubProcessRequestHandler agentRequestHandler;
+  @Mock private V1ToV2ProviderConfigurationMapper providerConfigurationMapper;
+  @Mock private OutboundConnectorContext context;
+  @Mock private JobContext jobContext;
+
+  @Captor private ArgumentCaptor<AgentSubProcessExecutionContext> executionContextCaptor;
+
+  @BeforeEach
+  void setUp() {
+    when(context.bindVariables(AgentSubProcessV1Request.class)).thenReturn(REQUEST);
+    when(context.getJobContext()).thenReturn(jobContext);
+  }
+
+  @Test
+  void routesThroughNativeProviderWhenSwitchIsEnabled() throws Exception {
+    when(providerConfigurationMapper.map(V1_PROVIDER)).thenReturn(V2_PROVIDER);
+    var function =
+        new AgentSubProcessV1Function(agentRequestHandler, providerConfigurationMapper, true);
+
+    function.execute(context);
+
+    verify(agentRequestHandler).handleRequest(executionContextCaptor.capture());
+    var chatModel = executionContextCaptor.getValue().configuration().chatModel();
+    assertThat(chatModel).isInstanceOf(AnthropicChatModelConfiguration.class).isSameAs(V2_PROVIDER);
+  }
+
+  @Test
+  void keepsV1ProviderConfigurationWhenSwitchIsDisabled() throws Exception {
+    var function =
+        new AgentSubProcessV1Function(agentRequestHandler, providerConfigurationMapper, false);
+
+    function.execute(context);
+
+    verify(agentRequestHandler).handleRequest(executionContextCaptor.capture());
+    verifyNoInteractions(providerConfigurationMapper);
+    var chatModel = executionContextCaptor.getValue().configuration().chatModel();
+    assertThat(chatModel).isSameAs(V1_PROVIDER);
+  }
+}

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/AgentTaskV1FunctionTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/AgentTaskV1FunctionTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.agenticai.aiagent;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import io.camunda.connector.agenticai.adhoctoolsschema.processdefinition.ProcessDefinitionAdHocToolElementsResolver;
+import io.camunda.connector.agenticai.aiagent.agent.AgentTaskRequestHandler;
+import io.camunda.connector.agenticai.aiagent.model.AgentTaskExecutionContext;
+import io.camunda.connector.agenticai.aiagent.model.request.AgentTaskRequestData;
+import io.camunda.connector.agenticai.aiagent.model.request.AgentTaskV1Request;
+import io.camunda.connector.agenticai.aiagent.model.request.PromptConfiguration.SystemPromptConfiguration;
+import io.camunda.connector.agenticai.aiagent.model.request.PromptConfiguration.UserPromptConfiguration;
+import io.camunda.connector.agenticai.aiagent.model.request.V1ToV2ProviderConfigurationMapper;
+import io.camunda.connector.agenticai.aiagent.model.request.v1.AnthropicProviderConfiguration;
+import io.camunda.connector.agenticai.aiagent.model.request.v1.AnthropicProviderConfiguration.AnthropicAuthentication;
+import io.camunda.connector.agenticai.aiagent.model.request.v1.AnthropicProviderConfiguration.AnthropicConnection;
+import io.camunda.connector.agenticai.aiagent.model.request.v1.AnthropicProviderConfiguration.AnthropicModel;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.AnthropicChatModelConfiguration;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.AnthropicChatModelConfiguration.AnthropicBackend.AnthropicApiBackend;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.AnthropicChatModelConfiguration.AnthropicBackend.AnthropicApiBackend.AnthropicApi;
+import io.camunda.connector.api.outbound.JobContext;
+import io.camunda.connector.api.outbound.OutboundConnectorContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class AgentTaskV1FunctionTest {
+
+  private static final AnthropicProviderConfiguration V1_PROVIDER =
+      new AnthropicProviderConfiguration(
+          new AnthropicConnection(
+              null,
+              new AnthropicAuthentication("anthropic-api-key"),
+              null,
+              new AnthropicModel("claude-sonnet-4-6", null)));
+
+  private static final AnthropicChatModelConfiguration V2_PROVIDER =
+      new AnthropicChatModelConfiguration(
+          new AnthropicChatModelConfiguration.AnthropicConnection(
+              new AnthropicApiBackend(
+                  new AnthropicApi("anthropic-api-key", null, null, null, null)),
+              new AnthropicChatModelConfiguration.AnthropicModel("claude-sonnet-4-6", null),
+              null));
+
+  private static final AgentTaskRequestData DATA =
+      new AgentTaskRequestData(
+          null,
+          new SystemPromptConfiguration("system prompt"),
+          new UserPromptConfiguration("user prompt", null),
+          null,
+          null,
+          null,
+          null);
+
+  private static final AgentTaskV1Request REQUEST = new AgentTaskV1Request(V1_PROVIDER, DATA);
+
+  @Mock private ProcessDefinitionAdHocToolElementsResolver toolElementsResolver;
+  @Mock private AgentTaskRequestHandler agentRequestHandler;
+  @Mock private V1ToV2ProviderConfigurationMapper providerConfigurationMapper;
+  @Mock private OutboundConnectorContext context;
+  @Mock private JobContext jobContext;
+
+  @Captor private ArgumentCaptor<AgentTaskExecutionContext> executionContextCaptor;
+
+  @BeforeEach
+  void setUp() {
+    when(context.bindVariables(AgentTaskV1Request.class)).thenReturn(REQUEST);
+    when(context.getJobContext()).thenReturn(jobContext);
+  }
+
+  @Test
+  void routesThroughNativeProviderWhenSwitchIsEnabled() {
+    when(providerConfigurationMapper.map(V1_PROVIDER)).thenReturn(V2_PROVIDER);
+    var function =
+        new AgentTaskV1Function(
+            toolElementsResolver, agentRequestHandler, providerConfigurationMapper, true);
+
+    function.execute(context);
+
+    verify(agentRequestHandler).handleRequest(executionContextCaptor.capture());
+    var chatModel = executionContextCaptor.getValue().configuration().chatModel();
+    assertThat(chatModel).isInstanceOf(AnthropicChatModelConfiguration.class).isSameAs(V2_PROVIDER);
+  }
+
+  @Test
+  void keepsV1ProviderConfigurationWhenSwitchIsDisabled() {
+    var function =
+        new AgentTaskV1Function(
+            toolElementsResolver, agentRequestHandler, providerConfigurationMapper, false);
+
+    function.execute(context);
+
+    verify(agentRequestHandler).handleRequest(executionContextCaptor.capture());
+    verifyNoInteractions(providerConfigurationMapper);
+    var chatModel = executionContextCaptor.getValue().configuration().chatModel();
+    assertThat(chatModel).isSameAs(V1_PROVIDER);
+  }
+}

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/agent/AgentSubProcessRequestHandlerTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/agent/AgentSubProcessRequestHandlerTest.java
@@ -33,7 +33,7 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import io.camunda.client.api.command.AgentInstanceUpdateStatus;
-import io.camunda.connector.agenticai.aiagent.AgentSubProcessV1Function;
+import io.camunda.connector.agenticai.aiagent.AgentProcessVariables;
 import io.camunda.connector.agenticai.aiagent.agent.AgentInitializationResult.DeferConversation;
 import io.camunda.connector.agenticai.aiagent.agent.AgentInitializationResult.DiscoverTools;
 import io.camunda.connector.agenticai.aiagent.agent.AgentInitializationResult.ReadyToConverse;
@@ -290,17 +290,17 @@ class AgentSubProcessRequestHandlerTest {
     assertThat(response.elementActivations().get(0).variables())
         .isEqualTo(
             Map.of(
-                AgentSubProcessV1Function.TOOL_CALL_VARIABLE,
+                AgentProcessVariables.TOOL_CALL,
                 agentResponse.toolCalls().get(0),
-                AgentSubProcessV1Function.TOOL_CALL_RESULT_VARIABLE,
+                AgentProcessVariables.TOOL_CALL_RESULT,
                 ""));
     assertThat(response.elementActivations().get(1).elementId()).isEqualTo("getDateTime");
     assertThat(response.elementActivations().get(1).variables())
         .isEqualTo(
             Map.of(
-                AgentSubProcessV1Function.TOOL_CALL_VARIABLE,
+                AgentProcessVariables.TOOL_CALL,
                 agentResponse.toolCalls().get(1),
-                AgentSubProcessV1Function.TOOL_CALL_RESULT_VARIABLE,
+                AgentProcessVariables.TOOL_CALL_RESULT,
                 ""));
   }
 

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/model/request/V1ToV2ProviderConfigurationMapperImplTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/model/request/V1ToV2ProviderConfigurationMapperImplTest.java
@@ -130,6 +130,30 @@ class V1ToV2ProviderConfigurationMapperImplTest {
   }
 
   @Test
+  void stripsAnthropicApiVersionSuffixFromEndpoint() {
+    final var source =
+        new AnthropicProviderConfiguration(
+            new AnthropicConnection(
+                "https://proxy.example.com/v1/",
+                new AnthropicAuthentication("anthropic-api-key"),
+                null,
+                new AnthropicModel("claude-3", null)));
+
+    final var result = mapper.map(source);
+
+    final var expected =
+        new AnthropicChatModelConfiguration(
+            new AnthropicChatModelConfiguration.AnthropicConnection(
+                new AnthropicApiBackend(
+                    new AnthropicApi(
+                        "anthropic-api-key", "https://proxy.example.com", null, null, null)),
+                new AnthropicChatModelConfiguration.AnthropicModel("claude-3", null),
+                null));
+
+    assertThat(result).isEqualTo(expected);
+  }
+
+  @Test
   void mapsOpenAiProviderConfigurationWithParameters() {
     final var source =
         new OpenAiProviderConfiguration(

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/model/request/V1ToV2ProviderConfigurationMapperImplTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/model/request/V1ToV2ProviderConfigurationMapperImplTest.java
@@ -1,0 +1,598 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.agenticai.aiagent.model.request;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.connector.agenticai.aiagent.model.request.v1.AnthropicProviderConfiguration;
+import io.camunda.connector.agenticai.aiagent.model.request.v1.AnthropicProviderConfiguration.AnthropicAuthentication;
+import io.camunda.connector.agenticai.aiagent.model.request.v1.AnthropicProviderConfiguration.AnthropicConnection;
+import io.camunda.connector.agenticai.aiagent.model.request.v1.AnthropicProviderConfiguration.AnthropicModel;
+import io.camunda.connector.agenticai.aiagent.model.request.v1.AnthropicProviderConfiguration.AnthropicModel.AnthropicModelParameters;
+import io.camunda.connector.agenticai.aiagent.model.request.v1.AzureOpenAiProviderConfiguration;
+import io.camunda.connector.agenticai.aiagent.model.request.v1.AzureOpenAiProviderConfiguration.AzureAuthentication.AzureApiKeyAuthentication;
+import io.camunda.connector.agenticai.aiagent.model.request.v1.AzureOpenAiProviderConfiguration.AzureAuthentication.AzureClientCredentialsAuthentication;
+import io.camunda.connector.agenticai.aiagent.model.request.v1.AzureOpenAiProviderConfiguration.AzureOpenAiConnection;
+import io.camunda.connector.agenticai.aiagent.model.request.v1.AzureOpenAiProviderConfiguration.AzureOpenAiModel;
+import io.camunda.connector.agenticai.aiagent.model.request.v1.AzureOpenAiProviderConfiguration.AzureOpenAiModel.AzureOpenAiModelParameters;
+import io.camunda.connector.agenticai.aiagent.model.request.v1.BedrockProviderConfiguration;
+import io.camunda.connector.agenticai.aiagent.model.request.v1.BedrockProviderConfiguration.AwsAuthentication.AwsApiKeyAuthentication;
+import io.camunda.connector.agenticai.aiagent.model.request.v1.BedrockProviderConfiguration.AwsAuthentication.AwsDefaultCredentialsChainAuthentication;
+import io.camunda.connector.agenticai.aiagent.model.request.v1.BedrockProviderConfiguration.AwsAuthentication.AwsStaticCredentialsAuthentication;
+import io.camunda.connector.agenticai.aiagent.model.request.v1.BedrockProviderConfiguration.BedrockConnection;
+import io.camunda.connector.agenticai.aiagent.model.request.v1.BedrockProviderConfiguration.BedrockModel;
+import io.camunda.connector.agenticai.aiagent.model.request.v1.BedrockProviderConfiguration.BedrockModel.BedrockModelParameters;
+import io.camunda.connector.agenticai.aiagent.model.request.v1.GoogleVertexAiProviderConfiguration;
+import io.camunda.connector.agenticai.aiagent.model.request.v1.GoogleVertexAiProviderConfiguration.GoogleVertexAiAuthentication.ApplicationDefaultCredentialsAuthentication;
+import io.camunda.connector.agenticai.aiagent.model.request.v1.GoogleVertexAiProviderConfiguration.GoogleVertexAiAuthentication.ServiceAccountCredentialsAuthentication;
+import io.camunda.connector.agenticai.aiagent.model.request.v1.GoogleVertexAiProviderConfiguration.GoogleVertexAiConnection;
+import io.camunda.connector.agenticai.aiagent.model.request.v1.GoogleVertexAiProviderConfiguration.GoogleVertexAiModel;
+import io.camunda.connector.agenticai.aiagent.model.request.v1.GoogleVertexAiProviderConfiguration.GoogleVertexAiModel.GoogleVertexAiModelParameters;
+import io.camunda.connector.agenticai.aiagent.model.request.v1.OpenAiCompatibleProviderConfiguration;
+import io.camunda.connector.agenticai.aiagent.model.request.v1.OpenAiCompatibleProviderConfiguration.OpenAiCompatibleAuthentication;
+import io.camunda.connector.agenticai.aiagent.model.request.v1.OpenAiCompatibleProviderConfiguration.OpenAiCompatibleConnection;
+import io.camunda.connector.agenticai.aiagent.model.request.v1.OpenAiCompatibleProviderConfiguration.OpenAiCompatibleModel;
+import io.camunda.connector.agenticai.aiagent.model.request.v1.OpenAiCompatibleProviderConfiguration.OpenAiCompatibleModel.OpenAiCompatibleModelParameters;
+import io.camunda.connector.agenticai.aiagent.model.request.v1.OpenAiProviderConfiguration;
+import io.camunda.connector.agenticai.aiagent.model.request.v1.OpenAiProviderConfiguration.OpenAiAuthentication;
+import io.camunda.connector.agenticai.aiagent.model.request.v1.OpenAiProviderConfiguration.OpenAiModel.OpenAiModelParameters;
+import io.camunda.connector.agenticai.aiagent.model.request.v1.shared.TimeoutConfiguration;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.AnthropicChatModelConfiguration;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.AnthropicChatModelConfiguration.AnthropicBackend.AnthropicApiBackend;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.AnthropicChatModelConfiguration.AnthropicBackend.AnthropicApiBackend.AnthropicApi;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.AwsAuthentication;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.BedrockConverseChatModelConfiguration;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.BedrockConverseChatModelConfiguration.BedrockConverseConnection;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.BedrockConverseChatModelConfiguration.BedrockConverseModel;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.BedrockConverseChatModelConfiguration.BedrockConverseModel.BedrockConverseModelParameters;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.GeminiChatModelConfiguration;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.GeminiChatModelConfiguration.GeminiBackend.GeminiVertexAiBackend;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.GeminiChatModelConfiguration.GeminiBackend.GeminiVertexAiBackend.GoogleVertexAi;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.GeminiChatModelConfiguration.GeminiBackend.GoogleVertexAiAuthentication;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.GeminiChatModelConfiguration.GeminiConnection;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.GeminiChatModelConfiguration.GeminiModel;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.GeminiChatModelConfiguration.GeminiModel.GeminiModelParameters;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.OpenAiChatModelConfiguration;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.OpenAiChatModelConfiguration.OpenAiApi.OpenAiCompletionsApi;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.OpenAiChatModelConfiguration.OpenAiApi.OpenAiCompletionsApi.CompletionsParameters;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.OpenAiChatModelConfiguration.OpenAiBackend.FoundryAuthentication;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.OpenAiChatModelConfiguration.OpenAiBackend.OpenAiApiBackend;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.OpenAiChatModelConfiguration.OpenAiBackend.OpenAiApiBackend.OpenAiApiConnection;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.OpenAiChatModelConfiguration.OpenAiBackend.OpenAiCustomBackend;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.OpenAiChatModelConfiguration.OpenAiBackend.OpenAiCustomBackend.CustomBackend;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.OpenAiChatModelConfiguration.OpenAiBackend.OpenAiFoundryBackend;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.OpenAiChatModelConfiguration.OpenAiBackend.OpenAiFoundryBackend.FoundryBackend;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.OpenAiChatModelConfiguration.OpenAiConnection;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.OpenAiChatModelConfiguration.OpenAiModel;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.OpenAiCustomEndpointAuthentication.ApiKeyAuthentication;
+import java.time.Duration;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class V1ToV2ProviderConfigurationMapperImplTest {
+
+  private final V1ToV2ProviderConfigurationMapper mapper =
+      new V1ToV2ProviderConfigurationMapperImpl();
+
+  @Test
+  void mapsAnthropicProviderConfigurationWithParameters() {
+    final var source =
+        new AnthropicProviderConfiguration(
+            new AnthropicConnection(
+                "https://custom.anthropic.example",
+                new AnthropicAuthentication("anthropic-api-key"),
+                new TimeoutConfiguration(Duration.ofSeconds(30)),
+                new AnthropicModel(
+                    "claude-sonnet-4-6", new AnthropicModelParameters(1024, 0.5, 0.9, 40))));
+
+    final var result = mapper.map(source);
+
+    final var expected =
+        new AnthropicChatModelConfiguration(
+            new AnthropicChatModelConfiguration.AnthropicConnection(
+                new AnthropicApiBackend(
+                    new AnthropicApi(
+                        "anthropic-api-key", "https://custom.anthropic.example", null, null, null)),
+                new AnthropicChatModelConfiguration.AnthropicModel(
+                    "claude-sonnet-4-6",
+                    new AnthropicChatModelConfiguration.AnthropicModel.AnthropicModelParameters(
+                        null, null, null, 1024, 0.5, 0.9, 40)),
+                new TimeoutConfiguration(Duration.ofSeconds(30))));
+
+    assertThat(result).isEqualTo(expected);
+  }
+
+  @Test
+  void mapsAnthropicProviderConfigurationWithNullParameters() {
+    final var source =
+        new AnthropicProviderConfiguration(
+            new AnthropicConnection(
+                null,
+                new AnthropicAuthentication("anthropic-api-key"),
+                null,
+                new AnthropicModel("claude-3", null)));
+
+    final var result = mapper.map(source);
+
+    final var expected =
+        new AnthropicChatModelConfiguration(
+            new AnthropicChatModelConfiguration.AnthropicConnection(
+                new AnthropicApiBackend(
+                    new AnthropicApi("anthropic-api-key", null, null, null, null)),
+                new AnthropicChatModelConfiguration.AnthropicModel("claude-3", null),
+                null));
+
+    assertThat(result).isEqualTo(expected);
+  }
+
+  @Test
+  void mapsOpenAiProviderConfigurationWithParameters() {
+    final var source =
+        new OpenAiProviderConfiguration(
+            new OpenAiProviderConfiguration.OpenAiConnection(
+                new OpenAiAuthentication("openai-key", "org-1", "proj-1"),
+                new TimeoutConfiguration(Duration.ofSeconds(45)),
+                new OpenAiProviderConfiguration.OpenAiModel(
+                    "gpt-4o", new OpenAiModelParameters(2048, 0.7, 0.8))));
+
+    final var result = mapper.map(source);
+
+    final var expected =
+        new OpenAiChatModelConfiguration(
+            new OpenAiConnection(
+                new OpenAiCompletionsApi(new CompletionsParameters(2048, null, 0.7, 0.8)),
+                new OpenAiApiBackend(
+                    new OpenAiApiConnection(
+                        "openai-key", "org-1", "proj-1", null, null, null, null)),
+                new OpenAiModel("gpt-4o"),
+                new TimeoutConfiguration(Duration.ofSeconds(45))));
+
+    assertThat(result).isEqualTo(expected);
+  }
+
+  @Test
+  void mapsOpenAiCompatibleProviderConfigurationWithApiKeyPresent() {
+    final var source =
+        new OpenAiCompatibleProviderConfiguration(
+            new OpenAiCompatibleConnection(
+                "https://compat.example/v1",
+                new OpenAiCompatibleAuthentication("compat-key"),
+                Map.of("X-Custom", "value1"),
+                Map.of("api-version", "2026-01-01"),
+                new TimeoutConfiguration(Duration.ofSeconds(20)),
+                new OpenAiCompatibleModel(
+                    "llama-70b",
+                    new OpenAiCompatibleModelParameters(512, 0.3, 0.95, Map.of("seed", 42)))));
+
+    final var result = mapper.map(source);
+
+    final var expected =
+        new OpenAiChatModelConfiguration(
+            new OpenAiConnection(
+                new OpenAiCompletionsApi(new CompletionsParameters(512, null, 0.3, 0.95)),
+                new OpenAiCustomBackend(
+                    new CustomBackend(
+                        "https://compat.example/v1",
+                        Map.of("X-Custom", "value1"),
+                        Map.of("api-version", "2026-01-01"),
+                        Map.of("seed", 42),
+                        new ApiKeyAuthentication("compat-key"))),
+                new OpenAiModel("llama-70b"),
+                new TimeoutConfiguration(Duration.ofSeconds(20))));
+
+    assertThat(result).isEqualTo(expected);
+  }
+
+  @Test
+  void mapsOpenAiCompatibleProviderConfiguration_liftsBearerTokenFromAuthorizationHeader() {
+    final var source =
+        new OpenAiCompatibleProviderConfiguration(
+            new OpenAiCompatibleConnection(
+                "https://compat.example/v1",
+                new OpenAiCompatibleAuthentication(""),
+                Map.of("Authorization", "Bearer xyz-token", "X-Other", "keep-me"),
+                null,
+                null,
+                new OpenAiCompatibleModel("llama-70b", null)));
+
+    final var result = mapper.map(source);
+
+    final var expected =
+        new OpenAiChatModelConfiguration(
+            new OpenAiConnection(
+                new OpenAiCompletionsApi(null),
+                new OpenAiCustomBackend(
+                    new CustomBackend(
+                        "https://compat.example/v1",
+                        Map.of("X-Other", "keep-me"),
+                        null,
+                        null,
+                        new ApiKeyAuthentication("xyz-token"))),
+                new OpenAiModel("llama-70b"),
+                null));
+
+    assertThat(result).isEqualTo(expected);
+  }
+
+  @Test
+  void mapsOpenAiCompatibleProviderConfiguration_usesPlaceholderWhenNoApiKeyOrAuthHeader() {
+    final var source =
+        new OpenAiCompatibleProviderConfiguration(
+            new OpenAiCompatibleConnection(
+                "https://compat.example/v1",
+                new OpenAiCompatibleAuthentication(""),
+                Map.of("X-Other", "value"),
+                null,
+                null,
+                new OpenAiCompatibleModel("llama-70b", null)));
+
+    final var result = mapper.map(source);
+
+    final var expected =
+        new OpenAiChatModelConfiguration(
+            new OpenAiConnection(
+                new OpenAiCompletionsApi(null),
+                new OpenAiCustomBackend(
+                    new CustomBackend(
+                        "https://compat.example/v1",
+                        Map.of("X-Other", "value"),
+                        null,
+                        null,
+                        new ApiKeyAuthentication(
+                            V1ToV2ProviderConfigurationMapperImpl.MISSING_API_KEY_PLACEHOLDER))),
+                new OpenAiModel("llama-70b"),
+                null));
+
+    assertThat(result).isEqualTo(expected);
+  }
+
+  @Test
+  void
+      mapsOpenAiCompatibleProviderConfiguration_keepsNonBearerAuthorizationHeaderAndUsesPlaceholder() {
+    final var source =
+        new OpenAiCompatibleProviderConfiguration(
+            new OpenAiCompatibleConnection(
+                "https://compat.example/v1",
+                new OpenAiCompatibleAuthentication(""),
+                Map.of("Authorization", "Basic abc123"),
+                null,
+                null,
+                new OpenAiCompatibleModel("llama-70b", null)));
+
+    final var result = mapper.map(source);
+
+    final var expected =
+        new OpenAiChatModelConfiguration(
+            new OpenAiConnection(
+                new OpenAiCompletionsApi(null),
+                new OpenAiCustomBackend(
+                    new CustomBackend(
+                        "https://compat.example/v1",
+                        Map.of("Authorization", "Basic abc123"),
+                        null,
+                        null,
+                        new ApiKeyAuthentication(
+                            V1ToV2ProviderConfigurationMapperImpl.MISSING_API_KEY_PLACEHOLDER))),
+                new OpenAiModel("llama-70b"),
+                null));
+
+    assertThat(result).isEqualTo(expected);
+  }
+
+  @Test
+  void mapsBedrockProviderConfigurationWithParameters() {
+    final var source =
+        new BedrockProviderConfiguration(
+            new BedrockConnection(
+                "eu-west-1",
+                "https://vpce.example",
+                new AwsStaticCredentialsAuthentication("AKIA-access", "secret-key"),
+                new TimeoutConfiguration(Duration.ofSeconds(15)),
+                new BedrockModel(
+                    "global.anthropic.claude-sonnet-4-6",
+                    new BedrockModelParameters(4096, 0.6, 0.85))));
+
+    final var result = mapper.map(source);
+
+    final var expected =
+        new BedrockConverseChatModelConfiguration(
+            new BedrockConverseConnection(
+                "eu-west-1",
+                "https://vpce.example",
+                new AwsAuthentication.AwsStaticCredentialsAuthentication(
+                    "AKIA-access", "secret-key"),
+                null,
+                null,
+                null,
+                new TimeoutConfiguration(Duration.ofSeconds(15)),
+                new BedrockConverseModel(
+                    "global.anthropic.claude-sonnet-4-6",
+                    new BedrockConverseModelParameters(null, 4096, 0.6, 0.85))));
+
+    assertThat(result).isEqualTo(expected);
+  }
+
+  @Test
+  void mapsBedrockProviderConfigurationWithNullParameters() {
+    final var source =
+        new BedrockProviderConfiguration(
+            new BedrockConnection(
+                "us-east-1",
+                null,
+                new AwsStaticCredentialsAuthentication("AKIA-access", "secret-key"),
+                null,
+                new BedrockModel("nova-lite", null)));
+
+    final var result = mapper.map(source);
+
+    final var expected =
+        new BedrockConverseChatModelConfiguration(
+            new BedrockConverseConnection(
+                "us-east-1",
+                null,
+                new AwsAuthentication.AwsStaticCredentialsAuthentication(
+                    "AKIA-access", "secret-key"),
+                null,
+                null,
+                null,
+                null,
+                new BedrockConverseModel("nova-lite", null)));
+
+    assertThat(result).isEqualTo(expected);
+  }
+
+  @Test
+  void mapsAwsStaticCredentialsAuthentication() {
+    final var source =
+        new BedrockProviderConfiguration(
+            new BedrockConnection(
+                "eu-west-1",
+                null,
+                new AwsStaticCredentialsAuthentication("AKIA-access", "secret-key"),
+                null,
+                new BedrockModel("nova-lite", null)));
+
+    final var result = mapper.map(source);
+
+    assertThat(((BedrockConverseChatModelConfiguration) result).bedrock().authentication())
+        .isEqualTo(
+            new AwsAuthentication.AwsStaticCredentialsAuthentication("AKIA-access", "secret-key"));
+  }
+
+  @Test
+  void mapsAwsApiKeyAuthentication() {
+    final var source =
+        new BedrockProviderConfiguration(
+            new BedrockConnection(
+                "eu-west-1",
+                null,
+                new AwsApiKeyAuthentication("bedrock-api-key"),
+                null,
+                new BedrockModel("nova-lite", null)));
+
+    final var result = mapper.map(source);
+
+    assertThat(((BedrockConverseChatModelConfiguration) result).bedrock().authentication())
+        .isEqualTo(new AwsAuthentication.AwsApiKeyAuthentication("bedrock-api-key"));
+  }
+
+  @Test
+  void mapsAwsDefaultCredentialsChainAuthentication() {
+    final var source =
+        new BedrockProviderConfiguration(
+            new BedrockConnection(
+                "eu-west-1",
+                null,
+                new AwsDefaultCredentialsChainAuthentication(),
+                null,
+                new BedrockModel("nova-lite", null)));
+
+    final var result = mapper.map(source);
+
+    assertThat(((BedrockConverseChatModelConfiguration) result).bedrock().authentication())
+        .isEqualTo(new AwsAuthentication.AwsDefaultCredentialsChainAuthentication());
+  }
+
+  @Test
+  void mapsAzureOpenAiProviderConfigurationWithApiKeyAuthenticationAndParameters() {
+    final var source =
+        new AzureOpenAiProviderConfiguration(
+            new AzureOpenAiConnection(
+                "https://my-resource.openai.azure.com",
+                new AzureApiKeyAuthentication("azure-api-key"),
+                new TimeoutConfiguration(Duration.ofSeconds(25)),
+                new AzureOpenAiModel(
+                    "gpt-4o-deployment", new AzureOpenAiModelParameters(2048, 0.6, 0.85))));
+
+    final var result = mapper.map(source);
+
+    final var expected =
+        new OpenAiChatModelConfiguration(
+            new OpenAiConnection(
+                new OpenAiCompletionsApi(new CompletionsParameters(2048, null, 0.6, 0.85)),
+                new OpenAiFoundryBackend(
+                    new FoundryBackend(
+                        "https://my-resource.openai.azure.com",
+                        null,
+                        new FoundryAuthentication.ApiKeyAuthentication("azure-api-key"),
+                        null,
+                        null,
+                        null)),
+                new OpenAiModel("gpt-4o-deployment"),
+                new TimeoutConfiguration(Duration.ofSeconds(25))));
+
+    assertThat(result).isEqualTo(expected);
+  }
+
+  @Test
+  void mapsAzureOpenAiProviderConfigurationWithClientCredentialsAuthentication() {
+    final var source =
+        new AzureOpenAiProviderConfiguration(
+            new AzureOpenAiConnection(
+                "https://my-resource.openai.azure.com",
+                new AzureClientCredentialsAuthentication(
+                    "client-id", "client-secret", "tenant-id", "https://login.contoso.com"),
+                null,
+                new AzureOpenAiModel("gpt-4o-deployment", null)));
+
+    final var result = mapper.map(source);
+
+    final var expected =
+        new OpenAiChatModelConfiguration(
+            new OpenAiConnection(
+                new OpenAiCompletionsApi(null),
+                new OpenAiFoundryBackend(
+                    new FoundryBackend(
+                        "https://my-resource.openai.azure.com",
+                        null,
+                        new FoundryAuthentication.ClientCredentialsAuthentication(
+                            "client-id",
+                            "client-secret",
+                            "tenant-id",
+                            "https://login.contoso.com",
+                            null),
+                        null,
+                        null,
+                        null)),
+                new OpenAiModel("gpt-4o-deployment"),
+                null));
+
+    assertThat(result).isEqualTo(expected);
+  }
+
+  @Test
+  void mapsAzureOpenAiProviderConfigurationWithNullParameters() {
+    final var source =
+        new AzureOpenAiProviderConfiguration(
+            new AzureOpenAiConnection(
+                "https://my-resource.openai.azure.com",
+                new AzureApiKeyAuthentication("azure-api-key"),
+                null,
+                new AzureOpenAiModel("gpt-4o-deployment", null)));
+
+    final var result = mapper.map(source);
+
+    final var expected =
+        new OpenAiChatModelConfiguration(
+            new OpenAiConnection(
+                new OpenAiCompletionsApi(null),
+                new OpenAiFoundryBackend(
+                    new FoundryBackend(
+                        "https://my-resource.openai.azure.com",
+                        null,
+                        new FoundryAuthentication.ApiKeyAuthentication("azure-api-key"),
+                        null,
+                        null,
+                        null)),
+                new OpenAiModel("gpt-4o-deployment"),
+                null));
+
+    assertThat(result).isEqualTo(expected);
+  }
+
+  @Test
+  void mapsGoogleVertexAiProviderConfigurationWithServiceAccountCredentialsAndParameters() {
+    final float sourceTemperature = 0.5f;
+    final float sourceTopP = 0.9f;
+
+    final var source =
+        new GoogleVertexAiProviderConfiguration(
+            new GoogleVertexAiConnection(
+                "my-gcp-project",
+                "us-central1",
+                new ServiceAccountCredentialsAuthentication("{\"type\":\"service_account\"}"),
+                new GoogleVertexAiModel(
+                    "gemini-3-pro-preview",
+                    new GoogleVertexAiModelParameters(1024, sourceTemperature, sourceTopP, 40))));
+
+    final var result = mapper.map(source);
+
+    // v1 vertex temperature/topP are Float; v2 GeminiModelParameters uses Double. The expected
+    // values below use the natural widening of the source floats (not literal double constants)
+    // because a float like 0.9f is not exactly representable and widens to
+    // 0.8999999761581421d, not 0.9d.
+    final var expected =
+        new GeminiChatModelConfiguration(
+            new GeminiConnection(
+                new GeminiVertexAiBackend(
+                    new GoogleVertexAi(
+                        "my-gcp-project",
+                        "us-central1",
+                        null,
+                        new GoogleVertexAiAuthentication.ServiceAccountCredentialsAuthentication(
+                            "{\"type\":\"service_account\"}"))),
+                new GeminiModel(
+                    "gemini-3-pro-preview",
+                    new GeminiModelParameters(
+                        1024, (double) sourceTemperature, (double) sourceTopP, 40, null)),
+                null));
+
+    assertThat(result).isEqualTo(expected);
+
+    final var geminiModelParameters =
+        ((GeminiChatModelConfiguration) result).googleGemini().model().parameters();
+    assertThat(geminiModelParameters).isNotNull();
+    assertThat(geminiModelParameters.temperature()).isEqualTo((double) sourceTemperature);
+    assertThat(geminiModelParameters.topP()).isEqualTo((double) sourceTopP);
+  }
+
+  @Test
+  void mapsGoogleVertexAiProviderConfigurationWithApplicationDefaultCredentials() {
+    final var source =
+        new GoogleVertexAiProviderConfiguration(
+            new GoogleVertexAiConnection(
+                "my-gcp-project",
+                "us-central1",
+                new ApplicationDefaultCredentialsAuthentication(),
+                new GoogleVertexAiModel("gemini-3-pro-preview", null)));
+
+    final var result = mapper.map(source);
+
+    final var expected =
+        new GeminiChatModelConfiguration(
+            new GeminiConnection(
+                new GeminiVertexAiBackend(
+                    new GoogleVertexAi(
+                        "my-gcp-project",
+                        "us-central1",
+                        null,
+                        new GoogleVertexAiAuthentication
+                            .ApplicationDefaultCredentialsAuthentication())),
+                new GeminiModel("gemini-3-pro-preview", null),
+                null));
+
+    assertThat(result).isEqualTo(expected);
+  }
+
+  @Test
+  void mapsGoogleVertexAiProviderConfigurationWithNullParameters() {
+    final var source =
+        new GoogleVertexAiProviderConfiguration(
+            new GoogleVertexAiConnection(
+                "my-gcp-project",
+                "us-central1",
+                new ServiceAccountCredentialsAuthentication("{\"type\":\"service_account\"}"),
+                new GoogleVertexAiModel("gemini-3-pro-preview", null)));
+
+    final var result = mapper.map(source);
+
+    final var expected =
+        new GeminiChatModelConfiguration(
+            new GeminiConnection(
+                new GeminiVertexAiBackend(
+                    new GoogleVertexAi(
+                        "my-gcp-project",
+                        "us-central1",
+                        null,
+                        new GoogleVertexAiAuthentication.ServiceAccountCredentialsAuthentication(
+                            "{\"type\":\"service_account\"}"))),
+                new GeminiModel("gemini-3-pro-preview", null),
+                null));
+
+    assertThat(result).isEqualTo(expected);
+  }
+}

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/model/request/V1ToV2ProviderConfigurationMapperImplTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/model/request/V1ToV2ProviderConfigurationMapperImplTest.java
@@ -69,14 +69,19 @@ import io.camunda.connector.agenticai.aiagent.model.request.v2.OpenAiChatModelCo
 import io.camunda.connector.agenticai.aiagent.model.request.v2.OpenAiChatModelConfiguration.OpenAiConnection;
 import io.camunda.connector.agenticai.aiagent.model.request.v2.OpenAiChatModelConfiguration.OpenAiModel;
 import io.camunda.connector.agenticai.aiagent.model.request.v2.OpenAiCustomEndpointAuthentication.ApiKeyAuthentication;
+import io.camunda.connector.agenticai.autoconfigure.AgenticAiConnectorsConfigurationProperties.ChatModelProperties;
+import io.camunda.connector.agenticai.autoconfigure.AgenticAiConnectorsConfigurationProperties.ChatModelProperties.ApiProperties;
 import java.time.Duration;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 
 class V1ToV2ProviderConfigurationMapperImplTest {
 
+  private static final Duration DEFAULT_TIMEOUT = Duration.ofMinutes(3);
+
   private final V1ToV2ProviderConfigurationMapper mapper =
-      new V1ToV2ProviderConfigurationMapperImpl();
+      new V1ToV2ProviderConfigurationMapperImpl(
+          new ChatModelProperties(new ApiProperties(DEFAULT_TIMEOUT), null));
 
   @Test
   void mapsAnthropicProviderConfigurationWithParameters() {
@@ -124,7 +129,7 @@ class V1ToV2ProviderConfigurationMapperImplTest {
                 new AnthropicApiBackend(
                     new AnthropicApi("anthropic-api-key", null, null, null, null)),
                 new AnthropicChatModelConfiguration.AnthropicModel("claude-3", null),
-                null));
+                new TimeoutConfiguration(DEFAULT_TIMEOUT)));
 
     assertThat(result).isEqualTo(expected);
   }
@@ -148,7 +153,7 @@ class V1ToV2ProviderConfigurationMapperImplTest {
                     new AnthropicApi(
                         "anthropic-api-key", "https://proxy.example.com", null, null, null)),
                 new AnthropicChatModelConfiguration.AnthropicModel("claude-3", null),
-                null));
+                new TimeoutConfiguration(DEFAULT_TIMEOUT)));
 
     assertThat(result).isEqualTo(expected);
   }
@@ -237,7 +242,7 @@ class V1ToV2ProviderConfigurationMapperImplTest {
                         null,
                         new ApiKeyAuthentication("xyz-token"))),
                 new OpenAiModel("llama-70b"),
-                null));
+                new TimeoutConfiguration(DEFAULT_TIMEOUT)));
 
     assertThat(result).isEqualTo(expected);
   }
@@ -269,7 +274,7 @@ class V1ToV2ProviderConfigurationMapperImplTest {
                         new ApiKeyAuthentication(
                             V1ToV2ProviderConfigurationMapperImpl.MISSING_API_KEY_PLACEHOLDER))),
                 new OpenAiModel("llama-70b"),
-                null));
+                new TimeoutConfiguration(DEFAULT_TIMEOUT)));
 
     assertThat(result).isEqualTo(expected);
   }
@@ -302,9 +307,88 @@ class V1ToV2ProviderConfigurationMapperImplTest {
                         new ApiKeyAuthentication(
                             V1ToV2ProviderConfigurationMapperImpl.MISSING_API_KEY_PLACEHOLDER))),
                 new OpenAiModel("llama-70b"),
-                null));
+                new TimeoutConfiguration(DEFAULT_TIMEOUT)));
 
     assertThat(result).isEqualTo(expected);
+  }
+
+  @Test
+  void mapsOpenAiCompatibleProviderConfiguration_authorizationHeaderWinsOverApiKey() {
+    final var source =
+        new OpenAiCompatibleProviderConfiguration(
+            new OpenAiCompatibleConnection(
+                "https://compat.example/v1",
+                new OpenAiCompatibleAuthentication("configured-key"),
+                Map.of("Authorization", "Bearer header-token", "X-Other", "keep-me"),
+                null,
+                null,
+                new OpenAiCompatibleModel("llama-70b", null)));
+
+    final var result = mapper.map(source);
+
+    final var expected =
+        new OpenAiChatModelConfiguration(
+            new OpenAiConnection(
+                new OpenAiCompletionsApi(null),
+                new OpenAiCustomBackend(
+                    new CustomBackend(
+                        "https://compat.example/v1",
+                        Map.of("X-Other", "keep-me"),
+                        null,
+                        null,
+                        new ApiKeyAuthentication("header-token"))),
+                new OpenAiModel("llama-70b"),
+                new TimeoutConfiguration(DEFAULT_TIMEOUT)));
+
+    assertThat(result).isEqualTo(expected);
+  }
+
+  @Test
+  void mapsOpenAiCompatibleProviderConfiguration_nonBearerAuthorizationHeaderWinsOverApiKey() {
+    final var source =
+        new OpenAiCompatibleProviderConfiguration(
+            new OpenAiCompatibleConnection(
+                "https://compat.example/v1",
+                new OpenAiCompatibleAuthentication("configured-key"),
+                Map.of("Authorization", "Basic abc123"),
+                null,
+                null,
+                new OpenAiCompatibleModel("llama-70b", null)));
+
+    final var result = mapper.map(source);
+
+    final var expected =
+        new OpenAiChatModelConfiguration(
+            new OpenAiConnection(
+                new OpenAiCompletionsApi(null),
+                new OpenAiCustomBackend(
+                    new CustomBackend(
+                        "https://compat.example/v1",
+                        Map.of("Authorization", "Basic abc123"),
+                        null,
+                        null,
+                        new ApiKeyAuthentication(
+                            V1ToV2ProviderConfigurationMapperImpl.MISSING_API_KEY_PLACEHOLDER))),
+                new OpenAiModel("llama-70b"),
+                new TimeoutConfiguration(DEFAULT_TIMEOUT)));
+
+    assertThat(result).isEqualTo(expected);
+  }
+
+  @Test
+  void fallsBackToConfiguredDefaultTimeoutWhenV1TimeoutNonPositive() {
+    final var source =
+        new AnthropicProviderConfiguration(
+            new AnthropicConnection(
+                null,
+                new AnthropicAuthentication("anthropic-api-key"),
+                new TimeoutConfiguration(Duration.ZERO),
+                new AnthropicModel("claude-3", null)));
+
+    final var result = mapper.map(source);
+
+    assertThat(((AnthropicChatModelConfiguration) result).anthropic().timeouts())
+        .isEqualTo(new TimeoutConfiguration(DEFAULT_TIMEOUT));
   }
 
   @Test
@@ -363,7 +447,7 @@ class V1ToV2ProviderConfigurationMapperImplTest {
                 null,
                 null,
                 null,
-                null,
+                new TimeoutConfiguration(DEFAULT_TIMEOUT),
                 new BedrockConverseModel("nova-lite", null)));
 
     assertThat(result).isEqualTo(expected);
@@ -483,7 +567,7 @@ class V1ToV2ProviderConfigurationMapperImplTest {
                         null,
                         null)),
                 new OpenAiModel("gpt-4o-deployment"),
-                null));
+                new TimeoutConfiguration(DEFAULT_TIMEOUT)));
 
     assertThat(result).isEqualTo(expected);
   }
@@ -513,7 +597,7 @@ class V1ToV2ProviderConfigurationMapperImplTest {
                         null,
                         null)),
                 new OpenAiModel("gpt-4o-deployment"),
-                null));
+                new TimeoutConfiguration(DEFAULT_TIMEOUT)));
 
     assertThat(result).isEqualTo(expected);
   }
@@ -553,7 +637,7 @@ class V1ToV2ProviderConfigurationMapperImplTest {
                     "gemini-3-pro-preview",
                     new GeminiModelParameters(
                         1024, (double) sourceTemperature, (double) sourceTopP, 40, null)),
-                null));
+                new TimeoutConfiguration(DEFAULT_TIMEOUT)));
 
     assertThat(result).isEqualTo(expected);
 
@@ -587,7 +671,7 @@ class V1ToV2ProviderConfigurationMapperImplTest {
                         new GoogleVertexAiAuthentication
                             .ApplicationDefaultCredentialsAuthentication())),
                 new GeminiModel("gemini-3-pro-preview", null),
-                null));
+                new TimeoutConfiguration(DEFAULT_TIMEOUT)));
 
     assertThat(result).isEqualTo(expected);
   }
@@ -615,7 +699,7 @@ class V1ToV2ProviderConfigurationMapperImplTest {
                         new GoogleVertexAiAuthentication.ServiceAccountCredentialsAuthentication(
                             "{\"type\":\"service_account\"}"))),
                 new GeminiModel("gemini-3-pro-preview", null),
-                null));
+                new TimeoutConfiguration(DEFAULT_TIMEOUT)));
 
     assertThat(result).isEqualTo(expected);
   }

--- a/connectors/agentic-ai/docs/adr/014-route-v1-requests-through-native-providers.md
+++ b/connectors/agentic-ai/docs/adr/014-route-v1-requests-through-native-providers.md
@@ -1,0 +1,140 @@
+# Route v1 agent requests through native providers
+
+* Deciders: Agentic AI Team
+* Date: Aug 21, 2026
+
+## Status
+
+**Accepted**. Realized in the PR that introduces the v1-to-native provider configuration mapping,
+gated behind a configuration switch. The LangChain4j integration is retained as the alternate path
+for now; its removal is a deferred follow-on.
+
+## Context and Problem Statement
+
+[ADR 009](009-chat-model-provider-spi.md) introduced a module-owned `ChatModel` provider SPI and
+reshaped LangChain4j into per-provider factories behind it, naming native (non-LangChain4j)
+providers as an explicit follow-on. Those native providers now exist for every vendor the v1
+provider union supports: Anthropic, OpenAI (including the Azure / Microsoft Foundry backend),
+Google Gemini (including the Vertex AI backend), and AWS Bedrock (Converse).
+
+The module still ships two execution stacks. A v1 request binds the sealed
+`request.v1.ProviderConfiguration`, which the LangChain4j factories `supports()`; a v2 request binds
+a native `request.v2` configuration, which the native factories `supports()`. Both stacks flow
+through the same request handler and the same `ChatModelRegistry` — they differ only in the provider
+configuration subtree, because the request data model (prompts, memory, limits, events, response) is
+shared and the handler and SPI are version-agnostic.
+
+The LangChain4j path caps provider capabilities at LangChain4j's abstraction, which is the
+constraint ADR 009 set out to escape. We want v1 jobs to run on the native providers without
+changing the v1 wire contract, and without a big-bang removal of the LangChain4j stack while the
+native routing is still proving out. Should we keep both stacks as they are, or route v1 requests
+through the native providers?
+
+## Decision Drivers
+
+* **Feature ceiling**: native providers surface vendor capabilities (native server-side tools,
+  structured reasoning, prompt caching, effort) that the LangChain4j abstraction cannot express.
+* **v1 wire compatibility**: existing v1 element templates, job worker types, and process variables
+  must keep working byte-for-byte — the migration must be invisible to deployed processes.
+* **Behavior identity per provider**: a native provider calls the same vendor API the corresponding
+  LangChain4j integration wrapped, so per-provider behavior is preserved.
+* **Controlled rollout**: keep a runtime lever to fall back to the LangChain4j path while the native
+  routing proves out, and avoid coupling the routing change to the larger LangChain4j removal.
+* **Pre-GA freedom**: the v2 request types and native providers are not released, so the migration
+  is not constrained by a released dual-path compatibility contract.
+
+## Considered Options
+
+1. Keep both stacks unchanged — v1 requests resolve LangChain4j factories, v2 requests resolve
+   native factories.
+2. Translate the v1 provider configuration to native at the v1 request boundary, gated behind a
+   configuration switch, retaining LangChain4j as the alternate path; remove LangChain4j in a later
+   change.
+3. Translate at the request boundary and remove LangChain4j in the same change (no switch, no
+   fallback).
+
+## Decision Outcome
+
+Chosen option: **Option 2 — translate v1 provider configuration to native at the request boundary,
+behind a configuration switch, retaining LangChain4j for now**, because it lifts the capability
+ceiling on the native path and preserves the v1 wire contract, while keeping a runtime fallback and
+decoupling the routing change from the LangChain4j removal.
+
+The decision comprises:
+
+* **D1 — The migration seam is provider-configuration translation, not a second execution path.**
+  Because a v1 and a v2 request differ only in the provider-configuration subtree, a v1 request is
+  served by mapping its `request.v1.ProviderConfiguration` to the equivalent native `request.v2`
+  configuration at the v1 connector function boundary, then reusing the existing native path
+  unchanged. The handler, registry, native factories, and request data model are not modified.
+
+* **D2 — v1 `bedrock` maps to the native Bedrock Converse provider, not to the Anthropic-over-Bedrock
+  (Bedrock Mantle) backend.** Converse is the same Bedrock API the LangChain4j integration wrapped
+  and serves every Bedrock foundation model, so it is the behavior-identical target for all v1
+  Bedrock jobs. The Anthropic Bedrock Mantle backend remains a v2-only opt-in for callers who want
+  Anthropic-native features over Bedrock.
+
+* **D3 — Gate native routing behind a configuration switch; retain LangChain4j for now.** The v1
+  functions route through the native providers, but a configuration switch selects the LangChain4j
+  path, kept as a runtime fallback while the native routing proves out. The LangChain4j framework
+  binding, factories, and `dev.langchain4j` dependencies are not removed in this change; their
+  removal — and with it the switch, which has no meaning once the fallback is gone — is a deferred
+  follow-on.
+
+* **D4 — Configurations a native provider cannot represent are mapped faithfully or fail loud, never
+  silently downgraded.** The v1 OpenAI-compatible provider allows an optional (blank) API key, with
+  authentication carried in custom headers; the native custom-endpoint authentication requires a
+  credential because the OpenAI SDK mandates one to build a client. A missing key is therefore mapped
+  to a placeholder value, with the real authentication carried in request headers — behavior
+  identical to v1 — rather than rejected. A configuration with no faithful native representation
+  fails loud at translation time.
+
+### Non-goals
+
+* A model **capability matrix** — a separate follow-on, as noted in ADR 009.
+* **LangChain4j removal** — deferred to a follow-on once native routing is proven; retained behind
+  the switch here.
+* Any change to the **v1 wire shape** — element templates, job worker types, and process variables
+  are unchanged; the translation layer is internal.
+
+### Positive Consequences
+
+* v1 jobs run on the native path, carrying provider capabilities beyond the LangChain4j ceiling.
+* The v1 wire contract is preserved by an internal translation layer.
+* The configuration switch provides a runtime fallback during rollout.
+* Per-provider behavior is preserved, since the native provider calls the same vendor API.
+
+### Negative Consequences
+
+* Two provider stacks and the `dev.langchain4j` dependency surface persist until the deferred
+  removal.
+* The switch is transitional and must be removed together with LangChain4j; left indefinitely it
+  reintroduces dual-path maintenance.
+* A permanent v1-to-native translation shim is retained for as long as the v1 element templates are
+  supported, so the v1 wire shape lives on in code even after its execution engine is eventually
+  removed.
+
+## Pros and Cons of the Options
+
+### Option 1: Keep both stacks unchanged
+
+* Good, because it requires no migration work.
+* Bad, because v1 jobs stay capped at the LangChain4j capability ceiling.
+* Bad, because two stacks are maintained behind one handler with no path toward convergence.
+
+### Option 2: Translate at the request boundary behind a switch, retain LangChain4j (chosen)
+
+* Good, because v1 jobs gain the native capability set while the v1 wire contract is preserved by an
+  internal translation layer.
+* Good, because the switch gives a runtime rollback lever and decouples routing from the larger
+  removal.
+* Good, because per-provider behavior is identity-preserving (native calls the same vendor API).
+* Bad, because LangChain4j, its dependency surface, and the switch are retained temporarily and must
+  be removed together in a follow-on; left indefinitely they reintroduce dual-path maintenance.
+
+### Option 3: Translate and remove LangChain4j in the same change
+
+* Good, because it converges to a single provider stack immediately and drops the `dev.langchain4j`
+  surface at once.
+* Bad, because it couples the routing change to a large removal with no runtime fallback if the
+  native routing misbehaves, offering no bake period even though one is cheap to keep.

--- a/connectors/agentic-ai/docs/adr/014-route-v1-requests-through-native-providers.md
+++ b/connectors/agentic-ai/docs/adr/014-route-v1-requests-through-native-providers.md
@@ -5,9 +5,9 @@
 
 ## Status
 
-**Accepted**. Realized in the PR that introduces the v1-to-native provider configuration mapping,
-gated behind a configuration switch. The LangChain4j integration is retained as the alternate path
-for now; its removal is a deferred follow-on.
+**Accepted**. Delivered across a short PR sequence: the v1-to-native provider configuration mapping,
+followed by removal of the LangChain4j integration. A transitional configuration flag exists only to
+sequence those PRs and is removed together with LangChain4j.
 
 ## Context and Problem Statement
 
@@ -26,39 +26,34 @@ shared and the handler and SPI are version-agnostic.
 
 The LangChain4j path caps provider capabilities at LangChain4j's abstraction, which is the
 constraint ADR 009 set out to escape. We want v1 jobs to run on the native providers without
-changing the v1 wire contract, and without a big-bang removal of the LangChain4j stack while the
-native routing is still proving out. Should we keep both stacks as they are, or route v1 requests
-through the native providers?
+changing the v1 wire contract, and we want to converge on a single provider stack rather than
+maintain two indefinitely. Should we keep both stacks as they are, or route v1 requests through the
+native providers and retire LangChain4j?
 
 ## Decision Drivers
 
-* **Feature ceiling**: native providers surface vendor capabilities (native server-side tools,
-  structured reasoning, prompt caching, effort) that the LangChain4j abstraction cannot express.
+* **Feature ceiling**: native providers surface vendor capabilities (structured reasoning, prompt
+  caching, effort) that the LangChain4j abstraction cannot express.
 * **v1 wire compatibility**: existing v1 element templates, job worker types, and process variables
   must keep working byte-for-byte — the migration must be invisible to deployed processes.
 * **Behavior identity per provider**: a native provider calls the same vendor API the corresponding
   LangChain4j integration wrapped, so per-provider behavior is preserved.
-* **Controlled rollout**: keep a runtime lever to fall back to the LangChain4j path while the native
-  routing proves out, and avoid coupling the routing change to the larger LangChain4j removal.
-* **Pre-GA freedom**: the v2 request types and native providers are not released, so the migration
-  is not constrained by a released dual-path compatibility contract.
+* **Single stack**: two execution stacks behind one handler have no path to convergence and double
+  the long-term maintenance surface; the module should end up on one.
 
 ## Considered Options
 
 1. Keep both stacks unchanged — v1 requests resolve LangChain4j factories, v2 requests resolve
    native factories.
-2. Translate the v1 provider configuration to native at the v1 request boundary, gated behind a
-   configuration switch, retaining LangChain4j as the alternate path; remove LangChain4j in a later
-   change.
-3. Translate at the request boundary and remove LangChain4j in the same change (no switch, no
-   fallback).
+2. Translate the v1 provider configuration to native at the v1 request boundary, then remove
+   LangChain4j.
 
 ## Decision Outcome
 
-Chosen option: **Option 2 — translate v1 provider configuration to native at the request boundary,
-behind a configuration switch, retaining LangChain4j for now**, because it lifts the capability
-ceiling on the native path and preserves the v1 wire contract, while keeping a runtime fallback and
-decoupling the routing change from the LangChain4j removal.
+Chosen option: **Option 2 — translate v1 provider configuration to native at the request boundary and
+remove LangChain4j**, because it lifts the capability ceiling on the native path, preserves the v1
+wire contract through an internal translation layer, and converges the module onto a single provider
+stack.
 
 The decision comprises:
 
@@ -74,12 +69,11 @@ The decision comprises:
   Bedrock jobs. The Anthropic Bedrock Mantle backend remains a v2-only opt-in for callers who want
   Anthropic-native features over Bedrock.
 
-* **D3 — Gate native routing behind a configuration switch; retain LangChain4j for now.** The v1
-  functions route through the native providers, but a configuration switch selects the LangChain4j
-  path, kept as a runtime fallback while the native routing proves out. The LangChain4j framework
-  binding, factories, and `dev.langchain4j` dependencies are not removed in this change; their
-  removal — and with it the switch, which has no meaning once the fallback is gone — is a deferred
-  follow-on.
+* **D3 — LangChain4j is removed, not retained as a fallback.** The v1 functions route through the
+  native providers unconditionally; the LangChain4j framework binding, factories, and
+  `dev.langchain4j` dependencies are removed as part of this decision, once the translation is in
+  place. Delivery is split across a short sequence of PRs for reviewable change size; a transitional
+  configuration flag exists only to sequence those PRs and carries no lasting meaning.
 
 * **D4 — Configurations a native provider cannot represent are mapped faithfully or fail loud, never
   silently downgraded.** The v1 OpenAI-compatible provider allows an optional (blank) API key, with
@@ -92,8 +86,6 @@ The decision comprises:
 ### Non-goals
 
 * A model **capability matrix** — a separate follow-on, as noted in ADR 009.
-* **LangChain4j removal** — deferred to a follow-on once native routing is proven; retained behind
-  the switch here.
 * Any change to the **v1 wire shape** — element templates, job worker types, and process variables
   are unchanged; the translation layer is internal.
 
@@ -101,18 +93,16 @@ The decision comprises:
 
 * v1 jobs run on the native path, carrying provider capabilities beyond the LangChain4j ceiling.
 * The v1 wire contract is preserved by an internal translation layer.
-* The configuration switch provides a runtime fallback during rollout.
 * Per-provider behavior is preserved, since the native provider calls the same vendor API.
+* The module converges onto a single provider stack, dropping the `dev.langchain4j` dependency
+  surface.
 
 ### Negative Consequences
 
-* Two provider stacks and the `dev.langchain4j` dependency surface persist until the deferred
-  removal.
-* The switch is transitional and must be removed together with LangChain4j; left indefinitely it
-  reintroduces dual-path maintenance.
 * A permanent v1-to-native translation shim is retained for as long as the v1 element templates are
-  supported, so the v1 wire shape lives on in code even after its execution engine is eventually
-  removed.
+  supported, so the v1 wire shape lives on in code even after its execution engine is removed.
+* Some v1 configurations require a faithful-but-indirect mapping (e.g. a placeholder credential for
+  header-based auth) to preserve behavior, adding translation-layer edge cases to maintain.
 
 ## Pros and Cons of the Options
 
@@ -122,19 +112,11 @@ The decision comprises:
 * Bad, because v1 jobs stay capped at the LangChain4j capability ceiling.
 * Bad, because two stacks are maintained behind one handler with no path toward convergence.
 
-### Option 2: Translate at the request boundary behind a switch, retain LangChain4j (chosen)
+### Option 2: Translate at the request boundary and remove LangChain4j (chosen)
 
 * Good, because v1 jobs gain the native capability set while the v1 wire contract is preserved by an
   internal translation layer.
-* Good, because the switch gives a runtime rollback lever and decouples routing from the larger
-  removal.
 * Good, because per-provider behavior is identity-preserving (native calls the same vendor API).
-* Bad, because LangChain4j, its dependency surface, and the switch are retained temporarily and must
-  be removed together in a follow-on; left indefinitely they reintroduce dual-path maintenance.
-
-### Option 3: Translate and remove LangChain4j in the same change
-
-* Good, because it converges to a single provider stack immediately and drops the `dev.langchain4j`
-  surface at once.
-* Bad, because it couples the routing change to a large removal with no runtime fallback if the
-  native routing misbehaves, offering no bake period even though one is cheap to keep.
+* Good, because it converges to a single provider stack and drops the `dev.langchain4j` surface.
+* Bad, because there is no runtime fallback to LangChain4j once it is removed if the native routing
+  misbehaves for some v1 configuration.


### PR DESCRIPTION
## Description

Routes legacy v1 AI Agent jobs (task + sub-process) through the native v2 chat-model providers by translating only the provider-configuration subtree at the v1 connector-function boundary. v1 and v2 requests are otherwise identical, so the shared handler and chat-model registry dispatch the mapped config onto the existing native factories unchanged.

- New config switch `camunda.connector.agenticai.aiagent.rewrite-v1-provider-config-to-v2` (default **on**). With the switch off, jobs keep executing on the LangChain4j path.
- All six v1 providers are mapped: Anthropic, OpenAI, OpenAI-compatible (native OpenAI custom backend), Bedrock (native Bedrock Converse), Azure OpenAI (OpenAI/Foundry), Google Vertex AI (Gemini/Vertex).
- v1 AI Agent connector functions are marked deprecated.
- Design captured in ADR 014.

## Related issues

closes #8409

## Checklist

- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest
  release, as this branch will be rebased onto main before the next release. Example backport labels:
    - `backport stable/8.8`: for changes that should be included in the next 8.8.x release.
    - **or** `backport release-8.8.7`: for changes that should be included in the specific release 8.8.7, and this
      *release has already been created*. The release branch will be merged back into stable/8.8 later, so the change
      will be included in future 8.8.x releases as well.
- [ ] Tests/Integration tests for the changes have been added if applicable.
- [ ] If the change requires a documentation update, it has been added to the appropriate section in the documentation.
