### PR TITLE
refactor(agentic-ai): rename Vertex AI backend label to Enterprise Agent Platform (Vertex AI)

### DIFF
--- a/connectors/agentic-ai/connector-agentic-ai/element-templates/agenticai-ai-agent-subprocess.v2.json
+++ b/connectors/agentic-ai/connector-agentic-ai/element-templates/agenticai-ai-agent-subprocess.v2.json
@@ -1194,7 +1194,7 @@
       "name" : "Google Gemini API",
       "value" : "google-gemini-api"
     }, {
-      "name" : "Google Vertex AI",
+      "name" : "Enterprise Agent Platform (Vertex AI)",
       "value" : "google-vertex-ai"
     } ]
   }, {
@@ -1319,7 +1319,7 @@
   }, {
     "id" : "provider.googleGemini.backend.googleVertexAi.authentication.type",
     "label" : "Authentication",
-    "description" : "Specify the Google Vertex AI authentication strategy.",
+    "description" : "Specify the Enterprise Agent Platform (Vertex AI) authentication strategy.",
     "value" : "serviceAccountCredentials",
     "group" : "provider",
     "binding" : {

--- a/connectors/agentic-ai/connector-agentic-ai/element-templates/agenticai-ai-agent-task.v2.json
+++ b/connectors/agentic-ai/connector-agentic-ai/element-templates/agenticai-ai-agent-task.v2.json
@@ -1166,7 +1166,7 @@
       "name" : "Google Gemini API",
       "value" : "google-gemini-api"
     }, {
-      "name" : "Google Vertex AI",
+      "name" : "Enterprise Agent Platform (Vertex AI)",
       "value" : "google-vertex-ai"
     } ]
   }, {
@@ -1291,7 +1291,7 @@
   }, {
     "id" : "provider.googleGemini.backend.googleVertexAi.authentication.type",
     "label" : "Authentication",
-    "description" : "Specify the Google Vertex AI authentication strategy.",
+    "description" : "Specify the Enterprise Agent Platform (Vertex AI) authentication strategy.",
     "value" : "serviceAccountCredentials",
     "group" : "provider",
     "binding" : {

--- a/connectors/agentic-ai/connector-agentic-ai/element-templates/agenticai-aiagent-job-worker.json
+++ b/connectors/agentic-ai/connector-agentic-ai/element-templates/agenticai-aiagent-job-worker.json
@@ -130,7 +130,7 @@
       "name" : "Azure OpenAI",
       "value" : "azureOpenAi"
     }, {
-      "name" : "Google Vertex AI",
+      "name" : "Enterprise Agent Platform (Vertex AI)",
       "value" : "google-vertex-ai"
     }, {
       "name" : "OpenAI",
@@ -596,7 +596,7 @@
   }, {
     "id" : "provider.googleVertexAi.authentication.type",
     "label" : "Authentication",
-    "description" : "Specify the Google Vertex AI authentication strategy.",
+    "description" : "Specify the Enterprise Agent Platform (Vertex AI) authentication strategy.",
     "value" : "serviceAccountCredentials",
     "group" : "provider",
     "binding" : {

--- a/connectors/agentic-ai/connector-agentic-ai/element-templates/agenticai-aiagent-outbound-connector.json
+++ b/connectors/agentic-ai/connector-agentic-ai/element-templates/agenticai-aiagent-outbound-connector.json
@@ -102,7 +102,7 @@
       "name" : "Azure OpenAI",
       "value" : "azureOpenAi"
     }, {
-      "name" : "Google Vertex AI",
+      "name" : "Enterprise Agent Platform (Vertex AI)",
       "value" : "google-vertex-ai"
     }, {
       "name" : "OpenAI",
@@ -568,7 +568,7 @@
   }, {
     "id" : "provider.googleVertexAi.authentication.type",
     "label" : "Authentication",
-    "description" : "Specify the Google Vertex AI authentication strategy.",
+    "description" : "Specify the Enterprise Agent Platform (Vertex AI) authentication strategy.",
     "value" : "serviceAccountCredentials",
     "group" : "provider",
     "binding" : {

--- a/connectors/agentic-ai/connector-agentic-ai/element-templates/hybrid/agenticai-ai-agent-subprocess.v2-hybrid.json
+++ b/connectors/agentic-ai/connector-agentic-ai/element-templates/hybrid/agenticai-ai-agent-subprocess.v2-hybrid.json
@@ -1199,7 +1199,7 @@
       "name" : "Google Gemini API",
       "value" : "google-gemini-api"
     }, {
-      "name" : "Google Vertex AI",
+      "name" : "Enterprise Agent Platform (Vertex AI)",
       "value" : "google-vertex-ai"
     } ]
   }, {
@@ -1324,7 +1324,7 @@
   }, {
     "id" : "provider.googleGemini.backend.googleVertexAi.authentication.type",
     "label" : "Authentication",
-    "description" : "Specify the Google Vertex AI authentication strategy.",
+    "description" : "Specify the Enterprise Agent Platform (Vertex AI) authentication strategy.",
     "value" : "serviceAccountCredentials",
     "group" : "provider",
     "binding" : {

--- a/connectors/agentic-ai/connector-agentic-ai/element-templates/hybrid/agenticai-ai-agent-task.v2-hybrid.json
+++ b/connectors/agentic-ai/connector-agentic-ai/element-templates/hybrid/agenticai-ai-agent-task.v2-hybrid.json
@@ -1171,7 +1171,7 @@
       "name" : "Google Gemini API",
       "value" : "google-gemini-api"
     }, {
-      "name" : "Google Vertex AI",
+      "name" : "Enterprise Agent Platform (Vertex AI)",
       "value" : "google-vertex-ai"
     } ]
   }, {
@@ -1296,7 +1296,7 @@
   }, {
     "id" : "provider.googleGemini.backend.googleVertexAi.authentication.type",
     "label" : "Authentication",
-    "description" : "Specify the Google Vertex AI authentication strategy.",
+    "description" : "Specify the Enterprise Agent Platform (Vertex AI) authentication strategy.",
     "value" : "serviceAccountCredentials",
     "group" : "provider",
     "binding" : {

--- a/connectors/agentic-ai/connector-agentic-ai/element-templates/hybrid/agenticai-aiagent-job-worker-hybrid.json
+++ b/connectors/agentic-ai/connector-agentic-ai/element-templates/hybrid/agenticai-aiagent-job-worker-hybrid.json
@@ -135,7 +135,7 @@
       "name" : "Azure OpenAI",
       "value" : "azureOpenAi"
     }, {
-      "name" : "Google Vertex AI",
+      "name" : "Enterprise Agent Platform (Vertex AI)",
       "value" : "google-vertex-ai"
     }, {
       "name" : "OpenAI",
@@ -601,7 +601,7 @@
   }, {
     "id" : "provider.googleVertexAi.authentication.type",
     "label" : "Authentication",
-    "description" : "Specify the Google Vertex AI authentication strategy.",
+    "description" : "Specify the Enterprise Agent Platform (Vertex AI) authentication strategy.",
     "value" : "serviceAccountCredentials",
     "group" : "provider",
     "binding" : {

--- a/connectors/agentic-ai/connector-agentic-ai/element-templates/hybrid/agenticai-aiagent-outbound-connector-hybrid.json
+++ b/connectors/agentic-ai/connector-agentic-ai/element-templates/hybrid/agenticai-aiagent-outbound-connector-hybrid.json
@@ -107,7 +107,7 @@
       "name" : "Azure OpenAI",
       "value" : "azureOpenAi"
     }, {
-      "name" : "Google Vertex AI",
+      "name" : "Enterprise Agent Platform (Vertex AI)",
       "value" : "google-vertex-ai"
     }, {
       "name" : "OpenAI",
@@ -573,7 +573,7 @@
   }, {
     "id" : "provider.googleVertexAi.authentication.type",
     "label" : "Authentication",
-    "description" : "Specify the Google Vertex AI authentication strategy.",
+    "description" : "Specify the Enterprise Agent Platform (Vertex AI) authentication strategy.",
     "value" : "serviceAccountCredentials",
     "group" : "provider",
     "binding" : {

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/langchain4j/factory/GoogleVertexAiChatModelFactory.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/langchain4j/factory/GoogleVertexAiChatModelFactory.java
@@ -95,7 +95,11 @@ public class GoogleVertexAiChatModelFactory
 
   private Client createGoogleGenAiClient(GoogleVertexAiConnection connection) {
     final var apiTimeout =
-        deriveTimeoutSetting("Google Vertex AI model call", config, connection.timeouts(), LOGGER);
+        deriveTimeoutSetting(
+            "Enterprise Agent Platform (Vertex AI) model call",
+            config,
+            connection.timeouts(),
+            LOGGER);
 
     final var httpOptions =
         HttpOptions.builder()
@@ -128,8 +132,9 @@ public class GoogleVertexAiChatModelFactory
       // application default credentials are resolved eagerly here
       return clientBuilder.build();
     } catch (GenAiIOException | IllegalArgumentException e) {
-      LOGGER.error("Failed to create Google Vertex AI client", e);
-      throw new ConnectorInputException("Failed to create Google Vertex AI client", e);
+      LOGGER.error("Failed to create Enterprise Agent Platform (Vertex AI) client", e);
+      throw new ConnectorInputException(
+          "Failed to create Enterprise Agent Platform (Vertex AI) client", e);
     }
   }
 

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/v1/GoogleVertexAiProviderConfiguration.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/v1/GoogleVertexAiProviderConfiguration.java
@@ -24,7 +24,7 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import org.jspecify.annotations.Nullable;
 
-@TemplateSubType(id = GOOGLE_VERTEX_AI_ID, label = "Google Vertex AI")
+@TemplateSubType(id = GOOGLE_VERTEX_AI_ID, label = "Enterprise Agent Platform (Vertex AI)")
 public record GoogleVertexAiProviderConfiguration(
     @Valid @NotNull GoogleVertexAiConnection googleVertexAi) implements ProviderConfiguration {
 
@@ -85,7 +85,7 @@ public record GoogleVertexAiProviderConfiguration(
       this(projectId, region, null, authentication, null, model);
     }
 
-    @AssertFalse(message = "Google Vertex AI is not supported on SaaS")
+    @AssertFalse(message = "Enterprise Agent Platform (Vertex AI) is not supported on SaaS")
     public boolean isUsedInSaaS() {
       return ConnectorUtils.isSaaS()
           && authentication
@@ -107,7 +107,7 @@ public record GoogleVertexAiProviderConfiguration(
       group = "provider",
       name = "type",
       defaultValue = "serviceAccountCredentials",
-      description = "Specify the Google Vertex AI authentication strategy.")
+      description = "Specify the Enterprise Agent Platform (Vertex AI) authentication strategy.")
   public sealed interface GoogleVertexAiAuthentication {
     @TemplateSubType(id = "serviceAccountCredentials", label = "Service account credentials")
     record ServiceAccountCredentialsAuthentication(

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/v1/GoogleVertexAiProviderConfiguration.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/v1/GoogleVertexAiProviderConfiguration.java
@@ -85,7 +85,9 @@ public record GoogleVertexAiProviderConfiguration(
       this(projectId, region, null, authentication, null, model);
     }
 
-    @AssertFalse(message = "Enterprise Agent Platform (Vertex AI) is not supported on SaaS")
+    @AssertFalse(
+        message =
+            "Application default credentials for Enterprise Agent Platform (Vertex AI) are not supported on SaaS")
     public boolean isUsedInSaaS() {
       return ConnectorUtils.isSaaS()
           && authentication

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/v2/GeminiChatModelConfiguration.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/v2/GeminiChatModelConfiguration.java
@@ -109,7 +109,7 @@ public record GeminiChatModelConfiguration(@Valid @NotNull GeminiConnection goog
       }
     }
 
-    @TemplateSubType(id = GOOGLE_VERTEX_AI_ID, label = "Google Vertex AI")
+    @TemplateSubType(id = GOOGLE_VERTEX_AI_ID, label = "Enterprise Agent Platform (Vertex AI)")
     record GeminiVertexAiBackend(@Valid @NotNull GoogleVertexAi googleVertexAi)
         implements GeminiBackend {
 
@@ -156,7 +156,7 @@ public record GeminiChatModelConfiguration(@Valid @NotNull GeminiConnection goog
         @JsonIgnore
         @AssertFalse(
             message =
-                "Application default credentials for Google Vertex AI are not supported on SaaS")
+                "Application default credentials for Enterprise Agent Platform (Vertex AI) are not supported on SaaS")
         public boolean isApplicationDefaultCredentialsUsedInSaaS() {
           return ConnectorUtils.isSaaS()
               && authentication
@@ -180,7 +180,7 @@ public record GeminiChatModelConfiguration(@Valid @NotNull GeminiConnection goog
         group = "provider",
         name = "type",
         defaultValue = "serviceAccountCredentials",
-        description = "Specify the Google Vertex AI authentication strategy.")
+        description = "Specify the Enterprise Agent Platform (Vertex AI) authentication strategy.")
     sealed interface GoogleVertexAiAuthentication {
       @TemplateSubType(id = "serviceAccountCredentials", label = "Service account credentials")
       record ServiceAccountCredentialsAuthentication(

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/langchain4j/factory/GoogleVertexAiChatModelFactoryTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/langchain4j/factory/GoogleVertexAiChatModelFactoryTest.java
@@ -294,7 +294,7 @@ class GoogleVertexAiChatModelFactoryTest {
 
       assertThatThrownBy(() -> factory.createChatModel(providerConfig))
           .isInstanceOf(ConnectorInputException.class)
-          .hasMessageContaining("Failed to create Google Vertex AI client");
+          .hasMessageContaining("Failed to create Enterprise Agent Platform (Vertex AI) client");
     }
   }
 

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/model/request/ProviderConfigurationTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/model/request/ProviderConfigurationTest.java
@@ -286,7 +286,7 @@ class ProviderConfigurationTest {
       assertThat(validator.validate(connection))
           .hasSize(1)
           .extracting(ConstraintViolation::getMessage)
-          .containsExactly("Google Vertex AI is not supported on SaaS");
+          .containsExactly("Enterprise Agent Platform (Vertex AI) is not supported on SaaS");
     }
 
     @Test

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/model/request/ProviderConfigurationTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/model/request/ProviderConfigurationTest.java
@@ -286,7 +286,9 @@ class ProviderConfigurationTest {
       assertThat(validator.validate(connection))
           .hasSize(1)
           .extracting(ConstraintViolation::getMessage)
-          .containsExactly("Enterprise Agent Platform (Vertex AI) is not supported on SaaS");
+          .containsExactly(
+              "Application default credentials for Enterprise Agent Platform (Vertex AI) are not"
+                  + " supported on SaaS");
     }
 
     @Test

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/model/request/v2/GeminiChatModelConfigurationTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/model/request/v2/GeminiChatModelConfigurationTest.java
@@ -432,7 +432,8 @@ class GeminiChatModelConfigurationTest {
 
     assertThat(validator.validate(config))
         .extracting(ConstraintViolation::getMessage)
-        .contains("Application default credentials for Google Vertex AI are not supported on SaaS");
+        .contains(
+            "Application default credentials for Enterprise Agent Platform (Vertex AI) are not supported on SaaS");
   }
 
   @Test


### PR DESCRIPTION
## Description

Renames every customer-visible "Google Vertex AI" string to "Enterprise Agent Platform (Vertex AI)" per new branding direction:

- v2 native Gemini provider: `@TemplateSubType` label, authentication-strategy description, SaaS application-default-credentials validation message.
- v1 legacy provider config: backend label, authentication-strategy description, SaaS validation message.
- v1 langchain4j `GoogleVertexAiChatModelFactory`: client-creation error message (log + `ConnectorInputException`) and the timeout-configuration log label.

Discriminator ids and constants (`google-vertex-ai`, `GOOGLE_VERTEX_AI_ID`), class/package names, and real Google product doc URLs are unchanged — only display text changed. `element-templates/versioned/**` (frozen historical snapshots) are untouched; the 8 current/hybrid element templates were regenerated via `mvn clean process-classes` and diffed to confirm only the expected label/description text changed.

## Related issues

relates to #8066

## Checklist

- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest
  release, as this branch will be rebased onto main before the next release. Example backport labels:
    - `backport stable/8.8`: for changes that should be included in the next 8.8.x release.
    - **or** `backport release-8.8.7`: for changes that should be included in the specific release 8.8.7, and this
      *release has already been created*. The release branch will be merged back into stable/8.8 later, so the change
      will be included in future 8.8.x releases as well.
- [x] Tests/Integration tests for the changes have been added if applicable.
- [ ] If the change requires a documentation update, it has been added to the appropriate section in the documentation.
