### PR TITLE
fix(agentic-ai): align v2 provider config dropdown UX

### DIFF
--- a/connectors/agentic-ai/connector-agentic-ai/bin/transform-ai-agent-sub-process-template.groovy
+++ b/connectors/agentic-ai/connector-agentic-ai/bin/transform-ai-agent-sub-process-template.groovy
@@ -13,6 +13,24 @@ static def replaceDocumentationLinks(String text) {
     )
 }
 
+// Moves the given property ids to sit right after another property id. No-op if either side
+// isn't found. Duplicated in transform-ai-agent-task-template.groovy since this script's
+// execution runs before that one's, per the pom's execution order for the v2 task/sub-process
+// pair.
+static def moveAfter(List properties, List idsToMove, String afterId) {
+    def moving = properties.findAll { it.id in idsToMove }
+    if (moving.isEmpty()) {
+        return properties
+    }
+    def remaining = properties.findAll { !(it.id in idsToMove) }
+    def anchorIndex = remaining.findIndexOf { it.id == afterId }
+    if (anchorIndex < 0) {
+        return properties
+    }
+    remaining.addAll(anchorIndex + 1, moving)
+    return remaining
+}
+
 def sourceFile = sourceFile
 if (!sourceFile) {
     System.err.println("Error: Source file path required as property")
@@ -287,6 +305,14 @@ updatedProperties.add([
     ],
     type: "Hidden"
 ])
+
+// OpenAI's Effort is declared per API family (a sibling of Model, like the other per-family
+// request parameters), so it's emitted before Model. Move it after, matching Anthropic/Bedrock.
+updatedProperties = moveAfter(
+    updatedProperties,
+    ["provider.openai.api.completions.effort", "provider.openai.api.responses.effort"],
+    "provider.openai.model.model"
+)
 
 json.put('properties', updatedProperties)
 mapper.writeValue(outputFilePath, json)

--- a/connectors/agentic-ai/connector-agentic-ai/bin/transform-ai-agent-task-template.groovy
+++ b/connectors/agentic-ai/connector-agentic-ai/bin/transform-ai-agent-task-template.groovy
@@ -53,6 +53,22 @@ if (deprecationMessage) {
     json.remove("deprecated")
 }
 
+// Moves the given property ids to sit right after another property id. No-op if either side
+// isn't found.
+static def moveAfter(List properties, List idsToMove, String afterId) {
+    def moving = properties.findAll { it.id in idsToMove }
+    if (moving.isEmpty()) {
+        return properties
+    }
+    def remaining = properties.findAll { !(it.id in idsToMove) }
+    def anchorIndex = remaining.findIndexOf { it.id == afterId }
+    if (anchorIndex < 0) {
+        return properties
+    }
+    remaining.addAll(anchorIndex + 1, moving)
+    return remaining
+}
+
 def updatedProperties = []
 
 ((List) json.get('properties')).each { property ->
@@ -76,6 +92,14 @@ def updatedProperties = []
         ])
     }
 }
+
+// OpenAI's Effort is declared per API family (a sibling of Model, like the other per-family
+// request parameters), so it's emitted before Model. Move it after, matching Anthropic/Bedrock.
+updatedProperties = moveAfter(
+    updatedProperties,
+    ["provider.openai.api.completions.effort", "provider.openai.api.responses.effort"],
+    "provider.openai.model.model"
+)
 
 json.put('properties', updatedProperties)
 mapper.writeValue(new File((String) outputFile), json)

--- a/connectors/agentic-ai/connector-agentic-ai/element-templates/agenticai-ai-agent-subprocess.v2.json
+++ b/connectors/agentic-ai/connector-agentic-ai/element-templates/agenticai-ai-agent-subprocess.v2.json
@@ -666,11 +666,11 @@
     },
     "type" : "Dropdown",
     "choices" : [ {
-      "name" : "Chat Completions",
-      "value" : "completions"
-    }, {
       "name" : "Responses",
       "value" : "responses"
+    }, {
+      "name" : "Chat Completions",
+      "value" : "completions"
     } ]
   }, {
     "id" : "provider.openai.backend.type",
@@ -2100,48 +2100,6 @@
     "tooltip" : "Enables AWS Bedrock automatic prompt caching. See the <a href=\"https://docs.aws.amazon.com/bedrock/latest/userguide/prompt-caching.html\" target=\"_blank\">documentation</a>.",
     "type" : "Boolean"
   }, {
-    "id" : "provider.openai.api.completions.effort",
-    "label" : "Effort",
-    "description" : "Leave unset to use the model default.",
-    "optional" : true,
-    "group" : "model",
-    "binding" : {
-      "name" : "provider.openai.api.completions.effort",
-      "type" : "zeebe:input"
-    },
-    "condition" : {
-      "allMatch" : [ {
-        "property" : "provider.openai.api.type",
-        "equals" : "completions",
-        "type" : "simple"
-      }, {
-        "property" : "provider.type",
-        "equals" : "openai",
-        "type" : "simple"
-      } ]
-    },
-    "tooltip" : "Controls how many tokens the model spends when responding, trading thoroughness against speed and cost. Not supported on all models.<br><br>See the <a href=\"https://developers.openai.com/api/reference/resources/chat/subresources/completions/methods/create\" target=\"_blank\">Chat Completions API reference</a>.",
-    "type" : "Dropdown",
-    "choices" : [ {
-      "name" : "minimal",
-      "value" : "minimal"
-    }, {
-      "name" : "low",
-      "value" : "low"
-    }, {
-      "name" : "medium",
-      "value" : "medium"
-    }, {
-      "name" : "high",
-      "value" : "high"
-    }, {
-      "name" : "xhigh",
-      "value" : "xhigh"
-    }, {
-      "name" : "max",
-      "value" : "max"
-    } ]
-  }, {
     "id" : "provider.openai.api.responses.effort",
     "label" : "Effort",
     "description" : "Leave unset to use the model default.",
@@ -2163,6 +2121,48 @@
       } ]
     },
     "tooltip" : "Controls how many tokens the model spends when responding, trading thoroughness against speed and cost. Not supported on all models.<br><br>See the <a href=\"https://developers.openai.com/api/reference/resources/responses/methods/create\" target=\"_blank\">Responses API reference</a>.",
+    "type" : "Dropdown",
+    "choices" : [ {
+      "name" : "minimal",
+      "value" : "minimal"
+    }, {
+      "name" : "low",
+      "value" : "low"
+    }, {
+      "name" : "medium",
+      "value" : "medium"
+    }, {
+      "name" : "high",
+      "value" : "high"
+    }, {
+      "name" : "xhigh",
+      "value" : "xhigh"
+    }, {
+      "name" : "max",
+      "value" : "max"
+    } ]
+  }, {
+    "id" : "provider.openai.api.completions.effort",
+    "label" : "Effort",
+    "description" : "Leave unset to use the model default.",
+    "optional" : true,
+    "group" : "model",
+    "binding" : {
+      "name" : "provider.openai.api.completions.effort",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "allMatch" : [ {
+        "property" : "provider.openai.api.type",
+        "equals" : "completions",
+        "type" : "simple"
+      }, {
+        "property" : "provider.type",
+        "equals" : "openai",
+        "type" : "simple"
+      } ]
+    },
+    "tooltip" : "Controls how many tokens the model spends when responding, trading thoroughness against speed and cost. Not supported on all models.<br><br>See the <a href=\"https://developers.openai.com/api/reference/resources/chat/subresources/completions/methods/create\" target=\"_blank\">Chat Completions API reference</a>.",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "minimal",
@@ -2421,75 +2421,6 @@
     "tooltip" : "Floating point number between 0 and 1. Recommended for advanced use cases only (you usually only need to use temperature).",
     "type" : "Number"
   }, {
-    "id" : "provider.openai.api.completions.maxCompletionTokens",
-    "label" : "Max completion tokens",
-    "optional" : true,
-    "feel" : "required",
-    "group" : "model-options",
-    "binding" : {
-      "name" : "provider.openai.api.completions.maxCompletionTokens",
-      "type" : "zeebe:input"
-    },
-    "condition" : {
-      "allMatch" : [ {
-        "property" : "provider.openai.api.type",
-        "equals" : "completions",
-        "type" : "simple"
-      }, {
-        "property" : "provider.type",
-        "equals" : "openai",
-        "type" : "simple"
-      } ]
-    },
-    "tooltip" : "The maximum number of tokens per request to generate before stopping. <br><br>Details in the <a href=\"https://developers.openai.com/api/reference/resources/chat/subresources/completions/methods/create\" target=\"_blank\">documentation</a>.",
-    "type" : "Number"
-  }, {
-    "id" : "provider.openai.api.completions.temperature",
-    "label" : "Temperature",
-    "optional" : true,
-    "feel" : "required",
-    "group" : "model-options",
-    "binding" : {
-      "name" : "provider.openai.api.completions.temperature",
-      "type" : "zeebe:input"
-    },
-    "condition" : {
-      "allMatch" : [ {
-        "property" : "provider.openai.api.type",
-        "equals" : "completions",
-        "type" : "simple"
-      }, {
-        "property" : "provider.type",
-        "equals" : "openai",
-        "type" : "simple"
-      } ]
-    },
-    "tooltip" : "Floating point number between 0 and 2. The higher the number, the more randomness will be injected into the response. <br><br>Details in the <a href=\"https://developers.openai.com/api/reference/resources/chat/subresources/completions/methods/create\" target=\"_blank\">documentation</a>.",
-    "type" : "Number"
-  }, {
-    "id" : "provider.openai.api.completions.topP",
-    "label" : "top P",
-    "optional" : true,
-    "feel" : "required",
-    "group" : "model-options",
-    "binding" : {
-      "name" : "provider.openai.api.completions.topP",
-      "type" : "zeebe:input"
-    },
-    "condition" : {
-      "allMatch" : [ {
-        "property" : "provider.openai.api.type",
-        "equals" : "completions",
-        "type" : "simple"
-      }, {
-        "property" : "provider.type",
-        "equals" : "openai",
-        "type" : "simple"
-      } ]
-    },
-    "tooltip" : "Recommended for advanced use cases only (you usually only need to use temperature). <br><br>Details in the <a href=\"https://developers.openai.com/api/reference/resources/chat/subresources/completions/methods/create\" target=\"_blank\">documentation</a>.",
-    "type" : "Number"
-  }, {
     "id" : "provider.openai.api.responses.maxOutputTokens",
     "label" : "Max output tokens",
     "optional" : true,
@@ -2557,6 +2488,75 @@
       } ]
     },
     "tooltip" : "Recommended for advanced use cases only (you usually only need to use temperature). <br><br>Details in the <a href=\"https://developers.openai.com/api/reference/resources/responses/methods/create\" target=\"_blank\">documentation</a>.",
+    "type" : "Number"
+  }, {
+    "id" : "provider.openai.api.completions.maxCompletionTokens",
+    "label" : "Max completion tokens",
+    "optional" : true,
+    "feel" : "required",
+    "group" : "model-options",
+    "binding" : {
+      "name" : "provider.openai.api.completions.maxCompletionTokens",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "allMatch" : [ {
+        "property" : "provider.openai.api.type",
+        "equals" : "completions",
+        "type" : "simple"
+      }, {
+        "property" : "provider.type",
+        "equals" : "openai",
+        "type" : "simple"
+      } ]
+    },
+    "tooltip" : "The maximum number of tokens per request to generate before stopping. <br><br>Details in the <a href=\"https://developers.openai.com/api/reference/resources/chat/subresources/completions/methods/create\" target=\"_blank\">documentation</a>.",
+    "type" : "Number"
+  }, {
+    "id" : "provider.openai.api.completions.temperature",
+    "label" : "Temperature",
+    "optional" : true,
+    "feel" : "required",
+    "group" : "model-options",
+    "binding" : {
+      "name" : "provider.openai.api.completions.temperature",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "allMatch" : [ {
+        "property" : "provider.openai.api.type",
+        "equals" : "completions",
+        "type" : "simple"
+      }, {
+        "property" : "provider.type",
+        "equals" : "openai",
+        "type" : "simple"
+      } ]
+    },
+    "tooltip" : "Floating point number between 0 and 2. The higher the number, the more randomness will be injected into the response. <br><br>Details in the <a href=\"https://developers.openai.com/api/reference/resources/chat/subresources/completions/methods/create\" target=\"_blank\">documentation</a>.",
+    "type" : "Number"
+  }, {
+    "id" : "provider.openai.api.completions.topP",
+    "label" : "top P",
+    "optional" : true,
+    "feel" : "required",
+    "group" : "model-options",
+    "binding" : {
+      "name" : "provider.openai.api.completions.topP",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "allMatch" : [ {
+        "property" : "provider.openai.api.type",
+        "equals" : "completions",
+        "type" : "simple"
+      }, {
+        "property" : "provider.type",
+        "equals" : "openai",
+        "type" : "simple"
+      } ]
+    },
+    "tooltip" : "Recommended for advanced use cases only (you usually only need to use temperature). <br><br>Details in the <a href=\"https://developers.openai.com/api/reference/resources/chat/subresources/completions/methods/create\" target=\"_blank\">documentation</a>.",
     "type" : "Number"
   }, {
     "id" : "provider.googleGemini.model.parameters.maxTokens",

--- a/connectors/agentic-ai/connector-agentic-ai/element-templates/agenticai-ai-agent-subprocess.v2.json
+++ b/connectors/agentic-ai/connector-agentic-ai/element-templates/agenticai-ai-agent-subprocess.v2.json
@@ -2100,6 +2100,27 @@
     "tooltip" : "Enables AWS Bedrock automatic prompt caching. See the <a href=\"https://docs.aws.amazon.com/bedrock/latest/userguide/prompt-caching.html\" target=\"_blank\">documentation</a>.",
     "type" : "Boolean"
   }, {
+    "id" : "provider.openai.model.model",
+    "label" : "Model",
+    "description" : "Specify the model ID. Details in the <a href=\"https://platform.openai.com/docs/models\" target=\"_blank\">documentation</a>.",
+    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "model",
+    "binding" : {
+      "name" : "provider.openai.model.model",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "provider.type",
+      "equals" : "openai",
+      "type" : "simple"
+    },
+    "placeholder" : "gpt-5.5",
+    "type" : "String"
+  }, {
     "id" : "provider.openai.api.responses.effort",
     "label" : "Effort",
     "description" : "Leave unset to use the model default.",
@@ -2183,27 +2204,6 @@
       "name" : "max",
       "value" : "max"
     } ]
-  }, {
-    "id" : "provider.openai.model.model",
-    "label" : "Model",
-    "description" : "Specify the model ID. Details in the <a href=\"https://platform.openai.com/docs/models\" target=\"_blank\">documentation</a>.",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "feel" : "optional",
-    "group" : "model",
-    "binding" : {
-      "name" : "provider.openai.model.model",
-      "type" : "zeebe:input"
-    },
-    "condition" : {
-      "property" : "provider.type",
-      "equals" : "openai",
-      "type" : "simple"
-    },
-    "placeholder" : "gpt-5.5",
-    "type" : "String"
   }, {
     "id" : "provider.googleGemini.model.model",
     "label" : "Model",

--- a/connectors/agentic-ai/connector-agentic-ai/element-templates/agenticai-ai-agent-subprocess.v2.json
+++ b/connectors/agentic-ai/connector-agentic-ai/element-templates/agenticai-ai-agent-subprocess.v2.json
@@ -2123,8 +2123,8 @@
   }, {
     "id" : "provider.openai.api.responses.effort",
     "label" : "Effort",
-    "description" : "Leave unset to use the model default.",
-    "optional" : true,
+    "optional" : false,
+    "value" : "modelDefault",
     "group" : "model",
     "binding" : {
       "name" : "provider.openai.api.responses.effort",
@@ -2144,6 +2144,9 @@
     "tooltip" : "Controls how many tokens the model spends when responding, trading thoroughness against speed and cost. Not supported on all models.<br><br>See the <a href=\"https://developers.openai.com/api/reference/resources/responses/methods/create\" target=\"_blank\">Responses API reference</a>.",
     "type" : "Dropdown",
     "choices" : [ {
+      "name" : "default",
+      "value" : "modelDefault"
+    }, {
       "name" : "minimal",
       "value" : "minimal"
     }, {
@@ -2165,8 +2168,8 @@
   }, {
     "id" : "provider.openai.api.completions.effort",
     "label" : "Effort",
-    "description" : "Leave unset to use the model default.",
-    "optional" : true,
+    "optional" : false,
+    "value" : "modelDefault",
     "group" : "model",
     "binding" : {
       "name" : "provider.openai.api.completions.effort",
@@ -2186,6 +2189,9 @@
     "tooltip" : "Controls how many tokens the model spends when responding, trading thoroughness against speed and cost. Not supported on all models.<br><br>See the <a href=\"https://developers.openai.com/api/reference/resources/chat/subresources/completions/methods/create\" target=\"_blank\">Chat Completions API reference</a>.",
     "type" : "Dropdown",
     "choices" : [ {
+      "name" : "default",
+      "value" : "modelDefault"
+    }, {
       "name" : "minimal",
       "value" : "minimal"
     }, {

--- a/connectors/agentic-ai/connector-agentic-ai/element-templates/agenticai-ai-agent-subprocess.v2.json
+++ b/connectors/agentic-ai/connector-agentic-ai/element-templates/agenticai-ai-agent-subprocess.v2.json
@@ -1926,8 +1926,8 @@
   }, {
     "id" : "provider.anthropic.model.parameters.effort",
     "label" : "Effort",
-    "description" : "Leave unset to use the model default.",
-    "optional" : true,
+    "optional" : false,
+    "value" : "modelDefault",
     "group" : "model",
     "binding" : {
       "name" : "provider.anthropic.model.parameters.effort",
@@ -1941,6 +1941,9 @@
     "tooltip" : "Controls how many tokens the model spends when responding, trading thoroughness against speed and cost. Not supported on all models.<br><br>See the <a href=\"https://platform.claude.com/docs/en/build-with-claude/effort\" target=\"_blank\">effort documentation</a>.",
     "type" : "Dropdown",
     "choices" : [ {
+      "name" : "default",
+      "value" : "modelDefault"
+    }, {
       "name" : "low",
       "value" : "low"
     }, {
@@ -1959,7 +1962,8 @@
   }, {
     "id" : "provider.anthropic.model.parameters.thinking.mode",
     "label" : "Thinking mode",
-    "optional" : true,
+    "optional" : false,
+    "value" : "modelDefault",
     "group" : "model",
     "binding" : {
       "name" : "provider.anthropic.model.parameters.thinking.mode",
@@ -1970,9 +1974,12 @@
       "equals" : "anthropic",
       "type" : "simple"
     },
-    "tooltip" : "Extended thinking mechanism. Leave blank to use the model default.<br><br><code>enabled</code> uses a manual token budget (older models). <code>adaptive</code> is managed by the model (newer models). <code>disabled</code> turns it off.<br><br>Support varies by model.",
+    "tooltip" : "Extended thinking mechanism.<br><br><code>enabled</code> uses a manual token budget (older models). <code>adaptive</code> is managed by the model (newer models). <code>disabled</code> turns it off.<br><br>Support varies by model.",
     "type" : "Dropdown",
     "choices" : [ {
+      "name" : "default",
+      "value" : "modelDefault"
+    }, {
       "name" : "enabled",
       "value" : "enabled"
     }, {
@@ -2026,7 +2033,7 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "Controls how the model's extended thinking is returned. <code>summarized</code> includes a plain-text summary of the thinking in the response. <code>omitted</code> leaves it out.<br><br>Leave unset to use <code>summarized</code>.",
+    "tooltip" : "Controls how the model's extended thinking is returned. <code>summarized</code> includes a plain-text summary of the thinking in the response. <code>omitted</code> leaves it out.",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "summarized",

--- a/connectors/agentic-ai/connector-agentic-ai/element-templates/agenticai-ai-agent-task.v2.json
+++ b/connectors/agentic-ai/connector-agentic-ai/element-templates/agenticai-ai-agent-task.v2.json
@@ -2072,6 +2072,27 @@
     "tooltip" : "Enables AWS Bedrock automatic prompt caching. See the <a href=\"https://docs.aws.amazon.com/bedrock/latest/userguide/prompt-caching.html\" target=\"_blank\">documentation</a>.",
     "type" : "Boolean"
   }, {
+    "id" : "provider.openai.model.model",
+    "label" : "Model",
+    "description" : "Specify the model ID. Details in the <a href=\"https://platform.openai.com/docs/models\" target=\"_blank\">documentation</a>.",
+    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "model",
+    "binding" : {
+      "name" : "provider.openai.model.model",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "provider.type",
+      "equals" : "openai",
+      "type" : "simple"
+    },
+    "placeholder" : "gpt-5.5",
+    "type" : "String"
+  }, {
     "id" : "provider.openai.api.responses.effort",
     "label" : "Effort",
     "description" : "Leave unset to use the model default.",
@@ -2155,27 +2176,6 @@
       "name" : "max",
       "value" : "max"
     } ]
-  }, {
-    "id" : "provider.openai.model.model",
-    "label" : "Model",
-    "description" : "Specify the model ID. Details in the <a href=\"https://platform.openai.com/docs/models\" target=\"_blank\">documentation</a>.",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "feel" : "optional",
-    "group" : "model",
-    "binding" : {
-      "name" : "provider.openai.model.model",
-      "type" : "zeebe:input"
-    },
-    "condition" : {
-      "property" : "provider.type",
-      "equals" : "openai",
-      "type" : "simple"
-    },
-    "placeholder" : "gpt-5.5",
-    "type" : "String"
   }, {
     "id" : "provider.googleGemini.model.model",
     "label" : "Model",

--- a/connectors/agentic-ai/connector-agentic-ai/element-templates/agenticai-ai-agent-task.v2.json
+++ b/connectors/agentic-ai/connector-agentic-ai/element-templates/agenticai-ai-agent-task.v2.json
@@ -2095,8 +2095,8 @@
   }, {
     "id" : "provider.openai.api.responses.effort",
     "label" : "Effort",
-    "description" : "Leave unset to use the model default.",
-    "optional" : true,
+    "optional" : false,
+    "value" : "modelDefault",
     "group" : "model",
     "binding" : {
       "name" : "provider.openai.api.responses.effort",
@@ -2116,6 +2116,9 @@
     "tooltip" : "Controls how many tokens the model spends when responding, trading thoroughness against speed and cost. Not supported on all models.<br><br>See the <a href=\"https://developers.openai.com/api/reference/resources/responses/methods/create\" target=\"_blank\">Responses API reference</a>.",
     "type" : "Dropdown",
     "choices" : [ {
+      "name" : "default",
+      "value" : "modelDefault"
+    }, {
       "name" : "minimal",
       "value" : "minimal"
     }, {
@@ -2137,8 +2140,8 @@
   }, {
     "id" : "provider.openai.api.completions.effort",
     "label" : "Effort",
-    "description" : "Leave unset to use the model default.",
-    "optional" : true,
+    "optional" : false,
+    "value" : "modelDefault",
     "group" : "model",
     "binding" : {
       "name" : "provider.openai.api.completions.effort",
@@ -2158,6 +2161,9 @@
     "tooltip" : "Controls how many tokens the model spends when responding, trading thoroughness against speed and cost. Not supported on all models.<br><br>See the <a href=\"https://developers.openai.com/api/reference/resources/chat/subresources/completions/methods/create\" target=\"_blank\">Chat Completions API reference</a>.",
     "type" : "Dropdown",
     "choices" : [ {
+      "name" : "default",
+      "value" : "modelDefault"
+    }, {
       "name" : "minimal",
       "value" : "minimal"
     }, {

--- a/connectors/agentic-ai/connector-agentic-ai/element-templates/agenticai-ai-agent-task.v2.json
+++ b/connectors/agentic-ai/connector-agentic-ai/element-templates/agenticai-ai-agent-task.v2.json
@@ -638,11 +638,11 @@
     },
     "type" : "Dropdown",
     "choices" : [ {
-      "name" : "Chat Completions",
-      "value" : "completions"
-    }, {
       "name" : "Responses",
       "value" : "responses"
+    }, {
+      "name" : "Chat Completions",
+      "value" : "completions"
     } ]
   }, {
     "id" : "provider.openai.backend.type",
@@ -2072,48 +2072,6 @@
     "tooltip" : "Enables AWS Bedrock automatic prompt caching. See the <a href=\"https://docs.aws.amazon.com/bedrock/latest/userguide/prompt-caching.html\" target=\"_blank\">documentation</a>.",
     "type" : "Boolean"
   }, {
-    "id" : "provider.openai.api.completions.effort",
-    "label" : "Effort",
-    "description" : "Leave unset to use the model default.",
-    "optional" : true,
-    "group" : "model",
-    "binding" : {
-      "name" : "provider.openai.api.completions.effort",
-      "type" : "zeebe:input"
-    },
-    "condition" : {
-      "allMatch" : [ {
-        "property" : "provider.openai.api.type",
-        "equals" : "completions",
-        "type" : "simple"
-      }, {
-        "property" : "provider.type",
-        "equals" : "openai",
-        "type" : "simple"
-      } ]
-    },
-    "tooltip" : "Controls how many tokens the model spends when responding, trading thoroughness against speed and cost. Not supported on all models.<br><br>See the <a href=\"https://developers.openai.com/api/reference/resources/chat/subresources/completions/methods/create\" target=\"_blank\">Chat Completions API reference</a>.",
-    "type" : "Dropdown",
-    "choices" : [ {
-      "name" : "minimal",
-      "value" : "minimal"
-    }, {
-      "name" : "low",
-      "value" : "low"
-    }, {
-      "name" : "medium",
-      "value" : "medium"
-    }, {
-      "name" : "high",
-      "value" : "high"
-    }, {
-      "name" : "xhigh",
-      "value" : "xhigh"
-    }, {
-      "name" : "max",
-      "value" : "max"
-    } ]
-  }, {
     "id" : "provider.openai.api.responses.effort",
     "label" : "Effort",
     "description" : "Leave unset to use the model default.",
@@ -2135,6 +2093,48 @@
       } ]
     },
     "tooltip" : "Controls how many tokens the model spends when responding, trading thoroughness against speed and cost. Not supported on all models.<br><br>See the <a href=\"https://developers.openai.com/api/reference/resources/responses/methods/create\" target=\"_blank\">Responses API reference</a>.",
+    "type" : "Dropdown",
+    "choices" : [ {
+      "name" : "minimal",
+      "value" : "minimal"
+    }, {
+      "name" : "low",
+      "value" : "low"
+    }, {
+      "name" : "medium",
+      "value" : "medium"
+    }, {
+      "name" : "high",
+      "value" : "high"
+    }, {
+      "name" : "xhigh",
+      "value" : "xhigh"
+    }, {
+      "name" : "max",
+      "value" : "max"
+    } ]
+  }, {
+    "id" : "provider.openai.api.completions.effort",
+    "label" : "Effort",
+    "description" : "Leave unset to use the model default.",
+    "optional" : true,
+    "group" : "model",
+    "binding" : {
+      "name" : "provider.openai.api.completions.effort",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "allMatch" : [ {
+        "property" : "provider.openai.api.type",
+        "equals" : "completions",
+        "type" : "simple"
+      }, {
+        "property" : "provider.type",
+        "equals" : "openai",
+        "type" : "simple"
+      } ]
+    },
+    "tooltip" : "Controls how many tokens the model spends when responding, trading thoroughness against speed and cost. Not supported on all models.<br><br>See the <a href=\"https://developers.openai.com/api/reference/resources/chat/subresources/completions/methods/create\" target=\"_blank\">Chat Completions API reference</a>.",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "minimal",
@@ -2393,75 +2393,6 @@
     "tooltip" : "Floating point number between 0 and 1. Recommended for advanced use cases only (you usually only need to use temperature).",
     "type" : "Number"
   }, {
-    "id" : "provider.openai.api.completions.maxCompletionTokens",
-    "label" : "Max completion tokens",
-    "optional" : true,
-    "feel" : "required",
-    "group" : "model-options",
-    "binding" : {
-      "name" : "provider.openai.api.completions.maxCompletionTokens",
-      "type" : "zeebe:input"
-    },
-    "condition" : {
-      "allMatch" : [ {
-        "property" : "provider.openai.api.type",
-        "equals" : "completions",
-        "type" : "simple"
-      }, {
-        "property" : "provider.type",
-        "equals" : "openai",
-        "type" : "simple"
-      } ]
-    },
-    "tooltip" : "The maximum number of tokens per request to generate before stopping. <br><br>Details in the <a href=\"https://developers.openai.com/api/reference/resources/chat/subresources/completions/methods/create\" target=\"_blank\">documentation</a>.",
-    "type" : "Number"
-  }, {
-    "id" : "provider.openai.api.completions.temperature",
-    "label" : "Temperature",
-    "optional" : true,
-    "feel" : "required",
-    "group" : "model-options",
-    "binding" : {
-      "name" : "provider.openai.api.completions.temperature",
-      "type" : "zeebe:input"
-    },
-    "condition" : {
-      "allMatch" : [ {
-        "property" : "provider.openai.api.type",
-        "equals" : "completions",
-        "type" : "simple"
-      }, {
-        "property" : "provider.type",
-        "equals" : "openai",
-        "type" : "simple"
-      } ]
-    },
-    "tooltip" : "Floating point number between 0 and 2. The higher the number, the more randomness will be injected into the response. <br><br>Details in the <a href=\"https://developers.openai.com/api/reference/resources/chat/subresources/completions/methods/create\" target=\"_blank\">documentation</a>.",
-    "type" : "Number"
-  }, {
-    "id" : "provider.openai.api.completions.topP",
-    "label" : "top P",
-    "optional" : true,
-    "feel" : "required",
-    "group" : "model-options",
-    "binding" : {
-      "name" : "provider.openai.api.completions.topP",
-      "type" : "zeebe:input"
-    },
-    "condition" : {
-      "allMatch" : [ {
-        "property" : "provider.openai.api.type",
-        "equals" : "completions",
-        "type" : "simple"
-      }, {
-        "property" : "provider.type",
-        "equals" : "openai",
-        "type" : "simple"
-      } ]
-    },
-    "tooltip" : "Recommended for advanced use cases only (you usually only need to use temperature). <br><br>Details in the <a href=\"https://developers.openai.com/api/reference/resources/chat/subresources/completions/methods/create\" target=\"_blank\">documentation</a>.",
-    "type" : "Number"
-  }, {
     "id" : "provider.openai.api.responses.maxOutputTokens",
     "label" : "Max output tokens",
     "optional" : true,
@@ -2529,6 +2460,75 @@
       } ]
     },
     "tooltip" : "Recommended for advanced use cases only (you usually only need to use temperature). <br><br>Details in the <a href=\"https://developers.openai.com/api/reference/resources/responses/methods/create\" target=\"_blank\">documentation</a>.",
+    "type" : "Number"
+  }, {
+    "id" : "provider.openai.api.completions.maxCompletionTokens",
+    "label" : "Max completion tokens",
+    "optional" : true,
+    "feel" : "required",
+    "group" : "model-options",
+    "binding" : {
+      "name" : "provider.openai.api.completions.maxCompletionTokens",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "allMatch" : [ {
+        "property" : "provider.openai.api.type",
+        "equals" : "completions",
+        "type" : "simple"
+      }, {
+        "property" : "provider.type",
+        "equals" : "openai",
+        "type" : "simple"
+      } ]
+    },
+    "tooltip" : "The maximum number of tokens per request to generate before stopping. <br><br>Details in the <a href=\"https://developers.openai.com/api/reference/resources/chat/subresources/completions/methods/create\" target=\"_blank\">documentation</a>.",
+    "type" : "Number"
+  }, {
+    "id" : "provider.openai.api.completions.temperature",
+    "label" : "Temperature",
+    "optional" : true,
+    "feel" : "required",
+    "group" : "model-options",
+    "binding" : {
+      "name" : "provider.openai.api.completions.temperature",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "allMatch" : [ {
+        "property" : "provider.openai.api.type",
+        "equals" : "completions",
+        "type" : "simple"
+      }, {
+        "property" : "provider.type",
+        "equals" : "openai",
+        "type" : "simple"
+      } ]
+    },
+    "tooltip" : "Floating point number between 0 and 2. The higher the number, the more randomness will be injected into the response. <br><br>Details in the <a href=\"https://developers.openai.com/api/reference/resources/chat/subresources/completions/methods/create\" target=\"_blank\">documentation</a>.",
+    "type" : "Number"
+  }, {
+    "id" : "provider.openai.api.completions.topP",
+    "label" : "top P",
+    "optional" : true,
+    "feel" : "required",
+    "group" : "model-options",
+    "binding" : {
+      "name" : "provider.openai.api.completions.topP",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "allMatch" : [ {
+        "property" : "provider.openai.api.type",
+        "equals" : "completions",
+        "type" : "simple"
+      }, {
+        "property" : "provider.type",
+        "equals" : "openai",
+        "type" : "simple"
+      } ]
+    },
+    "tooltip" : "Recommended for advanced use cases only (you usually only need to use temperature). <br><br>Details in the <a href=\"https://developers.openai.com/api/reference/resources/chat/subresources/completions/methods/create\" target=\"_blank\">documentation</a>.",
     "type" : "Number"
   }, {
     "id" : "provider.googleGemini.model.parameters.maxTokens",

--- a/connectors/agentic-ai/connector-agentic-ai/element-templates/agenticai-ai-agent-task.v2.json
+++ b/connectors/agentic-ai/connector-agentic-ai/element-templates/agenticai-ai-agent-task.v2.json
@@ -1898,8 +1898,8 @@
   }, {
     "id" : "provider.anthropic.model.parameters.effort",
     "label" : "Effort",
-    "description" : "Leave unset to use the model default.",
-    "optional" : true,
+    "optional" : false,
+    "value" : "modelDefault",
     "group" : "model",
     "binding" : {
       "name" : "provider.anthropic.model.parameters.effort",
@@ -1913,6 +1913,9 @@
     "tooltip" : "Controls how many tokens the model spends when responding, trading thoroughness against speed and cost. Not supported on all models.<br><br>See the <a href=\"https://platform.claude.com/docs/en/build-with-claude/effort\" target=\"_blank\">effort documentation</a>.",
     "type" : "Dropdown",
     "choices" : [ {
+      "name" : "default",
+      "value" : "modelDefault"
+    }, {
       "name" : "low",
       "value" : "low"
     }, {
@@ -1931,7 +1934,8 @@
   }, {
     "id" : "provider.anthropic.model.parameters.thinking.mode",
     "label" : "Thinking mode",
-    "optional" : true,
+    "optional" : false,
+    "value" : "modelDefault",
     "group" : "model",
     "binding" : {
       "name" : "provider.anthropic.model.parameters.thinking.mode",
@@ -1942,9 +1946,12 @@
       "equals" : "anthropic",
       "type" : "simple"
     },
-    "tooltip" : "Extended thinking mechanism. Leave blank to use the model default.<br><br><code>enabled</code> uses a manual token budget (older models). <code>adaptive</code> is managed by the model (newer models). <code>disabled</code> turns it off.<br><br>Support varies by model.",
+    "tooltip" : "Extended thinking mechanism.<br><br><code>enabled</code> uses a manual token budget (older models). <code>adaptive</code> is managed by the model (newer models). <code>disabled</code> turns it off.<br><br>Support varies by model.",
     "type" : "Dropdown",
     "choices" : [ {
+      "name" : "default",
+      "value" : "modelDefault"
+    }, {
       "name" : "enabled",
       "value" : "enabled"
     }, {
@@ -1998,7 +2005,7 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "Controls how the model's extended thinking is returned. <code>summarized</code> includes a plain-text summary of the thinking in the response. <code>omitted</code> leaves it out.<br><br>Leave unset to use <code>summarized</code>.",
+    "tooltip" : "Controls how the model's extended thinking is returned. <code>summarized</code> includes a plain-text summary of the thinking in the response. <code>omitted</code> leaves it out.",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "summarized",

--- a/connectors/agentic-ai/connector-agentic-ai/element-templates/hybrid/agenticai-ai-agent-subprocess.v2-hybrid.json
+++ b/connectors/agentic-ai/connector-agentic-ai/element-templates/hybrid/agenticai-ai-agent-subprocess.v2-hybrid.json
@@ -1931,8 +1931,8 @@
   }, {
     "id" : "provider.anthropic.model.parameters.effort",
     "label" : "Effort",
-    "description" : "Leave unset to use the model default.",
-    "optional" : true,
+    "optional" : false,
+    "value" : "modelDefault",
     "group" : "model",
     "binding" : {
       "name" : "provider.anthropic.model.parameters.effort",
@@ -1946,6 +1946,9 @@
     "tooltip" : "Controls how many tokens the model spends when responding, trading thoroughness against speed and cost. Not supported on all models.<br><br>See the <a href=\"https://platform.claude.com/docs/en/build-with-claude/effort\" target=\"_blank\">effort documentation</a>.",
     "type" : "Dropdown",
     "choices" : [ {
+      "name" : "default",
+      "value" : "modelDefault"
+    }, {
       "name" : "low",
       "value" : "low"
     }, {
@@ -1964,7 +1967,8 @@
   }, {
     "id" : "provider.anthropic.model.parameters.thinking.mode",
     "label" : "Thinking mode",
-    "optional" : true,
+    "optional" : false,
+    "value" : "modelDefault",
     "group" : "model",
     "binding" : {
       "name" : "provider.anthropic.model.parameters.thinking.mode",
@@ -1975,9 +1979,12 @@
       "equals" : "anthropic",
       "type" : "simple"
     },
-    "tooltip" : "Extended thinking mechanism. Leave blank to use the model default.<br><br><code>enabled</code> uses a manual token budget (older models). <code>adaptive</code> is managed by the model (newer models). <code>disabled</code> turns it off.<br><br>Support varies by model.",
+    "tooltip" : "Extended thinking mechanism.<br><br><code>enabled</code> uses a manual token budget (older models). <code>adaptive</code> is managed by the model (newer models). <code>disabled</code> turns it off.<br><br>Support varies by model.",
     "type" : "Dropdown",
     "choices" : [ {
+      "name" : "default",
+      "value" : "modelDefault"
+    }, {
       "name" : "enabled",
       "value" : "enabled"
     }, {
@@ -2031,7 +2038,7 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "Controls how the model's extended thinking is returned. <code>summarized</code> includes a plain-text summary of the thinking in the response. <code>omitted</code> leaves it out.<br><br>Leave unset to use <code>summarized</code>.",
+    "tooltip" : "Controls how the model's extended thinking is returned. <code>summarized</code> includes a plain-text summary of the thinking in the response. <code>omitted</code> leaves it out.",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "summarized",

--- a/connectors/agentic-ai/connector-agentic-ai/element-templates/hybrid/agenticai-ai-agent-subprocess.v2-hybrid.json
+++ b/connectors/agentic-ai/connector-agentic-ai/element-templates/hybrid/agenticai-ai-agent-subprocess.v2-hybrid.json
@@ -2105,6 +2105,27 @@
     "tooltip" : "Enables AWS Bedrock automatic prompt caching. See the <a href=\"https://docs.aws.amazon.com/bedrock/latest/userguide/prompt-caching.html\" target=\"_blank\">documentation</a>.",
     "type" : "Boolean"
   }, {
+    "id" : "provider.openai.model.model",
+    "label" : "Model",
+    "description" : "Specify the model ID. Details in the <a href=\"https://platform.openai.com/docs/models\" target=\"_blank\">documentation</a>.",
+    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "model",
+    "binding" : {
+      "name" : "provider.openai.model.model",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "provider.type",
+      "equals" : "openai",
+      "type" : "simple"
+    },
+    "placeholder" : "gpt-5.5",
+    "type" : "String"
+  }, {
     "id" : "provider.openai.api.responses.effort",
     "label" : "Effort",
     "description" : "Leave unset to use the model default.",
@@ -2188,27 +2209,6 @@
       "name" : "max",
       "value" : "max"
     } ]
-  }, {
-    "id" : "provider.openai.model.model",
-    "label" : "Model",
-    "description" : "Specify the model ID. Details in the <a href=\"https://platform.openai.com/docs/models\" target=\"_blank\">documentation</a>.",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "feel" : "optional",
-    "group" : "model",
-    "binding" : {
-      "name" : "provider.openai.model.model",
-      "type" : "zeebe:input"
-    },
-    "condition" : {
-      "property" : "provider.type",
-      "equals" : "openai",
-      "type" : "simple"
-    },
-    "placeholder" : "gpt-5.5",
-    "type" : "String"
   }, {
     "id" : "provider.googleGemini.model.model",
     "label" : "Model",

--- a/connectors/agentic-ai/connector-agentic-ai/element-templates/hybrid/agenticai-ai-agent-subprocess.v2-hybrid.json
+++ b/connectors/agentic-ai/connector-agentic-ai/element-templates/hybrid/agenticai-ai-agent-subprocess.v2-hybrid.json
@@ -671,11 +671,11 @@
     },
     "type" : "Dropdown",
     "choices" : [ {
-      "name" : "Chat Completions",
-      "value" : "completions"
-    }, {
       "name" : "Responses",
       "value" : "responses"
+    }, {
+      "name" : "Chat Completions",
+      "value" : "completions"
     } ]
   }, {
     "id" : "provider.openai.backend.type",
@@ -2105,48 +2105,6 @@
     "tooltip" : "Enables AWS Bedrock automatic prompt caching. See the <a href=\"https://docs.aws.amazon.com/bedrock/latest/userguide/prompt-caching.html\" target=\"_blank\">documentation</a>.",
     "type" : "Boolean"
   }, {
-    "id" : "provider.openai.api.completions.effort",
-    "label" : "Effort",
-    "description" : "Leave unset to use the model default.",
-    "optional" : true,
-    "group" : "model",
-    "binding" : {
-      "name" : "provider.openai.api.completions.effort",
-      "type" : "zeebe:input"
-    },
-    "condition" : {
-      "allMatch" : [ {
-        "property" : "provider.openai.api.type",
-        "equals" : "completions",
-        "type" : "simple"
-      }, {
-        "property" : "provider.type",
-        "equals" : "openai",
-        "type" : "simple"
-      } ]
-    },
-    "tooltip" : "Controls how many tokens the model spends when responding, trading thoroughness against speed and cost. Not supported on all models.<br><br>See the <a href=\"https://developers.openai.com/api/reference/resources/chat/subresources/completions/methods/create\" target=\"_blank\">Chat Completions API reference</a>.",
-    "type" : "Dropdown",
-    "choices" : [ {
-      "name" : "minimal",
-      "value" : "minimal"
-    }, {
-      "name" : "low",
-      "value" : "low"
-    }, {
-      "name" : "medium",
-      "value" : "medium"
-    }, {
-      "name" : "high",
-      "value" : "high"
-    }, {
-      "name" : "xhigh",
-      "value" : "xhigh"
-    }, {
-      "name" : "max",
-      "value" : "max"
-    } ]
-  }, {
     "id" : "provider.openai.api.responses.effort",
     "label" : "Effort",
     "description" : "Leave unset to use the model default.",
@@ -2168,6 +2126,48 @@
       } ]
     },
     "tooltip" : "Controls how many tokens the model spends when responding, trading thoroughness against speed and cost. Not supported on all models.<br><br>See the <a href=\"https://developers.openai.com/api/reference/resources/responses/methods/create\" target=\"_blank\">Responses API reference</a>.",
+    "type" : "Dropdown",
+    "choices" : [ {
+      "name" : "minimal",
+      "value" : "minimal"
+    }, {
+      "name" : "low",
+      "value" : "low"
+    }, {
+      "name" : "medium",
+      "value" : "medium"
+    }, {
+      "name" : "high",
+      "value" : "high"
+    }, {
+      "name" : "xhigh",
+      "value" : "xhigh"
+    }, {
+      "name" : "max",
+      "value" : "max"
+    } ]
+  }, {
+    "id" : "provider.openai.api.completions.effort",
+    "label" : "Effort",
+    "description" : "Leave unset to use the model default.",
+    "optional" : true,
+    "group" : "model",
+    "binding" : {
+      "name" : "provider.openai.api.completions.effort",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "allMatch" : [ {
+        "property" : "provider.openai.api.type",
+        "equals" : "completions",
+        "type" : "simple"
+      }, {
+        "property" : "provider.type",
+        "equals" : "openai",
+        "type" : "simple"
+      } ]
+    },
+    "tooltip" : "Controls how many tokens the model spends when responding, trading thoroughness against speed and cost. Not supported on all models.<br><br>See the <a href=\"https://developers.openai.com/api/reference/resources/chat/subresources/completions/methods/create\" target=\"_blank\">Chat Completions API reference</a>.",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "minimal",
@@ -2426,75 +2426,6 @@
     "tooltip" : "Floating point number between 0 and 1. Recommended for advanced use cases only (you usually only need to use temperature).",
     "type" : "Number"
   }, {
-    "id" : "provider.openai.api.completions.maxCompletionTokens",
-    "label" : "Max completion tokens",
-    "optional" : true,
-    "feel" : "required",
-    "group" : "model-options",
-    "binding" : {
-      "name" : "provider.openai.api.completions.maxCompletionTokens",
-      "type" : "zeebe:input"
-    },
-    "condition" : {
-      "allMatch" : [ {
-        "property" : "provider.openai.api.type",
-        "equals" : "completions",
-        "type" : "simple"
-      }, {
-        "property" : "provider.type",
-        "equals" : "openai",
-        "type" : "simple"
-      } ]
-    },
-    "tooltip" : "The maximum number of tokens per request to generate before stopping. <br><br>Details in the <a href=\"https://developers.openai.com/api/reference/resources/chat/subresources/completions/methods/create\" target=\"_blank\">documentation</a>.",
-    "type" : "Number"
-  }, {
-    "id" : "provider.openai.api.completions.temperature",
-    "label" : "Temperature",
-    "optional" : true,
-    "feel" : "required",
-    "group" : "model-options",
-    "binding" : {
-      "name" : "provider.openai.api.completions.temperature",
-      "type" : "zeebe:input"
-    },
-    "condition" : {
-      "allMatch" : [ {
-        "property" : "provider.openai.api.type",
-        "equals" : "completions",
-        "type" : "simple"
-      }, {
-        "property" : "provider.type",
-        "equals" : "openai",
-        "type" : "simple"
-      } ]
-    },
-    "tooltip" : "Floating point number between 0 and 2. The higher the number, the more randomness will be injected into the response. <br><br>Details in the <a href=\"https://developers.openai.com/api/reference/resources/chat/subresources/completions/methods/create\" target=\"_blank\">documentation</a>.",
-    "type" : "Number"
-  }, {
-    "id" : "provider.openai.api.completions.topP",
-    "label" : "top P",
-    "optional" : true,
-    "feel" : "required",
-    "group" : "model-options",
-    "binding" : {
-      "name" : "provider.openai.api.completions.topP",
-      "type" : "zeebe:input"
-    },
-    "condition" : {
-      "allMatch" : [ {
-        "property" : "provider.openai.api.type",
-        "equals" : "completions",
-        "type" : "simple"
-      }, {
-        "property" : "provider.type",
-        "equals" : "openai",
-        "type" : "simple"
-      } ]
-    },
-    "tooltip" : "Recommended for advanced use cases only (you usually only need to use temperature). <br><br>Details in the <a href=\"https://developers.openai.com/api/reference/resources/chat/subresources/completions/methods/create\" target=\"_blank\">documentation</a>.",
-    "type" : "Number"
-  }, {
     "id" : "provider.openai.api.responses.maxOutputTokens",
     "label" : "Max output tokens",
     "optional" : true,
@@ -2562,6 +2493,75 @@
       } ]
     },
     "tooltip" : "Recommended for advanced use cases only (you usually only need to use temperature). <br><br>Details in the <a href=\"https://developers.openai.com/api/reference/resources/responses/methods/create\" target=\"_blank\">documentation</a>.",
+    "type" : "Number"
+  }, {
+    "id" : "provider.openai.api.completions.maxCompletionTokens",
+    "label" : "Max completion tokens",
+    "optional" : true,
+    "feel" : "required",
+    "group" : "model-options",
+    "binding" : {
+      "name" : "provider.openai.api.completions.maxCompletionTokens",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "allMatch" : [ {
+        "property" : "provider.openai.api.type",
+        "equals" : "completions",
+        "type" : "simple"
+      }, {
+        "property" : "provider.type",
+        "equals" : "openai",
+        "type" : "simple"
+      } ]
+    },
+    "tooltip" : "The maximum number of tokens per request to generate before stopping. <br><br>Details in the <a href=\"https://developers.openai.com/api/reference/resources/chat/subresources/completions/methods/create\" target=\"_blank\">documentation</a>.",
+    "type" : "Number"
+  }, {
+    "id" : "provider.openai.api.completions.temperature",
+    "label" : "Temperature",
+    "optional" : true,
+    "feel" : "required",
+    "group" : "model-options",
+    "binding" : {
+      "name" : "provider.openai.api.completions.temperature",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "allMatch" : [ {
+        "property" : "provider.openai.api.type",
+        "equals" : "completions",
+        "type" : "simple"
+      }, {
+        "property" : "provider.type",
+        "equals" : "openai",
+        "type" : "simple"
+      } ]
+    },
+    "tooltip" : "Floating point number between 0 and 2. The higher the number, the more randomness will be injected into the response. <br><br>Details in the <a href=\"https://developers.openai.com/api/reference/resources/chat/subresources/completions/methods/create\" target=\"_blank\">documentation</a>.",
+    "type" : "Number"
+  }, {
+    "id" : "provider.openai.api.completions.topP",
+    "label" : "top P",
+    "optional" : true,
+    "feel" : "required",
+    "group" : "model-options",
+    "binding" : {
+      "name" : "provider.openai.api.completions.topP",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "allMatch" : [ {
+        "property" : "provider.openai.api.type",
+        "equals" : "completions",
+        "type" : "simple"
+      }, {
+        "property" : "provider.type",
+        "equals" : "openai",
+        "type" : "simple"
+      } ]
+    },
+    "tooltip" : "Recommended for advanced use cases only (you usually only need to use temperature). <br><br>Details in the <a href=\"https://developers.openai.com/api/reference/resources/chat/subresources/completions/methods/create\" target=\"_blank\">documentation</a>.",
     "type" : "Number"
   }, {
     "id" : "provider.googleGemini.model.parameters.maxTokens",

--- a/connectors/agentic-ai/connector-agentic-ai/element-templates/hybrid/agenticai-ai-agent-subprocess.v2-hybrid.json
+++ b/connectors/agentic-ai/connector-agentic-ai/element-templates/hybrid/agenticai-ai-agent-subprocess.v2-hybrid.json
@@ -2128,8 +2128,8 @@
   }, {
     "id" : "provider.openai.api.responses.effort",
     "label" : "Effort",
-    "description" : "Leave unset to use the model default.",
-    "optional" : true,
+    "optional" : false,
+    "value" : "modelDefault",
     "group" : "model",
     "binding" : {
       "name" : "provider.openai.api.responses.effort",
@@ -2149,6 +2149,9 @@
     "tooltip" : "Controls how many tokens the model spends when responding, trading thoroughness against speed and cost. Not supported on all models.<br><br>See the <a href=\"https://developers.openai.com/api/reference/resources/responses/methods/create\" target=\"_blank\">Responses API reference</a>.",
     "type" : "Dropdown",
     "choices" : [ {
+      "name" : "default",
+      "value" : "modelDefault"
+    }, {
       "name" : "minimal",
       "value" : "minimal"
     }, {
@@ -2170,8 +2173,8 @@
   }, {
     "id" : "provider.openai.api.completions.effort",
     "label" : "Effort",
-    "description" : "Leave unset to use the model default.",
-    "optional" : true,
+    "optional" : false,
+    "value" : "modelDefault",
     "group" : "model",
     "binding" : {
       "name" : "provider.openai.api.completions.effort",
@@ -2191,6 +2194,9 @@
     "tooltip" : "Controls how many tokens the model spends when responding, trading thoroughness against speed and cost. Not supported on all models.<br><br>See the <a href=\"https://developers.openai.com/api/reference/resources/chat/subresources/completions/methods/create\" target=\"_blank\">Chat Completions API reference</a>.",
     "type" : "Dropdown",
     "choices" : [ {
+      "name" : "default",
+      "value" : "modelDefault"
+    }, {
       "name" : "minimal",
       "value" : "minimal"
     }, {

--- a/connectors/agentic-ai/connector-agentic-ai/element-templates/hybrid/agenticai-ai-agent-task.v2-hybrid.json
+++ b/connectors/agentic-ai/connector-agentic-ai/element-templates/hybrid/agenticai-ai-agent-task.v2-hybrid.json
@@ -1903,8 +1903,8 @@
   }, {
     "id" : "provider.anthropic.model.parameters.effort",
     "label" : "Effort",
-    "description" : "Leave unset to use the model default.",
-    "optional" : true,
+    "optional" : false,
+    "value" : "modelDefault",
     "group" : "model",
     "binding" : {
       "name" : "provider.anthropic.model.parameters.effort",
@@ -1918,6 +1918,9 @@
     "tooltip" : "Controls how many tokens the model spends when responding, trading thoroughness against speed and cost. Not supported on all models.<br><br>See the <a href=\"https://platform.claude.com/docs/en/build-with-claude/effort\" target=\"_blank\">effort documentation</a>.",
     "type" : "Dropdown",
     "choices" : [ {
+      "name" : "default",
+      "value" : "modelDefault"
+    }, {
       "name" : "low",
       "value" : "low"
     }, {
@@ -1936,7 +1939,8 @@
   }, {
     "id" : "provider.anthropic.model.parameters.thinking.mode",
     "label" : "Thinking mode",
-    "optional" : true,
+    "optional" : false,
+    "value" : "modelDefault",
     "group" : "model",
     "binding" : {
       "name" : "provider.anthropic.model.parameters.thinking.mode",
@@ -1947,9 +1951,12 @@
       "equals" : "anthropic",
       "type" : "simple"
     },
-    "tooltip" : "Extended thinking mechanism. Leave blank to use the model default.<br><br><code>enabled</code> uses a manual token budget (older models). <code>adaptive</code> is managed by the model (newer models). <code>disabled</code> turns it off.<br><br>Support varies by model.",
+    "tooltip" : "Extended thinking mechanism.<br><br><code>enabled</code> uses a manual token budget (older models). <code>adaptive</code> is managed by the model (newer models). <code>disabled</code> turns it off.<br><br>Support varies by model.",
     "type" : "Dropdown",
     "choices" : [ {
+      "name" : "default",
+      "value" : "modelDefault"
+    }, {
       "name" : "enabled",
       "value" : "enabled"
     }, {
@@ -2003,7 +2010,7 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "Controls how the model's extended thinking is returned. <code>summarized</code> includes a plain-text summary of the thinking in the response. <code>omitted</code> leaves it out.<br><br>Leave unset to use <code>summarized</code>.",
+    "tooltip" : "Controls how the model's extended thinking is returned. <code>summarized</code> includes a plain-text summary of the thinking in the response. <code>omitted</code> leaves it out.",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "summarized",

--- a/connectors/agentic-ai/connector-agentic-ai/element-templates/hybrid/agenticai-ai-agent-task.v2-hybrid.json
+++ b/connectors/agentic-ai/connector-agentic-ai/element-templates/hybrid/agenticai-ai-agent-task.v2-hybrid.json
@@ -2077,6 +2077,27 @@
     "tooltip" : "Enables AWS Bedrock automatic prompt caching. See the <a href=\"https://docs.aws.amazon.com/bedrock/latest/userguide/prompt-caching.html\" target=\"_blank\">documentation</a>.",
     "type" : "Boolean"
   }, {
+    "id" : "provider.openai.model.model",
+    "label" : "Model",
+    "description" : "Specify the model ID. Details in the <a href=\"https://platform.openai.com/docs/models\" target=\"_blank\">documentation</a>.",
+    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "model",
+    "binding" : {
+      "name" : "provider.openai.model.model",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "provider.type",
+      "equals" : "openai",
+      "type" : "simple"
+    },
+    "placeholder" : "gpt-5.5",
+    "type" : "String"
+  }, {
     "id" : "provider.openai.api.responses.effort",
     "label" : "Effort",
     "description" : "Leave unset to use the model default.",
@@ -2160,27 +2181,6 @@
       "name" : "max",
       "value" : "max"
     } ]
-  }, {
-    "id" : "provider.openai.model.model",
-    "label" : "Model",
-    "description" : "Specify the model ID. Details in the <a href=\"https://platform.openai.com/docs/models\" target=\"_blank\">documentation</a>.",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "feel" : "optional",
-    "group" : "model",
-    "binding" : {
-      "name" : "provider.openai.model.model",
-      "type" : "zeebe:input"
-    },
-    "condition" : {
-      "property" : "provider.type",
-      "equals" : "openai",
-      "type" : "simple"
-    },
-    "placeholder" : "gpt-5.5",
-    "type" : "String"
   }, {
     "id" : "provider.googleGemini.model.model",
     "label" : "Model",

--- a/connectors/agentic-ai/connector-agentic-ai/element-templates/hybrid/agenticai-ai-agent-task.v2-hybrid.json
+++ b/connectors/agentic-ai/connector-agentic-ai/element-templates/hybrid/agenticai-ai-agent-task.v2-hybrid.json
@@ -2100,8 +2100,8 @@
   }, {
     "id" : "provider.openai.api.responses.effort",
     "label" : "Effort",
-    "description" : "Leave unset to use the model default.",
-    "optional" : true,
+    "optional" : false,
+    "value" : "modelDefault",
     "group" : "model",
     "binding" : {
       "name" : "provider.openai.api.responses.effort",
@@ -2121,6 +2121,9 @@
     "tooltip" : "Controls how many tokens the model spends when responding, trading thoroughness against speed and cost. Not supported on all models.<br><br>See the <a href=\"https://developers.openai.com/api/reference/resources/responses/methods/create\" target=\"_blank\">Responses API reference</a>.",
     "type" : "Dropdown",
     "choices" : [ {
+      "name" : "default",
+      "value" : "modelDefault"
+    }, {
       "name" : "minimal",
       "value" : "minimal"
     }, {
@@ -2142,8 +2145,8 @@
   }, {
     "id" : "provider.openai.api.completions.effort",
     "label" : "Effort",
-    "description" : "Leave unset to use the model default.",
-    "optional" : true,
+    "optional" : false,
+    "value" : "modelDefault",
     "group" : "model",
     "binding" : {
       "name" : "provider.openai.api.completions.effort",
@@ -2163,6 +2166,9 @@
     "tooltip" : "Controls how many tokens the model spends when responding, trading thoroughness against speed and cost. Not supported on all models.<br><br>See the <a href=\"https://developers.openai.com/api/reference/resources/chat/subresources/completions/methods/create\" target=\"_blank\">Chat Completions API reference</a>.",
     "type" : "Dropdown",
     "choices" : [ {
+      "name" : "default",
+      "value" : "modelDefault"
+    }, {
       "name" : "minimal",
       "value" : "minimal"
     }, {

--- a/connectors/agentic-ai/connector-agentic-ai/element-templates/hybrid/agenticai-ai-agent-task.v2-hybrid.json
+++ b/connectors/agentic-ai/connector-agentic-ai/element-templates/hybrid/agenticai-ai-agent-task.v2-hybrid.json
@@ -643,11 +643,11 @@
     },
     "type" : "Dropdown",
     "choices" : [ {
-      "name" : "Chat Completions",
-      "value" : "completions"
-    }, {
       "name" : "Responses",
       "value" : "responses"
+    }, {
+      "name" : "Chat Completions",
+      "value" : "completions"
     } ]
   }, {
     "id" : "provider.openai.backend.type",
@@ -2077,48 +2077,6 @@
     "tooltip" : "Enables AWS Bedrock automatic prompt caching. See the <a href=\"https://docs.aws.amazon.com/bedrock/latest/userguide/prompt-caching.html\" target=\"_blank\">documentation</a>.",
     "type" : "Boolean"
   }, {
-    "id" : "provider.openai.api.completions.effort",
-    "label" : "Effort",
-    "description" : "Leave unset to use the model default.",
-    "optional" : true,
-    "group" : "model",
-    "binding" : {
-      "name" : "provider.openai.api.completions.effort",
-      "type" : "zeebe:input"
-    },
-    "condition" : {
-      "allMatch" : [ {
-        "property" : "provider.openai.api.type",
-        "equals" : "completions",
-        "type" : "simple"
-      }, {
-        "property" : "provider.type",
-        "equals" : "openai",
-        "type" : "simple"
-      } ]
-    },
-    "tooltip" : "Controls how many tokens the model spends when responding, trading thoroughness against speed and cost. Not supported on all models.<br><br>See the <a href=\"https://developers.openai.com/api/reference/resources/chat/subresources/completions/methods/create\" target=\"_blank\">Chat Completions API reference</a>.",
-    "type" : "Dropdown",
-    "choices" : [ {
-      "name" : "minimal",
-      "value" : "minimal"
-    }, {
-      "name" : "low",
-      "value" : "low"
-    }, {
-      "name" : "medium",
-      "value" : "medium"
-    }, {
-      "name" : "high",
-      "value" : "high"
-    }, {
-      "name" : "xhigh",
-      "value" : "xhigh"
-    }, {
-      "name" : "max",
-      "value" : "max"
-    } ]
-  }, {
     "id" : "provider.openai.api.responses.effort",
     "label" : "Effort",
     "description" : "Leave unset to use the model default.",
@@ -2140,6 +2098,48 @@
       } ]
     },
     "tooltip" : "Controls how many tokens the model spends when responding, trading thoroughness against speed and cost. Not supported on all models.<br><br>See the <a href=\"https://developers.openai.com/api/reference/resources/responses/methods/create\" target=\"_blank\">Responses API reference</a>.",
+    "type" : "Dropdown",
+    "choices" : [ {
+      "name" : "minimal",
+      "value" : "minimal"
+    }, {
+      "name" : "low",
+      "value" : "low"
+    }, {
+      "name" : "medium",
+      "value" : "medium"
+    }, {
+      "name" : "high",
+      "value" : "high"
+    }, {
+      "name" : "xhigh",
+      "value" : "xhigh"
+    }, {
+      "name" : "max",
+      "value" : "max"
+    } ]
+  }, {
+    "id" : "provider.openai.api.completions.effort",
+    "label" : "Effort",
+    "description" : "Leave unset to use the model default.",
+    "optional" : true,
+    "group" : "model",
+    "binding" : {
+      "name" : "provider.openai.api.completions.effort",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "allMatch" : [ {
+        "property" : "provider.openai.api.type",
+        "equals" : "completions",
+        "type" : "simple"
+      }, {
+        "property" : "provider.type",
+        "equals" : "openai",
+        "type" : "simple"
+      } ]
+    },
+    "tooltip" : "Controls how many tokens the model spends when responding, trading thoroughness against speed and cost. Not supported on all models.<br><br>See the <a href=\"https://developers.openai.com/api/reference/resources/chat/subresources/completions/methods/create\" target=\"_blank\">Chat Completions API reference</a>.",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "minimal",
@@ -2398,75 +2398,6 @@
     "tooltip" : "Floating point number between 0 and 1. Recommended for advanced use cases only (you usually only need to use temperature).",
     "type" : "Number"
   }, {
-    "id" : "provider.openai.api.completions.maxCompletionTokens",
-    "label" : "Max completion tokens",
-    "optional" : true,
-    "feel" : "required",
-    "group" : "model-options",
-    "binding" : {
-      "name" : "provider.openai.api.completions.maxCompletionTokens",
-      "type" : "zeebe:input"
-    },
-    "condition" : {
-      "allMatch" : [ {
-        "property" : "provider.openai.api.type",
-        "equals" : "completions",
-        "type" : "simple"
-      }, {
-        "property" : "provider.type",
-        "equals" : "openai",
-        "type" : "simple"
-      } ]
-    },
-    "tooltip" : "The maximum number of tokens per request to generate before stopping. <br><br>Details in the <a href=\"https://developers.openai.com/api/reference/resources/chat/subresources/completions/methods/create\" target=\"_blank\">documentation</a>.",
-    "type" : "Number"
-  }, {
-    "id" : "provider.openai.api.completions.temperature",
-    "label" : "Temperature",
-    "optional" : true,
-    "feel" : "required",
-    "group" : "model-options",
-    "binding" : {
-      "name" : "provider.openai.api.completions.temperature",
-      "type" : "zeebe:input"
-    },
-    "condition" : {
-      "allMatch" : [ {
-        "property" : "provider.openai.api.type",
-        "equals" : "completions",
-        "type" : "simple"
-      }, {
-        "property" : "provider.type",
-        "equals" : "openai",
-        "type" : "simple"
-      } ]
-    },
-    "tooltip" : "Floating point number between 0 and 2. The higher the number, the more randomness will be injected into the response. <br><br>Details in the <a href=\"https://developers.openai.com/api/reference/resources/chat/subresources/completions/methods/create\" target=\"_blank\">documentation</a>.",
-    "type" : "Number"
-  }, {
-    "id" : "provider.openai.api.completions.topP",
-    "label" : "top P",
-    "optional" : true,
-    "feel" : "required",
-    "group" : "model-options",
-    "binding" : {
-      "name" : "provider.openai.api.completions.topP",
-      "type" : "zeebe:input"
-    },
-    "condition" : {
-      "allMatch" : [ {
-        "property" : "provider.openai.api.type",
-        "equals" : "completions",
-        "type" : "simple"
-      }, {
-        "property" : "provider.type",
-        "equals" : "openai",
-        "type" : "simple"
-      } ]
-    },
-    "tooltip" : "Recommended for advanced use cases only (you usually only need to use temperature). <br><br>Details in the <a href=\"https://developers.openai.com/api/reference/resources/chat/subresources/completions/methods/create\" target=\"_blank\">documentation</a>.",
-    "type" : "Number"
-  }, {
     "id" : "provider.openai.api.responses.maxOutputTokens",
     "label" : "Max output tokens",
     "optional" : true,
@@ -2534,6 +2465,75 @@
       } ]
     },
     "tooltip" : "Recommended for advanced use cases only (you usually only need to use temperature). <br><br>Details in the <a href=\"https://developers.openai.com/api/reference/resources/responses/methods/create\" target=\"_blank\">documentation</a>.",
+    "type" : "Number"
+  }, {
+    "id" : "provider.openai.api.completions.maxCompletionTokens",
+    "label" : "Max completion tokens",
+    "optional" : true,
+    "feel" : "required",
+    "group" : "model-options",
+    "binding" : {
+      "name" : "provider.openai.api.completions.maxCompletionTokens",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "allMatch" : [ {
+        "property" : "provider.openai.api.type",
+        "equals" : "completions",
+        "type" : "simple"
+      }, {
+        "property" : "provider.type",
+        "equals" : "openai",
+        "type" : "simple"
+      } ]
+    },
+    "tooltip" : "The maximum number of tokens per request to generate before stopping. <br><br>Details in the <a href=\"https://developers.openai.com/api/reference/resources/chat/subresources/completions/methods/create\" target=\"_blank\">documentation</a>.",
+    "type" : "Number"
+  }, {
+    "id" : "provider.openai.api.completions.temperature",
+    "label" : "Temperature",
+    "optional" : true,
+    "feel" : "required",
+    "group" : "model-options",
+    "binding" : {
+      "name" : "provider.openai.api.completions.temperature",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "allMatch" : [ {
+        "property" : "provider.openai.api.type",
+        "equals" : "completions",
+        "type" : "simple"
+      }, {
+        "property" : "provider.type",
+        "equals" : "openai",
+        "type" : "simple"
+      } ]
+    },
+    "tooltip" : "Floating point number between 0 and 2. The higher the number, the more randomness will be injected into the response. <br><br>Details in the <a href=\"https://developers.openai.com/api/reference/resources/chat/subresources/completions/methods/create\" target=\"_blank\">documentation</a>.",
+    "type" : "Number"
+  }, {
+    "id" : "provider.openai.api.completions.topP",
+    "label" : "top P",
+    "optional" : true,
+    "feel" : "required",
+    "group" : "model-options",
+    "binding" : {
+      "name" : "provider.openai.api.completions.topP",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "allMatch" : [ {
+        "property" : "provider.openai.api.type",
+        "equals" : "completions",
+        "type" : "simple"
+      }, {
+        "property" : "provider.type",
+        "equals" : "openai",
+        "type" : "simple"
+      } ]
+    },
+    "tooltip" : "Recommended for advanced use cases only (you usually only need to use temperature). <br><br>Details in the <a href=\"https://developers.openai.com/api/reference/resources/chat/subresources/completions/methods/create\" target=\"_blank\">documentation</a>.",
     "type" : "Number"
   }, {
     "id" : "provider.googleGemini.model.parameters.maxTokens",

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/anthropic/AnthropicMessageRequestConverter.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/anthropic/AnthropicMessageRequestConverter.java
@@ -132,7 +132,7 @@ public class AnthropicMessageRequestConverter {
     validateThinking(thinking, modelId);
 
     final ThinkingMode mode = thinking == null ? null : thinking.mode();
-    if (thinking == null || mode == null) {
+    if (thinking == null || mode == null || mode == ThinkingMode.MODEL_DEFAULT) {
       return;
     }
 
@@ -344,7 +344,8 @@ public class AnthropicMessageRequestConverter {
       MessageCreateParams.Builder builder,
       @Nullable AnthropicModelParameters params,
       @Nullable ResponseConfiguration response) {
-    final AnthropicEffort effort = params == null ? null : params.effort();
+    final AnthropicEffort rawEffort = params == null ? null : params.effort();
+    final AnthropicEffort effort = rawEffort == AnthropicEffort.MODEL_DEFAULT ? null : rawEffort;
     final Map<String, Object> jsonSchema =
         response != null && response.format() instanceof JsonResponseFormatConfiguration json
             ? json.schema()

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/anthropic/AnthropicMessageRequestConverter.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/anthropic/AnthropicMessageRequestConverter.java
@@ -118,9 +118,10 @@ public class AnthropicMessageRequestConverter {
   }
 
   /**
-   * Maps the {@code thinking} configuration onto the SDK's {@code thinking} union. {@code mode ==
-   * null} (the modeler left the dropdown blank) means unset - no thinking param is emitted and the
-   * model's own default applies. Wire enum values use {@code name().toLowerCase()} ({@link
+   * Maps the {@code thinking} configuration onto the SDK's {@code thinking} union. Both {@code mode
+   * == null} (legacy/omitted input) and {@code mode == MODEL_DEFAULT} (the modeler's "default"
+   * dropdown choice) mean unset - no thinking param is emitted and the model's own default applies.
+   * The remaining concrete modes map onto the wire via {@code name().toLowerCase()} ({@link
    * ThinkingMode}/{@code ThinkingDisplay} already carry matching lowercase {@code JsonProperty}
    * values, see those enums).
    */

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/openai/family/completions/OpenAiCompletionsRequestConverter.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/openai/family/completions/OpenAiCompletionsRequestConverter.java
@@ -144,7 +144,7 @@ public class OpenAiCompletionsRequestConverter {
   private void applyReasoning(
       ChatCompletionCreateParams.Builder builder, @Nullable CompletionsParameters params) {
     final OpenAiEffort effort = params == null ? null : params.effort();
-    if (effort == null) {
+    if (effort == null || effort == OpenAiEffort.MODEL_DEFAULT) {
       return;
     }
     builder.reasoningEffort(ReasoningEffort.of(effort.name().toLowerCase(Locale.ROOT)));

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/openai/family/responses/OpenAiResponsesRequestConverter.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/openai/family/responses/OpenAiResponsesRequestConverter.java
@@ -149,7 +149,7 @@ public class OpenAiResponsesRequestConverter {
     builder.addInclude(ResponseIncludable.REASONING_ENCRYPTED_CONTENT);
 
     final OpenAiEffort effort = params == null ? null : params.effort();
-    if (effort == null) {
+    if (effort == null || effort == OpenAiEffort.MODEL_DEFAULT) {
       return;
     }
     builder.reasoning(Reasoning.builder().effort(mapEffort(effort)).build());

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/v2/AnthropicChatModelConfiguration.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/v2/AnthropicChatModelConfiguration.java
@@ -323,19 +323,19 @@ public record AnthropicChatModelConfiguration(@Valid @NotNull AnthropicConnectio
         @TemplateProperty(
                 group = "model",
                 label = "Effort",
-                description = "Leave unset to use the model default.",
                 tooltip =
                     "Controls how many tokens the model spends when responding, trading thoroughness against speed and cost. Not supported on all models."
                         + "<br><br>See the <a href=\"https://platform.claude.com/docs/en/build-with-claude/effort\" target=\"_blank\">effort documentation</a>.",
                 type = TemplateProperty.PropertyType.Dropdown,
                 choices = {
+                  @DropdownPropertyChoice(value = "modelDefault", label = "default"),
                   @DropdownPropertyChoice(value = "low", label = "low"),
                   @DropdownPropertyChoice(value = "medium", label = "medium"),
                   @DropdownPropertyChoice(value = "high", label = "high"),
                   @DropdownPropertyChoice(value = "xhigh", label = "xhigh"),
                   @DropdownPropertyChoice(value = "max", label = "max")
                 },
-                optional = true)
+                defaultValue = "modelDefault")
             @Nullable AnthropicEffort effort,
         @Valid @Nullable AnthropicThinking thinking,
         @Valid @Nullable AnthropicPromptCaching promptCaching,
@@ -404,6 +404,8 @@ public record AnthropicChatModelConfiguration(@Valid @NotNull AnthropicConnectio
 
     /** Anthropic effort levels, trading thoroughness against speed and cost. */
     public enum AnthropicEffort {
+      @JsonProperty("modelDefault")
+      MODEL_DEFAULT,
       @JsonProperty("low")
       LOW,
       @JsonProperty("medium")
@@ -439,18 +441,19 @@ public record AnthropicChatModelConfiguration(@Valid @NotNull AnthropicConnectio
                 group = "model",
                 label = "Thinking mode",
                 tooltip =
-                    "Extended thinking mechanism. Leave blank to use the model default."
+                    "Extended thinking mechanism."
                         + "<br><br><code>enabled</code> uses a manual token budget (older models). "
                         + "<code>adaptive</code> is managed by the model (newer models). "
                         + "<code>disabled</code> turns it off."
                         + "<br><br>Support varies by model.",
                 type = TemplateProperty.PropertyType.Dropdown,
                 choices = {
+                  @DropdownPropertyChoice(value = "modelDefault", label = "default"),
                   @DropdownPropertyChoice(value = "enabled", label = "enabled"),
                   @DropdownPropertyChoice(value = "adaptive", label = "adaptive"),
                   @DropdownPropertyChoice(value = "disabled", label = "disabled")
                 },
-                optional = true)
+                defaultValue = "modelDefault")
             @Nullable ThinkingMode mode,
         @Min(1024)
             @TemplateProperty(
@@ -470,8 +473,7 @@ public record AnthropicChatModelConfiguration(@Valid @NotNull AnthropicConnectio
                 label = "Thinking display",
                 tooltip =
                     "Controls how the model's extended thinking is returned. <code>summarized</code> includes a "
-                        + "plain-text summary of the thinking in the response. <code>omitted</code> leaves it out."
-                        + "<br><br>Leave unset to use <code>summarized</code>.",
+                        + "plain-text summary of the thinking in the response. <code>omitted</code> leaves it out.",
                 type = TemplateProperty.PropertyType.Dropdown,
                 choices = {
                   @DropdownPropertyChoice(value = "summarized", label = "summarized"),
@@ -491,6 +493,8 @@ public record AnthropicChatModelConfiguration(@Valid @NotNull AnthropicConnectio
      * budget, older models), {@code adaptive} (model-managed, newer models) or {@code disabled}.
      */
     public enum ThinkingMode {
+      @JsonProperty("modelDefault")
+      MODEL_DEFAULT,
       @JsonProperty("enabled")
       ENABLED,
       @JsonProperty("adaptive")

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/v2/OpenAiChatModelConfiguration.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/v2/OpenAiChatModelConfiguration.java
@@ -61,8 +61,8 @@ public record OpenAiChatModelConfiguration(@Valid @NotNull OpenAiConnection open
 
   @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
   @JsonSubTypes({
-    @JsonSubTypes.Type(value = OpenAiApi.OpenAiCompletionsApi.class, name = COMPLETIONS_ID),
-    @JsonSubTypes.Type(value = OpenAiApi.OpenAiResponsesApi.class, name = RESPONSES_ID)
+    @JsonSubTypes.Type(value = OpenAiApi.OpenAiResponsesApi.class, name = RESPONSES_ID),
+    @JsonSubTypes.Type(value = OpenAiApi.OpenAiCompletionsApi.class, name = COMPLETIONS_ID)
   })
   @TemplateDiscriminatorProperty(
       label = "API",
@@ -74,6 +74,70 @@ public record OpenAiChatModelConfiguration(@Valid @NotNull OpenAiConnection open
 
     /** The API family discriminator string. */
     String type();
+
+    @TemplateSubType(id = RESPONSES_ID, label = "Responses")
+    record OpenAiResponsesApi(@Valid @Nullable ResponsesParameters responses) implements OpenAiApi {
+
+      @TemplateProperty(ignore = true)
+      public static final String RESPONSES_ID = "responses";
+
+      @Override
+      public String type() {
+        return RESPONSES_ID;
+      }
+
+      public record ResponsesParameters(
+          @Min(1)
+              @TemplateProperty(
+                  group = "model-options",
+                  label = "Max output tokens",
+                  tooltip =
+                      "The maximum number of tokens per request to generate before stopping. <br><br>Details in the <a href=\"https://developers.openai.com/api/reference/resources/responses/methods/create\" target=\"_blank\">documentation</a>.",
+                  type = TemplateProperty.PropertyType.Number,
+                  feel = FeelMode.required,
+                  optional = true)
+              @Nullable Integer maxOutputTokens,
+          @TemplateProperty(
+                  group = "model",
+                  label = "Effort",
+                  description = "Leave unset to use the model default.",
+                  tooltip =
+                      "Controls how many tokens the model spends when responding, trading thoroughness against speed and cost. Not supported on all models."
+                          + "<br><br>See the <a href=\"https://developers.openai.com/api/reference/resources/responses/methods/create\" target=\"_blank\">Responses API reference</a>.",
+                  type = TemplateProperty.PropertyType.Dropdown,
+                  choices = {
+                    @DropdownPropertyChoice(value = "minimal", label = "minimal"),
+                    @DropdownPropertyChoice(value = "low", label = "low"),
+                    @DropdownPropertyChoice(value = "medium", label = "medium"),
+                    @DropdownPropertyChoice(value = "high", label = "high"),
+                    @DropdownPropertyChoice(value = "xhigh", label = "xhigh"),
+                    @DropdownPropertyChoice(value = "max", label = "max")
+                  },
+                  optional = true)
+              @Nullable OpenAiEffort effort,
+          @DecimalMin("0.0")
+              @DecimalMax("2.0")
+              @TemplateProperty(
+                  group = "model-options",
+                  label = "Temperature",
+                  tooltip =
+                      "Floating point number between 0 and 2. The higher the number, the more randomness will be injected into the response. <br><br>Details in the <a href=\"https://developers.openai.com/api/reference/resources/responses/methods/create\" target=\"_blank\">documentation</a>.",
+                  type = TemplateProperty.PropertyType.Number,
+                  feel = FeelMode.required,
+                  optional = true)
+              @Nullable Double temperature,
+          @DecimalMin("0.0")
+              @DecimalMax("1.0")
+              @TemplateProperty(
+                  group = "model-options",
+                  label = "top P",
+                  tooltip =
+                      "Recommended for advanced use cases only (you usually only need to use temperature). <br><br>Details in the <a href=\"https://developers.openai.com/api/reference/resources/responses/methods/create\" target=\"_blank\">documentation</a>.",
+                  type = TemplateProperty.PropertyType.Number,
+                  feel = FeelMode.required,
+                  optional = true)
+              @Nullable Double topP) {}
+    }
 
     @TemplateSubType(id = COMPLETIONS_ID, label = "Chat Completions")
     record OpenAiCompletionsApi(@Valid @Nullable CompletionsParameters completions)
@@ -134,70 +198,6 @@ public record OpenAiChatModelConfiguration(@Valid @NotNull OpenAiConnection open
                   label = "top P",
                   tooltip =
                       "Recommended for advanced use cases only (you usually only need to use temperature). <br><br>Details in the <a href=\"https://developers.openai.com/api/reference/resources/chat/subresources/completions/methods/create\" target=\"_blank\">documentation</a>.",
-                  type = TemplateProperty.PropertyType.Number,
-                  feel = FeelMode.required,
-                  optional = true)
-              @Nullable Double topP) {}
-    }
-
-    @TemplateSubType(id = RESPONSES_ID, label = "Responses")
-    record OpenAiResponsesApi(@Valid @Nullable ResponsesParameters responses) implements OpenAiApi {
-
-      @TemplateProperty(ignore = true)
-      public static final String RESPONSES_ID = "responses";
-
-      @Override
-      public String type() {
-        return RESPONSES_ID;
-      }
-
-      public record ResponsesParameters(
-          @Min(1)
-              @TemplateProperty(
-                  group = "model-options",
-                  label = "Max output tokens",
-                  tooltip =
-                      "The maximum number of tokens per request to generate before stopping. <br><br>Details in the <a href=\"https://developers.openai.com/api/reference/resources/responses/methods/create\" target=\"_blank\">documentation</a>.",
-                  type = TemplateProperty.PropertyType.Number,
-                  feel = FeelMode.required,
-                  optional = true)
-              @Nullable Integer maxOutputTokens,
-          @TemplateProperty(
-                  group = "model",
-                  label = "Effort",
-                  description = "Leave unset to use the model default.",
-                  tooltip =
-                      "Controls how many tokens the model spends when responding, trading thoroughness against speed and cost. Not supported on all models."
-                          + "<br><br>See the <a href=\"https://developers.openai.com/api/reference/resources/responses/methods/create\" target=\"_blank\">Responses API reference</a>.",
-                  type = TemplateProperty.PropertyType.Dropdown,
-                  choices = {
-                    @DropdownPropertyChoice(value = "minimal", label = "minimal"),
-                    @DropdownPropertyChoice(value = "low", label = "low"),
-                    @DropdownPropertyChoice(value = "medium", label = "medium"),
-                    @DropdownPropertyChoice(value = "high", label = "high"),
-                    @DropdownPropertyChoice(value = "xhigh", label = "xhigh"),
-                    @DropdownPropertyChoice(value = "max", label = "max")
-                  },
-                  optional = true)
-              @Nullable OpenAiEffort effort,
-          @DecimalMin("0.0")
-              @DecimalMax("2.0")
-              @TemplateProperty(
-                  group = "model-options",
-                  label = "Temperature",
-                  tooltip =
-                      "Floating point number between 0 and 2. The higher the number, the more randomness will be injected into the response. <br><br>Details in the <a href=\"https://developers.openai.com/api/reference/resources/responses/methods/create\" target=\"_blank\">documentation</a>.",
-                  type = TemplateProperty.PropertyType.Number,
-                  feel = FeelMode.required,
-                  optional = true)
-              @Nullable Double temperature,
-          @DecimalMin("0.0")
-              @DecimalMax("1.0")
-              @TemplateProperty(
-                  group = "model-options",
-                  label = "top P",
-                  tooltip =
-                      "Recommended for advanced use cases only (you usually only need to use temperature). <br><br>Details in the <a href=\"https://developers.openai.com/api/reference/resources/responses/methods/create\" target=\"_blank\">documentation</a>.",
                   type = TemplateProperty.PropertyType.Number,
                   feel = FeelMode.required,
                   optional = true)

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/v2/OpenAiChatModelConfiguration.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/v2/OpenAiChatModelConfiguration.java
@@ -100,12 +100,12 @@ public record OpenAiChatModelConfiguration(@Valid @NotNull OpenAiConnection open
           @TemplateProperty(
                   group = "model",
                   label = "Effort",
-                  description = "Leave unset to use the model default.",
                   tooltip =
                       "Controls how many tokens the model spends when responding, trading thoroughness against speed and cost. Not supported on all models."
                           + "<br><br>See the <a href=\"https://developers.openai.com/api/reference/resources/responses/methods/create\" target=\"_blank\">Responses API reference</a>.",
                   type = TemplateProperty.PropertyType.Dropdown,
                   choices = {
+                    @DropdownPropertyChoice(value = "modelDefault", label = "default"),
                     @DropdownPropertyChoice(value = "minimal", label = "minimal"),
                     @DropdownPropertyChoice(value = "low", label = "low"),
                     @DropdownPropertyChoice(value = "medium", label = "medium"),
@@ -113,7 +113,7 @@ public record OpenAiChatModelConfiguration(@Valid @NotNull OpenAiConnection open
                     @DropdownPropertyChoice(value = "xhigh", label = "xhigh"),
                     @DropdownPropertyChoice(value = "max", label = "max")
                   },
-                  optional = true)
+                  defaultValue = "modelDefault")
               @Nullable OpenAiEffort effort,
           @DecimalMin("0.0")
               @DecimalMax("2.0")
@@ -165,12 +165,12 @@ public record OpenAiChatModelConfiguration(@Valid @NotNull OpenAiConnection open
           @TemplateProperty(
                   group = "model",
                   label = "Effort",
-                  description = "Leave unset to use the model default.",
                   tooltip =
                       "Controls how many tokens the model spends when responding, trading thoroughness against speed and cost. Not supported on all models."
                           + "<br><br>See the <a href=\"https://developers.openai.com/api/reference/resources/chat/subresources/completions/methods/create\" target=\"_blank\">Chat Completions API reference</a>.",
                   type = TemplateProperty.PropertyType.Dropdown,
                   choices = {
+                    @DropdownPropertyChoice(value = "modelDefault", label = "default"),
                     @DropdownPropertyChoice(value = "minimal", label = "minimal"),
                     @DropdownPropertyChoice(value = "low", label = "low"),
                     @DropdownPropertyChoice(value = "medium", label = "medium"),
@@ -178,7 +178,7 @@ public record OpenAiChatModelConfiguration(@Valid @NotNull OpenAiConnection open
                     @DropdownPropertyChoice(value = "xhigh", label = "xhigh"),
                     @DropdownPropertyChoice(value = "max", label = "max")
                   },
-                  optional = true)
+                  defaultValue = "modelDefault")
               @Nullable OpenAiEffort effort,
           @DecimalMin("0.0")
               @DecimalMax("2.0")
@@ -207,6 +207,8 @@ public record OpenAiChatModelConfiguration(@Valid @NotNull OpenAiConnection open
 
   /** OpenAI effort levels, trading thoroughness against speed and cost. */
   public enum OpenAiEffort {
+    @JsonProperty("modelDefault")
+    MODEL_DEFAULT,
     @JsonProperty("minimal")
     MINIMAL,
     @JsonProperty("low")

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/anthropic/AnthropicMessageRequestConverterTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/anthropic/AnthropicMessageRequestConverterTest.java
@@ -601,6 +601,19 @@ class AnthropicMessageRequestConverterTest {
   }
 
   @Test
+  void modelDefaultThinkingModeEmitsNoThinkingParam() {
+    // The "default" dropdown choice binds to ThinkingMode.MODEL_DEFAULT rather than an unset
+    // value; applyThinking treats it the same as null.
+    final var parameters =
+        thinkingParams(new AnthropicThinking(ThinkingMode.MODEL_DEFAULT, null, null));
+    final var snapshot = new ConversationSnapshot(List.of(), List.of());
+
+    final var params = converter.toMessageCreateParams(model(parameters), null, snapshot);
+
+    assertThat(params.thinking()).isEmpty();
+  }
+
+  @Test
   void budgetTokensOnlyWithNullModeEmitsNoThinkingParam() {
     // {thinking:{budgetTokens:...}} with a null mode must still emit no thinking param (mode null
     // means unset, regardless of any other field being populated).
@@ -622,6 +635,19 @@ class AnthropicMessageRequestConverterTest {
 
     assertThatThrownBy(() -> converter.toMessageCreateParams(model(parameters), null, snapshot))
         .isInstanceOf(ConnectorException.class);
+  }
+
+  @Test
+  void modelDefaultEffortEmitsNoOutputConfig() {
+    // The "default" dropdown choice binds to AnthropicEffort.MODEL_DEFAULT rather than an unset
+    // value (see AnthropicChatModelConfiguration); it must still be treated as "don't send an
+    // effort" rather than being mapped onto the wire as the literal string "modelDefault".
+    final var parameters = effortParams(AnthropicEffort.MODEL_DEFAULT);
+    final var snapshot = new ConversationSnapshot(List.of(), List.of());
+
+    final var params = converter.toMessageCreateParams(model(parameters), null, snapshot);
+
+    assertThat(params.outputConfig()).isEmpty();
   }
 
   @Test

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/openai/family/completions/OpenAiCompletionsRequestConverterTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/openai/family/completions/OpenAiCompletionsRequestConverterTest.java
@@ -451,6 +451,22 @@ class OpenAiCompletionsRequestConverterTest {
   }
 
   @Test
+  void modelDefaultEffortOmitsReasoningEffort() {
+    // The "default" dropdown choice binds to OpenAiEffort.MODEL_DEFAULT rather than an unset
+    // value; it must still be treated as "don't send reasoning_effort".
+    final var snapshot = new ConversationSnapshot(List.of(), List.of());
+
+    final var params =
+        converter.toRequest(
+            model(new CompletionsParameters(null, OpenAiEffort.MODEL_DEFAULT, null, null)),
+            null,
+            snapshot);
+
+    assertThat(params.reasoningEffort()).isEmpty();
+    assertThat(requestBodyAsJson(params).has("reasoning_effort")).isFalse();
+  }
+
+  @Test
   void mapsEachEffortLevelToItsLowercaseWireValue() {
     final var snapshot = new ConversationSnapshot(List.of(), List.of());
 

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/openai/family/responses/OpenAiResponsesRequestConverterTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/openai/family/responses/OpenAiResponsesRequestConverterTest.java
@@ -608,6 +608,20 @@ class OpenAiResponsesRequestConverterTest {
         .contains(ResponseIncludable.REASONING_ENCRYPTED_CONTENT);
   }
 
+  @Test
+  void requestsEncryptedReasoningButOmitsEffortParamWhenModelDefault() {
+    // The "default" dropdown choice binds to OpenAiEffort.MODEL_DEFAULT rather than an unset
+    // value; it must still be treated as "don't send the effort dial".
+    final var parameters = new ResponsesParameters(null, OpenAiEffort.MODEL_DEFAULT, null, null);
+    final var snapshot = new ConversationSnapshot(List.of(), List.of());
+
+    final var params = converter.toRequest(model(parameters), null, snapshot);
+
+    assertThat(params.reasoning()).isEmpty();
+    assertThat(params.include().orElseThrow())
+        .contains(ResponseIncludable.REASONING_ENCRYPTED_CONTENT);
+  }
+
   /**
    * Regression test: {@code responses} itself (not just its fields) can be {@code null} - every one
    * of its fields is optional, so real job binding produces a {@code null} object, not one with

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/model/request/v2/AnthropicChatModelConfigurationTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/model/request/v2/AnthropicChatModelConfigurationTest.java
@@ -93,6 +93,37 @@ class AnthropicChatModelConfigurationTest {
   }
 
   @Test
+  void deserialisesModelDefaultEffortAndThinkingModeAndRoundTrips() throws Exception {
+    final String json =
+        """
+        {
+          "type": "anthropic",
+          "anthropic": {
+            "backend": { "type": "anthropic-api", "anthropic": { "apiKey": "sk-ant-123" } },
+            "model": {
+              "model": "claude-sonnet-4-6",
+              "parameters": {
+                "effort": "modelDefault",
+                "thinking": { "mode": "modelDefault" }
+              }
+            }
+          }
+        }
+        """;
+
+    final AnthropicChatModelConfiguration parsed =
+        (AnthropicChatModelConfiguration) mapper.readValue(json, ProviderConfiguration.class);
+
+    final AnthropicModelParameters parameters = parsed.anthropic().model().parameters();
+    assertThat(parameters).isNotNull();
+    assertThat(parameters.effort()).isEqualTo(AnthropicEffort.MODEL_DEFAULT);
+    assertThat(parameters.thinking().mode()).isEqualTo(ThinkingMode.MODEL_DEFAULT);
+
+    final String reserialised = mapper.writeValueAsString(parsed);
+    assertThat(mapper.readValue(reserialised, ProviderConfiguration.class)).isEqualTo(parsed);
+  }
+
+  @Test
   void deserialisesCustomBackendWithApiKeyAuthAndHeadersAndRoundTrips() throws Exception {
     final String json =
         """

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/model/request/v2/OpenAiChatModelConfigurationTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/model/request/v2/OpenAiChatModelConfigurationTest.java
@@ -258,6 +258,31 @@ class OpenAiChatModelConfigurationTest {
   }
 
   @Test
+  void deserialisesModelDefaultEffortForBothApiFamiliesAndRoundTrips() throws Exception {
+    final String json =
+        """
+        {
+          "type": "openai",
+          "openai": {
+            "api": { "type": "completions", "completions": { "effort": "modelDefault" } },
+            "backend": { "type": "openai-api", "openai": { "apiKey": "sk-test-123" } },
+            "model": { "model": "gpt-5.5" }
+          }
+        }
+        """;
+
+    final OpenAiChatModelConfiguration parsed =
+        (OpenAiChatModelConfiguration) mapper.readValue(json, ProviderConfiguration.class);
+
+    final CompletionsParameters parameters =
+        ((OpenAiCompletionsApi) parsed.openai().api()).completions();
+    assertThat(parameters.effort()).isEqualTo(OpenAiEffort.MODEL_DEFAULT);
+
+    final String reserialised = mapper.writeValueAsString(parsed);
+    assertThat(mapper.readValue(reserialised, ProviderConfiguration.class)).isEqualTo(parsed);
+  }
+
+  @Test
   void deserialisesCustomBackendWithApiKeyAuthAndHeadersAndRoundTrips() throws Exception {
     final String json =
         """
@@ -296,6 +321,7 @@ class OpenAiChatModelConfigurationTest {
   void effortValuesSerializeLowercase() throws Exception {
     for (final var entry :
         Map.of(
+                OpenAiEffort.MODEL_DEFAULT, "modelDefault",
                 OpenAiEffort.MINIMAL, "minimal",
                 OpenAiEffort.LOW, "low",
                 OpenAiEffort.MEDIUM, "medium",

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/model/request/v2/OpenAiChatModelConfigurationTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/model/request/v2/OpenAiChatModelConfigurationTest.java
@@ -258,7 +258,7 @@ class OpenAiChatModelConfigurationTest {
   }
 
   @Test
-  void deserialisesModelDefaultEffortForBothApiFamiliesAndRoundTrips() throws Exception {
+  void deserialisesModelDefaultEffortForCompletionsApiAndRoundTrips() throws Exception {
     final String json =
         """
         {


### PR DESCRIPTION
## Description

Align dropdown UX across the v2 agentic-ai provider configs: Anthropic and OpenAI's effort/thinking-mode dropdowns now use a labeled "default" choice instead of a blank entry with explanatory text, OpenAI's "Responses" API is listed first (it's already the default), and OpenAI's "Effort" field now shows after "Model" like it does for Anthropic/Bedrock.

## Related issues

closes #8429

## Checklist

- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest
  release, as this branch will be rebased onto main before the next release. Example backport labels:
    - `backport stable/8.8`: for changes that should be included in the next 8.8.x release.
    - **or** `backport release-8.8.7`: for changes that should be included in the specific release 8.8.7, and this
      *release has already been created*. The release branch will be merged back into stable/8.8 later, so the change
      will be included in future 8.8.x releases as well.
- [x] Tests/Integration tests for the changes have been added if applicable.
- [ ] If the change requires a documentation update, it has been added to the appropriate section in the documentation.
