### PR TITLE
fix(agentic-ai): deprecate the 8.10 v1 AI Agent element templates

### DIFF
--- a/connectors/agentic-ai/AGENTS.md
+++ b/connectors/agentic-ai/AGENTS.md
@@ -284,6 +284,19 @@ Maven property. Both scripts drop any incoming `zeebe:agentDefinition` before ad
 execution order does not matter — the sub-process transformer cannot carry the task marker into the
 derived template regardless of when the task-marker script runs.
 
+### Deprecation marker (v1 only)
+
+Only the v1 AI Agent Task and Sub-process templates whose minimum Camunda version is 8.10 carry a
+top-level `deprecated` block pointing modelers to the v2 template: the current main/hybrid templates
+(version 13) and their `versioned/` snapshots at versions 10–12. Earlier v1 versions (8.8/8.9-minimum,
+versions 0–7) do not carry it, and neither do v2 templates. For the generated main/hybrid templates,
+both transform scripts accept optional `deprecationMessage` / `deprecationDocumentationRef` Maven
+properties — wired only into the v1 executions in `pom.xml` — and each script strips any inherited
+`deprecated` block before deciding its own, the same pattern used for the agent definition marker
+above. `versioned/` snapshots
+are static and were patched by hand instead (three pre-8.10 snapshots already carried an unrelated
+legacy `"deprecated": true` boolean flag and were left untouched).
+
 ## Key entry points
 
 | File                                        | Purpose                                    |

--- a/connectors/agentic-ai/connector-agentic-ai/bin/transform-ai-agent-sub-process-template.groovy
+++ b/connectors/agentic-ai/connector-agentic-ai/bin/transform-ai-agent-sub-process-template.groovy
@@ -41,6 +41,10 @@ if (!connectorType) {
 // optional: agentType for the zeebe:agentDefinition marker; unset means no marker is added
 def agentType = binding.hasVariable('agentType') ? agentType : null
 
+// optional: mark the derived template as deprecated; unset means no "deprecated" block is added
+def deprecationMessage = binding.hasVariable('deprecationMessage') ? deprecationMessage : null
+def deprecationDocumentationRef = binding.hasVariable('deprecationDocumentationRef') ? deprecationDocumentationRef : null
+
 def file = new File((String) sourceFile)
 if (!file.exists()) {
     System.err.println("Error: Source file ${sourceFile} not found")
@@ -51,6 +55,24 @@ def mapper = new ObjectMapper()
 mapper.enable(SerializationFeature.INDENT_OUTPUT)
 
 def json = mapper.readValue(file, Map.class)
+
+// never carry over a "deprecated" block from the source template; this script decides
+// deprecation for the derived template on its own, via the properties above
+if (deprecationMessage) {
+    def orderedJson = new LinkedHashMap()
+    json.each { key, value ->
+        orderedJson.put(key, value)
+        if (key == "keywords") {
+            orderedJson.put("deprecated", [
+                message         : (String) deprecationMessage,
+                documentationRef: (String) deprecationDocumentationRef
+            ])
+        }
+    }
+    json = orderedJson
+} else {
+    json.remove("deprecated")
+}
 
 def isHybrid = json.id?.toString()?.contains("-hybrid")
 

--- a/connectors/agentic-ai/connector-agentic-ai/bin/transform-ai-agent-task-template.groovy
+++ b/connectors/agentic-ai/connector-agentic-ai/bin/transform-ai-agent-task-template.groovy
@@ -18,6 +18,10 @@ if (!outputFile) {
 // optional: agentType for the zeebe:agentDefinition marker; unset means no marker is added
 def agentType = binding.hasVariable('agentType') ? agentType : null
 
+// optional: mark the template as deprecated; unset means no "deprecated" block is added
+def deprecationMessage = binding.hasVariable('deprecationMessage') ? deprecationMessage : null
+def deprecationDocumentationRef = binding.hasVariable('deprecationDocumentationRef') ? deprecationDocumentationRef : null
+
 def file = new File((String) sourceFile)
 if (!file.exists()) {
     System.err.println("Error: Source file ${sourceFile} not found")
@@ -28,6 +32,23 @@ def mapper = new ObjectMapper()
 mapper.enable(SerializationFeature.INDENT_OUTPUT)
 
 def json = mapper.readValue(file, Map.class)
+
+if (deprecationMessage) {
+    def orderedJson = new LinkedHashMap()
+    json.each { key, value ->
+        orderedJson.put(key, value)
+        if (key == "keywords") {
+            orderedJson.put("deprecated", [
+                message         : (String) deprecationMessage,
+                documentationRef: (String) deprecationDocumentationRef
+            ])
+        }
+    }
+    json = orderedJson
+} else {
+    // never carry over a marker from the source template if this run doesn't want one
+    json.remove("deprecated")
+}
 
 def updatedProperties = []
 

--- a/connectors/agentic-ai/connector-agentic-ai/element-templates/README.md
+++ b/connectors/agentic-ai/connector-agentic-ai/element-templates/README.md
@@ -24,27 +24,30 @@ The AI Agent ships in two flavors that share the same versioning scheme.
 
 ### AI Agent Task
 
-The v2 template is a new, independently versioned connector type (`io.camunda.agenticai:aiagent:task:2`)
-running on the new chat-model provider SPI; it does not supersede the v1 template below.
+AI Agent Task (v2) is a new, independently versioned connector type (`io.camunda.agenticai:aiagent:task:2`)
+running on the new chat-model provider SPI, not a new template version of AI Agent Task (v1). As of
+Camunda 8.10, AI Agent Task (v1) is deprecated in favor of (v2).
 
-| Connector         | Minimum Camunda version | Template version | File |
+| Connector                      | Minimum Camunda version | Template version | File |
 | --- | --- | --- | --- |
-| AI Agent Task v2  | 8.10 | 1  | [`agenticai-ai-agent-task.v2.json`](./agenticai-ai-agent-task.v2.json) |
-| AI Agent Task     | 8.10 | 13 | [`agenticai-aiagent-outbound-connector.json`](./agenticai-aiagent-outbound-connector.json) |
-| AI Agent Task     | 8.9  | 7  | [`versioned/agenticai-aiagent-outbound-connector-7.json`](./versioned/agenticai-aiagent-outbound-connector-7.json) |
-| AI Agent Task     | 8.8  | 5  | [`versioned/agenticai-aiagent-outbound-connector-5.json`](./versioned/agenticai-aiagent-outbound-connector-5.json) |
+| AI Agent Task (v2)             | 8.10 | 1  | [`agenticai-ai-agent-task.v2.json`](./agenticai-ai-agent-task.v2.json) |
+| AI Agent Task (v1, deprecated) | 8.10 | 13 | [`agenticai-aiagent-outbound-connector.json`](./agenticai-aiagent-outbound-connector.json) |
+| AI Agent Task (v1)             | 8.9  | 7  | [`versioned/agenticai-aiagent-outbound-connector-7.json`](./versioned/agenticai-aiagent-outbound-connector-7.json) |
+| AI Agent Task (v1)             | 8.8  | 5  | [`versioned/agenticai-aiagent-outbound-connector-5.json`](./versioned/agenticai-aiagent-outbound-connector-5.json) |
 
 ### AI Agent Sub-process
 
-The v2 template is a new, independently versioned connector type (`io.camunda.agenticai:aiagent:subprocess:2`)
-running on the new chat-model provider SPI; it does not supersede the v1 template below.
+AI Agent Sub-process (v2) is a new, independently versioned connector type
+(`io.camunda.agenticai:aiagent:subprocess:2`) running on the new chat-model provider SPI, not a new
+template version of AI Agent Sub-process (v1). As of Camunda 8.10, AI Agent Sub-process (v1) is
+deprecated in favor of (v2).
 
-| Connector                | Minimum Camunda version | Template version | File |
+| Connector                             | Minimum Camunda version | Template version | File |
 | --- | --- | --- | --- |
-| AI Agent Sub-process v2  | 8.10 | 1  | [`agenticai-ai-agent-subprocess.v2.json`](./agenticai-ai-agent-subprocess.v2.json) |
-| AI Agent Sub-process     | 8.10 | 13 | [`agenticai-aiagent-job-worker.json`](./agenticai-aiagent-job-worker.json) |
-| AI Agent Sub-process     | 8.9  | 7  | [`versioned/agenticai-aiagent-job-worker-7.json`](./versioned/agenticai-aiagent-job-worker-7.json) |
-| AI Agent Sub-process     | 8.8  | 5  | [`versioned/agenticai-aiagent-job-worker-5.json`](./versioned/agenticai-aiagent-job-worker-5.json) |
+| AI Agent Sub-process (v2)             | 8.10 | 1  | [`agenticai-ai-agent-subprocess.v2.json`](./agenticai-ai-agent-subprocess.v2.json) |
+| AI Agent Sub-process (v1, deprecated) | 8.10 | 13 | [`agenticai-aiagent-job-worker.json`](./agenticai-aiagent-job-worker.json) |
+| AI Agent Sub-process (v1)             | 8.9  | 7  | [`versioned/agenticai-aiagent-job-worker-7.json`](./versioned/agenticai-aiagent-job-worker-7.json) |
+| AI Agent Sub-process (v1)             | 8.8  | 5  | [`versioned/agenticai-aiagent-job-worker-5.json`](./versioned/agenticai-aiagent-job-worker-5.json) |
 
 ## MCP Client connectors
 

--- a/connectors/agentic-ai/connector-agentic-ai/element-templates/agenticai-aiagent-job-worker.json
+++ b/connectors/agentic-ai/connector-agentic-ai/element-templates/agenticai-aiagent-job-worker.json
@@ -4,6 +4,10 @@
   "id" : "io.camunda.connectors.agenticai.aiagent.jobworker.v1",
   "description" : "Run a multi-step AI reasoning loop with dynamic tool selection",
   "keywords" : [ "AI", "AI Agent", "agentic orchestration" ],
+  "deprecated" : {
+    "message" : "For Camunda 8.10+, please replace with the v2 version of the AI Agent element template. See documentation for details.",
+    "documentationRef" : "https://docs.camunda.io/docs/8.10/reference/announcements-release-notes/8100/8100-announcements/#agentic-orchestration"
+  },
   "documentationRef" : "https://docs.camunda.io/docs/8.10/components/connectors/out-of-the-box-connectors/agentic-ai-aiagent-subprocess/",
   "version" : 13,
   "category" : {

--- a/connectors/agentic-ai/connector-agentic-ai/element-templates/agenticai-aiagent-outbound-connector.json
+++ b/connectors/agentic-ai/connector-agentic-ai/element-templates/agenticai-aiagent-outbound-connector.json
@@ -4,6 +4,10 @@
   "id" : "io.camunda.connectors.agenticai.aiagent.v1",
   "description" : "Execute a single AI-powered action with tool calling capabilities",
   "keywords" : [ "AI", "AI Agent", "agentic orchestration" ],
+  "deprecated" : {
+    "message" : "For Camunda 8.10+, please replace with the v2 version of the AI Agent element template. See documentation for details.",
+    "documentationRef" : "https://docs.camunda.io/docs/8.10/reference/announcements-release-notes/8100/8100-announcements/#agentic-orchestration"
+  },
   "documentationRef" : "https://docs.camunda.io/docs/8.10/components/connectors/out-of-the-box-connectors/agentic-ai-aiagent-task/",
   "version" : 13,
   "category" : {

--- a/connectors/agentic-ai/connector-agentic-ai/element-templates/hybrid/agenticai-aiagent-job-worker-hybrid.json
+++ b/connectors/agentic-ai/connector-agentic-ai/element-templates/hybrid/agenticai-aiagent-job-worker-hybrid.json
@@ -4,6 +4,10 @@
   "id" : "io.camunda.connectors.agenticai.aiagent.jobworker.v1-hybrid",
   "description" : "Run a multi-step AI reasoning loop with dynamic tool selection",
   "keywords" : [ "AI", "AI Agent", "agentic orchestration" ],
+  "deprecated" : {
+    "message" : "For Camunda 8.10+, please replace with the v2 version of the AI Agent element template. See documentation for details.",
+    "documentationRef" : "https://docs.camunda.io/docs/8.10/reference/announcements-release-notes/8100/8100-announcements/#agentic-orchestration"
+  },
   "documentationRef" : "https://docs.camunda.io/docs/8.10/components/connectors/out-of-the-box-connectors/agentic-ai-aiagent-subprocess/",
   "version" : 13,
   "category" : {

--- a/connectors/agentic-ai/connector-agentic-ai/element-templates/hybrid/agenticai-aiagent-outbound-connector-hybrid.json
+++ b/connectors/agentic-ai/connector-agentic-ai/element-templates/hybrid/agenticai-aiagent-outbound-connector-hybrid.json
@@ -4,6 +4,10 @@
   "id" : "io.camunda.connectors.agenticai.aiagent.v1-hybrid",
   "description" : "Execute a single AI-powered action with tool calling capabilities",
   "keywords" : [ "AI", "AI Agent", "agentic orchestration" ],
+  "deprecated" : {
+    "message" : "For Camunda 8.10+, please replace with the v2 version of the AI Agent element template. See documentation for details.",
+    "documentationRef" : "https://docs.camunda.io/docs/8.10/reference/announcements-release-notes/8100/8100-announcements/#agentic-orchestration"
+  },
   "documentationRef" : "https://docs.camunda.io/docs/8.10/components/connectors/out-of-the-box-connectors/agentic-ai-aiagent-task/",
   "version" : 13,
   "category" : {

--- a/connectors/agentic-ai/connector-agentic-ai/element-templates/versioned/agenticai-aiagent-job-worker-10.json
+++ b/connectors/agentic-ai/connector-agentic-ai/element-templates/versioned/agenticai-aiagent-job-worker-10.json
@@ -4,6 +4,10 @@
   "id" : "io.camunda.connectors.agenticai.aiagent.jobworker.v1",
   "description" : "Run a multi-step AI reasoning loop with dynamic tool selection",
   "keywords" : [ "AI", "AI Agent", "agentic orchestration" ],
+  "deprecated" : {
+    "message" : "For Camunda 8.10+, please replace with the v2 version of the AI Agent element template. See documentation for details.",
+    "documentationRef" : "https://docs.camunda.io/docs/8.10/reference/announcements-release-notes/8100/8100-announcements/#agentic-orchestration"
+  },
   "documentationRef" : "https://docs.camunda.io/docs/8.10/components/connectors/out-of-the-box-connectors/agentic-ai-aiagent-subprocess/",
   "version" : 10,
   "category" : {

--- a/connectors/agentic-ai/connector-agentic-ai/element-templates/versioned/agenticai-aiagent-job-worker-11.json
+++ b/connectors/agentic-ai/connector-agentic-ai/element-templates/versioned/agenticai-aiagent-job-worker-11.json
@@ -4,6 +4,10 @@
   "id" : "io.camunda.connectors.agenticai.aiagent.jobworker.v1",
   "description" : "Run a multi-step AI reasoning loop with dynamic tool selection",
   "keywords" : [ "AI", "AI Agent", "agentic orchestration" ],
+  "deprecated" : {
+    "message" : "For Camunda 8.10+, please replace with the v2 version of the AI Agent element template. See documentation for details.",
+    "documentationRef" : "https://docs.camunda.io/docs/8.10/reference/announcements-release-notes/8100/8100-announcements/#agentic-orchestration"
+  },
   "documentationRef" : "https://docs.camunda.io/docs/8.10/components/connectors/out-of-the-box-connectors/agentic-ai-aiagent-subprocess/",
   "version" : 11,
   "category" : {

--- a/connectors/agentic-ai/connector-agentic-ai/element-templates/versioned/agenticai-aiagent-job-worker-12.json
+++ b/connectors/agentic-ai/connector-agentic-ai/element-templates/versioned/agenticai-aiagent-job-worker-12.json
@@ -4,6 +4,10 @@
   "id" : "io.camunda.connectors.agenticai.aiagent.jobworker.v1",
   "description" : "Run a multi-step AI reasoning loop with dynamic tool selection",
   "keywords" : [ "AI", "AI Agent", "agentic orchestration" ],
+  "deprecated" : {
+    "message" : "For Camunda 8.10+, please replace with the v2 version of the AI Agent element template. See documentation for details.",
+    "documentationRef" : "https://docs.camunda.io/docs/8.10/reference/announcements-release-notes/8100/8100-announcements/#agentic-orchestration"
+  },
   "documentationRef" : "https://docs.camunda.io/docs/8.10/components/connectors/out-of-the-box-connectors/agentic-ai-aiagent-subprocess/",
   "version" : 12,
   "category" : {

--- a/connectors/agentic-ai/connector-agentic-ai/element-templates/versioned/agenticai-aiagent-outbound-connector-10.json
+++ b/connectors/agentic-ai/connector-agentic-ai/element-templates/versioned/agenticai-aiagent-outbound-connector-10.json
@@ -4,6 +4,10 @@
   "id" : "io.camunda.connectors.agenticai.aiagent.v1",
   "description" : "Execute a single AI-powered action with tool calling capabilities",
   "keywords" : [ "AI", "AI Agent", "agentic orchestration" ],
+  "deprecated" : {
+    "message" : "For Camunda 8.10+, please replace with the v2 version of the AI Agent element template. See documentation for details.",
+    "documentationRef" : "https://docs.camunda.io/docs/8.10/reference/announcements-release-notes/8100/8100-announcements/#agentic-orchestration"
+  },
   "documentationRef" : "https://docs.camunda.io/docs/8.10/components/connectors/out-of-the-box-connectors/agentic-ai-aiagent-task/",
   "version" : 10,
   "category" : {

--- a/connectors/agentic-ai/connector-agentic-ai/element-templates/versioned/agenticai-aiagent-outbound-connector-11.json
+++ b/connectors/agentic-ai/connector-agentic-ai/element-templates/versioned/agenticai-aiagent-outbound-connector-11.json
@@ -4,6 +4,10 @@
   "id" : "io.camunda.connectors.agenticai.aiagent.v1",
   "description" : "Execute a single AI-powered action with tool calling capabilities",
   "keywords" : [ "AI", "AI Agent", "agentic orchestration" ],
+  "deprecated" : {
+    "message" : "For Camunda 8.10+, please replace with the v2 version of the AI Agent element template. See documentation for details.",
+    "documentationRef" : "https://docs.camunda.io/docs/8.10/reference/announcements-release-notes/8100/8100-announcements/#agentic-orchestration"
+  },
   "documentationRef" : "https://docs.camunda.io/docs/8.10/components/connectors/out-of-the-box-connectors/agentic-ai-aiagent-task/",
   "version" : 11,
   "category" : {

--- a/connectors/agentic-ai/connector-agentic-ai/element-templates/versioned/agenticai-aiagent-outbound-connector-12.json
+++ b/connectors/agentic-ai/connector-agentic-ai/element-templates/versioned/agenticai-aiagent-outbound-connector-12.json
@@ -4,6 +4,10 @@
   "id" : "io.camunda.connectors.agenticai.aiagent.v1",
   "description" : "Execute a single AI-powered action with tool calling capabilities",
   "keywords" : [ "AI", "AI Agent", "agentic orchestration" ],
+  "deprecated" : {
+    "message" : "For Camunda 8.10+, please replace with the v2 version of the AI Agent element template. See documentation for details.",
+    "documentationRef" : "https://docs.camunda.io/docs/8.10/reference/announcements-release-notes/8100/8100-announcements/#agentic-orchestration"
+  },
   "documentationRef" : "https://docs.camunda.io/docs/8.10/components/connectors/out-of-the-box-connectors/agentic-ai-aiagent-task/",
   "version" : 12,
   "category" : {

--- a/connectors/agentic-ai/connector-agentic-ai/pom.xml
+++ b/connectors/agentic-ai/connector-agentic-ai/pom.xml
@@ -664,6 +664,14 @@
                   <name>agentType</name>
                   <value>aiAgentSubProcess</value>
                 </property>
+                <property>
+                  <name>deprecationMessage</name>
+                  <value>For Camunda 8.10+, please replace with the v2 version of the AI Agent element template. See documentation for details.</value>
+                </property>
+                <property>
+                  <name>deprecationDocumentationRef</name>
+                  <value>https://docs.camunda.io/docs/8.10/reference/announcements-release-notes/8100/8100-announcements/#agentic-orchestration</value>
+                </property>
               </properties>
             </configuration>
           </execution>
@@ -702,6 +710,14 @@
                   <name>agentType</name>
                   <value>aiAgentSubProcess</value>
                 </property>
+                <property>
+                  <name>deprecationMessage</name>
+                  <value>For Camunda 8.10+, please replace with the v2 version of the AI Agent element template. See documentation for details.</value>
+                </property>
+                <property>
+                  <name>deprecationDocumentationRef</name>
+                  <value>https://docs.camunda.io/docs/8.10/reference/announcements-release-notes/8100/8100-announcements/#agentic-orchestration</value>
+                </property>
               </properties>
             </configuration>
           </execution>
@@ -727,6 +743,14 @@
                 <property>
                   <name>agentType</name>
                   <value>aiAgentTask</value>
+                </property>
+                <property>
+                  <name>deprecationMessage</name>
+                  <value>For Camunda 8.10+, please replace with the v2 version of the AI Agent element template. See documentation for details.</value>
+                </property>
+                <property>
+                  <name>deprecationDocumentationRef</name>
+                  <value>https://docs.camunda.io/docs/8.10/reference/announcements-release-notes/8100/8100-announcements/#agentic-orchestration</value>
                 </property>
               </properties>
             </configuration>
@@ -757,6 +781,14 @@
                 <property>
                   <name>agentType</name>
                   <value>aiAgentTask</value>
+                </property>
+                <property>
+                  <name>deprecationMessage</name>
+                  <value>For Camunda 8.10+, please replace with the v2 version of the AI Agent element template. See documentation for details.</value>
+                </property>
+                <property>
+                  <name>deprecationDocumentationRef</name>
+                  <value>https://docs.camunda.io/docs/8.10/reference/announcements-release-notes/8100/8100-announcements/#agentic-orchestration</value>
                 </property>
               </properties>
             </configuration>


### PR DESCRIPTION
## Description

Marks the v1 AI Agent Task and Sub-process element templates as deprecated in favor of v2, for their 8.10-minimum releases only (main/hybrid templates and versioned/ snapshots 10-12). Earlier 8.8/8.9-minimum v1 releases are unaffected.

Versioned snapshots are patched directly; the generated main/hybrid templates get the block through new optional Maven properties on the existing transform groovy scripts, wired only into the v1 executions, so it survives regeneration.

Stacked ahead of #8416 (LangChain4j removal): the deprecation notice should ship before v1's implementation is removed.

## Related issues

closes #8411

## Checklist

- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest
  release, as this branch will be rebased onto main before the next release. Example backport labels:
    - `backport stable/8.8`: for changes that should be included in the next 8.8.x release.
    - **or** `backport release-8.8.7`: for changes that should be included in the specific release 8.8.7, and this
      *release has already been created*. The release branch will be merged back into stable/8.8 later, so the change
      will be included in future 8.8.x releases as well.
- [x] Tests/Integration tests for the changes have been added if applicable. (existing element-template regression tests cover it; no new test needed for metadata-only change)
- [x] If the change requires a documentation update, it has been added to the appropriate section in the documentation.