### PR TITLE
chore(agentic-ai): publish v2 AI agent connector element templates

### DIFF
--- a/ignore-templates.json
+++ b/ignore-templates.json
@@ -2,7 +2,5 @@
   "io.camunda.connector.IdpClassificationOutBoundTemplate.v1",
   "io.camunda.connector.IdpExtractionOutBoundTemplate.v1",
   "io.camunda.connector.IdpStructuredExtractionOutBoundTemplate.v1",
-  "io.camunda.connector.IdpUnstructuredExtractionOutBoundTemplate.v1",
-  "io.camunda.connectors.agenticai.ai-agent-task.v2",
-  "io.camunda.connectors.agenticai.ai-agent-subprocess.v2"
+  "io.camunda.connector.IdpUnstructuredExtractionOutBoundTemplate.v1"
 ]


### PR DESCRIPTION
## Description

Unignores the v2 AI agent connector element templates so they get published.
Removes `io.camunda.connectors.agenticai.ai-agent-task.v2` and
`io.camunda.connectors.agenticai.ai-agent-subprocess.v2` from `ignore-templates.json`,
the uniquet ignore list. Both v2 templates are now included in the generated
single-file element templates.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #

## Checklist

- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest
  release, as this branch will be rebased onto main before the next release. Example backport labels:
    - `backport stable/8.8`: for changes that should be included in the next 8.8.x release.
    - **or** `backport release-8.8.7`: for changes that should be included in the specific release 8.8.7, and this
      *release has already been created*. The release branch will be merged back into stable/8.8 later, so the change
      will be included in future 8.8.x releases as well.
- [ ] Tests/Integration tests for the changes have been added if applicable.
- [ ] If the change requires a documentation update, it has been added to the appropriate section in the documentation.
