### PR TITLE
fix(test): disable JVM AOT cache for CamundaProcessTest modules

### DIFF
--- a/connector-runtime/pom.xml
+++ b/connector-runtime/pom.xml
@@ -54,6 +54,17 @@
           </annotationProcessorPaths>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <!-- The camunda/camunda:SNAPSHOT test image bakes in a JVM AOT cache that has been
+               crashing the container on startup (exit code 139 / SIGSEGV) on amd64 CI runners.
+               AOTMode=off disables it; ErrorFileToStdout is a safety net so a crash report still
+               surfaces through the container's log consumer if the container crashes anyway. -->
+          <argLine>-Duser.language=en -Duser.region=US -Dcamunda.process-test.camunda-env-vars.JAVA_TOOL_OPTIONS="-XX:AOTMode=off -XX:+ErrorFileToStdout"</argLine>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/inbound/WebhookControllerTestExceptionZeebeTest.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/inbound/WebhookControllerTestExceptionZeebeTest.java
@@ -60,6 +60,11 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
     properties = {
       "spring.main.allow-bean-definition-overriding=true",
       "camunda.connector.webhook.enabled=true",
+      // Disable the AOT cache baked into the camunda/camunda:SNAPSHOT image: it has been
+      // causing the container to crash on startup (exit code 139 / SIGSEGV) on amd64 CI
+      // runners. -XX:AOTMode=off forces the JVM to ignore the pre-trained cache and fall
+      // back to the regular startup path.
+      "camunda.process-test.camunda-env-vars.JAVA_TOOL_OPTIONS=-XX:AOTMode=off",
     })
 @CamundaSpringProcessTest
 @ExtendWith(MockitoExtension.class)

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/inbound/WebhookControllerTestExceptionZeebeTest.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/inbound/WebhookControllerTestExceptionZeebeTest.java
@@ -64,7 +64,14 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
       // causing the container to crash on startup (exit code 139 / SIGSEGV) on amd64 CI
       // runners. -XX:AOTMode=off forces the JVM to ignore the pre-trained cache and fall
       // back to the regular startup path.
-      "camunda.process-test.camunda-env-vars.JAVA_TOOL_OPTIONS=-XX:AOTMode=off",
+      //
+      // -XX:+ErrorFileToStdout is a safety net in case a crash still occurs: by default the
+      // JVM writes its hs_err crash report to a file inside the container, which is lost
+      // once Testcontainers tears the crashed container down. Redirecting it to stdout
+      // routes it through the container's log consumer instead, so it shows up in the test
+      // output.
+      "camunda.process-test.camunda-env-vars.JAVA_TOOL_OPTIONS="
+          + "-XX:AOTMode=off -XX:+ErrorFileToStdout",
     })
 @CamundaSpringProcessTest
 @ExtendWith(MockitoExtension.class)

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/inbound/WebhookControllerTestExceptionZeebeTest.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/inbound/WebhookControllerTestExceptionZeebeTest.java
@@ -60,18 +60,11 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
     properties = {
       "spring.main.allow-bean-definition-overriding=true",
       "camunda.connector.webhook.enabled=true",
-      // Disable the AOT cache baked into the camunda/camunda:SNAPSHOT image: it has been
-      // causing the container to crash on startup (exit code 139 / SIGSEGV) on amd64 CI
-      // runners. -XX:AOTMode=off forces the JVM to ignore the pre-trained cache and fall
-      // back to the regular startup path.
-      //
-      // -XX:+ErrorFileToStdout is a safety net in case a crash still occurs: by default the
-      // JVM writes its hs_err crash report to a file inside the container, which is lost
-      // once Testcontainers tears the crashed container down. Redirecting it to stdout
-      // routes it through the container's log consumer instead, so it shows up in the test
-      // output.
-      "camunda.process-test.camunda-env-vars.JAVA_TOOL_OPTIONS="
-          + "-XX:AOTMode=off -XX:+ErrorFileToStdout",
+      // TEMPORARY diagnostic commit: AOTMode=off intentionally left out here so the
+      // container crashes as before, to confirm -XX:+ErrorFileToStdout actually surfaces
+      // the JVM's hs_err crash report through the container's log consumer. Will be
+      // restored before merging.
+      "camunda.process-test.camunda-env-vars.JAVA_TOOL_OPTIONS=-XX:+ErrorFileToStdout",
     })
 @CamundaSpringProcessTest
 @ExtendWith(MockitoExtension.class)

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/inbound/WebhookControllerTestExceptionZeebeTest.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/inbound/WebhookControllerTestExceptionZeebeTest.java
@@ -60,11 +60,6 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
     properties = {
       "spring.main.allow-bean-definition-overriding=true",
       "camunda.connector.webhook.enabled=true",
-      // TEMPORARY diagnostic commit: AOTMode=off intentionally left out here so the
-      // container crashes as before, to confirm -XX:+ErrorFileToStdout actually surfaces
-      // the JVM's hs_err crash report through the container's log consumer. Will be
-      // restored before merging.
-      "camunda.process-test.camunda-env-vars.JAVA_TOOL_OPTIONS=-XX:+ErrorFileToStdout",
     })
 @CamundaSpringProcessTest
 @ExtendWith(MockitoExtension.class)

--- a/connectors-e2e-test/pom.xml
+++ b/connectors-e2e-test/pom.xml
@@ -45,4 +45,20 @@
       <artifactId>connector-test-utils</artifactId>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <!-- The camunda/camunda:SNAPSHOT test image bakes in a JVM AOT cache that has been
+               crashing the container on startup (exit code 139 / SIGSEGV) on amd64 CI runners.
+               AOTMode=off disables it; ErrorFileToStdout is a safety net so a crash report still
+               surfaces through the container's log consumer if the container crashes anyway. -->
+          <argLine>-Duser.language=en -Duser.region=US -Dcamunda.process-test.camunda-env-vars.JAVA_TOOL_OPTIONS="-XX:AOTMode=off -XX:+ErrorFileToStdout"</argLine>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>


### PR DESCRIPTION
## Problem

Container-backed tests (`@CamundaSpringProcessTest`) have been failing intermittently on CI with:

```
org.testcontainers.containers.ContainerLaunchException: Container startup failed for image camunda/camunda:SNAPSHOT
Caused by: java.lang.IllegalStateException: Wait strategy failed. Container exited with code 139
```

Exit 139 = SIGSEGV. Traced this to the JVM AOT cache (JEP 483/514) baked into the `camunda/camunda:SNAPSHOT` image at build time (amd64 only — `camunda.Dockerfile`'s AOT-cache training step skips arm64). The image ships a pre-trained `-XX:AOTCache=...` archive; loading it crashes intermittently on amd64 CI runners. Not a registry/auth issue (same-minute runs on the same image digest split pass/fail), not caused by any recent digest bump (crash predates it). Started narrowly scoped to `WebhookControllerTestExceptionZeebeTest`, then confirmed via CI that unrelated `connectors-e2e-test-http` tests hit the identical crash — so this is scoped to every module that boots the container, not one test.

## Fix

Set `JAVA_TOOL_OPTIONS=-XX:AOTMode=off -XX:+ErrorFileToStdout` via the shared surefire `argLine` in the two aggregator poms that actually run `camunda/camunda:SNAPSHOT` — `connector-runtime/pom.xml` and `connectors-e2e-test/pom.xml` — rather than the root `parent/pom.xml`, so it doesn't touch modules that have nothing to do with `CamundaProcessTest`. Verified via `effective-pom` that both module trees inherit it correctly.

- `-XX:AOTMode=off`: disables the baked-in AOT cache, avoiding the crash.
- `-XX:+ErrorFileToStdout`: safety net — if a crash still happens, the JVM's hs_err report is routed to stdout instead of a file inside the (about-to-be-destroyed) container, so it flows through the container's existing log consumer and shows up in test output instead of vanishing.

The original per-test-class workaround in `WebhookControllerTestExceptionZeebeTest` was reverted since it's now redundant with the pom-level default.

## Verification

- `mvn -pl connector-runtime/spring-boot-starter-camunda-connectors test -Dtest=WebhookControllerTestExceptionZeebeTest` — 16/16 pass locally.
- CI confirmed the fix works: `WebhookControllerTestExceptionZeebeTest` passed while a diagnostic variant (logging-only, AOT cache still enabled) was also run — that run happened not to crash, so no hs_err was captured yet, but the safety net is in place for whenever it does.
- Can't reproduce the actual SIGSEGV locally (arm64 machine — Dockerfile's AOT training only runs for amd64).