### PR TITLE
fix: send cluster and physical tenant identity from the App Integrations connector

### DIFF
--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/outbound/ActivatedJobContext.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/outbound/ActivatedJobContext.java
@@ -87,6 +87,11 @@ public class ActivatedJobContext implements JobContext {
   }
 
   @Override
+  public String getPhysicalTenantId() {
+    return activatedJob.getPhysicalTenantId();
+  }
+
+  @Override
   public String getLeaseToken() {
     return activatedJob.getLeaseToken();
   }

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/outbound/ActivatedJobContext.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/outbound/ActivatedJobContext.java
@@ -88,7 +88,10 @@ public class ActivatedJobContext implements JobContext {
 
   @Override
   public String getPhysicalTenantId() {
-    return activatedJob.getPhysicalTenantId();
+    // clients report an unset physical tenant as an empty string (protobuf/REST default); normalize
+    // it the same way SecretContext does, so callers only have to check for null
+    var physicalTenantId = activatedJob.getPhysicalTenantId();
+    return physicalTenantId == null || physicalTenantId.isBlank() ? null : physicalTenantId;
   }
 
   @Override

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/outbound/ActivatedJobContextTest.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/outbound/ActivatedJobContextTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.runtime.core.outbound;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import io.camunda.client.api.response.ActivatedJob;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ActivatedJobContextTest {
+
+  @Mock private ActivatedJob activatedJob;
+
+  private ActivatedJobContext context() {
+    return new ActivatedJobContext(activatedJob, () -> "{}");
+  }
+
+  @Test
+  void physicalTenantId_isTakenFromTheJob() {
+    when(activatedJob.getPhysicalTenantId()).thenReturn("engine-1");
+
+    assertThat(context().getPhysicalTenantId()).isEqualTo("engine-1");
+  }
+
+  @Test
+  void physicalTenantId_isNullWhenTheJobReportsNone() {
+    // clusters that predate multi-engine support report an empty physical tenant
+    when(activatedJob.getPhysicalTenantId()).thenReturn("");
+
+    assertThat(context().getPhysicalTenantId()).isNull();
+  }
+}

--- a/connector-runtime/connector-runtime-test/src/main/java/io/camunda/connector/runtime/test/outbound/TestJobContext.java
+++ b/connector-runtime/connector-runtime-test/src/main/java/io/camunda/connector/runtime/test/outbound/TestJobContext.java
@@ -37,6 +37,8 @@ public class TestJobContext implements JobContext {
 
   private String tenantId;
 
+  private String physicalTenantId;
+
   private String leaseToken;
 
   public TestJobContext(Supplier<Map<String, String>> headers, Supplier<String> variables) {
@@ -133,6 +135,15 @@ public class TestJobContext implements JobContext {
 
   public void setTenantId(String tenantId) {
     this.tenantId = tenantId;
+  }
+
+  @Override
+  public String getPhysicalTenantId() {
+    return physicalTenantId;
+  }
+
+  public void setPhysicalTenantId(String physicalTenantId) {
+    this.physicalTenantId = physicalTenantId;
   }
 
   @Override

--- a/connector-runtime/connector-runtime-test/src/test/java/io/camunda/connector/runtime/test/outbound/TestJobContextTest.java
+++ b/connector-runtime/connector-runtime-test/src/test/java/io/camunda/connector/runtime/test/outbound/TestJobContextTest.java
@@ -38,4 +38,20 @@ class TestJobContextTest {
 
     assertThat(jobContext.getLeaseToken()).isEqualTo("lease-token-1");
   }
+
+  @Test
+  void getPhysicalTenantId_returnsNullByDefault() {
+    var jobContext = new TestJobContext(Map::of, () -> "{}");
+
+    assertThat(jobContext.getPhysicalTenantId()).isNull();
+  }
+
+  @Test
+  void getPhysicalTenantId_returnsValueSetBySetter() {
+    var jobContext = new TestJobContext(Map::of, () -> "{}");
+
+    jobContext.setPhysicalTenantId("engine-1");
+
+    assertThat(jobContext.getPhysicalTenantId()).isEqualTo("engine-1");
+  }
 }

--- a/connector-sdk/core/src/main/java/io/camunda/connector/api/outbound/JobContext.java
+++ b/connector-sdk/core/src/main/java/io/camunda/connector/api/outbound/JobContext.java
@@ -64,6 +64,15 @@ public interface JobContext {
   String getTenantId();
 
   /**
+   * The physical tenant — the orchestration cluster (engine) the job was activated from — or {@code
+   * null} when the job carries none. Distinct from {@link #getTenantId()}, which identifies a
+   * logical tenant within a single cluster.
+   */
+  default String getPhysicalTenantId() {
+    return null;
+  }
+
+  /**
    * The lease token identifying this job's activation, or {@code null} if the job was activated
    * without a lease. Pass it along when making requests that should be fenced against a stale,
    * superseded activation of this same job.

--- a/connectors/app-integrations/README.md
+++ b/connectors/app-integrations/README.md
@@ -32,18 +32,44 @@ template. Nothing about the connection is part of the process model.
 | `APP_INTEGRATIONS_OAUTH_AUDIENCE` | no | Target API identifier. |
 | `APP_INTEGRATIONS_OAUTH_SCOPES` | no | |
 | `APP_INTEGRATIONS_OAUTH_CLIENT_AUTHENTICATION` | no | `credentialsBody` (default) or `basicAuthHeader` — the literals `OAuthService` switches on. |
+| `APP_INTEGRATIONS_CLUSTER_ID` | for OAuth | The orchestration cluster's **UUID**, as configured in the App Integrations backend (`clusters[].uuid`). Not a cluster name. Sent in the `X-Cluster-Id` header. |
 
 The mechanism is selected per runtime, not per element:
 
 1. If the OAuth token endpoint, client ID and client secret are all set → **OAuth 2.0 client
    credentials**. The token is fetched, cached, and attached by the connector SDK's HTTP client; on
    a `401` the cached token is invalidated and the request is retried once with a fresh token.
+   `APP_INTEGRATIONS_CLUSTER_ID` is required too, see below.
 2. Otherwise, if `APP_INTEGRATIONS_API_KEY` is set → **API key**.
 3. Otherwise the connector is not configured — see below.
 
-Blank values count as absent. When running in SaaS, the `X-Org-Id` and `X-Cluster-Id` headers are
-added automatically from the runtime environment so the backend can attribute the call to the
-originating cluster.
+Blank values count as absent.
+
+### Cluster and tenant identification
+
+The backend has to know which cluster a call comes from. It reads the `X-Cluster-Id` header first
+and only falls back to the API key, which is per-cluster or per-tenant. Under OAuth there is no such
+fallback, so a runtime that sends no cluster id is rejected.
+
+The connector therefore sends `X-Cluster-Id` on every runtime, taking it from
+`APP_INTEGRATIONS_CLUSTER_ID` and falling back to `CAMUNDA_CLIENT_CLOUD_CLUSTERID`, which SaaS
+injects on its own. Set `APP_INTEGRATIONS_CLUSTER_ID` in Self-Managed. It is required under OAuth,
+where a missing value raises `APP_INTEGRATIONS_NOT_CONFIGURED` before any HTTP call, and optional
+under API key auth, where the backend recovers the cluster from the key.
+
+`X-Org-Id` is sent only in SaaS, from the runtime environment. Self-Managed has no organization to
+configure and the backend substitutes its own.
+
+`X-Physical-Tenant-Id` carries the job's physical tenant, meaning the orchestration cluster (engine)
+the job was activated from, so a runtime serving several engines routes to the right Teams or Slack
+installation. The connector reads it off the job rather than from the environment, and omits the
+header when the job carries none, leaving the backend to apply its own `default`. The value must
+match a `clusters[].physicalTenants[].id` in the backend configuration, or the literal `default`;
+anything else is rejected. This is the runtime's existing `camunda.clients.<name>.physical-tenant-id`
+configuration and needs nothing App-Integrations-specific.
+
+Do not confuse the physical tenant with the logical (multi-tenancy) tenant. The logical tenant is
+not part of this contract and is never sent.
 
 ### When the connector is not configured
 

--- a/connectors/app-integrations/src/main/java/io/camunda/connector/appintegrations/AppIntegrationsConnector.java
+++ b/connectors/app-integrations/src/main/java/io/camunda/connector/appintegrations/AppIntegrationsConnector.java
@@ -118,7 +118,10 @@ public class AppIntegrationsConnector implements OutboundConnectorProvider {
     }
 
     return executor.sendMessage(
-        request, formResourceKey, context.getJobContext().getBpmnProcessId());
+        request,
+        formResourceKey,
+        context.getJobContext().getBpmnProcessId(),
+        context.getJobContext().getPhysicalTenantId());
   }
 
   @Operation(
@@ -133,9 +136,10 @@ public class AppIntegrationsConnector implements OutboundConnectorProvider {
         "slack channel",
         "open channel"
       })
-  public CreateChannelResult createChannel(@Variable CreateChannelRequest request) {
+  public CreateChannelResult createChannel(
+      @Variable CreateChannelRequest request, OutboundConnectorContext context) {
     LOGGER.debug("Creating {} channel via App Integrations connector", request.platform());
-    return executor.createChannel(request);
+    return executor.createChannel(request, context.getJobContext().getPhysicalTenantId());
   }
 
   /**

--- a/connectors/app-integrations/src/main/java/io/camunda/connector/appintegrations/AppIntegrationsExecutor.java
+++ b/connectors/app-integrations/src/main/java/io/camunda/connector/appintegrations/AppIntegrationsExecutor.java
@@ -64,10 +64,12 @@ class AppIntegrationsExecutor {
 
   private static final String SAAS_ENV_VAR = "CAMUNDA_CONNECTOR_RUNTIME_SAAS";
   private static final String ORG_ID_ENV_VAR = "CAMUNDA_CONNECTOR_CLOUD_ORGANIZATION_ID";
-  private static final String CLUSTER_ID_ENV_VAR = "CAMUNDA_CLIENT_CLOUD_CLUSTERID";
+  private static final String CLUSTER_ID_ENV_VAR = "APP_INTEGRATIONS_CLUSTER_ID";
+  private static final String CLUSTER_ID_CLOUD_ENV_VAR = "CAMUNDA_CLIENT_CLOUD_CLUSTERID";
 
   private static final String ORG_ID_HEADER = "X-Org-Id";
   private static final String CLUSTER_ID_HEADER = "X-Cluster-Id";
+  private static final String PHYSICAL_TENANT_HEADER = "X-Physical-Tenant-Id";
   private static final String API_KEY_HEADER = "X-API-KEY";
 
   private static final String BASE_URL_ENV_VAR = "APP_INTEGRATIONS_BASE_URL";
@@ -95,15 +97,23 @@ class AppIntegrationsExecutor {
   }
 
   SendMessageResult sendMessage(
-      SendMessageRequest request, String formResourceKey, String processDefinitionId) {
+      SendMessageRequest request,
+      String formResourceKey,
+      String processDefinitionId,
+      String physicalTenantId) {
     return post(
         SEND_MESSAGE_PATH,
         messagePayload(request, formResourceKey, processDefinitionId),
-        SendMessageResult.class);
+        SendMessageResult.class,
+        physicalTenantId);
   }
 
-  CreateChannelResult createChannel(CreateChannelRequest request) {
-    return post(CREATE_CHANNEL_PATH, createChannelPayload(request), CreateChannelResult.class);
+  CreateChannelResult createChannel(CreateChannelRequest request, String physicalTenantId) {
+    return post(
+        CREATE_CHANNEL_PATH,
+        createChannelPayload(request),
+        CreateChannelResult.class,
+        physicalTenantId);
   }
 
   /**
@@ -276,18 +286,18 @@ class AppIntegrationsExecutor {
    * stale or revoked: it is invalidated and the call is retried once with a freshly fetched token.
    * Any other failure — or a second {@code 401} on the retry — propagates to the caller.
    */
-  private <T> T post(String path, Object payload, Class<T> resultType) {
+  private <T> T post(String path, Object payload, Class<T> resultType, String physicalTenantId) {
     var config = resolveConfig();
     var body = serialize(payload);
 
     HttpResponse<String> response;
     try {
-      response = send(config, path, body);
+      response = send(config, path, body, physicalTenantId);
     } catch (ConnectorException e) {
       if ("401".equals(e.getErrorCode()) && config.oauth() != null) {
         LOGGER.debug("Received 401 from {}; invalidating OAuth token and retrying", path);
         OAuthTokenCacheHolder.get().invalidate(config.oauth());
-        response = send(config, path, body);
+        response = send(config, path, body, physicalTenantId);
       } else {
         throw e;
       }
@@ -301,6 +311,11 @@ class AppIntegrationsExecutor {
    * Resolves the backend URL and credentials from the environment. OAuth wins when fully configured
    * (this is what SaaS injects); otherwise an API key is used. With neither, the connector is not
    * usable on this runtime and the job fails without retrying — see {@link #notConfigured}.
+   *
+   * <p>OAuth additionally requires a cluster id: the backend resolves the calling cluster from the
+   * {@code X-Cluster-Id} header, and only recovers it from the credential on the API-key path.
+   * Without one, an OAuth-authenticated call is rejected with an opaque {@code 400}, so it is
+   * caught here instead.
    */
   private EffectiveConfig resolveConfig() {
     var baseUrl = env(BASE_URL_ENV_VAR);
@@ -312,6 +327,9 @@ class AppIntegrationsExecutor {
     var clientId = env(OAUTH_CLIENT_ID_ENV_VAR);
     var clientSecret = env(OAUTH_CLIENT_SECRET_ENV_VAR);
     if (tokenEndpoint != null && clientId != null && clientSecret != null) {
+      if (clusterId() == null) {
+        throw notConfigured("set " + CLUSTER_ID_ENV_VAR);
+      }
       var clientAuthentication = env(OAUTH_CLIENT_AUTHENTICATION_ENV_VAR);
       return new EffectiveConfig(
           baseUrl,
@@ -379,6 +397,21 @@ class AppIntegrationsExecutor {
     return value == null || value.isBlank() ? null : value;
   }
 
+  /**
+   * Reads a context-identification variable. Beyond {@link #env}, an unset value can reach the
+   * runtime rendered as the literal string {@code "null"}.
+   */
+  private String contextEnv(String name) {
+    var value = env(name);
+    return "null".equals(value) ? null : value;
+  }
+
+  /** The Self-Managed variable wins over the one SaaS injects. */
+  private String clusterId() {
+    var clusterId = contextEnv(CLUSTER_ID_ENV_VAR);
+    return clusterId != null ? clusterId : contextEnv(CLUSTER_ID_CLOUD_ENV_VAR);
+  }
+
   private boolean isSaaS() {
     return getenv.apply(SAAS_ENV_VAR) != null;
   }
@@ -405,13 +438,14 @@ class AppIntegrationsExecutor {
     }
   }
 
-  private HttpResponse<String> send(EffectiveConfig config, String path, String body) {
+  private HttpResponse<String> send(
+      EffectiveConfig config, String path, String body, String physicalTenantId) {
     var headers = new HashMap<String, String>();
     headers.put("Content-Type", "application/json");
     if (config.apiKey() != null) {
       headers.put(API_KEY_HEADER, config.apiKey());
     }
-    applyContextHeaders(headers);
+    applyContextHeaders(headers, physicalTenantId);
 
     var request = new HttpClientRequest();
     request.setMethod(HttpMethod.POST);
@@ -430,22 +464,28 @@ class AppIntegrationsExecutor {
   }
 
   /**
-   * Attaches the SaaS context-identification headers ({@code X-Org-Id}, {@code X-Cluster-Id}) when
-   * running in SaaS and the corresponding values are available, so the backend can attribute the
-   * call to the originating organization/cluster. A runtime without them is a valid Self-Managed
-   * runtime, so these are not part of the not-configured check.
+   * Attaches the context-identification headers so the backend can attribute the call to the
+   * originating cluster, organization and orchestration cluster (engine).
+   *
+   * <p>{@code X-Cluster-Id} travels on every runtime: the backend resolves the cluster header-first
+   * and only falls back to the API key, so Self-Managed OAuth deployments have to send it too.
+   * {@code X-Org-Id} stays SaaS-only — Self-Managed has no organization to configure and the
+   * backend substitutes its own. {@code X-Physical-Tenant-Id} is omitted when the job carries no
+   * physical tenant, leaving the backend to apply its own default.
    */
-  private void applyContextHeaders(Map<String, String> headers) {
-    if (!isSaaS()) {
-      return;
-    }
-    var orgId = getenv.apply(ORG_ID_ENV_VAR);
-    var clusterId = getenv.apply(CLUSTER_ID_ENV_VAR);
-    if (orgId != null && !orgId.isBlank() && !"null".equals(orgId)) {
-      headers.put(ORG_ID_HEADER, orgId);
-    }
-    if (clusterId != null && !clusterId.isBlank()) {
+  private void applyContextHeaders(Map<String, String> headers, String physicalTenantId) {
+    var clusterId = clusterId();
+    if (clusterId != null) {
       headers.put(CLUSTER_ID_HEADER, clusterId);
+    }
+    if (isSaaS()) {
+      var orgId = contextEnv(ORG_ID_ENV_VAR);
+      if (orgId != null) {
+        headers.put(ORG_ID_HEADER, orgId);
+      }
+    }
+    if (physicalTenantId != null && !physicalTenantId.isBlank()) {
+      headers.put(PHYSICAL_TENANT_HEADER, physicalTenantId);
     }
   }
 

--- a/connectors/app-integrations/src/test/java/io/camunda/connector/appintegrations/AppIntegrationsConnectorTest.java
+++ b/connectors/app-integrations/src/test/java/io/camunda/connector/appintegrations/AppIntegrationsConnectorTest.java
@@ -76,7 +76,8 @@ class AppIntegrationsConnectorTest {
           "APP_INTEGRATIONS_OAUTH_TOKEN_ENDPOINT", TOKEN_ENDPOINT,
           "APP_INTEGRATIONS_OAUTH_CLIENT_ID", "client-id",
           "APP_INTEGRATIONS_OAUTH_CLIENT_SECRET", "client-secret",
-          "APP_INTEGRATIONS_OAUTH_AUDIENCE", "app-integrations");
+          "APP_INTEGRATIONS_OAUTH_AUDIENCE", "app-integrations",
+          "APP_INTEGRATIONS_CLUSTER_ID", "cluster-789");
 
   private static final ObjectMapper MAPPER = new ObjectMapper();
 
@@ -795,7 +796,8 @@ class AppIntegrationsConnectorTest {
         .when(httpClient)
         .execute(any(HttpClientRequest.class), any());
 
-    var result = connector.createChannel(teamsChannel("b7779302-e8cb-4b34-901b-5b150a19fd47"));
+    var result =
+        connector.createChannel(teamsChannel("b7779302-e8cb-4b34-901b-5b150a19fd47"), context);
 
     assertThat(result).isInstanceOf(CreateChannelResult.class);
     assertThat(result.channelId()).isEqualTo("19:new-channel@thread.tacv2");
@@ -818,7 +820,8 @@ class AppIntegrationsConnectorTest {
 
     connector.createChannel(
         teamsChannel(
-            "https://teams.cloud.microsoft/l/team/19%3Axxx?groupId=b7779302-e8cb-4b34-901b-5b150a19fd47&tenantId=abc"));
+            "https://teams.cloud.microsoft/l/team/19%3Axxx?groupId=b7779302-e8cb-4b34-901b-5b150a19fd47&tenantId=abc"),
+        context);
 
     assertThat(captureBody()).contains("\"teamId\":\"b7779302-e8cb-4b34-901b-5b150a19fd47\"");
   }
@@ -831,7 +834,8 @@ class AppIntegrationsConnectorTest {
 
     connector.createChannel(
         new CreateChannelRequest(
-            new ChannelPlatform.TeamsChannelPlatform("My Channel", "group-1", null), null));
+            new ChannelPlatform.TeamsChannelPlatform("My Channel", "group-1", null), null),
+        context);
 
     assertThat(captureBody()).contains("\"membershipType\":\"standard\"");
   }
@@ -846,7 +850,8 @@ class AppIntegrationsConnectorTest {
         connector.createChannel(
             new CreateChannelRequest(
                 new ChannelPlatform.SlackChannelPlatform("releases", "T0123", true),
-                "Automated releases"));
+                "Automated releases"),
+            context);
 
     assertThat(result.channelId()).isEqualTo("C0999");
     var body = captureBody();
@@ -903,7 +908,7 @@ class AppIntegrationsConnectorTest {
         .execute(any(HttpClientRequest.class), any());
 
     var request = teamsChannel("group-1");
-    assertThatThrownBy(() -> connector.createChannel(request))
+    assertThatThrownBy(() -> connector.createChannel(request, context))
         .isInstanceOfSatisfying(
             ConnectorException.class, e -> assertThat(e.getErrorCode()).isEqualTo("500"));
   }
@@ -985,7 +990,7 @@ class AppIntegrationsConnectorTest {
     void createChannel_isGatedTheSameWay() {
       var noEnv = connectorWith(Map.of());
       assertNotConfigured(
-          () -> noEnv.createChannel(teamsChannel("group-1")), "APP_INTEGRATIONS_BASE_URL");
+          () -> noEnv.createChannel(teamsChannel("group-1"), context), "APP_INTEGRATIONS_BASE_URL");
     }
   }
 }

--- a/connectors/app-integrations/src/test/java/io/camunda/connector/appintegrations/AppIntegrationsConnectorWireMockTest.java
+++ b/connectors/app-integrations/src/test/java/io/camunda/connector/appintegrations/AppIntegrationsConnectorWireMockTest.java
@@ -60,12 +60,14 @@ class AppIntegrationsConnectorWireMockTest {
   private static final String CHANNEL_PATH = "/api/connector/channel";
   private static final String MESSAGE_PATH = "/api/connector/message";
   private static final String TOKEN_PATH = "/oauth/token";
+  private static final String CLUSTER_ID = "cluster-789";
+  private static final String CLOUD_CLUSTER_ID = "cluster-456";
 
   private final OutboundConnectorContext context = mock(OutboundConnectorContext.class);
+  private final JobContext jobContext = mock(JobContext.class);
 
   @BeforeEach
   void setUpContext() {
-    var jobContext = mock(JobContext.class);
     when(context.getJobContext()).thenReturn(jobContext);
     when(jobContext.getCustomHeaders()).thenReturn(Map.of());
     when(jobContext.getBpmnProcessId()).thenReturn("order-process");
@@ -95,9 +97,15 @@ class AppIntegrationsConnectorWireMockTest {
   }
 
   private static AppIntegrationsConnector oauthConnector(WireMockRuntimeInfo wm) {
-    return connectorWith(oauthEnv(wm));
+    var env = new HashMap<>(oauthEnv(wm));
+    env.put("APP_INTEGRATIONS_CLUSTER_ID", CLUSTER_ID);
+    return connectorWith(env);
   }
 
+  /**
+   * The OAuth credentials alone. The cluster id is deliberately left out, because SaaS and
+   * Self-Managed supply it through different variables.
+   */
   private static Map<String, String> oauthEnv(WireMockRuntimeInfo wm) {
     return Map.of(
         "APP_INTEGRATIONS_BASE_URL", wm.getHttpBaseUrl(),
@@ -111,7 +119,7 @@ class AppIntegrationsConnectorWireMockTest {
     var env = new HashMap<>(oauthEnv(wm));
     env.put("CAMUNDA_CONNECTOR_RUNTIME_SAAS", "true");
     env.put("CAMUNDA_CONNECTOR_CLOUD_ORGANIZATION_ID", orgId);
-    env.put("CAMUNDA_CLIENT_CLOUD_CLUSTERID", "cluster-456");
+    env.put("CAMUNDA_CLIENT_CLOUD_CLUSTERID", CLOUD_CLUSTER_ID);
     return connectorWith(env);
   }
 
@@ -130,13 +138,33 @@ class AppIntegrationsConnectorWireMockTest {
                     "{\"access_token\":\"tok\",\"expires_in\":3600,\"token_type\":\"Bearer\"}")));
   }
 
-  @Test
-  void createChannel_realClient_success(WireMockRuntimeInfo wm) {
+  private static void stubChannel() {
     stubFor(
         post(urlPathEqualTo(CHANNEL_PATH))
             .willReturn(okJson("{\"channelId\":\"19:new-channel@thread.tacv2\"}").withStatus(201)));
+  }
 
-    var result = apiKeyConnector(wm).createChannel(channelRequest());
+  private static void stubMessage() {
+    stubFor(
+        post(urlPathEqualTo(MESSAGE_PATH))
+            .willReturn(
+                okJson(
+                        "{\"deliveries\":[{\"platform\":\"teams\",\"conversation\":\"conv-1\",\"messageId\":\"m-1\"}],\"failures\":[]}")
+                    .withStatus(201)));
+  }
+
+  private static SendMessageRequest messageRequest() {
+    return new SendMessageRequest(
+        new Recipient.CamundaRecipient(
+            "user@example.com", null, null, new AdditionalContent.None()),
+        "Please approve");
+  }
+
+  @Test
+  void createChannel_realClient_success(WireMockRuntimeInfo wm) {
+    stubChannel();
+
+    var result = apiKeyConnector(wm).createChannel(channelRequest(), context);
 
     assertThat(result.channelId()).isEqualTo("19:new-channel@thread.tacv2");
   }
@@ -151,7 +179,7 @@ class AppIntegrationsConnectorWireMockTest {
 
     var connector = apiKeyConnector(wm);
 
-    assertThatThrownBy(() -> connector.createChannel(channelRequest()))
+    assertThatThrownBy(() -> connector.createChannel(channelRequest(), context))
         .isInstanceOfSatisfying(
             ConnectorException.class, e -> assertThat(e.getErrorCode()).isEqualTo("500"));
   }
@@ -172,7 +200,7 @@ class AppIntegrationsConnectorWireMockTest {
             .whenScenarioStateIs("retried")
             .willReturn(okJson("{\"channelId\":\"19:after-retry@thread.tacv2\"}").withStatus(201)));
 
-    var result = oauthConnector(wm).createChannel(channelRequest());
+    var result = oauthConnector(wm).createChannel(channelRequest(), context);
 
     assertThat(result.channelId()).isEqualTo("19:after-retry@thread.tacv2");
     // The backend was called twice (the 401, then the successful retry) and the token was
@@ -313,14 +341,14 @@ class AppIntegrationsConnectorWireMockTest {
         post(urlPathEqualTo(CHANNEL_PATH))
             .willReturn(okJson("{\"channelId\":\"19:saas@thread.tacv2\"}").withStatus(201)));
 
-    var result = saasConnector(wm, "org-123").createChannel(channelRequest());
+    var result = saasConnector(wm, "org-123").createChannel(channelRequest(), context);
 
     assertThat(result.channelId()).isEqualTo("19:saas@thread.tacv2");
     verify(postRequestedFor(urlPathEqualTo(TOKEN_PATH)));
     verify(
         postRequestedFor(urlPathEqualTo(CHANNEL_PATH))
             .withHeader("X-Org-Id", equalTo("org-123"))
-            .withHeader("X-Cluster-Id", equalTo("cluster-456")));
+            .withHeader("X-Cluster-Id", equalTo(CLOUD_CLUSTER_ID)));
   }
 
   @Test
@@ -330,8 +358,131 @@ class AppIntegrationsConnectorWireMockTest {
         post(urlPathEqualTo(CHANNEL_PATH))
             .willReturn(okJson("{\"channelId\":\"19:saas@thread.tacv2\"}").withStatus(201)));
 
-    saasConnector(wm, "null").createChannel(channelRequest());
+    saasConnector(wm, "null").createChannel(channelRequest(), context);
 
     verify(postRequestedFor(urlPathEqualTo(CHANNEL_PATH)).withHeader("X-Org-Id", absent()));
+  }
+
+  // --- context identification headers ---
+
+  @Test
+  void selfManagedOAuth_sendsClusterIdAndNoOrgId(WireMockRuntimeInfo wm) {
+    stubToken();
+    stubChannel();
+
+    oauthConnector(wm).createChannel(channelRequest(), context);
+
+    verify(
+        postRequestedFor(urlPathEqualTo(CHANNEL_PATH))
+            .withHeader("X-Cluster-Id", equalTo(CLUSTER_ID))
+            .withHeader("X-Org-Id", absent()));
+  }
+
+  @Test
+  void appIntegrationsClusterId_winsOverTheCloudOne(WireMockRuntimeInfo wm) {
+    stubToken();
+    stubChannel();
+
+    var env = new HashMap<>(oauthEnv(wm));
+    env.put("CAMUNDA_CLIENT_CLOUD_CLUSTERID", CLOUD_CLUSTER_ID);
+    env.put("APP_INTEGRATIONS_CLUSTER_ID", CLUSTER_ID);
+
+    connectorWith(env).createChannel(channelRequest(), context);
+
+    verify(
+        postRequestedFor(urlPathEqualTo(CHANNEL_PATH))
+            .withHeader("X-Cluster-Id", equalTo(CLUSTER_ID)));
+  }
+
+  @Test
+  void oauthWithoutAnyClusterId_failsWithoutCallingTheBackend(WireMockRuntimeInfo wm) {
+    stubToken();
+    stubChannel();
+
+    var connector = connectorWith(oauthEnv(wm));
+
+    assertThatThrownBy(() -> connector.createChannel(channelRequest(), context))
+        .isInstanceOfSatisfying(
+            ConnectorException.class,
+            e -> {
+              assertThat(e.getErrorCode())
+                  .isEqualTo(AppIntegrationsExecutor.NOT_CONFIGURED_ERROR_CODE);
+              assertThat(e.getMessage()).contains("APP_INTEGRATIONS_CLUSTER_ID");
+            });
+    verify(exactly(0), postRequestedFor(urlPathEqualTo(CHANNEL_PATH)));
+  }
+
+  @Test
+  void apiKeyWithoutClusterId_stillCallsTheBackend(WireMockRuntimeInfo wm) {
+    // The backend recovers the cluster from the API key itself, so it stays optional on this path.
+    stubChannel();
+
+    apiKeyConnector(wm).createChannel(channelRequest(), context);
+
+    verify(postRequestedFor(urlPathEqualTo(CHANNEL_PATH)).withHeader("X-Cluster-Id", absent()));
+  }
+
+  @Test
+  void physicalTenantOnTheJob_isSentAsHeader(WireMockRuntimeInfo wm) {
+    when(jobContext.getPhysicalTenantId()).thenReturn("tenanta");
+    stubMessage();
+
+    apiKeyConnector(wm).sendMessage(messageRequest(), context);
+
+    verify(
+        postRequestedFor(urlPathEqualTo(MESSAGE_PATH))
+            .withHeader("X-Physical-Tenant-Id", equalTo("tenanta")));
+  }
+
+  @Test
+  void defaultPhysicalTenant_isSentVerbatim(WireMockRuntimeInfo wm) {
+    // "default" is the broker's canonical physical tenant and the backend accepts it literally, so
+    // there is nothing to strip.
+    when(jobContext.getPhysicalTenantId()).thenReturn("default");
+    stubMessage();
+
+    apiKeyConnector(wm).sendMessage(messageRequest(), context);
+
+    verify(
+        postRequestedFor(urlPathEqualTo(MESSAGE_PATH))
+            .withHeader("X-Physical-Tenant-Id", equalTo("default")));
+  }
+
+  @Test
+  void noPhysicalTenantOnTheJob_omitsTheHeader(WireMockRuntimeInfo wm) {
+    when(jobContext.getPhysicalTenantId()).thenReturn(null);
+    stubMessage();
+
+    apiKeyConnector(wm).sendMessage(messageRequest(), context);
+
+    verify(
+        postRequestedFor(urlPathEqualTo(MESSAGE_PATH))
+            .withHeader("X-Physical-Tenant-Id", absent()));
+  }
+
+  @Test
+  void logicalTenant_isNeverSentAsThePhysicalTenant(WireMockRuntimeInfo wm) {
+    // The two are different concepts, and the backend rejects the logical default "<default>".
+    when(jobContext.getTenantId()).thenReturn("<default>");
+    when(jobContext.getPhysicalTenantId()).thenReturn(null);
+    stubMessage();
+
+    apiKeyConnector(wm).sendMessage(messageRequest(), context);
+
+    verify(
+        postRequestedFor(urlPathEqualTo(MESSAGE_PATH))
+            .withHeader("X-Physical-Tenant-Id", absent()));
+  }
+
+  @Test
+  void createChannel_propagatesThePhysicalTenant(WireMockRuntimeInfo wm) {
+    when(jobContext.getPhysicalTenantId()).thenReturn("tenantb");
+    stubChannel();
+
+    apiKeyConnector(wm).createChannel(channelRequest(), context);
+
+    verify(
+        postRequestedFor(urlPathEqualTo(CHANNEL_PATH))
+            .withHeader("X-Physical-Tenant-Id", equalTo("tenantb")));
   }
 }


### PR DESCRIPTION
## Description

Two Self-Managed defects in the App Integrations connector. Neither shows up on SaaS.

**OAuth never worked on Self-Managed.** The connector sent its cluster id only when running on the
SaaS runtime. The App Integrations backend reads that cluster id first and can otherwise only
recover the cluster from an API key, so it rejected every OAuth-authenticated call from a
Self-Managed runtime. The connector now sends the cluster id from every runtime, read from a new
`APP_INTEGRATIONS_CLUSTER_ID` variable holding the cluster's UUID as configured in the App
Integrations backend. SaaS keeps using the value it already injects, so nothing changes there.
API-key deployments are unaffected, because the backend recovers the cluster from the key.

If OAuth is configured and no cluster id is set, the job now fails right away with a message naming
the missing variable. Before, the backend returned an error that said nothing about the cause.

**Every message went to the default tenant.** The connector never told the backend which
orchestration cluster a job came from. A deployment serving several orchestration clusters through
one Connectors runtime therefore sent every message to the default tenant's Teams or Slack
installation. The connector now sends the job's orchestration cluster. Connectors could not read
that value before, so this adds it to the SDK as well, which existing connectors can ignore.

One behaviour change to note. The backend now rejects a job whose orchestration cluster has no
matching entry in the App Integrations configuration. Such a job used to reach the default tenant
instead. Rejecting it is the correct outcome, since the silent misrouting was the bug, but the
backend configuration and the runtime's orchestration cluster names now have to match. Deployments
using a single orchestration cluster are unaffected.

## Related issues

None.

## Checklist

- [x] Backport labels are added if these code changes should be backported. Not needed. The App
  Integrations connector first ships in 8.10 and has not been released, so no Self-Managed
  deployment runs the broken code.
- [x] Tests/Integration tests for the changes have been added if applicable.
- [x] If the change requires a documentation update, it has been added to the appropriate section in
  the documentation. The connector's README covers the new variable and the identification headers.
  The Self-Managed tab of the App Integrations page in `camunda/camunda-docs` is a separate
  follow-up, since it lives in another repository.
