### PR TITLE
fix: bump httpclient5 to 5.6.4

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -141,7 +141,7 @@ limitations under the License.</license.inlineheader>
 
     <version.httpcore>4.4.16</version.httpcore>
     <version.httpcore5>5.4.3</version.httpcore5>
-    <version.httpclient5>5.6.3</version.httpclient5>
+    <version.httpclient5>5.6.4</version.httpclient5>
     <version.httpclient>4.5.14</version.httpclient>
     <version.pdfbox>3.0.8</version.pdfbox>
     <version.collections4>4.5.0</version.collections4>


### PR DESCRIPTION
## Summary

Bumps `org.apache.httpcomponents.client5:httpclient5` from `5.6.3` to `5.6.4`.

Security fix. Details in the internal tracking issue: camunda/team-connectors#1263
