### PR TITLE
fix(agentic-ai): restore legacy HTTP+SSE MCP transport

### DIFF
--- a/connectors/agentic-ai/pom.xml
+++ b/connectors/agentic-ai/pom.xml
@@ -93,9 +93,14 @@
       <groupId>dev.langchain4j</groupId>
       <artifactId>langchain4j</artifactId>
     </dependency>
+    <!-- Pinned to the last release that ships HttpMcpTransport (legacy HTTP+SSE, MCP 2024-11-05).
+         langchain4j 1.19.0 removed it; StreamableHttpMcpTransport is not wire-compatible with
+         legacy-SSE MCP servers. Temporary until langchain4j-mcp is replaced by the official MCP SDK
+         (see #8456). Do not bump without restoring SSE support. -->
     <dependency>
       <groupId>dev.langchain4j</groupId>
       <artifactId>langchain4j-mcp</artifactId>
+      <version>1.18.1-beta28</version>
     </dependency>
     <dependency>
       <groupId>dev.langchain4j</groupId>

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/mcp/client/framework/langchain4j/Langchain4JMcpClientFactory.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/mcp/client/framework/langchain4j/Langchain4JMcpClientFactory.java
@@ -9,7 +9,7 @@ package io.camunda.connector.agenticai.mcp.client.framework.langchain4j;
 import dev.langchain4j.mcp.client.DefaultMcpClient;
 import dev.langchain4j.mcp.client.McpClient;
 import dev.langchain4j.mcp.client.transport.McpTransport;
-import dev.langchain4j.mcp.client.transport.http.StreamableHttpMcpTransport;
+import dev.langchain4j.mcp.client.transport.http.HttpMcpTransport;
 import dev.langchain4j.mcp.client.transport.stdio.StdioMcpTransport;
 import io.camunda.connector.agenticai.mcp.client.McpClientFactory;
 import io.camunda.connector.agenticai.mcp.client.configuration.McpClientConfigurationProperties;
@@ -46,8 +46,8 @@ public class Langchain4JMcpClientFactory implements McpClientFactory<McpClient> 
             .build();
       }
       case McpClientConfigurationProperties.SseHttpMcpClientTransportConfiguration http ->
-          new StreamableHttpMcpTransport.Builder()
-              .url(http.url())
+          new HttpMcpTransport.Builder()
+              .sseUrl(http.url())
               .timeout(http.timeout())
               .logRequests(http.logRequests())
               .logResponses(http.logResponses())

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/mcp/client/framework/langchain4j/Langchain4JMcpClientFactory.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/mcp/client/framework/langchain4j/Langchain4JMcpClientFactory.java
@@ -23,32 +23,13 @@ public class Langchain4JMcpClientFactory implements McpClientFactory<McpClient> 
   public McpClient createClient(String clientId, McpClientConfiguration config) {
     final var transportConfig = config.stdio() != null ? config.stdio() : config.sse();
     final var transport = createTransport(transportConfig);
-    final var builder =
-        new DefaultMcpClient.Builder()
-            .key(clientId)
-            .transport(transport)
-            .protocolVersion(protocolVersion(transportConfig));
+    final var builder = new DefaultMcpClient.Builder().key(clientId).transport(transport);
 
     Optional.ofNullable(config.initializationTimeout()).map(builder::initializationTimeout);
     Optional.ofNullable(config.toolExecutionTimeout()).map(builder::toolExecutionTimeout);
     Optional.ofNullable(config.reconnectInterval()).map(builder::reconnectInterval);
 
     return builder.build();
-  }
-
-  /**
-   * HttpMcpTransport implements the legacy HTTP+SSE transport (MCP protocol revision 2024-11-05).
-   * DefaultMcpClient otherwise advertises a much newer default revision, which legacy SSE servers
-   * reject/ignore, stalling initialization. Pin the negotiated revision for the SSE transport;
-   * stdio keeps the client default (null -> builder default).
-   */
-  private String protocolVersion(
-      McpClientConfigurationProperties.McpClientTransportConfiguration transportConfig) {
-    return switch (transportConfig) {
-      case McpClientConfigurationProperties.SseHttpMcpClientTransportConfiguration sse ->
-          "2024-11-05";
-      default -> null;
-    };
   }
 
   private McpTransport createTransport(

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/mcp/client/framework/langchain4j/Langchain4JMcpClientFactory.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/mcp/client/framework/langchain4j/Langchain4JMcpClientFactory.java
@@ -21,14 +21,34 @@ public class Langchain4JMcpClientFactory implements McpClientFactory<McpClient> 
 
   @Override
   public McpClient createClient(String clientId, McpClientConfiguration config) {
-    final var transport = createTransport(config.stdio() != null ? config.stdio() : config.sse());
-    final var builder = new DefaultMcpClient.Builder().key(clientId).transport(transport);
+    final var transportConfig = config.stdio() != null ? config.stdio() : config.sse();
+    final var transport = createTransport(transportConfig);
+    final var builder =
+        new DefaultMcpClient.Builder()
+            .key(clientId)
+            .transport(transport)
+            .protocolVersion(protocolVersion(transportConfig));
 
     Optional.ofNullable(config.initializationTimeout()).map(builder::initializationTimeout);
     Optional.ofNullable(config.toolExecutionTimeout()).map(builder::toolExecutionTimeout);
     Optional.ofNullable(config.reconnectInterval()).map(builder::reconnectInterval);
 
     return builder.build();
+  }
+
+  /**
+   * HttpMcpTransport implements the legacy HTTP+SSE transport (MCP protocol revision 2024-11-05).
+   * DefaultMcpClient otherwise advertises a much newer default revision, which legacy SSE servers
+   * reject/ignore, stalling initialization. Pin the negotiated revision for the SSE transport;
+   * stdio keeps the client default (null -> builder default).
+   */
+  private String protocolVersion(
+      McpClientConfigurationProperties.McpClientTransportConfiguration transportConfig) {
+    return switch (transportConfig) {
+      case McpClientConfigurationProperties.SseHttpMcpClientTransportConfiguration sse ->
+          "2024-11-05";
+      default -> null;
+    };
   }
 
   private McpTransport createTransport(

--- a/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/mcp/client/framework/langchain4j/Langchain4JMcpClientFactoryTest.java
+++ b/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/mcp/client/framework/langchain4j/Langchain4JMcpClientFactoryTest.java
@@ -18,7 +18,7 @@ import static org.mockito.Mockito.withSettings;
 
 import dev.langchain4j.mcp.client.DefaultMcpClient;
 import dev.langchain4j.mcp.client.transport.McpTransport;
-import dev.langchain4j.mcp.client.transport.http.StreamableHttpMcpTransport;
+import dev.langchain4j.mcp.client.transport.http.HttpMcpTransport;
 import dev.langchain4j.mcp.client.transport.stdio.StdioMcpTransport;
 import io.camunda.connector.agenticai.mcp.client.configuration.McpClientConfigurationProperties.McpClientConfiguration;
 import io.camunda.connector.agenticai.mcp.client.configuration.McpClientConfigurationProperties.SseHttpMcpClientTransportConfiguration;
@@ -43,7 +43,7 @@ class Langchain4JMcpClientFactoryTest {
 
   @Mock private DefaultMcpClient mcpClient;
   @Mock private StdioMcpTransport stdioMcpTransport;
-  @Mock private StreamableHttpMcpTransport httpMcpTransport;
+  @Mock private HttpMcpTransport httpMcpTransport;
 
   private final Langchain4JMcpClientFactory factory = new Langchain4JMcpClientFactory();
 
@@ -106,9 +106,9 @@ class Langchain4JMcpClientFactoryTest {
   void createsHttpMcpClient(boolean logRequests, boolean logResponses) {
     withMockedMcpClientBuilder(
         mockedMcpClientConstruction -> {
-          try (MockedConstruction<StreamableHttpMcpTransport.Builder> mockedTransportBuilder =
+          try (MockedConstruction<HttpMcpTransport.Builder> mockedTransportBuilder =
               mockConstruction(
-                  StreamableHttpMcpTransport.Builder.class,
+                  HttpMcpTransport.Builder.class,
                   withSettings().defaultAnswer(CALLS_REAL_METHODS),
                   (mock, context) -> doReturn(httpMcpTransport).when(mock).build())) {
             final var sseConfig =
@@ -119,7 +119,7 @@ class Langchain4JMcpClientFactoryTest {
             assertThat(client).isEqualTo(mcpClient);
 
             final var transportBuilder = mockedTransportBuilder.constructed().getFirst();
-            verify(transportBuilder).url(sseConfig.url());
+            verify(transportBuilder).sseUrl(sseConfig.url());
             verify(transportBuilder).timeout(sseConfig.timeout());
             verify(transportBuilder).logRequests(sseConfig.logRequests());
             verify(transportBuilder).logResponses(sseConfig.logResponses());
@@ -139,9 +139,9 @@ class Langchain4JMcpClientFactoryTest {
                       StdioMcpTransport.Builder.class,
                       withSettings().defaultAnswer(CALLS_REAL_METHODS),
                       (mock, context) -> doReturn(stdioMcpTransport).when(mock).build());
-              MockedConstruction<StreamableHttpMcpTransport.Builder> mockedHttpTransportBuilder =
+              MockedConstruction<HttpMcpTransport.Builder> mockedHttpTransportBuilder =
                   mockConstruction(
-                      StreamableHttpMcpTransport.Builder.class,
+                      HttpMcpTransport.Builder.class,
                       withSettings().defaultAnswer(CALLS_REAL_METHODS),
                       (mock, context) -> doReturn(httpMcpTransport).when(mock).build())) {
             final var stdioConfig = createStdioMcpClientTransportConfiguration(List.of(), true);

--- a/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/mcp/client/framework/langchain4j/Langchain4JMcpClientFactoryTest.java
+++ b/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/mcp/client/framework/langchain4j/Langchain4JMcpClientFactoryTest.java
@@ -124,8 +124,10 @@ class Langchain4JMcpClientFactoryTest {
             verify(transportBuilder).logRequests(sseConfig.logRequests());
             verify(transportBuilder).logResponses(sseConfig.logResponses());
 
-            verifyMcpClientBuilder(
-                mockedMcpClientConstruction.constructed().getFirst(), httpMcpTransport);
+            final var mcpClientBuilder = mockedMcpClientConstruction.constructed().getFirst();
+            // legacy HTTP+SSE transport must negotiate the matching MCP protocol revision
+            verify(mcpClientBuilder).protocolVersion("2024-11-05");
+            verifyMcpClientBuilder(mcpClientBuilder, httpMcpTransport);
           }
         });
   }
@@ -196,6 +198,7 @@ class Langchain4JMcpClientFactoryTest {
             (mock, context) -> {
               when(mock.key(any())).thenReturn(mock);
               when(mock.transport(any())).thenReturn(mock);
+              when(mock.protocolVersion(any())).thenReturn(mock);
               when(mock.build()).thenReturn(mcpClient);
             })) {
       testLogic.accept(mockedBuilder);

--- a/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/mcp/client/framework/langchain4j/Langchain4JMcpClientFactoryTest.java
+++ b/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/mcp/client/framework/langchain4j/Langchain4JMcpClientFactoryTest.java
@@ -125,8 +125,6 @@ class Langchain4JMcpClientFactoryTest {
             verify(transportBuilder).logResponses(sseConfig.logResponses());
 
             final var mcpClientBuilder = mockedMcpClientConstruction.constructed().getFirst();
-            // legacy HTTP+SSE transport must negotiate the matching MCP protocol revision
-            verify(mcpClientBuilder).protocolVersion("2024-11-05");
             verifyMcpClientBuilder(mcpClientBuilder, httpMcpTransport);
           }
         });
@@ -198,7 +196,6 @@ class Langchain4JMcpClientFactoryTest {
             (mock, context) -> {
               when(mock.key(any())).thenReturn(mock);
               when(mock.transport(any())).thenReturn(mock);
-              when(mock.protocolVersion(any())).thenReturn(mock);
               when(mock.build()).thenReturn(mcpClient);
             })) {
       testLogic.accept(mockedBuilder);

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -260,6 +260,11 @@ limitations under the License.</license.inlineheader>
       <!-- LangChain4j BOM -->
       <dependency>
         <groupId>dev.langchain4j</groupId>
+        <artifactId>langchain4j-mcp</artifactId>
+        <version>1.18.1-beta28</version>
+      </dependency>
+      <dependency>
+        <groupId>dev.langchain4j</groupId>
         <artifactId>langchain4j-bom</artifactId>
         <version>${version.langchain4j}</version>
         <type>pom</type>


### PR DESCRIPTION
## Description

Restore the legacy HTTP+SSE MCP transport (MCP protocol revision `2024-11-05`) for remote MCP clients.

langchain4j `1.19.0` removed `HttpMcpTransport`, and the code had moved to `StreamableHttpMcpTransport`, which is not wire-compatible with legacy-SSE MCP servers. Initialization stalled: the job logged `Creating remote HTTP client` and then nothing until a retry.

Changes:

- Pin `langchain4j-mcp` to `1.18.1-beta28` (the last release shipping `HttpMcpTransport`) in the agentic-ai module **and** override the managed version in `parent/pom.xml`. The `langchain4j-bom` manages `langchain4j-mcp` to `1.19.0`, and a module-level direct version does not win transitively, so the bundles resolved `1.19.0`.
- Switch the SSE transport back to `HttpMcpTransport` and pin the negotiated protocol revision to `2024-11-05` for SSE; stdio keeps the client default.

## Related issues

related to #8456
## Checklist

- [ ] PR has a **milestone** or the `no milestone` label.
- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest release, as this branch will be rebased onto main before the next release.
