### PR TITLE
fix: pin dd-plist transitive dependency to 1.30

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -126,6 +126,10 @@ limitations under the License.</license.inlineheader>
     <!-- CVE-2026-9563: parsson transitive override — remove once opensearch-java ships parsson >= 1.1.8
          Ref: https://nvd.nist.gov/vuln/detail/CVE-2026-9563 -->
     <version.parsson>1.1.9</version.parsson>
+    <!-- GHSA-xjjv-qfjr-95c3: dd-plist transitive override — remove once langchain4j-document-parser-apache-tika
+         ships a Tika version whose tika-parser-apple-module pulls dd-plist >= 1.30.
+         Ref: https://github.com/3breadt/dd-plist/security/advisories/GHSA-xjjv-qfjr-95c3 -->
+    <version.ddplist>1.30</version.ddplist>
 
     <version.google-api-client>2.9.0</version.google-api-client>
 
@@ -245,6 +249,15 @@ limitations under the License.</license.inlineheader>
         <groupId>org.eclipse.parsson</groupId>
         <artifactId>parsson</artifactId>
         <version>${version.parsson}</version>
+      </dependency>
+
+      <!-- GHSA-xjjv-qfjr-95c3: override dd-plist transitive version brought in via
+           langchain4j-document-parser-apache-tika -> tika-parser-apple-module. Remove once that
+           chain ships dd-plist >= 1.30. -->
+      <dependency>
+        <groupId>com.googlecode.plist</groupId>
+        <artifactId>dd-plist</artifactId>
+        <version>${version.ddplist}</version>
       </dependency>
 
       <!-- Netty BOM imported before Spring Boot so its version takes precedence -->
@@ -1082,6 +1095,18 @@ limitations under the License.</license.inlineheader>
               <requirePluginVersions>
                 <banSnapshots>false</banSnapshots>
               </requirePluginVersions>
+              <!-- GHSA-xjjv-qfjr-95c3 guard: fails if langchain4j is bumped, as a reminder to
+                   check whether the dd-plist override can be removed (see version.ddplist). -->
+              <requireProperty>
+                <property>version.langchain4j</property>
+                <regex>^1\.18\.1$</regex>
+                <regexMessage>
+version.langchain4j was changed! Check if the dd-plist GHSA-xjjv-qfjr-95c3 override can be removed.
+If the new langchain4j-document-parser-apache-tika version ships a Tika whose tika-parser-apple-module
+pulls dd-plist &gt;= 1.30, remove the version.ddplist property and the dd-plist dependencyManagement entry.
+See: https://github.com/3breadt/dd-plist/security/advisories/GHSA-xjjv-qfjr-95c3
+                </regexMessage>
+              </requireProperty>
               <!-- CVE-2026-9563 guard: fails if opensearch-java is bumped, as a reminder to
                    check whether the parsson override can be removed (see version.parsson). -->
               <requireProperty>


### PR DESCRIPTION
## Summary

Bumps `com.googlecode.plist:dd-plist` (transitive, via `langchain4j-document-parser-apache-tika` -> `tika-parser-apple-module`) from `1.29` to `1.30`.

Security fix. Details in the internal tracking issue: camunda/team-connectors#1264