### PR TITLE
ci: wire the AlwaysGreen triage and fix agents into stable/8.9

### DIFF
--- a/.github/workflows/MERGE_QUEUE_HELM_TEST.yaml
+++ b/.github/workflows/MERGE_QUEUE_HELM_TEST.yaml
@@ -176,6 +176,11 @@ jobs:
     permissions:
       pull-requests: write
       contents: read
+    outputs:
+      # Triage replies in this message's thread rather than opening a second
+      # top-level alert for the same failure.
+      slack_ts: ${{ steps.feedback.outputs.slack_ts }}
+      slack_channel: ${{ steps.feedback.outputs.slack_channel }}
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v4
@@ -196,8 +201,9 @@ jobs:
           owner: camunda
           repositories: connectors
       - name: Post AlwaysGreen failure feedback
+        id: feedback
         continue-on-error: true
-        uses: ./.github/actions/post-failure-feedback
+        uses: camunda/connectors/.github/actions/post-failure-feedback@main
         with:
           failure_category: unknown
           stage: sm-e2e-helm
@@ -217,6 +223,12 @@ jobs:
     timeout-minutes: 25
     continue-on-error: ${{ github.event_name == 'merge_group' }}
     permissions: { }
+    outputs:
+      # Whether this job failed, stated explicitly. On merge_group the job carries
+      # continue-on-error, and GitHub does not document what needs.<job>.result then
+      # reports to a dependent job -- so a gate built on that alone could silently never
+      # fire for the one event that supplies a PR to comment on.
+      status: ${{ steps.job-status.outputs.status }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -396,3 +408,147 @@ jobs:
             fi
             echo "**Full guide:** [CI Debugging Cookbook — SaaS E2E section](${COOKBOOK_URL}#failure-type-5--saas-e2e-tests)"
           } >> "$GITHUB_STEP_SUMMARY"
+
+
+      # AlwaysGreen triage runs in this repository but the SaaS evidence lives on the
+      # downstream run in c8-cross-component-e2e-tests, and a job summary is not
+      # machine-readable. This artifact is the only channel that carries the link
+      # across; without it triage classifies every SaaS failure as saas-infra and
+      # dispatches nothing. Deliberately just the link: triage recomputes the
+      # category from the downstream report itself.
+      - name: Write SaaS downstream context for AlwaysGreen triage
+        id: saas-context
+        if: always() && steps.wait-downstream.outputs.downstream_run_url != ''
+        env:
+          DOWNSTREAM_RUN_URL: ${{ steps.wait-downstream.outputs.downstream_run_url }}
+        run: |
+          set -euo pipefail
+          jq -n \
+            --arg stage "${{ github.job }}" \
+            --arg run_url "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+            --arg downstream_run_url "${DOWNSTREAM_RUN_URL}" \
+            '{stage: $stage, run_url: $run_url, downstream_run_url: $downstream_run_url}' \
+            > "${RUNNER_TEMP}/alwaysgreen-saas-category.json"
+
+      - name: Upload SaaS downstream context artifact
+        if: always() && steps.saas-context.outcome == 'success'
+        uses: actions/upload-artifact@v7
+        with:
+          name: alwaysgreen-saas-category
+          path: ${{ runner.temp }}/alwaysgreen-saas-category.json
+          retention-days: 14
+          # Artifacts are immutable and a re-run reuses the run id, so without this the
+          # second attempt fails to upload and triage reads the first attempt's stale
+          # downstream link -- pointing the fix agent at the wrong evidence.
+          overwrite: true
+
+      # Last step in the job, so job.status here reflects everything above it.
+      - name: Record job status
+        id: job-status
+        if: always()
+        run: echo "status=${{ job.status }}" >> "$GITHUB_OUTPUT"
+
+  # Mirror of sm-e2e-debug-summary. Until this existed a SaaS failure produced no
+  # Slack message and no PR comment at all -- only the streak detector's aggregate,
+  # which fires at three consecutive failures and says nothing about a single one.
+  saas-e2e-debug-summary:
+    name: AlwaysGreen failure feedback (SaaS E2E)
+    needs: trigger-saas-e2e
+    # Two signals for one condition. `result` covers push, where the job fails
+    # normally; the explicit output covers merge_group, where continue-on-error may
+    # present the failure to dependents as a success. merge_group is the only trigger
+    # that supplies a PR, so relying on `result` alone risks the PR comment never
+    # being posted at all.
+    if: >-
+      always() && (needs.trigger-saas-e2e.result == 'failure' ||
+      needs.trigger-saas-e2e.outputs.status == 'failure')
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    continue-on-error: ${{ github.event_name == 'merge_group' }}
+    permissions:
+      pull-requests: write
+      contents: read
+    outputs:
+      slack_ts: ${{ steps.feedback.outputs.slack_ts }}
+      slack_channel: ${{ steps.feedback.outputs.slack_channel }}
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7.0.0
+        with:
+          node-version: "24"
+      - name: Generate GitHub App Token
+        id: app-token
+        uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@main
+        with:
+          github-app-id-vault-key: GITHUB_APP_ID
+          github-app-id-vault-path: secret/data/products/qa/ci/github.com/apps/camunda/quality-assurance-ci
+          github-app-private-key-vault-key: GITHUB_APP_SECRET
+          github-app-private-key-vault-path: secret/data/products/qa/ci/github.com/apps/camunda/quality-assurance-ci
+          vault-auth-method: approle
+          vault-auth-role-id: ${{ secrets.VAULT_ROLE_ID }}
+          vault-auth-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+          vault-url: ${{ secrets.VAULT_ADDR }}
+          owner: camunda
+          repositories: connectors
+      - name: Post AlwaysGreen failure feedback
+        id: feedback
+        continue-on-error: true
+        uses: camunda/connectors/.github/actions/post-failure-feedback@main
+        with:
+          failure_category: unknown
+          stage: saas-e2e
+          owner_team: "@camunda/connectors"
+          run_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          status: failure
+          evidence: "SaaS E2E tests failed. The downstream run in c8-cross-component-e2e-tests is linked from the Trigger SaaS E2E tests job summary."
+          pr: ${{ github.event.merge_group.head_ref }}
+          # merge_group is the only trigger here that supplies a PR, and a
+          # draft cannot enter a merge queue -- so state the answer instead of
+          # paying for a lookup that would also need pull-requests: read.
+          pr_is_draft: "false"
+          slack_channel: "C0AK0AVKRL0"
+          slack_bot_token: ${{ secrets.CONNECTORS_SLACK_BOT_TOKEN }}
+          github_token: ${{ steps.app-token.outputs.token }}
+
+  # Final job: hand a failed run to AlwaysGreen triage, which classifies the failure
+  # and dispatches the fix agent. github.run_id here is this run, so the SM Playwright
+  # report and the SaaS downstream-context artifact are both readable from it.
+  #
+  # Pinned to @main rather than a local ./ path: the triage/fix workflows and their
+  # .github/scripts/alwaysgreen tooling live only on main (see camunda/camunda's own
+  # stable branches calling `alwaysgreen-triage.yml@main` the same way from
+  # docker-build-helm-integration.yml). Nothing under alwaysgreen needs backporting to
+  # this branch as a result -- updating main is enough, by construction.
+  #
+  # push only, for now. Half the failing jobs come from merge_group, but those belong
+  # to the PR under test -- its author is already looking at it, and a fix PR in the
+  # e2e repository would not unblock that queue entry. Same gate as
+  # connectors-streak-detector.yml.
+  alwaysgreen-triage:
+    name: AlwaysGreen triage and fix dispatch
+    # run-ai-agent-cpt is deliberately absent: it exists only on main, and a `needs`
+    # entry naming a job this branch does not have makes the whole workflow invalid --
+    # so this list stays backport-safe. Nothing is lost, because that surface is
+    # classified but never dispatched, and the streak detector already pages its owner.
+    needs:
+      - build-image
+      - trigger-sm-e2e
+      - sm-e2e-debug-summary
+      - trigger-saas-e2e
+      - saas-e2e-debug-summary
+    if: >-
+      always() && github.event_name == 'push' &&
+      contains(needs.*.result, 'failure')
+    permissions:
+      contents: read
+      actions: write
+      pull-requests: read
+    uses: camunda/connectors/.github/workflows/alwaysgreen-triage.yml@main
+    secrets: inherit
+    with:
+      base_ref: ${{ github.ref_name }}
+      tooling_ref: main
+      # Reply in whichever feedback message was posted, so one failure stays one
+      # Slack thread. Empty when neither stage failed or Slack was unavailable.
+      parent_slack_ts: ${{ needs.sm-e2e-debug-summary.outputs.slack_ts || needs.saas-e2e-debug-summary.outputs.slack_ts }}
+      parent_slack_channel: ${{ needs.sm-e2e-debug-summary.outputs.slack_channel || needs.saas-e2e-debug-summary.outputs.slack_channel }}


### PR DESCRIPTION
Backports the AlwaysGreen wiring #8267 added to `main`, following the exact pattern camunda/camunda already uses for this same workflow: this branch's copy of `MERGE_QUEUE_HELM_TEST.yaml` calls the shared triage logic on `main` rather than carrying its own copy of it.

**Nothing under `alwaysgreen` is duplicated onto this branch.** `alwaysgreen-triage.yml`, `alwaysgreen-fix.yml`, and the `.github/scripts/alwaysgreen/*.py` tooling stay `main`-only:

- The final job calls `camunda/connectors/.github/workflows/alwaysgreen-triage.yml@main` with `tooling_ref: main` — a cross-repo self-reference pinned to a ref, the same mechanism `camunda/camunda`'s stable branches already use for `alwaysgreen-triage.yml@main` from `docker-build-helm-integration.yml`, and already in production use in this repo's own `E2E_BRANCH_RUN.yml` (`codeowners-slack-mentions@main`).
- The two `post-failure-feedback` action calls are redirected the same way, to `camunda/connectors/.github/actions/post-failure-feedback@main`.

So a future change to classification logic, the fix agent, or the feedback action needs updating on `main` only — this file never needs touching again for that.

## What's added, mirroring #8267's own wiring commit

- `sm-e2e-debug-summary` gains `slack_ts`/`slack_channel` outputs so triage can reply in its existing thread instead of opening a second alert.
- `trigger-saas-e2e` gains an explicit `outputs.status` (needed because `continue-on-error` on `merge_group` makes `needs.<job>.result` alone unreliable) and now publishes its downstream run link as a machine-readable artifact — without it, triage classifies every SaaS failure as infrastructure and dispatches nothing.
- `saas-e2e-debug-summary` is new: until now a SaaS-only failure reached nobody at all — only the streak detector's 3-in-a-row aggregate, which says nothing about a single failure.
- `alwaysgreen-triage` runs last, gated to `push` only (same as `connectors-streak-detector.yml` — a `merge_group` failure belongs to the PR under test, whose author is already looking, and a fix PR here wouldn't unblock that queue entry). `run-ai-agent-cpt` is deliberately absent from its `needs` list, matching main's own comment: that job only exists on `main`, and naming a job this branch doesn't have would make the whole workflow invalid here.

## Verification

- YAML parses; `bash -n` clean on every `run:` block in the file.
- Diffed against the pre-existing file to confirm nothing outside the additions changed (branch-specific values — secrets paths, tool versions, image tags — are untouched).
- The `@main` cross-repo pattern (both for the reusable workflow and the composite action) is verified against two live precedents rather than assumed: `camunda/camunda`'s own stable branches, and this repo's own `E2E_BRANCH_RUN.yml`.

Part of camunda/team-test-automation#142.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
