### PR TITLE
ci: report SaaS and cancelled AlwaysGreen failures to Slack

### DIFF
--- a/.github/workflows/MERGE_QUEUE_HELM_TEST.yaml
+++ b/.github/workflows/MERGE_QUEUE_HELM_TEST.yaml
@@ -171,7 +171,13 @@ jobs:
   sm-e2e-debug-summary:
     name: AlwaysGreen failure feedback (SM E2E)
     needs: trigger-sm-e2e
-    if: always() && needs.trigger-sm-e2e.result == 'failure'
+    # `cancelled` is included for push only: on a protected branch the concurrency
+    # group is keyed by sha so nothing supersedes a run, meaning a cancellation is a
+    # timeout or an abort rather than a newer commit. merge_group runs are superseded
+    # routinely, so folding `cancelled` in there would alert on every queue reshuffle.
+    if: >-
+      always() && (needs.trigger-sm-e2e.result == 'failure' ||
+      (github.event_name == 'push' && needs.trigger-sm-e2e.result == 'cancelled'))
     runs-on: ubuntu-latest
     timeout-minutes: 5
     continue-on-error: ${{ github.event_name == 'merge_group' }}
@@ -218,9 +224,18 @@ jobs:
     runs-on: ubuntu-latest
     needs: [ build-image ]
     if: needs.build-image.outputs.connectors-version != ''
-    timeout-minutes: 25
+    # Must stay above the wait loop's own budget below (80 x 30s = 40 min). A job
+    # timeout ends the job as `cancelled`, which no gate below treats as red, and it
+    # also drops the remaining steps; letting the loop hit its own limit exits 1 and
+    # surfaces as `failure`.
+    timeout-minutes: 50
     continue-on-error: ${{ github.event_name == 'merge_group' }}
     permissions: { }
+    outputs:
+      # Whether this job failed, stated explicitly. On merge_group the job carries
+      # continue-on-error, and GitHub does not document what needs.<job>.result then
+      # reports to a dependent job.
+      status: ${{ steps.job-status.outputs.status }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -399,3 +414,63 @@ jobs:
             fi
             echo "**Full guide:** [CI Debugging Cookbook — SaaS E2E section](${COOKBOOK_URL}#failure-type-5--saas-e2e-tests)"
           } >> "$GITHUB_STEP_SUMMARY"
+
+      # Last step in the job, so job.status here reflects everything above it.
+      - name: Record job status
+        id: job-status
+        if: always()
+        run: echo "status=${{ job.status }}" >> "$GITHUB_OUTPUT"
+
+  # Mirror of sm-e2e-debug-summary. Without it a SaaS failure produces no Slack
+  # message and no PR comment at all — only the streak detector's aggregate, which
+  # fires at three consecutive failures and says nothing about a single one.
+  saas-e2e-debug-summary:
+    name: AlwaysGreen failure feedback (SaaS E2E)
+    needs: trigger-saas-e2e
+    # `result` covers push, where the job fails normally; the explicit output covers
+    # merge_group, where continue-on-error may present the failure to dependents as a
+    # success. `cancelled` is push-only for the same reason as sm-e2e-debug-summary.
+    if: >-
+      always() && (needs.trigger-saas-e2e.result == 'failure' ||
+      needs.trigger-saas-e2e.outputs.status == 'failure' ||
+      (github.event_name == 'push' && needs.trigger-saas-e2e.result == 'cancelled'))
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    continue-on-error: ${{ github.event_name == 'merge_group' }}
+    permissions:
+      pull-requests: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - name: Generate GitHub App Token
+        id: app-token
+        continue-on-error: true
+        uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@main
+        with:
+          github-app-id-vault-key: GITHUB_APP_ID
+          github-app-id-vault-path: secret/data/products/qa/ci/github.com/apps/camunda/quality-assurance-ci
+          github-app-private-key-vault-key: GITHUB_APP_SECRET
+          github-app-private-key-vault-path: secret/data/products/qa/ci/github.com/apps/camunda/quality-assurance-ci
+          vault-auth-method: approle
+          vault-auth-role-id: ${{ secrets.VAULT_ROLE_ID }}
+          vault-auth-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+          vault-url: ${{ secrets.VAULT_ADDR }}
+          owner: camunda
+          repositories: connectors
+      - name: Post AlwaysGreen failure feedback
+        continue-on-error: true
+        uses: ./.github/actions/post-failure-feedback
+        with:
+          failure_category: unknown
+          stage: saas-e2e
+          owner_team: "@camunda/connectors"
+          run_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          status: failure
+          evidence: "SaaS E2E tests failed. The downstream run in c8-cross-component-e2e-tests is linked from the Trigger SaaS E2E tests job summary."
+          pr: ${{ github.event.merge_group.head_ref }}
+          slack_channel: "C0AK0AVKRL0"
+          slack_bot_token: ${{ secrets.CONNECTORS_SLACK_BOT_TOKEN }}
+          github_token: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
## Description

SaaS E2E failures on this branch currently produce **no AlwaysGreen feedback at all** — no Slack
message, no PR comment. Two independent causes, both fixed here.

**1. There is no SaaS feedback job on this branch.** `saas-e2e-debug-summary` exists only on `main`
and was never backported, so `sm-e2e-debug-summary` is the only feedback job here and it is gated on
the SM result alone. A SaaS failure has nothing listening to it. This PR adds the mirror job, using
this branch's own pinned action versions (`checkout@v6`, `setup-node@v4`, node 20) rather than
main's, and reusing the `post-failure-feedback` action already present here.

**2. `trigger-saas-e2e` times out before its own wait loop does.** The job carries
`timeout-minutes: 25`, but the "Wait for downstream workflow to finish" loop is dimensioned for
40 minutes (`for _ in {1..80}` × `sleep 30`). Any downstream run over ~25 minutes therefore ends the
job as **`cancelled`**, not `failure` — and a job timeout also drops the remaining steps, so an
`if: always()` status-recording fallback never runs either. Raising the job timeout to 50 lets the
loop hit its own limit and `exit 1`, which surfaces correctly as `failure`.

As a backstop, both feedback gates now treat `cancelled` as red **on `push` only**. On a protected
branch the concurrency group is keyed by `github.sha`, so nothing supersedes a run and a cancellation
means a timeout or an abort. `merge_group` runs are superseded routinely, so folding `cancelled` in
there would alert on every queue reshuffle.

### Worked example

Run [33001673998](https://github.com/camunda/connectors/actions/runs/33001673998) (push, `stable/8.8`):

| Time | Event |
|---|---|
| 19:00:38 | `Trigger SaaS E2E tests` starts |
| 19:00:47 | Downstream run [33002856062](https://github.com/camunda/c8-cross-component-e2e-tests/actions/runs/33002856062) created |
| 19:25:52 | Upstream job killed by `timeout-minutes: 25`, downstream still `in_progress` |
| 19:32:15 | `Run tests (chromium-v1)` **fails** |
| 19:37:08 | `Run tests (chromium-v2)` **fails** |
| 19:38:11 | Downstream concludes `failure` |

The watcher was dead 6–11 minutes before the failures existed, and nothing on this branch would have
reported them even if it had survived.

### Known follow-up, not fixed here

Delivery is still blocked on a Slack-side change: the bot behind `CONNECTORS_SLACK_BOT_TOKEN`
(**Connector Slack Automation**, `U05Q4U3PX7Z`) is **not a member of `#alwaysgreen-reliability`**
(`C0AK0AVKRL0`). Every post returns `not_in_channel` and is swallowed — `post-failure-feedback` logs
`[feedback] Slack post failed: not_in_channel` under `continue-on-error: true`, and
`connectors-streak-detector.yml` passes `errors: false`, so both report success while delivering
nothing. The app must be invited to the channel before any of this reaches Slack; the PR-comment path
works regardless.

Automatic triage/fix-agent dispatch is deliberately **not** backported — `alwaysgreen-triage.yml`
and `alwaysgreen-fix.yml` are absent on the stable branches. This PR is notifications only.

## Related issues

Surfaced while triaging https://github.com/camunda/connectors/actions/runs/33001673998

## Checklist

- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest
  release, as this branch will be rebased onto main before the next release. Example backport labels:
    - `backport stable/8.8`: for changes that should be included in the next 8.8.x release.
    - **or** `backport release-8.8.7`: for changes that should be included in the specific release 8.8.7, and this
      *release has already been created*. The release branch will be merged back into stable/8.8 later, so the change
      will be included in future 8.8.x releases as well.
- [ ] Tests/Integration tests for the changes have been added if applicable.
- [ ] If the change requires a documentation update, it has been added to the appropriate section in the documentation.

### Companion PRs

- main: camunda/connectors#8475
- stable/8.9: camunda/connectors#8473
- stable/8.8: camunda/connectors#8472
- stable/8.7: camunda/connectors#8474
