### PR TITLE
ci: report SaaS and cancelled AlwaysGreen failures to Slack

### DIFF
--- a/.github/workflows/MERGE_QUEUE_HELM_TEST.yaml
+++ b/.github/workflows/MERGE_QUEUE_HELM_TEST.yaml
@@ -172,7 +172,13 @@ jobs:
   sm-e2e-debug-summary:
     name: AlwaysGreen failure feedback (SM E2E)
     needs: trigger-sm-e2e
-    if: always() && needs.trigger-sm-e2e.result == 'failure'
+    # `cancelled` is included for push only: on a protected branch the concurrency
+    # group is keyed by sha so nothing supersedes a run, meaning a cancellation is a
+    # timeout or an abort rather than a newer commit. merge_group runs are superseded
+    # routinely, so folding `cancelled` in there would alert on every queue reshuffle.
+    if: >-
+      always() && (needs.trigger-sm-e2e.result == 'failure' ||
+      (github.event_name == 'push' && needs.trigger-sm-e2e.result == 'cancelled'))
     runs-on: ubuntu-latest
     timeout-minutes: 5
     continue-on-error: ${{ github.event_name == 'merge_group' }}
@@ -232,7 +238,11 @@ jobs:
     runs-on: ubuntu-latest
     needs: [ build-image ]
     if: needs.build-image.outputs.connectors-version != ''
-    timeout-minutes: 25
+    # Must stay above the wait loop's own budget below (80 x 30s = 40 min). A job
+    # timeout ends the job as `cancelled`, which no gate below treats as red, and it
+    # also drops the remaining steps; letting the loop hit its own limit exits 1 and
+    # surfaces as `failure`.
+    timeout-minutes: 50
     continue-on-error: ${{ github.event_name == 'merge_group' }}
     permissions: { }
     outputs:
@@ -474,7 +484,8 @@ jobs:
     # being posted at all.
     if: >-
       always() && (needs.trigger-saas-e2e.result == 'failure' ||
-      needs.trigger-saas-e2e.outputs.status == 'failure')
+      needs.trigger-saas-e2e.outputs.status == 'failure' ||
+      (github.event_name == 'push' && needs.trigger-saas-e2e.result == 'cancelled'))
     runs-on: ubuntu-latest
     timeout-minutes: 5
     continue-on-error: ${{ github.event_name == 'merge_group' }}
@@ -659,7 +670,8 @@ jobs:
       - saas-e2e-debug-summary
     if: >-
       always() && github.event_name == 'push' &&
-      contains(needs.*.result, 'failure')
+      (contains(needs.*.result, 'failure') ||
+      contains(needs.*.result, 'cancelled'))
     permissions:
       contents: read
       actions: write


### PR DESCRIPTION
## Description

A SaaS E2E failure can pass through AlwaysGreen silently. `trigger-saas-e2e` carries
`timeout-minutes: 25`, but its "Wait for downstream workflow to finish" loop is dimensioned for
40 minutes (`for _ in {1..80}` × `sleep 30`). Any downstream run over ~25 minutes ends the job as
**`cancelled`** rather than `failure`, and neither `saas-e2e-debug-summary`
(`result == 'failure' || outputs.status == 'failure'`) nor `alwaysgreen-triage`
(`contains(needs.*.result, 'failure')`) treats `cancelled` as red — so no Slack message, no PR
comment, and no fix-agent dispatch.

The `outputs.status` fallback cannot rescue this: a **job** timeout drops the remaining steps, so the
`if: always()` `Record job status` step never runs and the output is empty. The same cancellation
drops `Write SaaS downstream context` / `Upload SaaS downstream context artifact`, so the
`alwaysgreen-saas-category` artifact is missing too and triage would have no downstream link even if
its gate had fired.

**Raising the job timeout to 50 is the primary fix.** The loop then hits its own limit and `exit 1`,
which surfaces as `failure`, and every `always()` step — status output and downstream-context
artifact included — runs normally. No restructuring of the wait script is needed.

As a backstop, all three gates now also treat `cancelled` as red **on `push` only**. On a protected
branch the concurrency group is keyed by `github.sha`, so nothing supersedes a run and a cancellation
means a timeout or an abort. `merge_group` runs are superseded routinely, so folding `cancelled` in
there would alert on every queue reshuffle.

### Evidence

Run [33001673998](https://github.com/camunda/connectors/actions/runs/33001673998) (push, `stable/8.8`):

| Time | Event |
|---|---|
| 19:00:38 | `Trigger SaaS E2E tests` starts |
| 19:00:47 | Downstream run [33002856062](https://github.com/camunda/c8-cross-component-e2e-tests/actions/runs/33002856062) created |
| 19:25:52 | Upstream job killed by `timeout-minutes: 25`, downstream still `in_progress` |
| 19:32:15 | `Run tests (chromium-v1)` **fails** |
| 19:37:08 | `Run tests (chromium-v2)` **fails** |
| 19:38:11 | Downstream concludes `failure` |

The watcher was dead 6–11 minutes before the failures existed. 12 of the 40 most recent runs of this
workflow concluded `cancelled`, each with the SaaS job at exactly 25 minutes.

### Backporting

`main` only, then by label — deliberately **not** hand-written per branch. The stable branches are
receiving the AlwaysGreen wiring (including `saas-e2e-debug-summary`) in #8468 / #8469 / #8470, which
is what this diff needs as context.

Ordering matters: add `backport stable/8.7`, `backport stable/8.8` and `backport stable/8.9`
**after** those three have landed. Verified by dry-run against #8469's head — with that wiring in
place, all four hunks apply cleanly:

```
Hunk #1 succeeded at 171 (offset -1 lines).
Hunk #2 succeeded at 230 (offset -8 lines).
Hunk #3 succeeded at 474 (offset -10 lines).
Hunk #4 succeeded at 552 (offset -118 lines).
```

Against the current stable branches it does **not** apply (fails at line 232), which is why the
labels should wait.

### Known follow-up, not fixed here

Slack delivery is separately blocked: the bot behind `CONNECTORS_SLACK_BOT_TOKEN`
(**Connector Slack Automation**, `U05Q4U3PX7Z`) is **not a member of `#alwaysgreen-reliability`**
(`C0AK0AVKRL0`). Every post returns `not_in_channel` and is swallowed — `post-failure-feedback` logs
`[feedback] Slack post failed: not_in_channel` under `continue-on-error: true`, and
`connectors-streak-detector.yml` passes `errors: false`, so both report success while delivering
nothing. The app must be invited to the channel before any of this reaches Slack; the PR-comment and
triage-dispatch paths work regardless.

## Related issues

Surfaced while triaging https://github.com/camunda/connectors/actions/runs/33001673998

## Checklist

- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest
  release, as this branch will be rebased onto main before the next release. Example backport labels:
    - `backport stable/8.8`: for changes that should be included in the next 8.8.x release.
    - **or** `backport release-8.8.7`: for changes that should be included in the specific release 8.8.7, and this
      *release has already been created*. The release branch will be merged back into stable/8.8 later, so the change
      will be included in future 8.8.x releases as well.
- [ ] Tests/Integration tests for the changes have been added if applicable.
- [ ] If the change requires a documentation update, it has been added to the appropriate section in the documentation.
