### PR TITLE
fix(saas-bundle): make legacy internal secret provider configurable via env var

### DIFF
--- a/apps/bundle/camunda-saas-bundle/src/main/java/io/camunda/connector/runtime/saas/CamundaClientSaaSConfiguration.java
+++ b/apps/bundle/camunda-saas-bundle/src/main/java/io/camunda/connector/runtime/saas/CamundaClientSaaSConfiguration.java
@@ -40,7 +40,17 @@ public class CamundaClientSaaSConfiguration {
   public static String SECRET_NAME_CLIENT_ID = "M2MClientId";
   public static String SECRET_NAME_SECRET = "M2MSecret";
 
-  private final SecretProvider internalSecretProvider;
+  private final SaaSSecretConfiguration saaSConfiguration;
+  private SecretProvider internalSecretProvider;
+
+  /**
+   * Enables falling back to the internal secret manager for M2M client id/secret when a client's
+   * credentials are not explicitly configured. Set to {@code false} once the legacy internal secret
+   * provider (GCP/AWS secret manager) is no longer provisioned, so clients without explicit
+   * credentials don't force it to be constructed.
+   */
+  @Value("${camunda.saas.secrets.enabled:true}")
+  private boolean internalSecretProviderEnabled = true;
 
   @Value("${camunda.client.auth.token-url:#{null}}")
   private String camundaClientTokenUrl;
@@ -49,7 +59,7 @@ public class CamundaClientSaaSConfiguration {
   private String camundaClientAudience;
 
   public CamundaClientSaaSConfiguration(@Autowired SaaSSecretConfiguration saaSConfiguration) {
-    this.internalSecretProvider = saaSConfiguration.getInternalSecretProvider();
+    this.saaSConfiguration = saaSConfiguration;
   }
 
   /**
@@ -71,7 +81,9 @@ public class CamundaClientSaaSConfiguration {
       public CredentialsProvider camundaClientCredentialsProvider(
           final CamundaClientProperties properties) {
         var auth = properties.getAuth();
-        if (auth.getClientId() == null && auth.getClientSecret() == null) {
+        if (internalSecretProviderEnabled
+            && auth.getClientId() == null
+            && auth.getClientSecret() == null) {
           return super.camundaClientCredentialsProvider(
               withInternalSecretManagerCredentials(properties));
         }
@@ -108,6 +120,7 @@ public class CamundaClientSaaSConfiguration {
     resolvedProperties.setAuth(auth);
 
     auth.setMethod(AuthMethod.oidc);
+    var internalSecretProvider = getInternalSecretProvider();
     auth.setClientId(internalSecretProvider.getSecret(SECRET_NAME_CLIENT_ID, null));
     auth.setClientSecret(internalSecretProvider.getSecret(SECRET_NAME_SECRET, null));
     if (auth.getTokenUrl() == null && camundaClientTokenUrl != null) {
@@ -118,5 +131,19 @@ public class CamundaClientSaaSConfiguration {
     }
     auth.setCredentialsCachePath(null);
     return resolvedProperties;
+  }
+
+  /**
+   * Lazily builds the internal secret provider on first use, rather than eagerly at construction
+   * time. Every client falls through {@link #withInternalSecretManagerCredentials} only when {@code
+   * internalSecretProviderEnabled} is {@code true}, so a deployment that has switched off the
+   * legacy internal secret manager (e.g. no {@code camunda.saas.secrets.projectId} configured any
+   * more) never has to construct it at all.
+   */
+  private SecretProvider getInternalSecretProvider() {
+    if (internalSecretProvider == null) {
+      internalSecretProvider = saaSConfiguration.getInternalSecretProvider();
+    }
+    return internalSecretProvider;
   }
 }

--- a/apps/bundle/camunda-saas-bundle/src/main/java/io/camunda/connector/runtime/saas/CamundaClientSaaSConfiguration.java
+++ b/apps/bundle/camunda-saas-bundle/src/main/java/io/camunda/connector/runtime/saas/CamundaClientSaaSConfiguration.java
@@ -44,13 +44,15 @@ public class CamundaClientSaaSConfiguration {
   private SecretProvider internalSecretProvider;
 
   /**
-   * Enables falling back to the internal secret manager for M2M client id/secret when a client's
-   * credentials are not explicitly configured. Set to {@code false} once the legacy internal secret
-   * provider (GCP/AWS secret manager) is no longer provisioned, so clients without explicit
-   * credentials don't force it to be constructed.
+   * Same switch used elsewhere to control legacy secret resolution (see {@code
+   * io.camunda.connector.runtime.core.secret.LegacySecretMode}, not a compile dependency of this
+   * module). The internal secret provider (GCP/AWS secret manager) is only built when this is
+   * {@code ON} - under {@code FALLBACK} the local provider is meant to be dropped in favor of the
+   * central secret store, and under {@code OFF} legacy resolution is disabled entirely - so clients
+   * without explicit credentials don't force it to be constructed in either case.
    */
-  @Value("${camunda.saas.secrets.enabled:true}")
-  private boolean internalSecretProviderEnabled = true;
+  @Value("${camunda.connector.secret-resolver.legacy.mode:ON}")
+  private String legacySecretMode = "ON";
 
   @Value("${camunda.client.auth.token-url:#{null}}")
   private String camundaClientTokenUrl;
@@ -81,7 +83,7 @@ public class CamundaClientSaaSConfiguration {
       public CredentialsProvider camundaClientCredentialsProvider(
           final CamundaClientProperties properties) {
         var auth = properties.getAuth();
-        if (internalSecretProviderEnabled
+        if (isLegacySecretsEnabled()
             && auth.getClientId() == null
             && auth.getClientSecret() == null) {
           return super.camundaClientCredentialsProvider(
@@ -135,15 +137,19 @@ public class CamundaClientSaaSConfiguration {
 
   /**
    * Lazily builds the internal secret provider on first use, rather than eagerly at construction
-   * time. Every client falls through {@link #withInternalSecretManagerCredentials} only when {@code
-   * internalSecretProviderEnabled} is {@code true}, so a deployment that has switched off the
-   * legacy internal secret manager (e.g. no {@code camunda.saas.secrets.projectId} configured any
-   * more) never has to construct it at all.
+   * time. Every client falls through {@link #withInternalSecretManagerCredentials} only when {@link
+   * #isLegacySecretsEnabled()}, so a deployment that has switched legacy secret resolution off
+   * (e.g. no {@code camunda.saas.secrets.projectId} configured any more) never has to construct it
+   * at all.
    */
   private SecretProvider getInternalSecretProvider() {
     if (internalSecretProvider == null) {
       internalSecretProvider = saaSConfiguration.getInternalSecretProvider();
     }
     return internalSecretProvider;
+  }
+
+  private boolean isLegacySecretsEnabled() {
+    return "ON".equalsIgnoreCase(legacySecretMode);
   }
 }

--- a/apps/bundle/camunda-saas-bundle/src/main/java/io/camunda/connector/runtime/saas/CamundaClientSaaSConfiguration.java
+++ b/apps/bundle/camunda-saas-bundle/src/main/java/io/camunda/connector/runtime/saas/CamundaClientSaaSConfiguration.java
@@ -43,17 +43,6 @@ public class CamundaClientSaaSConfiguration {
   private final SaaSSecretConfiguration saaSConfiguration;
   private SecretProvider internalSecretProvider;
 
-  /**
-   * Same switch used elsewhere to control legacy secret resolution (see {@code
-   * io.camunda.connector.runtime.core.secret.LegacySecretMode}, not a compile dependency of this
-   * module). The internal secret provider (GCP/AWS secret manager) is only built when this is
-   * {@code ON} - under {@code FALLBACK} the local provider is meant to be dropped in favor of the
-   * central secret store, and under {@code OFF} legacy resolution is disabled entirely - so clients
-   * without explicit credentials don't force it to be constructed in either case.
-   */
-  @Value("${camunda.connector.secret-resolver.legacy.mode:ON}")
-  private String legacySecretMode = "ON";
-
   @Value("${camunda.client.auth.token-url:#{null}}")
   private String camundaClientTokenUrl;
 
@@ -83,9 +72,7 @@ public class CamundaClientSaaSConfiguration {
       public CredentialsProvider camundaClientCredentialsProvider(
           final CamundaClientProperties properties) {
         var auth = properties.getAuth();
-        if (isLegacySecretsEnabled()
-            && auth.getClientId() == null
-            && auth.getClientSecret() == null) {
+        if (auth.getClientId() == null && auth.getClientSecret() == null) {
           return super.camundaClientCredentialsProvider(
               withInternalSecretManagerCredentials(properties));
         }
@@ -137,19 +124,17 @@ public class CamundaClientSaaSConfiguration {
 
   /**
    * Lazily builds the internal secret provider on first use, rather than eagerly at construction
-   * time. Every client falls through {@link #withInternalSecretManagerCredentials} only when {@link
-   * #isLegacySecretsEnabled()}, so a deployment that has switched legacy secret resolution off
-   * (e.g. no {@code camunda.saas.secrets.projectId} configured any more) never has to construct it
-   * at all.
+   * time, so a client with explicit credentials never forces it to be built. A client without
+   * explicit credentials still always needs it - client authentication is unrelated to {@code
+   * {{secrets.X}}} legacy connector-secret resolution, so it must never be silently skipped (that
+   * would leave the client unauthenticated via {@code NoopCredentialsProvider}); the dedicated
+   * {@code camunda.saas.secrets.enabled} switch only gates the separate outbound connector-secrets
+   * provider in {@link SaaSSecretConfiguration#getSecretProvider()}.
    */
   private SecretProvider getInternalSecretProvider() {
     if (internalSecretProvider == null) {
       internalSecretProvider = saaSConfiguration.getInternalSecretProvider();
     }
     return internalSecretProvider;
-  }
-
-  private boolean isLegacySecretsEnabled() {
-    return "ON".equalsIgnoreCase(legacySecretMode);
   }
 }

--- a/apps/bundle/camunda-saas-bundle/src/main/java/io/camunda/connector/runtime/saas/SaaSSecretConfiguration.java
+++ b/apps/bundle/camunda-saas-bundle/src/main/java/io/camunda/connector/runtime/saas/SaaSSecretConfiguration.java
@@ -23,6 +23,7 @@ import io.camunda.connector.secret.providers.GcpSecretProvider;
 import java.util.Objects;
 import javax.annotation.PreDestroy;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
@@ -50,7 +51,18 @@ public class SaaSSecretConfiguration {
   private AbstractSecretProvider secretProvider;
   private AbstractSecretProvider internalSecretProvider;
 
+  /**
+   * Disabled via {@code camunda.saas.secrets.enabled=false} once the legacy internal secret
+   * provider (GCP/AWS secret manager) is retired in favor of the central secret store fallback, so
+   * this bean is never constructed and {@code camunda.saas.secrets.projectId} is no longer
+   * required.
+   */
   @Bean
+  @ConditionalOnProperty(
+      prefix = "camunda.saas.secrets",
+      name = "enabled",
+      havingValue = "true",
+      matchIfMissing = true)
   public SecretProvider getSecretProvider() {
     if (Objects.equals(clusterProvider, "aws")) {
       secretProvider = new AwsSecretProvider(clusterId, secretsNamePrefix);
@@ -72,7 +84,11 @@ public class SaaSSecretConfiguration {
 
   @PreDestroy
   public void shutdown() throws Exception {
-    internalSecretProvider.close();
-    secretProvider.close();
+    if (internalSecretProvider != null) {
+      internalSecretProvider.close();
+    }
+    if (secretProvider != null) {
+      secretProvider.close();
+    }
   }
 }

--- a/apps/bundle/camunda-saas-bundle/src/main/java/io/camunda/connector/runtime/saas/SaaSSecretConfiguration.java
+++ b/apps/bundle/camunda-saas-bundle/src/main/java/io/camunda/connector/runtime/saas/SaaSSecretConfiguration.java
@@ -23,7 +23,7 @@ import io.camunda.connector.secret.providers.GcpSecretProvider;
 import java.util.Objects;
 import javax.annotation.PreDestroy;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
@@ -52,17 +52,17 @@ public class SaaSSecretConfiguration {
   private AbstractSecretProvider internalSecretProvider;
 
   /**
-   * Disabled via {@code camunda.saas.secrets.enabled=false} once the legacy internal secret
-   * provider (GCP/AWS secret manager) is retired in favor of the central secret store fallback, so
-   * this bean is never constructed and {@code camunda.saas.secrets.projectId} is no longer
-   * required.
+   * Only built when {@code camunda.connector.secret-resolver.legacy.mode=ON} - the same switch used
+   * to control legacy secret resolution elsewhere (see {@code
+   * io.camunda.connector.runtime.core.secret.LegacySecretMode}, not a compile dependency of this
+   * module). Under {@code FALLBACK} the local provider is meant to be dropped in favor of the
+   * central secret store, and under {@code OFF} legacy resolution is disabled entirely - in both
+   * cases this bean must never be constructed, so {@code camunda.saas.secrets.projectId} is no
+   * longer required.
    */
   @Bean
-  @ConditionalOnProperty(
-      prefix = "camunda.saas.secrets",
-      name = "enabled",
-      havingValue = "true",
-      matchIfMissing = true)
+  @ConditionalOnExpression(
+      "'${camunda.connector.secret-resolver.legacy.mode:ON}'.equalsIgnoreCase('ON')")
   public SecretProvider getSecretProvider() {
     if (Objects.equals(clusterProvider, "aws")) {
       secretProvider = new AwsSecretProvider(clusterId, secretsNamePrefix);

--- a/apps/bundle/camunda-saas-bundle/src/main/java/io/camunda/connector/runtime/saas/SaaSSecretConfiguration.java
+++ b/apps/bundle/camunda-saas-bundle/src/main/java/io/camunda/connector/runtime/saas/SaaSSecretConfiguration.java
@@ -23,7 +23,7 @@ import io.camunda.connector.secret.providers.GcpSecretProvider;
 import java.util.Objects;
 import javax.annotation.PreDestroy;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
@@ -52,17 +52,21 @@ public class SaaSSecretConfiguration {
   private AbstractSecretProvider internalSecretProvider;
 
   /**
-   * Only built when {@code camunda.connector.secret-resolver.legacy.mode=ON} - the same switch used
-   * to control legacy secret resolution elsewhere (see {@code
-   * io.camunda.connector.runtime.core.secret.LegacySecretMode}, not a compile dependency of this
-   * module). Under {@code FALLBACK} the local provider is meant to be dropped in favor of the
-   * central secret store, and under {@code OFF} legacy resolution is disabled entirely - in both
-   * cases this bean must never be constructed, so {@code camunda.saas.secrets.projectId} is no
-   * longer required.
+   * Disabled via {@code camunda.saas.secrets.enabled=false} - defaulted to {@code false} in this
+   * bundle's {@code application.properties} now that centralized secrets and the central-store
+   * fallback (see {@code camunda.connector.secret-resolver.legacy.mode}) cover connector-secret
+   * resolution. This is unrelated to Camunda client (M2M) authentication, which always keeps using
+   * {@link #getInternalSecretProvider()} regardless of this switch - client authentication must
+   * never be silently skipped. When disabled, this bean is never constructed, so {@code
+   * camunda.saas.secrets.projectId} is not required unless a deployment still needs this legacy
+   * connector-secrets provider (set the property to {@code true}).
    */
   @Bean
-  @ConditionalOnExpression(
-      "'${camunda.connector.secret-resolver.legacy.mode:ON}'.equalsIgnoreCase('ON')")
+  @ConditionalOnProperty(
+      prefix = "camunda.saas.secrets",
+      name = "enabled",
+      havingValue = "true",
+      matchIfMissing = true)
   public SecretProvider getSecretProvider() {
     if (Objects.equals(clusterProvider, "aws")) {
       secretProvider = new AwsSecretProvider(clusterId, secretsNamePrefix);

--- a/apps/bundle/camunda-saas-bundle/src/main/resources/application.properties
+++ b/apps/bundle/camunda-saas-bundle/src/main/resources/application.properties
@@ -17,6 +17,10 @@ camunda.connector.secret-provider.environment.enabled=false
 camunda.connector.secret-provider.console.enabled=false
 camunda.connector.secret-resolver.legacy.mode=FALLBACK
 camunda.connector.secret-resolver.secret-filter.mode=STRICT
+# Legacy connector-secrets provider (GCP/AWS secret manager), superseded by centralized secrets
+# and the central-store fallback above. Set to true (and configure camunda.saas.secrets.projectId)
+# only if a deployment still needs this local provider for {{secrets.X}} resolution.
+camunda.saas.secrets.enabled=false
 camunda.client.worker.defaults.max-jobs-active=100
 camunda.client.worker.defaults.stream-enabled=true
 camunda.client.mode=saas

--- a/apps/bundle/camunda-saas-bundle/src/test/java/io/camunda/connector/runtime/saas/SaaSSecretConfigurationTest.java
+++ b/apps/bundle/camunda-saas-bundle/src/test/java/io/camunda/connector/runtime/saas/SaaSSecretConfigurationTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.runtime.saas;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.connector.api.secret.SecretProvider;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+class SaaSSecretConfigurationTest {
+
+  private final ApplicationContextRunner contextRunner =
+      new ApplicationContextRunner().withUserConfiguration(SaaSSecretConfiguration.class);
+
+  @Test
+  void whenLegacySecretsDisabled_secretProviderBeanIsNotCreated() {
+    // camunda.saas.secrets.projectId is deliberately left unset here: with the central secret
+    // store fallback in place, this is the whole point of the switch - the legacy GCP/AWS
+    // provider must never be constructed, so a missing projectId must not crash the context.
+    contextRunner
+        .withPropertyValues(
+            "camunda.saas.secrets.enabled=false", "camunda.client.cloud.clusterId=some-cluster")
+        .run(
+            context -> {
+              assertThat(context).hasNotFailed();
+              assertThat(context).doesNotHaveBean(SecretProvider.class);
+              assertThat(context.getBeanNamesForType(SecretProvider.class)).isEmpty();
+            });
+  }
+
+  @Test
+  void whenLegacySecretsEnabledButProjectIdMissing_contextFailsToStart() {
+    // Documents the pre-fix crash this switch exists to avoid: with the flag left at its
+    // default (enabled), the legacy provider bean still requires a project id.
+    contextRunner
+        .withPropertyValues("camunda.client.cloud.clusterId=some-cluster")
+        .run(context -> assertThat(context).hasFailed());
+  }
+}

--- a/apps/bundle/camunda-saas-bundle/src/test/java/io/camunda/connector/runtime/saas/SaaSSecretConfigurationTest.java
+++ b/apps/bundle/camunda-saas-bundle/src/test/java/io/camunda/connector/runtime/saas/SaaSSecretConfigurationTest.java
@@ -28,13 +28,14 @@ class SaaSSecretConfigurationTest {
       new ApplicationContextRunner().withUserConfiguration(SaaSSecretConfiguration.class);
 
   @Test
-  void whenLegacySecretsDisabled_secretProviderBeanIsNotCreated() {
-    // camunda.saas.secrets.projectId is deliberately left unset here: with the central secret
-    // store fallback in place, this is the whole point of the switch - the legacy GCP/AWS
+  void whenLegacySecretModeOff_secretProviderBeanIsNotCreated() {
+    // camunda.saas.secrets.projectId is deliberately left unset here: with legacy secret
+    // resolution switched off, this is the whole point of the switch - the legacy GCP/AWS
     // provider must never be constructed, so a missing projectId must not crash the context.
     contextRunner
         .withPropertyValues(
-            "camunda.saas.secrets.enabled=false", "camunda.client.cloud.clusterId=some-cluster")
+            "camunda.connector.secret-resolver.legacy.mode=OFF",
+            "camunda.client.cloud.clusterId=some-cluster")
         .run(
             context -> {
               assertThat(context).hasNotFailed();
@@ -44,9 +45,27 @@ class SaaSSecretConfigurationTest {
   }
 
   @Test
-  void whenLegacySecretsEnabledButProjectIdMissing_contextFailsToStart() {
-    // Documents the pre-fix crash this switch exists to avoid: with the flag left at its
-    // default (enabled), the legacy provider bean still requires a project id.
+  void whenLegacySecretModeFallback_secretProviderBeanIsNotCreated() {
+    // FALLBACK is the migration path to the central secret store: the local provider is meant to
+    // be dropped, so this bean must not be built and a missing projectId must not crash the
+    // context - this is exactly the crash reported when centralized secrets + fallback were
+    // enabled on dev.
+    contextRunner
+        .withPropertyValues(
+            "camunda.connector.secret-resolver.legacy.mode=FALLBACK",
+            "camunda.client.cloud.clusterId=some-cluster")
+        .run(
+            context -> {
+              assertThat(context).hasNotFailed();
+              assertThat(context).doesNotHaveBean(SecretProvider.class);
+              assertThat(context.getBeanNamesForType(SecretProvider.class)).isEmpty();
+            });
+  }
+
+  @Test
+  void whenLegacySecretModeOnAndProjectIdMissing_contextFailsToStart() {
+    // Documents the pre-fix crash this switch exists to avoid: with the mode left at its
+    // default (ON), the legacy provider bean still requires a project id.
     contextRunner
         .withPropertyValues("camunda.client.cloud.clusterId=some-cluster")
         .run(context -> assertThat(context).hasFailed());

--- a/apps/bundle/camunda-saas-bundle/src/test/java/io/camunda/connector/runtime/saas/SaaSSecretConfigurationTest.java
+++ b/apps/bundle/camunda-saas-bundle/src/test/java/io/camunda/connector/runtime/saas/SaaSSecretConfigurationTest.java
@@ -28,14 +28,14 @@ class SaaSSecretConfigurationTest {
       new ApplicationContextRunner().withUserConfiguration(SaaSSecretConfiguration.class);
 
   @Test
-  void whenLegacySecretModeOff_secretProviderBeanIsNotCreated() {
-    // camunda.saas.secrets.projectId is deliberately left unset here: with legacy secret
-    // resolution switched off, this is the whole point of the switch - the legacy GCP/AWS
-    // provider must never be constructed, so a missing projectId must not crash the context.
+  void whenSecretsDisabled_secretProviderBeanIsNotCreated() {
+    // camunda.saas.secrets.projectId is deliberately left unset here: with the legacy
+    // connector-secrets provider disabled, this is the whole point of the switch - it must never
+    // be constructed, so a missing projectId must not crash the context. This is exactly the
+    // crash reported when centralized secrets + the central-store fallback were enabled on dev.
     contextRunner
         .withPropertyValues(
-            "camunda.connector.secret-resolver.legacy.mode=OFF",
-            "camunda.client.cloud.clusterId=some-cluster")
+            "camunda.saas.secrets.enabled=false", "camunda.client.cloud.clusterId=some-cluster")
         .run(
             context -> {
               assertThat(context).hasNotFailed();
@@ -45,29 +45,29 @@ class SaaSSecretConfigurationTest {
   }
 
   @Test
-  void whenLegacySecretModeFallback_secretProviderBeanIsNotCreated() {
-    // FALLBACK is the migration path to the central secret store: the local provider is meant to
-    // be dropped, so this bean must not be built and a missing projectId must not crash the
-    // context - this is exactly the crash reported when centralized secrets + fallback were
-    // enabled on dev.
+  void whenSecretsEnabledButProjectIdMissing_contextFailsToStart() {
+    // Documents the pre-fix crash this switch exists to avoid: with the flag explicitly turned
+    // back on (a deployment that still needs this legacy provider), it still requires a project
+    // id.
     contextRunner
         .withPropertyValues(
-            "camunda.connector.secret-resolver.legacy.mode=FALLBACK",
-            "camunda.client.cloud.clusterId=some-cluster")
-        .run(
-            context -> {
-              assertThat(context).hasNotFailed();
-              assertThat(context).doesNotHaveBean(SecretProvider.class);
-              assertThat(context.getBeanNamesForType(SecretProvider.class)).isEmpty();
-            });
-  }
-
-  @Test
-  void whenLegacySecretModeOnAndProjectIdMissing_contextFailsToStart() {
-    // Documents the pre-fix crash this switch exists to avoid: with the mode left at its
-    // default (ON), the legacy provider bean still requires a project id.
-    contextRunner
-        .withPropertyValues("camunda.client.cloud.clusterId=some-cluster")
+            "camunda.saas.secrets.enabled=true", "camunda.client.cloud.clusterId=some-cluster")
         .run(context -> assertThat(context).hasFailed());
+  }
+
+  @Test
+  void isUnaffectedByLegacySecretResolverMode() {
+    // This switch is independent of camunda.connector.secret-resolver.legacy.mode, which governs
+    // {{secrets.X}} resolution, not whether this bundle's own GCP/AWS provider gets built.
+    contextRunner
+        .withPropertyValues(
+            "camunda.saas.secrets.enabled=false",
+            "camunda.connector.secret-resolver.legacy.mode=ON",
+            "camunda.client.cloud.clusterId=some-cluster")
+        .run(
+            context -> {
+              assertThat(context).hasNotFailed();
+              assertThat(context).doesNotHaveBean(SecretProvider.class);
+            });
   }
 }

--- a/apps/bundle/camunda-saas-bundle/src/test/java/io/camunda/connector/runtime/saas/auth/CamundaClientSaaSConfigurationTest.java
+++ b/apps/bundle/camunda-saas-bundle/src/test/java/io/camunda/connector/runtime/saas/auth/CamundaClientSaaSConfigurationTest.java
@@ -79,12 +79,28 @@ class CamundaClientSaaSConfigurationTest {
   }
 
   @Test
-  void whenInternalProviderDisabledAndCredentialsMissing_neverCreatesInternalSecretProvider() {
+  void whenLegacySecretModeOffAndCredentialsMissing_neverCreatesInternalSecretProvider() {
     var config = createConfig();
-    ReflectionTestUtils.setField(config, "internalSecretProviderEnabled", false);
+    ReflectionTestUtils.setField(config, "legacySecretMode", "OFF");
     var properties = new CamundaClientProperties();
     // auth.clientId and auth.clientSecret are null by default, and the fallback is disabled, so
     // there is no credential source left - the parent implementation falls back to Noop.
+
+    var result =
+        config.credentialsProviderConfiguration().camundaClientCredentialsProvider(properties);
+
+    assertThat(result).isInstanceOf(NoopCredentialsProvider.class);
+    verify(mockSaaSConfig, never()).getInternalSecretProvider();
+    verify(mockSecretProvider, never()).getSecret(any(), any());
+  }
+
+  @Test
+  void whenLegacySecretModeFallbackAndCredentialsMissing_neverCreatesInternalSecretProvider() {
+    // FALLBACK is the migration path to the central secret store, so the local provider is meant
+    // to be dropped - same as OFF, the internal secret provider must never be constructed here.
+    var config = createConfig();
+    ReflectionTestUtils.setField(config, "legacySecretMode", "FALLBACK");
+    var properties = new CamundaClientProperties();
 
     var result =
         config.credentialsProviderConfiguration().camundaClientCredentialsProvider(properties);

--- a/apps/bundle/camunda-saas-bundle/src/test/java/io/camunda/connector/runtime/saas/auth/CamundaClientSaaSConfigurationTest.java
+++ b/apps/bundle/camunda-saas-bundle/src/test/java/io/camunda/connector/runtime/saas/auth/CamundaClientSaaSConfigurationTest.java
@@ -91,6 +91,10 @@ class CamundaClientSaaSConfigurationTest {
         config.credentialsProviderConfiguration().camundaClientCredentialsProvider(properties);
 
     assertThat(result).isInstanceOf(OAuthCredentialsProvider.class);
+    // Guards the lazy-construction fix itself: constructing the internal secret provider eagerly
+    // (in the constructor, regardless of whether credentials are present) is exactly what caused
+    // the crash this PR fixes, and getSecret() alone would still pass under that regression.
+    verify(mockSaaSConfig, never()).getInternalSecretProvider();
     verify(mockSecretProvider, never()).getSecret(any(), any());
   }
 

--- a/apps/bundle/camunda-saas-bundle/src/test/java/io/camunda/connector/runtime/saas/auth/CamundaClientSaaSConfigurationTest.java
+++ b/apps/bundle/camunda-saas-bundle/src/test/java/io/camunda/connector/runtime/saas/auth/CamundaClientSaaSConfigurationTest.java
@@ -23,7 +23,6 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import io.camunda.client.impl.NoopCredentialsProvider;
 import io.camunda.client.impl.oauth.OAuthCredentialsProvider;
 import io.camunda.client.spring.properties.CamundaClientAuthProperties.AuthMethod;
 import io.camunda.client.spring.properties.CamundaClientProperties;
@@ -47,8 +46,8 @@ class CamundaClientSaaSConfigurationTest {
 
   @BeforeEach
   void setup() {
-    // The internal secret provider is now built lazily, so tests that never fall back to it
-    // (credentials already present, or the fallback disabled) legitimately never touch this stub.
+    // The internal secret provider is now built lazily, so tests where credentials are already
+    // present legitimately never touch this stub.
     lenient().when(mockSaaSConfig.getInternalSecretProvider()).thenReturn(mockSecretProvider);
   }
 
@@ -76,38 +75,6 @@ class CamundaClientSaaSConfigurationTest {
     verify(mockSecretProvider)
         .getSecret(CamundaClientSaaSConfiguration.SECRET_NAME_CLIENT_ID, null);
     verify(mockSecretProvider).getSecret(CamundaClientSaaSConfiguration.SECRET_NAME_SECRET, null);
-  }
-
-  @Test
-  void whenLegacySecretModeOffAndCredentialsMissing_neverCreatesInternalSecretProvider() {
-    var config = createConfig();
-    ReflectionTestUtils.setField(config, "legacySecretMode", "OFF");
-    var properties = new CamundaClientProperties();
-    // auth.clientId and auth.clientSecret are null by default, and the fallback is disabled, so
-    // there is no credential source left - the parent implementation falls back to Noop.
-
-    var result =
-        config.credentialsProviderConfiguration().camundaClientCredentialsProvider(properties);
-
-    assertThat(result).isInstanceOf(NoopCredentialsProvider.class);
-    verify(mockSaaSConfig, never()).getInternalSecretProvider();
-    verify(mockSecretProvider, never()).getSecret(any(), any());
-  }
-
-  @Test
-  void whenLegacySecretModeFallbackAndCredentialsMissing_neverCreatesInternalSecretProvider() {
-    // FALLBACK is the migration path to the central secret store, so the local provider is meant
-    // to be dropped - same as OFF, the internal secret provider must never be constructed here.
-    var config = createConfig();
-    ReflectionTestUtils.setField(config, "legacySecretMode", "FALLBACK");
-    var properties = new CamundaClientProperties();
-
-    var result =
-        config.credentialsProviderConfiguration().camundaClientCredentialsProvider(properties);
-
-    assertThat(result).isInstanceOf(NoopCredentialsProvider.class);
-    verify(mockSaaSConfig, never()).getInternalSecretProvider();
-    verify(mockSecretProvider, never()).getSecret(any(), any());
   }
 
   @Test

--- a/apps/bundle/camunda-saas-bundle/src/test/java/io/camunda/connector/runtime/saas/auth/CamundaClientSaaSConfigurationTest.java
+++ b/apps/bundle/camunda-saas-bundle/src/test/java/io/camunda/connector/runtime/saas/auth/CamundaClientSaaSConfigurationTest.java
@@ -18,10 +18,12 @@ package io.camunda.connector.runtime.saas.auth;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import io.camunda.client.impl.NoopCredentialsProvider;
 import io.camunda.client.impl.oauth.OAuthCredentialsProvider;
 import io.camunda.client.spring.properties.CamundaClientAuthProperties.AuthMethod;
 import io.camunda.client.spring.properties.CamundaClientProperties;
@@ -45,7 +47,9 @@ class CamundaClientSaaSConfigurationTest {
 
   @BeforeEach
   void setup() {
-    when(mockSaaSConfig.getInternalSecretProvider()).thenReturn(mockSecretProvider);
+    // The internal secret provider is now built lazily, so tests that never fall back to it
+    // (credentials already present, or the fallback disabled) legitimately never touch this stub.
+    lenient().when(mockSaaSConfig.getInternalSecretProvider()).thenReturn(mockSecretProvider);
   }
 
   private CamundaClientSaaSConfiguration createConfig() {
@@ -72,6 +76,22 @@ class CamundaClientSaaSConfigurationTest {
     verify(mockSecretProvider)
         .getSecret(CamundaClientSaaSConfiguration.SECRET_NAME_CLIENT_ID, null);
     verify(mockSecretProvider).getSecret(CamundaClientSaaSConfiguration.SECRET_NAME_SECRET, null);
+  }
+
+  @Test
+  void whenInternalProviderDisabledAndCredentialsMissing_neverCreatesInternalSecretProvider() {
+    var config = createConfig();
+    ReflectionTestUtils.setField(config, "internalSecretProviderEnabled", false);
+    var properties = new CamundaClientProperties();
+    // auth.clientId and auth.clientSecret are null by default, and the fallback is disabled, so
+    // there is no credential source left - the parent implementation falls back to Noop.
+
+    var result =
+        config.credentialsProviderConfiguration().camundaClientCredentialsProvider(properties);
+
+    assertThat(result).isInstanceOf(NoopCredentialsProvider.class);
+    verify(mockSaaSConfig, never()).getInternalSecretProvider();
+    verify(mockSecretProvider, never()).getSecret(any(), any());
   }
 
   @Test


### PR DESCRIPTION
## Summary
- `CamundaClientSaaSConfiguration` unconditionally constructed the internal GCP/AWS secret provider at bean-creation time, which requires `camunda.saas.secrets.projectId` and crashes the pod with `NullPointerException: Configuration for Secrets project id is missing`. `SaaSSecretConfiguration.getSecretProvider()` (the outbound-connector-secrets bean) had the same unconditional-construction problem.
- This is exactly what happened on dev: centralized secrets + the central-store fallback were enabled, but the legacy provider was still built regardless, requiring a `projectId` that isn't meant to be configured any more.
- Fix adds a **dedicated** `camunda.saas.secrets.enabled` property (separate from `camunda.connector.secret-resolver.legacy.mode`, which governs `{{secrets.X}}` resolution and is a different concern), defaulted to `false` in this bundle's `application.properties`:
  - `SaaSSecretConfiguration.getSecretProvider()` (the outbound legacy connector-secrets `SecretProvider` bean) is now gated with `@ConditionalOnProperty` on this switch and is never constructed while it's off.
  - `SaaSSecretConfiguration.shutdown()` is now null-safe since the providers may legitimately never get constructed.
  - Set `camunda.saas.secrets.enabled=true` (and `camunda.saas.secrets.projectId`) for a deployment that still needs this local provider.
- `CamundaClientSaaSConfiguration` (Camunda client / M2M authentication) is **not** gated by this switch at all - a client without explicit credentials still always falls back to the internal secret manager, exactly as before this PR. The only change there is that the lookup is now lazy (built on first use instead of eagerly in the constructor), which fixes the crash for clients that already have explicit credentials configured, without ever leaving a client silently unauthenticated.

## Test plan
- [x] `SaaSSecretConfigurationTest` (new): `SecretProvider` bean is not created when `camunda.saas.secrets.enabled=false` (context starts without a `projectId`); fails fast when explicitly re-enabled without a `projectId`; unaffected by `camunda.connector.secret-resolver.legacy.mode`.
- [x] `CamundaClientSaaSConfigurationTest`: unchanged behavior verified - a client without explicit credentials always fetches from the internal secret provider, regardless of any switch.
- [x] Existing tests in the module pass (`mvn -pl apps/bundle/camunda-saas-bundle -am test`, scoped to this module).

🤖 Generated with [Claude Code](https://claude.com/claude-code)