### PR TITLE
fix: override reactor-core and reactor-netty to fixed versions

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -93,6 +93,11 @@ limitations under the License.</license.inlineheader>
          Ref: https://github.com/rabbitmq/rabbitmq-java-client/security/advisories/GHSA-jh4v-gfqj-7rhx -->
     <version.amqp-client>5.35.0</version.amqp-client>
     <tomcat.version>10.1.59</tomcat.version>
+    <!-- CVE-2026-47863 / CVE-2026-47874: reactor-core and reactor-netty transitive override —
+         remove once spring-boot-dependencies ships a Reactor BOM with reactor-core >= 3.8.7 and
+         reactor-netty >= 1.3.7. Guarded by the version.spring-boot enforcer rule below. -->
+    <version.reactor-core>3.8.7</version.reactor-core>
+    <version.reactor-netty>1.3.7</version.reactor-netty>
     <version.spring-cloud-gcp-starter-logging>5.13.11</version.spring-cloud-gcp-starter-logging>
     <version.logback>1.6.3</version.logback>
 
@@ -198,6 +203,28 @@ limitations under the License.</license.inlineheader>
         <version>${version.netty}</version>
         <scope>import</scope>
         <type>pom</type>
+      </dependency>
+
+      <!-- CVE-2026-47863 / CVE-2026-47874: the Reactor BOM that spring-boot-dependencies 3.5.x
+           imports pins reactor-core 3.7.19 and reactor-netty 1.2.18, both vulnerable. Pin the
+           fixed OSS versions directly until spring-boot-dependencies ships a Reactor BOM with the
+           fixes natively. -->
+      <dependency>
+        <groupId>io.projectreactor</groupId>
+        <artifactId>reactor-core</artifactId>
+        <version>${version.reactor-core}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>io.projectreactor.netty</groupId>
+        <artifactId>reactor-netty-core</artifactId>
+        <version>${version.reactor-netty}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>io.projectreactor.netty</groupId>
+        <artifactId>reactor-netty-http</artifactId>
+        <version>${version.reactor-netty}</version>
       </dependency>
 
       <!-- Spring Boot BOM -->
@@ -940,6 +967,25 @@ If the new spring-boot-dependencies BOM ships com.rabbitmq:amqp-client &gt;= 5.3
 version.amqp-client property, the amqp-client dependencyManagement entry, and this enforcer rule
 from parent/pom.xml.
 See: https://github.com/rabbitmq/rabbitmq-java-client/security/advisories/GHSA-jh4v-gfqj-7rhx
+                </regexMessage>
+              </requireProperty>
+              <!-- CVE-2026-47863 / CVE-2026-47874 guard: fails if version.spring-boot is bumped,
+                   as a reminder to check whether the reactor-core/reactor-netty overrides can be
+                   removed (see version.reactor-core, version.reactor-netty). -->
+              <requireProperty>
+                <property>version.spring-boot</property>
+                <regex>^3\.5\.16-spring-boot-3\.5\.18$</regex>
+                <regexMessage>
+version.spring-boot was changed! Check if the reactor-core/reactor-netty CVE-2026-47863 /
+CVE-2026-47874 overrides can be removed.
+If the new spring-boot-dependencies BOM ships a Reactor BOM with reactor-core &gt;= 3.8.7 and
+reactor-netty &gt;= 1.3.7 (confirm with
+`mvn dependency:tree -Dincludes=io.projectreactor:reactor-core,io.projectreactor.netty`, not just
+the property), remove the version.reactor-core/version.reactor-netty properties, the reactor-core/
+reactor-netty-core/reactor-netty-http dependencyManagement entries, and this enforcer rule from
+parent/pom.xml.
+See: https://spring.io/security/cve-2026-47863/
+See: https://spring.io/security/cve-2026-47874/
                 </regexMessage>
               </requireProperty>
             </rules>


### PR DESCRIPTION
## Summary

Overrides `io.projectreactor:reactor-core` and `io.projectreactor.netty:reactor-netty-core`/`reactor-netty-http`
transitive versions (pulled in via the Azure SDK) to fixed versions ahead of what the current
Spring Boot BOM manages, with an enforcer guard to revisit once Spring Boot ships the fix natively.

Security fix. Details in the internal tracking issues: camunda/team-connectors#1268, camunda/team-connectors#1269