### PR TITLE
fix(commands): implement addVariable and addVariables methods in main

### DIFF
--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/testutil/command/CorrelateMessageCommandDummy.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/testutil/command/CorrelateMessageCommandDummy.java
@@ -74,6 +74,16 @@ public class CorrelateMessageCommandDummy
   }
 
   @Override
+  public CorrelateMessageCommandStep3 addVariable(String key, Object value) {
+    return this;
+  }
+
+  @Override
+  public CorrelateMessageCommandStep3 addVariables(Map<String, Object> variables) {
+    return this;
+  }
+
+  @Override
   public CorrelateMessageCommandStep3 tenantId(String tenantId) {
     return this;
   }

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/testutil/command/CreateCommandDummy.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/testutil/command/CreateCommandDummy.java
@@ -167,6 +167,16 @@ public class CreateCommandDummy
   }
 
   @Override
+  public CreateProcessInstanceCommandStep3 addVariable(String key, Object value) {
+    return this;
+  }
+
+  @Override
+  public CreateProcessInstanceCommandStep3 addVariables(Map<String, Object> variables) {
+    return this;
+  }
+
+  @Override
   public CreateProcessInstanceCommandStep3 tenantId(String tenantId) {
     return this;
   }

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/testutil/command/PublishMessageCommandDummy.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/testutil/command/PublishMessageCommandDummy.java
@@ -82,6 +82,16 @@ public class PublishMessageCommandDummy
   }
 
   @Override
+  public PublishMessageCommandStep3 addVariable(String key, Object value) {
+    return this;
+  }
+
+  @Override
+  public PublishMessageCommandStep3 addVariables(Map<String, Object> variables) {
+    return this;
+  }
+
+  @Override
   public PublishMessageCommandStep3 tenantId(String tenantId) {
     return this;
   }


### PR DESCRIPTION
This pull request adds support for the new `addVariable` and `addVariables` methods to several dummy command classes used in testing. These methods are now implemented as no-ops to align the test utility classes with their corresponding production interfaces.

**Test utility enhancements:**

* Added `addVariable` and `addVariables` methods (as no-ops) to `CorrelateMessageCommandDummy`, `CreateCommandDummy`, and `PublishMessageCommandDummy` to match the latest interface requirements. [[1]](diffhunk://#diff-e6f0b314a7189f4682d4c8a7a3ff8c43295553980ccf834109d91cb0c3bdda4cR76-R85) [[2]](diffhunk://#diff-fa449e4a7fff2d5c7f320f8b9b5f5e9338199902152bbaac1050f25a785864c3R169-R178) [[3]](diffhunk://#diff-d32babfa65a8d3846331d5318fea375edab5ffc7f0ba77005bb62babe92f24f4R84-R93)