### PR TITLE
ci: trigger AlwaysGreen triage on every failing run

### DIFF
--- a/.github/workflows/MERGE_QUEUE_HELM_TEST.yaml
+++ b/.github/workflows/MERGE_QUEUE_HELM_TEST.yaml
@@ -189,15 +189,18 @@ jobs:
   # `.github/scripts/alwaysgreen/discover.py` reads, so gating on it puts the gate and
   # the classifier on the same evidence.
   #
-  # run-ai-agent-cpt is absent from `needs` for the same reason as in alwaysgreen-triage:
-  # it exists only on main, and naming it would make this file invalid on the stable
-  # branches. The scan reads the whole run rather than this job's dependencies, so a
-  # failure there is still counted — that job finishes well before the e2e stages this
-  # one waits on. Its surface is classified and reported but never dispatched, so the
-  # only effect is that triage reports it instead of ignoring it.
+  # run-ai-agent-cpt IS in `needs` here, unlike in alwaysgreen-triage. The scan reads
+  # whatever has concluded at the moment it runs, so a job with no ordering edge to it
+  # contributes only if it happens to have finished first — and "it usually finishes
+  # early" is not a scheduling guarantee. The edge is what makes the answer
+  # deterministic.
+  #
+  # Backport note: that job exists on main and stable/8.10 only. Drop it from this list
+  # when carrying this change to stable/8.7-8.9, where naming it would make the whole
+  # workflow invalid. It is the one entry here that is not backport-safe.
   detect-failures:
     name: AlwaysGreen failure detection
-    needs: [ build-image, trigger-sm-e2e, trigger-saas-e2e ]
+    needs: [ build-image, trigger-sm-e2e, trigger-saas-e2e, run-ai-agent-cpt ]
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -207,6 +210,7 @@ jobs:
       any_failed: ${{ steps.scan.outputs.any_failed }}
       sm_failed: ${{ steps.scan.outputs.sm_failed }}
       base_ref: ${{ steps.scan.outputs.base_ref }}
+      base_ref_supported: ${{ steps.scan.outputs.base_ref_supported }}
     steps:
       - name: Scan this run's job conclusions
         id: scan
@@ -252,10 +256,34 @@ jobs:
               ;;
           esac
 
+          # Mirrors the list alwaysgreen-triage.yml's "Resolve target run" step accepts,
+          # and alwaysgreen-fix.yml's. workflow_dispatch can be started from ANY ref, so
+          # without this a failing manual run from a feature branch would hand triage a
+          # base_ref it rejects — turning every such run into a guaranteed triage
+          # failure that fixes nothing. Reported loudly rather than swallowed: the
+          # failure is still in the log, the annotation and the summary.
+          base_ref_supported=true
+          case "$base_ref" in
+            main|stable/8.7|stable/8.8|stable/8.9) ;;
+            *) base_ref_supported=false ;;
+          esac
+          if [ "$base_ref_supported" != "true" ] && [ "$any_failed" = "true" ]; then
+            echo "::warning::AlwaysGreen triage does not accept base_ref '${base_ref}', so this run's failures are reported here only. Add the ref to alwaysgreen-triage.yml and alwaysgreen-fix.yml to enable it."
+            {
+              echo "## AlwaysGreen failure detection"
+              echo ""
+              echo "Failing jobs on ${base_ref}, a ref AlwaysGreen triage does not"
+              echo "accept — no classification or fix dispatch ran:"
+              echo ""
+              printf '%s\n' "$failed" | sed 's/^/- /'
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
+
           {
             echo "any_failed=${any_failed}"
             echo "sm_failed=${sm_failed}"
             echo "base_ref=${base_ref}"
+            echo "base_ref_supported=${base_ref_supported}"
           } | tee -a "$GITHUB_OUTPUT"
 
   sm-e2e-debug-summary:
@@ -758,7 +786,13 @@ jobs:
     # detect-failures, not contains(needs.*.result, 'failure'): continue-on-error —
     # here and on the non-blocking SM Playwright leg — keeps a real failure out of
     # every `result` this job can see. See the comment on that job.
-    if: always() && needs.detect-failures.outputs.any_failed == 'true'
+    #
+    # base_ref_supported keeps a manual dispatch from an arbitrary ref out: triage
+    # hard-errors on a base_ref outside main|stable/8.7-8.9, so calling it for one
+    # would only add a red job. detect-failures annotates and summarises that case.
+    if: >-
+      always() && needs.detect-failures.outputs.any_failed == 'true' &&
+      needs.detect-failures.outputs.base_ref_supported == 'true'
     permissions:
       contents: read
       actions: write

--- a/.github/workflows/MERGE_QUEUE_HELM_TEST.yaml
+++ b/.github/workflows/MERGE_QUEUE_HELM_TEST.yaml
@@ -169,10 +169,101 @@ jobs:
       scenario: alwaysgreen
       shortname: agrn
 
+  # The failure signal for everything AlwaysGreen, read from the jobs API rather than
+  # from `needs.*.result`.
+  #
+  # `needs.*.result` cannot see two of the ways a job in this pipeline fails:
+  #
+  #   * A nested job of a called workflow that carries continue-on-error. The SM
+  #     Playwright matrix in camunda-platform-helm is
+  #     `continue-on-error: ${{ !matrix.blocking }}`, and its `full` leg is
+  #     `blocking: false` — so when only that leg fails, INTEGRATION_TEST.yml still
+  #     reports success and `needs.trigger-sm-e2e.result` is `success`.
+  #   * This workflow's own `continue-on-error: ${{ github.event_name == 'merge_group' }}`,
+  #     which does the same one level up.
+  #
+  # Both are real, observed states: in run 33366607997 the SM `full` leg and the SaaS
+  # stage both failed, yet no `needs.*.result` said `failure`, the run concluded
+  # `success`, and neither the SM feedback job nor triage ran. The jobs API reported
+  # `conclusion: failure` for both jobs the whole time — which is also what
+  # `.github/scripts/alwaysgreen/discover.py` reads, so gating on it puts the gate and
+  # the classifier on the same evidence.
+  #
+  # run-ai-agent-cpt is absent from `needs` for the same reason as in alwaysgreen-triage:
+  # it exists only on main, and naming it would make this file invalid on the stable
+  # branches. The scan reads the whole run rather than this job's dependencies, so a
+  # failure there is still counted — that job finishes well before the e2e stages this
+  # one waits on. Its surface is classified and reported but never dispatched, so the
+  # only effect is that triage reports it instead of ignoring it.
+  detect-failures:
+    name: AlwaysGreen failure detection
+    needs: [ build-image, trigger-sm-e2e, trigger-saas-e2e ]
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      actions: read
+    outputs:
+      any_failed: ${{ steps.scan.outputs.any_failed }}
+      sm_failed: ${{ steps.scan.outputs.sm_failed }}
+      base_ref: ${{ steps.scan.outputs.base_ref }}
+    steps:
+      - name: Scan this run's job conclusions
+        id: scan
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_ID: ${{ github.run_id }}
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+
+          # filter=latest is the default, stated so a re-run cannot pick up a previous
+          # attempt's failures and re-trigger triage for a failure that is already gone.
+          failed=$(gh api --paginate \
+            "repos/${GITHUB_REPOSITORY}/actions/runs/${RUN_ID}/jobs?filter=latest&per_page=100" \
+            --jq '.jobs[] | select(.conclusion == "failure") | .name')
+
+          # AlwaysGreen's own jobs are dropped rather than relied on to be unfinished:
+          # a Slack or Vault hiccup in the feedback job must not read as a pipeline
+          # failure, and on a re-run they may already carry a conclusion.
+          failed=$(printf '%s\n' "$failed" | grep -v '^AlwaysGreen ' || true)
+          failed=$(printf '%s\n' "$failed" | sed '/^[[:space:]]*$/d')
+
+          any_failed=false
+          sm_failed=false
+          if [ -n "$failed" ]; then
+            any_failed=true
+            if printf '%s\n' "$failed" | grep -q '^Trigger SM E2E tests'; then
+              sm_failed=true
+            fi
+            printf 'Failing jobs:\n%s\n' "$failed"
+          else
+            echo "No failing jobs in this run."
+          fi
+
+          # Normalised the same way as classify.normalise_base_ref, so the value this
+          # gate derives and the value discovery derives cannot disagree — triage
+          # validates it against the supported branches and errors on a queue ref.
+          base_ref="${REF_NAME#refs/heads/}"
+          case "$base_ref" in
+            gh-readonly-queue/*)
+              base_ref="${base_ref#gh-readonly-queue/}"
+              base_ref="${base_ref%/pr-*}"
+              ;;
+          esac
+
+          {
+            echo "any_failed=${any_failed}"
+            echo "sm_failed=${sm_failed}"
+            echo "base_ref=${base_ref}"
+          } | tee -a "$GITHUB_OUTPUT"
+
   sm-e2e-debug-summary:
     name: AlwaysGreen failure feedback (SM E2E)
-    needs: trigger-sm-e2e
-    if: always() && needs.trigger-sm-e2e.result == 'failure'
+    needs: [ trigger-sm-e2e, detect-failures ]
+    # Not needs.trigger-sm-e2e.result: a non-blocking SM leg failing leaves that at
+    # `success`, which is how run 33366607997 produced no SM feedback at all.
+    if: always() && needs.detect-failures.outputs.sm_failed == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     continue-on-error: ${{ github.event_name == 'merge_group' }}
@@ -640,10 +731,16 @@ jobs:
   # CALLER's ref, so without it a stable/8.x run would need the whole
   # .github/scripts/alwaysgreen tree backported alongside this file.
   #
-  # push only, for now. Half the failing jobs come from merge_group, but those belong
-  # to the PR under test — its author is already looking at it, and a fix PR in the
-  # e2e repository would not unblock that queue entry. Same gate as
-  # connectors-streak-detector.yml.
+  # Every event this workflow runs on, not push only. merge_group failures were held
+  # back on the reasoning that they belong to the PR under test — but a merge-queue
+  # entry runs the same SM and SaaS suites against the same clusters, so a red one is
+  # the same e2e regression seen ~10 minutes earlier, and holding it back lost the
+  # majority of the signal. It is also safe to let through: this workflow is not a
+  # required check for the queue (no required_status_checks rule on main), which
+  # merge_group run 33178384934 demonstrates — it concluded `failure` and PR #8485
+  # merged anyway. Dedupe is unchanged: the queue ref normalises to its base branch,
+  # so a merge_group run and the push run that follows it derive the same dispatch
+  # key, and the second is suppressed by the in-flight / open-fix-PR layers.
   alwaysgreen-triage:
     name: AlwaysGreen triage and fix dispatch
     # run-ai-agent-cpt is deliberately absent: it exists only on main, and a `needs`
@@ -657,9 +754,11 @@ jobs:
       - sm-e2e-debug-summary
       - trigger-saas-e2e
       - saas-e2e-debug-summary
-    if: >-
-      always() && github.event_name == 'push' &&
-      contains(needs.*.result, 'failure')
+      - detect-failures
+    # detect-failures, not contains(needs.*.result, 'failure'): continue-on-error —
+    # here and on the non-blocking SM Playwright leg — keeps a real failure out of
+    # every `result` this job can see. See the comment on that job.
+    if: always() && needs.detect-failures.outputs.any_failed == 'true'
     permissions:
       contents: read
       actions: write
@@ -667,7 +766,9 @@ jobs:
     uses: ./.github/workflows/alwaysgreen-triage.yml
     secrets: inherit
     with:
-      base_ref: ${{ github.ref_name }}
+      # Normalised by detect-failures: on merge_group github.ref_name is the
+      # per-PR queue ref, which triage rejects as an unsupported base_ref.
+      base_ref: ${{ needs.detect-failures.outputs.base_ref }}
       tooling_ref: main
       # Reply in whichever feedback message was posted, so one failure stays one
       # Slack thread. Empty when neither stage failed or Slack was unavailable.


### PR DESCRIPTION
## Description

Two independent gates kept AlwaysGreen triage from ever seeing the failure in
[run 33366607997](https://github.com/camunda/connectors/actions/runs/33366607997),
where **both** the SM and the SaaS e2e stages were genuinely red. Triage was `skipped`,
`AlwaysGreen failure feedback (SM E2E)` was `skipped`, and the run itself concluded
`success`.

### Gate 1 — the event gate

```yaml
if: always() && github.event_name == 'push' && contains(needs.*.result, 'failure')
```

The run was `merge_group`, so the job was skipped outright. `merge_group` is roughly half
of this workflow's runs, and the matching push run for the same merged commit
([33367418814](https://github.com/camunda/connectors/actions/runs/33367418814)) was fully
green — so there was no push run to dispatch from either.

### Gate 2 — the failure signal, which would have missed it on `push` too

Only the **non-blocking `full`** Playwright leg failed, not `smoke`. The matrix from the
run log:

```
e2e-matrix=[{"suite":"smoke","blocking":true,...},{"suite":"full","blocking":false,...}]
```

and `camunda-platform-helm`'s runner marks that leg
[`continue-on-error: ${{ !matrix.blocking }}`](https://github.com/camunda/camunda-platform-helm/blob/main/.github/workflows/test-integration-runner.yaml#L1276).
So `needs.trigger-sm-e2e.result` stayed `success`, which is also why the SM feedback job
was skipped and the run reported `success` with two red jobs in it.

For contrast, push run
[33179631020](https://github.com/camunda/connectors/actions/runs/33179631020) *did* reach
triage — there the **blocking `smoke`** leg failed as well.

The jobs API reported `conclusion: failure` for both jobs the whole time. That is the same
evidence `.github/scripts/alwaysgreen/discover.py` already classifies from, so the gate and
the classifier were reading different things.

## What changed

- **New `detect-failures` job** — reads the real per-job conclusions from
  `/actions/runs/{id}/jobs?filter=latest` and emits `any_failed`, `sm_failed`, a
  `base_ref` normalised the same way as `classify.normalise_base_ref` (a merge-queue ref
  would otherwise be rejected by triage as an unsupported `base_ref`), and
  `base_ref_supported`. AlwaysGreen's own jobs are excluded from the scan.
- **`alwaysgreen-triage`** — gated on `detect-failures.outputs.any_failed` **and**
  `base_ref_supported`, event gate removed, `base_ref` taken from the detection job.
- **`sm-e2e-debug-summary`** — gated on `detect-failures.outputs.sm_failed` instead of
  `needs.trigger-sm-e2e.result`, so a non-blocking SM failure still produces a PR comment
  and a Slack message. `saas-e2e-debug-summary` is untouched; its explicit `status` output
  already worked, which is why SaaS was the one stage that did report.

## Why letting `merge_group` through is safe

This workflow is **not a required check** for the merge queue — `main` has no
`required_status_checks` rule, and merge_group run
[33178384934](https://github.com/camunda/connectors/actions/runs/33178384934) concluded
`failure` while
[#8485](https://github.com/camunda/connectors/pull/8485) merged anyway. A triage failure
therefore cannot block a queue entry, which matters because `continue-on-error` is not a
valid key on a reusable-workflow-call job.

Dedupe is unaffected: the queue ref normalises to its base branch, so a `merge_group` run
and the push run that follows it derive the **same** dispatch key. The second is suppressed
by the in-flight / open-fix-PR layers, and the triage job's per-branch `concurrency` group
serialises the two.

## Verification

The detection logic was replayed against four real runs:

| Run | Event | `any_failed` | `sm_failed` | `base_ref` |
|---|---|---|---|---|
| 33366607997 | merge_group | `true` | `true` | `main` |
| 33367418814 (green) | push | `false` | `false` | `main` |
| 33179631020 | push | `true` | `true` | `main` |
| 33178384934 | merge_group (stable/8.9 queue) | `true` | `true` | `stable/8.9` |

and against an unsupported ref: run 33179631020 replayed with `ref_name=my-feature-branch`
gives `any_failed=true`, `base_ref_supported=false` — a warning and a summary, no triage
call.

`discover.py` was then replayed against 33366607997 with `--base-ref main`. It classifies
both failures correctly — SaaS as `saas-smoke-e2e` (1 real spec failure in
`tests/8.10/smoke-tests.spec.ts`), SM as `sm-smoke-e2e` — and suppresses both dispatches
because they are already claimed (`tests/8.10/smoke-tests.spec.ts` by
camunda/c8-cross-component-e2e-tests#3153, and the SM surface by
camunda/c8-cross-component-e2e-tests#3154 via its `ag-key:connectors:main:sm-smoke-e2e`
label). So this run would have been classified, summarised and threaded into Slack rather
than silently skipped — which is the point — even though no new agent would have been
dispatched for it.

`actionlint` is clean on the changed file (the one remaining `SC2046` finding is
pre-existing, in `run-ai-agent-cpt`).

## Known trade-offs / follow-ups

- `sm-e2e-debug-summary` now waits for `detect-failures`, which waits for the SaaS stage,
  so the SM PR comment lands later than before. Triage's start time is unchanged — it
  already waited for both stages.
- Triage now also runs for non-e2e failures (build, helm install/cleanup, matrix
  generation, AI Agent CPT). Those surfaces are classified and reported but never
  dispatched, so the effect is a report instead of silence.
- `run-ai-agent-cpt` is in `detect-failures`' `needs` so its conclusion is counted
  deterministically rather than by luck of scheduling. It exists on `main` and
  `stable/8.10` only, so it is the one entry that must be dropped when this change is
  carried to `stable/8.7`–`8.9`.
- `workflow_dispatch` accepts any ref, and triage accepts only
  `main|stable/8.7|stable/8.8|stable/8.9`. A failing run on any other ref is reported by
  `detect-failures` (a `::warning` plus a job-summary list) instead of being handed to
  triage, which would reject it and add a guaranteed red job.
- `connectors-streak-detector.yml` still carries the same `push`-only gate. Not touched
  here.
- `alwaysgreen-triage.yml` and `alwaysgreen-fix.yml` accept only
  `main|stable/8.7|stable/8.8|stable/8.9`, but `stable/8.10` exists. The stable branches'
  copies of this workflow keep their `push`-only gate, so nothing regresses today — but
  `stable/8.10` should be added to those lists before this change is backported.

## Related issues

Reported from run https://github.com/camunda/connectors/actions/runs/33366607997

## Checklist

- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest
  release, as this branch will be rebased onto main before the next release. Example backport labels:
    - `backport stable/8.8`: for changes that should be included in the next 8.8.x release.
    - **or** `backport release-8.8.7`: for changes that should be included in the specific release 8.8.7, and this
      *release has already been created*. The release branch will be merged back into stable/8.8 later, so the change
      will be included in future 8.8.x releases as well.
- [ ] Tests/Integration tests for the changes have been added if applicable.
- [ ] If the change requires a documentation update, it has been added to the appropriate section in the documentation.
