### PR TITLE
deps: block Tika major bump for connector-embeddings-vector-database

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -186,6 +186,13 @@
         "connectors/google/pom.xml"
       ],
       "enabled": false
+    },
+    {
+      "description": "Disable major version updates for Apache Tika in connector-embeddings-vector-database — 4.0.0 (GA, released 2026-08-21) is a hard blocker there, not a mirror/staleness issue. (1) tika-parsers-standard-package was restructured from a shaded jar into a POM-only aggregator, so a plain jar dependency on it no longer resolves. (2) Tika 4's Parser interface dropped parse(InputStream,...) in favor of parse(TikaInputStream,...); langchain4j-document-parser-apache-tika 1.19.0, which this connector uses, still calls the old signature and would fail with NoSuchMethodError at runtime even if (1) were fixed — confirmed via bytecode inspection of both jars. Needs LangChain4j to ship Tika 4 support, plus a dependency-shape migration on our side. Scoped to this file only (matching the Google libraries-bom rule above) — connector-aws-bedrock's independent tika-core dependency only uses the MimeTypes API, confirmed compatible with 4.0.0, so it can keep receiving major-version proposals. Tracked in camunda/connectors#8502. Re-enable once that lands.",
+      "matchUpdateTypes": ["major"],
+      "matchPackageNames": ["org.apache.tika:tika-core", "org.apache.tika:tika-parsers-standard-package"],
+      "matchFileNames": ["connectors/embeddings-vector-database/pom.xml"],
+      "enabled": false
     }
   ],
   "baseBranchPatterns": [


### PR DESCRIPTION
## Summary

Renovate PR #8405 proposed bumping `org.apache.tika` from 3.3.2 to 4.0.0 in `connector-embeddings-vector-database` and `connector-aws-bedrock`. It was closed because its title/description said it upgrades Tika, when the actual state after triage kept the version at 3.3.2 and only added a suppression rule — misleading, so it's replaced by this PR, which does exactly and only that: **add the renovate.json rule, no dependency version change.**

Tika 4.0.0 GA shipped 2026-08-21, but it's a hard blocker for `connector-embeddings-vector-database` specifically, not a staleness/mirror issue:

1. `org.apache.tika:tika-parsers-standard-package` was restructured from a shaded jar into a POM-only aggregator in 4.0.0 — a plain jar dependency on it can never resolve, confirmed directly against Maven Central.
2. Tika 4's `Parser` interface dropped `parse(InputStream,...)` in favor of `parse(TikaInputStream,...)`. `langchain4j-document-parser-apache-tika` 1.19.0, which this connector uses, still calls the old signature and would fail with `NoSuchMethodError` at runtime even past (1) — confirmed via bytecode inspection of both jars.

Migrating needs LangChain4j to ship Tika 4 support first; tracked in #8502.

`connector-aws-bedrock` also depends on `tika-core` directly, but only uses the `MimeTypes` API (confirmed unaffected/compatible with 4.0.0) — the rule is scoped with `matchFileNames` to `connectors/embeddings-vector-database/pom.xml` only, so Renovate can still propose that independent bump.

## Test plan

- [x] Validated `renovate.json` is well-formed JSON
- [x] Diff is isolated to the one new `packageRule`; no dependency versions touched

## Related

- Closes/replaces #8405
- Tracking issue for the actual migration: #8502