### PR TITLE
fix: default outbound secret filter mode to STRICT

### DIFF
--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/OutboundConnectorRuntimeConfiguration.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/OutboundConnectorRuntimeConfiguration.java
@@ -170,7 +170,7 @@ public class OutboundConnectorRuntimeConfiguration {
 
   @Bean
   public SecretFilterFactory secretFilterFactory(
-      @Value("${camunda.connector.secret-resolver.secret-filter.mode:DISABLED}")
+      @Value("${camunda.connector.secret-resolver.secret-filter.mode:STRICT}")
           SecretFilterMode secretFilterMode,
       SecretKeyCache secretKeyCache) {
     return new ConfigurableSecretFilterFactory(secretFilterMode, secretKeyCache);

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/OutboundConnectorExceptionHandler.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/OutboundConnectorExceptionHandler.java
@@ -67,6 +67,16 @@ public class OutboundConnectorExceptionHandler {
     return Map.copyOf(result);
   }
 
+  /**
+   * Preserves the pre-existing three-argument overload for callers compiled against it, defaulting
+   * to an unfiltered {@link SecretFilter#allowAll()}.
+   */
+  public ConnectorResult.ErrorResult manageConnectorJobHandlerException(
+      Exception e, ActivatedJob job, Duration retryBackoffDuration) {
+    return manageConnectorJobHandlerException(
+        e, job, retryBackoffDuration, SecretFilter.allowAll());
+  }
+
   public ConnectorResult.ErrorResult manageConnectorJobHandlerException(
       Exception e, ActivatedJob job, Duration retryBackoffDuration, SecretFilter secretFilter) {
     List<String> secrets;
@@ -170,15 +180,50 @@ public class OutboundConnectorExceptionHandler {
     return handleSDKException(job, newException, retries, errorCode, retryBackoff);
   }
 
+  /**
+   * Preserves the pre-existing two-argument overload for callers compiled against it, defaulting to
+   * an unfiltered {@link SecretFilter#allowAll()}.
+   */
+  public ConnectorResult.ErrorResult handleFinalResultException(Exception ex, ActivatedJob job) {
+    return handleFinalResultException(ex, job, SecretFilter.allowAll());
+  }
+
+  /**
+   * Reports a failure raised while processing a connector's final result (its result or error
+   * expression).
+   *
+   * <p>This must not throw: its only caller is already inside a catch block handling the failure it
+   * is being told about, and an exception escaping here would leave the job neither completed nor
+   * failed until its activation times out. So a secret lookup failure here (e.g. a STRICT filter
+   * whose process-definition lookup fails) is caught and reported the same way an initial
+   * secret-fetch failure already is in {@link #manageConnectorJobHandlerException}, rather than
+   * being allowed to propagate.
+   */
   public ConnectorResult.ErrorResult handleFinalResultException(
       Exception ex, ActivatedJob job, SecretFilter secretFilter) {
-    var allowedKeys =
-        SecretUtil.retrieveSecretKeysInInput(job.getVariables()).stream()
-            .filter(secretFilter::isAllowed)
-            .toList();
-    List<String> secrets =
-        this.secretProvider.fetchAll(
-            allowedKeys, new SecretContext(job.getTenantId(), job.getBpmnProcessId()));
+    List<String> secrets;
+    try {
+      var allowedKeys =
+          SecretUtil.retrieveSecretKeysInInput(job.getVariables()).stream()
+              .filter(secretFilter::isAllowed)
+              .toList();
+      secrets =
+          this.secretProvider.fetchAll(
+              allowedKeys, new SecretContext(job.getTenantId(), job.getBpmnProcessId()));
+    } catch (Exception fetchException) {
+      LOGGER.error(
+          "Exception while processing job: {} for tenant: {} can't be displayed because fetching secrets failed: {}",
+          job.getKey(),
+          job.getTenantId(),
+          fetchException.getMessage());
+      var wrappedException =
+          new RuntimeException(
+              "Fetching secrets failed, original error can't be displayed as the error message might contain secrets: "
+                  + fetchException.getMessage(),
+              fetchException);
+      return new ConnectorResult.ErrorResult(
+          Map.of("error", exceptionToMap(wrappedException)), wrappedException, 0);
+    }
     Exception newException = new Exception(hideSecretsFromMessage(ex.getMessage(), secrets), ex);
     LOGGER.error(
         "Exception while processing job: {} for tenant: {}, message: {}",

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/OutboundConnectorExceptionHandler.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/OutboundConnectorExceptionHandler.java
@@ -43,6 +43,14 @@ public class OutboundConnectorExceptionHandler {
     this.secretProvider = secretProvider;
   }
 
+  /**
+   * Stands in for the real exception in the legacy no-filter overloads below, so that {@link
+   * #exceptionToMap} never reaches into the real exception's message or, if it is a {@link
+   * ConnectorException}, its error variables -- either can carry a resolved secret, and neither
+   * overload has a filter to redact it with.
+   */
+  private static final class SecretFilterUnavailableException extends RuntimeException {}
+
   private static Map<String, Object> exceptionToMap(Exception wrappedException) {
     Map<String, Object> result = new HashMap<>();
     Throwable originalCause = wrappedException.getCause();
@@ -72,7 +80,9 @@ public class OutboundConnectorExceptionHandler {
    * overload has no filter to redact secrets with, so it withholds the original message outright
    * rather than falling back to an unfiltered {@link SecretFilter#allowAll()} — the whole point of
    * the secret filter is to restrict what gets resolved, and defaulting to allow-all here would let
-   * a legacy caller bypass that restriction.
+   * a legacy caller bypass that restriction. It still classifies {@code e} by type to preserve the
+   * pre-existing retry/backoff semantics per exception type, but never attaches {@code e} itself
+   * (or its message) to the returned result.
    */
   public ConnectorResult.ErrorResult manageConnectorJobHandlerException(
       Exception e, ActivatedJob job, Duration retryBackoffDuration) {
@@ -85,9 +95,28 @@ public class OutboundConnectorExceptionHandler {
         new RuntimeException(
             "Original error can't be displayed: this legacy entry point has no secret filter to"
                 + " redact it with, and its message might contain secrets.",
-            e);
-    return new ConnectorResult.ErrorResult(
-        Map.of("error", exceptionToMap(wrappedException)), wrappedException, job.getRetries() - 1);
+            new SecretFilterUnavailableException());
+    var errorPayload = Map.of("error", exceptionToMap(wrappedException));
+    return switch (e) {
+      case InvalidBackOffDurationException ignored ->
+          new ConnectorResult.ErrorResult(errorPayload, wrappedException, 0);
+      case ConnectorRetryException connectorRetryException ->
+          new ConnectorResult.ErrorResult(
+              errorPayload,
+              wrappedException,
+              Optional.ofNullable(connectorRetryException.getRetries())
+                  .orElse(job.getRetries() - 1),
+              Optional.ofNullable(connectorRetryException.getBackoffDuration())
+                  .orElse(retryBackoffDuration));
+      case Exception exception -> {
+        int retries = job.getRetries() - 1;
+        if (exception instanceof ConnectorInputException
+            || exception.getCause() instanceof ConnectorInputException) {
+          retries = 0;
+        }
+        yield new ConnectorResult.ErrorResult(errorPayload, wrappedException, retries);
+      }
+    };
   }
 
   public ConnectorResult.ErrorResult manageConnectorJobHandlerException(
@@ -211,7 +240,7 @@ public class OutboundConnectorExceptionHandler {
         new RuntimeException(
             "Original error can't be displayed: this legacy entry point has no secret filter to"
                 + " redact it with, and its message might contain secrets.",
-            ex);
+            new SecretFilterUnavailableException());
     return new ConnectorResult.ErrorResult(
         Map.of("error", exceptionToMap(wrappedException)), wrappedException, 0);
   }

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/OutboundConnectorExceptionHandler.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/OutboundConnectorExceptionHandler.java
@@ -77,21 +77,18 @@ public class OutboundConnectorExceptionHandler {
   }
 
   /**
-   * Builds the error map for the legacy no-filter overloads: {@code type} and, for a {@link
-   * ConnectorException}, {@code code} are read straight off {@code e} because neither can carry a
-   * secret and error expressions match on {@code code}, but {@code message} always comes from
-   * {@code wrappedException}'s fixed, filter-free text, and {@code variables} is never included.
+   * Builds the error map for the legacy no-filter overloads: {@code type} is read straight off
+   * {@code e}'s class, which can never carry a secret. {@code code} is deliberately omitted even
+   * for a {@link ConnectorException} -- unlike {@code type}, it's an arbitrary caller-supplied
+   * string ({@link io.camunda.connector.api.error.ConnectorExceptionBuilder#errorCode}), so nothing
+   * rules out a connector constructing one from a resolved secret. {@code message} always comes
+   * from {@code wrappedException}'s fixed, filter-free text, and {@code variables} is never
+   * included.
    */
   private static Map<String, Object> withheldExceptionToMap(
       Exception e, Exception wrappedException) {
     Map<String, Object> result = new HashMap<>();
     result.put("type", e.getClass().getName());
-    if (e instanceof ConnectorException connectorException) {
-      var code = connectorException.getErrorCode();
-      if (code != null) {
-        result.put("code", code);
-      }
-    }
     var message = wrappedException.getMessage();
     if (message != null) {
       result.put(

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/OutboundConnectorExceptionHandler.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/OutboundConnectorExceptionHandler.java
@@ -222,7 +222,9 @@ public class OutboundConnectorExceptionHandler {
                   + fetchException.getMessage(),
               fetchException);
       return new ConnectorResult.ErrorResult(
-          Map.of("error", exceptionToMap(wrappedException)), wrappedException, 0);
+          Map.of("error", exceptionToMap(wrappedException)),
+          wrappedException,
+          job.getRetries() - 1);
     }
     Exception newException = new Exception(hideSecretsFromMessage(ex.getMessage(), secrets), ex);
     LOGGER.error(

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/OutboundConnectorExceptionHandler.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/OutboundConnectorExceptionHandler.java
@@ -44,10 +44,11 @@ public class OutboundConnectorExceptionHandler {
   }
 
   /**
-   * Stands in for the real exception in the legacy no-filter overloads below, so that {@link
-   * #exceptionToMap} never reaches into the real exception's message or, if it is a {@link
+   * Stands in as the returned exception's cause in the legacy no-filter overloads below, so that a
+   * caller walking the cause chain never reaches the real exception's message or, if it is a {@link
    * ConnectorException}, its error variables -- either can carry a resolved secret, and neither
-   * overload has a filter to redact it with.
+   * overload has a filter to redact it with. See {@link #withheldExceptionToMap} for how the
+   * returned map itself stays free of both while still keeping {@code type} and {@code code}.
    */
   private static final class SecretFilterUnavailableException extends RuntimeException {}
 
@@ -76,6 +77,30 @@ public class OutboundConnectorExceptionHandler {
   }
 
   /**
+   * Builds the error map for the legacy no-filter overloads: {@code type} and, for a {@link
+   * ConnectorException}, {@code code} are read straight off {@code e} because neither can carry a
+   * secret and error expressions match on {@code code}, but {@code message} always comes from
+   * {@code wrappedException}'s fixed, filter-free text, and {@code variables} is never included.
+   */
+  private static Map<String, Object> withheldExceptionToMap(
+      Exception e, Exception wrappedException) {
+    Map<String, Object> result = new HashMap<>();
+    result.put("type", e.getClass().getName());
+    if (e instanceof ConnectorException connectorException) {
+      var code = connectorException.getErrorCode();
+      if (code != null) {
+        result.put("code", code);
+      }
+    }
+    var message = wrappedException.getMessage();
+    if (message != null) {
+      result.put(
+          "message", message.substring(0, Math.min(message.length(), MAX_ERROR_MESSAGE_LENGTH)));
+    }
+    return Map.copyOf(result);
+  }
+
+  /**
    * Preserves the pre-existing three-argument overload for callers compiled against it. This
    * overload has no filter to redact secrets with, so it withholds the original message outright
    * rather than falling back to an unfiltered {@link SecretFilter#allowAll()} — the whole point of
@@ -96,7 +121,7 @@ public class OutboundConnectorExceptionHandler {
             "Original error can't be displayed: this legacy entry point has no secret filter to"
                 + " redact it with, and its message might contain secrets.",
             new SecretFilterUnavailableException());
-    var errorPayload = Map.of("error", exceptionToMap(wrappedException));
+    var errorPayload = Map.of("error", withheldExceptionToMap(e, wrappedException));
     return switch (e) {
       case InvalidBackOffDurationException ignored ->
           new ConnectorResult.ErrorResult(errorPayload, wrappedException, 0);
@@ -242,7 +267,7 @@ public class OutboundConnectorExceptionHandler {
                 + " redact it with, and its message might contain secrets.",
             new SecretFilterUnavailableException());
     return new ConnectorResult.ErrorResult(
-        Map.of("error", exceptionToMap(wrappedException)), wrappedException, 0);
+        Map.of("error", withheldExceptionToMap(ex, wrappedException)), wrappedException, 0);
   }
 
   /**

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/OutboundConnectorExceptionHandler.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/OutboundConnectorExceptionHandler.java
@@ -68,13 +68,26 @@ public class OutboundConnectorExceptionHandler {
   }
 
   /**
-   * Preserves the pre-existing three-argument overload for callers compiled against it, defaulting
-   * to an unfiltered {@link SecretFilter#allowAll()}.
+   * Preserves the pre-existing three-argument overload for callers compiled against it. This
+   * overload has no filter to redact secrets with, so it withholds the original message outright
+   * rather than falling back to an unfiltered {@link SecretFilter#allowAll()} — the whole point of
+   * the secret filter is to restrict what gets resolved, and defaulting to allow-all here would let
+   * a legacy caller bypass that restriction.
    */
   public ConnectorResult.ErrorResult manageConnectorJobHandlerException(
       Exception e, ActivatedJob job, Duration retryBackoffDuration) {
-    return manageConnectorJobHandlerException(
-        e, job, retryBackoffDuration, SecretFilter.allowAll());
+    LOGGER.error(
+        "Error for job: {} for tenant: {} can't be displayed: this legacy entry point has no"
+            + " secret filter to redact it with.",
+        job.getKey(),
+        job.getTenantId());
+    var wrappedException =
+        new RuntimeException(
+            "Original error can't be displayed: this legacy entry point has no secret filter to"
+                + " redact it with, and its message might contain secrets.",
+            e);
+    return new ConnectorResult.ErrorResult(
+        Map.of("error", exceptionToMap(wrappedException)), wrappedException, job.getRetries() - 1);
   }
 
   public ConnectorResult.ErrorResult manageConnectorJobHandlerException(
@@ -181,11 +194,26 @@ public class OutboundConnectorExceptionHandler {
   }
 
   /**
-   * Preserves the pre-existing two-argument overload for callers compiled against it, defaulting to
-   * an unfiltered {@link SecretFilter#allowAll()}.
+   * Preserves the pre-existing two-argument overload for callers compiled against it. This overload
+   * has no filter to redact secrets with, so it withholds the original message outright rather than
+   * falling back to an unfiltered {@link SecretFilter#allowAll()} — the whole point of the secret
+   * filter is to restrict what gets resolved, and defaulting to allow-all here would let a legacy
+   * caller bypass that restriction.
    */
   public ConnectorResult.ErrorResult handleFinalResultException(Exception ex, ActivatedJob job) {
-    return handleFinalResultException(ex, job, SecretFilter.allowAll());
+    LOGGER.error(
+        "Exception while processing job: {} for tenant: {}, type: {}. Its message is withheld:"
+            + " this legacy entry point has no secret filter to redact it with.",
+        job.getKey(),
+        job.getTenantId(),
+        ex.getClass().getName());
+    var wrappedException =
+        new RuntimeException(
+            "Original error can't be displayed: this legacy entry point has no secret filter to"
+                + " redact it with, and its message might contain secrets.",
+            ex);
+    return new ConnectorResult.ErrorResult(
+        Map.of("error", exceptionToMap(wrappedException)), wrappedException, 0);
   }
 
   /**

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/OutboundConnectorExceptionHandler.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/OutboundConnectorExceptionHandler.java
@@ -48,7 +48,7 @@ public class OutboundConnectorExceptionHandler {
    * caller walking the cause chain never reaches the real exception's message or, if it is a {@link
    * ConnectorException}, its error variables -- either can carry a resolved secret, and neither
    * overload has a filter to redact it with. See {@link #withheldExceptionToMap} for how the
-   * returned map itself stays free of both while still keeping {@code type} and {@code code}.
+   * returned map itself stays free of both, keeping only {@code type}.
    */
   private static final class SecretFilterUnavailableException extends RuntimeException {}
 

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/job/OutboundConnectorExceptionHandlerTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/job/OutboundConnectorExceptionHandlerTest.java
@@ -53,7 +53,7 @@ class OutboundConnectorExceptionHandlerTest {
     var result =
         handler.handleFinalResultException(new RuntimeException("boom"), job, throwingFilter);
 
-    assertThat(result.retries()).isEqualTo(0);
+    assertThat(result.retries()).isEqualTo(2);
     assertThat(result.exception().getMessage()).contains("Fetching secrets failed");
   }
 
@@ -73,7 +73,7 @@ class OutboundConnectorExceptionHandlerTest {
         handlerWithThrowingProvider.handleFinalResultException(
             new RuntimeException("boom"), job, SecretFilter.allowAll());
 
-    assertThat(result.retries()).isEqualTo(0);
+    assertThat(result.retries()).isEqualTo(2);
     assertThat(result.exception().getMessage()).contains("Fetching secrets failed");
   }
 

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/job/OutboundConnectorExceptionHandlerTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/job/OutboundConnectorExceptionHandlerTest.java
@@ -21,10 +21,14 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import io.camunda.client.api.response.ActivatedJob;
+import io.camunda.connector.api.error.ConnectorExceptionBuilder;
+import io.camunda.connector.api.error.ConnectorInputException;
+import io.camunda.connector.api.error.ConnectorRetryExceptionBuilder;
 import io.camunda.connector.api.secret.SecretProvider;
 import io.camunda.connector.runtime.core.secret.SecretFilter;
 import io.camunda.connector.runtime.secret.FooBarSecretProvider;
 import java.time.Duration;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 
 class OutboundConnectorExceptionHandlerTest {
@@ -114,5 +118,59 @@ class OutboundConnectorExceptionHandlerTest {
 
     assertThat(result.retries()).isEqualTo(2);
     assertThat(result.exception().getMessage()).doesNotContain("boom");
+  }
+
+  @Test
+  void
+      manageConnectorJobHandlerException_threeArgOverload_neverExposesTheOriginalExceptionsVariables() {
+    var job = jobWithSecretReference();
+    var connectorException =
+        new ConnectorExceptionBuilder()
+            .message("original response body: " + FooBarSecretProvider.SECRET_VALUE)
+            .errorVariables(Map.of("responseBody", FooBarSecretProvider.SECRET_VALUE))
+            .build();
+
+    var result = handler.manageConnectorJobHandlerException(connectorException, job, null);
+
+    @SuppressWarnings("unchecked")
+    var errorPayload =
+        (Map<String, Object>) ((Map<String, Object>) result.responseValue()).get("error");
+    assertThat(errorPayload).doesNotContainKey("variables");
+    assertThat(errorPayload.get("message").toString())
+        .doesNotContain(FooBarSecretProvider.SECRET_VALUE);
+    assertThat(result.exception().getMessage()).doesNotContain(FooBarSecretProvider.SECRET_VALUE);
+  }
+
+  @Test
+  void
+      manageConnectorJobHandlerException_threeArgOverload_honorsConnectorRetryExceptionConfiguration()
+          throws Exception {
+    var job = jobWithSecretReference();
+    var retryException =
+        new ConnectorRetryExceptionBuilder()
+            .message("boom")
+            .retries(7)
+            .backoffDuration(Duration.ofMinutes(5))
+            .build();
+
+    var result =
+        handler.manageConnectorJobHandlerException(retryException, job, Duration.ofSeconds(1));
+
+    assertThat(result.retries()).isEqualTo(7);
+    assertThat(result.retryBackoff()).isEqualTo(Duration.ofMinutes(5));
+  }
+
+  @Test
+  void
+      manageConnectorJobHandlerException_threeArgOverload_zeroesRetriesForConnectorInputException() {
+    var job = jobWithSecretReference();
+
+    var result =
+        handler.manageConnectorJobHandlerException(
+            new ConnectorInputException("bad input", new RuntimeException()),
+            job,
+            Duration.ofSeconds(1));
+
+    assertThat(result.retries()).isEqualTo(0);
   }
 }

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/job/OutboundConnectorExceptionHandlerTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/job/OutboundConnectorExceptionHandlerTest.java
@@ -126,6 +126,7 @@ class OutboundConnectorExceptionHandlerTest {
     var job = jobWithSecretReference();
     var connectorException =
         new ConnectorExceptionBuilder()
+            .errorCode("SOME_CODE")
             .message("original response body: " + FooBarSecretProvider.SECRET_VALUE)
             .errorVariables(Map.of("responseBody", FooBarSecretProvider.SECRET_VALUE))
             .build();
@@ -139,6 +140,8 @@ class OutboundConnectorExceptionHandlerTest {
     assertThat(errorPayload.get("message").toString())
         .doesNotContain(FooBarSecretProvider.SECRET_VALUE);
     assertThat(result.exception().getMessage()).doesNotContain(FooBarSecretProvider.SECRET_VALUE);
+    assertThat(errorPayload.get("type")).isEqualTo(connectorException.getClass().getName());
+    assertThat(errorPayload.get("code")).isEqualTo("SOME_CODE");
   }
 
   @Test

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/job/OutboundConnectorExceptionHandlerTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/job/OutboundConnectorExceptionHandlerTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.runtime.outbound.job;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.camunda.client.api.response.ActivatedJob;
+import io.camunda.connector.api.secret.SecretProvider;
+import io.camunda.connector.runtime.core.secret.SecretFilter;
+import io.camunda.connector.runtime.secret.FooBarSecretProvider;
+import java.time.Duration;
+import org.junit.jupiter.api.Test;
+
+class OutboundConnectorExceptionHandlerTest {
+
+  private final OutboundConnectorExceptionHandler handler =
+      new OutboundConnectorExceptionHandler(new FooBarSecretProvider());
+
+  private static ActivatedJob jobWithSecretReference() {
+    var job = mock(ActivatedJob.class);
+    when(job.getVariables()).thenReturn("{\"value\":\"{{secrets.FOO}}\"}");
+    when(job.getKey()).thenReturn(1L);
+    when(job.getTenantId()).thenReturn("tenant");
+    when(job.getBpmnProcessId()).thenReturn("process");
+    when(job.getRetries()).thenReturn(3);
+    return job;
+  }
+
+  @Test
+  void handleFinalResultException_secretFilterThrows_returnsSanitizedResultInsteadOfPropagating() {
+    var job = jobWithSecretReference();
+    SecretFilter throwingFilter =
+        name -> {
+          throw new IllegalStateException("process-definition lookup failed");
+        };
+
+    var result =
+        handler.handleFinalResultException(new RuntimeException("boom"), job, throwingFilter);
+
+    assertThat(result.retries()).isEqualTo(0);
+    assertThat(result.exception().getMessage()).contains("Fetching secrets failed");
+  }
+
+  @Test
+  void
+      handleFinalResultException_secretProviderThrows_returnsSanitizedResultInsteadOfPropagating() {
+    var job = jobWithSecretReference();
+    SecretProvider throwingProvider =
+        mock(
+            SecretProvider.class,
+            invocation -> {
+              throw new IllegalStateException("secret store unavailable");
+            });
+    var handlerWithThrowingProvider = new OutboundConnectorExceptionHandler(throwingProvider);
+
+    var result =
+        handlerWithThrowingProvider.handleFinalResultException(
+            new RuntimeException("boom"), job, SecretFilter.allowAll());
+
+    assertThat(result.retries()).isEqualTo(0);
+    assertThat(result.exception().getMessage()).contains("Fetching secrets failed");
+  }
+
+  @Test
+  void handleFinalResultException_twoArgOverload_stillAvailableForExternalCallers() {
+    var job = jobWithSecretReference();
+
+    var result = handler.handleFinalResultException(new RuntimeException("boom"), job);
+
+    assertThat(result.retries()).isEqualTo(0);
+    assertThat(result.exception().getMessage()).isEqualTo("boom");
+  }
+
+  @Test
+  void manageConnectorJobHandlerException_threeArgOverload_stillAvailableForExternalCallers() {
+    var job = jobWithSecretReference();
+
+    var result =
+        handler.manageConnectorJobHandlerException(
+            new RuntimeException("boom"), job, Duration.ofSeconds(1));
+
+    assertThat(result.retries()).isEqualTo(2);
+  }
+}

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/job/OutboundConnectorExceptionHandlerTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/job/OutboundConnectorExceptionHandlerTest.java
@@ -78,23 +78,41 @@ class OutboundConnectorExceptionHandlerTest {
   }
 
   @Test
-  void handleFinalResultException_twoArgOverload_stillAvailableForExternalCallers() {
+  void handleFinalResultException_twoArgOverload_withholdsMessageWithoutTouchingTheProvider() {
     var job = jobWithSecretReference();
+    SecretProvider providerThatMustNotBeCalled =
+        mock(
+            SecretProvider.class,
+            invocation -> {
+              throw new AssertionError(
+                  "this legacy overload has no filter and must not resolve any secret");
+            });
+    var handlerWithGuard = new OutboundConnectorExceptionHandler(providerThatMustNotBeCalled);
 
-    var result = handler.handleFinalResultException(new RuntimeException("boom"), job);
+    var result = handlerWithGuard.handleFinalResultException(new RuntimeException("boom"), job);
 
     assertThat(result.retries()).isEqualTo(0);
-    assertThat(result.exception().getMessage()).isEqualTo("boom");
+    assertThat(result.exception().getMessage()).doesNotContain("boom");
   }
 
   @Test
-  void manageConnectorJobHandlerException_threeArgOverload_stillAvailableForExternalCallers() {
+  void
+      manageConnectorJobHandlerException_threeArgOverload_withholdsMessageWithoutTouchingTheProvider() {
     var job = jobWithSecretReference();
+    SecretProvider providerThatMustNotBeCalled =
+        mock(
+            SecretProvider.class,
+            invocation -> {
+              throw new AssertionError(
+                  "this legacy overload has no filter and must not resolve any secret");
+            });
+    var handlerWithGuard = new OutboundConnectorExceptionHandler(providerThatMustNotBeCalled);
 
     var result =
-        handler.manageConnectorJobHandlerException(
+        handlerWithGuard.manageConnectorJobHandlerException(
             new RuntimeException("boom"), job, Duration.ofSeconds(1));
 
     assertThat(result.retries()).isEqualTo(2);
+    assertThat(result.exception().getMessage()).doesNotContain("boom");
   }
 }

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/job/OutboundConnectorExceptionHandlerTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/job/OutboundConnectorExceptionHandlerTest.java
@@ -126,7 +126,7 @@ class OutboundConnectorExceptionHandlerTest {
     var job = jobWithSecretReference();
     var connectorException =
         new ConnectorExceptionBuilder()
-            .errorCode("SOME_CODE")
+            .errorCode(FooBarSecretProvider.SECRET_VALUE)
             .message("original response body: " + FooBarSecretProvider.SECRET_VALUE)
             .errorVariables(Map.of("responseBody", FooBarSecretProvider.SECRET_VALUE))
             .build();
@@ -137,11 +137,11 @@ class OutboundConnectorExceptionHandlerTest {
     var errorPayload =
         (Map<String, Object>) ((Map<String, Object>) result.responseValue()).get("error");
     assertThat(errorPayload).doesNotContainKey("variables");
+    assertThat(errorPayload).doesNotContainKey("code");
     assertThat(errorPayload.get("message").toString())
         .doesNotContain(FooBarSecretProvider.SECRET_VALUE);
     assertThat(result.exception().getMessage()).doesNotContain(FooBarSecretProvider.SECRET_VALUE);
     assertThat(errorPayload.get("type")).isEqualTo(connectorException.getClass().getName());
-    assertThat(errorPayload.get("code")).isEqualTo("SOME_CODE");
   }
 
   @Test

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/OutboundConnectorsAutoConfigurationTest.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/OutboundConnectorsAutoConfigurationTest.java
@@ -34,7 +34,9 @@ import io.camunda.client.spring.properties.CamundaClientProperties;
 import io.camunda.connector.jackson.ConnectorsObjectMapperSupplier;
 import io.camunda.connector.runtime.annotation.ConnectorsObjectMapper;
 import io.camunda.connector.runtime.annotation.OutboundConnectorObjectMapper;
+import io.camunda.connector.runtime.core.secret.SecretFilterFactory;
 import io.camunda.connector.runtime.core.secret.SecretProviderAggregator;
+import io.camunda.connector.runtime.outbound.job.ConfigurableSecretFilterFactory.SecretFilterMode;
 import java.net.URI;
 import java.util.List;
 import org.junit.jupiter.api.Test;
@@ -43,6 +45,7 @@ import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.core.annotation.MergedAnnotations;
+import org.springframework.test.util.ReflectionTestUtils;
 
 class OutboundConnectorsAutoConfigurationTest {
 
@@ -87,6 +90,16 @@ class OutboundConnectorsAutoConfigurationTest {
               assertThat(context).doesNotHaveBean(CONNECTOR_EXECUTOR_BEAN_NAME);
               assertThat(context).hasSingleBean(CamundaClientExecutorService.class);
             });
+  }
+
+  @Test
+  void shouldDefaultSecretFilterModeToStrict() {
+    contextRunner.run(
+        context -> {
+          var secretFilterFactory = context.getBean(SecretFilterFactory.class);
+          assertThat(ReflectionTestUtils.getField(secretFilterFactory, "secretFilterMode"))
+              .isEqualTo(SecretFilterMode.STRICT);
+        });
   }
 
   static class RequiredOutboundRuntimeBeans {


### PR DESCRIPTION
## Summary

Follow-up to #7749 (the release-8.10.0-alpha3 backport of #7568), which shipped the outbound secret filter with a `DISABLED` default. A fresh install therefore stays unfiltered until an operator explicitly sets `camunda.connector.secret-resolver.secret-filter.mode=STRICT` (or `LAX`), which makes the security fix opt-in rather than on by default.

Flips the single default declaration in `OutboundConnectorRuntimeConfiguration#secretFilterFactory` to `STRICT`.

Flipping the default surfaces two latent issues in `OutboundConnectorExceptionHandler`'s final-result error-masking path, previously only reachable by opting into STRICT/LAX explicitly — fixed alongside so they don't ship live-by-default:
- A STRICT-mode secret-lookup failure raised while processing a connector's final result (result/error-expression evaluation, rather than `bindVariables`) could escape uncaught, leaving the job neither completed nor failed until its activation timed out. `handleFinalResultException` now catches that failure and returns a sanitized `ErrorResult` instead of propagating.
- That fetch-failure branch, and the legacy no-filter compatibility overloads for both `handleFinalResultException` and `manageConnectorJobHandlerException`, are now retry-safe and filter-safe: the fetch-failure branch preserves the remaining retry count (it's a transient failure, not a permanent one), and the legacy overloads withhold the message outright rather than defaulting to an unfiltered `allowAll()` (which would have let a legacy caller bypass the filter entirely).

## Changes
- `OutboundConnectorRuntimeConfiguration`: default `secret-filter.mode` flipped to `STRICT`.
- `OutboundConnectorExceptionHandler`: `handleFinalResultException` no longer lets a masking-fetch failure escape uncaught; its fetch-failure branch and the legacy 2-/3-arg overloads no longer bypass the configured filter or hard-code an unretryable failure.

## Test plan
- [x] Added `OutboundConnectorsAutoConfigurationTest#shouldDefaultSecretFilterModeToStrict`, which boots the real bean graph with no `secret-filter.mode` property set and asserts the resolved mode is `STRICT`.
- [x] Added `OutboundConnectorExceptionHandlerTest` covering: a masking-fetch failure returning a sanitized, retryable result instead of propagating; and the legacy overloads withholding the message without ever calling the secret provider.
- [x] Full suite for `connector-runtime-spring` and `spring-boot-starter-camunda-connectors`: all green.
- [x] `spotless:check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
