### PR TITLE
fix: include AdHocSubProcess, IntermediateThrowEvent, and EndEvent in outbound secret key extraction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,7 @@
 
 # Worktrees
 .worktree
- 
+
 # BlueJ files
 *.ctxt
 

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/secret/ProcessDefinitionSecretKeyCache.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/secret/ProcessDefinitionSecretKeyCache.java
@@ -20,7 +20,6 @@ import io.camunda.client.CamundaClient;
 import io.camunda.connector.runtime.core.secret.SecretUtil;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
-import io.camunda.zeebe.model.bpmn.instance.AdHocSubProcess;
 import io.camunda.zeebe.model.bpmn.instance.BaseElement;
 import io.camunda.zeebe.model.bpmn.instance.BusinessRuleTask;
 import io.camunda.zeebe.model.bpmn.instance.EndEvent;
@@ -56,7 +55,7 @@ public class ProcessDefinitionSecretKeyCache implements SecretKeyCache {
     OUTBOUND_ELIGIBLE_TYPES.add(SendTask.class);
     OUTBOUND_ELIGIBLE_TYPES.add(ScriptTask.class);
     OUTBOUND_ELIGIBLE_TYPES.add(BusinessRuleTask.class);
-    OUTBOUND_ELIGIBLE_TYPES.add(AdHocSubProcess.class);
+    OUTBOUND_ELIGIBLE_TYPES.add(SubProcess.class);
     OUTBOUND_ELIGIBLE_TYPES.add(IntermediateThrowEvent.class);
     OUTBOUND_ELIGIBLE_TYPES.add(EndEvent.class);
   }
@@ -167,17 +166,12 @@ public class ProcessDefinitionSecretKeyCache implements SecretKeyCache {
   private Collection<FlowElement> collectFlowElements(
       final Collection<FlowElement> processFlowElements, final Collection<FlowElement> buffer) {
     for (FlowElement element : processFlowElements) {
-      // an ad-hoc subprocess can itself be a connector element (its own zeebe:ioMapping declares
-      // secrets, e.g. the AI Agent Sub-process template), so it must be considered directly, in
-      // addition to expanding its children below
-      if (element instanceof AdHocSubProcess adHocSubProcess) {
-        buffer.add(adHocSubProcess);
-        buffer.addAll(retrieveEligibleElementsFromSubprocess(adHocSubProcess));
-        continue;
-      }
-      // if we detect a subprocess, we have to expand it
-      // its building blocks to identify where are connectors
+      // a subprocess (embedded, event, multi-instance, ad-hoc, or nested) can itself be a
+      // connector element (its own zeebe:ioMapping declares secrets, e.g. the AI Agent Sub-process
+      // template on an ad-hoc subprocess), so it must be considered directly, in addition to
+      // expanding its children below
       if (element instanceof SubProcess subprocess) {
+        buffer.add(subprocess);
         buffer.addAll(retrieveEligibleElementsFromSubprocess(subprocess));
         continue;
       }

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/secret/ProcessDefinitionSecretKeyCache.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/secret/ProcessDefinitionSecretKeyCache.java
@@ -20,6 +20,7 @@ import io.camunda.client.CamundaClient;
 import io.camunda.connector.runtime.core.secret.SecretUtil;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.model.bpmn.instance.AdHocSubProcess;
 import io.camunda.zeebe.model.bpmn.instance.BaseElement;
 import io.camunda.zeebe.model.bpmn.instance.BusinessRuleTask;
 import io.camunda.zeebe.model.bpmn.instance.FlowElement;
@@ -53,6 +54,7 @@ public class ProcessDefinitionSecretKeyCache implements SecretKeyCache {
     OUTBOUND_ELIGIBLE_TYPES.add(SendTask.class);
     OUTBOUND_ELIGIBLE_TYPES.add(ScriptTask.class);
     OUTBOUND_ELIGIBLE_TYPES.add(BusinessRuleTask.class);
+    OUTBOUND_ELIGIBLE_TYPES.add(AdHocSubProcess.class);
   }
 
   private final String physicalTenantId;
@@ -161,6 +163,14 @@ public class ProcessDefinitionSecretKeyCache implements SecretKeyCache {
   private Collection<FlowElement> collectFlowElements(
       final Collection<FlowElement> processFlowElements, final Collection<FlowElement> buffer) {
     for (FlowElement element : processFlowElements) {
+      // an ad-hoc subprocess can itself be a connector element (its own zeebe:ioMapping declares
+      // secrets, e.g. the AI Agent Sub-process template), so it must be considered directly, in
+      // addition to expanding its children below
+      if (element instanceof AdHocSubProcess adHocSubProcess) {
+        buffer.add(adHocSubProcess);
+        buffer.addAll(retrieveEligibleElementsFromSubprocess(adHocSubProcess));
+        continue;
+      }
       // if we detect a subprocess, we have to expand it
       // its building blocks to identify where are connectors
       if (element instanceof SubProcess subprocess) {

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/secret/ProcessDefinitionSecretKeyCache.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/secret/ProcessDefinitionSecretKeyCache.java
@@ -23,7 +23,9 @@ import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.model.bpmn.instance.AdHocSubProcess;
 import io.camunda.zeebe.model.bpmn.instance.BaseElement;
 import io.camunda.zeebe.model.bpmn.instance.BusinessRuleTask;
+import io.camunda.zeebe.model.bpmn.instance.EndEvent;
 import io.camunda.zeebe.model.bpmn.instance.FlowElement;
+import io.camunda.zeebe.model.bpmn.instance.IntermediateThrowEvent;
 import io.camunda.zeebe.model.bpmn.instance.Process;
 import io.camunda.zeebe.model.bpmn.instance.ScriptTask;
 import io.camunda.zeebe.model.bpmn.instance.SendTask;
@@ -55,6 +57,8 @@ public class ProcessDefinitionSecretKeyCache implements SecretKeyCache {
     OUTBOUND_ELIGIBLE_TYPES.add(ScriptTask.class);
     OUTBOUND_ELIGIBLE_TYPES.add(BusinessRuleTask.class);
     OUTBOUND_ELIGIBLE_TYPES.add(AdHocSubProcess.class);
+    OUTBOUND_ELIGIBLE_TYPES.add(IntermediateThrowEvent.class);
+    OUTBOUND_ELIGIBLE_TYPES.add(EndEvent.class);
   }
 
   private final String physicalTenantId;

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/secret/ProcessDefinitionSecretKeyCacheTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/secret/ProcessDefinitionSecretKeyCacheTest.java
@@ -112,6 +112,19 @@ class ProcessDefinitionSecretKeyCacheTest {
   }
 
   @Test
+  void getSecretKeys_adHocSubProcessAndChild_returnsEachElementsOwnSecrets() throws IOException {
+    when(xmlRequest.execute()).thenReturn(loadBpmn("outbound-adhoc-subprocess.bpmn"));
+
+    var subProcessKeys =
+        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "agent-subprocess"));
+    var childKeys =
+        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "child-task"));
+
+    assertThat(subProcessKeys).containsExactly("ADHOC_SECRET");
+    assertThat(childKeys).containsExactly("CHILD_SECRET");
+  }
+
+  @Test
   void getSecretKeys_unknownElementId_returnsEmptyList() throws IOException {
     when(xmlRequest.execute()).thenReturn(loadBpmn("outbound-with-secrets.bpmn"));
 

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/secret/ProcessDefinitionSecretKeyCacheTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/secret/ProcessDefinitionSecretKeyCacheTest.java
@@ -125,6 +125,20 @@ class ProcessDefinitionSecretKeyCacheTest {
   }
 
   @Test
+  void getSecretKeys_messageIntermediateThrowEventAndEndEvent_returnsEachElementsOwnSecrets()
+      throws IOException {
+    when(xmlRequest.execute()).thenReturn(loadBpmn("outbound-message-events.bpmn"));
+
+    var throwEventKeys =
+        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "send-message-throw"));
+    var endEventKeys =
+        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "send-message-end"));
+
+    assertThat(throwEventKeys).containsExactly("THROW_EVENT_SECRET");
+    assertThat(endEventKeys).containsExactly("END_EVENT_SECRET");
+  }
+
+  @Test
   void getSecretKeys_unknownElementId_returnsEmptyList() throws IOException {
     when(xmlRequest.execute()).thenReturn(loadBpmn("outbound-with-secrets.bpmn"));
 

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/secret/ProcessDefinitionSecretKeyCacheTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/secret/ProcessDefinitionSecretKeyCacheTest.java
@@ -125,6 +125,25 @@ class ProcessDefinitionSecretKeyCacheTest {
   }
 
   @Test
+  void getSecretKeys_nestedEmbeddedSubProcessesAndGrandchild_returnsEachElementsOwnSecrets()
+      throws IOException {
+    // Verifies the fix generalizes beyond AdHocSubProcess: a plain (embedded) SubProcess can
+    // itself be a connector host, at any nesting depth, same as the ad-hoc flavor.
+    when(xmlRequest.execute()).thenReturn(loadBpmn("outbound-nested-embedded-subprocess.bpmn"));
+
+    var outerKeys =
+        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "outer-subprocess"));
+    var innerKeys =
+        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "inner-subprocess"));
+    var grandchildKeys =
+        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "grandchild-task"));
+
+    assertThat(outerKeys).containsExactly("OUTER_SECRET");
+    assertThat(innerKeys).containsExactly("INNER_SECRET");
+    assertThat(grandchildKeys).containsExactly("GRANDCHILD_SECRET");
+  }
+
+  @Test
   void getSecretKeys_messageIntermediateThrowEventAndEndEvent_returnsEachElementsOwnSecrets()
       throws IOException {
     when(xmlRequest.execute()).thenReturn(loadBpmn("outbound-message-events.bpmn"));

--- a/connector-runtime/connector-runtime-spring/src/test/resources/bpmn/outbound-adhoc-subprocess.bpmn
+++ b/connector-runtime/connector-runtime-spring/src/test/resources/bpmn/outbound-adhoc-subprocess.bpmn
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+                  xmlns:zeebe="http://camunda.org/schema/zeebe/1.0"
+                  id="Definitions_adhoc_subprocess"
+                  targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="outbound-adhoc-subprocess" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_1" sourceRef="StartEvent_1" targetRef="agent-subprocess"/>
+    <bpmn:adHocSubProcess id="agent-subprocess" name="Agent Sub-process">
+      <bpmn:extensionElements>
+        <zeebe:adHoc/>
+        <zeebe:ioMapping>
+          <zeebe:input source="{{secrets.ADHOC_SECRET}}" target="apiKey"/>
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1</bpmn:incoming>
+      <bpmn:outgoing>Flow_2</bpmn:outgoing>
+      <bpmn:serviceTask id="child-task" name="Tool">
+        <bpmn:extensionElements>
+          <zeebe:ioMapping>
+            <zeebe:input source="{{secrets.CHILD_SECRET}}" target="token"/>
+          </zeebe:ioMapping>
+        </bpmn:extensionElements>
+      </bpmn:serviceTask>
+    </bpmn:adHocSubProcess>
+    <bpmn:sequenceFlow id="Flow_2" sourceRef="agent-subprocess" targetRef="EndEvent_1"/>
+    <bpmn:endEvent id="EndEvent_1">
+      <bpmn:incoming>Flow_2</bpmn:incoming>
+    </bpmn:endEvent>
+  </bpmn:process>
+</bpmn:definitions>

--- a/connector-runtime/connector-runtime-spring/src/test/resources/bpmn/outbound-message-events.bpmn
+++ b/connector-runtime/connector-runtime-spring/src/test/resources/bpmn/outbound-message-events.bpmn
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+                  xmlns:zeebe="http://camunda.org/schema/zeebe/1.0"
+                  id="Definitions_message_events"
+                  targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="outbound-message-events" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_1" sourceRef="StartEvent_1" targetRef="send-message-throw"/>
+    <bpmn:intermediateThrowEvent id="send-message-throw" name="Send Message">
+      <bpmn:extensionElements>
+        <zeebe:ioMapping>
+          <zeebe:input source="{{secrets.THROW_EVENT_SECRET}}" target="apiKey"/>
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1</bpmn:incoming>
+      <bpmn:outgoing>Flow_2</bpmn:outgoing>
+      <bpmn:messageEventDefinition/>
+    </bpmn:intermediateThrowEvent>
+    <bpmn:sequenceFlow id="Flow_2" sourceRef="send-message-throw" targetRef="send-message-end"/>
+    <bpmn:endEvent id="send-message-end" name="Send Message">
+      <bpmn:extensionElements>
+        <zeebe:ioMapping>
+          <zeebe:input source="{{secrets.END_EVENT_SECRET}}" target="apiKey"/>
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_2</bpmn:incoming>
+      <bpmn:messageEventDefinition/>
+    </bpmn:endEvent>
+  </bpmn:process>
+</bpmn:definitions>

--- a/connector-runtime/connector-runtime-spring/src/test/resources/bpmn/outbound-nested-embedded-subprocess.bpmn
+++ b/connector-runtime/connector-runtime-spring/src/test/resources/bpmn/outbound-nested-embedded-subprocess.bpmn
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+                  xmlns:zeebe="http://camunda.org/schema/zeebe/1.0"
+                  id="Definitions_nested_embedded_subprocess"
+                  targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="outbound-nested-embedded-subprocess" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_1" sourceRef="StartEvent_1" targetRef="outer-subprocess"/>
+    <bpmn:subProcess id="outer-subprocess" name="Outer Sub-process">
+      <bpmn:extensionElements>
+        <zeebe:ioMapping>
+          <zeebe:input source="{{secrets.OUTER_SECRET}}" target="apiKey"/>
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1</bpmn:incoming>
+      <bpmn:outgoing>Flow_2</bpmn:outgoing>
+      <bpmn:startEvent id="InnerStart_1">
+        <bpmn:outgoing>InnerFlow_1</bpmn:outgoing>
+      </bpmn:startEvent>
+      <bpmn:sequenceFlow id="InnerFlow_1" sourceRef="InnerStart_1" targetRef="inner-subprocess"/>
+      <bpmn:subProcess id="inner-subprocess" name="Inner Sub-process">
+        <bpmn:extensionElements>
+          <zeebe:ioMapping>
+            <zeebe:input source="{{secrets.INNER_SECRET}}" target="apiKey"/>
+          </zeebe:ioMapping>
+        </bpmn:extensionElements>
+        <bpmn:incoming>InnerFlow_1</bpmn:incoming>
+        <bpmn:outgoing>InnerFlow_2</bpmn:outgoing>
+        <bpmn:serviceTask id="grandchild-task" name="Tool">
+          <bpmn:extensionElements>
+            <zeebe:ioMapping>
+              <zeebe:input source="{{secrets.GRANDCHILD_SECRET}}" target="token"/>
+            </zeebe:ioMapping>
+          </bpmn:extensionElements>
+        </bpmn:serviceTask>
+      </bpmn:subProcess>
+      <bpmn:sequenceFlow id="InnerFlow_2" sourceRef="inner-subprocess" targetRef="InnerEnd_1"/>
+      <bpmn:endEvent id="InnerEnd_1">
+        <bpmn:incoming>InnerFlow_2</bpmn:incoming>
+      </bpmn:endEvent>
+    </bpmn:subProcess>
+    <bpmn:sequenceFlow id="Flow_2" sourceRef="outer-subprocess" targetRef="EndEvent_1"/>
+    <bpmn:endEvent id="EndEvent_1">
+      <bpmn:incoming>Flow_2</bpmn:incoming>
+    </bpmn:endEvent>
+  </bpmn:process>
+</bpmn:definitions>


### PR DESCRIPTION
## Summary

`ProcessDefinitionSecretKeyCache`'s element traversal (`collectFlowElements`) replaces every `SubProcess` with only its children, and `OUTBOUND_ELIGIBLE_TYPES` doesn't include any subprocess type either way. The current (non-deprecated) "AI Agent Sub-process" v2 element template targets `bpmn:AdHocSubProcess` directly and declares its own secrets (e.g. an LLM provider API key) in that element's own `zeebe:ioMapping` — so its allow-list always comes back empty, and every secret it references gets silently blocked once secret filtering is active.

This predates #7568 and is independent of it, but matters much more now: under the old `DISABLED` default it was silent/opt-in, but #8506 makes `STRICT` the default, turning this into a live-by-default break for every AI Agent Sub-process deployment. Found via automated review on the stable/8.8 backport (#8496) — see that PR's discussion for the full trace.

While fixing this, automated review also flagged that the shipped Send Message connector templates target `bpmn:IntermediateThrowEvent` and `bpmn:EndEvent`, which had the same gap — neither type was in `OUTBOUND_ELIGIBLE_TYPES`, so their declared secrets were silently unresolvable too. Fixed alongside since it's the identical class of bug in the same list.

The fix originally special-cased `AdHocSubProcess` only, but [#8493](https://github.com/camunda/connectors/pull/8493) independently fixed the same root cause with a broader `SubProcess.class` change and verified on a real Camunda 8.10 cluster ([details](https://github.com/camunda/connectors/pull/8493#issuecomment-5477579342)) that it also correctly resolves secrets on embedded, event, multi-instance, and nested sub-processes — any subprocess type with a connector configured directly on its boundary, not just the ad-hoc flavor. Adopted that broader scope here, since `AdHocSubProcess` is itself a `SubProcess`.

## Changes
- Add `SubProcess.class` to `OUTBOUND_ELIGIBLE_TYPES`, covering every subprocess flavor (embedded, event, multi-instance, ad-hoc, nested).
- In `collectFlowElements`, add each `SubProcess` element itself to the eligible-elements buffer (so its own `zeebe:ioMapping` is inspected), while still recursing into its children (who may declare their own secrets too).
- Add `IntermediateThrowEvent.class` and `EndEvent.class` to `OUTBOUND_ELIGIBLE_TYPES` (targeted by the shipped Send Message connector templates).

## Test plan
- [x] Added `outbound-adhoc-subprocess.bpmn` fixture: an `AdHocSubProcess` with its own secret plus a nested child task with a different secret.
- [x] Added `outbound-nested-embedded-subprocess.bpmn` fixture and a test covering a plain embedded subprocess nested inside another, each with its own secret, plus a grandchild task — proving the fix isn't ad-hoc-specific.
- [x] Added `outbound-message-events.bpmn` fixture and a test covering the intermediate-throw-event and end-event case.
- [x] Full suite for `connector-runtime-spring`: all green.
- [x] `spotless:check` clean.

## Follow-up
Backport labels are on this PR for `stable/8.9` and `release-8.10.0-alpha5`; `stable/8.7` (#8501) and `stable/8.8` (#8496) have the equivalent fix applied directly since they predate the label-based backport bot for this cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
