### PR TITLE
fix: bump reactor-core to 3.8.7

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -132,6 +132,10 @@ limitations under the License.</license.inlineheader>
     <version.commons-codec>1.16.1</version.commons-codec>
 
     <version.kafka-clients>4.3.1</version.kafka-clients>
+    <!-- CVE-2026-47857: reactor-core transitive override — remove once spring-boot-dependencies
+         ships a reactor-bom with reactor-core >= 3.8.7
+         Ref: https://spring.io/security/cve-2026-47857/ -->
+    <version.reactor-core>3.8.7</version.reactor-core>
     <!-- CVE-2026-59949: lz4-java transitive override — remove once kafka-clients ships lz4-java >= 1.11.1
          Ref: https://nvd.nist.gov/vuln/detail/CVE-2026-59949 -->
     <version.lz4-java>1.11.2</version.lz4-java>
@@ -619,6 +623,16 @@ limitations under the License.</license.inlineheader>
         <version>${version.amqp-client}</version>
       </dependency>
 
+      <!-- CVE-2026-47857 (https://spring.io/security/cve-2026-47857/): override reactor-core
+           transitive version brought in by spring-boot-dependencies' reactor-bom. Remove once
+           spring-boot-dependencies ships reactor-core >= 3.8.7. Guarded by the version.spring-boot
+           enforcer rule below. -->
+      <dependency>
+        <groupId>io.projectreactor</groupId>
+        <artifactId>reactor-core</artifactId>
+        <version>${version.reactor-core}</version>
+      </dependency>
+
       <dependency>
         <groupId>com.microsoft.graph</groupId>
         <artifactId>microsoft-graph</artifactId>
@@ -963,6 +977,24 @@ If the new spring-boot-dependencies BOM ships com.rabbitmq:amqp-client &gt;= 5.3
 version.amqp-client property, the amqp-client dependencyManagement entry, and this enforcer rule
 from parent/pom.xml.
 See: https://github.com/rabbitmq/rabbitmq-java-client/security/advisories/GHSA-jh4v-gfqj-7rhx
+                </regexMessage>
+              </requireProperty>
+              <!-- CVE-2026-47857 guard: fails if version.spring-boot is bumped, as a reminder to
+                   check whether the reactor-core override can be removed (see version.reactor-core).
+                   spring-boot-dependencies manages io.projectreactor:reactor-core via its own
+                   reactor-bom import. Confirmed still needed as of spring-boot
+                   3.5.16-spring-boot-3.5.19: its reactor-bom (2024.0.18) ships reactor-core 3.7.19,
+                   still short of the 3.8.7 fix. -->
+              <requireProperty>
+                <property>version.spring-boot</property>
+                <regex>^3\.5\.16-spring-boot-3\.5\.19$</regex>
+                <regexMessage>
+version.spring-boot was changed! Check if the reactor-core CVE-2026-47857 override can be removed.
+If the new spring-boot-dependencies BOM ships io.projectreactor:reactor-core &gt;= 3.8.7 (confirm with
+`mvn dependency:tree -Dincludes=io.projectreactor:reactor-core`, not just the property), remove the
+version.reactor-core property, the reactor-core dependencyManagement entry, and this enforcer rule
+from parent/pom.xml.
+See: https://spring.io/security/cve-2026-47857/
                 </regexMessage>
               </requireProperty>
             </rules>


### PR DESCRIPTION
## Summary

Bumps `io.projectreactor:reactor-core` from `3.7.19` to `3.8.7`.

Security fix. Details in the internal tracking issue: camunda/team-connectors#1272