### PR TITLE
feat: receive App Integrations chat messages in a process

### DIFF
--- a/connectors/app-integrations/README.md
+++ b/connectors/app-integrations/README.md
@@ -142,6 +142,26 @@ plus a character restriction for Slack — and an element template cannot expres
 `maxLength`. Both bind to the same `platform.displayName` variable, so only the template property IDs
 differ.
 
+### Chat message templates
+
+Four further templates let a process take part in a Teams or Slack conversation. They are not
+connectors: the backend publishes the messages itself, so these are plain BPMN message events with
+nothing to configure on the runtime.
+
+| Template | Element | What it does |
+| --- | --- | --- |
+| App Integrations Chat Conversation Start Event | Message start event | Starts a process when someone writes to the Camunda app in Teams or Slack. |
+| App Integrations Chat Message Intermediate Event | Intermediate catch event | Waits for the next message in the conversation. |
+| App Integrations Chat Message Receive Task | Receive task | The same wait, as a task. |
+| App Integrations Chat Message Boundary Event | Boundary event | The same wait, attached to an activity. |
+
+The three waiting templates listen on the conversation named by their **Conversation** field, which
+defaults to the conversation the process is already holding. A process started from the chat start
+event therefore loops through a conversation with no configuration at all; to reply into a
+conversation a *Send Message* opened instead, point the field at that delivery's `conversationKey`.
+
+The incoming message lands in the `chatMessage` variable.
+
 ## API
 
 The connector flattens the switchable input onto the backend's flat wire contract and sends an explicit
@@ -198,7 +218,8 @@ Both operations return the backend's JSON response (e.g. the created channel for
 
 ```json
 { "deliveries": [ { "platform": "teams", "conversation": "19:abc@thread.tacv2;messageid=17123456789",
-                    "messageId": "17123456789" } ],
+                    "messageId": "17123456789",
+                    "conversationKey": "teams:19:abc@thread.tacv2;messageid=17123456789" } ],
   "failures": [ { "platform": "slack", "conversation": "C0123", "reason": "not_in_channel" } ] }
 ```
 
@@ -207,9 +228,16 @@ A single delivery is a one-element list, read as `deliveries[1].conversation` (F
 fan-out can check it. To reply to a delivery, pass `conversation` back as the Slack channel target
 with `messageId` as **Thread**, or as the Teams conversation target.
 
+`conversationKey` identifies the chat conversation the message landed in. It is an opaque value to be
+compared, never taken apart, and it is what the chat message templates below correlate on. A backend
+that predates it sends no such field.
+
 ## Regenerating the element template
 
 The element template is generated from the connector annotations by the
 `element-template-generator-maven-plugin` and committed to
 [element-templates/app-integrations-connector.json](element-templates/app-integrations-connector.json).
 The hybrid (Self-Managed) variant is in [element-templates/hybrid](element-templates/hybrid).
+
+The four chat message templates are hand-written and have no generator and no hybrid variant — they
+configure BPMN message events, not a connector runtime.

--- a/connectors/app-integrations/README.md
+++ b/connectors/app-integrations/README.md
@@ -155,6 +155,22 @@ nothing to configure on the runtime.
 | App Integrations Chat Message Receive Task | Receive task | The same wait, as a task. |
 | App Integrations Chat Message Boundary Event | Boundary event | The same wait, attached to an activity. |
 
+The start template has a **Chat key** field holding the *whole* message name —
+`io.camunda.appIntegrations.conversationStarted.<chat key>`, defaulting to
+`…conversationStarted.default`. The chat key is configured per channel or chat on the App
+Integrations side, and the channel's Camunda settings in Teams and Slack display the composed name
+ready to copy. Paste it in as-is; the field is validated against the composed form, so a typo cannot
+silently subscribe the process to an unrelated business message.
+
+One chat key should belong to exactly one process definition per cluster. Two definitions carrying
+the same key both start on every message from that channel — a modelling error the backend cannot
+detect, because it does not see deployments.
+
+The backend validates only the short key, `^[a-zA-Z0-9][a-zA-Z0-9._-]{0,63}$`, and prepends the
+prefix itself; the template's pattern is that same grammar with the prefix spelled out. They are one
+grammar written twice, in two repositories, with nothing enforcing that they stay in step — change
+one and change the other.
+
 The three waiting templates listen on the conversation named by their **Conversation** field, which
 defaults to the conversation the process is already holding. A process started from the chat start
 event therefore loops through a conversation with no configuration at all; to reply into a

--- a/connectors/app-integrations/element-templates/app-integrations-chat-message-boundary.json
+++ b/connectors/app-integrations/element-templates/app-integrations-chat-message-boundary.json
@@ -1,0 +1,64 @@
+{
+  "$schema" : "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+  "name" : "App Integrations Chat Message Boundary Event",
+  "id" : "io.camunda.connectors.AppIntegrationsChat.Boundary.v1",
+  "description" : "Wait for the next message in the Teams or Slack conversation this process is holding",
+  "keywords" : [ "teams", "microsoft teams", "slack", "chat", "conversation", "reply", "message start", "receive message" ],
+  "documentationRef" : "https://docs.camunda.io/docs/8.10/components/connectors/out-of-the-box-connectors/app-integrations/",
+  "version" : 1,
+  "category" : {
+    "id" : "connectors",
+    "name" : "Connectors"
+  },
+  "appliesTo" : [ "bpmn:BoundaryEvent" ],
+  "elementType" : {
+    "value" : "bpmn:BoundaryEvent",
+    "eventDefinition" : "bpmn:MessageEventDefinition"
+  },
+  "engines" : {
+    "camunda" : "^8.10"
+  },
+  "groups" : [ {
+    "id" : "correlation",
+    "label" : "Correlation"
+  }, {
+    "id" : "output",
+    "label" : "Output mapping"
+  } ],
+  "properties" : [ {
+    "type" : "Hidden",
+    "value" : "io.camunda.appIntegrations.chatMessage",
+    "binding" : {
+      "type" : "bpmn:Message#property",
+      "name" : "name"
+    }
+  }, {
+    "id" : "correlationKey",
+    "label" : "Conversation",
+    "description" : "The conversation to listen to",
+    "type" : "String",
+    "value" : "=chatMessage.conversationKey",
+    "feel" : "required",
+    "group" : "correlation",
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "binding" : {
+      "type" : "bpmn:Message#zeebe:subscription#property",
+      "name" : "correlationKey"
+    }
+  }, {
+    "id" : "resultVariable",
+    "label" : "Result variable",
+    "value" : "chatMessage",
+    "type" : "String",
+    "group" : "output",
+    "binding" : {
+      "type" : "zeebe:output",
+      "source" : "=chatMessage"
+    }
+  } ],
+  "icon" : {
+    "contents" : "data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTgiIGhlaWdodD0iMTgiIHZpZXdCb3g9IjAgMCAyNCAyNCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZD0iTTIxIDguNUMyMSA3LjEzMzE3IDIxIDUgMjEgNUMyMSA0LjQ2OTU3IDIwLjc4OTMgMy45NjA4NiAyMC40MTQyIDMuNTg1NzlDMjAuMDM5MSAzLjIxMDcxIDE5LjUzMDQgMyAxOSAzSDRDMy40Njk1NyAzIDIuOTYwODYgMy4yMTA3MSAyLjU4NTc5IDMuNTg1NzlDMi4yMTA3MSAzLjk2MDg2IDIgNC40Njk1NyAyIDVWMjEuMjg2QzIuMDAwMDIgMjEuNDI2NCAyLjA0MTY3IDIxLjU2MzcgMi4xMTk2OSAyMS42ODA0QzIuMTk3NyAyMS43OTcxIDIuMzA4NTggMjEuODg4MSAyLjQzODMxIDIxLjk0MTlDMi41NjgwMyAyMS45OTU2IDIuNzEwNzcgMjIuMDA5NyAyLjg0ODQ5IDIxLjk4MjNDMi45ODYyIDIxLjk1NDkgMy4xMTI3IDIxLjg4NzMgMy4yMTIgMjEuNzg4TDUuNDE0IDE5LjU4NkM1Ljc4ODk5IDE5LjIxMDkgNi4yOTc2MSAxOS4wMDAxIDYuODI4IDE5SDEwIiBzdHJva2U9ImJsYWNrIiBzdHJva2Utd2lkdGg9IjEuNSIgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIiBzdHJva2UtbGluZWpvaW49InJvdW5kIi8+CjxwYXRoIGQ9Ik0yMC45MzU5IDE3LjcxNzFDMjEuMTI2OCAxNy41MjY4IDIxLjI3ODMgMTcuMzAwOCAyMS4zODE3IDE3LjA1MThDMjEuNDg1IDE2LjgwMjkgMjEuNTM4MiAxNi41MzYgMjEuNTM4MiAxNi4yNjY0QzIxLjUzODIgMTUuOTk2OSAyMS40ODUgMTUuNzMgMjEuMzgxNyAxNS40ODExQzIxLjI3ODMgMTUuMjMyMSAyMS4xMjY4IDE1LjAwNjEgMjAuOTM1OSAxNC44MTU4TDE4Ljk3MzIgMTIuODUzMkwxMy44NTMzIDE3Ljk3MzFMMTUuODE1OSAxOS45MzU3QzE2LjAwNjIgMjAuMTI2NyAxNi4yMzIzIDIwLjI3ODEgMTYuNDgxMiAyMC4zODE1QzE2LjczMDIgMjAuNDg0OSAxNi45OTcgMjAuNTM4MSAxNy4yNjY2IDIwLjUzODFDMTcuNTM2MSAyMC41MzgxIDE3LjgwMyAyMC40ODQ5IDE4LjA1MiAyMC4zODE1QzE4LjMwMDkgMjAuMjc4MSAxOC41MjcgMjAuMTI2NyAxOC43MTcyIDE5LjkzNTdMMjAuOTM1OSAxNy43MTcxWiIgc3Ryb2tlPSIjRkY0QzAwIiBzdHJva2Utd2lkdGg9IjEuNSIgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIiBzdHJva2UtbGluZWpvaW49InJvdW5kIi8+CjxwYXRoIGQ9Ik0yMi4zODY1IDIxLjM4NjdMMTkuODI2NiAxOC44MjY4IiBzdHJva2U9IiNGRjRDMDAiIHN0cm9rZS13aWR0aD0iMS41IiBzdHJva2UtbGluZWNhcD0icm91bmQiIHN0cm9rZS1saW5lam9pbj0icm91bmQiLz4KPHBhdGggZD0iTTE1LjEzMzMgMTYuNjkzNEwxMyAxNC41NjAxIiBzdHJva2U9IiNGRjRDMDAiIHN0cm9rZS13aWR0aD0iMS41IiBzdHJva2UtbGluZWNhcD0icm91bmQiIHN0cm9rZS1saW5lam9pbj0icm91bmQiLz4KPHBhdGggZD0iTTE3LjY5MzMgMTQuMTMzM0wxNS41NiAxMiIgc3Ryb2tlPSIjRkY0QzAwIiBzdHJva2Utd2lkdGg9IjEuNSIgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIiBzdHJva2UtbGluZWpvaW49InJvdW5kIi8+CjxwYXRoIGQ9Ik02IDhIMTUiIHN0cm9rZT0iYmxhY2siIHN0cm9rZS13aWR0aD0iMS41IiBzdHJva2UtbGluZWNhcD0icm91bmQiIHN0cm9rZS1saW5lam9pbj0icm91bmQiLz4KPHBhdGggZD0iTTYgMTJIMTAiIHN0cm9rZT0iYmxhY2siIHN0cm9rZS13aWR0aD0iMS41IiBzdHJva2UtbGluZWNhcD0icm91bmQiIHN0cm9rZS1saW5lam9pbj0icm91bmQiLz4KPC9zdmc+Cg=="
+  }
+}

--- a/connectors/app-integrations/element-templates/app-integrations-chat-message-intermediate.json
+++ b/connectors/app-integrations/element-templates/app-integrations-chat-message-intermediate.json
@@ -1,0 +1,64 @@
+{
+  "$schema" : "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+  "name" : "App Integrations Chat Message Intermediate Event",
+  "id" : "io.camunda.connectors.AppIntegrationsChat.Intermediate.v1",
+  "description" : "Wait for the next message in the Teams or Slack conversation this process is holding",
+  "keywords" : [ "teams", "microsoft teams", "slack", "chat", "conversation", "reply", "message start", "receive message" ],
+  "documentationRef" : "https://docs.camunda.io/docs/8.10/components/connectors/out-of-the-box-connectors/app-integrations/",
+  "version" : 1,
+  "category" : {
+    "id" : "connectors",
+    "name" : "Connectors"
+  },
+  "appliesTo" : [ "bpmn:IntermediateCatchEvent" ],
+  "elementType" : {
+    "value" : "bpmn:IntermediateCatchEvent",
+    "eventDefinition" : "bpmn:MessageEventDefinition"
+  },
+  "engines" : {
+    "camunda" : "^8.10"
+  },
+  "groups" : [ {
+    "id" : "correlation",
+    "label" : "Correlation"
+  }, {
+    "id" : "output",
+    "label" : "Output mapping"
+  } ],
+  "properties" : [ {
+    "type" : "Hidden",
+    "value" : "io.camunda.appIntegrations.chatMessage",
+    "binding" : {
+      "type" : "bpmn:Message#property",
+      "name" : "name"
+    }
+  }, {
+    "id" : "correlationKey",
+    "label" : "Conversation",
+    "description" : "The conversation to listen to",
+    "type" : "String",
+    "value" : "=chatMessage.conversationKey",
+    "feel" : "required",
+    "group" : "correlation",
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "binding" : {
+      "type" : "bpmn:Message#zeebe:subscription#property",
+      "name" : "correlationKey"
+    }
+  }, {
+    "id" : "resultVariable",
+    "label" : "Result variable",
+    "value" : "chatMessage",
+    "type" : "String",
+    "group" : "output",
+    "binding" : {
+      "type" : "zeebe:output",
+      "source" : "=chatMessage"
+    }
+  } ],
+  "icon" : {
+    "contents" : "data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTgiIGhlaWdodD0iMTgiIHZpZXdCb3g9IjAgMCAyNCAyNCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZD0iTTIxIDguNUMyMSA3LjEzMzE3IDIxIDUgMjEgNUMyMSA0LjQ2OTU3IDIwLjc4OTMgMy45NjA4NiAyMC40MTQyIDMuNTg1NzlDMjAuMDM5MSAzLjIxMDcxIDE5LjUzMDQgMyAxOSAzSDRDMy40Njk1NyAzIDIuOTYwODYgMy4yMTA3MSAyLjU4NTc5IDMuNTg1NzlDMi4yMTA3MSAzLjk2MDg2IDIgNC40Njk1NyAyIDVWMjEuMjg2QzIuMDAwMDIgMjEuNDI2NCAyLjA0MTY3IDIxLjU2MzcgMi4xMTk2OSAyMS42ODA0QzIuMTk3NyAyMS43OTcxIDIuMzA4NTggMjEuODg4MSAyLjQzODMxIDIxLjk0MTlDMi41NjgwMyAyMS45OTU2IDIuNzEwNzcgMjIuMDA5NyAyLjg0ODQ5IDIxLjk4MjNDMi45ODYyIDIxLjk1NDkgMy4xMTI3IDIxLjg4NzMgMy4yMTIgMjEuNzg4TDUuNDE0IDE5LjU4NkM1Ljc4ODk5IDE5LjIxMDkgNi4yOTc2MSAxOS4wMDAxIDYuODI4IDE5SDEwIiBzdHJva2U9ImJsYWNrIiBzdHJva2Utd2lkdGg9IjEuNSIgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIiBzdHJva2UtbGluZWpvaW49InJvdW5kIi8+CjxwYXRoIGQ9Ik0yMC45MzU5IDE3LjcxNzFDMjEuMTI2OCAxNy41MjY4IDIxLjI3ODMgMTcuMzAwOCAyMS4zODE3IDE3LjA1MThDMjEuNDg1IDE2LjgwMjkgMjEuNTM4MiAxNi41MzYgMjEuNTM4MiAxNi4yNjY0QzIxLjUzODIgMTUuOTk2OSAyMS40ODUgMTUuNzMgMjEuMzgxNyAxNS40ODExQzIxLjI3ODMgMTUuMjMyMSAyMS4xMjY4IDE1LjAwNjEgMjAuOTM1OSAxNC44MTU4TDE4Ljk3MzIgMTIuODUzMkwxMy44NTMzIDE3Ljk3MzFMMTUuODE1OSAxOS45MzU3QzE2LjAwNjIgMjAuMTI2NyAxNi4yMzIzIDIwLjI3ODEgMTYuNDgxMiAyMC4zODE1QzE2LjczMDIgMjAuNDg0OSAxNi45OTcgMjAuNTM4MSAxNy4yNjY2IDIwLjUzODFDMTcuNTM2MSAyMC41MzgxIDE3LjgwMyAyMC40ODQ5IDE4LjA1MiAyMC4zODE1QzE4LjMwMDkgMjAuMjc4MSAxOC41MjcgMjAuMTI2NyAxOC43MTcyIDE5LjkzNTdMMjAuOTM1OSAxNy43MTcxWiIgc3Ryb2tlPSIjRkY0QzAwIiBzdHJva2Utd2lkdGg9IjEuNSIgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIiBzdHJva2UtbGluZWpvaW49InJvdW5kIi8+CjxwYXRoIGQ9Ik0yMi4zODY1IDIxLjM4NjdMMTkuODI2NiAxOC44MjY4IiBzdHJva2U9IiNGRjRDMDAiIHN0cm9rZS13aWR0aD0iMS41IiBzdHJva2UtbGluZWNhcD0icm91bmQiIHN0cm9rZS1saW5lam9pbj0icm91bmQiLz4KPHBhdGggZD0iTTE1LjEzMzMgMTYuNjkzNEwxMyAxNC41NjAxIiBzdHJva2U9IiNGRjRDMDAiIHN0cm9rZS13aWR0aD0iMS41IiBzdHJva2UtbGluZWNhcD0icm91bmQiIHN0cm9rZS1saW5lam9pbj0icm91bmQiLz4KPHBhdGggZD0iTTE3LjY5MzMgMTQuMTMzM0wxNS41NiAxMiIgc3Ryb2tlPSIjRkY0QzAwIiBzdHJva2Utd2lkdGg9IjEuNSIgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIiBzdHJva2UtbGluZWpvaW49InJvdW5kIi8+CjxwYXRoIGQ9Ik02IDhIMTUiIHN0cm9rZT0iYmxhY2siIHN0cm9rZS13aWR0aD0iMS41IiBzdHJva2UtbGluZWNhcD0icm91bmQiIHN0cm9rZS1saW5lam9pbj0icm91bmQiLz4KPHBhdGggZD0iTTYgMTJIMTAiIHN0cm9rZT0iYmxhY2siIHN0cm9rZS13aWR0aD0iMS41IiBzdHJva2UtbGluZWNhcD0icm91bmQiIHN0cm9rZS1saW5lam9pbj0icm91bmQiLz4KPC9zdmc+Cg=="
+  }
+}

--- a/connectors/app-integrations/element-templates/app-integrations-chat-message-receive.json
+++ b/connectors/app-integrations/element-templates/app-integrations-chat-message-receive.json
@@ -1,0 +1,63 @@
+{
+  "$schema" : "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+  "name" : "App Integrations Chat Message Receive Task",
+  "id" : "io.camunda.connectors.AppIntegrationsChat.Receive.v1",
+  "description" : "Wait for the next message in the Teams or Slack conversation this process is holding",
+  "keywords" : [ "teams", "microsoft teams", "slack", "chat", "conversation", "reply", "message start", "receive message" ],
+  "documentationRef" : "https://docs.camunda.io/docs/8.10/components/connectors/out-of-the-box-connectors/app-integrations/",
+  "version" : 1,
+  "category" : {
+    "id" : "connectors",
+    "name" : "Connectors"
+  },
+  "appliesTo" : [ "bpmn:ReceiveTask" ],
+  "elementType" : {
+    "value" : "bpmn:ReceiveTask"
+  },
+  "engines" : {
+    "camunda" : "^8.10"
+  },
+  "groups" : [ {
+    "id" : "correlation",
+    "label" : "Correlation"
+  }, {
+    "id" : "output",
+    "label" : "Output mapping"
+  } ],
+  "properties" : [ {
+    "type" : "Hidden",
+    "value" : "io.camunda.appIntegrations.chatMessage",
+    "binding" : {
+      "type" : "bpmn:Message#property",
+      "name" : "name"
+    }
+  }, {
+    "id" : "correlationKey",
+    "label" : "Conversation",
+    "description" : "The conversation to listen to",
+    "type" : "String",
+    "value" : "=chatMessage.conversationKey",
+    "feel" : "required",
+    "group" : "correlation",
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "binding" : {
+      "type" : "bpmn:Message#zeebe:subscription#property",
+      "name" : "correlationKey"
+    }
+  }, {
+    "id" : "resultVariable",
+    "label" : "Result variable",
+    "value" : "chatMessage",
+    "type" : "String",
+    "group" : "output",
+    "binding" : {
+      "type" : "zeebe:output",
+      "source" : "=chatMessage"
+    }
+  } ],
+  "icon" : {
+    "contents" : "data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTgiIGhlaWdodD0iMTgiIHZpZXdCb3g9IjAgMCAyNCAyNCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZD0iTTIxIDguNUMyMSA3LjEzMzE3IDIxIDUgMjEgNUMyMSA0LjQ2OTU3IDIwLjc4OTMgMy45NjA4NiAyMC40MTQyIDMuNTg1NzlDMjAuMDM5MSAzLjIxMDcxIDE5LjUzMDQgMyAxOSAzSDRDMy40Njk1NyAzIDIuOTYwODYgMy4yMTA3MSAyLjU4NTc5IDMuNTg1NzlDMi4yMTA3MSAzLjk2MDg2IDIgNC40Njk1NyAyIDVWMjEuMjg2QzIuMDAwMDIgMjEuNDI2NCAyLjA0MTY3IDIxLjU2MzcgMi4xMTk2OSAyMS42ODA0QzIuMTk3NyAyMS43OTcxIDIuMzA4NTggMjEuODg4MSAyLjQzODMxIDIxLjk0MTlDMi41NjgwMyAyMS45OTU2IDIuNzEwNzcgMjIuMDA5NyAyLjg0ODQ5IDIxLjk4MjNDMi45ODYyIDIxLjk1NDkgMy4xMTI3IDIxLjg4NzMgMy4yMTIgMjEuNzg4TDUuNDE0IDE5LjU4NkM1Ljc4ODk5IDE5LjIxMDkgNi4yOTc2MSAxOS4wMDAxIDYuODI4IDE5SDEwIiBzdHJva2U9ImJsYWNrIiBzdHJva2Utd2lkdGg9IjEuNSIgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIiBzdHJva2UtbGluZWpvaW49InJvdW5kIi8+CjxwYXRoIGQ9Ik0yMC45MzU5IDE3LjcxNzFDMjEuMTI2OCAxNy41MjY4IDIxLjI3ODMgMTcuMzAwOCAyMS4zODE3IDE3LjA1MThDMjEuNDg1IDE2LjgwMjkgMjEuNTM4MiAxNi41MzYgMjEuNTM4MiAxNi4yNjY0QzIxLjUzODIgMTUuOTk2OSAyMS40ODUgMTUuNzMgMjEuMzgxNyAxNS40ODExQzIxLjI3ODMgMTUuMjMyMSAyMS4xMjY4IDE1LjAwNjEgMjAuOTM1OSAxNC44MTU4TDE4Ljk3MzIgMTIuODUzMkwxMy44NTMzIDE3Ljk3MzFMMTUuODE1OSAxOS45MzU3QzE2LjAwNjIgMjAuMTI2NyAxNi4yMzIzIDIwLjI3ODEgMTYuNDgxMiAyMC4zODE1QzE2LjczMDIgMjAuNDg0OSAxNi45OTcgMjAuNTM4MSAxNy4yNjY2IDIwLjUzODFDMTcuNTM2MSAyMC41MzgxIDE3LjgwMyAyMC40ODQ5IDE4LjA1MiAyMC4zODE1QzE4LjMwMDkgMjAuMjc4MSAxOC41MjcgMjAuMTI2NyAxOC43MTcyIDE5LjkzNTdMMjAuOTM1OSAxNy43MTcxWiIgc3Ryb2tlPSIjRkY0QzAwIiBzdHJva2Utd2lkdGg9IjEuNSIgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIiBzdHJva2UtbGluZWpvaW49InJvdW5kIi8+CjxwYXRoIGQ9Ik0yMi4zODY1IDIxLjM4NjdMMTkuODI2NiAxOC44MjY4IiBzdHJva2U9IiNGRjRDMDAiIHN0cm9rZS13aWR0aD0iMS41IiBzdHJva2UtbGluZWNhcD0icm91bmQiIHN0cm9rZS1saW5lam9pbj0icm91bmQiLz4KPHBhdGggZD0iTTE1LjEzMzMgMTYuNjkzNEwxMyAxNC41NjAxIiBzdHJva2U9IiNGRjRDMDAiIHN0cm9rZS13aWR0aD0iMS41IiBzdHJva2UtbGluZWNhcD0icm91bmQiIHN0cm9rZS1saW5lam9pbj0icm91bmQiLz4KPHBhdGggZD0iTTE3LjY5MzMgMTQuMTMzM0wxNS41NiAxMiIgc3Ryb2tlPSIjRkY0QzAwIiBzdHJva2Utd2lkdGg9IjEuNSIgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIiBzdHJva2UtbGluZWpvaW49InJvdW5kIi8+CjxwYXRoIGQ9Ik02IDhIMTUiIHN0cm9rZT0iYmxhY2siIHN0cm9rZS13aWR0aD0iMS41IiBzdHJva2UtbGluZWNhcD0icm91bmQiIHN0cm9rZS1saW5lam9pbj0icm91bmQiLz4KPHBhdGggZD0iTTYgMTJIMTAiIHN0cm9rZT0iYmxhY2siIHN0cm9rZS13aWR0aD0iMS41IiBzdHJva2UtbGluZWNhcD0icm91bmQiIHN0cm9rZS1saW5lam9pbj0icm91bmQiLz4KPC9zdmc+Cg=="
+  }
+}

--- a/connectors/app-integrations/element-templates/app-integrations-chat-start-message.json
+++ b/connectors/app-integrations/element-templates/app-integrations-chat-start-message.json
@@ -1,0 +1,46 @@
+{
+  "$schema" : "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+  "name" : "App Integrations Chat Conversation Start Event",
+  "id" : "io.camunda.connectors.AppIntegrationsChat.Start.v1",
+  "description" : "Start a process when someone writes to the Camunda app in Microsoft Teams or Slack",
+  "keywords" : [ "teams", "microsoft teams", "slack", "chat", "conversation", "reply", "message start", "receive message" ],
+  "documentationRef" : "https://docs.camunda.io/docs/8.10/components/connectors/out-of-the-box-connectors/app-integrations/",
+  "version" : 1,
+  "category" : {
+    "id" : "connectors",
+    "name" : "Connectors"
+  },
+  "appliesTo" : [ "bpmn:StartEvent" ],
+  "elementType" : {
+    "value" : "bpmn:StartEvent",
+    "eventDefinition" : "bpmn:MessageEventDefinition"
+  },
+  "engines" : {
+    "camunda" : "^8.10"
+  },
+  "groups" : [ {
+    "id" : "output",
+    "label" : "Output mapping"
+  } ],
+  "properties" : [ {
+    "type" : "Hidden",
+    "value" : "io.camunda.appIntegrations.conversationStarted",
+    "binding" : {
+      "type" : "bpmn:Message#property",
+      "name" : "name"
+    }
+  }, {
+    "id" : "resultVariable",
+    "label" : "Result variable",
+    "value" : "chatMessage",
+    "type" : "String",
+    "group" : "output",
+    "binding" : {
+      "type" : "zeebe:output",
+      "source" : "=chatMessage"
+    }
+  } ],
+  "icon" : {
+    "contents" : "data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTgiIGhlaWdodD0iMTgiIHZpZXdCb3g9IjAgMCAyNCAyNCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZD0iTTIxIDguNUMyMSA3LjEzMzE3IDIxIDUgMjEgNUMyMSA0LjQ2OTU3IDIwLjc4OTMgMy45NjA4NiAyMC40MTQyIDMuNTg1NzlDMjAuMDM5MSAzLjIxMDcxIDE5LjUzMDQgMyAxOSAzSDRDMy40Njk1NyAzIDIuOTYwODYgMy4yMTA3MSAyLjU4NTc5IDMuNTg1NzlDMi4yMTA3MSAzLjk2MDg2IDIgNC40Njk1NyAyIDVWMjEuMjg2QzIuMDAwMDIgMjEuNDI2NCAyLjA0MTY3IDIxLjU2MzcgMi4xMTk2OSAyMS42ODA0QzIuMTk3NyAyMS43OTcxIDIuMzA4NTggMjEuODg4MSAyLjQzODMxIDIxLjk0MTlDMi41NjgwMyAyMS45OTU2IDIuNzEwNzcgMjIuMDA5NyAyLjg0ODQ5IDIxLjk4MjNDMi45ODYyIDIxLjk1NDkgMy4xMTI3IDIxLjg4NzMgMy4yMTIgMjEuNzg4TDUuNDE0IDE5LjU4NkM1Ljc4ODk5IDE5LjIxMDkgNi4yOTc2MSAxOS4wMDAxIDYuODI4IDE5SDEwIiBzdHJva2U9ImJsYWNrIiBzdHJva2Utd2lkdGg9IjEuNSIgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIiBzdHJva2UtbGluZWpvaW49InJvdW5kIi8+CjxwYXRoIGQ9Ik0yMC45MzU5IDE3LjcxNzFDMjEuMTI2OCAxNy41MjY4IDIxLjI3ODMgMTcuMzAwOCAyMS4zODE3IDE3LjA1MThDMjEuNDg1IDE2LjgwMjkgMjEuNTM4MiAxNi41MzYgMjEuNTM4MiAxNi4yNjY0QzIxLjUzODIgMTUuOTk2OSAyMS40ODUgMTUuNzMgMjEuMzgxNyAxNS40ODExQzIxLjI3ODMgMTUuMjMyMSAyMS4xMjY4IDE1LjAwNjEgMjAuOTM1OSAxNC44MTU4TDE4Ljk3MzIgMTIuODUzMkwxMy44NTMzIDE3Ljk3MzFMMTUuODE1OSAxOS45MzU3QzE2LjAwNjIgMjAuMTI2NyAxNi4yMzIzIDIwLjI3ODEgMTYuNDgxMiAyMC4zODE1QzE2LjczMDIgMjAuNDg0OSAxNi45OTcgMjAuNTM4MSAxNy4yNjY2IDIwLjUzODFDMTcuNTM2MSAyMC41MzgxIDE3LjgwMyAyMC40ODQ5IDE4LjA1MiAyMC4zODE1QzE4LjMwMDkgMjAuMjc4MSAxOC41MjcgMjAuMTI2NyAxOC43MTcyIDE5LjkzNTdMMjAuOTM1OSAxNy43MTcxWiIgc3Ryb2tlPSIjRkY0QzAwIiBzdHJva2Utd2lkdGg9IjEuNSIgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIiBzdHJva2UtbGluZWpvaW49InJvdW5kIi8+CjxwYXRoIGQ9Ik0yMi4zODY1IDIxLjM4NjdMMTkuODI2NiAxOC44MjY4IiBzdHJva2U9IiNGRjRDMDAiIHN0cm9rZS13aWR0aD0iMS41IiBzdHJva2UtbGluZWNhcD0icm91bmQiIHN0cm9rZS1saW5lam9pbj0icm91bmQiLz4KPHBhdGggZD0iTTE1LjEzMzMgMTYuNjkzNEwxMyAxNC41NjAxIiBzdHJva2U9IiNGRjRDMDAiIHN0cm9rZS13aWR0aD0iMS41IiBzdHJva2UtbGluZWNhcD0icm91bmQiIHN0cm9rZS1saW5lam9pbj0icm91bmQiLz4KPHBhdGggZD0iTTE3LjY5MzMgMTQuMTMzM0wxNS41NiAxMiIgc3Ryb2tlPSIjRkY0QzAwIiBzdHJva2Utd2lkdGg9IjEuNSIgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIiBzdHJva2UtbGluZWpvaW49InJvdW5kIi8+CjxwYXRoIGQ9Ik02IDhIMTUiIHN0cm9rZT0iYmxhY2siIHN0cm9rZS13aWR0aD0iMS41IiBzdHJva2UtbGluZWNhcD0icm91bmQiIHN0cm9rZS1saW5lam9pbj0icm91bmQiLz4KPHBhdGggZD0iTTYgMTJIMTAiIHN0cm9rZT0iYmxhY2siIHN0cm9rZS13aWR0aD0iMS41IiBzdHJva2UtbGluZWNhcD0icm91bmQiIHN0cm9rZS1saW5lam9pbj0icm91bmQiLz4KPC9zdmc+Cg=="
+  }
+}

--- a/connectors/app-integrations/element-templates/app-integrations-chat-start-message.json
+++ b/connectors/app-integrations/element-templates/app-integrations-chat-start-message.json
@@ -19,12 +19,27 @@
     "camunda" : "^8.10"
   },
   "groups" : [ {
+    "id" : "correlation",
+    "label" : "Correlation"
+  }, {
     "id" : "output",
     "label" : "Output mapping"
   } ],
   "properties" : [ {
-    "type" : "Hidden",
-    "value" : "io.camunda.appIntegrations.conversationStarted",
+    "id" : "messageName",
+    "label" : "Chat key",
+    "description" : "Must match the chat key configured on the channel or chat this process should answer. Copy it from the Camunda settings in Teams, or from `/camunda chat` in Slack.",
+    "type" : "String",
+    "value" : "io.camunda.appIntegrations.conversationStarted.default",
+    "placeholder" : "io.camunda.appIntegrations.conversationStarted.hr-intake",
+    "group" : "correlation",
+    "constraints" : {
+      "notEmpty" : true,
+      "pattern" : {
+        "value" : "^io\\.camunda\\.appIntegrations\\.conversationStarted\\.[a-zA-Z0-9][a-zA-Z0-9._-]{0,63}$",
+        "message" : "must be io.camunda.appIntegrations.conversationStarted.<chat key>"
+      }
+    },
     "binding" : {
       "type" : "bpmn:Message#property",
       "name" : "name"

--- a/connectors/app-integrations/src/main/java/io/camunda/connector/appintegrations/model/SendMessageResult.java
+++ b/connectors/app-integrations/src/main/java/io/camunda/connector/appintegrations/model/SendMessageResult.java
@@ -22,8 +22,13 @@ public record SendMessageResult(List<Delivery> deliveries, List<Failure> failure
    * What a later send passes back to reply: for Slack {@code conversation} is the channel target
    * and {@code messageId} the thread anchor; for Teams {@code conversation} is the conversation
    * target.
+   *
+   * <p>{@code conversationKey} is an opaque handle on the chat conversation, to be compared and
+   * never parsed, that a chat-message catch event takes as its correlation key. A backend that
+   * predates it leaves it {@code null}.
    */
-  public record Delivery(String platform, String conversation, String messageId) {}
+  public record Delivery(
+      String platform, String conversation, String messageId, String conversationKey) {}
 
   public record Failure(String platform, String conversation, String reason) {}
 }

--- a/connectors/app-integrations/src/test/java/io/camunda/connector/appintegrations/AppIntegrationsConnectorTest.java
+++ b/connectors/app-integrations/src/test/java/io/camunda/connector/appintegrations/AppIntegrationsConnectorTest.java
@@ -82,7 +82,7 @@ class AppIntegrationsConnectorTest {
   private static final ObjectMapper MAPPER = new ObjectMapper();
 
   private static final String DELIVERED_BODY =
-      "{\"deliveries\":[{\"platform\":\"teams\",\"conversation\":\"conv-1\",\"messageId\":\"m-1\"}],\"failures\":[]}";
+      "{\"deliveries\":[{\"platform\":\"teams\",\"conversation\":\"conv-1\",\"messageId\":\"m-1\",\"conversationKey\":\"teams:conv-1\"}],\"failures\":[]}";
 
   private static final Validator VALIDATOR =
       Validation.byDefaultProvider()
@@ -755,6 +755,7 @@ class AppIntegrationsConnectorTest {
               assertThat(delivery.platform()).isEqualTo("teams");
               assertThat(delivery.conversation()).isEqualTo("conv-1");
               assertThat(delivery.messageId()).isEqualTo("m-1");
+              assertThat(delivery.conversationKey()).isEqualTo("teams:conv-1");
             });
     assertThat(result.failures()).isEmpty();
     var req = captureRequest();

--- a/connectors/app-integrations/src/test/java/io/camunda/connector/appintegrations/AppIntegrationsConnectorWireMockTest.java
+++ b/connectors/app-integrations/src/test/java/io/camunda/connector/appintegrations/AppIntegrationsConnectorWireMockTest.java
@@ -149,7 +149,7 @@ class AppIntegrationsConnectorWireMockTest {
         post(urlPathEqualTo(MESSAGE_PATH))
             .willReturn(
                 okJson(
-                        "{\"deliveries\":[{\"platform\":\"teams\",\"conversation\":\"conv-1\",\"messageId\":\"m-1\"}],\"failures\":[]}")
+                        "{\"deliveries\":[{\"platform\":\"teams\",\"conversation\":\"conv-1\",\"messageId\":\"m-1\",\"conversationKey\":\"teams:conv-1\"}],\"failures\":[]}")
                     .withStatus(201)));
   }
 
@@ -216,8 +216,10 @@ class AppIntegrationsConnectorWireMockTest {
             .willReturn(
                 okJson(
                         """
-                        {"deliveries":[{"platform":"slack","conversation":"D0123","messageId":"1712345678.000100"},
-                                       {"platform":"teams","conversation":"conv-2","messageId":"m-2"}],
+                        {"deliveries":[{"platform":"slack","conversation":"D0123","messageId":"1712345678.000100",
+                                        "conversationKey":"slack:D0123:1712345678.000100"},
+                                       {"platform":"teams","conversation":"conv-2","messageId":"m-2",
+                                        "conversationKey":"teams:conv-2"}],
                          "failures":[{"platform":"slack","conversation":"C0999","reason":"not_in_channel"}]}""")
                     .withStatus(201)));
 
@@ -235,6 +237,9 @@ class AppIntegrationsConnectorWireMockTest {
     assertThat(result.deliveries())
         .extracting(SendMessageResult.Delivery::conversation)
         .containsExactly("D0123", "conv-2");
+    assertThat(result.deliveries())
+        .extracting(SendMessageResult.Delivery::conversationKey)
+        .containsExactly("slack:D0123:1712345678.000100", "teams:conv-2");
     assertThat(result.failures())
         .singleElement()
         .satisfies(failure -> assertThat(failure.reason()).isEqualTo("not_in_channel"));
@@ -262,7 +267,7 @@ class AppIntegrationsConnectorWireMockTest {
         post(urlPathEqualTo(MESSAGE_PATH))
             .willReturn(
                 okJson(
-                        "{\"deliveries\":[{\"platform\":\"slack\",\"conversation\":\"C0123456789\",\"messageId\":\"1712345678.000200\"}],\"failures\":[]}")
+                        "{\"deliveries\":[{\"platform\":\"slack\",\"conversation\":\"C0123456789\",\"messageId\":\"1712345678.000200\",\"conversationKey\":\"slack:C0123456789:1712345678.000200\"}],\"failures\":[]}")
                     .withStatus(201)));
 
     var blocks =
@@ -304,7 +309,7 @@ class AppIntegrationsConnectorWireMockTest {
         post(urlPathEqualTo(MESSAGE_PATH))
             .willReturn(
                 okJson(
-                        "{\"deliveries\":[{\"platform\":\"teams\",\"conversation\":\"19:abc@thread.tacv2;messageid=17123456789\",\"messageId\":\"17123456790\"}],\"failures\":[]}")
+                        "{\"deliveries\":[{\"platform\":\"teams\",\"conversation\":\"19:abc@thread.tacv2;messageid=17123456789\",\"messageId\":\"17123456790\",\"conversationKey\":\"teams:19:abc@thread.tacv2;messageid=17123456789\"}],\"failures\":[]}")
                     .withStatus(201)));
 
     var request =

--- a/connectors/app-integrations/src/test/java/io/camunda/connector/appintegrations/AppIntegrationsRequestDeserializationTest.java
+++ b/connectors/app-integrations/src/test/java/io/camunda/connector/appintegrations/AppIntegrationsRequestDeserializationTest.java
@@ -194,7 +194,8 @@ class AppIntegrationsRequestDeserializationTest {
             """
             {"deliveries":[{"platform":"teams",
                             "conversation":"19:abc@thread.tacv2;messageid=17123456789",
-                            "messageId":"17123456789"}],
+                            "messageId":"17123456789",
+                            "conversationKey":"teams:19:abc@thread.tacv2;messageid=17123456789"}],
              "failures":[{"platform":"slack","conversation":"C0123","reason":"not_in_channel"}]}""",
             SendMessageResult.class);
 
@@ -206,6 +207,8 @@ class AppIntegrationsRequestDeserializationTest {
               assertThat(delivery.conversation())
                   .isEqualTo("19:abc@thread.tacv2;messageid=17123456789");
               assertThat(delivery.messageId()).isEqualTo("17123456789");
+              assertThat(delivery.conversationKey())
+                  .isEqualTo("teams:19:abc@thread.tacv2;messageid=17123456789");
             });
     assertThat(result.failures())
         .singleElement()


### PR DESCRIPTION
## Description

The App Integrations connector could send a message to Microsoft Teams or Slack, but a process had no way to receive what someone wrote back. This adds the modelling side of that: element templates for a chat conversation start event, an intermediate catch event, a receive task and a boundary event.

There is no runtime here on purpose. A chat catch element is an ordinary BPMN message event, so the templates only pin the message name and default the correlation key — a modeller who drops in a start event and a catch event and changes nothing gets a working conversation loop. Adding an inbound connector runtime instead would have meant a second delivery path for messages the backend already has in hand.

A delivery also now reports the conversation it landed in, so a process that speaks first can wait for the reply to that same thread. The field is additive and optional, so an older backend simply leaves it empty.

## Related issues

closes camunda/app-integrations#731

## Checklist

- [ ] Backport labels are added if these code changes should be backported. **Not needed — this is a new feature, not a fix, so it ships on main only.**
- [x] Tests/Integration tests for the changes have been added if applicable.
- [x] If the change requires a documentation update, it has been added to the appropriate section in the documentation. (Connector README; the docs.camunda.io page is tracked as a follow-up.)
