### PR TITLE
fix(http): surface TLS handshake failures and include root cause in connection-aborted errors (8.9)

### DIFF
--- a/connector-commons/http-client/src/main/java/io/camunda/connector/http/client/client/apache/CustomApacheHttpClient.java
+++ b/connector-commons/http-client/src/main/java/io/camunda/connector/http/client/client/apache/CustomApacheHttpClient.java
@@ -28,6 +28,7 @@ import io.camunda.connector.http.client.mapper.StreamingHttpResponse;
 import io.camunda.connector.http.client.model.HttpClientRequest;
 import java.io.IOException;
 import java.net.SocketTimeoutException;
+import javax.net.ssl.SSLException;
 import org.apache.hc.client5.http.ClientProtocolException;
 import org.apache.hc.core5.http.HttpStatus;
 
@@ -86,11 +87,29 @@ public class CustomApacheHttpClient implements HttpClient {
           String.valueOf(HttpStatus.SC_REQUEST_TIMEOUT),
           "The request timed out. Please try increasing the read and connection timeouts.",
           e);
+    } catch (SSLException e) {
+      throw new ConnectorException(
+          "SSL_HANDSHAKE_FAILED",
+          "TLS handshake failed: "
+              + rootMessage(e)
+              + ". Verify that the server's certificate is trusted by this runtime, and that no "
+              + "proxy or firewall is interfering with the TLS handshake.",
+          e);
     } catch (IOException e) {
       throw new ConnectorException(
           String.valueOf(HttpStatus.SC_REQUEST_TIMEOUT),
-          "An error occurred while executing the request, or the connection was aborted",
+          "An error occurred while executing the request, or the connection was aborted: "
+              + rootMessage(e),
           e);
     }
+  }
+
+  /** Returns the message of the deepest cause, e.g. the PKIX text of a wrapped TLS failure. */
+  private static String rootMessage(Throwable t) {
+    var cause = t;
+    while (cause.getCause() != null && cause.getCause() != cause) {
+      cause = cause.getCause();
+    }
+    return cause.getMessage();
   }
 }


### PR DESCRIPTION
## Summary
Backport of #8515 plus the TLS-handshake-diagnosis half of the mTLS PR (#7551 / commit 56349ee7a0), adapted for a branch without the `clientTls` mTLS feature:
- Adds a dedicated `catch (SSLException e)` in `CustomApacheHttpClient` that raises a `SSL_HANDSHAKE_FAILED` `ConnectorException` with the root-cause TLS error message, instead of letting it fall into the generic `IOException` catch with a misleading "connection was aborted" (408) message. Wording is generic (no mention of `clientTls.trustedCertificate`, which doesn't exist on this branch) — points at verifying server certificate trust and checking for an interfering proxy/firewall.
- Appends the root cause message to the generic `catch (IOException e)` fallback as well, so other unclassified I/O failures (connection reset, premature EOF, etc.) also surface their actual cause instead of a fixed generic string.

## Test plan
- [x] `mvn -pl connector-commons/http-client test -Dtest='*CustomApacheHttpClient*'` passes
- [x] Module compiles cleanly