### PR TITLE
fix: include AdHocSubProcess, IntermediateThrowEvent, and EndEvent in outbound secret key extraction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,7 @@
 
 # Worktrees
 .worktree
- 
+
 # BlueJ files
 *.ctxt
 

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/secret/ProcessDefinitionSecretKeyCache.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/secret/ProcessDefinitionSecretKeyCache.java
@@ -20,6 +20,7 @@ import io.camunda.client.CamundaClient;
 import io.camunda.connector.runtime.core.secret.SecretUtil;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.model.bpmn.instance.AdHocSubProcess;
 import io.camunda.zeebe.model.bpmn.instance.BaseElement;
 import io.camunda.zeebe.model.bpmn.instance.BusinessRuleTask;
 import io.camunda.zeebe.model.bpmn.instance.FlowElement;
@@ -53,6 +54,7 @@ public class ProcessDefinitionSecretKeyCache implements SecretKeyCache {
     OUTBOUND_ELIGIBLE_TYPES.add(SendTask.class);
     OUTBOUND_ELIGIBLE_TYPES.add(ScriptTask.class);
     OUTBOUND_ELIGIBLE_TYPES.add(BusinessRuleTask.class);
+    OUTBOUND_ELIGIBLE_TYPES.add(AdHocSubProcess.class);
   }
 
   private final String physicalTenantId;
@@ -161,6 +163,14 @@ public class ProcessDefinitionSecretKeyCache implements SecretKeyCache {
   private Collection<FlowElement> collectFlowElements(
       final Collection<FlowElement> processFlowElements, final Collection<FlowElement> buffer) {
     for (FlowElement element : processFlowElements) {
+      // an ad-hoc subprocess can itself be a connector element (its own zeebe:ioMapping declares
+      // secrets, e.g. the AI Agent Sub-process template), so it must be considered directly, in
+      // addition to expanding its children below
+      if (element instanceof AdHocSubProcess adHocSubProcess) {
+        buffer.add(adHocSubProcess);
+        buffer.addAll(retrieveEligibleElementsFromSubprocess(adHocSubProcess));
+        continue;
+      }
       // if we detect a subprocess, we have to expand it
       // its building blocks to identify where are connectors
       if (element instanceof SubProcess subprocess) {

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/secret/ProcessDefinitionSecretKeyCache.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/secret/ProcessDefinitionSecretKeyCache.java
@@ -23,7 +23,9 @@ import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.model.bpmn.instance.AdHocSubProcess;
 import io.camunda.zeebe.model.bpmn.instance.BaseElement;
 import io.camunda.zeebe.model.bpmn.instance.BusinessRuleTask;
+import io.camunda.zeebe.model.bpmn.instance.EndEvent;
 import io.camunda.zeebe.model.bpmn.instance.FlowElement;
+import io.camunda.zeebe.model.bpmn.instance.IntermediateThrowEvent;
 import io.camunda.zeebe.model.bpmn.instance.Process;
 import io.camunda.zeebe.model.bpmn.instance.ScriptTask;
 import io.camunda.zeebe.model.bpmn.instance.SendTask;
@@ -55,6 +57,8 @@ public class ProcessDefinitionSecretKeyCache implements SecretKeyCache {
     OUTBOUND_ELIGIBLE_TYPES.add(ScriptTask.class);
     OUTBOUND_ELIGIBLE_TYPES.add(BusinessRuleTask.class);
     OUTBOUND_ELIGIBLE_TYPES.add(AdHocSubProcess.class);
+    OUTBOUND_ELIGIBLE_TYPES.add(IntermediateThrowEvent.class);
+    OUTBOUND_ELIGIBLE_TYPES.add(EndEvent.class);
   }
 
   private final String physicalTenantId;

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/secret/ProcessDefinitionSecretKeyCacheTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/secret/ProcessDefinitionSecretKeyCacheTest.java
@@ -112,6 +112,19 @@ class ProcessDefinitionSecretKeyCacheTest {
   }
 
   @Test
+  void getSecretKeys_adHocSubProcessAndChild_returnsEachElementsOwnSecrets() throws IOException {
+    when(xmlRequest.execute()).thenReturn(loadBpmn("outbound-adhoc-subprocess.bpmn"));
+
+    var subProcessKeys =
+        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "agent-subprocess"));
+    var childKeys =
+        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "child-task"));
+
+    assertThat(subProcessKeys).containsExactly("ADHOC_SECRET");
+    assertThat(childKeys).containsExactly("CHILD_SECRET");
+  }
+
+  @Test
   void getSecretKeys_unknownElementId_returnsEmptyList() throws IOException {
     when(xmlRequest.execute()).thenReturn(loadBpmn("outbound-with-secrets.bpmn"));
 

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/secret/ProcessDefinitionSecretKeyCacheTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/secret/ProcessDefinitionSecretKeyCacheTest.java
@@ -125,6 +125,20 @@ class ProcessDefinitionSecretKeyCacheTest {
   }
 
   @Test
+  void getSecretKeys_messageIntermediateThrowEventAndEndEvent_returnsEachElementsOwnSecrets()
+      throws IOException {
+    when(xmlRequest.execute()).thenReturn(loadBpmn("outbound-message-events.bpmn"));
+
+    var throwEventKeys =
+        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "send-message-throw"));
+    var endEventKeys =
+        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "send-message-end"));
+
+    assertThat(throwEventKeys).containsExactly("THROW_EVENT_SECRET");
+    assertThat(endEventKeys).containsExactly("END_EVENT_SECRET");
+  }
+
+  @Test
   void getSecretKeys_unknownElementId_returnsEmptyList() throws IOException {
     when(xmlRequest.execute()).thenReturn(loadBpmn("outbound-with-secrets.bpmn"));
 

--- a/connector-runtime/connector-runtime-spring/src/test/resources/bpmn/outbound-adhoc-subprocess.bpmn
+++ b/connector-runtime/connector-runtime-spring/src/test/resources/bpmn/outbound-adhoc-subprocess.bpmn
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+                  xmlns:zeebe="http://camunda.org/schema/zeebe/1.0"
+                  id="Definitions_adhoc_subprocess"
+                  targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="outbound-adhoc-subprocess" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_1" sourceRef="StartEvent_1" targetRef="agent-subprocess"/>
+    <bpmn:adHocSubProcess id="agent-subprocess" name="Agent Sub-process">
+      <bpmn:extensionElements>
+        <zeebe:adHoc/>
+        <zeebe:ioMapping>
+          <zeebe:input source="{{secrets.ADHOC_SECRET}}" target="apiKey"/>
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1</bpmn:incoming>
+      <bpmn:outgoing>Flow_2</bpmn:outgoing>
+      <bpmn:serviceTask id="child-task" name="Tool">
+        <bpmn:extensionElements>
+          <zeebe:ioMapping>
+            <zeebe:input source="{{secrets.CHILD_SECRET}}" target="token"/>
+          </zeebe:ioMapping>
+        </bpmn:extensionElements>
+      </bpmn:serviceTask>
+    </bpmn:adHocSubProcess>
+    <bpmn:sequenceFlow id="Flow_2" sourceRef="agent-subprocess" targetRef="EndEvent_1"/>
+    <bpmn:endEvent id="EndEvent_1">
+      <bpmn:incoming>Flow_2</bpmn:incoming>
+    </bpmn:endEvent>
+  </bpmn:process>
+</bpmn:definitions>

--- a/connector-runtime/connector-runtime-spring/src/test/resources/bpmn/outbound-message-events.bpmn
+++ b/connector-runtime/connector-runtime-spring/src/test/resources/bpmn/outbound-message-events.bpmn
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+                  xmlns:zeebe="http://camunda.org/schema/zeebe/1.0"
+                  id="Definitions_message_events"
+                  targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="outbound-message-events" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_1" sourceRef="StartEvent_1" targetRef="send-message-throw"/>
+    <bpmn:intermediateThrowEvent id="send-message-throw" name="Send Message">
+      <bpmn:extensionElements>
+        <zeebe:ioMapping>
+          <zeebe:input source="{{secrets.THROW_EVENT_SECRET}}" target="apiKey"/>
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1</bpmn:incoming>
+      <bpmn:outgoing>Flow_2</bpmn:outgoing>
+      <bpmn:messageEventDefinition/>
+    </bpmn:intermediateThrowEvent>
+    <bpmn:sequenceFlow id="Flow_2" sourceRef="send-message-throw" targetRef="send-message-end"/>
+    <bpmn:endEvent id="send-message-end" name="Send Message">
+      <bpmn:extensionElements>
+        <zeebe:ioMapping>
+          <zeebe:input source="{{secrets.END_EVENT_SECRET}}" target="apiKey"/>
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_2</bpmn:incoming>
+      <bpmn:messageEventDefinition/>
+    </bpmn:endEvent>
+  </bpmn:process>
+</bpmn:definitions>


### PR DESCRIPTION
## Summary

Replaces #8511, which was opened against `release-8.10.0-alpha3` — the correct target for this work is `release-8.10.0-alpha5`. Force-pushing the existing branch to retarget it isn't possible (branch protection blocks force-push), so this is a fresh branch with the same fix cherry-picked from main (`a4b95f32da`, `bf7f5302b9`) directly onto `release-8.10.0-alpha5`, which is already in sync with `main` for every file this touches.

`ProcessDefinitionSecretKeyCache`'s element traversal (`collectFlowElements`) replaces every `SubProcess` with only its children, and `OUTBOUND_ELIGIBLE_TYPES` doesn't include `AdHocSubProcess` either way. The current "AI Agent Sub-process" v2 element template targets `bpmn:AdHocSubProcess` directly and declares its own secrets (e.g. an LLM provider API key) in that element's own `zeebe:ioMapping` — so its allow-list always comes back empty, and every secret it references gets silently blocked once secret filtering is active.

The shipped Send Message connector templates target `bpmn:IntermediateThrowEvent` and `bpmn:EndEvent`, which had the same gap — neither type was in `OUTBOUND_ELIGIBLE_TYPES`, so their declared secrets were silently unresolvable too.

## Changes
- Add `AdHocSubProcess.class` to `OUTBOUND_ELIGIBLE_TYPES`.
- Special-case `AdHocSubProcess` in `collectFlowElements`: add the element itself to the eligible-elements buffer (so its own `zeebe:ioMapping` is inspected), while still recursing into its children (who may declare their own secrets too, same as any other subprocess).
- Add `IntermediateThrowEvent.class` and `EndEvent.class` to `OUTBOUND_ELIGIBLE_TYPES` (targeted by the shipped Send Message connector templates).

## Test plan
- [x] Added `outbound-adhoc-subprocess.bpmn` fixture: an `AdHocSubProcess` with its own secret plus a nested child task with a different secret, and a test confirming both resolve their own secret keys.
- [x] Added `outbound-message-events.bpmn` fixture and a test covering the intermediate-throw-event and end-event case.
- [x] Full suite for `connector-runtime-spring`: all green.
- [x] `spotless:check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
