### PR TITLE
fix: default outbound secret filter mode to STRICT

### DIFF
--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/SecretFilterFactoryConfiguration.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/SecretFilterFactoryConfiguration.java
@@ -58,7 +58,7 @@ public class SecretFilterFactoryConfiguration {
 
   @Bean
   public SecretFilterFactory secretFilterFactory(
-      @Value("${camunda.connector.secret-resolver.secret-filter.mode:DISABLED}")
+      @Value("${camunda.connector.secret-resolver.secret-filter.mode:STRICT}")
           SecretFilterMode secretFilterMode,
       SecretKeyCache secretKeyCache) {
     return new ConfigurableSecretFilterFactory(secretFilterMode, secretKeyCache);

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/OutboundConnectorsAutoConfigurationTest.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/OutboundConnectorsAutoConfigurationTest.java
@@ -32,7 +32,10 @@ import io.camunda.client.spring.properties.CamundaClientProperties;
 import io.camunda.connector.jackson.ConnectorsObjectMapperSupplier;
 import io.camunda.connector.runtime.annotation.ConnectorsObjectMapper;
 import io.camunda.connector.runtime.annotation.OutboundConnectorObjectMapper;
+import io.camunda.connector.runtime.core.secret.SecretFilterFactory;
 import io.camunda.connector.runtime.core.secret.SecretProviderAggregator;
+import io.camunda.connector.runtime.outbound.SecretFilterFactoryConfiguration;
+import io.camunda.connector.runtime.outbound.job.ConfigurableSecretFilterFactory.SecretFilterMode;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
@@ -40,6 +43,7 @@ import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.core.annotation.MergedAnnotations;
+import org.springframework.test.util.ReflectionTestUtils;
 
 class OutboundConnectorsAutoConfigurationTest {
 
@@ -50,8 +54,22 @@ class OutboundConnectorsAutoConfigurationTest {
       new ApplicationContextRunner()
           .withConfiguration(
               AutoConfigurations.of(
-                  ExecutorServiceConfiguration.class, OutboundConnectorsAutoConfiguration.class))
+                  ExecutorServiceConfiguration.class,
+                  OutboundConnectorsAutoConfiguration.class,
+                  SecretFilterFactoryConfiguration.class))
           .withUserConfiguration(RequiredOutboundRuntimeBeans.class);
+
+  @Test
+  void shouldDefaultSecretFilterModeToStrict() {
+    contextRunner.run(
+        context -> {
+          var secretFilterFactory = context.getBean(SecretFilterFactory.class);
+          var mode =
+              (SecretFilterMode)
+                  ReflectionTestUtils.getField(secretFilterFactory, "secretFilterMode");
+          assertThat(mode).isEqualTo(SecretFilterMode.STRICT);
+        });
+  }
 
   @Test
   void shouldCreateConnectorExecutorServiceByDefault() {


### PR DESCRIPTION
## Summary

Manual backport of #8506 to `stable/8.9` — the automated backport bot failed to cherry-pick the commit (conflicts), because this branch's code predates a main-only refactor: `SecretFilterFactoryConfiguration`'s beans haven't been merged into `OutboundConnectorRuntimeConfiguration` here, and `ConnectorsAutoConfiguration#legacyFallbackSecretFilterGuard` doesn't exist on this branch at all. Neither does the ADR-0007 doc or `LegacySecretFallbackWiringTest` that #8506 also touched.

Applied the equivalent, smaller fix instead: on this branch, `SecretFilterFactoryConfiguration#secretFilterFactory` is the *only* place the `DISABLED` default is declared, so flipping that one `@Value` default has the same effect as #8506's four-site flip on main.

Follow-up to #7740 (the stable/8.9 backport of #7568), which shipped the outbound secret filter with a `DISABLED` default. A fresh install therefore stays unfiltered until an operator explicitly sets `camunda.connector.secret-resolver.secret-filter.mode=STRICT` (or `LAX`), which makes the security fix opt-in rather than on by default.

## Changes
- `SecretFilterFactoryConfiguration#secretFilterFactory`: default `secret-filter.mode` flipped to `STRICT`.

## Test plan
- [x] Added `OutboundConnectorsAutoConfigurationTest#shouldDefaultSecretFilterModeToStrict`, which boots the real bean graph (with `SecretFilterFactoryConfiguration` registered) and no `secret-filter.mode` property set, and asserts the resolved mode is `STRICT`.
- [x] Full suite for `connector-runtime-spring` and `spring-boot-starter-camunda-connectors`: all green.
- [x] `spotless:check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
