### PR TITLE
fix: include AdHocSubProcess, IntermediateThrowEvent, and EndEvent in outbound secret key extraction

### DIFF
--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/secret/ProcessDefinitionSecretKeyCache.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/secret/ProcessDefinitionSecretKeyCache.java
@@ -17,7 +17,6 @@
 package io.camunda.connector.runtime.outbound.secret;
 
 import io.camunda.client.CamundaClient;
-import io.camunda.connector.api.inbound.ElementTemplateDetails;
 import io.camunda.connector.runtime.core.secret.SecretUtil;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
@@ -135,7 +134,7 @@ public class ProcessDefinitionSecretKeyCache implements SecretKeyCache {
     for (FlowElement element : allElements) {
       OUTBOUND_ELIGIBLE_TYPES.forEach(
           iet -> {
-            if (iet.isInstance(element) && isElementTemplate(element)) {
+            if (iet.isInstance(element)) {
               outboundEligibleElements.add(element);
             }
           });
@@ -168,24 +167,5 @@ public class ProcessDefinitionSecretKeyCache implements SecretKeyCache {
     Collection<FlowElement> buffer = new HashSet<>();
     Collection<FlowElement> processFlowElements = subprocess.getFlowElements();
     return collectFlowElements(processFlowElements, buffer);
-  }
-
-  private boolean isElementTemplate(FlowElement element) {
-    ElementTemplateDetails elementTemplateDetails = getElementTemplateDetails(element);
-    return elementTemplateDetails.id() != null;
-  }
-
-  // pre-existing, move to util from ProcessDefinitionInspector
-  private static ElementTemplateDetails getElementTemplateDetails(BaseElement element) {
-    final String NAMESPACE = "http://camunda.org/schema/zeebe/1.0";
-
-    final String TEMPLATE_ID = "modelerTemplate";
-    final String TEMPLATE_VERSION = "modelerTemplateVersion";
-    final String TEMPLATE_ICON = "modelerTemplateIcon";
-
-    return new ElementTemplateDetails(
-        element.getAttributeValueNs(NAMESPACE, TEMPLATE_ID),
-        element.getAttributeValueNs(NAMESPACE, TEMPLATE_VERSION),
-        element.getAttributeValueNs(NAMESPACE, TEMPLATE_ICON));
   }
 }

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/secret/ProcessDefinitionSecretKeyCache.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/secret/ProcessDefinitionSecretKeyCache.java
@@ -23,7 +23,9 @@ import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.model.bpmn.instance.BaseElement;
 import io.camunda.zeebe.model.bpmn.instance.BusinessRuleTask;
+import io.camunda.zeebe.model.bpmn.instance.EndEvent;
 import io.camunda.zeebe.model.bpmn.instance.FlowElement;
+import io.camunda.zeebe.model.bpmn.instance.IntermediateThrowEvent;
 import io.camunda.zeebe.model.bpmn.instance.Process;
 import io.camunda.zeebe.model.bpmn.instance.ScriptTask;
 import io.camunda.zeebe.model.bpmn.instance.SendTask;
@@ -54,6 +56,9 @@ public class ProcessDefinitionSecretKeyCache implements SecretKeyCache {
     OUTBOUND_ELIGIBLE_TYPES.add(SendTask.class);
     OUTBOUND_ELIGIBLE_TYPES.add(ScriptTask.class);
     OUTBOUND_ELIGIBLE_TYPES.add(BusinessRuleTask.class);
+    OUTBOUND_ELIGIBLE_TYPES.add(SubProcess.class);
+    OUTBOUND_ELIGIBLE_TYPES.add(IntermediateThrowEvent.class);
+    OUTBOUND_ELIGIBLE_TYPES.add(EndEvent.class);
   }
 
   private final CamundaClient camundaClient;
@@ -142,9 +147,12 @@ public class ProcessDefinitionSecretKeyCache implements SecretKeyCache {
   private Collection<FlowElement> collectFlowElements(
       final Collection<FlowElement> processFlowElements, final Collection<FlowElement> buffer) {
     for (FlowElement element : processFlowElements) {
-      // if we detect a subprocess, we have to expand it
-      // its building blocks to identify where are connectors
+      // a subprocess (embedded, event, multi-instance, ad-hoc, or nested) can itself be a
+      // connector element (its own zeebe:ioMapping declares secrets, e.g. the AI Agent Sub-process
+      // template on an ad-hoc subprocess), so it must be considered directly, in addition to
+      // expanding its children below
       if (element instanceof SubProcess subprocess) {
+        buffer.add(subprocess);
         buffer.addAll(retrieveEligibleElementsFromSubprocess(subprocess));
         continue;
       }

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/secret/ProcessDefinitionSecretKeyCacheTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/secret/ProcessDefinitionSecretKeyCacheTest.java
@@ -100,6 +100,52 @@ class ProcessDefinitionSecretKeyCacheTest {
   }
 
   @Test
+  void getSecretKeys_adHocSubProcessAndChild_returnsEachElementsOwnSecrets() throws IOException {
+    when(xmlRequest.execute()).thenReturn(loadBpmn("outbound-adhoc-subprocess.bpmn"));
+
+    var subProcessKeys =
+        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "agent-subprocess"));
+    var childKeys =
+        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "child-task"));
+
+    assertThat(subProcessKeys).containsExactly("ADHOC_SECRET");
+    assertThat(childKeys).containsExactly("CHILD_SECRET");
+  }
+
+  @Test
+  void getSecretKeys_nestedEmbeddedSubProcessesAndGrandchild_returnsEachElementsOwnSecrets()
+      throws IOException {
+    // Verifies the fix generalizes beyond AdHocSubProcess: a plain (embedded) SubProcess can
+    // itself be a connector host, at any nesting depth, same as the ad-hoc flavor.
+    when(xmlRequest.execute()).thenReturn(loadBpmn("outbound-nested-embedded-subprocess.bpmn"));
+
+    var outerKeys =
+        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "outer-subprocess"));
+    var innerKeys =
+        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "inner-subprocess"));
+    var grandchildKeys =
+        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "grandchild-task"));
+
+    assertThat(outerKeys).containsExactly("OUTER_SECRET");
+    assertThat(innerKeys).containsExactly("INNER_SECRET");
+    assertThat(grandchildKeys).containsExactly("GRANDCHILD_SECRET");
+  }
+
+  @Test
+  void getSecretKeys_messageIntermediateThrowEventAndEndEvent_returnsEachElementsOwnSecrets()
+      throws IOException {
+    when(xmlRequest.execute()).thenReturn(loadBpmn("outbound-message-events.bpmn"));
+
+    var throwEventKeys =
+        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "send-message-throw"));
+    var endEventKeys =
+        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "send-message-end"));
+
+    assertThat(throwEventKeys).containsExactly("THROW_EVENT_SECRET");
+    assertThat(endEventKeys).containsExactly("END_EVENT_SECRET");
+  }
+
+  @Test
   void getSecretKeys_unknownElementId_returnsEmptyList() throws IOException {
     when(xmlRequest.execute()).thenReturn(loadBpmn("outbound-with-secrets.bpmn"));
 

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/secret/ProcessDefinitionSecretKeyCacheTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/secret/ProcessDefinitionSecretKeyCacheTest.java
@@ -91,12 +91,14 @@ class ProcessDefinitionSecretKeyCacheTest {
   }
 
   @Test
-  void getSecretKeys_taskWithoutTemplate_excluded_returnsEmptyList() throws IOException {
+  void getSecretKeys_taskWithoutTemplate_returnsItsOwnSecrets() throws IOException {
+    // zeebe:modelerTemplate records how an element was authored, not what it is, so a task
+    // without one is still eligible and its own declared secrets are still returned.
     when(xmlRequest.execute()).thenReturn(loadBpmn("outbound-no-template.bpmn"));
 
     var keys = secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "plain-task"));
 
-    assertThat(keys).isEmpty();
+    assertThat(keys).containsExactly("SECRET_X");
   }
 
   @Test

--- a/connector-runtime/connector-runtime-spring/src/test/resources/bpmn/outbound-adhoc-subprocess.bpmn
+++ b/connector-runtime/connector-runtime-spring/src/test/resources/bpmn/outbound-adhoc-subprocess.bpmn
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+                  xmlns:zeebe="http://camunda.org/schema/zeebe/1.0"
+                  id="Definitions_adhoc_subprocess"
+                  targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="outbound-adhoc-subprocess" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_1" sourceRef="StartEvent_1" targetRef="agent-subprocess"/>
+    <bpmn:adHocSubProcess id="agent-subprocess" name="Agent Sub-process"
+                          zeebe:modelerTemplate="io.camunda.connectors.agenticai.aiagent.v2">
+      <bpmn:extensionElements>
+        <zeebe:adHoc/>
+        <zeebe:ioMapping>
+          <zeebe:input source="{{secrets.ADHOC_SECRET}}" target="apiKey"/>
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1</bpmn:incoming>
+      <bpmn:outgoing>Flow_2</bpmn:outgoing>
+      <bpmn:serviceTask id="child-task" name="Tool"
+                        zeebe:modelerTemplate="io.camunda.connectors.SomeTool">
+        <bpmn:extensionElements>
+          <zeebe:ioMapping>
+            <zeebe:input source="{{secrets.CHILD_SECRET}}" target="token"/>
+          </zeebe:ioMapping>
+        </bpmn:extensionElements>
+      </bpmn:serviceTask>
+    </bpmn:adHocSubProcess>
+    <bpmn:sequenceFlow id="Flow_2" sourceRef="agent-subprocess" targetRef="EndEvent_1"/>
+    <bpmn:endEvent id="EndEvent_1">
+      <bpmn:incoming>Flow_2</bpmn:incoming>
+    </bpmn:endEvent>
+  </bpmn:process>
+</bpmn:definitions>

--- a/connector-runtime/connector-runtime-spring/src/test/resources/bpmn/outbound-adhoc-subprocess.bpmn
+++ b/connector-runtime/connector-runtime-spring/src/test/resources/bpmn/outbound-adhoc-subprocess.bpmn
@@ -8,8 +8,7 @@
       <bpmn:outgoing>Flow_1</bpmn:outgoing>
     </bpmn:startEvent>
     <bpmn:sequenceFlow id="Flow_1" sourceRef="StartEvent_1" targetRef="agent-subprocess"/>
-    <bpmn:adHocSubProcess id="agent-subprocess" name="Agent Sub-process"
-                          zeebe:modelerTemplate="io.camunda.connectors.agenticai.aiagent.v2">
+    <bpmn:adHocSubProcess id="agent-subprocess" name="Agent Sub-process">
       <bpmn:extensionElements>
         <zeebe:adHoc/>
         <zeebe:ioMapping>
@@ -18,8 +17,7 @@
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_1</bpmn:incoming>
       <bpmn:outgoing>Flow_2</bpmn:outgoing>
-      <bpmn:serviceTask id="child-task" name="Tool"
-                        zeebe:modelerTemplate="io.camunda.connectors.SomeTool">
+      <bpmn:serviceTask id="child-task" name="Tool">
         <bpmn:extensionElements>
           <zeebe:ioMapping>
             <zeebe:input source="{{secrets.CHILD_SECRET}}" target="token"/>

--- a/connector-runtime/connector-runtime-spring/src/test/resources/bpmn/outbound-message-events.bpmn
+++ b/connector-runtime/connector-runtime-spring/src/test/resources/bpmn/outbound-message-events.bpmn
@@ -8,8 +8,7 @@
       <bpmn:outgoing>Flow_1</bpmn:outgoing>
     </bpmn:startEvent>
     <bpmn:sequenceFlow id="Flow_1" sourceRef="StartEvent_1" targetRef="send-message-throw"/>
-    <bpmn:intermediateThrowEvent id="send-message-throw" name="Send Message"
-                                  zeebe:modelerTemplate="io.camunda.connectors.message.intermediate.v1">
+    <bpmn:intermediateThrowEvent id="send-message-throw" name="Send Message">
       <bpmn:extensionElements>
         <zeebe:ioMapping>
           <zeebe:input source="{{secrets.THROW_EVENT_SECRET}}" target="apiKey"/>
@@ -20,8 +19,7 @@
       <bpmn:messageEventDefinition/>
     </bpmn:intermediateThrowEvent>
     <bpmn:sequenceFlow id="Flow_2" sourceRef="send-message-throw" targetRef="send-message-end"/>
-    <bpmn:endEvent id="send-message-end" name="Send Message"
-                   zeebe:modelerTemplate="io.camunda.connectors.message.end.v1">
+    <bpmn:endEvent id="send-message-end" name="Send Message">
       <bpmn:extensionElements>
         <zeebe:ioMapping>
           <zeebe:input source="{{secrets.END_EVENT_SECRET}}" target="apiKey"/>

--- a/connector-runtime/connector-runtime-spring/src/test/resources/bpmn/outbound-message-events.bpmn
+++ b/connector-runtime/connector-runtime-spring/src/test/resources/bpmn/outbound-message-events.bpmn
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+                  xmlns:zeebe="http://camunda.org/schema/zeebe/1.0"
+                  id="Definitions_message_events"
+                  targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="outbound-message-events" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_1" sourceRef="StartEvent_1" targetRef="send-message-throw"/>
+    <bpmn:intermediateThrowEvent id="send-message-throw" name="Send Message"
+                                  zeebe:modelerTemplate="io.camunda.connectors.message.intermediate.v1">
+      <bpmn:extensionElements>
+        <zeebe:ioMapping>
+          <zeebe:input source="{{secrets.THROW_EVENT_SECRET}}" target="apiKey"/>
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1</bpmn:incoming>
+      <bpmn:outgoing>Flow_2</bpmn:outgoing>
+      <bpmn:messageEventDefinition/>
+    </bpmn:intermediateThrowEvent>
+    <bpmn:sequenceFlow id="Flow_2" sourceRef="send-message-throw" targetRef="send-message-end"/>
+    <bpmn:endEvent id="send-message-end" name="Send Message"
+                   zeebe:modelerTemplate="io.camunda.connectors.message.end.v1">
+      <bpmn:extensionElements>
+        <zeebe:ioMapping>
+          <zeebe:input source="{{secrets.END_EVENT_SECRET}}" target="apiKey"/>
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_2</bpmn:incoming>
+      <bpmn:messageEventDefinition/>
+    </bpmn:endEvent>
+  </bpmn:process>
+</bpmn:definitions>

--- a/connector-runtime/connector-runtime-spring/src/test/resources/bpmn/outbound-nested-embedded-subprocess.bpmn
+++ b/connector-runtime/connector-runtime-spring/src/test/resources/bpmn/outbound-nested-embedded-subprocess.bpmn
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+                  xmlns:zeebe="http://camunda.org/schema/zeebe/1.0"
+                  id="Definitions_nested_embedded_subprocess"
+                  targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="outbound-nested-embedded-subprocess" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_1" sourceRef="StartEvent_1" targetRef="outer-subprocess"/>
+    <bpmn:subProcess id="outer-subprocess" name="Outer Sub-process"
+                     zeebe:modelerTemplate="io.camunda.connectors.OuterSubProcess">
+      <bpmn:extensionElements>
+        <zeebe:ioMapping>
+          <zeebe:input source="{{secrets.OUTER_SECRET}}" target="apiKey"/>
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1</bpmn:incoming>
+      <bpmn:outgoing>Flow_2</bpmn:outgoing>
+      <bpmn:startEvent id="InnerStart_1">
+        <bpmn:outgoing>InnerFlow_1</bpmn:outgoing>
+      </bpmn:startEvent>
+      <bpmn:sequenceFlow id="InnerFlow_1" sourceRef="InnerStart_1" targetRef="inner-subprocess"/>
+      <bpmn:subProcess id="inner-subprocess" name="Inner Sub-process"
+                       zeebe:modelerTemplate="io.camunda.connectors.InnerSubProcess">
+        <bpmn:extensionElements>
+          <zeebe:ioMapping>
+            <zeebe:input source="{{secrets.INNER_SECRET}}" target="apiKey"/>
+          </zeebe:ioMapping>
+        </bpmn:extensionElements>
+        <bpmn:incoming>InnerFlow_1</bpmn:incoming>
+        <bpmn:outgoing>InnerFlow_2</bpmn:outgoing>
+        <bpmn:serviceTask id="grandchild-task" name="Tool"
+                          zeebe:modelerTemplate="io.camunda.connectors.SomeTool">
+          <bpmn:extensionElements>
+            <zeebe:ioMapping>
+              <zeebe:input source="{{secrets.GRANDCHILD_SECRET}}" target="token"/>
+            </zeebe:ioMapping>
+          </bpmn:extensionElements>
+        </bpmn:serviceTask>
+      </bpmn:subProcess>
+      <bpmn:sequenceFlow id="InnerFlow_2" sourceRef="inner-subprocess" targetRef="InnerEnd_1"/>
+      <bpmn:endEvent id="InnerEnd_1">
+        <bpmn:incoming>InnerFlow_2</bpmn:incoming>
+      </bpmn:endEvent>
+    </bpmn:subProcess>
+    <bpmn:sequenceFlow id="Flow_2" sourceRef="outer-subprocess" targetRef="EndEvent_1"/>
+    <bpmn:endEvent id="EndEvent_1">
+      <bpmn:incoming>Flow_2</bpmn:incoming>
+    </bpmn:endEvent>
+  </bpmn:process>
+</bpmn:definitions>

--- a/connector-runtime/connector-runtime-spring/src/test/resources/bpmn/outbound-nested-embedded-subprocess.bpmn
+++ b/connector-runtime/connector-runtime-spring/src/test/resources/bpmn/outbound-nested-embedded-subprocess.bpmn
@@ -8,8 +8,7 @@
       <bpmn:outgoing>Flow_1</bpmn:outgoing>
     </bpmn:startEvent>
     <bpmn:sequenceFlow id="Flow_1" sourceRef="StartEvent_1" targetRef="outer-subprocess"/>
-    <bpmn:subProcess id="outer-subprocess" name="Outer Sub-process"
-                     zeebe:modelerTemplate="io.camunda.connectors.OuterSubProcess">
+    <bpmn:subProcess id="outer-subprocess" name="Outer Sub-process">
       <bpmn:extensionElements>
         <zeebe:ioMapping>
           <zeebe:input source="{{secrets.OUTER_SECRET}}" target="apiKey"/>
@@ -21,8 +20,7 @@
         <bpmn:outgoing>InnerFlow_1</bpmn:outgoing>
       </bpmn:startEvent>
       <bpmn:sequenceFlow id="InnerFlow_1" sourceRef="InnerStart_1" targetRef="inner-subprocess"/>
-      <bpmn:subProcess id="inner-subprocess" name="Inner Sub-process"
-                       zeebe:modelerTemplate="io.camunda.connectors.InnerSubProcess">
+      <bpmn:subProcess id="inner-subprocess" name="Inner Sub-process">
         <bpmn:extensionElements>
           <zeebe:ioMapping>
             <zeebe:input source="{{secrets.INNER_SECRET}}" target="apiKey"/>
@@ -30,8 +28,7 @@
         </bpmn:extensionElements>
         <bpmn:incoming>InnerFlow_1</bpmn:incoming>
         <bpmn:outgoing>InnerFlow_2</bpmn:outgoing>
-        <bpmn:serviceTask id="grandchild-task" name="Tool"
-                          zeebe:modelerTemplate="io.camunda.connectors.SomeTool">
+        <bpmn:serviceTask id="grandchild-task" name="Tool">
           <bpmn:extensionElements>
             <zeebe:ioMapping>
               <zeebe:input source="{{secrets.GRANDCHILD_SECRET}}" target="token"/>


### PR DESCRIPTION
## Summary

Manual backport of #8509 to `stable/8.9` — the automated backport bot failed to cherry-pick the commit. It actually applied cleanly except for a recurring `.gitignore` conflict (main has an extra `# Worktrees` block this branch doesn't; resolved by keeping this branch's copy).

`ProcessDefinitionSecretKeyCache`'s element traversal (`collectFlowElements`) replaces every `SubProcess` with only its children, and `OUTBOUND_ELIGIBLE_TYPES` didn't include any subprocess type either way. The current "AI Agent Sub-process" v2 element template targets `bpmn:AdHocSubProcess` directly and declares its own secrets in that element's own `zeebe:ioMapping` — so its allow-list always comes back empty, and every secret it references gets silently blocked once secret filtering is active. The shipped Send Message connector templates (`bpmn:IntermediateThrowEvent`/`bpmn:EndEvent`) have the same gap.

The fix was generalized on main from `AdHocSubProcess`-only to `SubProcess.class` after [#8493](https://github.com/camunda/connectors/pull/8493) independently verified on a real Camunda 8.10 cluster that a connector can be configured directly on a subprocess boundary — embedded, event, multi-instance, or nested — not just the ad-hoc flavor.

## Changes
- Add `SubProcess.class`, `IntermediateThrowEvent.class`, and `EndEvent.class` to `OUTBOUND_ELIGIBLE_TYPES`.
- In `collectFlowElements`, add each `SubProcess` element itself to the eligible-elements buffer (so its own `zeebe:ioMapping` is inspected), while still recursing into its children.
- Remove the `isElementTemplate(element)` gate (and the now-unused `ElementTemplateDetails` import/helpers) from `retrieveOutboundEligibleElementsFromProcess`. Unlike main, this branch still had that check, which required an element to carry `zeebe:modelerTemplate` before its own declared secrets were ever considered — `zeebe:modelerTemplate` records how an element was authored, not what it is, so a task not authored via a Modeler element template got an empty (deny-all) allow-list instead of its own. Main already fixed this (592aeddc22f9a6ef2d2e3c2793f065f3972c340c, #8368) but it was never backported; this was originally worked around here by adding `zeebe:modelerTemplate` to the test fixtures below, then replaced with the real fix in a follow-up commit (superseding #8525, which did the same fix independently for the pre-#8509 eligible types on this branch).

## Test plan
- [x] `outbound-adhoc-subprocess.bpmn`: an `AdHocSubProcess` with its own secret plus a nested child task with a different secret.
- [x] `outbound-nested-embedded-subprocess.bpmn`: outer subprocess, inner subprocess, and a grandchild task, each with their own secret.
- [x] `outbound-message-events.bpmn`: intermediate-throw-event and end-event, each with their own secret.
- [x] `getSecretKeys_taskWithoutTemplate_excluded_returnsEmptyList` renamed to `getSecretKeys_taskWithoutTemplate_returnsItsOwnSecrets`, now asserting the task's own secret is returned instead of an empty list.
- [x] Full suite for `connector-runtime-spring`: all green.
- [x] `spotless:check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

