### PR TITLE
fix: collect outbound secret keys from tasks without an element template

### DIFF
--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/secret/ProcessDefinitionSecretKeyCache.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/secret/ProcessDefinitionSecretKeyCache.java
@@ -17,7 +17,6 @@
 package io.camunda.connector.runtime.outbound.secret;
 
 import io.camunda.client.CamundaClient;
-import io.camunda.connector.api.inbound.ElementTemplateDetails;
 import io.camunda.connector.runtime.core.secret.SecretUtil;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
@@ -130,7 +129,7 @@ public class ProcessDefinitionSecretKeyCache implements SecretKeyCache {
     for (FlowElement element : allElements) {
       OUTBOUND_ELIGIBLE_TYPES.forEach(
           iet -> {
-            if (iet.isInstance(element) && isElementTemplate(element)) {
+            if (iet.isInstance(element)) {
               outboundEligibleElements.add(element);
             }
           });
@@ -160,24 +159,5 @@ public class ProcessDefinitionSecretKeyCache implements SecretKeyCache {
     Collection<FlowElement> buffer = new HashSet<>();
     Collection<FlowElement> processFlowElements = subprocess.getFlowElements();
     return collectFlowElements(processFlowElements, buffer);
-  }
-
-  private boolean isElementTemplate(FlowElement element) {
-    ElementTemplateDetails elementTemplateDetails = getElementTemplateDetails(element);
-    return elementTemplateDetails.id() != null;
-  }
-
-  // pre-existing, move to util from ProcessDefinitionInspector
-  private static ElementTemplateDetails getElementTemplateDetails(BaseElement element) {
-    final String NAMESPACE = "http://camunda.org/schema/zeebe/1.0";
-
-    final String TEMPLATE_ID = "modelerTemplate";
-    final String TEMPLATE_VERSION = "modelerTemplateVersion";
-    final String TEMPLATE_ICON = "modelerTemplateIcon";
-
-    return new ElementTemplateDetails(
-        element.getAttributeValueNs(NAMESPACE, TEMPLATE_ID),
-        element.getAttributeValueNs(NAMESPACE, TEMPLATE_VERSION),
-        element.getAttributeValueNs(NAMESPACE, TEMPLATE_ICON));
   }
 }

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/secret/ProcessDefinitionSecretKeyCacheTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/secret/ProcessDefinitionSecretKeyCacheTest.java
@@ -91,12 +91,15 @@ class ProcessDefinitionSecretKeyCacheTest {
   }
 
   @Test
-  void getSecretKeys_taskWithoutTemplate_excluded_returnsEmptyList() throws IOException {
+  void getSecretKeys_taskWithoutTemplate_returnsItsOwnSecrets() throws IOException {
+    // zeebe:modelerTemplate records how an element was authored, not what it is. A task that
+    // declares a secret in its own input mapping must be allow-listed for it whether or not it was
+    // built by applying an element template in Modeler.
     when(xmlRequest.execute()).thenReturn(loadBpmn("outbound-no-template.bpmn"));
 
     var keys = secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "plain-task"));
 
-    assertThat(keys).isEmpty();
+    assertThat(keys).containsExactly("SECRET_X");
   }
 
   @Test


### PR DESCRIPTION
## Summary

`ProcessDefinitionSecretKeyCache`'s outbound secret allow-list only collected secrets from elements carrying a `zeebe:modelerTemplate` attribute. An element without one never entered the map, so its allow-list came back empty, and an empty allow-list denies every name -- affecting any Service, Send, Script, or Business Rule task using legacy secret syntax that wasn't authored by applying an element template in Modeler: hand-written BPMN, generated BPMN, and anyone setting the task type directly.

`zeebe:modelerTemplate` records how an element was authored, not what it is. Dropping the gate is safe by construction: the allow-list only ever permits, and it's keyed per element id and built from that element's own inputs, so scanning more elements cannot admit a secret the model didn't declare.

This matches main's fix ([592aeddc22](https://github.com/camunda/connectors/commit/592aeddc22f9a6ef2d2e3c2793f065f3972c340c), from #8368), which was never backported to `stable/8.9`.

## Changes
- Remove the `isElementTemplate(element)` gate from `retrieveOutboundEligibleElementsFromProcess` -- eligibility is now type-only, matching main.
- Remove the now-unused `isElementTemplate`/`getElementTemplateDetails` helpers and the `ElementTemplateDetails` import.

## Test plan
- [x] `getSecretKeys_taskWithoutTemplate_excluded_returnsEmptyList` renamed to `getSecretKeys_taskWithoutTemplate_returnsItsOwnSecrets`, asserting the previously-excluded task's secret is now collected -- matches main's equivalent test.
- [x] Full suite for `connector-runtime-spring`: all green.
- [x] `spotless:check` clean.

## Note

#8524 (backport of #8509, the `AdHocSubProcess`/`SubProcess`/message-event eligible-types fix) currently works around this same gate by adding `zeebe:modelerTemplate` to its test fixtures. Once this PR lands, that workaround should be dropped there too -- doing so now in a follow-up commit on #8524.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
