### PR TITLE
fix: pin AlwaysGreen SaaS component versions to 8.10-SNAPSHOT

### DIFF
--- a/.github/workflows/MERGE_QUEUE_HELM_TEST.yaml
+++ b/.github/workflows/MERGE_QUEUE_HELM_TEST.yaml
@@ -401,11 +401,11 @@ jobs:
                       "source_sha": "${{ github.sha }}",
                       "gen_name": "'"${GEN_NAME}"'",
                       "c8Version": "8.10",
-                      "zeebeVersion": "SNAPSHOT",
-                      "operateVersion": "SNAPSHOT",
-                      "tasklistVersion": "SNAPSHOT",
+                      "zeebeVersion": "8.10-SNAPSHOT",
+                      "operateVersion": "8.10-SNAPSHOT",
+                      "tasklistVersion": "8.10-SNAPSHOT",
                       "connectorsVersion": "${{ needs.build-image.outputs.connectors-version }}",
-                      "optimizeVersion": "SNAPSHOT"
+                      "optimizeVersion": "8.10-SNAPSHOT"
                   }
                 }'
 


### PR DESCRIPTION
## Summary
- The AlwaysGreen `repository_dispatch` payload to `camunda/c8-cross-component-e2e-tests` (`MERGE_QUEUE_HELM_TEST.yaml`) hardcoded `zeebeVersion`, `operateVersion`, `tasklistVersion`, and `optimizeVersion` to plain `SNAPSHOT`, inconsistent with `c8Version` already being pinned to `"8.10"` in the same payload.
- Plain `SNAPSHOT` resolves to each component's latest main-line snapshot rather than the 8.10 release line's own snapshot build.
- `connectorsVersion` is left as-is (dynamic, this repo's own build output). Aligned the other four to `8.10-SNAPSHOT`.

Note: this repo doesn't have a `stable/8.10` branch (only `alpha/8.10`) — `c8Version` being hardcoded to `8.10` on `main` suggests this workflow is currently the one tracking the 8.10 line, so this PR targets `main` to match. Flag if that's wrong and a different branch should get this instead.

## Test plan
- [ ] Confirm the next AlwaysGreen SaaS dispatch from this workflow pulls `*:8.10-SNAPSHOT` images for Zeebe/Operate/Tasklist/Optimize instead of `*:SNAPSHOT`