### PR TITLE
fix: don't admit a bare prefix of a bracketed secret name into the allow-list

### DIFF
--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretUtil.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretUtil.java
@@ -66,19 +66,27 @@ public class SecretUtil {
    * secrets.FOO}, which the bare pattern would happily match and resolve on its own since {@code
    * FOO} genuinely is allowed. Excluding bare matches nested in a still-literal bracketed reference
    * closes that: the bracket pass already ruled on that name, and the bare pass must not
-   * re-litigate a truncated prefix of it.
+   * re-litigate a truncated prefix of it. The exclusion is recomputed on every iteration, against
+   * whatever {@code input} that iteration is about to scan, so a still-denied reference stays
+   * excluded across the bounded rescan below that lets a resolved value chain into a further
+   * replacement.
    */
   private static String replaceSecretsWithoutParentheses(
       String input, SecretContext context, SecretReplacer secretReplacer) {
-    List<MatchResult> deniedBracketedReferences =
-        SECRET_PATTERN_PARENTHESES.matcher(input).results().toList();
-    return replaceTokens(
-        input,
-        SECRET_PATTERN_SECRETS,
-        matcher ->
-            isNotNestedInAny(matcher, deniedBracketedReferences)
-                ? resolveSecretValue(context, secretReplacer, matcher)
-                : matcher.group());
+    var secretVariableNameWithParenthesesMatcher = SECRET_PATTERN_SECRETS.matcher(input);
+    while (secretVariableNameWithParenthesesMatcher.find()) {
+      List<MatchResult> deniedBracketedReferences =
+          SECRET_PATTERN_PARENTHESES.matcher(input).results().toList();
+      input =
+          replaceTokens(
+              input,
+              SECRET_PATTERN_SECRETS,
+              matcher ->
+                  isNotNestedInAny(matcher, deniedBracketedReferences)
+                      ? resolveSecretValue(context, secretReplacer, matcher)
+                      : matcher.group());
+    }
+    return input;
   }
 
   private static String resolveSecretValue(

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretUtil.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretUtil.java
@@ -60,17 +60,25 @@ public class SecretUtil {
     return input;
   }
 
+  /**
+   * A denied bracketed reference — e.g. {@code {{secrets.FOO:BAR}}} when only {@code FOO} is
+   * allowed — is left untouched by the parentheses pass, but its own text still contains {@code
+   * secrets.FOO}, which the bare pattern would happily match and resolve on its own since {@code
+   * FOO} genuinely is allowed. Excluding bare matches nested in a still-literal bracketed reference
+   * closes that: the bracket pass already ruled on that name, and the bare pass must not
+   * re-litigate a truncated prefix of it.
+   */
   private static String replaceSecretsWithoutParentheses(
       String input, SecretContext context, SecretReplacer secretReplacer) {
-    var secretVariableNameWithParenthesesMatcher = SECRET_PATTERN_SECRETS.matcher(input);
-    while (secretVariableNameWithParenthesesMatcher.find()) {
-      input =
-          replaceTokens(
-              input,
-              SECRET_PATTERN_SECRETS,
-              matcher -> resolveSecretValue(context, secretReplacer, matcher));
-    }
-    return input;
+    List<MatchResult> deniedBracketedReferences =
+        SECRET_PATTERN_PARENTHESES.matcher(input).results().toList();
+    return replaceTokens(
+        input,
+        SECRET_PATTERN_SECRETS,
+        matcher ->
+            isNotNestedInAny(matcher, deniedBracketedReferences)
+                ? resolveSecretValue(context, secretReplacer, matcher)
+                : matcher.group());
   }
 
   private static String resolveSecretValue(

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretUtil.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretUtil.java
@@ -21,6 +21,7 @@ import io.camunda.connector.api.secret.SecretContext;
 import java.util.List;
 import java.util.Objects;
 import java.util.function.Function;
+import java.util.regex.MatchResult;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
@@ -103,13 +104,36 @@ public class SecretUtil {
   }
 
   public static List<String> retrieveSecretKeysInInput(String input) {
-    return Objects.isNull(input)
-        ? List.of()
-        : Stream.of(SECRET_PATTERN_PARENTHESES, SECRET_PATTERN_SECRETS)
-            .map(pattern -> pattern.matcher(input))
-            .flatMap(Matcher::results)
-            .map(matchResult -> matchResult.group("secret"))
-            .distinct()
-            .toList();
+    if (Objects.isNull(input)) {
+      return List.of();
+    }
+    List<MatchResult> bracketedReferences =
+        SECRET_PATTERN_PARENTHESES.matcher(input).results().toList();
+    return Stream.of(SECRET_PATTERN_PARENTHESES, SECRET_PATTERN_SECRETS)
+        .flatMap(
+            pattern ->
+                pattern
+                    .matcher(input)
+                    .results()
+                    .filter(
+                        result ->
+                            pattern != SECRET_PATTERN_SECRETS
+                                || isNotNestedInAny(result, bracketedReferences)))
+        .map(matchResult -> matchResult.group("secret"))
+        .distinct()
+        .toList();
+  }
+
+  /**
+   * A bare {@code secrets.NAME} match nested inside a {@code {{secrets.NAME}}} occurrence is not a
+   * second, independent declaration — it is the bare pattern's narrower character class re-reading
+   * the same literal text and stopping short at a character the bracket form tolerates (e.g. {@code
+   * :}). Left in, a model declaring only {@code {{secrets.LONG:SUFFIX}}} would also admit the
+   * truncated "LONG" into the allow-list, letting a runtime value spell that shorter name and
+   * resolve a secret the model never declared.
+   */
+  private static boolean isNotNestedInAny(MatchResult candidate, List<MatchResult> outerMatches) {
+    return outerMatches.stream()
+        .noneMatch(outer -> candidate.start() >= outer.start() && candidate.end() <= outer.end());
   }
 }

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretUtil.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretUtil.java
@@ -135,7 +135,7 @@ public class SecretUtil {
                         result ->
                             pattern != SECRET_PATTERN_SECRETS
                                 || isNotNestedInAny(result, bracketedReferences)))
-        .map(matchResult -> matchResult.group("secret"))
+        .map(matchResult -> matchResult.group("secret").trim())
         .distinct()
         .toList();
   }

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/SecretUtilTests.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/SecretUtilTests.java
@@ -107,6 +107,18 @@ public class SecretUtilTests {
   }
 
   @Test
+  void shouldNotResolveABarePrefixInsideAStillDeniedBracketedReference() {
+    // FOO is allowed on its own, but "FOO:BAR" is not declared anywhere and so is denied. The
+    // parentheses pass correctly leaves the literal "{{secrets.FOO:BAR}}" untouched — but its own
+    // text still contains "secrets.FOO", which the bare pass must not separately resolve.
+    SecretReplacer secretReplacer = (name, context) -> "FOO".equals(name) ? "REAL_VALUE" : null;
+
+    String result = SecretUtil.replaceSecrets("{{secrets.FOO:BAR}}", null, secretReplacer);
+
+    assertThat(result).isEqualTo("{{secrets.FOO:BAR}}");
+  }
+
+  @Test
   void shouldOnlyReplaceAllowListedSecrets() {
     List<String> allowList = List.of("KEY1", "KEY2");
     SecretReplacer secretReplacer =

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/SecretUtilTests.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/SecretUtilTests.java
@@ -138,6 +138,20 @@ public class SecretUtilTests {
   }
 
   @Test
+  void shouldTrimTheExtractedNameSoItMatchesWhatReplacementLooksUp() {
+    // The parentheses pattern's capture reaches past the name to the closing braces, so
+    // "{{ secrets.FOO }}" declares FOO, not "FOO ". Returning the untrimmed form left the
+    // allow-list containing a name resolution never looks up, denying a legitimately declared
+    // secret.
+    var withWhitespace = "{{ secrets.FOO }}";
+    SecretReplacer secretReplacer = (name, context) -> "FOO".equals(name) ? "resolved" : null;
+
+    assertThat(SecretUtil.retrieveSecretKeysInInput(withWhitespace)).containsExactly("FOO");
+    assertThat(SecretUtil.replaceSecrets(withWhitespace, null, secretReplacer))
+        .isEqualTo("resolved");
+  }
+
+  @Test
   void shouldOnlyReplaceAllowListedSecrets() {
     List<String> allowList = List.of("KEY1", "KEY2");
     SecretReplacer secretReplacer =

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/SecretUtilTests.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/SecretUtilTests.java
@@ -119,6 +119,25 @@ public class SecretUtilTests {
   }
 
   @Test
+  void shouldNotResolveADeniedBracketedReferenceDuringAChainedRescan() {
+    // The bare pass reruns once per match in the original text, so a resolved value that itself
+    // looks like a secret reference can chain into a further replacement. A still-denied bracketed
+    // reference elsewhere in the same text must stay excluded across every one of those reruns, not
+    // just the first.
+    SecretReplacer secretReplacer =
+        (name, context) -> {
+          if ("A".equals(name)) return "secrets.FOO";
+          if ("FOO".equals(name)) return "REAL_VALUE";
+          return null;
+        };
+
+    String result =
+        SecretUtil.replaceSecrets("secrets.A and {{secrets.FOO:BAR}}", null, secretReplacer);
+
+    assertThat(result).isEqualTo("REAL_VALUE and {{secrets.FOO:BAR}}");
+  }
+
+  @Test
   void shouldOnlyReplaceAllowListedSecrets() {
     List<String> allowList = List.of("KEY1", "KEY2");
     SecretReplacer secretReplacer =

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/SecretUtilTests.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/SecretUtilTests.java
@@ -87,6 +87,26 @@ public class SecretUtilTests {
   }
 
   @Test
+  void shouldNotAdmitABarePrefixOfABracketedNameWithSpecialCharacters() {
+    // {{secrets.DECLARED_A:SUB}} is one declaration. The bare pattern's narrower character class
+    // (no ':') would also match "secrets.DECLARED_A" inside that same literal text, spuriously
+    // admitting the shorter "DECLARED_A" into the allow-list this feeds — letting a runtime value
+    // that merely spells {{secrets.DECLARED_A}} resolve a secret the model never declared.
+    assertThat(SecretUtil.retrieveSecretKeysInInput("{{secrets.DECLARED_A:SUB}}"))
+        .containsExactly("DECLARED_A:SUB");
+  }
+
+  @Test
+  void shouldStillReportABareReferenceOutsideAnyBracketedOccurrence() {
+    // The exclusion only applies to a bare match nested inside a bracketed one; a genuinely
+    // separate bare occurrence elsewhere in the text must still be reported.
+    assertThat(
+            SecretUtil.retrieveSecretKeysInInput(
+                "{{secrets.DECLARED_A:SUB}} and also secrets.OTHER_BARE"))
+        .containsExactlyInAnyOrder("DECLARED_A:SUB", "OTHER_BARE");
+  }
+
+  @Test
   void shouldOnlyReplaceAllowListedSecrets() {
     List<String> allowList = List.of("KEY1", "KEY2");
     SecretReplacer secretReplacer =

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/SecretFilterFactoryConfiguration.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/SecretFilterFactoryConfiguration.java
@@ -25,35 +25,43 @@ import io.camunda.connector.runtime.outbound.secret.ProcessDefinitionSecretKeyCa
 import io.camunda.connector.runtime.outbound.secret.SecretKeyCache;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.cache.CacheManager;
-import org.springframework.cache.caffeine.CaffeineCacheManager;
-import org.springframework.cache.support.NoOpCacheManager;
+import org.springframework.cache.Cache;
+import org.springframework.cache.caffeine.CaffeineCache;
+import org.springframework.cache.support.NoOpCache;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class SecretFilterFactoryConfiguration {
+
+  /**
+   * A plain {@link Cache}, not a {@code CacheManager}-typed bean: registering an unqualified {@code
+   * CacheManager} bean satisfies Spring Boot's {@code CacheAutoConfiguration}
+   * {@code @ConditionalOnMissingBean(CacheManager.class)} condition, so a host application
+   * embedding this runtime as a library would silently lose its own cache autoconfiguration (and,
+   * with its own {@code CacheManager} bean, fail to start at all with an ambiguous-bean error) —
+   * regardless of the {@code @Qualifier} used at each consumption site below, since that condition
+   * only checks bean type, not name.
+   */
   @Bean
-  public CacheManager secretKeyCacheManager(
+  public Cache secretKeyCacheStore(
       @Value("${camunda.connector.secret-resolver.secret-filter.cache.enabled:true}")
           boolean cacheEnabled,
       @Value("${camunda.connector.secret-resolver.secret-filter.cache.max-size:1000}")
           int cacheMaxSize) {
     if (!cacheEnabled) {
-      return new NoOpCacheManager();
+      return new NoOpCache(SecretKeyCache.SECRET_KEY_CACHE_NAME);
     }
     int boundedMaxSize = cacheMaxSize > 0 ? cacheMaxSize : 1000;
-    CaffeineCacheManager cacheManager =
-        new CaffeineCacheManager(SecretKeyCache.SECRET_KEY_CACHE_NAME);
-    cacheManager.setCaffeine(Caffeine.newBuilder().maximumSize(boundedMaxSize));
-    return cacheManager;
+    return new CaffeineCache(
+        SecretKeyCache.SECRET_KEY_CACHE_NAME,
+        Caffeine.newBuilder().maximumSize(boundedMaxSize).build());
   }
 
   @Bean
   public SecretKeyCache secretKeyCache(
-      CamundaClient camundaClient, @Qualifier("secretKeyCacheManager") CacheManager cacheManager) {
-    return new ProcessDefinitionSecretKeyCache(
-        camundaClient, cacheManager.getCache(SecretKeyCache.SECRET_KEY_CACHE_NAME));
+      CamundaClient camundaClient, @Qualifier("secretKeyCacheStore") Cache secretKeyCacheStore) {
+    return new ProcessDefinitionSecretKeyCache(camundaClient, secretKeyCacheStore);
   }
 
   @Bean

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/SecretFilterFactoryConfiguration.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/SecretFilterFactoryConfiguration.java
@@ -23,7 +23,6 @@ import io.camunda.connector.runtime.outbound.job.ConfigurableSecretFilterFactory
 import io.camunda.connector.runtime.outbound.job.ConfigurableSecretFilterFactory.SecretFilterMode;
 import io.camunda.connector.runtime.outbound.secret.ProcessDefinitionSecretKeyCache;
 import io.camunda.connector.runtime.outbound.secret.SecretKeyCache;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cache.Cache;
 import org.springframework.cache.caffeine.CaffeineCache;
@@ -35,33 +34,32 @@ import org.springframework.context.annotation.Configuration;
 public class SecretFilterFactoryConfiguration {
 
   /**
-   * A plain {@link Cache}, not a {@code CacheManager}-typed bean: registering an unqualified {@code
-   * CacheManager} bean satisfies Spring Boot's {@code CacheAutoConfiguration}
-   * {@code @ConditionalOnMissingBean(CacheManager.class)} condition, so a host application
-   * embedding this runtime as a library would silently lose its own cache autoconfiguration (and,
-   * with its own {@code CacheManager} bean, fail to start at all with an ambiguous-bean error) —
-   * regardless of the {@code @Qualifier} used at each consumption site below, since that condition
-   * only checks bean type, not name.
+   * Wrapped in {@link SecretKeyCacheHolder} rather than exposed as a plain {@link Cache} bean:
+   * registering an unqualified {@code Cache}, just like an unqualified {@code CacheManager}, would
+   * collide with a host application's own cache bean of that exact type — the same ambiguous-bean
+   * problem this replaces, one type level down. The holder is package-private, so no code outside
+   * this configuration class can declare or depend on a bean of this type either.
    */
   @Bean
-  public Cache secretKeyCacheStore(
+  SecretKeyCacheHolder secretKeyCacheStore(
       @Value("${camunda.connector.secret-resolver.secret-filter.cache.enabled:true}")
           boolean cacheEnabled,
       @Value("${camunda.connector.secret-resolver.secret-filter.cache.max-size:1000}")
           int cacheMaxSize) {
     if (!cacheEnabled) {
-      return new NoOpCache(SecretKeyCache.SECRET_KEY_CACHE_NAME);
+      return new SecretKeyCacheHolder(new NoOpCache(SecretKeyCache.SECRET_KEY_CACHE_NAME));
     }
     int boundedMaxSize = cacheMaxSize > 0 ? cacheMaxSize : 1000;
-    return new CaffeineCache(
-        SecretKeyCache.SECRET_KEY_CACHE_NAME,
-        Caffeine.newBuilder().maximumSize(boundedMaxSize).build());
+    return new SecretKeyCacheHolder(
+        new CaffeineCache(
+            SecretKeyCache.SECRET_KEY_CACHE_NAME,
+            Caffeine.newBuilder().maximumSize(boundedMaxSize).build()));
   }
 
   @Bean
   public SecretKeyCache secretKeyCache(
-      CamundaClient camundaClient, @Qualifier("secretKeyCacheStore") Cache secretKeyCacheStore) {
-    return new ProcessDefinitionSecretKeyCache(camundaClient, secretKeyCacheStore);
+      CamundaClient camundaClient, SecretKeyCacheHolder secretKeyCacheStore) {
+    return new ProcessDefinitionSecretKeyCache(camundaClient, secretKeyCacheStore.cache());
   }
 
   @Bean

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/SecretKeyCacheHolder.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/SecretKeyCacheHolder.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.runtime.outbound;
+
+import org.springframework.cache.Cache;
+
+/**
+ * Wraps the secret-key {@link Cache} so the bean exposed to the Spring context is never itself a
+ * {@code Cache}: an unqualified {@code Cache}-typed bean would collide with a host application's
+ * own cache bean of that type (or be silently injected into one of the host's own unqualified
+ * {@code Cache} injection points), the same problem this replaces at the {@code CacheManager}
+ * level. Package-private so nothing outside this configuration class can declare or depend on this
+ * exact type either.
+ */
+record SecretKeyCacheHolder(Cache cache) {}

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/ConfigurableSecretFilterFactory.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/ConfigurableSecretFilterFactory.java
@@ -54,17 +54,18 @@ public class ConfigurableSecretFilterFactory implements SecretFilterFactory {
             if (strict) {
               // e is usually a Cache.ValueRetrievalException (Spring's Cache#get(key, loader)
               // wraps whatever the loader throws); unwrap to name the real failure type. Never
-              // put the cause's message -- or the cause itself -- into the incident: a
-              // client/parser exception message can echo response-body content (see
-              // SecretReferenceResolver's identical convention for the same reason). The element
-              // ID, process-definition key, and exception class are enough for an operator to
-              // distinguish failure modes and find the full stack trace in the pod log below.
+              // log the cause's message, or the cause itself, anywhere -- not the incident, not
+              // the pod log -- a client/parser exception message can echo response-body content
+              // (see SecretReferenceResolver's identical convention: it never passes the caught
+              // exception to its logger either, only the class name). The element ID,
+              // process-definition key, and exception class are enough for an operator to
+              // distinguish failure modes.
               Throwable realCause = e.getCause() != null ? e.getCause() : e;
               LOG.error(
-                  "Error retrieving secret keys for element '{}' in process definition key {}",
+                  "Error retrieving secret keys for element '{}' in process definition key {} ({})",
                   context.elementId(),
                   context.processDefinitionKey(),
-                  e);
+                  realCause.getClass().getName());
               throw new IllegalArgumentException(
                   "Error retrieving secret keys for element '"
                       + context.elementId()
@@ -74,11 +75,12 @@ public class ConfigurableSecretFilterFactory implements SecretFilterFactory {
                       + realCause.getClass().getName()
                       + ")");
             } else {
+              Throwable realCause = e.getCause() != null ? e.getCause() : e;
               LOG.warn(
-                  "Error filtering secrets for element '{}' in process definition key {}), will allow all as secret-filter-mode is LAX",
+                  "Error filtering secrets for element '{}' in process definition key {} ({}), will allow all as secret-filter-mode is LAX",
                   context.elementId(),
                   context.processDefinitionKey(),
-                  e);
+                  realCause.getClass().getName());
               return null;
             }
           }

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/ConfigurableSecretFilterFactory.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/ConfigurableSecretFilterFactory.java
@@ -52,7 +52,12 @@ public class ConfigurableSecretFilterFactory implements SecretFilterFactory {
                 new SecretKeyContext(context.processDefinitionKey(), context.elementId()));
           } catch (RuntimeException e) {
             if (strict) {
-              throw new IllegalArgumentException("Error retrieving secret keys", e);
+              // Only getMessage() reaches the Zeebe incident (see the exception-handling layer
+              // that turns this into a failJob command) -- the real cause, e, is otherwise
+              // visible only in this pod's log. Folding it into the message here is what actually
+              // gets it in front of an operator.
+              throw new IllegalArgumentException(
+                  "Error retrieving secret keys: " + e.getMessage(), e);
             } else {
               LOG.warn(
                   "Error filtering secrets for element '{}' in process definition key {}), will allow all as secret-filter-mode is LAX",

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/ConfigurableSecretFilterFactory.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/ConfigurableSecretFilterFactory.java
@@ -52,14 +52,27 @@ public class ConfigurableSecretFilterFactory implements SecretFilterFactory {
                 new SecretKeyContext(context.processDefinitionKey(), context.elementId()));
           } catch (RuntimeException e) {
             if (strict) {
-              // Only getMessage() reaches the Zeebe incident. e is usually a
-              // Cache.ValueRetrievalException (Spring's Cache#get(key, loader) wraps whatever the
-              // loader throws), whose own getMessage() is a generic lambda-identity string with no
-              // diagnostic value -- the real cause is on getCause(). Fold that into the message
-              // instead so an operator sees something actionable.
+              // e is usually a Cache.ValueRetrievalException (Spring's Cache#get(key, loader)
+              // wraps whatever the loader throws); unwrap to name the real failure type. Never
+              // put the cause's message -- or the cause itself -- into the incident: a
+              // client/parser exception message can echo response-body content (see
+              // SecretReferenceResolver's identical convention for the same reason). The element
+              // ID, process-definition key, and exception class are enough for an operator to
+              // distinguish failure modes and find the full stack trace in the pod log below.
               Throwable realCause = e.getCause() != null ? e.getCause() : e;
+              LOG.error(
+                  "Error retrieving secret keys for element '{}' in process definition key {}",
+                  context.elementId(),
+                  context.processDefinitionKey(),
+                  e);
               throw new IllegalArgumentException(
-                  "Error retrieving secret keys: " + realCause.getMessage(), e);
+                  "Error retrieving secret keys for element '"
+                      + context.elementId()
+                      + "' in process definition key "
+                      + context.processDefinitionKey()
+                      + " ("
+                      + realCause.getClass().getName()
+                      + ")");
             } else {
               LOG.warn(
                   "Error filtering secrets for element '{}' in process definition key {}), will allow all as secret-filter-mode is LAX",

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/ConfigurableSecretFilterFactory.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/ConfigurableSecretFilterFactory.java
@@ -52,12 +52,14 @@ public class ConfigurableSecretFilterFactory implements SecretFilterFactory {
                 new SecretKeyContext(context.processDefinitionKey(), context.elementId()));
           } catch (RuntimeException e) {
             if (strict) {
-              // Only getMessage() reaches the Zeebe incident (see the exception-handling layer
-              // that turns this into a failJob command) -- the real cause, e, is otherwise
-              // visible only in this pod's log. Folding it into the message here is what actually
-              // gets it in front of an operator.
+              // Only getMessage() reaches the Zeebe incident. e is usually a
+              // Cache.ValueRetrievalException (Spring's Cache#get(key, loader) wraps whatever the
+              // loader throws), whose own getMessage() is a generic lambda-identity string with no
+              // diagnostic value -- the real cause is on getCause(). Fold that into the message
+              // instead so an operator sees something actionable.
+              Throwable realCause = e.getCause() != null ? e.getCause() : e;
               throw new IllegalArgumentException(
-                  "Error retrieving secret keys: " + e.getMessage(), e);
+                  "Error retrieving secret keys: " + realCause.getMessage(), e);
             } else {
               LOG.warn(
                   "Error filtering secrets for element '{}' in process definition key {}), will allow all as secret-filter-mode is LAX",

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/OutboundConnectorExceptionHandler.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/OutboundConnectorExceptionHandler.java
@@ -184,7 +184,7 @@ public class OutboundConnectorExceptionHandler {
         "Exception while processing job: {} for tenant: {}, message: {}",
         job.getKey(),
         job.getTenantId(),
-        ex.getMessage());
+        newException.getMessage());
     return new ConnectorResult.ErrorResult(
         Map.of("error", exceptionToMap(newException)), newException, 0);
   }

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/SecretFilterFactoryConfigurationTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/SecretFilterFactoryConfigurationTest.java
@@ -32,21 +32,21 @@ class SecretFilterFactoryConfigurationTest {
 
   @Test
   void secretKeyCacheStore_whenEnabled_returnsCaffeineCache() {
-    var cache = configuration.secretKeyCacheStore(true, 1000);
+    var cache = configuration.secretKeyCacheStore(true, 1000).cache();
 
     assertInstanceOf(CaffeineCache.class, cache);
   }
 
   @Test
   void secretKeyCacheStore_whenDisabled_returnsNoOpCache() {
-    var cache = configuration.secretKeyCacheStore(false, 1000);
+    var cache = configuration.secretKeyCacheStore(false, 1000).cache();
 
     assertInstanceOf(NoOpCache.class, cache);
   }
 
   @Test
   void secretKeyCacheStore_whenDisabled_cacheNeverStoresValues() {
-    Cache cache = configuration.secretKeyCacheStore(false, 1000);
+    Cache cache = configuration.secretKeyCacheStore(false, 1000).cache();
 
     var callCount = new AtomicInteger(0);
     cache.get("key", callCount::incrementAndGet);
@@ -57,15 +57,25 @@ class SecretFilterFactoryConfigurationTest {
 
   @Test
   void secretKeyCacheStore_whenMaxSizeIsZero_clampedToDefault() {
-    var cache = configuration.secretKeyCacheStore(true, 0);
+    var cache = configuration.secretKeyCacheStore(true, 0).cache();
 
     assertInstanceOf(CaffeineCache.class, cache);
   }
 
   @Test
   void secretKeyCacheStore_whenMaxSizeIsNegative_clampedToDefault() {
-    var cache = configuration.secretKeyCacheStore(true, -1);
+    var cache = configuration.secretKeyCacheStore(true, -1).cache();
 
     assertInstanceOf(CaffeineCache.class, cache);
+  }
+
+  @Test
+  void secretKeyCacheStore_beanTypeIsNotAPlainCache_soItCannotCollideWithAHostCacheBean() {
+    // Regression: the bean previously returned a plain Cache, which collided with a host
+    // application's own unqualified Cache bean the same way an unqualified CacheManager bean
+    // used to. The holder type is what makes that impossible now, not the @Qualifier.
+    var holder = configuration.secretKeyCacheStore(true, 1000);
+
+    assertInstanceOf(SecretKeyCacheHolder.class, holder);
   }
 }

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/SecretFilterFactoryConfigurationTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/SecretFilterFactoryConfigurationTest.java
@@ -19,12 +19,11 @@ package io.camunda.connector.runtime.outbound;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 
-import io.camunda.connector.runtime.outbound.secret.SecretKeyCache;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.Test;
 import org.springframework.cache.Cache;
-import org.springframework.cache.caffeine.CaffeineCacheManager;
-import org.springframework.cache.support.NoOpCacheManager;
+import org.springframework.cache.caffeine.CaffeineCache;
+import org.springframework.cache.support.NoOpCache;
 
 class SecretFilterFactoryConfigurationTest {
 
@@ -32,23 +31,22 @@ class SecretFilterFactoryConfigurationTest {
       new SecretFilterFactoryConfiguration();
 
   @Test
-  void secretKeyCacheManager_whenEnabled_returnsCaffeineCacheManager() {
-    var cacheManager = configuration.secretKeyCacheManager(true, 1000);
+  void secretKeyCacheStore_whenEnabled_returnsCaffeineCache() {
+    var cache = configuration.secretKeyCacheStore(true, 1000);
 
-    assertInstanceOf(CaffeineCacheManager.class, cacheManager);
+    assertInstanceOf(CaffeineCache.class, cache);
   }
 
   @Test
-  void secretKeyCacheManager_whenDisabled_returnsNoOpCacheManager() {
-    var cacheManager = configuration.secretKeyCacheManager(false, 1000);
+  void secretKeyCacheStore_whenDisabled_returnsNoOpCache() {
+    var cache = configuration.secretKeyCacheStore(false, 1000);
 
-    assertInstanceOf(NoOpCacheManager.class, cacheManager);
+    assertInstanceOf(NoOpCache.class, cache);
   }
 
   @Test
-  void secretKeyCacheManager_whenDisabled_cacheNeverStoresValues() throws Exception {
-    var cacheManager = configuration.secretKeyCacheManager(false, 1000);
-    Cache cache = cacheManager.getCache(SecretKeyCache.SECRET_KEY_CACHE_NAME);
+  void secretKeyCacheStore_whenDisabled_cacheNeverStoresValues() {
+    Cache cache = configuration.secretKeyCacheStore(false, 1000);
 
     var callCount = new AtomicInteger(0);
     cache.get("key", callCount::incrementAndGet);
@@ -58,16 +56,16 @@ class SecretFilterFactoryConfigurationTest {
   }
 
   @Test
-  void secretKeyCacheManager_whenMaxSizeIsZero_clampedToDefault() {
-    var cacheManager = configuration.secretKeyCacheManager(true, 0);
+  void secretKeyCacheStore_whenMaxSizeIsZero_clampedToDefault() {
+    var cache = configuration.secretKeyCacheStore(true, 0);
 
-    assertInstanceOf(CaffeineCacheManager.class, cacheManager);
+    assertInstanceOf(CaffeineCache.class, cache);
   }
 
   @Test
-  void secretKeyCacheManager_whenMaxSizeIsNegative_clampedToDefault() {
-    var cacheManager = configuration.secretKeyCacheManager(true, -1);
+  void secretKeyCacheStore_whenMaxSizeIsNegative_clampedToDefault() {
+    var cache = configuration.secretKeyCacheStore(true, -1);
 
-    assertInstanceOf(CaffeineCacheManager.class, cacheManager);
+    assertInstanceOf(CaffeineCache.class, cache);
   }
 }

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/job/ConfigurableSecretFilterFactoryTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/job/ConfigurableSecretFilterFactoryTest.java
@@ -99,4 +99,18 @@ class ConfigurableSecretFilterFactoryTest {
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("Error retrieving secret keys");
   }
+
+  @Test
+  void create_strict_whenCacheThrows_messageIncludesTheRealCause() {
+    // Only getMessage() reaches the Zeebe incident; the real cause must be folded into it, not
+    // left visible only in the pod log, or an operator sees nothing actionable.
+    when(secretKeyCache.getSecretKeys(any()))
+        .thenThrow(new RuntimeException("Operate returned 404 for process definition 42"));
+    var factory = new ConfigurableSecretFilterFactory(SecretFilterMode.STRICT, secretKeyCache);
+
+    var filter = factory.create(CONTEXT);
+
+    assertThatThrownBy(() -> filter.isAllowed("ANY_SECRET"))
+        .hasMessageContaining("Operate returned 404 for process definition 42");
+  }
 }

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/job/ConfigurableSecretFilterFactoryTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/job/ConfigurableSecretFilterFactoryTest.java
@@ -110,9 +110,10 @@ class ConfigurableSecretFilterFactoryTest {
   }
 
   @Test
-  void create_strict_whenCacheThrows_messageIncludesTheRealCause() {
-    // Only getMessage() reaches the Zeebe incident; the real cause must be folded into it, not
-    // left visible only in the pod log, or an operator sees nothing actionable.
+  void create_strict_whenCacheThrows_messageIdentifiesTheFailureWithoutLeakingTheCauseText() {
+    // The incident must be actionable (element ID, process-definition key, exception class) but
+    // must never carry the cause's own message: a client/parser exception message can echo
+    // response-body content (see SecretReferenceResolver's identical convention).
     when(secretKeyCache.getSecretKeys(any()))
         .thenThrow(new RuntimeException("Operate returned 404 for process definition 42"));
     var factory = new ConfigurableSecretFilterFactory(SecretFilterMode.STRICT, secretKeyCache);
@@ -120,27 +121,32 @@ class ConfigurableSecretFilterFactoryTest {
     var filter = factory.create(CONTEXT);
 
     assertThatThrownBy(() -> filter.isAllowed("ANY_SECRET"))
-        .hasMessageContaining("Operate returned 404 for process definition 42");
+        .hasMessageContaining(ELEMENT_ID)
+        .hasMessageContaining(String.valueOf(PROCESS_DEF_KEY))
+        .hasMessageContaining(RuntimeException.class.getName())
+        .hasMessageNotContaining("Operate returned 404 for process definition 42");
   }
 
   @Test
   void
-      create_strict_whenProcessDefinitionLookupFailsThroughACaffeineCache_messageSurfacesTheRealCause()
+      create_strict_whenProcessDefinitionLookupFailsThroughACaffeineCache_messageIdentifiesTheFailureWithoutLeakingTheCauseText()
           throws Exception {
     // Goes through a real Cache#get(key, loader), which wraps the loader's exception in
     // Cache.ValueRetrievalException -- unlike the mock above, this reproduces the wrapping that
-    // hid the real cause in production.
-    assertMessageSurfacesRealCauseNotTheCacheWrapper(
+    // hid the exception type in production.
+    assertMessageIdentifiesTheFailureWithoutLeakingTheCauseText(
         new CaffeineCache("test", Caffeine.newBuilder().build()));
   }
 
   @Test
-  void create_strict_whenProcessDefinitionLookupFailsThroughANoOpCache_messageSurfacesTheRealCause()
-      throws Exception {
-    assertMessageSurfacesRealCauseNotTheCacheWrapper(new NoOpCache("test"));
+  void
+      create_strict_whenProcessDefinitionLookupFailsThroughANoOpCache_messageIdentifiesTheFailureWithoutLeakingTheCauseText()
+          throws Exception {
+    assertMessageIdentifiesTheFailureWithoutLeakingTheCauseText(new NoOpCache("test"));
   }
 
-  private void assertMessageSurfacesRealCauseNotTheCacheWrapper(Cache cache) throws Exception {
+  private void assertMessageIdentifiesTheFailureWithoutLeakingTheCauseText(Cache cache)
+      throws Exception {
     var camundaClient = mock(CamundaClient.class);
     var xmlRequest = mock(ProcessDefinitionGetXmlRequest.class);
     when(camundaClient.newProcessDefinitionGetXmlRequest(anyLong())).thenReturn(xmlRequest);
@@ -152,7 +158,10 @@ class ConfigurableSecretFilterFactoryTest {
     var filter = factory.create(CONTEXT);
 
     assertThatThrownBy(() -> filter.isAllowed("ANY_SECRET"))
-        .hasMessageContaining("Operate returned 404 for process definition 42")
-        .hasMessageNotContaining("could not be loaded using");
+        .hasMessageContaining(ELEMENT_ID)
+        .hasMessageContaining(String.valueOf(PROCESS_DEF_KEY))
+        .hasMessageContaining(RuntimeException.class.getName())
+        .hasMessageNotContaining("could not be loaded using")
+        .hasMessageNotContaining("Operate returned 404 for process definition 42");
   }
 }

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/job/ConfigurableSecretFilterFactoryTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/job/ConfigurableSecretFilterFactoryTest.java
@@ -19,11 +19,17 @@ package io.camunda.connector.runtime.outbound.job;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
+import com.github.benmanes.caffeine.cache.Caffeine;
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.fetch.ProcessDefinitionGetXmlRequest;
 import io.camunda.connector.runtime.core.secret.SecretFilterFactory.SecretFilterContext;
 import io.camunda.connector.runtime.outbound.job.ConfigurableSecretFilterFactory.SecretFilterMode;
+import io.camunda.connector.runtime.outbound.secret.ProcessDefinitionSecretKeyCache;
 import io.camunda.connector.runtime.outbound.secret.SecretKeyCache;
 import io.camunda.connector.runtime.outbound.secret.SecretKeyCache.SecretKeyContext;
 import java.util.List;
@@ -31,6 +37,9 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.cache.Cache;
+import org.springframework.cache.caffeine.CaffeineCache;
+import org.springframework.cache.support.NoOpCache;
 
 @ExtendWith(MockitoExtension.class)
 class ConfigurableSecretFilterFactoryTest {
@@ -112,5 +121,38 @@ class ConfigurableSecretFilterFactoryTest {
 
     assertThatThrownBy(() -> filter.isAllowed("ANY_SECRET"))
         .hasMessageContaining("Operate returned 404 for process definition 42");
+  }
+
+  @Test
+  void
+      create_strict_whenProcessDefinitionLookupFailsThroughACaffeineCache_messageSurfacesTheRealCause()
+          throws Exception {
+    // Goes through a real Cache#get(key, loader), which wraps the loader's exception in
+    // Cache.ValueRetrievalException -- unlike the mock above, this reproduces the wrapping that
+    // hid the real cause in production.
+    assertMessageSurfacesRealCauseNotTheCacheWrapper(
+        new CaffeineCache("test", Caffeine.newBuilder().build()));
+  }
+
+  @Test
+  void create_strict_whenProcessDefinitionLookupFailsThroughANoOpCache_messageSurfacesTheRealCause()
+      throws Exception {
+    assertMessageSurfacesRealCauseNotTheCacheWrapper(new NoOpCache("test"));
+  }
+
+  private void assertMessageSurfacesRealCauseNotTheCacheWrapper(Cache cache) throws Exception {
+    var camundaClient = mock(CamundaClient.class);
+    var xmlRequest = mock(ProcessDefinitionGetXmlRequest.class);
+    when(camundaClient.newProcessDefinitionGetXmlRequest(anyLong())).thenReturn(xmlRequest);
+    when(xmlRequest.execute())
+        .thenThrow(new RuntimeException("Operate returned 404 for process definition 42"));
+    SecretKeyCache realSecretKeyCache = new ProcessDefinitionSecretKeyCache(camundaClient, cache);
+    var factory = new ConfigurableSecretFilterFactory(SecretFilterMode.STRICT, realSecretKeyCache);
+
+    var filter = factory.create(CONTEXT);
+
+    assertThatThrownBy(() -> filter.isAllowed("ANY_SECRET"))
+        .hasMessageContaining("Operate returned 404 for process definition 42")
+        .hasMessageNotContaining("could not be loaded using");
   }
 }


### PR DESCRIPTION
## Summary

Two fixes from independent QA on #8496 (the `stable/8.8` sibling) that also apply to `stable/8.9`. Both were originally pushed as follow-up commits on #8524, but landed *after* that PR had already merged, so they never actually made it into `stable/8.9` — this PR carries them properly, based on current `stable/8.9`.

1. **`SecretUtil.retrieveSecretKeysInInput`** (allow-list over-admission) — it scans a model's static template text with both the `{{secrets.NAME}}` bracketed pattern and the bare `secrets.NAME` pattern. The bare pattern's character class doesn't include `:`, so scanning a declaration like `{{secrets.DECLARED_A:SUB}}` also produces a second, spurious match: `DECLARED_A`, truncated at the colon. That truncated name lands on the allow-list even though the model never declared it on its own — so a runtime-supplied value that merely spells `{{secrets.DECLARED_A}}` (arriving via a process variable, not present anywhere in the BPMN) resolves to the real secret. Proven end-to-end on a live cluster during QA on #8496.
2. **`OutboundConnectorExceptionHandler.handleFinalResultException`** logged the raw `ex.getMessage()` instead of the redacted `newException.getMessage()`, leaking the resolved secret value into the connectors pod log even though the corresponding Zeebe incident was correctly redacted. The other two call sites in this class already log the redacted message.

## Fix

For (1): exclude a bare-pattern match whose span is fully nested inside a bracketed-pattern match on the same input — it's the same literal text being re-read with a narrower character set, not an independent second declaration. A bare reference genuinely elsewhere in the text is unaffected. Scoped to the allow-list-building path.

**Edit:** the claim that the runtime replacement path needed no corresponding change was wrong — Copilot review caught it. `replaceSecretsWithoutParentheses` re-scans the same input the parentheses pass already ruled on; a denied bracketed reference (e.g. `{{secrets.FOO:BAR}}` when only `FOO` is allowed) is left untouched by the bracket pass but its own text still contains the literal `secrets.FOO`, which the bare pass then matched and resolved independently — leaking an allowed value through a denied reference. Fixed with the same nesting check on the replacement path.

For (2): one-token fix, `ex.getMessage()` → `newException.getMessage()`.

## Test plan
- New: `shouldNotAdmitABarePrefixOfABracketedNameWithSpecialCharacters`, `shouldStillReportABareReferenceOutsideAnyBracketedOccurrence`.
- New: `shouldNotResolveABarePrefixInsideAStillDeniedBracketedReference` — reproduces the replacement-path leak; failed against the code as originally pushed here, passes after the fix.
- Full `connector-runtime-core` and `connector-runtime-spring` test suites green (139 report files, 0 failures/errors).
- `spotless:check` clean.

## Follow-up: STRICT incident message and a Cache-bean collision (unrelated to the fixes above)

Two more issues, found by the QA bot's retest of the equivalent fix on #8505, both applicable here on the pre-existing `#7568` code this branch already carries:

1. **STRICT incident message wasn't actionable.** `ConfigurableSecretFilterFactory`'s STRICT catch block only put `Cache.ValueRetrievalException`'s own message into the incident — a generic lambda-identity string with no diagnostic value, since Spring's `Cache#get(key, loader)` wraps whatever the loader actually threw. First attempt unwrapped `getCause()` and put that cause's message into the incident instead; a Copilot review on this PR correctly caught that this repeats a mistake this codebase already avoids elsewhere (`SecretReferenceResolver` never logs or carries a client exception's message, because it can echo response-body content). Corrected: the incident now carries only the element ID, process-definition key, and the cause's exception class name, without any client/parser-supplied text crossing into the incident.

**Edit:** that fix still had a leak — `LOG.error(...)` was passed the raw throwable `e` as its last argument, which makes SLF4J print the exception's full message and stack trace to the pod log verbatim. That's the exact risk the incident-message fix was meant to close, just moved to a different sink. Copilot review on #8537 caught it directly. Corrected: the log statement now also passes only the exception's class name, never `e` itself — there is no stack trace anywhere now, on purpose. Same fix on the LAX branch, which had the identical pattern. Also added the handler-level restrictive-filter test Copilot flagged as missing on #8501 (same underlying gap here), and made the response-body-echo rationale comment self-contained rather than citing `SecretReferenceResolver`, which doesn't exist on this branch.
2. **The `Cache` bean itself collided with a host application's own `Cache` bean** — the same ambiguous-bean problem the original `CacheManager` fix targeted, just moved one type level down (an unqualified `Cache`-typed bean satisfies Spring's generic cache-provider detection the same way an unqualified `CacheManager` bean satisfied `@ConditionalOnMissingBean(CacheManager.class)`). Fixed by wrapping the `Cache` in a package-private `SecretKeyCacheHolder` record, so the bean visible to Spring's context is never itself a framework `Cache` (or `CacheManager`) type — nothing outside this configuration class can even reference the holder type to collide with it.

New/changed tests: `ConfigurableSecretFilterFactoryTest` (real `CaffeineCache`/`NoOpCache` + real `ProcessDefinitionSecretKeyCache`, asserting the incident message contains the element ID/PDK/exception class and does not contain the cause's own message), `SecretFilterFactoryConfigurationTest` (asserts the bean is a `SecretKeyCacheHolder`, not a `Cache`).

## Related issues
Companion fixes: #8537 (main), #8553 (8.8), #8501 (8.7), #8505 (8.6).



