### PR TITLE
fix: bump reactor-netty to 1.3.7

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -951,6 +951,25 @@ from parent/pom.xml.
 See: https://spring.io/security/cve-2026-47857/
                 </regexMessage>
               </requireProperty>
+              <!-- CVE-2026-47874 guard: fails if version.spring-boot is bumped, as a reminder to
+                   check whether the reactor-netty override can be removed (see version.reactor-netty).
+                   spring-boot-dependencies manages io.projectreactor.netty via the same reactor-bom
+                   import as reactor-core above. Confirmed still needed as of spring-boot
+                   3.5.16-spring-boot-3.5.19: its reactor-bom (2024.0.18) ships reactor-netty 1.2.18,
+                   still short of the 1.3.7 fix. Note the 1.2.x-line fix (1.2.19) is Enterprise-only
+                   and is not published to Maven Central, so 1.3.7 is the only reachable fix. -->
+              <requireProperty>
+                <property>version.spring-boot</property>
+                <regex>^3\.5\.16-spring-boot-3\.5\.19$</regex>
+                <regexMessage>
+version.spring-boot was changed! Check if the reactor-netty CVE-2026-47874 override can be removed.
+If the new spring-boot-dependencies BOM ships io.projectreactor.netty:reactor-netty-http &gt;= 1.3.7
+(confirm with `mvn dependency:tree -Dincludes=io.projectreactor.netty:reactor-netty-http`, not just
+the property), remove the version.reactor-netty property, the reactor-netty-http and
+reactor-netty-core dependencyManagement entries, and this enforcer rule from parent/pom.xml.
+See: https://spring.io/security/cve-2026-47874/
+                </regexMessage>
+              </requireProperty>
             </rules>
           </configuration>
           <executions>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -130,6 +130,12 @@ limitations under the License.</license.inlineheader>
          ships a reactor-bom with reactor-core >= 3.8.7
          Ref: https://spring.io/security/cve-2026-47857/ -->
     <version.reactor-core>3.8.7</version.reactor-core>
+    <!-- CVE-2026-47874: reactor-netty transitive override — remove once spring-boot-dependencies
+         ships a reactor-bom with reactor-netty >= 1.3.7. The 1.2.x line fix (1.2.19) is
+         Enterprise-only and not published to Maven Central, so 1.3.7 is the only reachable fix.
+         1.3.7 is also the reactor-netty that reactor-bom pairs with reactor-core 3.8.7 above.
+         Ref: https://spring.io/security/cve-2026-47874/ -->
+    <version.reactor-netty>1.3.7</version.reactor-netty>
     <!-- CVE-2026-59949: lz4-java transitive override — remove once kafka-clients ships lz4-java >= 1.11.1
          Ref: https://nvd.nist.gov/vuln/detail/CVE-2026-59949 -->
     <version.lz4-java>1.11.2</version.lz4-java>
@@ -542,6 +548,21 @@ limitations under the License.</license.inlineheader>
         <groupId>io.projectreactor</groupId>
         <artifactId>reactor-core</artifactId>
         <version>${version.reactor-core}</version>
+      </dependency>
+
+      <!-- CVE-2026-47874 (https://spring.io/security/cve-2026-47874/): override reactor-netty
+           transitive versions brought in by spring-boot-dependencies' reactor-bom (via the Azure
+           SDK's azure-core-http-netty client transport). Remove once spring-boot-dependencies
+           ships a reactor-bom with reactor-netty >= 1.3.7. -->
+      <dependency>
+        <groupId>io.projectreactor.netty</groupId>
+        <artifactId>reactor-netty-http</artifactId>
+        <version>${version.reactor-netty}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.projectreactor.netty</groupId>
+        <artifactId>reactor-netty-core</artifactId>
+        <version>${version.reactor-netty}</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
## Summary

Bumps `io.projectreactor.netty:reactor-netty-http` / `reactor-netty-core` from `1.2.18` to `1.3.7`
via a new `version.reactor-netty` property and `dependencyManagement` overrides in
`parent/pom.xml`, mirroring the existing `reactor-core` override.

1.3.7 is the reactor-netty that reactor-bom pairs with `reactor-core 3.8.7`, which this branch is
already pinned to.

Verified with `mvn dependency:tree`: `reactor-netty-http` now resolves to `1.3.7`.

Security fix. Details in the internal tracking issue: camunda/team-connectors#1273
