### PR TITLE
feat(agentic-ai): expose unified prompt caching control

### DIFF
--- a/connectors/agentic-ai/connector-agentic-ai/bin/transform-ai-agent-sub-process-template.groovy
+++ b/connectors/agentic-ai/connector-agentic-ai/bin/transform-ai-agent-sub-process-template.groovy
@@ -13,118 +13,6 @@ static def replaceDocumentationLinks(String text) {
     )
 }
 
-// Moves the given property ids to sit right after another property id. No-op if either side
-// isn't found. Duplicated in transform-ai-agent-task-template.groovy since this script's
-// execution runs before that one's, per the pom's execution order for the v2 task/sub-process
-// pair.
-static def moveAfter(List properties, List idsToMove, String afterId) {
-    def moving = properties.findAll { it.id in idsToMove }
-    if (moving.isEmpty()) {
-        return properties
-    }
-    def remaining = properties.findAll { !(it.id in idsToMove) }
-    def anchorIndex = remaining.findIndexOf { it.id == afterId }
-    if (anchorIndex < 0) {
-        return properties
-    }
-    remaining.addAll(anchorIndex + 1, moving)
-    return remaining
-}
-
-// Adds the read-only prompt-caching states that the annotation generator cannot express and
-// places every provider's field directly after Model. Duplicated in the task transform for the
-// execution-order reason above.
-static def readOnlyPromptCachingProperty(
-    String id,
-    String description,
-    String tooltip,
-    boolean enabled,
-    String bindingName,
-    String provider
-) {
-    return [
-        id: id,
-        label: "Prompt caching",
-        description: description,
-        tooltip: tooltip,
-        value: enabled,
-        editable: false,
-        group: "model",
-        binding: [name: bindingName, type: "property"],
-        condition: [property: "provider.type", equals: provider, type: "simple"],
-        type: "Boolean"
-    ]
-}
-
-static def configurePromptCaching(List properties) {
-    def cachingPropertyIds = [
-        "provider.anthropic.model.parameters.promptCaching.enabled",
-        "provider.bedrock.model.parameters.promptCaching.enabled",
-        "promptCaching.openai.status",
-        "promptCaching.googleGemini.status",
-        "promptCaching.custom.status"
-    ]
-    def cachingProperties = properties.findAll { it.id in cachingPropertyIds }
-        .collectEntries { [(it.id): it] }
-    def remaining = properties.findAll { !(it.id in cachingPropertyIds) }
-
-    def cachingTooltip = { String documentationUrl ->
-        "Can speed up responses and lower API costs by reusing text from recent requests. Best for long conversations or large documents." +
-            "<br><br>See the <a href=\"${documentationUrl}\" target=\"_blank\">caching documentation</a>."
-    }
-    def integrations = [
-        [
-            modelId: "provider.anthropic.model.model",
-            cachingProperty: cachingProperties["provider.anthropic.model.parameters.promptCaching.enabled"]
-        ],
-        [
-            modelId: "provider.bedrock.model.model",
-            cachingProperty: cachingProperties["provider.bedrock.model.parameters.promptCaching.enabled"]
-        ],
-        [
-            modelId: "provider.openai.model.model",
-            cachingProperty: readOnlyPromptCachingProperty(
-                "promptCaching.openai.status",
-                "Automatic.",
-                cachingTooltip("https://developers.openai.com/api/docs/guides/prompt-caching"),
-                true,
-                "modeler:promptCachingOpenAI",
-                "openai"
-            )
-        ],
-        [
-            modelId: "provider.googleGemini.model.model",
-            cachingProperty: readOnlyPromptCachingProperty(
-                "promptCaching.googleGemini.status",
-                "Automatic.",
-                cachingTooltip("https://ai.google.dev/gemini-api/docs/caching"),
-                true,
-                "modeler:promptCachingGoogleGemini",
-                "google-gemini"
-            )
-        ],
-        [
-            modelId: "provider.model",
-            cachingProperty: readOnlyPromptCachingProperty(
-                "promptCaching.custom.status",
-                "Not available.",
-                "The prompt caching property does not control caching for custom implementations. Use a custom solution instead.",
-                false,
-                "modeler:promptCachingCustom",
-                "custom"
-            )
-        ]
-    ]
-
-    integrations.each { integration ->
-        def anchorIndex = remaining.findIndexOf { it.id == integration.modelId }
-        if (anchorIndex >= 0 && integration.cachingProperty) {
-            remaining.add(anchorIndex + 1, integration.cachingProperty)
-        }
-    }
-    return remaining
-}
-
 def sourceFile = sourceFile
 if (!sourceFile) {
     System.err.println("Error: Source file path required as property")
@@ -399,17 +287,6 @@ updatedProperties.add([
     ],
     type: "Hidden"
 ])
-
-// OpenAI's Effort is declared per API family (a sibling of Model, like the other per-family
-// request parameters), so it's emitted before Model. Move it after, matching Anthropic/Bedrock.
-updatedProperties = moveAfter(
-    updatedProperties,
-    ["provider.openai.api.completions.effort", "provider.openai.api.responses.effort"],
-    "provider.openai.model.model"
-)
-if (file.name.contains("ai-agent-task.v2")) {
-    updatedProperties = configurePromptCaching(updatedProperties)
-}
 
 json.put('properties', updatedProperties)
 mapper.writeValue(outputFilePath, json)

--- a/connectors/agentic-ai/connector-agentic-ai/bin/transform-ai-agent-sub-process-template.groovy
+++ b/connectors/agentic-ai/connector-agentic-ai/bin/transform-ai-agent-sub-process-template.groovy
@@ -31,6 +31,100 @@ static def moveAfter(List properties, List idsToMove, String afterId) {
     return remaining
 }
 
+// Adds the read-only prompt-caching states that the annotation generator cannot express and
+// places every provider's field directly after Model. Duplicated in the task transform for the
+// execution-order reason above.
+static def readOnlyPromptCachingProperty(
+    String id,
+    String description,
+    String tooltip,
+    boolean enabled,
+    String bindingName,
+    String provider
+) {
+    return [
+        id: id,
+        label: "Prompt caching",
+        description: description,
+        tooltip: tooltip,
+        value: enabled,
+        editable: false,
+        group: "model",
+        binding: [name: bindingName, type: "property"],
+        condition: [property: "provider.type", equals: provider, type: "simple"],
+        type: "Boolean"
+    ]
+}
+
+static def configurePromptCaching(List properties) {
+    def cachingPropertyIds = [
+        "provider.anthropic.model.parameters.promptCaching.enabled",
+        "provider.bedrock.model.parameters.promptCaching.enabled",
+        "promptCaching.openai.status",
+        "promptCaching.googleGemini.status",
+        "promptCaching.custom.status"
+    ]
+    def cachingProperties = properties.findAll { it.id in cachingPropertyIds }
+        .collectEntries { [(it.id): it] }
+    def remaining = properties.findAll { !(it.id in cachingPropertyIds) }
+
+    def cachingTooltip = { String documentationUrl ->
+        "Can speed up responses and lower API costs by reusing text from recent requests. Best for long conversations or large documents." +
+            "<br><br>See the <a href=\"${documentationUrl}\" target=\"_blank\">caching documentation</a>."
+    }
+    def integrations = [
+        [
+            modelId: "provider.anthropic.model.model",
+            cachingProperty: cachingProperties["provider.anthropic.model.parameters.promptCaching.enabled"]
+        ],
+        [
+            modelId: "provider.bedrock.model.model",
+            cachingProperty: cachingProperties["provider.bedrock.model.parameters.promptCaching.enabled"]
+        ],
+        [
+            modelId: "provider.openai.model.model",
+            cachingProperty: readOnlyPromptCachingProperty(
+                "promptCaching.openai.status",
+                "Automatic.",
+                cachingTooltip("https://developers.openai.com/api/docs/guides/prompt-caching"),
+                true,
+                "modeler:promptCachingOpenAI",
+                "openai"
+            )
+        ],
+        [
+            modelId: "provider.googleGemini.model.model",
+            cachingProperty: readOnlyPromptCachingProperty(
+                "promptCaching.googleGemini.status",
+                "Automatic.",
+                cachingTooltip("https://ai.google.dev/gemini-api/docs/caching"),
+                true,
+                "modeler:promptCachingGoogleGemini",
+                "google-gemini"
+            )
+        ],
+        [
+            modelId: "provider.model",
+            cachingProperty: readOnlyPromptCachingProperty(
+                "promptCaching.custom.status",
+                "Not available.",
+                "The prompt caching property does not control caching for custom implementations. Use a custom solution instead.",
+                false,
+                "modeler:promptCachingCustom",
+                "custom"
+            )
+        ]
+    ]
+
+    integrations.each { integration ->
+        def anchorIndex = remaining.findIndexOf { it.id == integration.modelId }
+        if (anchorIndex >= 0 && integration.cachingProperty) {
+            remaining.add(anchorIndex + 1, integration.cachingProperty)
+        }
+    }
+    return remaining
+}
+
 def sourceFile = sourceFile
 if (!sourceFile) {
     System.err.println("Error: Source file path required as property")
@@ -313,6 +407,9 @@ updatedProperties = moveAfter(
     ["provider.openai.api.completions.effort", "provider.openai.api.responses.effort"],
     "provider.openai.model.model"
 )
+if (file.name.contains("ai-agent-task.v2")) {
+    updatedProperties = configurePromptCaching(updatedProperties)
+}
 
 json.put('properties', updatedProperties)
 mapper.writeValue(outputFilePath, json)

--- a/connectors/agentic-ai/connector-agentic-ai/bin/transform-ai-agent-task-template.groovy
+++ b/connectors/agentic-ai/connector-agentic-ai/bin/transform-ai-agent-task-template.groovy
@@ -69,6 +69,99 @@ static def moveAfter(List properties, List idsToMove, String afterId) {
     return remaining
 }
 
+// Adds the read-only prompt-caching states that the annotation generator cannot express and
+// places every provider's field directly after Model.
+static def readOnlyPromptCachingProperty(
+    String id,
+    String description,
+    String tooltip,
+    boolean enabled,
+    String bindingName,
+    String provider
+) {
+    return [
+        id: id,
+        label: "Prompt caching",
+        description: description,
+        tooltip: tooltip,
+        value: enabled,
+        editable: false,
+        group: "model",
+        binding: [name: bindingName, type: "property"],
+        condition: [property: "provider.type", equals: provider, type: "simple"],
+        type: "Boolean"
+    ]
+}
+
+static def configurePromptCaching(List properties) {
+    def cachingPropertyIds = [
+        "provider.anthropic.model.parameters.promptCaching.enabled",
+        "provider.bedrock.model.parameters.promptCaching.enabled",
+        "promptCaching.openai.status",
+        "promptCaching.googleGemini.status",
+        "promptCaching.custom.status"
+    ]
+    def cachingProperties = properties.findAll { it.id in cachingPropertyIds }
+        .collectEntries { [(it.id): it] }
+    def remaining = properties.findAll { !(it.id in cachingPropertyIds) }
+
+    def cachingTooltip = { String documentationUrl ->
+        "Can speed up responses and lower API costs by reusing text from recent requests. Best for long conversations or large documents." +
+            "<br><br>See the <a href=\"${documentationUrl}\" target=\"_blank\">caching documentation</a>."
+    }
+    def integrations = [
+        [
+            modelId: "provider.anthropic.model.model",
+            cachingProperty: cachingProperties["provider.anthropic.model.parameters.promptCaching.enabled"]
+        ],
+        [
+            modelId: "provider.bedrock.model.model",
+            cachingProperty: cachingProperties["provider.bedrock.model.parameters.promptCaching.enabled"]
+        ],
+        [
+            modelId: "provider.openai.model.model",
+            cachingProperty: readOnlyPromptCachingProperty(
+                "promptCaching.openai.status",
+                "Automatic.",
+                cachingTooltip("https://developers.openai.com/api/docs/guides/prompt-caching"),
+                true,
+                "modeler:promptCachingOpenAI",
+                "openai"
+            )
+        ],
+        [
+            modelId: "provider.googleGemini.model.model",
+            cachingProperty: readOnlyPromptCachingProperty(
+                "promptCaching.googleGemini.status",
+                "Automatic.",
+                cachingTooltip("https://ai.google.dev/gemini-api/docs/caching"),
+                true,
+                "modeler:promptCachingGoogleGemini",
+                "google-gemini"
+            )
+        ],
+        [
+            modelId: "provider.model",
+            cachingProperty: readOnlyPromptCachingProperty(
+                "promptCaching.custom.status",
+                "Not available.",
+                "The prompt caching property does not control caching for custom implementations. Use a custom solution instead.",
+                false,
+                "modeler:promptCachingCustom",
+                "custom"
+            )
+        ]
+    ]
+
+    integrations.each { integration ->
+        def anchorIndex = remaining.findIndexOf { it.id == integration.modelId }
+        if (anchorIndex >= 0 && integration.cachingProperty) {
+            remaining.add(anchorIndex + 1, integration.cachingProperty)
+        }
+    }
+    return remaining
+}
+
 def updatedProperties = []
 
 ((List) json.get('properties')).each { property ->
@@ -100,6 +193,9 @@ updatedProperties = moveAfter(
     ["provider.openai.api.completions.effort", "provider.openai.api.responses.effort"],
     "provider.openai.model.model"
 )
+if (json.id?.toString()?.contains("ai-agent-task.v2")) {
+    updatedProperties = configurePromptCaching(updatedProperties)
+}
 
 json.put('properties', updatedProperties)
 mapper.writeValue(new File((String) outputFile), json)

--- a/connectors/agentic-ai/connector-agentic-ai/bin/transform-ai-agent-task-template.groovy
+++ b/connectors/agentic-ai/connector-agentic-ai/bin/transform-ai-agent-task-template.groovy
@@ -69,94 +69,33 @@ static def moveAfter(List properties, List idsToMove, String afterId) {
     return remaining
 }
 
-// Adds the read-only prompt-caching states that the annotation generator cannot express and
-// places every provider's field directly after Model.
-static def readOnlyPromptCachingProperty(
-    String id,
-    String description,
-    String tooltip,
-    boolean enabled,
-    String bindingName,
-    String provider
-) {
-    return [
-        id: id,
-        label: "Prompt caching",
-        description: description,
-        tooltip: tooltip,
-        value: enabled,
-        editable: false,
-        group: "model",
-        binding: [name: bindingName, type: "property"],
-        condition: [property: "provider.type", equals: provider, type: "simple"],
-        type: "Boolean"
-    ]
-}
-
 static def configurePromptCaching(List properties) {
-    def cachingPropertyIds = [
-        "provider.anthropic.model.parameters.promptCaching.enabled",
-        "provider.bedrock.model.parameters.promptCaching.enabled",
-        "promptCaching.openai.status",
-        "promptCaching.googleGemini.status",
-        "promptCaching.custom.status"
+    def integrations = [
+        [modelId: "provider.anthropic.model.model", cachingId: "provider.anthropic.model.parameters.promptCaching.enabled"],
+        [modelId: "provider.bedrock.model.model", cachingId: "provider.bedrock.model.parameters.promptCaching.enabled"],
+        [modelId: "provider.openai.model.model", cachingId: "promptCaching.openai.status"],
+        [modelId: "provider.googleGemini.model.model", cachingId: "promptCaching.googleGemini.status"],
+        [modelId: "provider.model", cachingId: "promptCaching.custom.status"]
     ]
+    def cachingPropertyIds = integrations*.cachingId
     def cachingProperties = properties.findAll { it.id in cachingPropertyIds }
         .collectEntries { [(it.id): it] }
     def remaining = properties.findAll { !(it.id in cachingPropertyIds) }
 
-    def cachingTooltip = { String documentationUrl ->
-        "Can speed up responses and lower API costs by reusing text from recent requests. Best for long conversations or large documents." +
-            "<br><br>See the <a href=\"${documentationUrl}\" target=\"_blank\">caching documentation</a>."
-    }
-    def integrations = [
-        [
-            modelId: "provider.anthropic.model.model",
-            cachingProperty: cachingProperties["provider.anthropic.model.parameters.promptCaching.enabled"]
-        ],
-        [
-            modelId: "provider.bedrock.model.model",
-            cachingProperty: cachingProperties["provider.bedrock.model.parameters.promptCaching.enabled"]
-        ],
-        [
-            modelId: "provider.openai.model.model",
-            cachingProperty: readOnlyPromptCachingProperty(
-                "promptCaching.openai.status",
-                "Automatic.",
-                cachingTooltip("https://developers.openai.com/api/docs/guides/prompt-caching"),
-                true,
-                "modeler:promptCachingOpenAI",
-                "openai"
-            )
-        ],
-        [
-            modelId: "provider.googleGemini.model.model",
-            cachingProperty: readOnlyPromptCachingProperty(
-                "promptCaching.googleGemini.status",
-                "Automatic.",
-                cachingTooltip("https://ai.google.dev/gemini-api/docs/caching"),
-                true,
-                "modeler:promptCachingGoogleGemini",
-                "google-gemini"
-            )
-        ],
-        [
-            modelId: "provider.model",
-            cachingProperty: readOnlyPromptCachingProperty(
-                "promptCaching.custom.status",
-                "Not available.",
-                "The prompt caching property does not control caching for custom implementations. Use a custom solution instead.",
-                false,
-                "modeler:promptCachingCustom",
-                "custom"
-            )
-        ]
-    ]
-
     integrations.each { integration ->
+        def cachingProperty = cachingProperties[integration.cachingId]
+        if (cachingProperty?.binding?.name?.startsWith("modeler.")) {
+            cachingProperty.binding = [
+                name: cachingProperty.binding.name.replaceFirst(/^modeler\./, "modeler:"),
+                type: "property"
+            ]
+            cachingProperty.editable = false
+            cachingProperty.remove("feel")
+            cachingProperty.remove("optional")
+        }
         def anchorIndex = remaining.findIndexOf { it.id == integration.modelId }
-        if (anchorIndex >= 0 && integration.cachingProperty) {
-            remaining.add(anchorIndex + 1, integration.cachingProperty)
+        if (anchorIndex >= 0 && cachingProperty) {
+            remaining.add(anchorIndex + 1, cachingProperty)
         }
     }
     return remaining

--- a/connectors/agentic-ai/connector-agentic-ai/element-templates/agenticai-ai-agent-subprocess.v2.json
+++ b/connectors/agentic-ai/connector-agentic-ai/element-templates/agenticai-ai-agent-subprocess.v2.json
@@ -1924,6 +1924,24 @@
     "placeholder" : "claude-sonnet-5",
     "type" : "String"
   }, {
+    "id" : "provider.anthropic.model.parameters.promptCaching.enabled",
+    "label" : "Prompt caching",
+    "optional" : true,
+    "value" : false,
+    "feel" : "static",
+    "group" : "model",
+    "binding" : {
+      "name" : "provider.anthropic.model.parameters.promptCaching.enabled",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "provider.type",
+      "equals" : "anthropic",
+      "type" : "simple"
+    },
+    "tooltip" : "Can speed up responses and lower API costs by reusing text from recent requests. Best for long conversations or large documents.<br><br>See the <a href=\"https://platform.claude.com/docs/en/build-with-claude/prompt-caching#automatic-caching\" target=\"_blank\">caching documentation</a>.",
+    "type" : "Boolean"
+  }, {
     "id" : "provider.anthropic.model.parameters.effort",
     "label" : "Effort",
     "optional" : false,
@@ -2043,24 +2061,6 @@
       "value" : "omitted"
     } ]
   }, {
-    "id" : "provider.anthropic.model.parameters.promptCaching.enabled",
-    "label" : "Enable prompt caching",
-    "optional" : true,
-    "value" : false,
-    "feel" : "static",
-    "group" : "model",
-    "binding" : {
-      "name" : "provider.anthropic.model.parameters.promptCaching.enabled",
-      "type" : "zeebe:input"
-    },
-    "condition" : {
-      "property" : "provider.type",
-      "equals" : "anthropic",
-      "type" : "simple"
-    },
-    "tooltip" : "Enables Anthropic automatic prompt caching. See the <a href=\"https://platform.claude.com/docs/en/build-with-claude/prompt-caching#automatic-caching\" target=\"_blank\">documentation</a>.",
-    "type" : "Boolean"
-  }, {
     "id" : "provider.bedrock.model.model",
     "label" : "Model",
     "description" : "Specify the model ID. Details in the <a href=\"https://docs.aws.amazon.com/bedrock/latest/userguide/inference-profiles-support.html\" target=\"_blank\">documentation</a>.",
@@ -2083,7 +2083,7 @@
     "type" : "String"
   }, {
     "id" : "provider.bedrock.model.parameters.promptCaching.enabled",
-    "label" : "Enable prompt caching",
+    "label" : "Prompt caching",
     "optional" : true,
     "value" : false,
     "feel" : "static",
@@ -2097,7 +2097,7 @@
       "equals" : "bedrock",
       "type" : "simple"
     },
-    "tooltip" : "Enables AWS Bedrock automatic prompt caching. See the <a href=\"https://docs.aws.amazon.com/bedrock/latest/userguide/prompt-caching.html\" target=\"_blank\">documentation</a>.",
+    "tooltip" : "Can speed up responses and lower API costs by reusing text from recent requests. Best for long conversations or large documents.<br><br>See the <a href=\"https://docs.aws.amazon.com/bedrock/latest/userguide/prompt-caching.html\" target=\"_blank\">caching documentation</a>.",
     "type" : "Boolean"
   }, {
     "id" : "provider.openai.model.model",
@@ -2120,6 +2120,24 @@
     },
     "placeholder" : "gpt-5.5",
     "type" : "String"
+  }, {
+    "id" : "promptCaching.openai.status",
+    "label" : "Prompt caching",
+    "description" : "Automatic.",
+    "tooltip" : "Can speed up responses and lower API costs by reusing text from recent requests. Best for long conversations or large documents.<br><br>See the <a href=\"https://developers.openai.com/api/docs/guides/prompt-caching\" target=\"_blank\">caching documentation</a>.",
+    "value" : true,
+    "editable" : false,
+    "group" : "model",
+    "binding" : {
+      "name" : "modeler:promptCachingOpenAI",
+      "type" : "property"
+    },
+    "condition" : {
+      "property" : "provider.type",
+      "equals" : "openai",
+      "type" : "simple"
+    },
+    "type" : "Boolean"
   }, {
     "id" : "provider.openai.api.responses.effort",
     "label" : "Effort",
@@ -2232,6 +2250,24 @@
     "placeholder" : "gemini-3-pro-preview",
     "type" : "String"
   }, {
+    "id" : "promptCaching.googleGemini.status",
+    "label" : "Prompt caching",
+    "description" : "Automatic.",
+    "tooltip" : "Can speed up responses and lower API costs by reusing text from recent requests. Best for long conversations or large documents.<br><br>See the <a href=\"https://ai.google.dev/gemini-api/docs/caching\" target=\"_blank\">caching documentation</a>.",
+    "value" : true,
+    "editable" : false,
+    "group" : "model",
+    "binding" : {
+      "name" : "modeler:promptCachingGoogleGemini",
+      "type" : "property"
+    },
+    "condition" : {
+      "property" : "provider.type",
+      "equals" : "google-gemini",
+      "type" : "simple"
+    },
+    "type" : "Boolean"
+  }, {
     "id" : "provider.googleGemini.model.parameters.thinking.thinkingBudget",
     "label" : "Thinking budget (tokens)",
     "optional" : true,
@@ -2307,6 +2343,24 @@
       "type" : "simple"
     },
     "type" : "String"
+  }, {
+    "id" : "promptCaching.custom.status",
+    "label" : "Prompt caching",
+    "description" : "Not available.",
+    "tooltip" : "The prompt caching property does not control caching for custom implementations. Use a custom solution instead.",
+    "value" : false,
+    "editable" : false,
+    "group" : "model",
+    "binding" : {
+      "name" : "modeler:promptCachingCustom",
+      "type" : "property"
+    },
+    "condition" : {
+      "property" : "provider.type",
+      "equals" : "custom",
+      "type" : "simple"
+    },
+    "type" : "Boolean"
   }, {
     "id" : "provider.anthropic.model.parameters.maxTokens",
     "label" : "Maximum tokens",

--- a/connectors/agentic-ai/connector-agentic-ai/element-templates/agenticai-ai-agent-subprocess.v2.json
+++ b/connectors/agentic-ai/connector-agentic-ai/element-templates/agenticai-ai-agent-subprocess.v2.json
@@ -2124,9 +2124,7 @@
     "id" : "promptCaching.openai.status",
     "label" : "Prompt caching",
     "description" : "Automatic.",
-    "tooltip" : "Can speed up responses and lower API costs by reusing text from recent requests. Best for long conversations or large documents.<br><br>See the <a href=\"https://developers.openai.com/api/docs/guides/prompt-caching\" target=\"_blank\">caching documentation</a>.",
     "value" : true,
-    "editable" : false,
     "group" : "model",
     "binding" : {
       "name" : "modeler:promptCachingOpenAI",
@@ -2137,7 +2135,9 @@
       "equals" : "openai",
       "type" : "simple"
     },
-    "type" : "Boolean"
+    "tooltip" : "Can speed up responses and lower API costs by reusing text from recent requests. Best for long conversations or large documents.<br><br>See the <a href=\"https://developers.openai.com/api/docs/guides/prompt-caching\" target=\"_blank\">caching documentation</a>.",
+    "type" : "Boolean",
+    "editable" : false
   }, {
     "id" : "provider.openai.api.responses.effort",
     "label" : "Effort",
@@ -2253,9 +2253,7 @@
     "id" : "promptCaching.googleGemini.status",
     "label" : "Prompt caching",
     "description" : "Automatic.",
-    "tooltip" : "Can speed up responses and lower API costs by reusing text from recent requests. Best for long conversations or large documents.<br><br>See the <a href=\"https://ai.google.dev/gemini-api/docs/caching\" target=\"_blank\">caching documentation</a>.",
     "value" : true,
-    "editable" : false,
     "group" : "model",
     "binding" : {
       "name" : "modeler:promptCachingGoogleGemini",
@@ -2266,7 +2264,9 @@
       "equals" : "google-gemini",
       "type" : "simple"
     },
-    "type" : "Boolean"
+    "tooltip" : "Can speed up responses and lower API costs by reusing text from recent requests. Best for long conversations or large documents.<br><br>See the <a href=\"https://ai.google.dev/gemini-api/docs/caching\" target=\"_blank\">caching documentation</a>.",
+    "type" : "Boolean",
+    "editable" : false
   }, {
     "id" : "provider.googleGemini.model.parameters.thinking.thinkingBudget",
     "label" : "Thinking budget (tokens)",
@@ -2347,9 +2347,7 @@
     "id" : "promptCaching.custom.status",
     "label" : "Prompt caching",
     "description" : "Not available.",
-    "tooltip" : "The prompt caching property does not control caching for custom implementations. Use a custom solution instead.",
     "value" : false,
-    "editable" : false,
     "group" : "model",
     "binding" : {
       "name" : "modeler:promptCachingCustom",
@@ -2360,7 +2358,9 @@
       "equals" : "custom",
       "type" : "simple"
     },
-    "type" : "Boolean"
+    "tooltip" : "The prompt caching property does not control caching for custom implementations. Use a custom solution instead.",
+    "type" : "Boolean",
+    "editable" : false
   }, {
     "id" : "provider.anthropic.model.parameters.maxTokens",
     "label" : "Maximum tokens",

--- a/connectors/agentic-ai/connector-agentic-ai/element-templates/agenticai-ai-agent-subprocess.v2.json
+++ b/connectors/agentic-ai/connector-agentic-ai/element-templates/agenticai-ai-agent-subprocess.v2.json
@@ -1926,6 +1926,7 @@
   }, {
     "id" : "provider.anthropic.model.parameters.promptCaching.enabled",
     "label" : "Prompt caching",
+    "description" : "Optional.",
     "optional" : true,
     "value" : false,
     "feel" : "static",
@@ -2084,6 +2085,7 @@
   }, {
     "id" : "provider.bedrock.model.parameters.promptCaching.enabled",
     "label" : "Prompt caching",
+    "description" : "Optional.",
     "optional" : true,
     "value" : false,
     "feel" : "static",

--- a/connectors/agentic-ai/connector-agentic-ai/element-templates/agenticai-ai-agent-task.v2.json
+++ b/connectors/agentic-ai/connector-agentic-ai/element-templates/agenticai-ai-agent-task.v2.json
@@ -2096,9 +2096,7 @@
     "id" : "promptCaching.openai.status",
     "label" : "Prompt caching",
     "description" : "Automatic.",
-    "tooltip" : "Can speed up responses and lower API costs by reusing text from recent requests. Best for long conversations or large documents.<br><br>See the <a href=\"https://developers.openai.com/api/docs/guides/prompt-caching\" target=\"_blank\">caching documentation</a>.",
     "value" : true,
-    "editable" : false,
     "group" : "model",
     "binding" : {
       "name" : "modeler:promptCachingOpenAI",
@@ -2109,7 +2107,9 @@
       "equals" : "openai",
       "type" : "simple"
     },
-    "type" : "Boolean"
+    "tooltip" : "Can speed up responses and lower API costs by reusing text from recent requests. Best for long conversations or large documents.<br><br>See the <a href=\"https://developers.openai.com/api/docs/guides/prompt-caching\" target=\"_blank\">caching documentation</a>.",
+    "type" : "Boolean",
+    "editable" : false
   }, {
     "id" : "provider.openai.api.responses.effort",
     "label" : "Effort",
@@ -2225,9 +2225,7 @@
     "id" : "promptCaching.googleGemini.status",
     "label" : "Prompt caching",
     "description" : "Automatic.",
-    "tooltip" : "Can speed up responses and lower API costs by reusing text from recent requests. Best for long conversations or large documents.<br><br>See the <a href=\"https://ai.google.dev/gemini-api/docs/caching\" target=\"_blank\">caching documentation</a>.",
     "value" : true,
-    "editable" : false,
     "group" : "model",
     "binding" : {
       "name" : "modeler:promptCachingGoogleGemini",
@@ -2238,7 +2236,9 @@
       "equals" : "google-gemini",
       "type" : "simple"
     },
-    "type" : "Boolean"
+    "tooltip" : "Can speed up responses and lower API costs by reusing text from recent requests. Best for long conversations or large documents.<br><br>See the <a href=\"https://ai.google.dev/gemini-api/docs/caching\" target=\"_blank\">caching documentation</a>.",
+    "type" : "Boolean",
+    "editable" : false
   }, {
     "id" : "provider.googleGemini.model.parameters.thinking.thinkingBudget",
     "label" : "Thinking budget (tokens)",
@@ -2319,9 +2319,7 @@
     "id" : "promptCaching.custom.status",
     "label" : "Prompt caching",
     "description" : "Not available.",
-    "tooltip" : "The prompt caching property does not control caching for custom implementations. Use a custom solution instead.",
     "value" : false,
-    "editable" : false,
     "group" : "model",
     "binding" : {
       "name" : "modeler:promptCachingCustom",
@@ -2332,7 +2330,9 @@
       "equals" : "custom",
       "type" : "simple"
     },
-    "type" : "Boolean"
+    "tooltip" : "The prompt caching property does not control caching for custom implementations. Use a custom solution instead.",
+    "type" : "Boolean",
+    "editable" : false
   }, {
     "id" : "provider.anthropic.model.parameters.maxTokens",
     "label" : "Maximum tokens",

--- a/connectors/agentic-ai/connector-agentic-ai/element-templates/agenticai-ai-agent-task.v2.json
+++ b/connectors/agentic-ai/connector-agentic-ai/element-templates/agenticai-ai-agent-task.v2.json
@@ -1898,6 +1898,7 @@
   }, {
     "id" : "provider.anthropic.model.parameters.promptCaching.enabled",
     "label" : "Prompt caching",
+    "description" : "Optional.",
     "optional" : true,
     "value" : false,
     "feel" : "static",
@@ -2056,6 +2057,7 @@
   }, {
     "id" : "provider.bedrock.model.parameters.promptCaching.enabled",
     "label" : "Prompt caching",
+    "description" : "Optional.",
     "optional" : true,
     "value" : false,
     "feel" : "static",

--- a/connectors/agentic-ai/connector-agentic-ai/element-templates/agenticai-ai-agent-task.v2.json
+++ b/connectors/agentic-ai/connector-agentic-ai/element-templates/agenticai-ai-agent-task.v2.json
@@ -1896,6 +1896,24 @@
     "placeholder" : "claude-sonnet-5",
     "type" : "String"
   }, {
+    "id" : "provider.anthropic.model.parameters.promptCaching.enabled",
+    "label" : "Prompt caching",
+    "optional" : true,
+    "value" : false,
+    "feel" : "static",
+    "group" : "model",
+    "binding" : {
+      "name" : "provider.anthropic.model.parameters.promptCaching.enabled",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "provider.type",
+      "equals" : "anthropic",
+      "type" : "simple"
+    },
+    "tooltip" : "Can speed up responses and lower API costs by reusing text from recent requests. Best for long conversations or large documents.<br><br>See the <a href=\"https://platform.claude.com/docs/en/build-with-claude/prompt-caching#automatic-caching\" target=\"_blank\">caching documentation</a>.",
+    "type" : "Boolean"
+  }, {
     "id" : "provider.anthropic.model.parameters.effort",
     "label" : "Effort",
     "optional" : false,
@@ -2015,24 +2033,6 @@
       "value" : "omitted"
     } ]
   }, {
-    "id" : "provider.anthropic.model.parameters.promptCaching.enabled",
-    "label" : "Enable prompt caching",
-    "optional" : true,
-    "value" : false,
-    "feel" : "static",
-    "group" : "model",
-    "binding" : {
-      "name" : "provider.anthropic.model.parameters.promptCaching.enabled",
-      "type" : "zeebe:input"
-    },
-    "condition" : {
-      "property" : "provider.type",
-      "equals" : "anthropic",
-      "type" : "simple"
-    },
-    "tooltip" : "Enables Anthropic automatic prompt caching. See the <a href=\"https://platform.claude.com/docs/en/build-with-claude/prompt-caching#automatic-caching\" target=\"_blank\">documentation</a>.",
-    "type" : "Boolean"
-  }, {
     "id" : "provider.bedrock.model.model",
     "label" : "Model",
     "description" : "Specify the model ID. Details in the <a href=\"https://docs.aws.amazon.com/bedrock/latest/userguide/inference-profiles-support.html\" target=\"_blank\">documentation</a>.",
@@ -2055,7 +2055,7 @@
     "type" : "String"
   }, {
     "id" : "provider.bedrock.model.parameters.promptCaching.enabled",
-    "label" : "Enable prompt caching",
+    "label" : "Prompt caching",
     "optional" : true,
     "value" : false,
     "feel" : "static",
@@ -2069,7 +2069,7 @@
       "equals" : "bedrock",
       "type" : "simple"
     },
-    "tooltip" : "Enables AWS Bedrock automatic prompt caching. See the <a href=\"https://docs.aws.amazon.com/bedrock/latest/userguide/prompt-caching.html\" target=\"_blank\">documentation</a>.",
+    "tooltip" : "Can speed up responses and lower API costs by reusing text from recent requests. Best for long conversations or large documents.<br><br>See the <a href=\"https://docs.aws.amazon.com/bedrock/latest/userguide/prompt-caching.html\" target=\"_blank\">caching documentation</a>.",
     "type" : "Boolean"
   }, {
     "id" : "provider.openai.model.model",
@@ -2092,6 +2092,24 @@
     },
     "placeholder" : "gpt-5.5",
     "type" : "String"
+  }, {
+    "id" : "promptCaching.openai.status",
+    "label" : "Prompt caching",
+    "description" : "Automatic.",
+    "tooltip" : "Can speed up responses and lower API costs by reusing text from recent requests. Best for long conversations or large documents.<br><br>See the <a href=\"https://developers.openai.com/api/docs/guides/prompt-caching\" target=\"_blank\">caching documentation</a>.",
+    "value" : true,
+    "editable" : false,
+    "group" : "model",
+    "binding" : {
+      "name" : "modeler:promptCachingOpenAI",
+      "type" : "property"
+    },
+    "condition" : {
+      "property" : "provider.type",
+      "equals" : "openai",
+      "type" : "simple"
+    },
+    "type" : "Boolean"
   }, {
     "id" : "provider.openai.api.responses.effort",
     "label" : "Effort",
@@ -2204,6 +2222,24 @@
     "placeholder" : "gemini-3-pro-preview",
     "type" : "String"
   }, {
+    "id" : "promptCaching.googleGemini.status",
+    "label" : "Prompt caching",
+    "description" : "Automatic.",
+    "tooltip" : "Can speed up responses and lower API costs by reusing text from recent requests. Best for long conversations or large documents.<br><br>See the <a href=\"https://ai.google.dev/gemini-api/docs/caching\" target=\"_blank\">caching documentation</a>.",
+    "value" : true,
+    "editable" : false,
+    "group" : "model",
+    "binding" : {
+      "name" : "modeler:promptCachingGoogleGemini",
+      "type" : "property"
+    },
+    "condition" : {
+      "property" : "provider.type",
+      "equals" : "google-gemini",
+      "type" : "simple"
+    },
+    "type" : "Boolean"
+  }, {
     "id" : "provider.googleGemini.model.parameters.thinking.thinkingBudget",
     "label" : "Thinking budget (tokens)",
     "optional" : true,
@@ -2279,6 +2315,24 @@
       "type" : "simple"
     },
     "type" : "String"
+  }, {
+    "id" : "promptCaching.custom.status",
+    "label" : "Prompt caching",
+    "description" : "Not available.",
+    "tooltip" : "The prompt caching property does not control caching for custom implementations. Use a custom solution instead.",
+    "value" : false,
+    "editable" : false,
+    "group" : "model",
+    "binding" : {
+      "name" : "modeler:promptCachingCustom",
+      "type" : "property"
+    },
+    "condition" : {
+      "property" : "provider.type",
+      "equals" : "custom",
+      "type" : "simple"
+    },
+    "type" : "Boolean"
   }, {
     "id" : "provider.anthropic.model.parameters.maxTokens",
     "label" : "Maximum tokens",

--- a/connectors/agentic-ai/connector-agentic-ai/element-templates/hybrid/agenticai-ai-agent-subprocess.v2-hybrid.json
+++ b/connectors/agentic-ai/connector-agentic-ai/element-templates/hybrid/agenticai-ai-agent-subprocess.v2-hybrid.json
@@ -2129,9 +2129,7 @@
     "id" : "promptCaching.openai.status",
     "label" : "Prompt caching",
     "description" : "Automatic.",
-    "tooltip" : "Can speed up responses and lower API costs by reusing text from recent requests. Best for long conversations or large documents.<br><br>See the <a href=\"https://developers.openai.com/api/docs/guides/prompt-caching\" target=\"_blank\">caching documentation</a>.",
     "value" : true,
-    "editable" : false,
     "group" : "model",
     "binding" : {
       "name" : "modeler:promptCachingOpenAI",
@@ -2142,7 +2140,9 @@
       "equals" : "openai",
       "type" : "simple"
     },
-    "type" : "Boolean"
+    "tooltip" : "Can speed up responses and lower API costs by reusing text from recent requests. Best for long conversations or large documents.<br><br>See the <a href=\"https://developers.openai.com/api/docs/guides/prompt-caching\" target=\"_blank\">caching documentation</a>.",
+    "type" : "Boolean",
+    "editable" : false
   }, {
     "id" : "provider.openai.api.responses.effort",
     "label" : "Effort",
@@ -2258,9 +2258,7 @@
     "id" : "promptCaching.googleGemini.status",
     "label" : "Prompt caching",
     "description" : "Automatic.",
-    "tooltip" : "Can speed up responses and lower API costs by reusing text from recent requests. Best for long conversations or large documents.<br><br>See the <a href=\"https://ai.google.dev/gemini-api/docs/caching\" target=\"_blank\">caching documentation</a>.",
     "value" : true,
-    "editable" : false,
     "group" : "model",
     "binding" : {
       "name" : "modeler:promptCachingGoogleGemini",
@@ -2271,7 +2269,9 @@
       "equals" : "google-gemini",
       "type" : "simple"
     },
-    "type" : "Boolean"
+    "tooltip" : "Can speed up responses and lower API costs by reusing text from recent requests. Best for long conversations or large documents.<br><br>See the <a href=\"https://ai.google.dev/gemini-api/docs/caching\" target=\"_blank\">caching documentation</a>.",
+    "type" : "Boolean",
+    "editable" : false
   }, {
     "id" : "provider.googleGemini.model.parameters.thinking.thinkingBudget",
     "label" : "Thinking budget (tokens)",
@@ -2352,9 +2352,7 @@
     "id" : "promptCaching.custom.status",
     "label" : "Prompt caching",
     "description" : "Not available.",
-    "tooltip" : "The prompt caching property does not control caching for custom implementations. Use a custom solution instead.",
     "value" : false,
-    "editable" : false,
     "group" : "model",
     "binding" : {
       "name" : "modeler:promptCachingCustom",
@@ -2365,7 +2363,9 @@
       "equals" : "custom",
       "type" : "simple"
     },
-    "type" : "Boolean"
+    "tooltip" : "The prompt caching property does not control caching for custom implementations. Use a custom solution instead.",
+    "type" : "Boolean",
+    "editable" : false
   }, {
     "id" : "provider.anthropic.model.parameters.maxTokens",
     "label" : "Maximum tokens",

--- a/connectors/agentic-ai/connector-agentic-ai/element-templates/hybrid/agenticai-ai-agent-subprocess.v2-hybrid.json
+++ b/connectors/agentic-ai/connector-agentic-ai/element-templates/hybrid/agenticai-ai-agent-subprocess.v2-hybrid.json
@@ -1929,6 +1929,24 @@
     "placeholder" : "claude-sonnet-5",
     "type" : "String"
   }, {
+    "id" : "provider.anthropic.model.parameters.promptCaching.enabled",
+    "label" : "Prompt caching",
+    "optional" : true,
+    "value" : false,
+    "feel" : "static",
+    "group" : "model",
+    "binding" : {
+      "name" : "provider.anthropic.model.parameters.promptCaching.enabled",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "provider.type",
+      "equals" : "anthropic",
+      "type" : "simple"
+    },
+    "tooltip" : "Can speed up responses and lower API costs by reusing text from recent requests. Best for long conversations or large documents.<br><br>See the <a href=\"https://platform.claude.com/docs/en/build-with-claude/prompt-caching#automatic-caching\" target=\"_blank\">caching documentation</a>.",
+    "type" : "Boolean"
+  }, {
     "id" : "provider.anthropic.model.parameters.effort",
     "label" : "Effort",
     "optional" : false,
@@ -2048,24 +2066,6 @@
       "value" : "omitted"
     } ]
   }, {
-    "id" : "provider.anthropic.model.parameters.promptCaching.enabled",
-    "label" : "Enable prompt caching",
-    "optional" : true,
-    "value" : false,
-    "feel" : "static",
-    "group" : "model",
-    "binding" : {
-      "name" : "provider.anthropic.model.parameters.promptCaching.enabled",
-      "type" : "zeebe:input"
-    },
-    "condition" : {
-      "property" : "provider.type",
-      "equals" : "anthropic",
-      "type" : "simple"
-    },
-    "tooltip" : "Enables Anthropic automatic prompt caching. See the <a href=\"https://platform.claude.com/docs/en/build-with-claude/prompt-caching#automatic-caching\" target=\"_blank\">documentation</a>.",
-    "type" : "Boolean"
-  }, {
     "id" : "provider.bedrock.model.model",
     "label" : "Model",
     "description" : "Specify the model ID. Details in the <a href=\"https://docs.aws.amazon.com/bedrock/latest/userguide/inference-profiles-support.html\" target=\"_blank\">documentation</a>.",
@@ -2088,7 +2088,7 @@
     "type" : "String"
   }, {
     "id" : "provider.bedrock.model.parameters.promptCaching.enabled",
-    "label" : "Enable prompt caching",
+    "label" : "Prompt caching",
     "optional" : true,
     "value" : false,
     "feel" : "static",
@@ -2102,7 +2102,7 @@
       "equals" : "bedrock",
       "type" : "simple"
     },
-    "tooltip" : "Enables AWS Bedrock automatic prompt caching. See the <a href=\"https://docs.aws.amazon.com/bedrock/latest/userguide/prompt-caching.html\" target=\"_blank\">documentation</a>.",
+    "tooltip" : "Can speed up responses and lower API costs by reusing text from recent requests. Best for long conversations or large documents.<br><br>See the <a href=\"https://docs.aws.amazon.com/bedrock/latest/userguide/prompt-caching.html\" target=\"_blank\">caching documentation</a>.",
     "type" : "Boolean"
   }, {
     "id" : "provider.openai.model.model",
@@ -2125,6 +2125,24 @@
     },
     "placeholder" : "gpt-5.5",
     "type" : "String"
+  }, {
+    "id" : "promptCaching.openai.status",
+    "label" : "Prompt caching",
+    "description" : "Automatic.",
+    "tooltip" : "Can speed up responses and lower API costs by reusing text from recent requests. Best for long conversations or large documents.<br><br>See the <a href=\"https://developers.openai.com/api/docs/guides/prompt-caching\" target=\"_blank\">caching documentation</a>.",
+    "value" : true,
+    "editable" : false,
+    "group" : "model",
+    "binding" : {
+      "name" : "modeler:promptCachingOpenAI",
+      "type" : "property"
+    },
+    "condition" : {
+      "property" : "provider.type",
+      "equals" : "openai",
+      "type" : "simple"
+    },
+    "type" : "Boolean"
   }, {
     "id" : "provider.openai.api.responses.effort",
     "label" : "Effort",
@@ -2237,6 +2255,24 @@
     "placeholder" : "gemini-3-pro-preview",
     "type" : "String"
   }, {
+    "id" : "promptCaching.googleGemini.status",
+    "label" : "Prompt caching",
+    "description" : "Automatic.",
+    "tooltip" : "Can speed up responses and lower API costs by reusing text from recent requests. Best for long conversations or large documents.<br><br>See the <a href=\"https://ai.google.dev/gemini-api/docs/caching\" target=\"_blank\">caching documentation</a>.",
+    "value" : true,
+    "editable" : false,
+    "group" : "model",
+    "binding" : {
+      "name" : "modeler:promptCachingGoogleGemini",
+      "type" : "property"
+    },
+    "condition" : {
+      "property" : "provider.type",
+      "equals" : "google-gemini",
+      "type" : "simple"
+    },
+    "type" : "Boolean"
+  }, {
     "id" : "provider.googleGemini.model.parameters.thinking.thinkingBudget",
     "label" : "Thinking budget (tokens)",
     "optional" : true,
@@ -2312,6 +2348,24 @@
       "type" : "simple"
     },
     "type" : "String"
+  }, {
+    "id" : "promptCaching.custom.status",
+    "label" : "Prompt caching",
+    "description" : "Not available.",
+    "tooltip" : "The prompt caching property does not control caching for custom implementations. Use a custom solution instead.",
+    "value" : false,
+    "editable" : false,
+    "group" : "model",
+    "binding" : {
+      "name" : "modeler:promptCachingCustom",
+      "type" : "property"
+    },
+    "condition" : {
+      "property" : "provider.type",
+      "equals" : "custom",
+      "type" : "simple"
+    },
+    "type" : "Boolean"
   }, {
     "id" : "provider.anthropic.model.parameters.maxTokens",
     "label" : "Maximum tokens",

--- a/connectors/agentic-ai/connector-agentic-ai/element-templates/hybrid/agenticai-ai-agent-subprocess.v2-hybrid.json
+++ b/connectors/agentic-ai/connector-agentic-ai/element-templates/hybrid/agenticai-ai-agent-subprocess.v2-hybrid.json
@@ -1931,6 +1931,7 @@
   }, {
     "id" : "provider.anthropic.model.parameters.promptCaching.enabled",
     "label" : "Prompt caching",
+    "description" : "Optional.",
     "optional" : true,
     "value" : false,
     "feel" : "static",
@@ -2089,6 +2090,7 @@
   }, {
     "id" : "provider.bedrock.model.parameters.promptCaching.enabled",
     "label" : "Prompt caching",
+    "description" : "Optional.",
     "optional" : true,
     "value" : false,
     "feel" : "static",

--- a/connectors/agentic-ai/connector-agentic-ai/element-templates/hybrid/agenticai-ai-agent-task.v2-hybrid.json
+++ b/connectors/agentic-ai/connector-agentic-ai/element-templates/hybrid/agenticai-ai-agent-task.v2-hybrid.json
@@ -1903,6 +1903,7 @@
   }, {
     "id" : "provider.anthropic.model.parameters.promptCaching.enabled",
     "label" : "Prompt caching",
+    "description" : "Optional.",
     "optional" : true,
     "value" : false,
     "feel" : "static",
@@ -2061,6 +2062,7 @@
   }, {
     "id" : "provider.bedrock.model.parameters.promptCaching.enabled",
     "label" : "Prompt caching",
+    "description" : "Optional.",
     "optional" : true,
     "value" : false,
     "feel" : "static",

--- a/connectors/agentic-ai/connector-agentic-ai/element-templates/hybrid/agenticai-ai-agent-task.v2-hybrid.json
+++ b/connectors/agentic-ai/connector-agentic-ai/element-templates/hybrid/agenticai-ai-agent-task.v2-hybrid.json
@@ -2101,9 +2101,7 @@
     "id" : "promptCaching.openai.status",
     "label" : "Prompt caching",
     "description" : "Automatic.",
-    "tooltip" : "Can speed up responses and lower API costs by reusing text from recent requests. Best for long conversations or large documents.<br><br>See the <a href=\"https://developers.openai.com/api/docs/guides/prompt-caching\" target=\"_blank\">caching documentation</a>.",
     "value" : true,
-    "editable" : false,
     "group" : "model",
     "binding" : {
       "name" : "modeler:promptCachingOpenAI",
@@ -2114,7 +2112,9 @@
       "equals" : "openai",
       "type" : "simple"
     },
-    "type" : "Boolean"
+    "tooltip" : "Can speed up responses and lower API costs by reusing text from recent requests. Best for long conversations or large documents.<br><br>See the <a href=\"https://developers.openai.com/api/docs/guides/prompt-caching\" target=\"_blank\">caching documentation</a>.",
+    "type" : "Boolean",
+    "editable" : false
   }, {
     "id" : "provider.openai.api.responses.effort",
     "label" : "Effort",
@@ -2230,9 +2230,7 @@
     "id" : "promptCaching.googleGemini.status",
     "label" : "Prompt caching",
     "description" : "Automatic.",
-    "tooltip" : "Can speed up responses and lower API costs by reusing text from recent requests. Best for long conversations or large documents.<br><br>See the <a href=\"https://ai.google.dev/gemini-api/docs/caching\" target=\"_blank\">caching documentation</a>.",
     "value" : true,
-    "editable" : false,
     "group" : "model",
     "binding" : {
       "name" : "modeler:promptCachingGoogleGemini",
@@ -2243,7 +2241,9 @@
       "equals" : "google-gemini",
       "type" : "simple"
     },
-    "type" : "Boolean"
+    "tooltip" : "Can speed up responses and lower API costs by reusing text from recent requests. Best for long conversations or large documents.<br><br>See the <a href=\"https://ai.google.dev/gemini-api/docs/caching\" target=\"_blank\">caching documentation</a>.",
+    "type" : "Boolean",
+    "editable" : false
   }, {
     "id" : "provider.googleGemini.model.parameters.thinking.thinkingBudget",
     "label" : "Thinking budget (tokens)",
@@ -2324,9 +2324,7 @@
     "id" : "promptCaching.custom.status",
     "label" : "Prompt caching",
     "description" : "Not available.",
-    "tooltip" : "The prompt caching property does not control caching for custom implementations. Use a custom solution instead.",
     "value" : false,
-    "editable" : false,
     "group" : "model",
     "binding" : {
       "name" : "modeler:promptCachingCustom",
@@ -2337,7 +2335,9 @@
       "equals" : "custom",
       "type" : "simple"
     },
-    "type" : "Boolean"
+    "tooltip" : "The prompt caching property does not control caching for custom implementations. Use a custom solution instead.",
+    "type" : "Boolean",
+    "editable" : false
   }, {
     "id" : "provider.anthropic.model.parameters.maxTokens",
     "label" : "Maximum tokens",

--- a/connectors/agentic-ai/connector-agentic-ai/element-templates/hybrid/agenticai-ai-agent-task.v2-hybrid.json
+++ b/connectors/agentic-ai/connector-agentic-ai/element-templates/hybrid/agenticai-ai-agent-task.v2-hybrid.json
@@ -1901,6 +1901,24 @@
     "placeholder" : "claude-sonnet-5",
     "type" : "String"
   }, {
+    "id" : "provider.anthropic.model.parameters.promptCaching.enabled",
+    "label" : "Prompt caching",
+    "optional" : true,
+    "value" : false,
+    "feel" : "static",
+    "group" : "model",
+    "binding" : {
+      "name" : "provider.anthropic.model.parameters.promptCaching.enabled",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "provider.type",
+      "equals" : "anthropic",
+      "type" : "simple"
+    },
+    "tooltip" : "Can speed up responses and lower API costs by reusing text from recent requests. Best for long conversations or large documents.<br><br>See the <a href=\"https://platform.claude.com/docs/en/build-with-claude/prompt-caching#automatic-caching\" target=\"_blank\">caching documentation</a>.",
+    "type" : "Boolean"
+  }, {
     "id" : "provider.anthropic.model.parameters.effort",
     "label" : "Effort",
     "optional" : false,
@@ -2020,24 +2038,6 @@
       "value" : "omitted"
     } ]
   }, {
-    "id" : "provider.anthropic.model.parameters.promptCaching.enabled",
-    "label" : "Enable prompt caching",
-    "optional" : true,
-    "value" : false,
-    "feel" : "static",
-    "group" : "model",
-    "binding" : {
-      "name" : "provider.anthropic.model.parameters.promptCaching.enabled",
-      "type" : "zeebe:input"
-    },
-    "condition" : {
-      "property" : "provider.type",
-      "equals" : "anthropic",
-      "type" : "simple"
-    },
-    "tooltip" : "Enables Anthropic automatic prompt caching. See the <a href=\"https://platform.claude.com/docs/en/build-with-claude/prompt-caching#automatic-caching\" target=\"_blank\">documentation</a>.",
-    "type" : "Boolean"
-  }, {
     "id" : "provider.bedrock.model.model",
     "label" : "Model",
     "description" : "Specify the model ID. Details in the <a href=\"https://docs.aws.amazon.com/bedrock/latest/userguide/inference-profiles-support.html\" target=\"_blank\">documentation</a>.",
@@ -2060,7 +2060,7 @@
     "type" : "String"
   }, {
     "id" : "provider.bedrock.model.parameters.promptCaching.enabled",
-    "label" : "Enable prompt caching",
+    "label" : "Prompt caching",
     "optional" : true,
     "value" : false,
     "feel" : "static",
@@ -2074,7 +2074,7 @@
       "equals" : "bedrock",
       "type" : "simple"
     },
-    "tooltip" : "Enables AWS Bedrock automatic prompt caching. See the <a href=\"https://docs.aws.amazon.com/bedrock/latest/userguide/prompt-caching.html\" target=\"_blank\">documentation</a>.",
+    "tooltip" : "Can speed up responses and lower API costs by reusing text from recent requests. Best for long conversations or large documents.<br><br>See the <a href=\"https://docs.aws.amazon.com/bedrock/latest/userguide/prompt-caching.html\" target=\"_blank\">caching documentation</a>.",
     "type" : "Boolean"
   }, {
     "id" : "provider.openai.model.model",
@@ -2097,6 +2097,24 @@
     },
     "placeholder" : "gpt-5.5",
     "type" : "String"
+  }, {
+    "id" : "promptCaching.openai.status",
+    "label" : "Prompt caching",
+    "description" : "Automatic.",
+    "tooltip" : "Can speed up responses and lower API costs by reusing text from recent requests. Best for long conversations or large documents.<br><br>See the <a href=\"https://developers.openai.com/api/docs/guides/prompt-caching\" target=\"_blank\">caching documentation</a>.",
+    "value" : true,
+    "editable" : false,
+    "group" : "model",
+    "binding" : {
+      "name" : "modeler:promptCachingOpenAI",
+      "type" : "property"
+    },
+    "condition" : {
+      "property" : "provider.type",
+      "equals" : "openai",
+      "type" : "simple"
+    },
+    "type" : "Boolean"
   }, {
     "id" : "provider.openai.api.responses.effort",
     "label" : "Effort",
@@ -2209,6 +2227,24 @@
     "placeholder" : "gemini-3-pro-preview",
     "type" : "String"
   }, {
+    "id" : "promptCaching.googleGemini.status",
+    "label" : "Prompt caching",
+    "description" : "Automatic.",
+    "tooltip" : "Can speed up responses and lower API costs by reusing text from recent requests. Best for long conversations or large documents.<br><br>See the <a href=\"https://ai.google.dev/gemini-api/docs/caching\" target=\"_blank\">caching documentation</a>.",
+    "value" : true,
+    "editable" : false,
+    "group" : "model",
+    "binding" : {
+      "name" : "modeler:promptCachingGoogleGemini",
+      "type" : "property"
+    },
+    "condition" : {
+      "property" : "provider.type",
+      "equals" : "google-gemini",
+      "type" : "simple"
+    },
+    "type" : "Boolean"
+  }, {
     "id" : "provider.googleGemini.model.parameters.thinking.thinkingBudget",
     "label" : "Thinking budget (tokens)",
     "optional" : true,
@@ -2284,6 +2320,24 @@
       "type" : "simple"
     },
     "type" : "String"
+  }, {
+    "id" : "promptCaching.custom.status",
+    "label" : "Prompt caching",
+    "description" : "Not available.",
+    "tooltip" : "The prompt caching property does not control caching for custom implementations. Use a custom solution instead.",
+    "value" : false,
+    "editable" : false,
+    "group" : "model",
+    "binding" : {
+      "name" : "modeler:promptCachingCustom",
+      "type" : "property"
+    },
+    "condition" : {
+      "property" : "provider.type",
+      "equals" : "custom",
+      "type" : "simple"
+    },
+    "type" : "Boolean"
   }, {
     "id" : "provider.anthropic.model.parameters.maxTokens",
     "label" : "Maximum tokens",

--- a/connectors/agentic-ai/connector-agentic-ai/pom.xml
+++ b/connectors/agentic-ai/connector-agentic-ai/pom.xml
@@ -794,6 +794,62 @@
             </configuration>
           </execution>
           <execution>
+            <id>add-agent-definition-marker-task-v2</id>
+            <phase>process-classes</phase>
+            <goals>
+              <goal>execute</goal>
+            </goals>
+            <configuration>
+              <scripts>
+                <script>file:///${project.basedir}/bin/transform-ai-agent-task-template.groovy</script>
+              </scripts>
+              <properties>
+                <property>
+                  <name>sourceFile</name>
+                  <value>${project.basedir}/element-templates/agenticai-ai-agent-task.v2.json</value>
+                </property>
+                <property>
+                  <name>outputFile</name>
+                  <value>${project.basedir}/element-templates/agenticai-ai-agent-task.v2.json</value>
+                </property>
+                <property>
+                  <name>agentType</name>
+                  <value>aiAgentTask</value>
+                </property>
+              </properties>
+            </configuration>
+          </execution>
+          <execution>
+            <id>add-agent-definition-marker-task-v2-hybrid</id>
+            <phase>process-classes</phase>
+            <goals>
+              <goal>execute</goal>
+            </goals>
+            <configuration>
+              <scripts>
+                <script>file:///${project.basedir}/bin/transform-ai-agent-task-template.groovy</script>
+              </scripts>
+              <properties>
+                <property>
+                  <name>sourceFile</name>
+                  <value>
+                    ${project.basedir}/element-templates/hybrid/agenticai-ai-agent-task.v2-hybrid.json
+                  </value>
+                </property>
+                <property>
+                  <name>outputFile</name>
+                  <value>
+                    ${project.basedir}/element-templates/hybrid/agenticai-ai-agent-task.v2-hybrid.json
+                  </value>
+                </property>
+                <property>
+                  <name>agentType</name>
+                  <value>aiAgentTask</value>
+                </property>
+              </properties>
+            </configuration>
+          </execution>
+          <execution>
             <id>generate-subprocess-v2-template</id>
             <phase>process-classes</phase>
             <goals>
@@ -861,62 +917,6 @@
                 <property>
                   <name>agentType</name>
                   <value>aiAgentSubProcess</value>
-                </property>
-              </properties>
-            </configuration>
-          </execution>
-          <execution>
-            <id>add-agent-definition-marker-task-v2</id>
-            <phase>process-classes</phase>
-            <goals>
-              <goal>execute</goal>
-            </goals>
-            <configuration>
-              <scripts>
-                <script>file:///${project.basedir}/bin/transform-ai-agent-task-template.groovy</script>
-              </scripts>
-              <properties>
-                <property>
-                  <name>sourceFile</name>
-                  <value>${project.basedir}/element-templates/agenticai-ai-agent-task.v2.json</value>
-                </property>
-                <property>
-                  <name>outputFile</name>
-                  <value>${project.basedir}/element-templates/agenticai-ai-agent-task.v2.json</value>
-                </property>
-                <property>
-                  <name>agentType</name>
-                  <value>aiAgentTask</value>
-                </property>
-              </properties>
-            </configuration>
-          </execution>
-          <execution>
-            <id>add-agent-definition-marker-task-v2-hybrid</id>
-            <phase>process-classes</phase>
-            <goals>
-              <goal>execute</goal>
-            </goals>
-            <configuration>
-              <scripts>
-                <script>file:///${project.basedir}/bin/transform-ai-agent-task-template.groovy</script>
-              </scripts>
-              <properties>
-                <property>
-                  <name>sourceFile</name>
-                  <value>
-                    ${project.basedir}/element-templates/hybrid/agenticai-ai-agent-task.v2-hybrid.json
-                  </value>
-                </property>
-                <property>
-                  <name>outputFile</name>
-                  <value>
-                    ${project.basedir}/element-templates/hybrid/agenticai-ai-agent-task.v2-hybrid.json
-                  </value>
-                </property>
-                <property>
-                  <name>agentType</name>
-                  <value>aiAgentTask</value>
                 </property>
               </properties>
             </configuration>

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/AgentTaskV2Request.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/AgentTaskV2Request.java
@@ -6,9 +6,66 @@
  */
 package io.camunda.connector.agenticai.aiagent.model.request;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.connector.agenticai.aiagent.model.request.v2.ProviderConfiguration;
+import io.camunda.connector.generator.java.annotation.TemplateProperty;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 
 public record AgentTaskV2Request(
-    @Valid @NotNull ProviderConfiguration provider, @Valid @NotNull AgentTaskRequestData data) {}
+    @Valid @NotNull ProviderConfiguration provider,
+    @Valid @NotNull AgentTaskRequestData data,
+    @JsonIgnore
+        @TemplateProperty(
+            id = "promptCaching.openai.status",
+            binding = @TemplateProperty.PropertyBinding(name = "modeler.promptCachingOpenAI"),
+            group = "model",
+            label = "Prompt caching",
+            description = "Automatic.",
+            tooltip =
+                "Can speed up responses and lower API costs by reusing text from recent requests. Best for long conversations or large documents."
+                    + "<br><br>See the <a href=\"https://developers.openai.com/api/docs/guides/prompt-caching\" target=\"_blank\">caching documentation</a>.",
+            condition =
+                @TemplateProperty.PropertyCondition(property = "provider.type", equals = "openai"),
+            type = TemplateProperty.PropertyType.Boolean,
+            defaultValue = "true",
+            defaultValueType = TemplateProperty.DefaultValueType.Boolean)
+        boolean openAiPromptCachingStatus,
+    @JsonIgnore
+        @TemplateProperty(
+            id = "promptCaching.googleGemini.status",
+            binding = @TemplateProperty.PropertyBinding(name = "modeler.promptCachingGoogleGemini"),
+            group = "model",
+            label = "Prompt caching",
+            description = "Automatic.",
+            tooltip =
+                "Can speed up responses and lower API costs by reusing text from recent requests. Best for long conversations or large documents."
+                    + "<br><br>See the <a href=\"https://ai.google.dev/gemini-api/docs/caching\" target=\"_blank\">caching documentation</a>.",
+            condition =
+                @TemplateProperty.PropertyCondition(
+                    property = "provider.type",
+                    equals = "google-gemini"),
+            type = TemplateProperty.PropertyType.Boolean,
+            defaultValue = "true",
+            defaultValueType = TemplateProperty.DefaultValueType.Boolean)
+        boolean googleGeminiPromptCachingStatus,
+    @JsonIgnore
+        @TemplateProperty(
+            id = "promptCaching.custom.status",
+            binding = @TemplateProperty.PropertyBinding(name = "modeler.promptCachingCustom"),
+            group = "model",
+            label = "Prompt caching",
+            description = "Not available.",
+            tooltip =
+                "The prompt caching property does not control caching for custom implementations. Use a custom solution instead.",
+            condition =
+                @TemplateProperty.PropertyCondition(property = "provider.type", equals = "custom"),
+            type = TemplateProperty.PropertyType.Boolean,
+            defaultValue = "false",
+            defaultValueType = TemplateProperty.DefaultValueType.Boolean)
+        boolean customPromptCachingStatus) {
+
+  public AgentTaskV2Request(ProviderConfiguration provider, AgentTaskRequestData data) {
+    this(provider, data, true, true, false);
+  }
+}

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/v2/AnthropicChatModelConfiguration.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/v2/AnthropicChatModelConfiguration.java
@@ -427,6 +427,7 @@ public record AnthropicChatModelConfiguration(@Valid @NotNull AnthropicConnectio
         @TemplateProperty(
                 group = "model",
                 label = "Prompt caching",
+                description = "Optional.",
                 tooltip =
                     "Can speed up responses and lower API costs by reusing text from recent requests. Best for long conversations or large documents."
                         + "<br><br>See the <a href=\"https://platform.claude.com/docs/en/build-with-claude/prompt-caching#automatic-caching\" target=\"_blank\">caching documentation</a>.",

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/v2/AnthropicChatModelConfiguration.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/v2/AnthropicChatModelConfiguration.java
@@ -426,9 +426,10 @@ public record AnthropicChatModelConfiguration(@Valid @NotNull AnthropicConnectio
     public record AnthropicPromptCaching(
         @TemplateProperty(
                 group = "model",
-                label = "Enable prompt caching",
+                label = "Prompt caching",
                 tooltip =
-                    "Enables Anthropic automatic prompt caching. See the <a href=\"https://platform.claude.com/docs/en/build-with-claude/prompt-caching#automatic-caching\" target=\"_blank\">documentation</a>.",
+                    "Can speed up responses and lower API costs by reusing text from recent requests. Best for long conversations or large documents."
+                        + "<br><br>See the <a href=\"https://platform.claude.com/docs/en/build-with-claude/prompt-caching#automatic-caching\" target=\"_blank\">caching documentation</a>.",
                 type = TemplateProperty.PropertyType.Boolean,
                 defaultValue = "false",
                 defaultValueType = TemplateProperty.DefaultValueType.Boolean,

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/v2/BedrockConverseChatModelConfiguration.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/v2/BedrockConverseChatModelConfiguration.java
@@ -197,6 +197,7 @@ public record BedrockConverseChatModelConfiguration(
         @TemplateProperty(
                 group = "model",
                 label = "Prompt caching",
+                description = "Optional.",
                 tooltip =
                     "Can speed up responses and lower API costs by reusing text from recent requests. "
                         + "Best for long conversations or large documents."

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/v2/BedrockConverseChatModelConfiguration.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/v2/BedrockConverseChatModelConfiguration.java
@@ -196,11 +196,13 @@ public record BedrockConverseChatModelConfiguration(
     public record BedrockConversePromptCaching(
         @TemplateProperty(
                 group = "model",
-                label = "Enable prompt caching",
+                label = "Prompt caching",
                 tooltip =
-                    "Enables AWS Bedrock automatic prompt caching. See the <a "
+                    "Can speed up responses and lower API costs by reusing text from recent requests. "
+                        + "Best for long conversations or large documents."
+                        + "<br><br>See the <a "
                         + "href=\"https://docs.aws.amazon.com/bedrock/latest/userguide/prompt-caching.html\" "
-                        + "target=\"_blank\">documentation</a>.",
+                        + "target=\"_blank\">caching documentation</a>.",
                 type = TemplateProperty.PropertyType.Boolean,
                 defaultValue = "false",
                 defaultValueType = TemplateProperty.DefaultValueType.Boolean,

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/PromptCachingElementTemplateTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/PromptCachingElementTemplateTest.java
@@ -17,6 +17,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Stream;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 /**
@@ -62,6 +63,7 @@ class PromptCachingElementTemplateTest {
               "modeler:promptCachingGoogleGemini",
               "https://ai.google.dev/gemini-api/docs/caching"),
           new ExpectedPromptCachingProperty(
+              "unavailable custom",
               "custom",
               "provider.model",
               "promptCaching.custom.status",
@@ -73,9 +75,44 @@ class PromptCachingElementTemplateTest {
               "The prompt caching property does not control caching for custom implementations. "
                   + "Use a custom solution instead."));
 
+  @ParameterizedTest(name = "{0} + {1}")
+  @MethodSource("templateAndPromptCachingProperties")
+  void exposesPromptCachingForProvider(Path templatePath, ExpectedPromptCachingProperty expected)
+      throws IOException {
+    final var properties = properties(OBJECT_MAPPER.readTree(templatePath.toFile()));
+    final var cachingProperties =
+        properties.stream()
+            .filter(property -> "Prompt caching".equals(property.path("label").asText()))
+            .toList();
+    final var cachingProperty = property(cachingProperties, expected.id());
+    final var modelProperty = property(properties, expected.modelId());
+
+    assertThat(properties.indexOf(cachingProperty))
+        .isEqualTo(properties.indexOf(modelProperty) + 1);
+    assertThat(cachingProperty.path("group").asText()).isEqualTo("model");
+    assertThat(cachingProperty.path("type").asText()).isEqualTo("Boolean");
+    assertThat(cachingProperty.path("condition").path("property").asText())
+        .isEqualTo("provider.type");
+    assertThat(cachingProperty.path("condition").path("equals").asText())
+        .isEqualTo(expected.provider());
+    assertThat(cachingProperty.path("editable").asBoolean(true)).isEqualTo(expected.editable());
+    assertThat(cachingProperty.path("value").asBoolean()).isEqualTo(expected.enabled());
+    assertThat(cachingProperty.path("binding").path("type").asText())
+        .isEqualTo(expected.bindingType());
+    assertThat(cachingProperty.path("binding").path("name").asText())
+        .isEqualTo(expected.bindingName());
+    assertThat(cachingProperty.path("tooltip").asText()).isEqualTo(expected.tooltip());
+
+    if (expected.description() == null) {
+      assertThat(cachingProperty.has("description")).isFalse();
+    } else {
+      assertThat(cachingProperty.path("description").asText()).isEqualTo(expected.description());
+    }
+  }
+
   @ParameterizedTest(name = "{0}")
   @MethodSource("templatePaths")
-  void exposesPromptCachingForEveryProvider(Path templatePath) throws IOException {
+  void exposesPromptCachingOnlyForSupportedProviders(Path templatePath) throws IOException {
     final var properties = properties(OBJECT_MAPPER.readTree(templatePath.toFile()));
     final var cachingProperties =
         properties.stream()
@@ -88,33 +125,13 @@ class PromptCachingElementTemplateTest {
             EXPECTED_PROPERTIES.stream()
                 .map(ExpectedPromptCachingProperty::provider)
                 .collect(java.util.stream.Collectors.toSet()));
+  }
 
-    for (final var expected : EXPECTED_PROPERTIES) {
-      final var cachingProperty = property(cachingProperties, expected.id());
-      final var modelProperty = property(properties, expected.modelId());
-
-      assertThat(properties.indexOf(cachingProperty))
-          .isEqualTo(properties.indexOf(modelProperty) + 1);
-      assertThat(cachingProperty.path("group").asText()).isEqualTo("model");
-      assertThat(cachingProperty.path("type").asText()).isEqualTo("Boolean");
-      assertThat(cachingProperty.path("condition").path("property").asText())
-          .isEqualTo("provider.type");
-      assertThat(cachingProperty.path("condition").path("equals").asText())
-          .isEqualTo(expected.provider());
-      assertThat(cachingProperty.path("editable").asBoolean(true)).isEqualTo(expected.editable());
-      assertThat(cachingProperty.path("value").asBoolean()).isEqualTo(expected.enabled());
-      assertThat(cachingProperty.path("binding").path("type").asText())
-          .isEqualTo(expected.bindingType());
-      assertThat(cachingProperty.path("binding").path("name").asText())
-          .isEqualTo(expected.bindingName());
-      assertThat(cachingProperty.path("tooltip").asText()).isEqualTo(expected.tooltip());
-
-      if (expected.description() == null) {
-        assertThat(cachingProperty.has("description")).isFalse();
-      } else {
-        assertThat(cachingProperty.path("description").asText()).isEqualTo(expected.description());
-      }
-    }
+  private static Stream<Arguments> templateAndPromptCachingProperties() {
+    return TEMPLATE_PATHS.stream()
+        .flatMap(
+            templatePath ->
+                EXPECTED_PROPERTIES.stream().map(expected -> Arguments.of(templatePath, expected)));
   }
 
   private static Stream<Path> templatePaths() {
@@ -145,12 +162,22 @@ class PromptCachingElementTemplateTest {
   private static ExpectedPromptCachingProperty optional(
       String provider, String modelId, String id, String documentationUrl) {
     return new ExpectedPromptCachingProperty(
-        provider, modelId, id, true, false, "zeebe:input", id, null, tooltip(documentationUrl));
+        "optional " + provider,
+        provider,
+        modelId,
+        id,
+        true,
+        false,
+        "zeebe:input",
+        id,
+        null,
+        tooltip(documentationUrl));
   }
 
   private static ExpectedPromptCachingProperty automatic(
       String provider, String modelId, String id, String bindingName, String documentationUrl) {
     return new ExpectedPromptCachingProperty(
+        "automatic " + provider,
         provider,
         modelId,
         id,
@@ -170,6 +197,7 @@ class PromptCachingElementTemplateTest {
   }
 
   private record ExpectedPromptCachingProperty(
+      String displayName,
       String provider,
       String modelId,
       String id,
@@ -178,5 +206,11 @@ class PromptCachingElementTemplateTest {
       String bindingType,
       String bindingName,
       String description,
-      String tooltip) {}
+      String tooltip) {
+
+    @Override
+    public String toString() {
+      return displayName;
+    }
+  }
 }

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/PromptCachingElementTemplateTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/PromptCachingElementTemplateTest.java
@@ -172,7 +172,7 @@ class PromptCachingElementTemplateTest {
         false,
         "zeebe:input",
         id,
-        null,
+        "Optional.",
         tooltip(documentationUrl));
   }
 

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/PromptCachingElementTemplateTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/PromptCachingElementTemplateTest.java
@@ -1,0 +1,182 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.agenticai.aiagent;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * Verifies the prompt-caching presentation for every provider in all four current AI Agent v2
+ * templates.
+ */
+class PromptCachingElementTemplateTest {
+
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+  private static final String GUIDANCE =
+      "Can speed up responses and lower API costs by reusing text from recent requests. "
+          + "Best for long conversations or large documents.";
+
+  private static final List<Path> TEMPLATE_PATHS =
+      List.of(
+          Path.of("element-templates/agenticai-ai-agent-task.v2.json"),
+          Path.of("element-templates/agenticai-ai-agent-subprocess.v2.json"),
+          Path.of("element-templates/hybrid/agenticai-ai-agent-task.v2-hybrid.json"),
+          Path.of("element-templates/hybrid/agenticai-ai-agent-subprocess.v2-hybrid.json"));
+
+  private static final List<ExpectedPromptCachingProperty> EXPECTED_PROPERTIES =
+      List.of(
+          optional(
+              "anthropic",
+              "provider.anthropic.model.model",
+              "provider.anthropic.model.parameters.promptCaching.enabled",
+              "https://platform.claude.com/docs/en/build-with-claude/prompt-caching#automatic-caching"),
+          optional(
+              "bedrock",
+              "provider.bedrock.model.model",
+              "provider.bedrock.model.parameters.promptCaching.enabled",
+              "https://docs.aws.amazon.com/bedrock/latest/userguide/prompt-caching.html"),
+          automatic(
+              "openai",
+              "provider.openai.model.model",
+              "promptCaching.openai.status",
+              "modeler:promptCachingOpenAI",
+              "https://developers.openai.com/api/docs/guides/prompt-caching"),
+          automatic(
+              "google-gemini",
+              "provider.googleGemini.model.model",
+              "promptCaching.googleGemini.status",
+              "modeler:promptCachingGoogleGemini",
+              "https://ai.google.dev/gemini-api/docs/caching"),
+          new ExpectedPromptCachingProperty(
+              "custom",
+              "provider.model",
+              "promptCaching.custom.status",
+              false,
+              false,
+              "property",
+              "modeler:promptCachingCustom",
+              "Not available.",
+              "The prompt caching property does not control caching for custom implementations. "
+                  + "Use a custom solution instead."));
+
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("templatePaths")
+  void exposesPromptCachingForEveryProvider(Path templatePath) throws IOException {
+    final var properties = properties(OBJECT_MAPPER.readTree(templatePath.toFile()));
+    final var cachingProperties =
+        properties.stream()
+            .filter(property -> "Prompt caching".equals(property.path("label").asText()))
+            .toList();
+
+    assertThat(cachingProperties).hasSize(EXPECTED_PROPERTIES.size());
+    assertThat(providerChoices(properties))
+        .containsExactlyInAnyOrderElementsOf(
+            EXPECTED_PROPERTIES.stream()
+                .map(ExpectedPromptCachingProperty::provider)
+                .collect(java.util.stream.Collectors.toSet()));
+
+    for (final var expected : EXPECTED_PROPERTIES) {
+      final var cachingProperty = property(cachingProperties, expected.id());
+      final var modelProperty = property(properties, expected.modelId());
+
+      assertThat(properties.indexOf(cachingProperty))
+          .isEqualTo(properties.indexOf(modelProperty) + 1);
+      assertThat(cachingProperty.path("group").asText()).isEqualTo("model");
+      assertThat(cachingProperty.path("type").asText()).isEqualTo("Boolean");
+      assertThat(cachingProperty.path("condition").path("property").asText())
+          .isEqualTo("provider.type");
+      assertThat(cachingProperty.path("condition").path("equals").asText())
+          .isEqualTo(expected.provider());
+      assertThat(cachingProperty.path("editable").asBoolean(true)).isEqualTo(expected.editable());
+      assertThat(cachingProperty.path("value").asBoolean()).isEqualTo(expected.enabled());
+      assertThat(cachingProperty.path("binding").path("type").asText())
+          .isEqualTo(expected.bindingType());
+      assertThat(cachingProperty.path("binding").path("name").asText())
+          .isEqualTo(expected.bindingName());
+      assertThat(cachingProperty.path("tooltip").asText()).isEqualTo(expected.tooltip());
+
+      if (expected.description() == null) {
+        assertThat(cachingProperty.has("description")).isFalse();
+      } else {
+        assertThat(cachingProperty.path("description").asText()).isEqualTo(expected.description());
+      }
+    }
+  }
+
+  private static Stream<Path> templatePaths() {
+    return TEMPLATE_PATHS.stream();
+  }
+
+  private static List<JsonNode> properties(JsonNode template) {
+    final var properties = new ArrayList<JsonNode>();
+    template.path("properties").forEach(properties::add);
+    return properties;
+  }
+
+  private static JsonNode property(List<JsonNode> properties, String id) {
+    return properties.stream()
+        .filter(property -> id.equals(property.path("id").asText()))
+        .findFirst()
+        .orElseThrow();
+  }
+
+  private static Set<String> providerChoices(List<JsonNode> properties) {
+    return property(properties, "provider.type")
+        .path("choices")
+        .valueStream()
+        .map(choice -> choice.path("value").asText())
+        .collect(java.util.stream.Collectors.toSet());
+  }
+
+  private static ExpectedPromptCachingProperty optional(
+      String provider, String modelId, String id, String documentationUrl) {
+    return new ExpectedPromptCachingProperty(
+        provider, modelId, id, true, false, "zeebe:input", id, null, tooltip(documentationUrl));
+  }
+
+  private static ExpectedPromptCachingProperty automatic(
+      String provider, String modelId, String id, String bindingName, String documentationUrl) {
+    return new ExpectedPromptCachingProperty(
+        provider,
+        modelId,
+        id,
+        false,
+        true,
+        "property",
+        bindingName,
+        "Automatic.",
+        tooltip(documentationUrl));
+  }
+
+  private static String tooltip(String documentationUrl) {
+    return GUIDANCE
+        + "<br><br>See the <a href=\""
+        + documentationUrl
+        + "\" target=\"_blank\">caching documentation</a>.";
+  }
+
+  private record ExpectedPromptCachingProperty(
+      String provider,
+      String modelId,
+      String id,
+      boolean editable,
+      boolean enabled,
+      String bindingType,
+      String bindingName,
+      String description,
+      String tooltip) {}
+}

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/PromptCachingElementTemplateTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/PromptCachingElementTemplateTest.java
@@ -75,6 +75,7 @@ class PromptCachingElementTemplateTest {
               "The prompt caching property does not control caching for custom implementations. "
                   + "Use a custom solution instead."));
 
+  // Verifies each provider's prompt-caching property shape and placement in every template.
   @ParameterizedTest(name = "{0} + {1}")
   @MethodSource("templateAndPromptCachingProperties")
   void exposesPromptCachingForProvider(Path templatePath, ExpectedPromptCachingProperty expected)
@@ -110,6 +111,7 @@ class PromptCachingElementTemplateTest {
     }
   }
 
+  // Verifies prompt-caching coverage stays aligned with the available providers.
   @ParameterizedTest(name = "{0}")
   @MethodSource("templatePaths")
   void exposesPromptCachingOnlyForSupportedProviders(Path templatePath) throws IOException {


### PR DESCRIPTION
## Description

Expose one consistently placed **Prompt caching** checkbox for every AI Agent v2 provider across Task, Sub-process, SaaS, and Hybrid templates:

- Anthropic and Bedrock Converse remain editable and off by default.
- OpenAI and Gemini are checked and read-only because caching is automatic when the provider's requirements are met.
- Custom implementations are unchecked and read-only because Camunda exposes no caching control for them.

Read-only values use inert `modeler:` metadata, create no connector input, and do not change runtime behavior. The unreleased AI Agent v2 templates remain at element-template version 1. Native generator support for read-only properties is tracked in #8607.

## Desktop Modeler verification

Uploading caching-controls.mov…


Verified with the generated template in Camunda Desktop Modeler 5.50.1.

| Anthropic | Bedrock Converse |
| --- | --- |
| <img width="360" alt="Anthropic prompt caching checkbox" src="https://github.com/user-attachments/assets/9f3733ac-efda-42aa-81a4-f329542dc031"> | <img width="360" alt="Bedrock Converse prompt caching checkbox" src="https://github.com/user-attachments/assets/a301db5b-2c25-4b14-aaaa-c4b326cb6985"> |

| OpenAI | Google Gemini | Custom Implementation |
| --- | --- | --- |
| <img width="300" alt="OpenAI automatic prompt caching" src="https://github.com/user-attachments/assets/5e3b1d81-fcd4-4cee-a94e-194a44b6126e"> | <img width="300" alt="Gemini automatic prompt caching" src="https://github.com/user-attachments/assets/639c3462-40f6-413c-8074-240c638f89e9"> | <img width="300" alt="Custom implementation prompt caching unavailable" src="https://github.com/user-attachments/assets/a0dc15aa-707b-4d66-89d2-f8b867b3ead8"> |

## Testing

- Compact generated-template contract test covers all five providers across all four templates.
- Existing Anthropic and Bedrock tests cover optional request directives and cache usage reporting.
- Credentialed Anthropic smoke tests confirmed cache creation and cache reads.
- Local enabled and disabled Anthropic process instances completed without incidents.

## Related issues

Closes #8546

## Checklist

- [x] Backport labels are added if needed. No backport is required for this unreleased feature.
- [x] Tests have been added.
- [x] No product documentation update is required.