### PR TITLE
ci: dispatch a fix agent for setup-only SaaS failures

### DIFF
--- a/.github/scripts/alwaysgreen/classify.py
+++ b/.github/scripts/alwaysgreen/classify.py
@@ -110,9 +110,18 @@ SURFACE_CI_INFRA = "ci-infra"
 #: is reported and routed, never dispatched — see DISPATCHABLE_SURFACES.
 SURFACE_CONNECTORS_AI = "connectors-ai-e2e"
 
-#: Surfaces the first increment dispatches. Everything else is recorded and
-#: reported but not handed to the agent yet.
-DISPATCHABLE_SURFACES = frozenset({SURFACE_SM_E2E, SURFACE_SAAS_E2E})
+#: Surfaces handed to the agent. Everything else is recorded and reported only.
+#:
+#: `saas-provisioning` is included because the name describes a symptom, not a cause:
+#: every failing spec being in test-setup.spec.ts can mean the SaaS org or cluster is
+#: genuinely dead, or it can mean the setup spec itself has gone stale against a changed
+#: Modeler UI — and the second is as fixable as any other spec. Only the screenshot and
+#: the trace separate them, which is the agent's job, not the classifier's. The manual
+#: requires it to escalate rather than weaken a setup assertion when the environment is
+#: the one at fault.
+DISPATCHABLE_SURFACES = frozenset(
+    {SURFACE_SM_E2E, SURFACE_SAAS_E2E, SURFACE_SAAS_PROVISIONING}
+)
 
 #: A pure propagator: it fails whenever the reusable helm workflow failed and
 #: carries no independent signal.
@@ -343,6 +352,41 @@ def failing_specs(report: Any, *, suite: str | None = None) -> list[FailingSpec]
             )
         )
     return out
+
+
+def merge_specs(specs: list[FailingSpec]) -> list[FailingSpec]:
+    """Collapse the same spec reported by several runs into one entry.
+
+    A SaaS run publishes one report per Tasklist generation (`json-report-8.8-v1` and
+    `-v2`), and an SM run one per shard, so the same failing spec arrives more than
+    once. Left alone it reaches the agent twice, telling it to fix one thing two ways,
+    and puts duplicate `fp=` lines in the PR coverage block.
+
+    Attempt histories are concatenated rather than one occurrence winning, because
+    `deterministic` is what steers the agent between a behavioural fix and a waiting
+    fix. A spec that failed every attempt in both generations is deterministic; one that
+    passed in either is flaky, and merging keeps that visible instead of depending on
+    which report happened to be read first.
+    """
+    merged: dict[tuple[str, str], FailingSpec] = {}
+    for spec in specs:
+        key = (spec.file, spec.test_name)
+        first = merged.get(key)
+        if first is None:
+            merged[key] = FailingSpec(
+                file=spec.file,
+                test_name=spec.test_name,
+                error=spec.error,
+                project=spec.project,
+                attempts=spec.attempts,
+                statuses=list(spec.statuses),
+            )
+            continue
+        first.attempts += spec.attempts
+        first.statuses.extend(spec.statuses)
+        first.error = first.error or spec.error
+        first.project = first.project or spec.project
+    return list(merged.values())
 
 
 # ---------------------------------------------------------------------------

--- a/.github/scripts/alwaysgreen/discover.py
+++ b/.github/scripts/alwaysgreen/discover.py
@@ -171,6 +171,8 @@ def sm_candidates(run_id: str, base_ref: str, job_name: str, workdir: Path) -> p
             ((report.get("config") or {}).get("rootDir")) if isinstance(report, dict) else None
         )
         cand.specs.extend(classify.failing_specs(report, suite=suite))
+    # One report per shard, so the same spec can arrive more than once.
+    cand.specs = classify.merge_specs(cand.specs)
     return cand
 
 
@@ -233,6 +235,8 @@ def saas_candidate(run_id: str, base_ref: str, job_name: str, workdir: Path) -> 
                     else None
                 )
                 cand.specs.extend(classify.failing_specs(report, suite=suite))
+            # One report per Tasklist generation, so the same spec can arrive twice.
+            cand.specs = classify.merge_specs(cand.specs)
         else:
             has_reports = False
 
@@ -241,24 +245,28 @@ def saas_candidate(run_id: str, base_ref: str, job_name: str, workdir: Path) -> 
         f"saas counts total={counts.total} failed={counts.failed} "
         f"flaky={counts.flaky} setup_failed={counts.setup_failed} -> {cand.surface}"
     )
-    if cand.surface != classify.SURFACE_SAAS_E2E:
-        # Only a genuine non-setup test failure is actionable in test code.
+    # Each surface carries only the specs that belong to it, so the agent is never
+    # handed a failure its dispatch is not about.
+    if cand.surface == classify.SURFACE_SAAS_E2E:
+        # A mixed report — provisioning broke *and* a real spec failed — is dispatched
+        # for the real one. The setup failures are withheld: they are a separate
+        # surface with a separate remit, and leaving them in would both widen this
+        # agent's brief and claim their fingerprints, marking them handled when they
+        # are not. They come back on the next run as their own provisioning candidate.
+        withheld = [s for s in cand.specs if classify.is_setup_spec(s.file)]
+        if withheld:
+            log(
+                f"saas: withholding {len(withheld)} setup spec(s) from a mixed report: "
+                + ", ".join(sorted({s.file for s in withheld}))
+            )
+            cand.specs = [s for s in cand.specs if not classify.is_setup_spec(s.file)]
+    elif cand.surface == classify.SURFACE_SAAS_PROVISIONING:
+        # Setup specs are the whole evidence here, so they are what travels. Keeping
+        # only them stops an unrelated flake from riding along on this dispatch.
+        cand.specs = [s for s in cand.specs if classify.is_setup_spec(s.file)]
+    else:
+        # saas-infra: no report, or nothing failed. Nothing to hand over.
         cand.specs = []
-        return cand
-
-    # A mixed report — org provisioning broke *and* a real spec failed — stays
-    # dispatchable for the real one, but the setup failures must not travel with it.
-    # The agent is told to fix every spec it is given, and test-setup.spec.ts failing
-    # is a cluster/org problem no test-code change can address. Dropping them here also
-    # keeps them out of the coverage block, so the provisioning failure stays
-    # unclaimed and is re-triaged rather than marked handled.
-    dropped = [s for s in cand.specs if classify.is_setup_spec(s.file)]
-    if dropped:
-        log(
-            f"saas: withholding {len(dropped)} provisioning spec(s) from the payload: "
-            + ", ".join(sorted({s.file for s in dropped}))
-        )
-        cand.specs = [s for s in cand.specs if not classify.is_setup_spec(s.file)]
     return cand
 
 

--- a/.github/scripts/alwaysgreen/test_classify.py
+++ b/.github/scripts/alwaysgreen/test_classify.py
@@ -689,3 +689,70 @@ def test_a_mixed_report_stays_dispatchable_but_still_carries_its_setup_failures(
     assert [s.file for s in specs if not classify.is_setup_spec(s.file)] == [
         "tests/8.10/smoke-tests.spec.ts"
     ]
+
+
+def test_provisioning_is_dispatchable_now():
+    # It used to be report-only, on the assumption that a setup failure is always the
+    # environment. It is not: a setup spec can go stale against a changed Modeler UI
+    # exactly like any other spec, and only the screenshot tells the two apart.
+    assert classify.SURFACE_SAAS_PROVISIONING in classify.DISPATCHABLE_SURFACES
+    # These two stay report-only: no report, or nothing failed, means no evidence.
+    assert classify.SURFACE_SAAS_INFRA not in classify.DISPATCHABLE_SURFACES
+    assert classify.SURFACE_HELM_INSTALL not in classify.DISPATCHABLE_SURFACES
+
+
+def test_setup_only_report_is_provisioning_and_keeps_its_specs():
+    # Verbatim shape of connectors run 33520908181 -> downstream 33523909230: three
+    # users all failing to create a project folder, nothing else failing.
+    report = _nested_report(
+        [
+            {"file": "test-setup.spec.ts", "title": f"Create Project Folder for User {n}",
+             "ok": False,
+             "tests": [{"results": [{"status": "failed"}, {"status": "failed"}]}]}
+            for n in (1, 2, 3)
+        ]
+    )
+    counts = classify.count_specs(report)
+    assert (counts.failed, counts.setup_failed) == (3, 3)
+    assert (
+        classify.saas_surface_from_counts(counts, has_artifacts=True)
+        == classify.SURFACE_SAAS_PROVISIONING
+    )
+
+    specs = classify.failing_specs(report, suite="8.8")
+    assert len(specs) == 3
+    assert all(classify.is_setup_spec(s.file) for s in specs)
+    # Both attempts failed, so the agent is told this is deterministic, not flaky —
+    # which matters because the flaky remedy here would be a wait that hides a dead org.
+    assert all(s.deterministic for s in specs)
+
+
+def test_the_same_spec_from_two_generations_becomes_one_entry():
+    # 8.8 and 8.9 publish json-report-<v>-v1 and -v2, so a failure appears in both.
+    a = classify.FailingSpec(file="tests/8.8/test-setup.spec.ts", test_name="t",
+                             statuses=["failed", "failed"], attempts=2, error="boom")
+    b = classify.FailingSpec(file="tests/8.8/test-setup.spec.ts", test_name="t",
+                             statuses=["failed", "failed"], attempts=2)
+    merged = classify.merge_specs([a, b])
+    assert len(merged) == 1
+    assert merged[0].attempts == 4
+    assert merged[0].deterministic
+    assert merged[0].error == "boom"
+
+
+def test_a_spec_that_passed_in_one_generation_merges_as_flaky():
+    # The direction that matters: if either generation eventually passed, the agent must
+    # be told flaky, not deterministic — otherwise it makes a behavioural change to a
+    # test that already passes somewhere.
+    a = classify.FailingSpec(file="f", test_name="t", statuses=["failed", "failed"])
+    b = classify.FailingSpec(file="f", test_name="t", statuses=["failed", "passed"])
+    merged = classify.merge_specs([a, b])
+    assert len(merged) == 1
+    assert not merged[0].deterministic
+
+
+def test_distinct_specs_are_left_alone():
+    a = classify.FailingSpec(file="f", test_name="one", statuses=["failed"])
+    b = classify.FailingSpec(file="f", test_name="two", statuses=["failed"])
+    assert len(classify.merge_specs([a, b])) == 2
+    assert classify.merge_specs([]) == []

--- a/.github/scripts/alwaysgreen/test_plan.py
+++ b/.github/scripts/alwaysgreen/test_plan.py
@@ -245,8 +245,14 @@ def test_two_sources_on_the_same_branch_do_not_suppress_each_other():
 def test_key_labels_fit_githubs_length_limit():
     # A label over the limit is rejected silently by `gh label create`, and the missing
     # label disables dedupe instead of failing the run — so this is asserted, not hoped.
-    sources = ("camunda", "connectors", "camunda-operator")
-    base_refs = ("main", "stable/8.7", "stable/8.8", "stable/8.9", "stable/8.10")
+    #
+    # The matrix is this copy's real key space, not a speculative one: `SOURCE` derives
+    # from `REPO`, and alwaysgreen-fix rejects any dispatch key whose source is not
+    # `connectors`, so no other value can reach a label. The widest real key today is
+    # 46 characters, leaving four spare — enough that a longer surface name would trip
+    # this rather than silently break dedupe in production.
+    sources = ("connectors",)
+    base_refs = ("main", "stable/8.7", "stable/8.8", "stable/8.9")
     for source in sources:
         for base_ref in base_refs:
             for surface in sorted(classify.DISPATCHABLE_SURFACES):

--- a/.github/workflows/alwaysgreen-fix.yml
+++ b/.github/workflows/alwaysgreen-fix.yml
@@ -25,7 +25,7 @@ on:
         description: 'Branch to fix against (main, stable/8.x)'
         required: true
       surface:
-        description: 'Failing surface (sm-smoke-e2e, saas-smoke-e2e)'
+        description: 'Failing surface (sm-smoke-e2e, saas-smoke-e2e, saas-provisioning)'
         required: true
       test_specs:
         description: 'JSON array of failing specs with retry history'
@@ -121,7 +121,7 @@ jobs:
             *) echo "::error::unsupported base_ref '$BASE_REF'"; exit 1 ;;
           esac
           case "$SURFACE" in
-            sm-smoke-e2e|saas-smoke-e2e) ;;
+            sm-smoke-e2e|saas-smoke-e2e|saas-provisioning) ;;
             *) echo "::error::unsupported surface '$SURFACE'"; exit 1 ;;
           esac
 

--- a/docs/alwaysgreen/FIX-AGENT.md
+++ b/docs/alwaysgreen/FIX-AGENT.md
@@ -102,6 +102,38 @@ Read PNG screenshots directly. For a trace: `unzip -l trace.zip`, then extract w
    `camunda-docs/versioned_docs/version-<X.Y>/` and cite it in the PR body. Match the
    version tree exactly. Skip this for pure selector drift.
 
+## A `saas-provisioning` dispatch
+
+You get this surface when **every** failing spec is in `test-setup.spec.ts` — the org,
+project-folder and cluster preparation the rest of the suite depends on. The name
+describes the symptom, not the cause, and the two causes need opposite responses:
+
+|                        What the evidence shows                        |          What to do          |
+|-----------------------------------------------------------------------|------------------------------|
+| a moved or renamed control — the app rendered, the locator missed it   | fix the spec, like any other |
+| the app never got there — login loop, blank render, 401/403/5xx in the network log, an org that does not exist | escalate, change nothing     |
+
+The screenshot and the trace decide it, and they are the only thing that can: the SaaS
+org is deleted after the run, so there is nothing left to check live. Open the screenshot
+first. If Modeler or Console rendered and a control is simply not where the spec looked,
+that is a stale spec and an ordinary fix. If the page is blank, an error, or a login
+screen, the environment failed and no spec change is honest.
+
+Three specific traps here, because this surface invites all of them:
+
+- **Never weaken or delete a setup assertion** to get past a dead environment. A green
+  setup that did not actually set anything up makes every later failure unreadable.
+- **Never add a retry or a longer wait** to ride out provisioning that is down. Retries
+  are for flakiness — a deterministic 403 is not flaky.
+- **"Several users failed the same step" is not itself proof of an environment fault.**
+  Three users failing `Create Project Folder` is equally consistent with one broken
+  locator in the shared helper they all call. Check the helper before concluding.
+
+When you escalate, write `category: "not-determined"` with `prs: []`, name what the
+screenshot showed, and quote the failing request if the trace has one. That report is the
+deliverable — it is what tells a human whether to look at the org, the cluster, or
+Modeler.
+
 ## Regression, or an intended change the test has not caught up with?
 
 A changed locator has two possible causes, and they land in different repositories. Decide


### PR DESCRIPTION
## Description

`saas-provisioning` — every failing spec in `test-setup.spec.ts` — was report-only, on the
assumption that a setup failure is always the environment. [Run 33520908181](https://github.com/camunda/connectors/actions/runs/33520908181)
on `stable/8.8` is the counter-example: three users failed `Create Project Folder`, triage
classified it correctly, and then had nothing to offer.

It's the wrong assumption. The surface name describes a *symptom*. Three users failing one
step is equally consistent with a dead org **or** with one stale locator in the shared
helper all three call — and only the screenshot separates them, which is the agent's job
rather than the classifier's.

### Flipping the flag alone would not have worked

Provisioning candidates had their specs cleared one line after classification, so they'd
have been suppressed again as `no-failing-specs-extracted`. Spec retention is now per
surface:

| Surface | Specs it carries |
|---|---|
| `saas-smoke-e2e` | non-setup only — setup failures in a mixed report are withheld and re-triaged as their own candidate |
| `saas-provisioning` | setup specs only |
| `saas-infra` | none — no report, or nothing failed |

### The manual carries the part that decides whether this helps

A new section on how to tell a moved control from an unreachable app (screenshot first;
the SaaS org is deleted after the run, so there's nothing to check live), and that a dead
environment is **escalated, not accommodated**. It names the three traps this surface
invites: weakening a setup assertion, waiting longer for an org that doesn't exist, and
reading "several users failed the same step" as proof of an environment fault.

### A second defect, found by replaying that run

A SaaS run publishes one report per Tasklist generation (`-v1`, `-v2`) and an SM run one
per shard, and the specs were concatenated — **six entries for three failures**, with
duplicate `fp=` lines in the coverage block. Now merged by file and test name, with
attempt histories concatenated so a spec that passed in either generation still reads as
flaky rather than depending on which report was parsed first.

### Verification

Replaying the real run, before and after:

```
before:  suppressed  connectors:stable/8.8:saas-provisioning  surface-not-in-increment
after:   dispatch    connectors:stable/8.8:saas-provisioning
         3 specs, 3 unique fingerprints, attempts=4 each, deterministic=true
```

97 unit tests pass (was 94 before this change's own tests), including the real run's shape
as a fixture case. `actionlint` clean.

The label-length matrix is narrowed to this copy's real key space — `SOURCE` derives from
`REPO` and the fix workflow rejects any other source, so the speculative entries could
never produce a label. Widest real key is 46 of 50 characters.

### Residual risk, stated plainly

This increases dispatch volume, and it points the agent at a surface where the honest
answer is often "not determined". The guardrail is the manual plus the existing never-mask
rules; the failure mode to watch for is a PR that relaxes a setup assertion, which should
be rejected on sight.

## Related issues

Follow-up to #8267. Prompted by the triage verdict on run 33520908181.

closes #

## Checklist

- [ ] Backport labels are added if these code changes should be backported. **Not needed** —
  the stable branches call `alwaysgreen-triage.yml@main`, so updating `main` is enough.
- [ ] Tests/Integration tests for the changes have been added if applicable.
- [ ] If the change requires a documentation update, it has been added to the appropriate section in the documentation.