### PR TITLE
fix: unwrap the real cause in STRICT incident messages; close the Cache-bean collision the CacheManager fix relocated

### DIFF
--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/outbound/JobHandlerContextTest.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/outbound/JobHandlerContextTest.java
@@ -19,6 +19,7 @@ package io.camunda.connector.runtime.core.outbound;
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -30,6 +31,7 @@ import io.camunda.connector.api.validation.ValidationProvider;
 import io.camunda.connector.runtime.core.secret.SecretFilter;
 import io.camunda.connector.runtime.core.testutil.classexample.TestClass;
 import io.camunda.connector.runtime.core.testutil.classexample.TestClassString;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -243,5 +245,27 @@ class JobHandlerContextTest {
     assertThat(thrown.getMessage())
         .isEqualTo(
             "Cannot deserialize value of type `java.lang.Integer` from Array value (token `JsonToken.START_ARRAY`)");
+  }
+
+  @Test
+  void bindVariables_undeclaredSecretIsLeftUnresolvedAndProviderIsNeverCalled() {
+    // Every other test in this file uses SecretFilter.allowAll(), which never exercises the
+    // security boundary #7568 introduced: nothing here previously verified that a restrictive
+    // filter actually blocks resolution through bindVariables.
+    var restrictiveContext =
+        new JobHandlerContext(
+            activatedJob,
+            secretProvider,
+            validationProvider,
+            null,
+            objectMapper,
+            SecretFilter.allowOnly(List.of("AUTH")));
+    String json = "{ \"value\": \"{{secrets.UNDECLARED}}\" }";
+    when(activatedJob.getVariables()).thenReturn(json);
+
+    var bound = restrictiveContext.bindVariables(TestClassString.class);
+
+    assertThat(bound.value).isEqualTo("{{secrets.UNDECLARED}}");
+    verify(secretProvider, never()).getSecret(eq("UNDECLARED"), any());
   }
 }

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/SecretFilterFactoryConfiguration.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/SecretFilterFactoryConfiguration.java
@@ -23,7 +23,6 @@ import io.camunda.connector.runtime.outbound.job.ConfigurableSecretFilterFactory
 import io.camunda.connector.runtime.outbound.job.ConfigurableSecretFilterFactory.SecretFilterMode;
 import io.camunda.connector.runtime.outbound.secret.ProcessDefinitionSecretKeyCache;
 import io.camunda.connector.runtime.outbound.secret.SecretKeyCache;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cache.Cache;
 import org.springframework.cache.caffeine.CaffeineCache;
@@ -35,33 +34,32 @@ import org.springframework.context.annotation.Configuration;
 public class SecretFilterFactoryConfiguration {
 
   /**
-   * A plain {@link Cache}, not a {@code CacheManager}-typed bean: registering an unqualified {@code
-   * CacheManager} bean satisfies Spring Boot's {@code CacheAutoConfiguration}
-   * {@code @ConditionalOnMissingBean(CacheManager.class)} condition, so a host application
-   * embedding this runtime as a library would silently lose its own cache autoconfiguration (and,
-   * with its own {@code CacheManager} bean, fail to start at all with an ambiguous-bean error) —
-   * regardless of the {@code @Qualifier} used at each consumption site below, since that condition
-   * only checks bean type, not name.
+   * Wrapped in {@link SecretKeyCacheHolder} rather than exposed as a plain {@link Cache} bean:
+   * registering an unqualified {@code Cache}, just like an unqualified {@code CacheManager}, would
+   * collide with a host application's own cache bean of that exact type — the same ambiguous-bean
+   * problem this replaces, one type level down. The holder is package-private, so no code outside
+   * this configuration class can declare or depend on a bean of this type either.
    */
   @Bean
-  public Cache secretKeyCacheStore(
+  SecretKeyCacheHolder secretKeyCacheStore(
       @Value("${camunda.connector.secret-resolver.secret-filter.cache.enabled:true}")
           boolean cacheEnabled,
       @Value("${camunda.connector.secret-resolver.secret-filter.cache.max-size:1000}")
           int cacheMaxSize) {
     if (!cacheEnabled) {
-      return new NoOpCache(SecretKeyCache.SECRET_KEY_CACHE_NAME);
+      return new SecretKeyCacheHolder(new NoOpCache(SecretKeyCache.SECRET_KEY_CACHE_NAME));
     }
     int boundedMaxSize = cacheMaxSize > 0 ? cacheMaxSize : 1000;
-    return new CaffeineCache(
-        SecretKeyCache.SECRET_KEY_CACHE_NAME,
-        Caffeine.newBuilder().maximumSize(boundedMaxSize).build());
+    return new SecretKeyCacheHolder(
+        new CaffeineCache(
+            SecretKeyCache.SECRET_KEY_CACHE_NAME,
+            Caffeine.newBuilder().maximumSize(boundedMaxSize).build()));
   }
 
   @Bean
   public SecretKeyCache secretKeyCache(
-      CamundaClient camundaClient, @Qualifier("secretKeyCacheStore") Cache secretKeyCacheStore) {
-    return new ProcessDefinitionSecretKeyCache(camundaClient, secretKeyCacheStore);
+      CamundaClient camundaClient, SecretKeyCacheHolder secretKeyCacheStore) {
+    return new ProcessDefinitionSecretKeyCache(camundaClient, secretKeyCacheStore.cache());
   }
 
   @Bean

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/SecretKeyCacheHolder.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/SecretKeyCacheHolder.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.runtime.outbound;
+
+import org.springframework.cache.Cache;
+
+/**
+ * Wraps the secret-key {@link Cache} so the bean exposed to the Spring context is never itself a
+ * {@code Cache}: an unqualified {@code Cache}-typed bean would collide with a host application's
+ * own cache bean of that type (or be silently injected into one of the host's own unqualified
+ * {@code Cache} injection points), the same problem this replaces at the {@code CacheManager}
+ * level. Package-private so nothing outside this configuration class can declare or depend on this
+ * exact type either.
+ */
+record SecretKeyCacheHolder(Cache cache) {}

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/ConfigurableSecretFilterFactory.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/ConfigurableSecretFilterFactory.java
@@ -54,17 +54,18 @@ public class ConfigurableSecretFilterFactory implements SecretFilterFactory {
             if (strict) {
               // e is usually a Cache.ValueRetrievalException (Spring's Cache#get(key, loader)
               // wraps whatever the loader throws); unwrap to name the real failure type. Never
-              // put the cause's message -- or the cause itself -- into the incident: a
-              // client/parser exception message can echo response-body content (see
-              // SecretReferenceResolver's identical convention for the same reason). The element
-              // ID, process-definition key, and exception class are enough for an operator to
-              // distinguish failure modes and find the full stack trace in the pod log below.
+              // log the cause's message, or the cause itself, anywhere -- not the incident, not
+              // the pod log -- a client/parser exception message can echo response-body content
+              // (see SecretReferenceResolver's identical convention: it never passes the caught
+              // exception to its logger either, only the class name). The element ID,
+              // process-definition key, and exception class are enough for an operator to
+              // distinguish failure modes.
               Throwable realCause = e.getCause() != null ? e.getCause() : e;
               LOG.error(
-                  "Error retrieving secret keys for element '{}' in process definition key {}",
+                  "Error retrieving secret keys for element '{}' in process definition key {} ({})",
                   context.elementId(),
                   context.processDefinitionKey(),
-                  e);
+                  realCause.getClass().getName());
               throw new IllegalArgumentException(
                   "Error retrieving secret keys for element '"
                       + context.elementId()
@@ -74,11 +75,12 @@ public class ConfigurableSecretFilterFactory implements SecretFilterFactory {
                       + realCause.getClass().getName()
                       + ")");
             } else {
+              Throwable realCause = e.getCause() != null ? e.getCause() : e;
               LOG.warn(
-                  "Error filtering secrets for element '{}' in process definition key {}, will allow all as secret-filter-mode is LAX",
+                  "Error filtering secrets for element '{}' in process definition key {} ({}), will allow all as secret-filter-mode is LAX",
                   context.elementId(),
                   context.processDefinitionKey(),
-                  e);
+                  realCause.getClass().getName());
               return null;
             }
           }

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/ConfigurableSecretFilterFactory.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/ConfigurableSecretFilterFactory.java
@@ -52,12 +52,14 @@ public class ConfigurableSecretFilterFactory implements SecretFilterFactory {
                 new SecretKeyContext(context.processDefinitionKey(), context.elementId()));
           } catch (RuntimeException e) {
             if (strict) {
-              // Only getMessage() reaches the Zeebe incident (see the exception-handling layer
-              // that turns this into a failJob command) -- the real cause, e, is otherwise
-              // visible only in this pod's log. Folding it into the message here is what actually
-              // gets it in front of an operator.
+              // Only getMessage() reaches the Zeebe incident. e is usually a
+              // Cache.ValueRetrievalException (Spring's Cache#get(key, loader) wraps whatever the
+              // loader throws), whose own getMessage() is a generic lambda-identity string with no
+              // diagnostic value -- the real cause is on getCause(). Fold that into the message
+              // instead so an operator sees something actionable.
+              Throwable realCause = e.getCause() != null ? e.getCause() : e;
               throw new IllegalArgumentException(
-                  "Error retrieving secret keys: " + e.getMessage(), e);
+                  "Error retrieving secret keys: " + realCause.getMessage(), e);
             } else {
               LOG.warn(
                   "Error filtering secrets for element '{}' in process definition key {}, will allow all as secret-filter-mode is LAX",

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/ConfigurableSecretFilterFactory.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/ConfigurableSecretFilterFactory.java
@@ -55,9 +55,8 @@ public class ConfigurableSecretFilterFactory implements SecretFilterFactory {
               // e is usually a Cache.ValueRetrievalException (Spring's Cache#get(key, loader)
               // wraps whatever the loader throws); unwrap to name the real failure type. Never
               // log the cause's message, or the cause itself, anywhere -- not the incident, not
-              // the pod log -- a client/parser exception message can echo response-body content
-              // (see SecretReferenceResolver's identical convention: it never passes the caught
-              // exception to its logger either, only the class name). The element ID,
+              // the pod log -- a client/parser exception message can echo response-body content,
+              // so neither sink gets more than the exception's class name. The element ID,
               // process-definition key, and exception class are enough for an operator to
               // distinguish failure modes.
               Throwable realCause = e.getCause() != null ? e.getCause() : e;

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/ConfigurableSecretFilterFactory.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/ConfigurableSecretFilterFactory.java
@@ -52,14 +52,27 @@ public class ConfigurableSecretFilterFactory implements SecretFilterFactory {
                 new SecretKeyContext(context.processDefinitionKey(), context.elementId()));
           } catch (RuntimeException e) {
             if (strict) {
-              // Only getMessage() reaches the Zeebe incident. e is usually a
-              // Cache.ValueRetrievalException (Spring's Cache#get(key, loader) wraps whatever the
-              // loader throws), whose own getMessage() is a generic lambda-identity string with no
-              // diagnostic value -- the real cause is on getCause(). Fold that into the message
-              // instead so an operator sees something actionable.
+              // e is usually a Cache.ValueRetrievalException (Spring's Cache#get(key, loader)
+              // wraps whatever the loader throws); unwrap to name the real failure type. Never
+              // put the cause's message -- or the cause itself -- into the incident: a
+              // client/parser exception message can echo response-body content (see
+              // SecretReferenceResolver's identical convention for the same reason). The element
+              // ID, process-definition key, and exception class are enough for an operator to
+              // distinguish failure modes and find the full stack trace in the pod log below.
               Throwable realCause = e.getCause() != null ? e.getCause() : e;
+              LOG.error(
+                  "Error retrieving secret keys for element '{}' in process definition key {}",
+                  context.elementId(),
+                  context.processDefinitionKey(),
+                  e);
               throw new IllegalArgumentException(
-                  "Error retrieving secret keys: " + realCause.getMessage(), e);
+                  "Error retrieving secret keys for element '"
+                      + context.elementId()
+                      + "' in process definition key "
+                      + context.processDefinitionKey()
+                      + " ("
+                      + realCause.getClass().getName()
+                      + ")");
             } else {
               LOG.warn(
                   "Error filtering secrets for element '{}' in process definition key {}, will allow all as secret-filter-mode is LAX",

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/SecretFilterFactoryConfigurationTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/SecretFilterFactoryConfigurationTest.java
@@ -32,21 +32,21 @@ class SecretFilterFactoryConfigurationTest {
 
   @Test
   void secretKeyCacheStore_whenEnabled_returnsCaffeineCache() {
-    var cache = configuration.secretKeyCacheStore(true, 1000);
+    var cache = configuration.secretKeyCacheStore(true, 1000).cache();
 
     assertInstanceOf(CaffeineCache.class, cache);
   }
 
   @Test
   void secretKeyCacheStore_whenDisabled_returnsNoOpCache() {
-    var cache = configuration.secretKeyCacheStore(false, 1000);
+    var cache = configuration.secretKeyCacheStore(false, 1000).cache();
 
     assertInstanceOf(NoOpCache.class, cache);
   }
 
   @Test
   void secretKeyCacheStore_whenDisabled_cacheNeverStoresValues() {
-    Cache cache = configuration.secretKeyCacheStore(false, 1000);
+    Cache cache = configuration.secretKeyCacheStore(false, 1000).cache();
 
     var callCount = new AtomicInteger(0);
     cache.get("key", callCount::incrementAndGet);
@@ -57,15 +57,25 @@ class SecretFilterFactoryConfigurationTest {
 
   @Test
   void secretKeyCacheStore_whenMaxSizeIsZero_clampedToDefault() {
-    var cache = configuration.secretKeyCacheStore(true, 0);
+    var cache = configuration.secretKeyCacheStore(true, 0).cache();
 
     assertInstanceOf(CaffeineCache.class, cache);
   }
 
   @Test
   void secretKeyCacheStore_whenMaxSizeIsNegative_clampedToDefault() {
-    var cache = configuration.secretKeyCacheStore(true, -1);
+    var cache = configuration.secretKeyCacheStore(true, -1).cache();
 
     assertInstanceOf(CaffeineCache.class, cache);
+  }
+
+  @Test
+  void secretKeyCacheStore_beanTypeIsNotAPlainCache_soItCannotCollideWithAHostCacheBean() {
+    // Regression: the bean previously returned a plain Cache, which collided with a host
+    // application's own unqualified Cache bean the same way an unqualified CacheManager bean
+    // used to. The holder type is what makes that impossible now, not the @Qualifier.
+    var holder = configuration.secretKeyCacheStore(true, 1000);
+
+    assertInstanceOf(SecretKeyCacheHolder.class, holder);
   }
 }

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/job/ConfigurableSecretFilterFactoryTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/job/ConfigurableSecretFilterFactoryTest.java
@@ -111,7 +111,7 @@ class ConfigurableSecretFilterFactoryTest {
   void create_strict_whenCacheThrows_messageIdentifiesTheFailureWithoutLeakingTheCauseText() {
     // The incident must be actionable (element ID, process-definition key, exception class) but
     // must never carry the cause's own message: a client/parser exception message can echo
-    // response-body content (see SecretReferenceResolver's identical convention).
+    // response-body content.
     when(secretKeyCache.getSecretKeys(any()))
         .thenThrow(new RuntimeException("Operate returned 404 for process definition 42"));
     var factory = new ConfigurableSecretFilterFactory(SecretFilterMode.STRICT, secretKeyCache);

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/job/ConfigurableSecretFilterFactoryTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/job/ConfigurableSecretFilterFactoryTest.java
@@ -108,9 +108,10 @@ class ConfigurableSecretFilterFactoryTest {
   }
 
   @Test
-  void create_strict_whenCacheThrows_messageIncludesTheRealCause() {
-    // Only getMessage() reaches the Zeebe incident; the real cause must be folded into it, not
-    // left visible only in the pod log, or an operator sees nothing actionable.
+  void create_strict_whenCacheThrows_messageIdentifiesTheFailureWithoutLeakingTheCauseText() {
+    // The incident must be actionable (element ID, process-definition key, exception class) but
+    // must never carry the cause's own message: a client/parser exception message can echo
+    // response-body content (see SecretReferenceResolver's identical convention).
     when(secretKeyCache.getSecretKeys(any()))
         .thenThrow(new RuntimeException("Operate returned 404 for process definition 42"));
     var factory = new ConfigurableSecretFilterFactory(SecretFilterMode.STRICT, secretKeyCache);
@@ -118,27 +119,32 @@ class ConfigurableSecretFilterFactoryTest {
     var filter = factory.create(CONTEXT);
 
     assertThatThrownBy(() -> filter.isAllowed("ANY_SECRET"))
-        .hasMessageContaining("Operate returned 404 for process definition 42");
+        .hasMessageContaining(ELEMENT_ID)
+        .hasMessageContaining(String.valueOf(PROCESS_DEF_KEY))
+        .hasMessageContaining(RuntimeException.class.getName())
+        .hasMessageNotContaining("Operate returned 404 for process definition 42");
   }
 
   @Test
   void
-      create_strict_whenProcessDefinitionLookupFailsThroughACaffeineCache_messageSurfacesTheRealCause()
+      create_strict_whenProcessDefinitionLookupFailsThroughACaffeineCache_messageIdentifiesTheFailureWithoutLeakingTheCauseText()
           throws Exception {
     // Goes through a real Cache#get(key, loader), which wraps the loader's exception in
     // Cache.ValueRetrievalException -- unlike the mock above, this reproduces the wrapping that
-    // hid the real cause in production.
-    assertMessageSurfacesRealCauseNotTheCacheWrapper(
+    // hid the exception type in production.
+    assertMessageIdentifiesTheFailureWithoutLeakingTheCauseText(
         new CaffeineCache("test", Caffeine.newBuilder().build()));
   }
 
   @Test
-  void create_strict_whenProcessDefinitionLookupFailsThroughANoOpCache_messageSurfacesTheRealCause()
-      throws Exception {
-    assertMessageSurfacesRealCauseNotTheCacheWrapper(new NoOpCache("test"));
+  void
+      create_strict_whenProcessDefinitionLookupFailsThroughANoOpCache_messageIdentifiesTheFailureWithoutLeakingTheCauseText()
+          throws Exception {
+    assertMessageIdentifiesTheFailureWithoutLeakingTheCauseText(new NoOpCache("test"));
   }
 
-  private void assertMessageSurfacesRealCauseNotTheCacheWrapper(Cache cache) throws Exception {
+  private void assertMessageIdentifiesTheFailureWithoutLeakingTheCauseText(Cache cache)
+      throws Exception {
     var camundaClient = mock(CamundaClient.class);
     when(camundaClient.newProcessDefinitionGetXmlRequest(PROCESS_DEF_KEY))
         .thenThrow(new RuntimeException("Operate returned 404 for process definition 42"));
@@ -148,7 +154,10 @@ class ConfigurableSecretFilterFactoryTest {
     var filter = factory.create(CONTEXT);
 
     assertThatThrownBy(() -> filter.isAllowed("ANY_SECRET"))
-        .hasMessageContaining("Operate returned 404 for process definition 42")
-        .hasMessageNotContaining("could not be loaded using");
+        .hasMessageContaining(ELEMENT_ID)
+        .hasMessageContaining(String.valueOf(PROCESS_DEF_KEY))
+        .hasMessageContaining(RuntimeException.class.getName())
+        .hasMessageNotContaining("could not be loaded using")
+        .hasMessageNotContaining("Operate returned 404 for process definition 42");
   }
 }

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/job/ConfigurableSecretFilterFactoryTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/job/ConfigurableSecretFilterFactoryTest.java
@@ -19,11 +19,15 @@ package io.camunda.connector.runtime.outbound.job;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
+import com.github.benmanes.caffeine.cache.Caffeine;
+import io.camunda.client.CamundaClient;
 import io.camunda.connector.runtime.core.secret.SecretFilterFactory.SecretFilterContext;
 import io.camunda.connector.runtime.outbound.job.ConfigurableSecretFilterFactory.SecretFilterMode;
+import io.camunda.connector.runtime.outbound.secret.ProcessDefinitionSecretKeyCache;
 import io.camunda.connector.runtime.outbound.secret.SecretKeyCache;
 import io.camunda.connector.runtime.outbound.secret.SecretKeyCache.SecretKeyContext;
 import java.util.List;
@@ -31,6 +35,9 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.cache.Cache;
+import org.springframework.cache.caffeine.CaffeineCache;
+import org.springframework.cache.support.NoOpCache;
 
 @ExtendWith(MockitoExtension.class)
 class ConfigurableSecretFilterFactoryTest {
@@ -112,5 +119,36 @@ class ConfigurableSecretFilterFactoryTest {
 
     assertThatThrownBy(() -> filter.isAllowed("ANY_SECRET"))
         .hasMessageContaining("Operate returned 404 for process definition 42");
+  }
+
+  @Test
+  void
+      create_strict_whenProcessDefinitionLookupFailsThroughACaffeineCache_messageSurfacesTheRealCause()
+          throws Exception {
+    // Goes through a real Cache#get(key, loader), which wraps the loader's exception in
+    // Cache.ValueRetrievalException -- unlike the mock above, this reproduces the wrapping that
+    // hid the real cause in production.
+    assertMessageSurfacesRealCauseNotTheCacheWrapper(
+        new CaffeineCache("test", Caffeine.newBuilder().build()));
+  }
+
+  @Test
+  void create_strict_whenProcessDefinitionLookupFailsThroughANoOpCache_messageSurfacesTheRealCause()
+      throws Exception {
+    assertMessageSurfacesRealCauseNotTheCacheWrapper(new NoOpCache("test"));
+  }
+
+  private void assertMessageSurfacesRealCauseNotTheCacheWrapper(Cache cache) throws Exception {
+    var camundaClient = mock(CamundaClient.class);
+    when(camundaClient.newProcessDefinitionGetXmlRequest(PROCESS_DEF_KEY))
+        .thenThrow(new RuntimeException("Operate returned 404 for process definition 42"));
+    SecretKeyCache realSecretKeyCache = new ProcessDefinitionSecretKeyCache(camundaClient, cache);
+    var factory = new ConfigurableSecretFilterFactory(SecretFilterMode.STRICT, realSecretKeyCache);
+
+    var filter = factory.create(CONTEXT);
+
+    assertThatThrownBy(() -> filter.isAllowed("ANY_SECRET"))
+        .hasMessageContaining("Operate returned 404 for process definition 42")
+        .hasMessageNotContaining("could not be loaded using");
   }
 }


### PR DESCRIPTION
## Summary

Follow-up to #8496 (already merged) — two defects found by the QA bot's retest of the equivalent fix on #8505 (8.6), both applicable here unchanged:

1. **STRICT incident message still didn't carry enough to be actionable.** `ConfigurableSecretFilterFactory`'s STRICT catch block folded `e.getMessage()` into the incident message, but `e` is `Cache.ValueRetrievalException` (Spring's `Cache#get(key, loader)` wraps whatever the loader throws), whose own `getMessage()` is a generic lambda-identity string with no diagnostic value.
2. **The CacheManager -> Cache fix only moved the ambiguous-bean problem down one type level.** An unqualified `Cache` bean still collides with a host application's own `Cache` bean, and a host with none silently receives this runtime's internal cache regardless of `@Qualifier` (which only narrows an already-eligible candidate set, it doesn't exempt the bean from type-based matching elsewhere). The `Cache` is now wrapped in a package-private `SecretKeyCacheHolder` record so the bean is never itself a framework `Cache` type.

**Edit:** the first fix for (1) unwrapped `getCause()` and put that cause's `getMessage()` into the incident. That repeats a mistake this codebase already avoids elsewhere (`SecretReferenceResolver` on main never logs or carries a client exception's message because it can echo response-body content) and a Copilot review on #8537 caught the same issue here. Corrected: the incident now carries only the element ID, process-definition key, and the cause's exception class name.

**Edit 2:** that fix still had a leak — `LOG.error(...)` was passed the raw throwable `e` as its last argument, which makes SLF4J print the exception's full message and stack trace to the pod log verbatim, moving the same leak to a different sink. Copilot caught it directly on #8537. Corrected: the log statement now also passes only the exception's class name, never `e` itself — there is no stack trace anywhere now, on purpose. Same fix on the LAX branch, which had the identical pattern. Also dropped the `SecretReferenceResolver` citation from the code comments here (Copilot flagged that it doesn't exist on this branch, so citing it as an in-repo precedent was misleading) and added the handler-level restrictive-filter test Copilot flagged as missing on #8501 (same underlying gap here).

Same fix as landed on main/#8537, 8.9/#8539, 8.7/#8501, 8.6/#8505.

## Test plan
- [x] `ConfigurableSecretFilterFactoryTest`: tests go through a real `CaffeineCache`/`NoOpCache` + real `ProcessDefinitionSecretKeyCache` with a mocked client throwing, asserting the incident message contains the element ID, process-definition key, and exception class name, and does **not** contain the cause's own message or the cache wrapper's generic message.
- [x] `SecretFilterFactoryConfigurationTest`: updated to unwrap `.cache()`, plus a new holder-type assertion.
- [x] `mvn -pl connector-runtime-core,connector-runtime-spring -am test` green on top of the real merged `stable/8.8` tip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

