### PR TITLE
fix(ci): mask decoded Vertex AI private key in CI logs

### DIFF
--- a/.github/workflows/MERGE_QUEUE_HELM_TEST.yaml
+++ b/.github/workflows/MERGE_QUEUE_HELM_TEST.yaml
@@ -679,6 +679,41 @@ jobs:
             secret/data/products/qa/ci/cross-component-e2e-test-suite IDP_GCP_VERTEX_PROJECT_ID;
             secret/data/products/qa/ci/cross-component-e2e-test-suite IDP_GCP_VERTEX_REGION;
 
+      # hashicorp/vault-action already masks IDP_GCP_SERVICE_ACCOUNT line-by-line as soon as it's
+      # fetched (see its own source: it splits the raw value on newlines and registers each
+      # non-empty line as a secret) - so most of what #8595 worried about is already covered.
+      # The real, narrower gap: once this step's JSON is decoded with jq, the PEM private key's
+      # *escaped* \n sequences become *real* newlines - a string vault-action never saw and never
+      # masked. If that decoded value is ever echoed (directly, via an SDK stack trace, etc.), it
+      # leaks. This masks the decoded private_key and private_key_id specifically.
+      #
+      # Masked one line at a time, not as a single multi-line value: GitHub Actions' ::add-mask::
+      # only recognizes the first line of a command as the command itself - a naive
+      # `echo "::add-mask::$value"` on a multi-line PEM key would register just the header line
+      # and print every other line of the actual key as plain, unmasked text. Confirmed by testing
+      # this exact failure mode locally before writing the fix this way.
+      - name: Mask decoded Vertex AI private key
+        if: steps.changes.outputs.ai == 'true'
+        env:
+          SERVICE_ACCOUNT_JSON: ${{ steps.secrets.outputs.IDP_GCP_SERVICE_ACCOUNT }}
+        run: |
+          mask_multiline_field() {
+            local field="$1"
+            local value
+            value=$(echo "$SERVICE_ACCOUNT_JSON" | jq -r --arg f "$field" '.[$f] // empty' 2>/dev/null) || {
+              echo "::warning::Could not extract '$field' from IDP_GCP_SERVICE_ACCOUNT for masking (parse failed or field missing)"
+              return 0
+            }
+            if [ -z "$value" ]; then
+              return 0
+            fi
+            while IFS= read -r line; do
+              [ -n "$line" ] && echo "::add-mask::$line"
+            done <<< "$value"
+          }
+          mask_multiline_field "private_key"
+          mask_multiline_field "private_key_id"
+
       - uses: actions/setup-java@v6
         if: steps.changes.outputs.ai == 'true'
         with:

--- a/.github/workflows/MERGE_QUEUE_HELM_TEST.yaml
+++ b/.github/workflows/MERGE_QUEUE_HELM_TEST.yaml
@@ -679,19 +679,10 @@ jobs:
             secret/data/products/qa/ci/cross-component-e2e-test-suite IDP_GCP_VERTEX_PROJECT_ID;
             secret/data/products/qa/ci/cross-component-e2e-test-suite IDP_GCP_VERTEX_REGION;
 
-      # hashicorp/vault-action already masks IDP_GCP_SERVICE_ACCOUNT line-by-line as soon as it's
-      # fetched (see its own source: it splits the raw value on newlines and registers each
-      # non-empty line as a secret) - so most of what #8595 worried about is already covered.
-      # The real, narrower gap: once this step's JSON is decoded with jq, the PEM private key's
-      # *escaped* \n sequences become *real* newlines - a string vault-action never saw and never
-      # masked. If that decoded value is ever echoed (directly, via an SDK stack trace, etc.), it
-      # leaks. This masks the decoded private_key and private_key_id specifically.
-      #
-      # Masked one line at a time, not as a single multi-line value: GitHub Actions' ::add-mask::
-      # only recognizes the first line of a command as the command itself - a naive
-      # `echo "::add-mask::$value"` on a multi-line PEM key would register just the header line
-      # and print every other line of the actual key as plain, unmasked text. Confirmed by testing
-      # this exact failure mode locally before writing the fix this way.
+      # vault-action already masks the raw JSON line-by-line, but jq-decoding private_key here
+      # turns its escaped \n into real newlines it never saw - masking those specifically.
+      # Per-line, not as one value: ::add-mask:: only recognizes its own first line as the
+      # command, so a naive one-shot mask would print the rest of a multi-line key unmasked.
       - name: Mask decoded Vertex AI private key
         if: steps.changes.outputs.ai == 'true'
         env:

--- a/.github/workflows/MERGE_QUEUE_HELM_TEST.yaml
+++ b/.github/workflows/MERGE_QUEUE_HELM_TEST.yaml
@@ -691,12 +691,9 @@ jobs:
           mask_multiline_field() {
             local field="$1"
             local value
-            value=$(echo "$SERVICE_ACCOUNT_JSON" | jq -r --arg f "$field" '.[$f] // empty' 2>/dev/null) || {
-              echo "::warning::Could not extract '$field' from IDP_GCP_SERVICE_ACCOUNT for masking (parse failed or field missing)"
-              return 0
-            }
-            if [ -z "$value" ]; then
-              return 0
+            if ! value=$(echo "$SERVICE_ACCOUNT_JSON" | jq -r --arg f "$field" '.[$f] // empty' 2>/dev/null) || [ -z "$value" ]; then
+              echo "::error::Could not extract '$field' from IDP_GCP_SERVICE_ACCOUNT - failing rather than running the real test unmasked"
+              exit 1
             fi
             while IFS= read -r line; do
               [ -n "$line" ] && echo "::add-mask::$line"


### PR DESCRIPTION
## Problem

Today, the Vertex AI service-account JSON is forwarded as-is into the
test run. `vault-action` masks the whole value as one string, but
that only redacts an exact, complete match - if a sub-field (the
private key, its id) were ever logged or printed separately, it
wouldn't be caught by that whole-blob mask.

This isn't a fix for something currently leaking - nothing today
actually decodes or prints this JSON's sub-fields anywhere. It's
pre-emptive hardening: implementing one of #8595's own suggested
options ("at minimum, register the individual sensitive sub-fields as
their own masked secrets"), so that if some future code change ever
does log a sub-field, it's already covered.

Relates to #8595.

## What this does

Adds one step after the Vault import that extracts `private_key` and
`private_key_id` with `jq` and masks each, one real line at a time
(GitHub Actions' masking only recognizes a value's first line, so a
naive one-shot mask would print the rest of a multi-line key
unmasked).

Note this step itself introduces the only place in this workflow that
decodes the JSON - so it needs its own care: if extraction ever fails
(malformed JSON, or the field is missing or empty), the step fails
the job instead of continuing, rather than logging a warning and
letting the real test run with the credential unmasked.

## What this doesn't fix

This is a mitigation, not the underlying fix. The durable fix is
moving this credential to GCP Workload Identity Federation via OIDC -
bigger change, out of scope here.
