### PR TITLE
ci: map stable/8.10 to camunda-platform-8.10 helm chart

### DIFF
--- a/.github/workflows/helm-git-refs.json
+++ b/.github/workflows/helm-git-refs.json
@@ -1,5 +1,6 @@
 {
   "main": "camunda-platform-8.10",
+  "stable/8.10": "camunda-platform-8.10",
   "stable/8.9": "camunda-platform-8.9",
   "stable/8.8": "camunda-platform-8.8",
   "stable/8.7": "camunda-platform-8.7",


### PR DESCRIPTION
## Description

Adds the missing `stable/8.10` entry to `.github/workflows/helm-git-refs.json`.

The `stable/8.10` branch was cut without adding it to the mapping, so `INTEGRATION_TEST.yml` cannot resolve a Helm chart directory and the `Deploy snapshots` → `Helm chart Integration Tests / Prepare inputs` job fails on that branch:

```
Final lookup key: 'stable/8.10'
Found helm-dir: 'null'
##[error]Could not determine Helm chart dir to use, please provide helm-dir input or adjust the mappings in .github/workflows/helm-git-refs.json
```

Failing run: https://github.com/camunda/connectors/actions/runs/33615565959/job/100210318390

`camunda-platform-8.10` is the newest chart directory on `camunda/camunda-platform-helm@main`, which is the ref `INTEGRATION_TEST.yml` pins via `camunda-helm-git-ref: main`.

`"main"` intentionally stays on `camunda-platform-8.10`: `main` is already `8.11.0-SNAPSHOT`, but no `camunda-platform-8.11` chart directory exists in the Helm repo yet. That bump belongs in a separate PR once the 8.11 chart lands.

## Backport

The lookup reads the file from the running branch's own checkout (`prepare-inputs` checks out `github.ref`, which for a local reusable workflow is the caller's ref). So this needs to land on `stable/8.10` to actually turn its snapshot runs green — hence the `backport stable/8.10` label. Keeping it on `main` as well so future `release-8.10.x` branches, which are normalized to `stable/8.10` by the lookup, resolve correctly.

## Related issues

n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)