### PR TITLE
feat(runtime): extend secret filtering to inbound connectors

### DIFF
--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/DefaultInboundConnectorContextFactory.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/DefaultInboundConnectorContextFactory.java
@@ -37,6 +37,7 @@ public class DefaultInboundConnectorContextFactory implements InboundConnectorCo
   private final ValidationProvider validationProvider;
   private final ProcessInstanceClient processInstanceClient;
   private final DocumentFactory documentFactory;
+  private final boolean secretFilterEnabled;
 
   public DefaultInboundConnectorContextFactory(
       final ObjectMapper mapper,
@@ -45,6 +46,25 @@ public class DefaultInboundConnectorContextFactory implements InboundConnectorCo
       final ValidationProvider validationProvider,
       final ProcessInstanceClient processInstanceClient,
       final DocumentFactory documentFactory) {
+    this(
+        mapper,
+        correlationHandler,
+        secretProviderAggregator,
+        validationProvider,
+        processInstanceClient,
+        documentFactory,
+        false);
+  }
+
+  public DefaultInboundConnectorContextFactory(
+      final ObjectMapper mapper,
+      final InboundCorrelationHandler correlationHandler,
+      final SecretProviderAggregator secretProviderAggregator,
+      final ValidationProvider validationProvider,
+      final ProcessInstanceClient processInstanceClient,
+      final DocumentFactory documentFactory,
+      final boolean secretFilterEnabled) {
+    this.secretFilterEnabled = secretFilterEnabled;
     this.objectMapper = mapper;
     this.correlationHandler = correlationHandler;
     this.secretProviderAggregator = secretProviderAggregator;
@@ -69,7 +89,8 @@ public class DefaultInboundConnectorContextFactory implements InboundConnectorCo
             correlationHandler,
             cancellationCallback,
             objectMapper,
-            logWriter);
+            logWriter,
+            secretFilterEnabled);
 
     if (isIntermediateContext(executableClass)) {
       inboundContext =

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextImpl.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextImpl.java
@@ -45,6 +45,7 @@ import io.camunda.connector.runtime.core.inbound.activitylog.ActivitySource;
 import io.camunda.connector.runtime.core.inbound.correlation.InboundCorrelationHandler;
 import io.camunda.connector.runtime.core.inbound.details.InboundConnectorDetails.ValidInboundConnectorDetails;
 import io.camunda.connector.runtime.core.secret.SecretFilter;
+import io.camunda.connector.runtime.core.secret.SecretUtil;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -79,7 +80,33 @@ public class InboundConnectorContextImpl extends AbstractConnectorContext
       Consumer<Throwable> cancellationCallback,
       ObjectMapper objectMapper,
       ActivityLogWriter activityLogWriter) {
-    super(secretProvider, SecretFilter.allowAll(), validationProvider);
+    this(
+        secretProvider,
+        validationProvider,
+        documentFactory,
+        connectorDetails,
+        correlationHandler,
+        cancellationCallback,
+        objectMapper,
+        activityLogWriter,
+        false);
+  }
+
+  /**
+   * @param secretFilterEnabled when {@code true}, restricts secret resolution to the names declared
+   *     by the deployed {@code zeebe:property} text replacement runs over (#7730).
+   */
+  public InboundConnectorContextImpl(
+      SecretProvider secretProvider,
+      ValidationProvider validationProvider,
+      DocumentFactory documentFactory,
+      ValidInboundConnectorDetails connectorDetails,
+      InboundCorrelationHandler correlationHandler,
+      Consumer<Throwable> cancellationCallback,
+      ObjectMapper objectMapper,
+      ActivityLogWriter activityLogWriter,
+      boolean secretFilterEnabled) {
+    super(secretProvider, secretFilter(connectorDetails, secretFilterEnabled), validationProvider);
     this.documentFactory = documentFactory;
     this.correlationHandler = correlationHandler;
     this.connectorDetails = connectorDetails;
@@ -267,6 +294,31 @@ public class InboundConnectorContextImpl extends AbstractConnectorContext
     } catch (Throwable e) {
       LOG.error("Failed to deliver the cancellation signal to the runtime", e);
     }
+  }
+
+  /**
+   * The allow-list is drawn from the same {@code rawPropertiesWithoutKeywords} map that {@link
+   * #properties} is built from, so the names permitted and the text filtered always come from one
+   * read. That text is fixed at construction here — {@code properties} is final and {@link
+   * #updateConnectorDetails} does not rebuild it — so unlike the outbound path there is no
+   * separately-timed state for a hot swap to leave stale.
+   *
+   * <p>This is what the filter stops: {@link SecretUtil#replaceSecrets} runs the brace pass and
+   * then runs the bare pass over that pass's output, so a resolved value containing
+   * reference-shaped text otherwise produces a lookup for a name no model declares.
+   *
+   * <p>Static because it feeds the {@code super(...)} call, before any field is assigned.
+   */
+  private static SecretFilter secretFilter(
+      ValidInboundConnectorDetails connectorDetails, boolean secretFilterEnabled) {
+    if (!secretFilterEnabled) {
+      return SecretFilter.allowAll();
+    }
+    return SecretFilter.allowOnly(
+        connectorDetails.rawPropertiesWithoutKeywords().values().stream()
+            .flatMap(value -> SecretUtil.retrieveSecretKeysInInput(value).stream())
+            .distinct()
+            .toList());
   }
 
   @Override

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextImplTest.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextImplTest.java
@@ -18,15 +18,24 @@ package io.camunda.connector.runtime.core.inbound;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.connector.api.annotation.FEEL;
 import io.camunda.connector.api.inbound.ActivityLogTag;
 import io.camunda.connector.api.inbound.Health;
 import io.camunda.connector.api.inbound.Severity;
+import io.camunda.connector.api.secret.SecretContext;
 import io.camunda.connector.api.secret.SecretProvider;
 import io.camunda.connector.runtime.core.FooBarSecretProvider;
 import io.camunda.connector.runtime.core.TestObjectMapperSupplier;
+import io.camunda.connector.runtime.core.document.DocumentFactoryImpl;
+import io.camunda.connector.runtime.core.document.store.InMemoryDocumentStore;
 import io.camunda.connector.runtime.core.inbound.InboundConnectorContextImplTest.TestPropertiesClass.InnerObject;
 import io.camunda.connector.runtime.core.inbound.activitylog.ActivityLogRegistry;
 import io.camunda.connector.runtime.core.inbound.correlation.MessageCorrelationPoint.StandaloneMessageCorrelationPoint;
@@ -90,6 +99,99 @@ class InboundConnectorContextImplTest {
     // then
     assertThat(propertiesAsType.getMapWithStringListWithNumbers().get("key").getFirst())
         .isInstanceOf(String.class);
+  }
+
+  // #7730: inbound secret resolution is restricted to the names the element's own deployed
+  // zeebe:property text declares. The allow-list is a superset of what a correctly-authored model
+  // names, so what it actually stops is a second-order lookup: replaceSecrets runs the brace pass
+  // and then runs the bare pass over that pass's output, letting a resolved value that contains
+  // reference-shaped text reach a secret no model ever declared.
+  //
+  // Main's suite also covers a hot swap, a sibling element's names, and the new
+  // camunda.secrets.<name> form. None of those are representable on this branch: `properties` is
+  // final and updateConnectorDetails does not rebuild it, there is a single connector-level text
+  // rather than a per-element one, and the new form does not exist here at all.
+
+  private InboundConnectorContextImpl filteringContext(
+      ValidInboundConnectorDetails details, SecretProvider secretProvider) {
+    return new InboundConnectorContextImpl(
+        secretProvider,
+        (e) -> {},
+        new DocumentFactoryImpl(InMemoryDocumentStore.INSTANCE),
+        details,
+        null,
+        (e) -> {},
+        mapper,
+        activityLogRegistry,
+        true);
+  }
+
+  private static String replace(InboundConnectorContextImpl context, String input) {
+    return context.getSecretHandler().replaceSecrets(input, new SecretContext("t", "p"));
+  }
+
+  @Test
+  void secretFilterEnabled_resolvesADeclaredSecret() {
+    var secretProvider = mock(SecretProvider.class);
+    when(secretProvider.getSecret(eq("DECLARED"), any())).thenReturn("resolved");
+    var context =
+        filteringContext(
+            getInboundConnectorDefinition(Map.of("token", "secrets.DECLARED")), secretProvider);
+
+    assertThat(replace(context, "secrets.DECLARED")).isEqualTo("resolved");
+  }
+
+  @Test
+  void secretFilterEnabled_resolvesADeclaredSecretInBraceSyntax() {
+    var secretProvider = mock(SecretProvider.class);
+    when(secretProvider.getSecret(eq("BRACED"), any())).thenReturn("resolved");
+    var context =
+        filteringContext(
+            getInboundConnectorDefinition(Map.of("token", "{{ secrets.BRACED }}")), secretProvider);
+
+    assertThat(replace(context, "{{ secrets.BRACED }}")).isEqualTo("resolved");
+  }
+
+  @Test
+  void secretFilterEnabled_leavesAnUndeclaredSecret() {
+    var secretProvider = mock(SecretProvider.class);
+    var context =
+        filteringContext(
+            getInboundConnectorDefinition(Map.of("token", "secrets.DECLARED")), secretProvider);
+
+    assertThat(replace(context, "secrets.INJECTED")).isEqualTo("secrets.INJECTED");
+    verify(secretProvider, never()).getSecret(eq("INJECTED"), any());
+  }
+
+  @Test
+  void secretFilterEnabled_leavesASecretNamedOnlyByAnotherSecretsValue() {
+    var secretProvider = mock(SecretProvider.class);
+    when(secretProvider.getSecret(eq("CHAIN_ROOT"), any())).thenReturn("secrets.CHAINED");
+    when(secretProvider.getSecret(eq("CHAINED"), any())).thenReturn("leaked-value");
+    var context =
+        filteringContext(
+            getInboundConnectorDefinition(Map.of("token", "{{secrets.CHAIN_ROOT}}")),
+            secretProvider);
+
+    assertThat(replace(context, "{{secrets.CHAIN_ROOT}}")).isEqualTo("secrets.CHAINED");
+    verify(secretProvider, never()).getSecret(eq("CHAINED"), any());
+  }
+
+  @Test
+  void secretFilterDisabled_resolvesAnUndeclaredSecret() {
+    var secretProvider = mock(SecretProvider.class);
+    when(secretProvider.getSecret(eq("INJECTED"), any())).thenReturn("resolved");
+    var context =
+        new InboundConnectorContextImpl(
+            secretProvider,
+            (e) -> {},
+            getInboundConnectorDefinition(Map.of("token", "secrets.DECLARED")),
+            null,
+            (e) -> {},
+            mapper,
+            activityLogRegistry);
+
+    assertThat(replace(context, "secrets.INJECTED")).isEqualTo("resolved");
   }
 
   private static ValidInboundConnectorDetails getInboundConnectorDefinition(

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/InboundConnectorRuntimeConfiguration.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/InboundConnectorRuntimeConfiguration.java
@@ -47,6 +47,7 @@ import io.camunda.connector.runtime.inbound.state.ProcessStateManager;
 import io.camunda.connector.runtime.inbound.state.ProcessStateManagerImpl;
 import io.camunda.connector.runtime.inbound.webhook.WebhookConnectorRegistry;
 import io.camunda.connector.runtime.metrics.ConnectorsInboundMetrics;
+import io.camunda.connector.runtime.outbound.job.ConfigurableSecretFilterFactory.SecretFilterMode;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.time.Duration;
 import java.util.Objects;
@@ -100,14 +101,21 @@ public class InboundConnectorRuntimeConfiguration {
       SecretProviderAggregator secretProviderAggregator,
       @Autowired(required = false) ValidationProvider validationProvider,
       ProcessInstanceClient processInstanceClient,
-      DocumentFactory documentFactory) {
+      DocumentFactory documentFactory,
+      @Value("${camunda.connector.secret-resolver.secret-filter.mode:STRICT}")
+          SecretFilterMode secretFilterMode) {
+    // LAX vs STRICT only matters outbound, where the allow-list needs a remote BPMN lookup that can
+    // fail; the inbound allow-list is built from data already in memory, so it never fails and both
+    // modes behave identically here — only DISABLED turns this off.
+    boolean secretFilterEnabled = secretFilterMode != SecretFilterMode.DISABLED;
     return new DefaultInboundConnectorContextFactory(
         mapper,
         correlationHandler,
         secretProviderAggregator,
         validationProvider,
         processInstanceClient,
-        documentFactory);
+        documentFactory,
+        secretFilterEnabled);
   }
 
   @Bean

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/inbound/InboundConnectorRuntimeConfigurationTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/inbound/InboundConnectorRuntimeConfigurationTest.java
@@ -18,8 +18,28 @@ package io.camunda.connector.runtime.inbound;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.mockito.Mockito.mock;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.connector.api.document.DocumentFactory;
+import io.camunda.connector.api.inbound.InboundConnectorContext;
+import io.camunda.connector.api.inbound.InboundConnectorExecutable;
+import io.camunda.connector.api.secret.SecretContext;
+import io.camunda.connector.api.secret.SecretProvider;
+import io.camunda.connector.api.validation.ValidationProvider;
+import io.camunda.connector.runtime.core.inbound.InboundConnectorContextImpl;
+import io.camunda.connector.runtime.core.inbound.InboundConnectorElement;
+import io.camunda.connector.runtime.core.inbound.ProcessElementWithRuntimeData;
+import io.camunda.connector.runtime.core.inbound.ProcessInstanceClient;
+import io.camunda.connector.runtime.core.inbound.correlation.InboundCorrelationHandler;
+import io.camunda.connector.runtime.core.inbound.correlation.MessageCorrelationPoint.StandaloneMessageCorrelationPoint;
+import io.camunda.connector.runtime.core.inbound.details.InboundConnectorDetails;
+import io.camunda.connector.runtime.core.inbound.details.InboundConnectorDetails.ValidInboundConnectorDetails;
+import io.camunda.connector.runtime.core.secret.SecretProviderAggregator;
 import io.camunda.connector.runtime.inbound.state.ProcessDefinitionInspector;
+import io.camunda.connector.runtime.outbound.job.ConfigurableSecretFilterFactory.SecretFilterMode;
+import java.util.List;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.Test;
 import org.springframework.cache.Cache;
@@ -55,5 +75,74 @@ class InboundConnectorRuntimeConfigurationTest {
     cache.get("key", callCount::incrementAndGet);
 
     assertEquals(2, callCount.get(), "NoOp cache must call loader on every get");
+  }
+
+  /**
+   * Pins the {@code SecretFilterMode} -> boolean hop: nothing else asserts that the mode reaches
+   * the context, and because {@code LAX} and {@code STRICT} behave identically on the inbound path
+   * this is the only place their equivalence — and {@code DISABLED}'s difference from both — is
+   * checked. Fails if the argument is dropped or the boolean inverted.
+   *
+   * <p>This calls the bean method directly and so bypasses Spring's {@code @Value} resolution
+   * entirely; {@code InboundSecretFilterDefaultModeWiringTest} covers the default string itself.
+   */
+  @Test
+  void springInboundConnectorContextFactory_filtersSecretsUnlessModeIsDisabled() {
+    assertEquals(
+        "secrets.UNDECLARED",
+        resolveUndeclared(contextForSecretFilterMode(SecretFilterMode.STRICT)));
+    assertEquals(
+        "secrets.UNDECLARED", resolveUndeclared(contextForSecretFilterMode(SecretFilterMode.LAX)));
+    assertEquals(
+        "resolved", resolveUndeclared(contextForSecretFilterMode(SecretFilterMode.DISABLED)));
+  }
+
+  private InboundConnectorContextImpl contextForSecretFilterMode(SecretFilterMode mode) {
+    var factory =
+        configuration.springInboundConnectorContextFactory(
+            new ObjectMapper(),
+            mock(InboundCorrelationHandler.class),
+            new SecretProviderAggregator(List.of(alwaysResolvingProvider())),
+            mock(ValidationProvider.class),
+            mock(ProcessInstanceClient.class),
+            mock(DocumentFactory.class),
+            mode);
+    return (InboundConnectorContextImpl)
+        factory.createContext(
+            detailsDeclaringNoSecret(), e -> {}, TestExecutable.class, entry -> {});
+  }
+
+  private static ValidInboundConnectorDetails detailsDeclaringNoSecret() {
+    var properties = Map.of("inbound.type", "io.camunda:connector:1");
+    var element =
+        new InboundConnectorElement(
+            properties,
+            new StandaloneMessageCorrelationPoint("", "", null, null),
+            new ProcessElementWithRuntimeData("process", 0, 0, "id", "<default>"));
+    return (ValidInboundConnectorDetails)
+        InboundConnectorDetails.of(element.deduplicationId(List.of()), List.of(element));
+  }
+
+  private static String resolveUndeclared(InboundConnectorContextImpl context) {
+    return context
+        .getSecretHandler()
+        .replaceSecrets("secrets.UNDECLARED", new SecretContext("t", "p"));
+  }
+
+  private static SecretProvider alwaysResolvingProvider() {
+    return new SecretProvider() {
+      @Override
+      public String getSecret(String name, SecretContext context) {
+        return "resolved";
+      }
+    };
+  }
+
+  static class TestExecutable implements InboundConnectorExecutable<InboundConnectorContext> {
+    @Override
+    public void activate(InboundConnectorContext context) {}
+
+    @Override
+    public void deactivate() {}
   }
 }

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/inbound/InboundSecretFilterDefaultModeWiringTest.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/inbound/InboundSecretFilterDefaultModeWiringTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.runtime.inbound;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.connector.api.inbound.InboundConnectorContext;
+import io.camunda.connector.api.inbound.InboundConnectorExecutable;
+import io.camunda.connector.api.secret.SecretContext;
+import io.camunda.connector.runtime.app.TestConnectorRuntimeApplication;
+import io.camunda.connector.runtime.core.inbound.InboundConnectorContextFactory;
+import io.camunda.connector.runtime.core.inbound.InboundConnectorContextImpl;
+import io.camunda.connector.runtime.core.inbound.InboundConnectorElement;
+import io.camunda.connector.runtime.core.inbound.ProcessElementWithRuntimeData;
+import io.camunda.connector.runtime.core.inbound.correlation.MessageCorrelationPoint.StandaloneMessageCorrelationPoint;
+import io.camunda.connector.runtime.core.inbound.details.InboundConnectorDetails;
+import io.camunda.connector.runtime.core.inbound.details.InboundConnectorDetails.ValidInboundConnectorDetails;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+/**
+ * No {@code camunda.connector.secret-resolver.secret-filter.mode} property is set here, so this
+ * exercises the {@code @Value} default on {@code springInboundConnectorContextFactory} itself —
+ * unlike a direct call to that bean method, which bypasses Spring's property resolution entirely. A
+ * typo in that default string turns inbound filtering off silently, and because every mode behaves
+ * identically on the live inbound path, no integration test would catch it.
+ */
+@SpringBootTest(classes = TestConnectorRuntimeApplication.class)
+class InboundSecretFilterDefaultModeWiringTest {
+
+  @Autowired private InboundConnectorContextFactory contextFactory;
+
+  static class TestExecutable implements InboundConnectorExecutable<InboundConnectorContext> {
+    @Override
+    public void activate(InboundConnectorContext context) {}
+
+    @Override
+    public void deactivate() {}
+  }
+
+  @Test
+  void defaultsToFilteringSecrets() {
+    var properties = Map.of("inbound.type", "io.camunda:connector:1");
+    var element =
+        new InboundConnectorElement(
+            properties,
+            new StandaloneMessageCorrelationPoint("", "", null, null),
+            new ProcessElementWithRuntimeData("process", 0, 0, "id", "<default>"));
+    var details =
+        (ValidInboundConnectorDetails)
+            InboundConnectorDetails.of(element.deduplicationId(List.of()), List.of(element));
+
+    var context =
+        (InboundConnectorContextImpl)
+            contextFactory.createContext(details, e -> {}, TestExecutable.class, entry -> {});
+    var result =
+        context
+            .getSecretHandler()
+            .replaceSecrets("secrets.UNDECLARED", new SecretContext("t", "p"));
+
+    assertThat(result).isEqualTo("secrets.UNDECLARED");
+  }
+}

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/inbound/InboundSecretFilterDefaultModeWiringTest.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/inbound/InboundSecretFilterDefaultModeWiringTest.java
@@ -38,9 +38,14 @@ import org.springframework.boot.test.context.SpringBootTest;
 /**
  * No {@code camunda.connector.secret-resolver.secret-filter.mode} property is set here, so this
  * exercises the {@code @Value} default on {@code springInboundConnectorContextFactory} itself —
- * unlike a direct call to that bean method, which bypasses Spring's property resolution entirely. A
- * typo in that default string turns inbound filtering off silently, and because every mode behaves
- * identically on the live inbound path, no integration test would catch it.
+ * unlike a direct call to that bean method, which bypasses Spring's property resolution entirely
+ * and so stays green however wrong that default string is.
+ *
+ * <p>What this catches is a default that resolves to {@code DISABLED}, which turns inbound
+ * filtering off silently. It cannot distinguish {@code LAX} from {@code STRICT}, because those two
+ * behave identically inbound — {@code
+ * InboundConnectorRuntimeConfigurationTest#springInboundConnectorContextFactory_filtersSecretsUnlessModeIsDisabled}
+ * pins that equivalence, and {@code DISABLED}'s difference from both, at the bean-method level.
  */
 @SpringBootTest(classes = TestConnectorRuntimeApplication.class)
 class InboundSecretFilterDefaultModeWiringTest {


### PR DESCRIPTION
## Summary

Manual backport of #8538 to `stable/8.9` — the automated backport bot failed to cherry-pick (7 files, 13 conflict hunks, two of them modify/delete), because this branch predates several main-only changes: `ADR-0007` and `InboundSecretReferenceBindingTest` don't exist here, `InboundConnectorContextImpl` takes no `CamundaClient`, and there is no `BindableProcessElement`, so main's correlation-scoped property binder has no call site to adapt.

Wires the existing `camunda.connector.secret-resolver.secret-filter.mode` property into the inbound path: the context's `SecretFilter` is now built from the secret names declared in its own elements' `zeebe:property` text, instead of always allowing every secret. `DISABLED` keeps the prior allow-all behavior; `LAX` and `STRICT` behave identically here since, unlike outbound, no remote lookup can fail.

The `STRICT` default matches the one #8521 already established on this branch, so inbound and outbound agree — no new default-mode decision is introduced here.

## Changes

3 production files, 85 lines. Both new constructors are additive overloads whose existing signatures delegate with `false`, so no existing call site changes.

- `InboundConnectorContextImpl`: `secretFilterEnabled` overload + a static `secretFilter(...)` helper feeding `super(...)`.
- `DefaultInboundConnectorContextFactory`: `secretFilterEnabled` overload, passed through to the context.
- `InboundConnectorRuntimeConfiguration`: reads the mode, maps it to a boolean.

## Two adaptations, both narrower than main rather than looser

**The allow-list is passed to `super(...)` at construction rather than derived per call.** On this branch `properties` is `final` and `updateConnectorDetails` does not rebuild it, so the filtered text cannot change after construction. The hot-swap and torn-read failure directions main had to close (rows 3 and 4 of #8538's risk ledger) are not representable here, and the allow-list and the text provably come from one read.

**Extraction uses this branch's `retrieveSecretKeysInInput`, not main's `retrieveLegacySecretKeysInInput`.** That split exists on main only because its `retrieveSecretKeysInInput` also matches the new `camunda.secrets.<name>` form (ledger row 13). That form does not exist anywhere on `stable/8.9` — zero occurrences in Java — so the method here is already legacy-only. It additionally filters bare matches nested inside a bracketed reference (`isNotNestedInAny`), which main no longer does, so this branch's allow-list is strictly narrower.

## Test plan

- [x] Four applicable cases from main's suite: a declared secret resolves, in brace syntax too, an undeclared name is left as a placeholder and never reaches the `SecretProvider`, and a name that only another secret's *value* spells is refused.
- [x] A control asserting allow-all still resolves an undeclared name when the filter is off.
- [x] `InboundSecretFilterDefaultModeWiringTest`: a `@SpringBootTest` with the property omitted, which is the only test that evaluates the `@Value` default string itself.
- [x] 626 tests green: `connector-runtime-core` (276), `connector-runtime-spring` (261), `spring-boot-starter-camunda-connectors` (89).
- [x] `spotless:apply` clean.

### Verified by falsification, not just green runs

#8538's ledger records that two of its tests initially passed vacuously, so a green test is not treated as evidence. Each protection was re-broken here and the named test observed to fail:

| Falsification | Observed |
|---|---|
| Filter forced off | `secretFilterEnabled_leavesASecretNamedOnlyByAnotherSecretsValue` fails — `expected "secrets.CHAINED"`, got the leaked value; `secretFilterEnabled_leavesAnUndeclaredSecret` errors with `Secret with name 'INJECTED' is not available`, i.e. the name reached the provider |
| `@Value` default flipped to `DISABLED` | `InboundSecretFilterDefaultModeWiringTest` fails with `Secret with name 'UNDECLARED' is not available`, while a direct bean-method call stays green — reproducing the asymmetry that motivated that test on main |

## Deliberately omitted

Main's hot-swap, sibling-element and new-form tests are structurally inapplicable on this branch for the reasons above, and are omitted with an in-file comment saying why. **This is the judgment call most worth a reviewer's eye.**

Relates to #7730
