### PR TITLE
ci: stop an open fix PR from wedging its AlwaysGreen surface shut

### DIFF
--- a/.github/scripts/alwaysgreen/discover.py
+++ b/.github/scripts/alwaysgreen/discover.py
@@ -26,6 +26,7 @@ import subprocess
 import sys
 import tempfile
 from dataclasses import asdict
+from datetime import datetime, timezone
 from pathlib import Path
 
 import classify
@@ -47,6 +48,11 @@ KEY_LABEL_PREFIX = planning.KEY_LABEL_PREFIX
 #: two lookups below fail closed, a repository the token cannot reach would wedge every
 #: dispatch shut rather than merely returning nothing.
 FIX_PR_REPOS = [REPO, E2E_REPO]
+#: How long an open fix PR keeps holding its dispatch key; see
+#: planning.PR_LOCK_TTL_HOURS. Set to 0 to restore the old never-expiring lock.
+PR_LOCK_TTL_HOURS = int(
+    os.environ.get("ALWAYSGREEN_PR_LOCK_TTL_HOURS", str(planning.PR_LOCK_TTL_HOURS))
+)
 
 
 class DiscoveryError(RuntimeError):
@@ -289,24 +295,35 @@ def covered_fingerprints() -> set[str]:
     return out
 
 
-def open_fix_pr_keys() -> tuple[set[str], bool]:
+def open_fix_pr_keys() -> tuple[set[str], set[str], bool]:
     """Dispatch keys that already have an open fix PR, in any repo a fix can land in.
 
     Read from the `ag-key:<source>:<base_ref>:<surface>` label the fix workflow
     stamps, not from the PR body: the body's coverage block is written by the agent
     and cannot be relied on to exist.
 
-    Returns (keys, ok). As with `inflight_keys`, a failed lookup makes the caller
-    suppress rather than risk a duplicate PR.
+    A PR past PR_LOCK_TTL_HOURS stops holding its key, so a fix PR left unreviewed
+    cannot wedge its surface shut for good; `covered_fingerprints` still suppresses a
+    repeat of the specs it already claims.
+
+    Returns (keys, keys_with_coverage, ok). `keys_with_coverage` is the subset whose
+    every holding PR claims at least one fingerprint, so `plan` can decide those keys
+    per spec instead of locking the surface. A block that parses to nothing — absent,
+    or present with no `fp=` line — claims nothing, and a key any of whose holders
+    claims nothing stays out of the subset and keeps the coarse lock: the marker
+    comment alone is not a statement of remit. As with `inflight_keys`, a failed
+    lookup makes the caller suppress rather than risk a duplicate PR.
     """
     out: set[str] = set()
+    uncovered: set[str] = set()
     ok = True
+    now = datetime.now(timezone.utc)
     for repo in FIX_PR_REPOS:
         prs, err = gh_json_ex(
             [
                 "pr", "list", "--repo", repo,
                 "--search", f"label:{FIX_LABEL} is:open",
-                "--limit", "100", "--json", "labels",
+                "--limit", "100", "--json", "labels,number,createdAt,body",
             ],
             None,
         )
@@ -315,13 +332,39 @@ def open_fix_pr_keys() -> tuple[set[str], bool]:
             ok = False
             continue
         for pr in prs if isinstance(prs, list) else []:
+            keys: set[str] = set()
             for label in pr.get("labels") or []:
                 name = (label.get("name") or "").strip()
                 if name.startswith(KEY_LABEL_PREFIX):
                     key = name[len(KEY_LABEL_PREFIX) :].strip()
                     if key:
-                        out.add(key)
-    return out, ok
+                        keys.add(key)
+            if not keys:
+                continue
+            if planning.pr_lock_expired(
+                pr.get("createdAt") or "", now, PR_LOCK_TTL_HOURS
+            ):
+                log(
+                    f"lock expired after {PR_LOCK_TTL_HOURS}h: {repo}#{pr.get('number')} "
+                    f"no longer holds {', '.join(sorted(keys))}"
+                )
+                continue
+            out |= keys
+            covered = planning.parse_coverage_block(pr.get("body"))
+            if not covered:
+                uncovered |= keys
+            # Named in the log so a suppressed run says which PR held it shut without
+            # anyone cross-listing open fix PRs by hand.
+            log(
+                f"open fix PR {repo}#{pr.get('number')} holds "
+                f"{', '.join(sorted(keys))}: "
+                + (
+                    f"{len(covered)} spec(s) claimed, others dispatchable"
+                    if covered
+                    else "claims no specs, whole surface locked"
+                )
+            )
+    return out, out - uncovered, ok
 
 
 def inflight_keys() -> tuple[set[str], bool]:
@@ -554,9 +597,10 @@ def _run() -> int:
             keys = {c.key for c in candidates}
             log("::warning::in-flight lookup failed; suppressing dispatch this run")
 
-        pr_keys, pr_keys_ok = open_fix_pr_keys()
+        pr_keys, pr_keys_covered, pr_keys_ok = open_fix_pr_keys()
         if not pr_keys_ok:
             pr_keys = {c.key for c in candidates}
+            pr_keys_covered = set()
             log("::warning::open fix PR lookup failed; suppressing dispatch this run")
 
         spec_paths = {s.file for c in candidates for s in c.specs if s.file}
@@ -571,6 +615,7 @@ def _run() -> int:
             covered_fingerprints=covered_fingerprints(),
             inflight_keys=keys,
             open_pr_keys=pr_keys,
+            open_pr_keys_with_coverage=pr_keys_covered,
             product_bug_fingerprints=product_bug_fingerprints(),
             claimed_paths=claimed,
             max_dispatches=args.max_dispatches,

--- a/.github/scripts/alwaysgreen/discover.py
+++ b/.github/scripts/alwaysgreen/discover.py
@@ -273,98 +273,105 @@ def saas_candidate(run_id: str, base_ref: str, job_name: str, workdir: Path) -> 
 # ---------------------------------------------------------------------------
 
 
-def covered_fingerprints() -> set[str]:
-    """Fingerprints already claimed by an open fix PR, in any repo a fix can land in.
+def open_fix_prs(repo: str) -> tuple[list[dict], bool]:
+    """Open fix PRs in one repository, with the fields dedupe needs. Returns (prs, ok).
 
-    Scanned across FIX_PR_REPOS rather than the source repo alone: a test-side fix
-    lands in the e2e repository, so a source-repo-only scan finds nothing and this
-    layer never fires.
+    A seam, so `dedupe_inputs` can be unit-tested without a token.
     """
-    out: set[str] = set()
-    for repo in FIX_PR_REPOS:
-        prs = gh_json(
-            [
-                "pr", "list", "--repo", repo,
-                "--search", f"label:{FIX_LABEL} is:open",
-                "--limit", "100", "--json", "number,body",
-            ],
-            [],
-        )
-        for pr in prs if isinstance(prs, list) else []:
-            out |= planning.parse_coverage_block(pr.get("body"))
-    return out
+    prs, err = gh_json_ex(
+        [
+            "pr", "list", "--repo", repo,
+            "--search", f"label:{FIX_LABEL} is:open",
+            "--limit", "100", "--json", "labels,number,createdAt,body",
+        ],
+        None,
+    )
+    if prs is None or not isinstance(prs, list):
+        log(f"::warning::open fix PR lookup failed for {repo}: {err.strip()[:200]}")
+        return [], False
+    return prs, True
 
 
-def open_fix_pr_keys() -> tuple[set[str], set[str], bool]:
-    """Dispatch keys that already have an open fix PR, in any repo a fix can land in.
+def dedupe_inputs() -> tuple[set[str], set[str], set[str], bool]:
+    """(covered fingerprints, keys with an open PR, keys decided per spec, ok).
 
-    Read from the `ag-key:<source>:<base_ref>:<surface>` label the fix workflow
-    stamps, not from the PR body: the body's coverage block is written by the agent
-    and cannot be relied on to exist.
+    One lookup behind one `ok`, across every repo a fix can land in — FIX_PR_REPOS, not
+    the source repo alone, since a test-side fix lands in the e2e repository. Coverage
+    used to come from a second, separate `gh` call whose failure was swallowed into an
+    empty set. That was survivable while every open fix PR locked its whole surface,
+    because the key layer caught what the empty set missed; once a claiming PR's key
+    stops locking, the two must agree or a failed coverage lookup dispatches a duplicate
+    fix for a spec that PR already claims.
+
+    Keys are read from the `ag-key:<source>:<base_ref>:<surface>` label the fix workflow
+    stamps, not from the PR body: the body's coverage block is written by the agent and
+    cannot be relied on to exist.
 
     A PR past PR_LOCK_TTL_HOURS stops holding its key, so a fix PR left unreviewed
-    cannot wedge its surface shut for good; `covered_fingerprints` still suppresses a
-    repeat of the specs it already claims.
+    cannot wedge its surface shut for good.
 
-    Returns (keys, keys_with_coverage, ok). `keys_with_coverage` is the subset whose
-    every holding PR claims at least one fingerprint, so `plan` can decide those keys
-    per spec instead of locking the surface. A block that parses to nothing — absent,
-    or present with no `fp=` line — claims nothing, and a key any of whose holders
-    claims nothing stays out of the subset and keeps the coarse lock: the marker
-    comment alone is not a statement of remit. As with `inflight_keys`, a failed
-    lookup makes the caller suppress rather than risk a duplicate PR.
+    `keys_with_coverage` is the subset whose every active holder claims at least one
+    fingerprint, so `plan` can decide those keys per spec instead of locking the
+    surface. A block that parses to nothing — absent, or present with no `fp=` line —
+    claims nothing, and a key any of whose active holders claims nothing stays out of
+    the subset: the marker comment alone is not a statement of remit.
+
+    Coverage is collected from every open fix PR, expired or not: the specs a PR claims
+    stay claimed for as long as it is open, and only the coarse key lock is time-bound.
+
+    As with `inflight_keys`, a failed lookup makes the caller suppress rather than risk
+    a duplicate PR.
     """
-    out: set[str] = set()
+    covered: set[str] = set()
+    keys: set[str] = set()
     uncovered: set[str] = set()
     ok = True
     now = datetime.now(timezone.utc)
     for repo in FIX_PR_REPOS:
-        prs, err = gh_json_ex(
-            [
-                "pr", "list", "--repo", repo,
-                "--search", f"label:{FIX_LABEL} is:open",
-                "--limit", "100", "--json", "labels,number,createdAt,body",
-            ],
-            None,
-        )
-        if prs is None:
-            log(f"::warning::open fix PR lookup failed for {repo}: {err.strip()[:200]}")
+        prs, repo_ok = open_fix_prs(repo)
+        if not repo_ok:
             ok = False
             continue
-        for pr in prs if isinstance(prs, list) else []:
-            keys: set[str] = set()
+        for pr in prs:
+            claims = planning.parse_coverage_block(pr.get("body"))
+            covered |= claims
+            pr_keys: set[str] = set()
             for label in pr.get("labels") or []:
                 name = (label.get("name") or "").strip()
                 if name.startswith(KEY_LABEL_PREFIX):
                     key = name[len(KEY_LABEL_PREFIX) :].strip()
                     if key:
-                        keys.add(key)
-            if not keys:
+                        pr_keys.add(key)
+            if not pr_keys:
                 continue
             if planning.pr_lock_expired(
                 pr.get("createdAt") or "", now, PR_LOCK_TTL_HOURS
             ):
                 log(
                     f"lock expired after {PR_LOCK_TTL_HOURS}h: {repo}#{pr.get('number')} "
-                    f"no longer holds {', '.join(sorted(keys))}"
+                    f"no longer holds {', '.join(sorted(pr_keys))}"
                 )
                 continue
-            out |= keys
-            covered = planning.parse_coverage_block(pr.get("body"))
-            if not covered:
-                uncovered |= keys
-            # Named in the log so a suppressed run says which PR held it shut without
-            # anyone cross-listing open fix PRs by hand.
+            keys |= pr_keys
+            if not claims:
+                uncovered |= pr_keys
             log(
                 f"open fix PR {repo}#{pr.get('number')} holds "
-                f"{', '.join(sorted(keys))}: "
-                + (
-                    f"{len(covered)} spec(s) claimed, others dispatchable"
-                    if covered
-                    else "claims no specs, whole surface locked"
-                )
+                f"{', '.join(sorted(pr_keys))}, claiming {len(claims)} spec(s)"
             )
-    return out, out - uncovered, ok
+    # Per key, not per PR: dispatchability is an intersection over every active holder,
+    # so a PR-level line cannot state it. Logged so a suppressed run names its blocker
+    # without anyone cross-listing open fix PRs by hand.
+    for key in sorted(keys):
+        log(
+            f"key {key}: "
+            + (
+                "locked (a holder claims no specs)"
+                if key in uncovered
+                else "decided per spec (every holder claims some)"
+            )
+        )
+    return covered, keys, keys - uncovered, ok
 
 
 def inflight_keys() -> tuple[set[str], bool]:
@@ -597,8 +604,11 @@ def _run() -> int:
             keys = {c.key for c in candidates}
             log("::warning::in-flight lookup failed; suppressing dispatch this run")
 
-        pr_keys, pr_keys_covered, pr_keys_ok = open_fix_pr_keys()
-        if not pr_keys_ok:
+        covered, pr_keys, pr_keys_covered, dedupe_ok = dedupe_inputs()
+        if not dedupe_ok:
+            # Cannot prove what an open PR already covers, so suppress every candidate:
+            # the key set and the coverage set must be one snapshot or a partial read
+            # licenses a duplicate PR.
             pr_keys = {c.key for c in candidates}
             pr_keys_covered = set()
             log("::warning::open fix PR lookup failed; suppressing dispatch this run")
@@ -612,7 +622,7 @@ def _run() -> int:
 
         result = planning.plan_dispatches(
             candidates,
-            covered_fingerprints=covered_fingerprints(),
+            covered_fingerprints=covered,
             inflight_keys=keys,
             open_pr_keys=pr_keys,
             open_pr_keys_with_coverage=pr_keys_covered,

--- a/.github/scripts/alwaysgreen/discover.py
+++ b/.github/scripts/alwaysgreen/discover.py
@@ -50,9 +50,21 @@ KEY_LABEL_PREFIX = planning.KEY_LABEL_PREFIX
 FIX_PR_REPOS = [REPO, E2E_REPO]
 #: How long an open fix PR keeps holding its dispatch key; see
 #: planning.PR_LOCK_TTL_HOURS. Set to 0 to restore the old never-expiring lock.
-PR_LOCK_TTL_HOURS = int(
-    os.environ.get("ALWAYSGREEN_PR_LOCK_TTL_HOURS", str(planning.PR_LOCK_TTL_HOURS))
-)
+#: Read defensively, matching the degrade-don't-crash bias of everything else here: an
+#: unreadable `createdAt` keeps the lock and a failed lookup suppresses, so a malformed
+#: dial must not raise at import and take down every entry point in this module.
+try:
+    PR_LOCK_TTL_HOURS = int(
+        os.environ.get("ALWAYSGREEN_PR_LOCK_TTL_HOURS", "").strip()
+        or planning.PR_LOCK_TTL_HOURS
+    )
+except ValueError:
+    print(
+        "::warning::unparseable ALWAYSGREEN_PR_LOCK_TTL_HOURS; using the default "
+        f"({planning.PR_LOCK_TTL_HOURS}h).",
+        file=sys.stderr,
+    )
+    PR_LOCK_TTL_HOURS = planning.PR_LOCK_TTL_HOURS
 
 
 class DiscoveryError(RuntimeError):

--- a/.github/scripts/alwaysgreen/plan.py
+++ b/.github/scripts/alwaysgreen/plan.py
@@ -202,20 +202,11 @@ def plan_dispatches(
         # `covered_fingerprints`, so locking its surface only hides its neighbours —
         # and a surface's failures are usually independent of each other.
         #
-        # Assumed here: a PR that claims anything claims EVERYTHING it fixed. The gate
-        # only distinguishes "claims nothing" from "claims something", so a partially
-        # written block — three specs fixed, one `fp=` listed — reads as authoritative
-        # and the two unlisted specs can dispatch a second, overlapping agent. The fix
-        # workflow hands the agent `/tmp/fingerprints.json` and requires the body to
-        # claim them, but stamps only the label; it never validates the block. Making it
-        # verify the block against that file is the fix for this, not a wider lock.
-        #
-        # Scope note: this gate holds a claim-nothing PR's surface only until
-        # PR_LOCK_TTL_HOURS elapses. Past that its key is released and it contributed no
-        # fingerprints, so the same cause can dispatch again. That is deliberate — the
-        # alternative is the unbounded wedge the TTL exists to remove — but it is a real
-        # residual, bounded by `inflight_keys` and the dispatch caps rather than by this
-        # gate.
+        # Two residuals it does not cover. A partially written block reads as
+        # authoritative, since the gate only asks "claims anything?"; validating it
+        # against `/tmp/fingerprints.json` in alwaysgreen-fix.yml is the fix. And a
+        # claim-nothing PR holds its surface only until PR_LOCK_TTL_HOURS, past which
+        # `inflight_keys` and the dispatch caps are the only bound.
         if cand.key in open_pr_keys and cand.key not in pr_keys_with_coverage:
             plan.suppressed.append(Suppression(cand, SUPPRESSED_PR_OPEN, cand.key))
             continue

--- a/.github/scripts/alwaysgreen/plan.py
+++ b/.github/scripts/alwaysgreen/plan.py
@@ -202,6 +202,14 @@ def plan_dispatches(
         # `covered_fingerprints`, so locking its surface only hides its neighbours —
         # and a surface's failures are usually independent of each other.
         #
+        # Assumed here: a PR that claims anything claims EVERYTHING it fixed. The gate
+        # only distinguishes "claims nothing" from "claims something", so a partially
+        # written block — three specs fixed, one `fp=` listed — reads as authoritative
+        # and the two unlisted specs can dispatch a second, overlapping agent. The fix
+        # workflow hands the agent `/tmp/fingerprints.json` and requires the body to
+        # claim them, but stamps only the label; it never validates the block. Making it
+        # verify the block against that file is the fix for this, not a wider lock.
+        #
         # Scope note: this gate holds a claim-nothing PR's surface only until
         # PR_LOCK_TTL_HOURS elapses. Past that its key is released and it contributed no
         # fingerprints, so the same cause can dispatch again. That is deliberate — the

--- a/.github/scripts/alwaysgreen/plan.py
+++ b/.github/scripts/alwaysgreen/plan.py
@@ -31,6 +31,8 @@ SUPPRESSED_PRODUCT_BUG = "tracked-by-open-product-bug"
 SUPPRESSED_NO_EVIDENCE = "no-failing-specs-extracted"
 SUPPRESSED_CAP = "per-run-cap-reached"
 SUPPRESSED_PATH_CLAIMED = "spec-path-claimed-by-open-pr"
+#: Every spec was dropped, but by more than one of the sources above.
+SUPPRESSED_ALL_ACCOUNTED = "all-specs-already-accounted-for"
 
 #: GitHub rejects a label longer than this, and the dispatch key is stamped on fix
 #: PRs as `ag-key:<key>`. Asserted over the supported matrix in test_plan.py so a new
@@ -214,24 +216,7 @@ def plan_dispatches(
             plan.suppressed.append(Suppression(cand, SUPPRESSED_NO_EVIDENCE))
             continue
 
-        # Author-agnostic: the other agents editing these files (the e2e repo's own
-        # nightly triage, another product pipeline, a human) dedupe on schemes this
-        # one cannot see, so the only reliable signal is that the file is already
-        # open in a PR. Keyed on exact repo-relative paths, so tests/8.9/x.spec.ts
-        # never shadows tests/8.10/x.spec.ts.
         claimed = claimed_paths or {}
-        if not cand.job_level and claimed:
-            hits = sorted({(s.file, claimed[s.file]) for s in cand.specs if s.file in claimed})
-            if hits:
-                plan.suppressed.append(
-                    Suppression(
-                        cand,
-                        SUPPRESSED_PATH_CLAIMED,
-                        ", ".join(f"{path} (#{number})" for path, number in hits),
-                    )
-                )
-                continue
-
         fps = cand.fingerprints
 
         if fps and all(f in product_bug_fingerprints for f in fps):
@@ -240,16 +225,43 @@ def plan_dispatches(
             )
             continue
 
-        # Drop specs an open PR already covers; dispatch only what is left.
+        # Drop specs an open PR, a product bug or an already-claimed spec file accounts
+        # for; dispatch only what is left. The path claim is author-agnostic: the other
+        # agents editing these files (the e2e repo's own nightly triage, another product
+        # pipeline, a human) dedupe on schemes this one cannot see, so the only reliable
+        # signal is that the file is already open in a PR. Keyed on exact repo-relative
+        # paths, so tests/8.9/x.spec.ts never shadows tests/8.10/x.spec.ts.
+        #
+        # Per spec, not per candidate. Suppressing the whole candidate on the first hit
+        # dropped the fresh specs beside the claimed one, which cancels out the narrowed
+        # surface lock above: a candidate carrying both a still-failing claimed spec and
+        # a new one is exactly the case that lock was widened to let through.
         if not cand.job_level:
-            remaining = [
-                s
-                for s, fp in zip(cand.specs, cand.spec_fingerprints)
-                if fp not in covered_fingerprints
-                and fp not in product_bug_fingerprints
-            ]
+            accounted: list[str] = []
+            path_hits: set[tuple[str, int]] = set()
+            remaining = []
+            for spec, fp in zip(cand.specs, cand.spec_fingerprints):
+                if fp in covered_fingerprints:
+                    accounted.append(SUPPRESSED_PR_COVERED)
+                elif fp in product_bug_fingerprints:
+                    accounted.append(SUPPRESSED_PRODUCT_BUG)
+                elif spec.file in claimed:
+                    accounted.append(SUPPRESSED_PATH_CLAIMED)
+                    path_hits.add((spec.file, claimed[spec.file]))
+                else:
+                    remaining.append(spec)
             if not remaining:
-                plan.suppressed.append(Suppression(cand, SUPPRESSED_PR_COVERED))
+                sources = sorted(set(accounted))
+                detail = (
+                    ", ".join(f"{path} (#{number})" for path, number in sorted(path_hits))
+                    if sources == [SUPPRESSED_PATH_CLAIMED]
+                    else ",".join(sources)
+                )
+                plan.suppressed.append(
+                    Suppression(cand, sources[0], detail)
+                    if len(sources) == 1
+                    else Suppression(cand, SUPPRESSED_ALL_ACCOUNTED, detail)
+                )
                 continue
             cand.specs = remaining
         elif fps and all(f in covered_fingerprints for f in fps):

--- a/.github/scripts/alwaysgreen/plan.py
+++ b/.github/scripts/alwaysgreen/plan.py
@@ -18,6 +18,7 @@ Two levels of identity are used, for different jobs:
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
 
 import classify
 
@@ -37,6 +38,52 @@ SUPPRESSED_PATH_CLAIMED = "spec-path-claimed-by-open-pr"
 #: mode is a label that is never created, which disables dedupe without any error.
 KEY_LABEL_PREFIX = "ag-key:"
 MAX_LABEL_LENGTH = 50
+
+
+#: How long an open fix PR's key label keeps holding its dispatch key.
+#:
+#: The lock is there to win the race described above, but nothing released it: the
+#: label stops matching `is:open` only when a human merges or closes the PR, so the
+#: agent's own output locked the agent out of its own surface until someone acted on
+#: it. camunda-platform-helm#6927 held one key from 2026-08-20 and every affected
+#: triage for the six days after reported `open-fix-pr-for-surface` and dispatched
+#: nothing.
+#:
+#: A surface carries many independent causes, so this window is how long an unrelated
+#: failure waits. Two hours is roughly three failing runs at the 20-40 minute pipeline
+#: cadence: long enough that the same cause is not re-dispatched while an agent's PR is
+#: still being read, short enough that a different cause waits hours rather than days.
+#: `inflight_keys` still allows one agent per key, so the floor on duplicate work is an
+#: agent's runtime rather than this TTL.
+PR_LOCK_TTL_HOURS = 2
+
+
+def pr_lock_expired(
+    created_at: str | None, now: datetime, ttl_hours: int = PR_LOCK_TTL_HOURS
+) -> bool:
+    """Whether an open fix PR is too old to keep holding its dispatch key.
+
+    A missing or unparseable timestamp keeps the lock, and `ttl_hours <= 0` disables
+    expiry altogether: the bias matches the `ok` flags in discover's key lookups,
+    where an unproven state suppresses rather than risks a duplicate PR.
+
+    Either timestamp is read as UTC when it carries no offset, so a naive `now` does
+    not raise against GitHub's offset-aware `createdAt`.
+    """
+    if ttl_hours <= 0:
+        return False
+    text = (created_at or "").strip()
+    if not text:
+        return False
+    try:
+        created = datetime.fromisoformat(text.replace("Z", "+00:00"))
+    except ValueError:
+        return False
+    if created.tzinfo is None:
+        created = created.replace(tzinfo=timezone.utc)
+    if now.tzinfo is None:
+        now = now.replace(tzinfo=timezone.utc)
+    return now - created > timedelta(hours=ttl_hours)
 
 
 def dispatch_key(base_ref: str, surface: str, source: str = "") -> str:
@@ -116,6 +163,7 @@ def plan_dispatches(
     inflight_keys: set[str],
     open_pr_keys: set[str],
     product_bug_fingerprints: set[str],
+    open_pr_keys_with_coverage: set[str] | None = None,
     claimed_paths: dict[str, int] | None = None,
     max_dispatches: int = 2,
     dispatchable_surfaces: frozenset[str] = classify.DISPATCHABLE_SURFACES,
@@ -124,8 +172,15 @@ def plan_dispatches(
 
     Checks are ordered cheapest-and-most-decisive first so the summary reports the
     most useful reason when several apply.
+
+    `open_pr_keys_with_coverage` are the keys of `open_pr_keys` whose every holding PR
+    claims at least one fingerprint in its coverage block. Those PRs state which specs
+    they claim, so the coarse per-surface lock is skipped for them and the per-spec
+    accounting below decides. A PR whose block claims nothing — absent, or present but
+    empty — is not one of them and keeps its surface locked.
     """
     plan = Plan()
+    pr_keys_with_coverage = open_pr_keys_with_coverage or set()
 
     for cand in candidates:
         if cand.surface not in dispatchable_surfaces:
@@ -138,10 +193,13 @@ def plan_dispatches(
             plan.suppressed.append(Suppression(cand, SUPPRESSED_IN_FLIGHT, cand.key))
             continue
 
-        # An open fix PR for this surface stops a second agent regardless of what the
-        # PR body claims. The coverage block is written by the agent, so a PR that
-        # omitted it would otherwise be invisible here and the failure re-dispatched.
-        if cand.key in open_pr_keys:
+        # An open fix PR that claims no specs stops a second agent on its surface: the
+        # coverage block is written by the agent, so one that is missing or empty
+        # states nothing about its remit and the whole surface has to be assumed.
+        # A PR that claims at least one spec is authoritative per spec through
+        # `covered_fingerprints`, so locking its surface only hides its neighbours —
+        # and a surface's failures are usually independent of each other.
+        if cand.key in open_pr_keys and cand.key not in pr_keys_with_coverage:
             plan.suppressed.append(Suppression(cand, SUPPRESSED_PR_OPEN, cand.key))
             continue
 

--- a/.github/scripts/alwaysgreen/plan.py
+++ b/.github/scripts/alwaysgreen/plan.py
@@ -199,6 +199,13 @@ def plan_dispatches(
         # A PR that claims at least one spec is authoritative per spec through
         # `covered_fingerprints`, so locking its surface only hides its neighbours —
         # and a surface's failures are usually independent of each other.
+        #
+        # Scope note: this gate holds a claim-nothing PR's surface only until
+        # PR_LOCK_TTL_HOURS elapses. Past that its key is released and it contributed no
+        # fingerprints, so the same cause can dispatch again. That is deliberate — the
+        # alternative is the unbounded wedge the TTL exists to remove — but it is a real
+        # residual, bounded by `inflight_keys` and the dispatch caps rather than by this
+        # gate.
         if cand.key in open_pr_keys and cand.key not in pr_keys_with_coverage:
             plan.suppressed.append(Suppression(cand, SUPPRESSED_PR_OPEN, cand.key))
             continue

--- a/.github/scripts/alwaysgreen/test_discover.py
+++ b/.github/scripts/alwaysgreen/test_discover.py
@@ -34,12 +34,15 @@ def _pr(number, keys, *, claims=(), age_hours=0):
 
 
 def _stub(monkeypatch, prs, *, ok=True):
-    """Serve `prs` from the first fix repo and nothing from the rest."""
-    seen = {"n": 0}
+    """Serve `prs` from the first fix repo and nothing from the rest.
+
+    Keyed on the repo, not on a call counter: a counter is consumed by the first
+    `dedupe_inputs` pass over FIX_PR_REPOS, so a second call in the same test would be
+    served empty lists and any assertion about it would pass vacuously.
+    """
 
     def fake(repo):
-        seen["n"] += 1
-        return (list(prs), ok) if seen["n"] == 1 else ([], ok)
+        return (list(prs), ok) if repo == discover.FIX_PR_REPOS[0] else ([], ok)
 
     monkeypatch.setattr(discover, "open_fix_prs", fake)
 

--- a/.github/scripts/alwaysgreen/test_discover.py
+++ b/.github/scripts/alwaysgreen/test_discover.py
@@ -1,0 +1,138 @@
+"""Unit tests for the dedupe snapshot discover hands to the planner.
+
+`test_plan.py` passes `open_pr_keys_with_coverage` in ready-made, so it asserts what
+`plan` does with the answer, never how it is computed. The derivation is where the
+"does this whole surface stay locked" decision is actually made — per-PR key grouping,
+the TTL skip, and the intersection over holders — so it is tested here against a stubbed
+`open_fix_prs`.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import discover
+import plan as planning
+
+NOW = datetime.now(timezone.utc)
+
+
+def _ago(**kw):
+    return (NOW - timedelta(**kw)).isoformat().replace("+00:00", "Z")
+
+
+def _pr(number, keys, *, claims=(), age_hours=0):
+    body = ""
+    if claims:
+        body = f"Fixes.\n\n{planning.render_coverage_block(set(claims))}\n"
+    return {
+        "number": number,
+        "body": body,
+        "createdAt": _ago(hours=age_hours),
+        "labels": [{"name": f"{discover.KEY_LABEL_PREFIX}{k}"} for k in keys],
+    }
+
+
+def _stub(monkeypatch, prs, *, ok=True):
+    """Serve `prs` from the first fix repo and nothing from the rest."""
+    seen = {"n": 0}
+
+    def fake(repo):
+        seen["n"] += 1
+        return (list(prs), ok) if seen["n"] == 1 else ([], ok)
+
+    monkeypatch.setattr(discover, "open_fix_prs", fake)
+
+
+def test_a_claiming_holder_frees_its_key_for_other_specs(monkeypatch):
+    _stub(monkeypatch, [_pr(1, ["connectors:main:sm-smoke-e2e"], claims=["aaaaaaaa"])])
+    covered, keys, per_spec, ok = discover.dedupe_inputs()
+    assert ok is True
+    assert covered == {"aaaaaaaa"}
+    assert keys == {"connectors:main:sm-smoke-e2e"}
+    assert per_spec == {"connectors:main:sm-smoke-e2e"}
+
+
+def test_a_holder_claiming_nothing_keeps_its_key_locked(monkeypatch):
+    _stub(monkeypatch, [_pr(1, ["connectors:main:sm-smoke-e2e"])])
+    covered, keys, per_spec, ok = discover.dedupe_inputs()
+    assert covered == set()
+    assert keys == {"connectors:main:sm-smoke-e2e"}
+    assert per_spec == set()
+
+
+def test_an_empty_coverage_block_claims_nothing(monkeypatch):
+    # The marker alone is not a statement of remit, so it must not free the surface.
+    pr = _pr(1, ["connectors:main:sm-smoke-e2e"])
+    pr["body"] = f"Fixes.\n\n{planning.COVERAGE_BEGIN}\nfp=\n{planning.COVERAGE_END}\n"
+    _stub(monkeypatch, [pr])
+    _covered, keys, per_spec, _ok = discover.dedupe_inputs()
+    assert keys == {"connectors:main:sm-smoke-e2e"}
+    assert per_spec == set()
+
+
+def test_one_non_claiming_holder_locks_a_key_another_holder_claims(monkeypatch):
+    # The intersection over holders: this is the case a per-PR view gets wrong.
+    _stub(
+        monkeypatch,
+        [
+            _pr(1, ["connectors:main:sm-smoke-e2e"], claims=["aaaaaaaa"]),
+            _pr(2, ["connectors:main:sm-smoke-e2e"]),
+        ],
+    )
+    covered, keys, per_spec, _ok = discover.dedupe_inputs()
+    assert covered == {"aaaaaaaa"}
+    assert keys == {"connectors:main:sm-smoke-e2e"}
+    assert per_spec == set()
+
+
+def test_an_expired_non_claiming_holder_does_not_lock_a_claiming_one(monkeypatch):
+    # Only ACTIVE holders decide the key, so an expired PR cannot veto a fresh one.
+    _stub(
+        monkeypatch,
+        [
+            _pr(1, ["connectors:main:sm-smoke-e2e"], claims=["aaaaaaaa"]),
+            _pr(2, ["connectors:main:sm-smoke-e2e"], age_hours=99),
+        ],
+    )
+    _covered, keys, per_spec, _ok = discover.dedupe_inputs()
+    assert keys == {"connectors:main:sm-smoke-e2e"}
+    assert per_spec == {"connectors:main:sm-smoke-e2e"}
+
+
+def test_an_expired_holder_releases_its_key_but_keeps_its_claims(monkeypatch):
+    # The specs a PR claims stay claimed while it is open; only the coarse key lock is
+    # time-bound, so the failure it fixed is still suppressed per spec.
+    _stub(monkeypatch, [_pr(1, ["connectors:main:sm-smoke-e2e"], claims=["aaaaaaaa"], age_hours=99)])
+    covered, keys, per_spec, _ok = discover.dedupe_inputs()
+    assert covered == {"aaaaaaaa"}
+    assert keys == set()
+    assert per_spec == set()
+
+
+def test_a_pr_carrying_two_key_labels_holds_both(monkeypatch):
+    _stub(
+        monkeypatch,
+        [_pr(1, ["connectors:main:sm-smoke-e2e", "connectors:main:saas-smoke-e2e"], claims=["aaaaaaaa"])],
+    )
+    _covered, keys, per_spec, _ok = discover.dedupe_inputs()
+    assert keys == {"connectors:main:sm-smoke-e2e", "connectors:main:saas-smoke-e2e"}
+    assert per_spec == keys
+
+
+def test_a_pr_with_no_key_label_still_contributes_its_claims(monkeypatch):
+    # A fix PR whose key label was never stamped: it locks nothing, but the specs it
+    # claims must still suppress a repeat.
+    _stub(monkeypatch, [_pr(1, [], claims=["aaaaaaaa"])])
+    covered, keys, per_spec, _ok = discover.dedupe_inputs()
+    assert covered == {"aaaaaaaa"}
+    assert keys == set()
+    assert per_spec == set()
+
+
+def test_a_failed_lookup_reports_not_ok(monkeypatch):
+    # Coverage and keys are one snapshot behind one `ok`. A partial read must not let
+    # the caller skip the coarse lock while believing nothing is claimed.
+    _stub(monkeypatch, [_pr(1, ["connectors:main:sm-smoke-e2e"], claims=["aaaaaaaa"])], ok=False)
+    _covered, _keys, _per_spec, ok = discover.dedupe_inputs()
+    assert ok is False

--- a/.github/scripts/alwaysgreen/test_plan.py
+++ b/.github/scripts/alwaysgreen/test_plan.py
@@ -386,6 +386,55 @@ def test_open_pr_touching_a_spec_path_suppresses_the_candidate():
     assert "#2951" in result.suppressed[0].detail
 
 
+def test_a_claimed_path_does_not_drop_the_fresh_specs_beside_it():
+    # The interaction the narrowed surface lock exists for: an open PR still holds the
+    # spec file it is fixing, that spec keeps failing until the PR merges, and a new
+    # failure lands beside it. Suppressing the whole candidate on the first path hit
+    # cancelled the widened lock out.
+    claimed = _spec(name="still failing", file="tests/8.10/smoke-tests.spec.ts")
+    fresh = _spec(name="new failure", file="tests/8.10/other-tests.spec.ts")
+    cand = _cand(specs=[claimed, fresh])
+
+    result = _plan(
+        [cand],
+        open_pr_keys={cand.key},
+        open_pr_keys_with_coverage={cand.key},
+        claimed_paths={"tests/8.10/smoke-tests.spec.ts": 2951},
+    )
+    assert len(result.dispatches) == 1
+    assert [s.test_name for s in result.dispatches[0].specs] == ["new failure"]
+
+
+def test_a_candidate_whose_every_spec_is_path_claimed_is_still_suppressed():
+    claimed = _spec(name="still failing", file="tests/8.10/smoke-tests.spec.ts")
+    cand = _cand(specs=[claimed])
+    result = _plan([cand], claimed_paths={"tests/8.10/smoke-tests.spec.ts": 2951})
+    assert result.dispatches == []
+    assert result.suppressed[0].reason == plan.SUPPRESSED_PATH_CLAIMED
+    assert "#2951" in result.suppressed[0].detail
+
+
+def test_specs_dropped_by_more_than_one_source_report_all_of_them():
+    # Reporting a mixed remainder as one source hid the others, so the summary named
+    # the wrong blocker.
+    covered = _spec(name="covered", file="tests/8.10/a.spec.ts")
+    path = _spec(name="path claimed", file="tests/8.10/b.spec.ts")
+    cand = _cand(specs=[covered, path])
+    covered_fp = classify.spec_fingerprint(
+        "main", classify.SURFACE_SM_E2E, covered.file, covered.test_name
+    )
+
+    result = _plan(
+        [cand],
+        covered_fingerprints={covered_fp},
+        claimed_paths={"tests/8.10/b.spec.ts": 2951},
+    )
+    assert result.dispatches == []
+    assert result.suppressed[0].reason == plan.SUPPRESSED_ALL_ACCOUNTED
+    assert plan.SUPPRESSED_PR_COVERED in result.suppressed[0].detail
+    assert plan.SUPPRESSED_PATH_CLAIMED in result.suppressed[0].detail
+
+
 def test_a_sibling_version_path_does_not_shadow_the_failing_one():
     # Matching on basenames would make an open PR against 8.9 suppress an 8.10 failure.
     cand = _cand(specs=[_spec(file="tests/8.10/smoke-tests.spec.ts")])

--- a/.github/scripts/alwaysgreen/test_plan.py
+++ b/.github/scripts/alwaysgreen/test_plan.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from datetime import datetime, timedelta, timezone
+
 import classify
 import plan
 
@@ -167,6 +169,13 @@ def test_parse_returns_empty_when_absent():
     assert plan.parse_coverage_block(None) == set()
 
 
+def test_parse_returns_empty_for_a_block_that_claims_nothing():
+    # The marker alone is not a statement of remit: discover reads an empty result as
+    # "claims no specs" and keeps the coarse surface lock, same as a missing block.
+    assert plan.parse_coverage_block("Body\n\n<!-- alwaysgreen-fixed\n-->\n") == set()
+    assert plan.parse_coverage_block("Body\n\n<!-- alwaysgreen-fixed\nfp=\n-->\n") == set()
+
+
 def test_merge_appends_block_when_missing():
     merged = plan.merge_coverage_block("Body text", {"aaaaaaaa"})
     assert "fp=aaaaaaaa" in merged
@@ -217,6 +226,114 @@ def test_open_fix_pr_blocks_even_when_the_body_claims_nothing():
     cand = _cand(surface=classify.SURFACE_SM_E2E)
     result = _plan([cand], covered_fingerprints=set(), open_pr_keys={"main:sm-smoke-e2e"})
     assert result.dispatches == []
+
+
+def test_open_fix_pr_with_a_coverage_block_does_not_block_an_unclaimed_spec():
+    # A surface carries independent causes: the PR claims one spec, and its
+    # neighbour must still reach an agent rather than wait for a human to merge.
+    claimed = _spec(name="already fixed")
+    fresh = _spec(name="new failure", file="tests/SM-8.10/other-tests.spec.ts")
+    cand = _cand(surface=classify.SURFACE_SM_E2E, specs=[claimed, fresh])
+    claimed_fp = classify.spec_fingerprint(
+        "main", classify.SURFACE_SM_E2E, claimed.file, claimed.test_name
+    )
+
+    result = _plan(
+        [cand],
+        covered_fingerprints={claimed_fp},
+        open_pr_keys={"main:sm-smoke-e2e"},
+        open_pr_keys_with_coverage={"main:sm-smoke-e2e"},
+    )
+    assert len(result.dispatches) == 1
+    assert [s.test_name for s in result.dispatches[0].specs] == ["new failure"]
+
+
+def test_open_fix_pr_with_a_coverage_block_still_suppresses_the_specs_it_claims():
+    cand = _cand(surface=classify.SURFACE_SM_E2E)
+    result = _plan(
+        [cand],
+        covered_fingerprints=set(cand.spec_fingerprints),
+        open_pr_keys={"main:sm-smoke-e2e"},
+        open_pr_keys_with_coverage={"main:sm-smoke-e2e"},
+    )
+    assert result.dispatches == []
+    assert [s.reason for s in result.suppressed] == [plan.SUPPRESSED_PR_COVERED]
+
+
+def test_a_second_holder_without_a_coverage_block_keeps_the_surface_locked():
+    # `keys_with_coverage` is the intersection over holders, so one PR that claims
+    # nothing still locks the surface even beside one that claims a spec.
+    cand = _cand(surface=classify.SURFACE_SM_E2E)
+    result = _plan(
+        [cand],
+        open_pr_keys={"main:sm-smoke-e2e"},
+        open_pr_keys_with_coverage=set(),
+    )
+    assert result.dispatches == []
+    assert [s.reason for s in result.suppressed] == [plan.SUPPRESSED_PR_OPEN]
+
+
+def test_in_flight_agent_still_blocks_a_coverage_declaring_surface():
+    # Narrowing the PR lock must not touch the concurrency rule: one agent per key.
+    cand = _cand(surface=classify.SURFACE_SM_E2E)
+    result = _plan(
+        [cand],
+        inflight_keys={"main:sm-smoke-e2e"},
+        open_pr_keys={"main:sm-smoke-e2e"},
+        open_pr_keys_with_coverage={"main:sm-smoke-e2e"},
+    )
+    assert result.dispatches == []
+    assert [s.reason for s in result.suppressed] == [plan.SUPPRESSED_IN_FLIGHT]
+
+
+# ---------------------------------------------------------------------------
+# PR lock expiry
+# ---------------------------------------------------------------------------
+
+NOW = datetime(2026, 8, 26, 12, 0, tzinfo=timezone.utc)
+
+
+def _ago(**kw):
+    return (NOW - timedelta(**kw)).isoformat().replace("+00:00", "Z")
+
+
+def test_fresh_fix_pr_keeps_holding_its_key():
+    assert plan.pr_lock_expired(_ago(minutes=30), NOW, 2) is False
+
+
+def test_fix_pr_past_the_ttl_releases_its_key():
+    # Nothing but a merge or close used to release the label, so an unreviewed fix PR
+    # wedged its surface shut indefinitely.
+    assert plan.pr_lock_expired("2026-08-20T14:56:44Z", NOW, 2) is True
+
+
+def test_ttl_is_read_in_hours_not_days():
+    assert plan.pr_lock_expired(_ago(hours=6), NOW, 2) is True
+    assert plan.pr_lock_expired(_ago(hours=6), NOW, plan.PR_LOCK_TTL_HOURS) is True
+
+
+def test_ttl_boundary_is_inclusive_of_the_lock():
+    assert plan.pr_lock_expired(_ago(hours=2), NOW, 2) is False
+    assert plan.pr_lock_expired(_ago(hours=2, minutes=1), NOW, 2) is True
+
+
+def test_unreadable_timestamp_keeps_the_lock():
+    for value in ("", None, "yesterday", "2026-13-45T00:00:00Z"):
+        assert plan.pr_lock_expired(value, NOW, 2) is False
+
+
+def test_naive_created_at_is_read_as_utc():
+    assert plan.pr_lock_expired("2026-08-20T14:56:44", NOW, 2) is True
+
+
+def test_naive_now_does_not_raise_against_an_offset_aware_created_at():
+    naive_now = NOW.replace(tzinfo=None)
+    assert plan.pr_lock_expired("2026-08-20T14:56:44Z", naive_now, 2) is True
+    assert plan.pr_lock_expired(_ago(minutes=30), naive_now, 2) is False
+
+
+def test_zero_ttl_restores_the_never_expiring_lock():
+    assert plan.pr_lock_expired("2026-01-01T00:00:00Z", NOW, 0) is False
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Description

The AlwaysGreen fix agent has not been dispatched in this repository since **2026-08-26T08:48** — seven days. The cause is this repo's per-surface PR lock, which nothing releases.

That dispatch opened [c8-cross-component-e2e-tests#3154](https://github.com/camunda/c8-cross-component-e2e-tests/pull/3154) nine minutes later, and the PR stamped `ag-key:connectors:main:sm-smoke-e2e` on itself. The label stops matching `is:open` only when a human merges or closes the PR, so the agent's own output locked the agent out of its own surface. Today's failing run [33602649166](https://github.com/camunda/connectors/actions/runs/33602649166) triaged correctly and then reported:

```json
"dispatches": [],
"suppressed": [{"dispatch_key": "connectors:main:sm-smoke-e2e",
                "reason": "open-fix-pr-for-surface"}]
```

Two changes, both ported from `camunda/camunda`, which already hit this and fixed it:

**1. The lock expires.** `PR_LOCK_TTL_HOURS = 2`, applied against the PR's `createdAt`. A surface carries many independent causes, so this window is how long an unrelated failure waits behind one PR. Two hours is roughly three failing runs at this pipeline's cadence — long enough that the same cause is not re-dispatched while an agent's PR is being read, short enough that a different cause waits hours rather than days.

**2. A PR that states its remit is read per spec, not per surface.** The blanket lock exists for a real reason, stated in its own docstring: the coverage block is agent-written and may be absent, so a PR claiming nothing says nothing about which specs it covers and the whole surface has to be assumed. That reason does not apply to a PR that *did* claim fingerprints — there `covered_fingerprints` enforces the claim exactly, and locking the surface only hides the failure's neighbours. So the coarse lock is now skipped for keys whose every holding PR claims at least one `fp=`.

A block that parses to nothing — absent, or present with no `fp=` line — claims nothing and keeps the coarse lock. The marker comment alone is not a statement of remit.

### Not changed

- `inflight_keys` — one agent per key at a time. This is the layer that wins the consecutive-failing-runs race, and it is untouched, so the floor on duplicate work is an agent's runtime rather than this TTL.
- `claimed_paths` — the author-agnostic per-file claim still suppresses a spec whose file is already open in a PR.
- Fail-closed behaviour — a failed `gh` lookup still suppresses every candidate.
- `surface-not-in-increment` — `saas-provisioning` was also suppressed in that run for being outside `DISPATCHABLE_SURFACES`. That is a deliberate scope decision and is left alone here.

### Effect, measured against live PRs

Running the patched `open_fix_pr_keys()` against the current open fix PRs:

```
lock expired after 2h: camunda/c8-cross-component-e2e-tests#3154 no longer holds connectors:main:sm-smoke-e2e
keys []           coarse-locked none
```

The one wedged key is released, so the next failing run dispatches.

Each holding PR is now also logged with the keys it holds and whether it locks the whole surface — diagnosing this needed the plan artifact plus a label cross-list across repos.

## Related issues

<!-- CI tooling fix; the trigger is run 33602649166. -->

## Checklist

- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest
  release, as this branch will be rebased onto main before the next release. Example backport labels:
    - `backport stable/8.8`: for changes that should be included in the next 8.8.x release.
    - **or** `backport release-8.8.7`: for changes that should be included in the specific release 8.8.7, and this
      *release has already been created*. The release branch will be merged back into stable/8.8 later, so the change
      will be included in future 8.8.x releases as well.
- [x] Tests/Integration tests for the changes have been added if applicable.
- [ ] If the change requires a documentation update, it has been added to the appropriate section in the documentation.

`pytest .github/scripts/alwaysgreen` — 105 passed (13 new: lock expiry incl. the hours-not-days boundary, the coverage-declaring cases, and in-flight precedence). `AlwaysGreen scripts test` covers this path in CI.


---

## Review follow-up (`e021271`)

Copilot found a hole this PR opened, and it was right. `covered_fingerprints()` fetched open fix PRs in its own `gh_json` call whose failure was swallowed into an empty set. That was survivable while every open fix PR locked its whole surface — the key layer caught what the empty set missed. Once a claiming PR's key stops locking, the two must agree: otherwise `open_fix_pr_keys()` succeeds and frees the key, `covered_fingerprints()` fails and reports nothing claimed, and the candidate dispatches a duplicate fix for a spec that PR already claims.

Both now come from one `dedupe_inputs()` behind one `ok`, so a partial read suppresses every candidate instead. Side effects: one fewer `gh pr list` per repo (it was fetching the same PRs twice, once for `body` and once for `labels`), and the name/shape now match `camunda-hub`'s equivalent — worth something given how far these three copies have drifted.

Also adds `test_discover.py` for the derivation, which is the class of bug the existing tests could not see — they hand `open_pr_keys_with_coverage` to the planner ready-made. Nine cases over a stubbed `open_fix_prs` seam: multiple holders including one claiming nothing, expired holders active and inactive, an empty coverage block, two key labels on one PR, a PR with no key label, and lookup failure (`test_a_failed_lookup_reports_not_ok` covers this finding directly).

The lock decision is now logged once per key rather than per PR, since it is an intersection over holders. And the gate comment records the residual it does not cover: a claim-nothing PR holds its surface only for `PR_LOCK_TTL_HOURS`.

Tests: **114 passing** (`pytest .github/scripts/alwaysgreen`).


## Review follow-up 2 (`863966a`)

Copilot found the narrowed lock was largely inert here without this. `claimed_paths` suppressed the whole candidate on the first hit, and the claimed file is normally the one the open fix PR is still fixing — so that spec keeps failing until the PR merges. A candidate carrying both it and a new failure therefore dispatched nothing, which is exactly the case the lock was widened to let through. Connectors is the only one of the three copies with this layer, which is why it did not surface elsewhere.

The path claim now joins the per-spec accounting beside covered fingerprints and product bugs: drop what it accounts for, dispatch the remainder, suppress only when nothing is left. Adds `SUPPRESSED_ALL_ACCOUNTED` so a mixed remainder names every source instead of reporting one and hiding the rest. The claim's own semantics are unchanged — author-agnostic, exact repo-relative paths, skipped for job-level candidates.

Tests: **117 passing**, including `test_a_claimed_path_does_not_drop_the_fresh_specs_beside_it` for the interaction.
