### PR TITLE
ci: pin the 8.9 merge-queue helm test to the 8.9 chart

### DIFF
--- a/.github/workflows/INTEGRATION_TEST.yml
+++ b/.github/workflows/INTEGRATION_TEST.yml
@@ -25,6 +25,10 @@ on:
         required: false
         type: string
         default: 'keyco'
+      helm-dir:
+        description: 'The camunda-platform-helm/charts directory of the Helm chart to test against. If not provided, the directory is determined based on the ref this workflow was triggered on (see helm-git-refs.json)'
+        required: false
+        type: string
   workflow_dispatch:
     inputs:
       image-source:

--- a/.github/workflows/MERGE_QUEUE_HELM_TEST.yaml
+++ b/.github/workflows/MERGE_QUEUE_HELM_TEST.yaml
@@ -162,8 +162,7 @@ jobs:
     with:
       image-source: artifactory
       connectors-version: ${{ needs.build-image.outputs.connectors-version }}
-      release-branch: main
-      helm-dir: camunda-platform-8.9
+      release-branch: stable/8.9
       # Route to the dedicated AlwaysGreen GKE namespace/node pool that finance tracks for cost.
       scenario: alwaysgreen
       shortname: agrn

--- a/.github/workflows/MERGE_QUEUE_HELM_TEST.yaml
+++ b/.github/workflows/MERGE_QUEUE_HELM_TEST.yaml
@@ -163,6 +163,7 @@ jobs:
       image-source: artifactory
       connectors-version: ${{ needs.build-image.outputs.connectors-version }}
       release-branch: main
+      helm-dir: camunda-platform-8.9
       # Route to the dedicated AlwaysGreen GKE namespace/node pool that finance tracks for cost.
       scenario: alwaysgreen
       shortname: agrn

--- a/.github/workflows/MERGE_QUEUE_HELM_TEST.yaml
+++ b/.github/workflows/MERGE_QUEUE_HELM_TEST.yaml
@@ -163,6 +163,7 @@ jobs:
       image-source: artifactory
       connectors-version: ${{ needs.build-image.outputs.connectors-version }}
       release-branch: stable/8.9
+      helm-dir: camunda-platform-8.9
       # Route to the dedicated AlwaysGreen GKE namespace/node pool that finance tracks for cost.
       scenario: alwaysgreen
       shortname: agrn


### PR DESCRIPTION
## Description

`stable/8.9` merge-queue Helm tests have been deploying the **8.10** chart, not 8.9.

`MERGE_QUEUE_HELM_TEST.yaml` passed a hardcoded `release-branch: main`, and
`INTEGRATION_TEST.yml` resolves the chart dir as:

```bash
LOOKUP_KEY="${{ inputs.release-branch || github.ref_name }}"
helm_dir_from_map=$(jq -r ".[\"${LOOKUP_KEY}\"]" .github/workflows/helm-git-refs.json)
```

`release-branch` wins over `github.ref_name`, so the key was always `main` — and this branch's
`helm-git-refs.json` maps `"main": "camunda-platform-8.10"`. The `"stable/8.9": "camunda-platform-8.9"`
entry right next to it was never consulted.

Observed on run [33633136074](https://github.com/camunda/connectors/actions/runs/33633136074) (push on `stable/8.9`):

```
github.ref_name: stable/8.9
Initial lookup key: 'main'
Final lookup key: 'main'
Found helm-dir: 'camunda-platform-8.10'
```

Effect: 8.9 connectors validated against the 8.10 chart and 8.10 component images. False signal in
both directions — 8.9 regressions can pass, and 8.10-only breakage surfaces as an 8.9 failure.

## What's in this PR

1. `INTEGRATION_TEST.yml` — declare `helm-dir` under `on.workflow_call.inputs`. It existed only
   under `workflow_dispatch` on this branch, so a reusable-workflow caller passing it was rejected
   before the job started. The declaration mirrors the one `stable/8.8` already carries.
2. `MERGE_QUEUE_HELM_TEST.yaml` — pass `helm-dir: camunda-platform-8.9`, and point
   `release-branch` at `stable/8.9` instead of `main`.

Both are set deliberately, so either path lands on the right chart: `helm-dir` short-circuits the
lookup entirely (`>>> Branch taken: EXPLICIT HELM-DIR PROVIDED`), and if it is ever dropped the
`release-branch` fallback now resolves `stable/8.9` → `camunda-platform-8.9` rather than silently
borrowing `main`'s mapping.

Keeping an explicit key also matters for `merge_group` runs: there `github.ref_name` is
`gh-readonly-queue/<base>/pr-N-<sha>`, which is not a key in `helm-git-refs.json`, so relying on the
ref alone on this branch would fail the lookup.

`release-branch` is read only for this lookup (plus two `echo`s) — nothing else on this branch
depends on its value.

## Verification

- `helm-git-refs.json` on this branch: `"stable/8.9": "camunda-platform-8.9"` ✅
- `camunda-platform-8.9` exists in `camunda-platform-helm/charts/` ✅
- Unaffected callers: `DEPLOY_SNAPSHOTS.yaml` and `RELEASE.yaml` pass `release-branch` dynamically
  and already resolved correctly — run [33633136107](https://github.com/camunda/connectors/actions/runs/33633136107) shows
  `Initial lookup key: 'stable/8.9'` → `Found helm-dir: 'camunda-platform-8.9'`.

A follow-up on `main` (#8608) teaches `INTEGRATION_TEST.yml` to strip the merge-queue prefix so the
`release-branch` hardcode can be dropped repo-wide; this PR is the branch-local fix.

## Related issues

closes #

## Checklist

- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest
  release, as this branch will be rebased onto main before the next release. Example backport labels:
    - `backport stable/8.8`: for changes that should be included in the next 8.8.x release.
    - **or** `backport release-8.8.7`: for changes that should be included in the specific release 8.8.7, and this
      *release has already been created*. The release branch will be merged back into stable/8.8 later, so the change
      will be included in future 8.8.x releases as well.
- [ ] Tests/Integration tests for the changes have been added if applicable.
- [ ] If the change requires a documentation update, it has been added to the appropriate section in the documentation.
