### PR TITLE
ci: resolve the helm chart dir from the real ref on merge-queue runs

### DIFF
--- a/.github/workflows/INTEGRATION_TEST.yml
+++ b/.github/workflows/INTEGRATION_TEST.yml
@@ -119,6 +119,13 @@ jobs:
             LOOKUP_KEY="${{ inputs.release-branch || github.ref_name }}"
             echo "Initial lookup key: '${LOOKUP_KEY}'"
             
+            # Merge-queue refs carry the real base branch as everything between the
+            # gh-readonly-queue/ prefix and the trailing /pr-<number>-<sha> segment.
+            if [[ "$LOOKUP_KEY" =~ ^gh-readonly-queue/(.+)/pr-[0-9]+ ]]; then
+              LOOKUP_KEY="${BASH_REMATCH[1]}"
+              echo "Detected merge-queue ref, transformed to '${LOOKUP_KEY}'"
+            fi
+            
             # Transform release-x.y.z branches to their base branch for lookup
             # Format: release-x.y.z(-alphaN)?(-rcM)?
             if [[ "$LOOKUP_KEY" =~ ^release-([0-9]+)\.([0-9]+)\.[0-9]+ ]]; then

--- a/.github/workflows/INTEGRATION_TEST.yml
+++ b/.github/workflows/INTEGRATION_TEST.yml
@@ -12,9 +12,10 @@ on:
         required: true
         type: string
       release-branch:
-        description: 'Connectors release branch containing code to test. Used to determine the Helm chart directory via helm-git-refs.json'
-        required: true
+        description: 'Connectors release branch containing code to test. Used to determine the Helm chart directory via helm-git-refs.json. Defaults to the calling ref when omitted.'
+        required: false
         type: string
+        default: ''
       scenario:
         description: 'Helm test scenario passed through to camunda-platform-helm test-integration-template (e.g. keycloak-original, alwaysgreen)'
         required: false

--- a/.github/workflows/MERGE_QUEUE_HELM_TEST.yaml
+++ b/.github/workflows/MERGE_QUEUE_HELM_TEST.yaml
@@ -164,7 +164,6 @@ jobs:
     with:
       image-source: artifactory
       connectors-version: ${{ needs.build-image.outputs.connectors-version }}
-      release-branch: main
       # Route to the dedicated AlwaysGreen GKE namespace/node pool that finance tracks for cost.
       scenario: alwaysgreen
       shortname: agrn


### PR DESCRIPTION
## Description

Follow-up to #8606, which fixed the symptom on `stable/8.9`. This removes the cause.

### The problem

`INTEGRATION_TEST.yml` resolves the chart dir from a branch→dir map:

```bash
LOOKUP_KEY="${{ inputs.release-branch || github.ref_name }}"
helm_dir_from_map=$(jq -r ".[\"${LOOKUP_KEY}\"]" .github/workflows/helm-git-refs.json)
```

On a `merge_group` run, `github.ref_name` is `gh-readonly-queue/<base>/pr-<n>-<sha>`, which is not
a key in `helm-git-refs.json` — the lookup would return `null` and the step would exit 1. Callers
worked around that by passing an explicit `release-branch`, and `MERGE_QUEUE_HELM_TEST.yaml`
hardcoded `release-branch: main`.

Because `release-branch` wins over `github.ref_name`, that hardcode made **every** branch carrying
this workflow look up `"main"` rather than its own ref. `main` and `stable/8.10` were unaffected
only because their maps happen to point `"main"` at `camunda-platform-8.10`; `stable/8.9` silently
tested against the 8.10 chart, and `stable/8.8` had to add an explicit `helm-dir` to escape it.

### The change

1. `INTEGRATION_TEST.yml` — strip the merge-queue prefix down to the base branch before the lookup,
   alongside the existing `release-x.y.z` transform.
2. `MERGE_QUEUE_HELM_TEST.yaml` — drop the now-unnecessary `release-branch: main`, so the real ref
   is used.

`release-branch` remains an input and is untouched for the other two callers
(`DEPLOY_SNAPSHOTS.yaml`, `RELEASE.yaml`), which pass it dynamically and already resolve correctly.
It is only read for this lookup — no other behaviour depends on it.

### Verification

The transform chain, exercised under `bash` against real ref shapes:

| `github.ref_name` | lookup key | `main`'s map |
|---|---|---|
| `gh-readonly-queue/main/pr-8606-abc123` | `main` | `camunda-platform-8.10` |
| `gh-readonly-queue/stable/8.10/pr-8549-6d15e45…` | `stable/8.10` | `camunda-platform-8.10` |
| `gh-readonly-queue/stable/8.9/pr-1-a` | `stable/8.9` | `camunda-platform-8.9` |
| `stable/8.9` | `stable/8.9` | `camunda-platform-8.9` |
| `main` | `main` | `camunda-platform-8.10` |
| `release-8.10.0-rc1` | `stable/8.10` | `camunda-platform-8.10` |
| `release-8.11.0-alpha2` | `main` | `camunda-platform-8.10` |

Every resolved key exists in `helm-git-refs.json`, and the greedy `(.+)/pr-[0-9]+` capture handles
base branches that themselves contain a slash (`stable/8.10`).

Behaviour on this branch is unchanged (`main` → `camunda-platform-8.10` either way) — the fix is
that it now arrives there via the actual ref instead of a hardcoded string.

Backporting this to `stable/8.10` and `stable/8.9` would let the explicit `helm-dir` pins on
`stable/8.9` (#8606) and `stable/8.8` be dropped, but that is a separate call — leaving the
backport labels to the reviewer.

## Related issues

closes #

## Checklist

- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest
  release, as this branch will be rebased onto main before the next release. Example backport labels:
    - `backport stable/8.8`: for changes that should be included in the next 8.8.x release.
    - **or** `backport release-8.8.7`: for changes that should be included in the specific release 8.8.7, and this
      *release has already been created*. The release branch will be merged back into stable/8.8 later, so the change
      will be included in future 8.8.x releases as well.
- [ ] Tests/Integration tests for the changes have been added if applicable.
- [ ] If the change requires a documentation update, it has been added to the appropriate section in the documentation.
