### PR TITLE
feat(runtime): extend secret filtering to inbound connectors

### DIFF
--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/DefaultInboundConnectorContextFactory.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/DefaultInboundConnectorContextFactory.java
@@ -37,6 +37,7 @@ public class DefaultInboundConnectorContextFactory implements InboundConnectorCo
   private final ValidationProvider validationProvider;
   private final ProcessInstanceClient processInstanceClient;
   private final DocumentFactory documentFactory;
+  private final boolean secretFilterEnabled;
 
   public DefaultInboundConnectorContextFactory(
       final ObjectMapper mapper,
@@ -45,6 +46,25 @@ public class DefaultInboundConnectorContextFactory implements InboundConnectorCo
       final ValidationProvider validationProvider,
       final ProcessInstanceClient processInstanceClient,
       final DocumentFactory documentFactory) {
+    this(
+        mapper,
+        correlationHandler,
+        secretProviderAggregator,
+        validationProvider,
+        processInstanceClient,
+        documentFactory,
+        false);
+  }
+
+  public DefaultInboundConnectorContextFactory(
+      final ObjectMapper mapper,
+      final InboundCorrelationHandler correlationHandler,
+      final SecretProviderAggregator secretProviderAggregator,
+      final ValidationProvider validationProvider,
+      final ProcessInstanceClient processInstanceClient,
+      final DocumentFactory documentFactory,
+      final boolean secretFilterEnabled) {
+    this.secretFilterEnabled = secretFilterEnabled;
     this.objectMapper = mapper;
     this.correlationHandler = correlationHandler;
     this.secretProviderAggregator = secretProviderAggregator;
@@ -69,7 +89,8 @@ public class DefaultInboundConnectorContextFactory implements InboundConnectorCo
             correlationHandler,
             cancellationCallback,
             objectMapper,
-            logWriter);
+            logWriter,
+            secretFilterEnabled);
 
     if (isIntermediateContext(executableClass)) {
       inboundContext =

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextImpl.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextImpl.java
@@ -46,6 +46,7 @@ import io.camunda.connector.runtime.core.inbound.correlation.InboundCorrelationH
 import io.camunda.connector.runtime.core.inbound.details.InboundConnectorDetails;
 import io.camunda.connector.runtime.core.inbound.details.InboundConnectorDetails.ValidInboundConnectorDetails;
 import io.camunda.connector.runtime.core.secret.SecretFilter;
+import io.camunda.connector.runtime.core.secret.SecretUtil;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -80,7 +81,33 @@ public class InboundConnectorContextImpl extends AbstractConnectorContext
       Consumer<Throwable> cancellationCallback,
       ObjectMapper objectMapper,
       ActivityLogWriter activityLogWriter) {
-    super(secretProvider, SecretFilter.allowAll(), validationProvider);
+    this(
+        secretProvider,
+        validationProvider,
+        documentFactory,
+        connectorDetails,
+        correlationHandler,
+        cancellationCallback,
+        objectMapper,
+        activityLogWriter,
+        false);
+  }
+
+  /**
+   * @param secretFilterEnabled when {@code true}, restricts secret resolution to the names declared
+   *     by the deployed {@code zeebe:property} text replacement runs over (#7730).
+   */
+  public InboundConnectorContextImpl(
+      SecretProvider secretProvider,
+      ValidationProvider validationProvider,
+      DocumentFactory documentFactory,
+      ValidInboundConnectorDetails connectorDetails,
+      InboundCorrelationHandler correlationHandler,
+      Consumer<Throwable> cancellationCallback,
+      ObjectMapper objectMapper,
+      ActivityLogWriter activityLogWriter,
+      boolean secretFilterEnabled) {
+    super(secretProvider, secretFilter(connectorDetails, secretFilterEnabled), validationProvider);
     this.documentFactory = documentFactory;
     this.correlationHandler = correlationHandler;
     this.connectorDetails = connectorDetails;
@@ -244,6 +271,38 @@ public class InboundConnectorContextImpl extends AbstractConnectorContext
     } catch (Throwable e) {
       LOG.error("Failed to deliver the cancellation signal to the runtime", e);
     }
+  }
+
+  /**
+   * The allow-list is drawn from the same {@code rawPropertiesWithoutKeywords} map that {@link
+   * #properties} is built from, so the names permitted and the text filtered always come from one
+   * read. Both are fixed at construction on this branch — {@code connectorDetails} and {@code
+   * properties} are final and there is no {@code updateConnectorDetails} — so the hot-swap and
+   * torn-read failure directions the outbound path had to close are not representable here.
+   *
+   * <p>This is what the filter stops: {@link SecretUtil#replaceSecrets} runs the brace pass and
+   * then runs the bare pass over that pass's output, so a resolved value containing
+   * reference-shaped text otherwise produces a lookup for a name no model declares. Verified
+   * present on this branch before backporting: a secret whose value is the literal {@code
+   * secrets.CHAINED} resolved {@code CHAINED} under the previous allow-all filter.
+   *
+   * <p>Distinct from the denied-bracket exclusion in {@code replaceSecretsWithoutParentheses}
+   * (#8593), which stops the bare pass re-litigating a truncated prefix of a bracketed name the
+   * bracket pass already refused. The two are complementary: that one guards a name the text still
+   * spells, this one a name only a resolved value spells.
+   *
+   * <p>Static because it feeds the {@code super(...)} call, before any field is assigned.
+   */
+  private static SecretFilter secretFilter(
+      ValidInboundConnectorDetails connectorDetails, boolean secretFilterEnabled) {
+    if (!secretFilterEnabled) {
+      return SecretFilter.allowAll();
+    }
+    return SecretFilter.allowOnly(
+        connectorDetails.rawPropertiesWithoutKeywords().values().stream()
+            .flatMap(value -> SecretUtil.retrieveSecretKeysInInput(value).stream())
+            .distinct()
+            .toList());
   }
 
   @Override

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextImplTest.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextImplTest.java
@@ -18,15 +18,24 @@ package io.camunda.connector.runtime.core.inbound;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.connector.api.annotation.FEEL;
 import io.camunda.connector.api.inbound.ActivityLogTag;
 import io.camunda.connector.api.inbound.Health;
 import io.camunda.connector.api.inbound.Severity;
+import io.camunda.connector.api.secret.SecretContext;
 import io.camunda.connector.api.secret.SecretProvider;
 import io.camunda.connector.runtime.core.FooBarSecretProvider;
 import io.camunda.connector.runtime.core.TestObjectMapperSupplier;
+import io.camunda.connector.runtime.core.document.DocumentFactoryImpl;
+import io.camunda.connector.runtime.core.document.store.InMemoryDocumentStore;
 import io.camunda.connector.runtime.core.inbound.InboundConnectorContextImplTest.TestPropertiesClass.InnerObject;
 import io.camunda.connector.runtime.core.inbound.activitylog.ActivityLogRegistry;
 import io.camunda.connector.runtime.core.inbound.correlation.MessageCorrelationPoint.StandaloneMessageCorrelationPoint;
@@ -90,6 +99,101 @@ class InboundConnectorContextImplTest {
     // then
     assertThat(propertiesAsType.getMapWithStringListWithNumbers().get("key").getFirst())
         .isInstanceOf(String.class);
+  }
+
+  // #7730: inbound secret resolution is restricted to the names the element's own deployed
+  // zeebe:property text declares. The allow-list is a superset of what a correctly-authored model
+  // names, so what it actually stops is a second-order lookup: replaceSecrets runs the brace pass
+  // and then runs the bare pass over that pass's output, letting a resolved value that contains
+  // reference-shaped text reach a secret no model ever declared. Confirmed present on this branch
+  // before backporting: under the previous allow-all filter, a secret whose value is the literal
+  // "secrets.CHAINED" resolved CHAINED.
+  //
+  // Main's suite also covers a hot swap, a sibling element's names, and the new
+  // camunda.secrets.<name> form. None are representable on this branch: connectorDetails and
+  // properties are both final and there is no updateConnectorDetails at all, there is a single
+  // connector-level text rather than a per-element one, and the new form does not exist here.
+
+  private InboundConnectorContextImpl filteringContext(
+      ValidInboundConnectorDetails details, SecretProvider secretProvider) {
+    return new InboundConnectorContextImpl(
+        secretProvider,
+        (e) -> {},
+        new DocumentFactoryImpl(InMemoryDocumentStore.INSTANCE),
+        details,
+        null,
+        (e) -> {},
+        mapper,
+        activityLogRegistry,
+        true);
+  }
+
+  private static String replace(InboundConnectorContextImpl context, String input) {
+    return context.getSecretHandler().replaceSecrets(input, new SecretContext("t"));
+  }
+
+  @Test
+  void secretFilterEnabled_resolvesADeclaredSecret() {
+    var secretProvider = mock(SecretProvider.class);
+    when(secretProvider.getSecret(eq("DECLARED"), any())).thenReturn("resolved");
+    var context =
+        filteringContext(
+            getInboundConnectorDefinition(Map.of("token", "secrets.DECLARED")), secretProvider);
+
+    assertThat(replace(context, "secrets.DECLARED")).isEqualTo("resolved");
+  }
+
+  @Test
+  void secretFilterEnabled_resolvesADeclaredSecretInBraceSyntax() {
+    var secretProvider = mock(SecretProvider.class);
+    when(secretProvider.getSecret(eq("BRACED"), any())).thenReturn("resolved");
+    var context =
+        filteringContext(
+            getInboundConnectorDefinition(Map.of("token", "{{ secrets.BRACED }}")), secretProvider);
+
+    assertThat(replace(context, "{{ secrets.BRACED }}")).isEqualTo("resolved");
+  }
+
+  @Test
+  void secretFilterEnabled_leavesAnUndeclaredSecret() {
+    var secretProvider = mock(SecretProvider.class);
+    var context =
+        filteringContext(
+            getInboundConnectorDefinition(Map.of("token", "secrets.DECLARED")), secretProvider);
+
+    assertThat(replace(context, "secrets.INJECTED")).isEqualTo("secrets.INJECTED");
+    verify(secretProvider, never()).getSecret(eq("INJECTED"), any());
+  }
+
+  @Test
+  void secretFilterEnabled_leavesASecretNamedOnlyByAnotherSecretsValue() {
+    var secretProvider = mock(SecretProvider.class);
+    when(secretProvider.getSecret(eq("CHAIN_ROOT"), any())).thenReturn("secrets.CHAINED");
+    when(secretProvider.getSecret(eq("CHAINED"), any())).thenReturn("leaked-value");
+    var context =
+        filteringContext(
+            getInboundConnectorDefinition(Map.of("token", "{{secrets.CHAIN_ROOT}}")),
+            secretProvider);
+
+    assertThat(replace(context, "{{secrets.CHAIN_ROOT}}")).isEqualTo("secrets.CHAINED");
+    verify(secretProvider, never()).getSecret(eq("CHAINED"), any());
+  }
+
+  @Test
+  void secretFilterDisabled_resolvesAnUndeclaredSecret() {
+    var secretProvider = mock(SecretProvider.class);
+    when(secretProvider.getSecret(eq("INJECTED"), any())).thenReturn("resolved");
+    var context =
+        new InboundConnectorContextImpl(
+            secretProvider,
+            (e) -> {},
+            getInboundConnectorDefinition(Map.of("token", "secrets.DECLARED")),
+            null,
+            (e) -> {},
+            mapper,
+            activityLogRegistry);
+
+    assertThat(replace(context, "secrets.INJECTED")).isEqualTo("resolved");
   }
 
   private static ValidInboundConnectorDetails getInboundConnectorDefinition(

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/InboundConnectorRuntimeConfiguration.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/InboundConnectorRuntimeConfiguration.java
@@ -44,6 +44,7 @@ import io.camunda.connector.runtime.inbound.state.ProcessStateStore;
 import io.camunda.connector.runtime.inbound.state.TenantAwareProcessStateStoreImpl;
 import io.camunda.connector.runtime.inbound.webhook.WebhookConnectorRegistry;
 import io.camunda.connector.runtime.metrics.ConnectorsInboundMetrics;
+import io.camunda.connector.runtime.outbound.job.ConfigurableSecretFilterFactory.SecretFilterMode;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.time.Duration;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -92,14 +93,21 @@ public class InboundConnectorRuntimeConfiguration {
       SecretProviderAggregator secretProviderAggregator,
       @Autowired(required = false) ValidationProvider validationProvider,
       ProcessInstanceClient processInstanceClient,
-      DocumentFactory documentFactory) {
+      DocumentFactory documentFactory,
+      @Value("${camunda.connector.secret-resolver.secret-filter.mode:STRICT}")
+          SecretFilterMode secretFilterMode) {
+    // LAX vs STRICT only matters outbound, where the allow-list needs a remote BPMN lookup that can
+    // fail; the inbound allow-list is built from data already in memory, so it never fails and both
+    // modes behave identically here — only DISABLED turns this off.
+    boolean secretFilterEnabled = secretFilterMode != SecretFilterMode.DISABLED;
     return new DefaultInboundConnectorContextFactory(
         mapper,
         correlationHandler,
         secretProviderAggregator,
         validationProvider,
         processInstanceClient,
-        documentFactory);
+        documentFactory,
+        secretFilterEnabled);
   }
 
   @Bean

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/inbound/InboundConnectorRuntimeConfigurationTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/inbound/InboundConnectorRuntimeConfigurationTest.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.runtime.inbound;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.connector.api.document.DocumentFactory;
+import io.camunda.connector.api.inbound.InboundConnectorContext;
+import io.camunda.connector.api.inbound.InboundConnectorExecutable;
+import io.camunda.connector.api.secret.SecretContext;
+import io.camunda.connector.api.secret.SecretProvider;
+import io.camunda.connector.api.validation.ValidationProvider;
+import io.camunda.connector.runtime.core.inbound.InboundConnectorContextImpl;
+import io.camunda.connector.runtime.core.inbound.InboundConnectorElement;
+import io.camunda.connector.runtime.core.inbound.ProcessElementWithRuntimeData;
+import io.camunda.connector.runtime.core.inbound.ProcessInstanceClient;
+import io.camunda.connector.runtime.core.inbound.correlation.InboundCorrelationHandler;
+import io.camunda.connector.runtime.core.inbound.correlation.MessageCorrelationPoint.StandaloneMessageCorrelationPoint;
+import io.camunda.connector.runtime.core.inbound.details.InboundConnectorDetails;
+import io.camunda.connector.runtime.core.inbound.details.InboundConnectorDetails.ValidInboundConnectorDetails;
+import io.camunda.connector.runtime.core.secret.SecretProviderAggregator;
+import io.camunda.connector.runtime.outbound.job.ConfigurableSecretFilterFactory.SecretFilterMode;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class InboundConnectorRuntimeConfigurationTest {
+
+  private final InboundConnectorRuntimeConfiguration configuration =
+      new InboundConnectorRuntimeConfiguration();
+
+  /**
+   * Pins the {@code SecretFilterMode} -> boolean hop: nothing else asserts that the mode reaches
+   * the context, and because {@code LAX} and {@code STRICT} behave identically on the inbound path
+   * this is the only place their equivalence — and {@code DISABLED}'s difference from both — is
+   * checked. Fails if the argument is dropped or the boolean inverted.
+   *
+   * <p>This calls the bean method directly and so bypasses Spring's {@code @Value} resolution
+   * entirely; {@code InboundSecretFilterDefaultModeWiringTest} covers the default string itself.
+   */
+  @Test
+  void springInboundConnectorContextFactory_filtersSecretsUnlessModeIsDisabled() {
+    assertEquals(
+        "secrets.UNDECLARED",
+        resolveUndeclared(contextForSecretFilterMode(SecretFilterMode.STRICT)));
+    assertEquals(
+        "secrets.UNDECLARED", resolveUndeclared(contextForSecretFilterMode(SecretFilterMode.LAX)));
+    assertEquals(
+        "resolved", resolveUndeclared(contextForSecretFilterMode(SecretFilterMode.DISABLED)));
+  }
+
+  private InboundConnectorContextImpl contextForSecretFilterMode(SecretFilterMode mode) {
+    var factory =
+        configuration.springInboundConnectorContextFactory(
+            new ObjectMapper(),
+            mock(InboundCorrelationHandler.class),
+            new SecretProviderAggregator(List.of(alwaysResolvingProvider())),
+            mock(ValidationProvider.class),
+            mock(ProcessInstanceClient.class),
+            mock(DocumentFactory.class),
+            mode);
+    return (InboundConnectorContextImpl)
+        factory.createContext(
+            detailsDeclaringNoSecret(), e -> {}, TestExecutable.class, entry -> {});
+  }
+
+  private static ValidInboundConnectorDetails detailsDeclaringNoSecret() {
+    var properties = Map.of("inbound.type", "io.camunda:connector:1");
+    var element =
+        new InboundConnectorElement(
+            properties,
+            new StandaloneMessageCorrelationPoint("", "", null, null),
+            new ProcessElementWithRuntimeData("process", 0, 0, "id", "<default>"));
+    return (ValidInboundConnectorDetails)
+        InboundConnectorDetails.of(element.deduplicationId(List.of()), List.of(element));
+  }
+
+  private static String resolveUndeclared(InboundConnectorContextImpl context) {
+    return context.getSecretHandler().replaceSecrets("secrets.UNDECLARED", new SecretContext("t"));
+  }
+
+  private static SecretProvider alwaysResolvingProvider() {
+    return new SecretProvider() {
+      @Override
+      public String getSecret(String name, SecretContext context) {
+        return "resolved";
+      }
+    };
+  }
+
+  static class TestExecutable implements InboundConnectorExecutable<InboundConnectorContext> {
+    @Override
+    public void activate(InboundConnectorContext context) {}
+
+    @Override
+    public void deactivate() {}
+  }
+}

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/inbound/InboundSecretFilterDefaultModeWiringTest.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/inbound/InboundSecretFilterDefaultModeWiringTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.runtime.inbound;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.connector.api.inbound.InboundConnectorContext;
+import io.camunda.connector.api.inbound.InboundConnectorExecutable;
+import io.camunda.connector.api.secret.SecretContext;
+import io.camunda.connector.runtime.app.TestConnectorRuntimeApplication;
+import io.camunda.connector.runtime.core.inbound.InboundConnectorContextFactory;
+import io.camunda.connector.runtime.core.inbound.InboundConnectorContextImpl;
+import io.camunda.connector.runtime.core.inbound.InboundConnectorElement;
+import io.camunda.connector.runtime.core.inbound.ProcessElementWithRuntimeData;
+import io.camunda.connector.runtime.core.inbound.correlation.MessageCorrelationPoint.StandaloneMessageCorrelationPoint;
+import io.camunda.connector.runtime.core.inbound.details.InboundConnectorDetails;
+import io.camunda.connector.runtime.core.inbound.details.InboundConnectorDetails.ValidInboundConnectorDetails;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+/**
+ * No {@code camunda.connector.secret-resolver.secret-filter.mode} property is set here, so this
+ * exercises the {@code @Value} default on {@code springInboundConnectorContextFactory} itself —
+ * unlike a direct call to that bean method, which bypasses Spring's property resolution entirely
+ * and so stays green however wrong that default string is.
+ *
+ * <p>What this catches is a default that resolves to {@code DISABLED}, which turns inbound
+ * filtering off silently. It cannot distinguish {@code LAX} from {@code STRICT}, because those two
+ * behave identically inbound — {@code
+ * InboundConnectorRuntimeConfigurationTest#springInboundConnectorContextFactory_filtersSecretsUnlessModeIsDisabled}
+ * pins that equivalence, and {@code DISABLED}'s difference from both, at the bean-method level.
+ */
+@SpringBootTest(classes = TestConnectorRuntimeApplication.class)
+class InboundSecretFilterDefaultModeWiringTest {
+
+  @Autowired private InboundConnectorContextFactory contextFactory;
+
+  static class TestExecutable implements InboundConnectorExecutable<InboundConnectorContext> {
+    @Override
+    public void activate(InboundConnectorContext context) {}
+
+    @Override
+    public void deactivate() {}
+  }
+
+  @Test
+  void defaultsToFilteringSecrets() {
+    var properties = Map.of("inbound.type", "io.camunda:connector:1");
+    var element =
+        new InboundConnectorElement(
+            properties,
+            new StandaloneMessageCorrelationPoint("", "", null, null),
+            new ProcessElementWithRuntimeData("process", 0, 0, "id", "<default>"));
+    var details =
+        (ValidInboundConnectorDetails)
+            InboundConnectorDetails.of(element.deduplicationId(List.of()), List.of(element));
+
+    var context =
+        (InboundConnectorContextImpl)
+            contextFactory.createContext(details, e -> {}, TestExecutable.class, entry -> {});
+    var result =
+        context.getSecretHandler().replaceSecrets("secrets.UNDECLARED", new SecretContext("t"));
+
+    assertThat(result).isEqualTo("secrets.UNDECLARED");
+  }
+}


### PR DESCRIPTION
## Summary

Manual backport of #8538 to `stable/8.8` — the automated backport bot failed to cherry-pick (8 files, 12 conflict hunks, 4 of them modify/delete), because this branch predates several main-only changes. `ADR-0007`, `InboundSecretReferenceBindingTest`, `InboundConnectorRuntimeConfigurationTest` and `ConnectorsAutoConfiguration` don't exist here at all; `InboundConnectorContextImpl` takes no `CamundaClient`; and there is no `BindableProcessElement`, so main's correlation-scoped property binder has no call site to adapt.

Wires the existing `camunda.connector.secret-resolver.secret-filter.mode` property into the inbound path: the context's `SecretFilter` is now built from the secret names declared in its own elements' `zeebe:property` text, instead of always allowing every secret. `DISABLED` keeps the prior allow-all behavior; `LAX` and `STRICT` behave identically here since, unlike outbound, no remote lookup can fail.

**The `STRICT` default already applies on this branch** (since #8496, which backported #7568 with `STRICT` from the start), so inbound and outbound agree and no default-mode change is introduced here.

## The leak was confirmed present here, not assumed

Before writing anything, this branch's own `SecretUtil` was probed with an allow-all filter — a secret whose stored value is the literal `secrets.CHAINED` resolved `CHAINED`, a name no model declares:

```
ALLOW-ALL CHAIN RESULT: [LEAKED]
DENIED-BRACKET RESULT: [{{secrets.FOO:BAR}}]
```

The second line is the control: #8593's denied-bracket hardening already works here. The two protections are **complementary, not overlapping** — #8593 stops the bare pass re-litigating a truncated prefix of a bracketed name the bracket pass already refused (a name the text still spells); this stops a name only a *resolved value* spells.

## Changes

3 production files, 92 lines. Both new constructors are additive overloads whose existing signatures delegate with `false`, so no existing call site changes.

- `InboundConnectorContextImpl`: `secretFilterEnabled` overload + a static `secretFilter(...)` helper feeding `super(...)`.
- `DefaultInboundConnectorContextFactory`: `secretFilterEnabled` overload, passed through to the context.
- `InboundConnectorRuntimeConfiguration`: reads the mode, maps it to a boolean.

## Two adaptations, both narrower than main rather than looser

**The allow-list is passed to `super(...)` at construction rather than derived per call.** On this branch `connectorDetails` and `properties` are both `final` and there is **no `updateConnectorDetails` at all**, so the filtered text cannot change after construction. The hot-swap and torn-read failure directions main had to close (rows 3 and 4 of #8538's risk ledger) are not representable here, and the allow-list and the text provably come from one read.

**Extraction uses this branch's `retrieveSecretKeysInInput`, not main's `retrieveLegacySecretKeysInInput`.** That split exists on main only because its `retrieveSecretKeysInInput` also matches the new `camunda.secrets.<name>` form (ledger row 13). That form does not exist anywhere on `stable/8.8` — zero occurrences in Java — so the method here is already legacy-only. It additionally excludes bare matches nested inside a bracketed reference, which main does not do, so this branch's allow-list is strictly narrower.

## Test plan

- [x] Four applicable cases from main's suite: a declared secret resolves, in brace syntax too, an undeclared name is left as a placeholder and never reaches the `SecretProvider`, and a name that only another secret's *value* spells is refused.
- [x] A control asserting allow-all still resolves an undeclared name when the filter is off.
- [x] `InboundConnectorRuntimeConfigurationTest` (new file on this branch): pins the `SecretFilterMode` → boolean hop across all three modes — `STRICT` and `LAX` filter, `DISABLED` resolves.
- [x] `InboundSecretFilterDefaultModeWiringTest`: a `@SpringBootTest` with the property omitted, the only test that evaluates the `@Value` default string itself.
- [x] 544 tests green: `connector-runtime-core` (257), `connector-runtime-spring` (214), `spring-boot-starter-camunda-connectors` (73).
- [x] `spotless:apply` clean.

### Verified by falsification, not just green runs

#8538's ledger records that two of its tests initially passed vacuously, so a green test is not treated as evidence. Each protection was re-broken here and the named test observed to fail:

| Falsification | Observed |
|---|---|
| Filter forced off | `secretFilterEnabled_leavesASecretNamedOnlyByAnotherSecretsValue` fails — `expected "secrets.CHAINED"`, got the leaked value; `secretFilterEnabled_leavesAnUndeclaredSecret` errors with `Secret with name 'INJECTED' is not available` |
| Mode boolean inverted | `springInboundConnectorContextFactory_filtersSecretsUnlessModeIsDisabled` fails — `expected <secrets.UNDECLARED> but was <resolved>` |
| `@Value` default flipped to `DISABLED` | `InboundSecretFilterDefaultModeWiringTest` fails with `Secret with name 'UNDECLARED' is not available`, while the bean-method test stays green |

## Scope note for reviewers

This branch has **no `LegacySecretMode`/`FALLBACK` and no `CentralStoreSecretProvider`** — #8368 never reached it. A chained reference here can therefore only reach **locally configured** providers (env vars, Spring properties, SPI, custom aggregators), *not* the cluster secret store. Still a real exfiltration path for any locally-configured secret it names, but a narrower blast radius than on main or `stable/8.9`. Worth weighing when deciding how urgently this ships.

## Deliberately omitted

Main's hot-swap, sibling-element and new-form tests are structurally inapplicable on this branch for the reasons above, and are omitted with an in-file comment saying why. **This is the judgment call most worth a reviewer's eye.**

Companion backport: #8600 (`stable/8.9`).

Relates to #7730
