### PR TITLE
feat(agentic-ai): report reasoning and cache token metrics to agent instance

### DIFF
--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/subprocess/AgentSubProcessAgentInstanceTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/subprocess/AgentSubProcessAgentInstanceTests.java
@@ -319,4 +319,41 @@ class AgentSubProcessAgentInstanceTests extends BaseAgentSubProcessTest {
                     results.stream().anyMatch(r -> "fast-002".equals(r.id()))),
             any(AgentConversationTurn.class));
   }
+
+  /**
+   * Single model call whose usage carries non-zero cache-read and reasoning token counts, to verify
+   * the connector reports them to the Agent Instance API and the engine's aggregated metrics
+   * reflect them on read-back.
+   */
+  @Test
+  void shouldUpdateAgentInstanceMetricsWithCacheAndReasoningTokenCounts() throws Exception {
+    OpenAiCompletionsChatModelStubs.stubConversation(
+        new OpenAiCompletionsChatModelStubs.UsageDetailsTurnStub(
+            "The superflux calculation of 5 and 3 is complete.", 10, 20, 50, 7));
+
+    enqueueUserFeedback(userSatisfiedFeedback());
+
+    final var zeebeTest =
+        awaitProcessCompletion(
+            createProcessInstance(
+                Map.of("userPrompt", "Calculate the superflux product of 5 and 3")));
+
+    final var expectedMetrics =
+        new AgentMetrics(1, new AgentMetrics.TokenUsage(10, 20, 50, 0, 7), 0);
+    final var agentInstanceKey = new AtomicLong();
+    assertAgentResponse(
+        zeebeTest,
+        agentResponse -> {
+          AgentSubProcessResponseAssert.assertThat(agentResponse)
+              .isReady()
+              .hasAgentInstanceKey()
+              .hasMetrics(expectedMetrics);
+          agentInstanceKey.set(agentResponse.context().metadata().agentInstanceKey());
+        });
+
+    AgentInstanceEngineVerifier.verify(camundaClient, agentInstanceKey.get())
+        .hasStatus(AgentInstanceStatus.COMPLETED)
+        .hasMetrics(expectedMetrics)
+        .verify();
+  }
 }

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/subprocess/AgentSubProcessAgentInstanceTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/subprocess/AgentSubProcessAgentInstanceTests.java
@@ -338,8 +338,62 @@ class AgentSubProcessAgentInstanceTests extends BaseAgentSubProcessTest {
             createProcessInstance(
                 Map.of("userPrompt", "Calculate the superflux product of 5 and 3")));
 
-    final var expectedMetrics =
-        new AgentMetrics(1, new AgentMetrics.TokenUsage(10, 20, 50, 0, 7), 0);
+    final var expectedTokenUsage =
+        AgentMetrics.TokenUsage.builder()
+            .inputTokenCount(10)
+            .outputTokenCount(20)
+            .cacheReadTokenCount(50)
+            .cacheCreationTokenCount(0)
+            .reasoningTokenCount(7)
+            .build();
+    final var expectedMetrics = new AgentMetrics(1, expectedTokenUsage, 0);
+    final var agentInstanceKey = new AtomicLong();
+    assertAgentResponse(
+        zeebeTest,
+        agentResponse -> {
+          AgentSubProcessResponseAssert.assertThat(agentResponse)
+              .isReady()
+              .hasAgentInstanceKey()
+              .hasMetrics(expectedMetrics);
+          agentInstanceKey.set(agentResponse.context().metadata().agentInstanceKey());
+        });
+
+    AgentInstanceEngineVerifier.verify(camundaClient, agentInstanceKey.get())
+        .hasStatus(AgentInstanceStatus.COMPLETED)
+        .hasMetrics(expectedMetrics)
+        .verify();
+  }
+
+  /**
+   * Two model calls, each with distinct non-zero cache-read and reasoning token counts, chained via
+   * the feedback loop (follow-up, then satisfied) so no tool call is needed to drive a second model
+   * call. A single-turn test cannot distinguish the engine summing these counts across history
+   * items from it merely keeping the latest turn's values; this asserts the summed totals on
+   * read-back, so only the former passes.
+   */
+  @Test
+  void shouldSumCacheAndReasoningTokenCountsAcrossMultipleTurns() throws Exception {
+    OpenAiCompletionsChatModelStubs.stubConversation(
+        new OpenAiCompletionsChatModelStubs.UsageDetailsTurnStub(
+            "A haiku about the sea.", 10, 20, 30, 5),
+        new OpenAiCompletionsChatModelStubs.UsageDetailsTurnStub(
+            "A haiku about the sea, with more feeling.", 15, 25, 40, 9));
+
+    enqueueUserFeedback(userFollowUpFeedback("Add more feeling"), userSatisfiedFeedback());
+
+    final var zeebeTest =
+        awaitProcessCompletion(
+            createProcessInstance(Map.of("userPrompt", "Write a haiku about the sea")));
+
+    final var expectedTokenUsage =
+        AgentMetrics.TokenUsage.builder()
+            .inputTokenCount(25)
+            .outputTokenCount(45)
+            .cacheReadTokenCount(70)
+            .cacheCreationTokenCount(0)
+            .reasoningTokenCount(14)
+            .build();
+    final var expectedMetrics = new AgentMetrics(2, expectedTokenUsage, 0);
     final var agentInstanceKey = new AtomicLong();
     assertAgentResponse(
         zeebeTest,

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/subprocess/provider/anthropic/AgentSubProcessAnthropicPromptCachingTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/subprocess/provider/anthropic/AgentSubProcessAnthropicPromptCachingTests.java
@@ -18,10 +18,15 @@ package io.camunda.connector.e2e.agenticai.aiagent.subprocess.provider.anthropic
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.camunda.client.api.search.enums.AgentInstanceStatus;
+import io.camunda.connector.agenticai.aiagent.model.AgentMetrics;
 import io.camunda.connector.e2e.ElementTemplate;
 import io.camunda.connector.e2e.agenticai.aiagent.wiremock.anthropic.StreamingAnthropicMessagesSseChatModelStubs;
 import io.camunda.connector.e2e.agenticai.aiagent.wiremock.spi.TurnStub;
+import io.camunda.connector.e2e.agenticai.assertj.AgentInstanceEngineVerifier;
+import io.camunda.connector.e2e.agenticai.assertj.AgentSubProcessResponseAssert;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Function;
 import org.junit.jupiter.api.Test;
 
@@ -65,5 +70,54 @@ class AgentSubProcessAnthropicPromptCachingTests extends BaseAnthropicSubProcess
     assertThat(request.has("cache_control"))
         .as("top-level cache_control must not be present when prompt caching is not enabled")
         .isFalse();
+  }
+
+  /**
+   * Single model call whose usage carries non-zero cache-creation and cache-read token counts, to
+   * verify the connector reports them to the Agent Instance API and the engine's aggregated metrics
+   * reflect them on read-back. Anthropic is the only provider stub that can dial cache-creation,
+   * unlike the OpenAI-based coverage in {@code AgentSubProcessAgentInstanceTests}.
+   */
+  @Test
+  void enablePromptCachingSurfacesCacheTokenCountsInAgentInstanceMetrics() throws Exception {
+    final var userPrompt = "Write a haiku about the sea";
+
+    StreamingAnthropicMessagesSseChatModelStubs.stubConversation(
+        new StreamingAnthropicMessagesSseChatModelStubs.UsageDetailsTurnStub(
+            "A haiku about the endless sea.", 10, 20, 30, 50));
+    enqueueUserFeedback(userSatisfiedFeedback());
+
+    final Function<ElementTemplate, ElementTemplate> elementTemplateModifier =
+        template ->
+            template.property("provider.anthropic.model.parameters.promptCaching.enabled", "true");
+
+    final var zeebeTest =
+        awaitProcessCompletion(
+            createProcessInstance(elementTemplateModifier, Map.of("userPrompt", userPrompt)));
+
+    final var expectedTokenUsage =
+        AgentMetrics.TokenUsage.builder()
+            .inputTokenCount(10)
+            .outputTokenCount(20)
+            .cacheReadTokenCount(50)
+            .cacheCreationTokenCount(30)
+            .reasoningTokenCount(0)
+            .build();
+    final var expectedMetrics = new AgentMetrics(1, expectedTokenUsage, 0);
+    final var agentInstanceKey = new AtomicLong();
+    assertAgentResponse(
+        zeebeTest,
+        agentResponse -> {
+          AgentSubProcessResponseAssert.assertThat(agentResponse)
+              .isReady()
+              .hasAgentInstanceKey()
+              .hasMetrics(expectedMetrics);
+          agentInstanceKey.set(agentResponse.context().metadata().agentInstanceKey());
+        });
+
+    AgentInstanceEngineVerifier.verify(camundaClient, agentInstanceKey.get())
+        .hasStatus(AgentInstanceStatus.COMPLETED)
+        .hasMetrics(expectedMetrics)
+        .verify();
   }
 }

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/task/AgentTaskAgentInstanceTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/task/AgentTaskAgentInstanceTests.java
@@ -207,8 +207,15 @@ class AgentTaskAgentInstanceTests extends BaseAgentTaskTest {
                 e -> e.property("provider.openai.model.model", "gpt-4o"),
                 Map.of("userPrompt", "Calculate the superflux product of 5 and 3")));
 
-    final var expectedMetrics =
-        new AgentMetrics(1, new AgentMetrics.TokenUsage(10, 20, 50, 0, 7), 0);
+    final var expectedTokenUsage =
+        AgentMetrics.TokenUsage.builder()
+            .inputTokenCount(10)
+            .outputTokenCount(20)
+            .cacheReadTokenCount(50)
+            .cacheCreationTokenCount(0)
+            .reasoningTokenCount(7)
+            .build();
+    final var expectedMetrics = new AgentMetrics(1, expectedTokenUsage, 0);
     final var agentInstanceKey = new AtomicLong();
     assertAgentResponse(
         zeebeTest,

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/task/AgentTaskAgentInstanceTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/task/AgentTaskAgentInstanceTests.java
@@ -187,4 +187,42 @@ class AgentTaskAgentInstanceTests extends BaseAgentTaskTest {
             AgentInstanceHistoryRole.ASSISTANT)
         .verify();
   }
+
+  /**
+   * Single model call whose usage carries non-zero cache-read and reasoning token counts, to verify
+   * the connector reports them to the Agent Instance API and the engine's aggregated metrics
+   * reflect them on read-back.
+   */
+  @Test
+  void shouldUpdateAgentInstanceMetricsWithCacheAndReasoningTokenCounts() throws Exception {
+    OpenAiCompletionsChatModelStubs.stubConversation(
+        new OpenAiCompletionsChatModelStubs.UsageDetailsTurnStub(
+            "The superflux calculation of 5 and 3 is complete.", 10, 20, 50, 7));
+
+    enqueueUserFeedback(userSatisfiedFeedback());
+
+    final var zeebeTest =
+        awaitProcessCompletion(
+            createProcessInstance(
+                e -> e.property("provider.openai.model.model", "gpt-4o"),
+                Map.of("userPrompt", "Calculate the superflux product of 5 and 3")));
+
+    final var expectedMetrics =
+        new AgentMetrics(1, new AgentMetrics.TokenUsage(10, 20, 50, 0, 7), 0);
+    final var agentInstanceKey = new AtomicLong();
+    assertAgentResponse(
+        zeebeTest,
+        agentResponse -> {
+          AgentResponseAssert.assertThat(agentResponse)
+              .isReady()
+              .hasAgentInstanceKey()
+              .hasMetrics(expectedMetrics);
+          agentInstanceKey.set(agentResponse.context().metadata().agentInstanceKey());
+        });
+
+    AgentInstanceEngineVerifier.verify(camundaClient, agentInstanceKey.get())
+        .hasStatus(AgentInstanceStatus.COMPLETED)
+        .hasMetrics(expectedMetrics)
+        .verify();
+  }
 }

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/wiremock/anthropic/StreamingAnthropicMessagesSseChatModelStubs.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/wiremock/anthropic/StreamingAnthropicMessagesSseChatModelStubs.java
@@ -277,6 +277,49 @@ public final class StreamingAnthropicMessagesSseChatModelStubs {
   }
 
   /**
+   * A single-turn conversation whose usage carries explicit {@code cache_creation_input_tokens}
+   * and/or {@code cache_read_input_tokens} values - the shape a prompt-cache write or hit returns.
+   * The generic {@link TurnStub} API has no dial for these fields, so the other {@code
+   * stubConversation} overloads always render them as absent (mirroring real Anthropic behavior
+   * when a call has no cache activity); this dedicated single-turn stub exists purely so e2e
+   * coverage can exercise the non-zero case.
+   */
+  public record UsageDetailsTurnStub(
+      String text,
+      int inputTokens,
+      int outputTokens,
+      long cacheCreationInputTokens,
+      long cacheReadInputTokens) {}
+
+  public static void stubConversation(UsageDetailsTurnStub turn) {
+    stubScenario(List.of(usageDetailsSseBody(turn)));
+  }
+
+  private static String usageDetailsSseBody(UsageDetailsTurnStub turn) {
+    final int id = TURN_COUNTER.getAndIncrement();
+    final StringBuilder body = new StringBuilder();
+
+    writeEvent(
+        body,
+        "message_start",
+        messageStartEvent(
+            id, turn.inputTokens(), turn.cacheCreationInputTokens(), turn.cacheReadInputTokens()));
+    writeTextBlock(body, 0, turn.text());
+    writeEvent(
+        body,
+        "message_delta",
+        messageDeltaEvent(
+            StopReason.END_TURN,
+            turn.inputTokens(),
+            turn.outputTokens(),
+            turn.cacheCreationInputTokens(),
+            turn.cacheReadInputTokens()));
+    writeEvent(body, "message_stop", RawMessageStopEvent.builder().build());
+
+    return body.toString();
+  }
+
+  /**
    * Wires a single-turn scenario whose response is delayed by {@code delay} via WireMock's {@code
    * withFixedDelay} - used by HTTP-transport-timeout e2e coverage to simulate a slow/hanging model
    * response on the native streaming endpoint.
@@ -346,6 +389,11 @@ public final class StreamingAnthropicMessagesSseChatModelStubs {
   }
 
   private static RawMessageStartEvent messageStartEvent(int id, int inputTokens) {
+    return messageStartEvent(id, inputTokens, null, null);
+  }
+
+  private static RawMessageStartEvent messageStartEvent(
+      int id, int inputTokens, Long cacheCreationInputTokens, Long cacheReadInputTokens) {
     final Message message =
         Message.builder()
             .id("msg-test-sse-%s".formatted(id))
@@ -360,8 +408,8 @@ public final class StreamingAnthropicMessagesSseChatModelStubs {
                     .inputTokens(inputTokens)
                     .outputTokens(0)
                     .cacheCreation((CacheCreation) null)
-                    .cacheCreationInputTokens((Long) null)
-                    .cacheReadInputTokens((Long) null)
+                    .cacheCreationInputTokens(cacheCreationInputTokens)
+                    .cacheReadInputTokens(cacheReadInputTokens)
                     .inferenceGeo((String) null)
                     .outputTokensDetails((OutputTokensDetails) null)
                     .serverToolUse((ServerToolUsage) null)
@@ -418,6 +466,15 @@ public final class StreamingAnthropicMessagesSseChatModelStubs {
 
   private static RawMessageDeltaEvent messageDeltaEvent(
       StopReason stopReason, int inputTokens, int outputTokens) {
+    return messageDeltaEvent(stopReason, inputTokens, outputTokens, null, null);
+  }
+
+  private static RawMessageDeltaEvent messageDeltaEvent(
+      StopReason stopReason,
+      int inputTokens,
+      int outputTokens,
+      Long cacheCreationInputTokens,
+      Long cacheReadInputTokens) {
     return RawMessageDeltaEvent.builder()
         .delta(
             RawMessageDeltaEvent.Delta.builder()
@@ -428,8 +485,8 @@ public final class StreamingAnthropicMessagesSseChatModelStubs {
                 .build())
         .usage(
             MessageDeltaUsage.builder()
-                .cacheCreationInputTokens((Long) null)
-                .cacheReadInputTokens((Long) null)
+                .cacheCreationInputTokens(cacheCreationInputTokens)
+                .cacheReadInputTokens(cacheReadInputTokens)
                 .inputTokens(inputTokens)
                 .outputTokens(outputTokens)
                 .outputTokensDetails((OutputTokensDetails) null)

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/wiremock/openai/OpenAiCompletionsChatModelStubs.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/wiremock/openai/OpenAiCompletionsChatModelStubs.java
@@ -152,6 +152,34 @@ public final class OpenAiCompletionsChatModelStubs {
     stubFor(post(urlPathEqualTo(CHAT_COMPLETIONS_PATH)).willReturn(sseResponse(sseBody(turn))));
   }
 
+  /**
+   * Wires the scenario chain returning each {@link UsageDetailsTurnStub}'s response in order - the
+   * multi-turn counterpart of {@link #stubConversation(UsageDetailsTurnStub)}, letting e2e coverage
+   * dial distinct non-zero cache/reasoning counts per turn to exercise aggregation across turns
+   * (rather than a single pass-through value).
+   */
+  public static void stubConversation(UsageDetailsTurnStub... turns) {
+    if (turns.length == 0) {
+      throw new IllegalArgumentException("At least one conversation turn is required");
+    }
+
+    for (int i = 0; i < turns.length; i++) {
+      final String fromState = i == 0 ? Scenario.STARTED : stateName(i);
+
+      ScenarioMappingBuilder mapping =
+          post(urlPathEqualTo(CHAT_COMPLETIONS_PATH))
+              .inScenario(SCENARIO_NAME)
+              .whenScenarioStateIs(fromState)
+              .willReturn(sseResponse(sseBody(turns[i])));
+
+      if (i < turns.length - 1) {
+        mapping = mapping.willSetStateTo(stateName(i + 1));
+      }
+
+      stubFor(mapping);
+    }
+  }
+
   private static String sseBody(UsageDetailsTurnStub turn) {
     final String id = "chatcmpl-test-" + TURN_COUNTER.getAndIncrement();
 

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/assertj/AgentInstanceEngineVerifier.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/assertj/AgentInstanceEngineVerifier.java
@@ -66,6 +66,15 @@ public class AgentInstanceEngineVerifier {
           assertThat(metrics.getOutputTokens())
               .as("outputTokens")
               .isEqualTo(expected.tokenUsage().outputTokenCount());
+          assertThat(metrics.getReasoningTokenCount())
+              .as("reasoningTokenCount")
+              .isEqualTo(expected.tokenUsage().reasoningTokenCount());
+          assertThat(metrics.getCacheCreationTokenCount())
+              .as("cacheCreationTokenCount")
+              .isEqualTo(expected.tokenUsage().cacheCreationTokenCount());
+          assertThat(metrics.getCacheReadTokenCount())
+              .as("cacheReadTokenCount")
+              .isEqualTo(expected.tokenUsage().cacheReadTokenCount());
           assertThat(metrics.getToolCalls()).as("toolCalls").isEqualTo(expected.toolCalls());
         });
     return this;

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/agentinstance/AgentInstanceHistoryMapper.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/agentinstance/AgentInstanceHistoryMapper.java
@@ -191,6 +191,9 @@ public class AgentInstanceHistoryMapper {
     return new AgentInstanceHistoryMetrics()
         .inputTokens(metrics.tokenUsage().inputTokenCount())
         .outputTokens(metrics.tokenUsage().outputTokenCount())
+        .reasoningTokenCount(metrics.tokenUsage().reasoningTokenCount())
+        .cacheCreationTokenCount(metrics.tokenUsage().cacheCreationTokenCount())
+        .cacheReadTokenCount(metrics.tokenUsage().cacheReadTokenCount())
         .durationMs(durationMs);
   }
 

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/agentinstance/AgentInstanceHistoryMapperTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/agentinstance/AgentInstanceHistoryMapperTest.java
@@ -11,6 +11,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.camunda.client.api.command.AgentInstanceHistoryContent;
 import io.camunda.client.api.search.enums.AgentInstanceHistoryRole;
+import io.camunda.connector.agenticai.aiagent.model.AgentMetrics;
 import io.camunda.connector.agenticai.aiagent.model.message.AssistantMessage;
 import io.camunda.connector.agenticai.aiagent.model.message.MessageUtil;
 import io.camunda.connector.agenticai.aiagent.model.message.ToolCallResultMessage;
@@ -21,6 +22,7 @@ import io.camunda.connector.agenticai.aiagent.model.message.content.TextContent;
 import io.camunda.connector.agenticai.aiagent.model.tool.ToolCall;
 import io.camunda.connector.agenticai.aiagent.model.tool.ToolCallResultContent;
 import io.camunda.connector.agenticai.aiagent.tool.GatewayToolHandlerRegistry;
+import java.time.Duration;
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Map;
@@ -161,5 +163,33 @@ class AgentInstanceHistoryMapperTest {
         .isInstanceOfSatisfying(
             AgentInstanceHistoryContent.ObjectContent.class,
             object -> assertThat(object.getObject()).isEqualTo(providerContent));
+  }
+
+  @Test
+  void historyMetricsMapsAllTokenCountsAndDuration() {
+    final var tokenUsage =
+        AgentMetrics.TokenUsage.builder()
+            .inputTokenCount(100)
+            .outputTokenCount(50)
+            .cacheReadTokenCount(200)
+            .cacheCreationTokenCount(30)
+            .reasoningTokenCount(20)
+            .build();
+    final var metrics =
+        AgentMetrics.builder()
+            .modelCalls(1)
+            .tokenUsage(tokenUsage)
+            .toolCalls(0)
+            .executionTime(Duration.ofMillis(1234))
+            .build();
+
+    final var result = mapper.historyMetrics(metrics);
+
+    assertThat(result.getInputTokens()).isEqualTo(100L);
+    assertThat(result.getOutputTokens()).isEqualTo(50L);
+    assertThat(result.getCacheReadTokenCount()).isEqualTo(200L);
+    assertThat(result.getCacheCreationTokenCount()).isEqualTo(30L);
+    assertThat(result.getReasoningTokenCount()).isEqualTo(20L);
+    assertThat(result.getDurationMs()).isEqualTo(1234L);
   }
 }


### PR DESCRIPTION
## Description

Agent instance metrics reported by the AI Agent connector now include reasoning, cache-creation, and cache-read token counts, alongside the existing input and output token counts. Callers of the Agent Instance API can see the full per-call and aggregated token breakdown, including tokens spent on prompt caching and model reasoning, which the connector previously dropped when reporting metrics.

- The connector reports the three new token counts for every model call.
- The Agent Instance query API returns the same three counts in the aggregated metrics once the engine persists them.

## Related issues

closes #8605

## Checklist

- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest
  release, as this branch will be rebased onto main before the next release. Example backport labels:
    - `backport stable/8.8`: for changes that should be included in the next 8.8.x release.
    - **or** `backport release-8.8.7`: for changes that should be included in the specific release 8.8.7, and this
      *release has already been created*. The release branch will be merged back into stable/8.8 later, so the change
      will be included in future 8.8.x releases as well.
- [x] Tests/Integration tests for the changes have been added if applicable.
- [ ] If the change requires a documentation update, it has been added to the appropriate section in the documentation.
