### PR TITLE
fix: trim the extracted secret name in retrieveSecretKeysInInput (8.7)

### DIFF
--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretUtil.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretUtil.java
@@ -99,13 +99,22 @@ public class SecretUtil {
     return output.toString();
   }
 
+  /**
+   * Names are trimmed, because that is the name {@link #resolveSecretValue} looks up: the
+   * parentheses pattern's capture reaches past the name to the closing braces, so {@code {{
+   * secrets.FOO }}} declares {@code FOO}, not {@code "FOO "}. Returning the untrimmed form denies a
+   * legitimately declared name at resolution time -- for a name outside the bare pattern's
+   * character class (e.g. {@code FOO:BAR}), there is no independent bare-pattern match to
+   * coincidentally supply the trimmed form, so the declared secret is silently left unresolved
+   * under STRICT.
+   */
   public static List<String> retrieveSecretKeysInInput(String input) {
     return Objects.isNull(input)
         ? List.of()
         : Stream.of(SECRET_PATTERN_PARENTHESES, SECRET_PATTERN_SECRETS)
             .map(pattern -> pattern.matcher(input))
             .flatMap(Matcher::results)
-            .map(matchResult -> matchResult.group("secret"))
+            .map(matchResult -> matchResult.group("secret").trim())
             .distinct()
             .toList();
   }

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretUtil.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretUtil.java
@@ -102,11 +102,11 @@ public class SecretUtil {
   /**
    * Names are trimmed, because that is the name {@link #resolveSecretValue} looks up: the
    * parentheses pattern's capture reaches past the name to the closing braces, so {@code {{
-   * secrets.FOO }}} declares {@code FOO}, not {@code "FOO "}. Returning the untrimmed form denies a
-   * legitimately declared name at resolution time -- for a name outside the bare pattern's
-   * character class (e.g. {@code FOO:BAR}), there is no independent bare-pattern match to
-   * coincidentally supply the trimmed form, so the declared secret is silently left unresolved
-   * under STRICT.
+   * secrets.FOO }}} declares {@code FOO}, not {@code "FOO "}. Returning the untrimmed form also
+   * breaks consumers that do not normalize again. For example, exception redaction filters extracted
+   * names against the allow-list before fetching their values; a colon-bearing name has no independent
+   * bare-pattern match, so the untrimmed name is filtered out and its value cannot be redacted from an
+   * exception message.
    */
   public static List<String> retrieveSecretKeysInInput(String input) {
     return Objects.isNull(input)

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/SecretUtilTests.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/SecretUtilTests.java
@@ -25,6 +25,7 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import io.camunda.connector.runtime.core.secret.SecretReplacer;
 import io.camunda.connector.runtime.core.secret.SecretUtil;
 import java.util.Map;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
@@ -81,5 +82,11 @@ public class SecretUtilTests {
     SecretReplacer secretReplacer = (name, context) -> secrets.get(name);
     var result = SecretUtil.replaceSecrets(input, null, secretReplacer);
     assertThat(result).isEqualTo(output);
+  }
+
+  @Test
+  void shouldTrimSecretKeyExtractedFromBracketedReference() {
+    var keys = SecretUtil.retrieveSecretKeysInInput("{{ secrets.FOO:BAR }}");
+    assertThat(keys).contains("FOO:BAR");
   }
 }


### PR DESCRIPTION
## Summary

- `SecretUtil.retrieveSecretKeysInInput` on this branch never trims the parentheses pattern's capture, unlike `resolveSecretValue`, which does. A model declaring `{{ secrets.FOO:BAR }}` with incidental whitespace puts `"FOO:BAR "` on the outbound allow-list while resolution looks up the trimmed `"FOO:BAR"` — denying a legitimately declared secret under the STRICT default this branch already ships (#8501).
- Unlike a plain `{{ secrets.FOO }}`, there's no independent bare-pattern match to coincidentally save a colon-bearing name: `:` isn't in the bare pattern's character class, so it never produces a fallback match. Confirmed via a two-line repro against `retrieveSecretKeysInInput` directly — this is a live gap on `stable/8.7` today, not hypothetical.
- `main`/`stable/8.8`/`stable/8.9` don't have this gap: their own pre-existing (and unrelated) history already added `.trim()` to this method before the #7568 secret-filtering backport ever touched it. `stable/8.7` and `end-of-life/8.6` authored `retrieveSecretKeysInInput` from scratch as part of that backport and never picked up the trim. The identical fix just landed on the 8.6 backport, [#8505](https://github.com/camunda/connectors/pull/8505).

## Test plan

- [x] Added `shouldTrimSecretKeyExtractedFromBracketedReference`, reproducing the denial before the fix and passing after.
- [x] `connector-runtime-core` module tests green (`mvn test -pl connector-runtime/connector-runtime-core -am`).

## Related issues

Related to the trim/nested-match coupling flagged in review on #8505; tracked at #8602.

🤖 Generated with [Claude Code](https://claude.com/claude-code)