### PR TITLE
ci: share AlwaysGreen failure detection with the stable branches

### DIFF
--- a/.github/workflows/MERGE_QUEUE_HELM_TEST.yaml
+++ b/.github/workflows/MERGE_QUEUE_HELM_TEST.yaml
@@ -168,25 +168,9 @@ jobs:
       scenario: alwaysgreen
       shortname: agrn
 
-  # The failure signal for everything AlwaysGreen, read from the jobs API rather than
-  # from `needs.*.result`.
-  #
-  # `needs.*.result` cannot see two of the ways a job in this pipeline fails:
-  #
-  #   * A nested job of a called workflow that carries continue-on-error. The SM
-  #     Playwright matrix in camunda-platform-helm is
-  #     `continue-on-error: ${{ !matrix.blocking }}`, and its `full` leg is
-  #     `blocking: false` — so when only that leg fails, INTEGRATION_TEST.yml still
-  #     reports success and `needs.trigger-sm-e2e.result` is `success`.
-  #   * This workflow's own `continue-on-error: ${{ github.event_name == 'merge_group' }}`,
-  #     which does the same one level up.
-  #
-  # Both are real, observed states: in run 33366607997 the SM `full` leg and the SaaS
-  # stage both failed, yet no `needs.*.result` said `failure`, the run concluded
-  # `success`, and neither the SM feedback job nor triage ran. The jobs API reported
-  # `conclusion: failure` for both jobs the whole time — which is also what
-  # `.github/scripts/alwaysgreen/discover.py` reads, so gating on it puts the gate and
-  # the classifier on the same evidence.
+  # The failure signal for everything AlwaysGreen. Why it reads the jobs API instead of
+  # `needs.*.result`, and why it is a reusable workflow rather than a job here, are both
+  # documented in alwaysgreen-detect-failures.yml.
   #
   # run-ai-agent-cpt IS in `needs` here, unlike in alwaysgreen-triage. The scan reads
   # whatever has concluded at the moment it runs, so a job with no ordering edge to it
@@ -195,95 +179,16 @@ jobs:
   # deterministic.
   #
   # Backport note: that job exists on main and stable/8.10 only. Drop it from this list
-  # when carrying this change to stable/8.7-8.9, where naming it would make the whole
-  # workflow invalid. It is the one entry here that is not backport-safe.
+  # when wiring this into stable/8.7-8.9, where naming it would make the whole workflow
+  # invalid. It is the one entry here that is not backport-safe.
   detect-failures:
     name: AlwaysGreen failure detection
     needs: [ build-image, trigger-sm-e2e, trigger-saas-e2e, run-ai-agent-cpt ]
     if: always()
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
     permissions:
       actions: read
-    outputs:
-      any_failed: ${{ steps.scan.outputs.any_failed }}
-      sm_failed: ${{ steps.scan.outputs.sm_failed }}
-      base_ref: ${{ steps.scan.outputs.base_ref }}
-      base_ref_supported: ${{ steps.scan.outputs.base_ref_supported }}
-    steps:
-      - name: Scan this run's job conclusions
-        id: scan
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          RUN_ID: ${{ github.run_id }}
-          REF_NAME: ${{ github.ref_name }}
-        run: |
-          set -euo pipefail
-
-          # filter=latest is the default, stated so a re-run cannot pick up a previous
-          # attempt's failures and re-trigger triage for a failure that is already gone.
-          failed=$(gh api --paginate \
-            "repos/${GITHUB_REPOSITORY}/actions/runs/${RUN_ID}/jobs?filter=latest&per_page=100" \
-            --jq '.jobs[] | select(.conclusion == "failure") | .name')
-
-          # AlwaysGreen's own jobs are dropped rather than relied on to be unfinished:
-          # a Slack or Vault hiccup in the feedback job must not read as a pipeline
-          # failure, and on a re-run they may already carry a conclusion.
-          failed=$(printf '%s\n' "$failed" | grep -v '^AlwaysGreen ' || true)
-          failed=$(printf '%s\n' "$failed" | sed '/^[[:space:]]*$/d')
-
-          any_failed=false
-          sm_failed=false
-          if [ -n "$failed" ]; then
-            any_failed=true
-            if printf '%s\n' "$failed" | grep -q '^Trigger SM E2E tests'; then
-              sm_failed=true
-            fi
-            printf 'Failing jobs:\n%s\n' "$failed"
-          else
-            echo "No failing jobs in this run."
-          fi
-
-          # Normalised the same way as classify.normalise_base_ref, so the value this
-          # gate derives and the value discovery derives cannot disagree — triage
-          # validates it against the supported branches and errors on a queue ref.
-          base_ref="${REF_NAME#refs/heads/}"
-          case "$base_ref" in
-            gh-readonly-queue/*)
-              base_ref="${base_ref#gh-readonly-queue/}"
-              base_ref="${base_ref%/pr-*}"
-              ;;
-          esac
-
-          # Mirrors the list alwaysgreen-triage.yml's "Resolve target run" step accepts,
-          # and alwaysgreen-fix.yml's. workflow_dispatch can be started from ANY ref, so
-          # without this a failing manual run from a feature branch would hand triage a
-          # base_ref it rejects — turning every such run into a guaranteed triage
-          # failure that fixes nothing. Reported loudly rather than swallowed: the
-          # failure is still in the log, the annotation and the summary.
-          base_ref_supported=true
-          case "$base_ref" in
-            main|stable/8.7|stable/8.8|stable/8.9) ;;
-            *) base_ref_supported=false ;;
-          esac
-          if [ "$base_ref_supported" != "true" ] && [ "$any_failed" = "true" ]; then
-            echo "::warning::AlwaysGreen triage does not accept base_ref '${base_ref}', so this run's failures are reported here only. Add the ref to alwaysgreen-triage.yml and alwaysgreen-fix.yml to enable it."
-            {
-              echo "## AlwaysGreen failure detection"
-              echo ""
-              echo "Failing jobs on ${base_ref}, a ref AlwaysGreen triage does not"
-              echo "accept — no classification or fix dispatch ran:"
-              echo ""
-              printf '%s\n' "$failed" | sed 's/^/- /'
-            } >> "$GITHUB_STEP_SUMMARY"
-          fi
-
-          {
-            echo "any_failed=${any_failed}"
-            echo "sm_failed=${sm_failed}"
-            echo "base_ref=${base_ref}"
-            echo "base_ref_supported=${base_ref_supported}"
-          } | tee -a "$GITHUB_OUTPUT"
+    # Local path on main, where the file lives; the stable branches call it `@main`.
+    uses: ./.github/workflows/alwaysgreen-detect-failures.yml
 
   sm-e2e-debug-summary:
     name: AlwaysGreen failure feedback (SM E2E)

--- a/.github/workflows/alwaysgreen-detect-failures.yml
+++ b/.github/workflows/alwaysgreen-detect-failures.yml
@@ -1,0 +1,141 @@
+# description: The failure signal for everything AlwaysGreen, read from the jobs API
+#              rather than from the caller's `needs.*.result`. Called by
+#              MERGE_QUEUE_HELM_TEST.yaml on main and, as `@main`, from every stable
+#              branch, so all of them gate on the same evidence.
+# type: CI
+# owner: @camunda/test-automation-team
+---
+name: AlwaysGreen failure detection
+
+# `needs.*.result` cannot see two of the ways a job in the merge-queue helm pipeline
+# fails:
+#
+#   * A nested job of a called workflow that carries continue-on-error. The SM
+#     Playwright matrix in camunda-platform-helm is
+#     `continue-on-error: ${{ !matrix.blocking }}`, and its `full` leg is
+#     `blocking: false` — so when only that leg fails, INTEGRATION_TEST.yml still
+#     reports success and `needs.trigger-sm-e2e.result` is `success`.
+#   * The caller's own `continue-on-error: ${{ github.event_name == 'merge_group' }}`,
+#     which does the same one level up.
+#
+# Both are real, observed states, and either one alone makes the whole run conclude
+# `success` with a red job in it: run 33366607997 (main) and run 33727876677
+# (stable/8.9) each had a failing job that no `needs.*.result` reported, so no feedback
+# job and no triage ran. The jobs API reported `conclusion: failure` for those jobs the
+# whole time — which is also what `.github/scripts/alwaysgreen/discover.py` reads, so
+# gating on it puts the gate and the classifier on the same evidence.
+#
+# Reusable rather than inlined per branch: the scan, the ref normalisation and the
+# supported-ref list have to agree with alwaysgreen-triage.yml and alwaysgreen-fix.yml,
+# which live on main only and are called `@main` from every stable branch. A copy of
+# this logic per branch would be four copies to keep in step with them, and the
+# stable copies are exactly the ones nobody looks at until a failure goes unreported.
+
+on:
+  workflow_call:
+    outputs:
+      any_failed:
+        description: 'true when any non-AlwaysGreen job in the calling run concluded failure'
+        value: ${{ jobs.scan.outputs.any_failed }}
+      sm_failed:
+        description: 'true when the failure is in the SM E2E stage'
+        value: ${{ jobs.scan.outputs.sm_failed }}
+      base_ref:
+        description: 'Branch the run belongs to, normalised (a merge-queue ref reduced to its base)'
+        value: ${{ jobs.scan.outputs.base_ref }}
+      base_ref_supported:
+        description: 'true when AlwaysGreen triage accepts that base_ref'
+        value: ${{ jobs.scan.outputs.base_ref_supported }}
+
+jobs:
+  scan:
+    # Named for the caller's log, where this appears as
+    # `<caller job name> / Scan job conclusions`.
+    name: Scan job conclusions
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      actions: read
+    outputs:
+      any_failed: ${{ steps.scan.outputs.any_failed }}
+      sm_failed: ${{ steps.scan.outputs.sm_failed }}
+      base_ref: ${{ steps.scan.outputs.base_ref }}
+      base_ref_supported: ${{ steps.scan.outputs.base_ref_supported }}
+    steps:
+      # github.run_id and github.ref_name are the CALLER's here: a called workflow
+      # shares the caller's run and context, so no inputs are needed and the scan
+      # cannot be pointed at the wrong run by a mistaken argument.
+      - name: Scan this run's job conclusions
+        id: scan
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_ID: ${{ github.run_id }}
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+
+          # filter=latest is the default, stated so a re-run cannot pick up a previous
+          # attempt's failures and re-trigger triage for a failure that is already gone.
+          failed=$(gh api --paginate \
+            "repos/${GITHUB_REPOSITORY}/actions/runs/${RUN_ID}/jobs?filter=latest&per_page=100" \
+            --jq '.jobs[] | select(.conclusion == "failure") | .name')
+
+          # AlwaysGreen's own jobs are dropped rather than relied on to be unfinished:
+          # a Slack or Vault hiccup in the feedback job must not read as a pipeline
+          # failure, and on a re-run they may already carry a conclusion. This job is
+          # dropped by the same prefix, since the caller names it `AlwaysGreen ...`.
+          failed=$(printf '%s\n' "$failed" | grep -v '^AlwaysGreen ' || true)
+          failed=$(printf '%s\n' "$failed" | sed '/^[[:space:]]*$/d')
+
+          any_failed=false
+          sm_failed=false
+          if [ -n "$failed" ]; then
+            any_failed=true
+            if printf '%s\n' "$failed" | grep -q '^Trigger SM E2E tests'; then
+              sm_failed=true
+            fi
+            printf 'Failing jobs:\n%s\n' "$failed"
+          else
+            echo "No failing jobs in this run."
+          fi
+
+          # Normalised the same way as classify.normalise_base_ref, so the value this
+          # gate derives and the value discovery derives cannot disagree — triage
+          # validates it against the supported branches and errors on a queue ref.
+          base_ref="${REF_NAME#refs/heads/}"
+          case "$base_ref" in
+            gh-readonly-queue/*)
+              base_ref="${base_ref#gh-readonly-queue/}"
+              base_ref="${base_ref%/pr-*}"
+              ;;
+          esac
+
+          # Mirrors the list alwaysgreen-triage.yml's "Resolve target run" step accepts,
+          # and alwaysgreen-fix.yml's. workflow_dispatch can be started from ANY ref, so
+          # without this a failing manual run from a feature branch would hand triage a
+          # base_ref it rejects — turning every such run into a guaranteed triage
+          # failure that fixes nothing. Reported loudly rather than swallowed: the
+          # failure is still in the log, the annotation and the summary.
+          base_ref_supported=true
+          case "$base_ref" in
+            main|stable/8.7|stable/8.8|stable/8.9) ;;
+            *) base_ref_supported=false ;;
+          esac
+          if [ "$base_ref_supported" != "true" ] && [ "$any_failed" = "true" ]; then
+            echo "::warning::AlwaysGreen triage does not accept base_ref '${base_ref}', so this run's failures are reported here only. Add the ref to alwaysgreen-triage.yml and alwaysgreen-fix.yml to enable it."
+            {
+              echo "## AlwaysGreen failure detection"
+              echo ""
+              echo "Failing jobs on ${base_ref}, a ref AlwaysGreen triage does not"
+              echo "accept — no classification or fix dispatch ran:"
+              echo ""
+              printf '%s\n' "$failed" | sed 's/^/- /'
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+          {
+            echo "any_failed=${any_failed}"
+            echo "sm_failed=${sm_failed}"
+            echo "base_ref=${base_ref}"
+            echo "base_ref_supported=${base_ref_supported}"
+          } | tee -a "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Description

The merge-queue helm pipeline can conclude `success` while carrying a red job. Two
independent reasons:

* the SM Playwright matrix in camunda-platform-helm runs its `full` leg with
  `continue-on-error: ${{ !matrix.blocking }}`, so a `full`-only failure leaves
  `needs.trigger-sm-e2e.result == 'success'`;
* this workflow is itself `continue-on-error` on `merge_group`, which does the same one
  level up.

Either one alone hides a real failure from every `needs.*.result` the AlwaysGreen gates
read. main was fixed by scanning the jobs API instead — but that scan is a job inside
main's own workflow, and the stable branches still gate on `needs.*.result`. Run
[33727876677](https://github.com/camunda/connectors/actions/runs/33727876677) on
stable/8.9 is the consequence: a failing Playwright job, a run that concluded `success`,
and no Slack alert, no PR comment and no fix agent.

This PR extracts the scan into a reusable workflow so the stable branches can call it
the way they already call `alwaysgreen-triage.yml@main`, rather than each carrying a
copy that has to stay in step with the ref normalisation and supported-ref list those
workflows enforce.

**No behaviour change on main** — same evidence, same four outputs, same gates. The job
keeps its id, name, `needs` list and `permissions`; only its body moves.

Merge this before the three branch-local PRs that call it:

* stable/8.9 — #8620
* stable/8.8 — #8621
* stable/8.7 — #8622

Considered and rejected: a `workflow_run` listener on main, which would need no stable
edits at all (verified that one does fire for stable runs — the streak detector's
listener run 33730238377 reports `BASE_REF: stable/8.9`). It cannot gate the SM and
SaaS feedback jobs, which are plain jobs in each caller, and it would mean restructuring
main's working in-pipeline triage. Worth revisiting for stable/8.10, whose workflow
still carries `push: branches: [main]` and so never runs on its own pushes.

## Related issues

Detected on:

* https://github.com/camunda/connectors/actions/runs/33727876677 (stable/8.9, concluded `success` with a red job)
* https://github.com/camunda/connectors/actions/runs/33366607997 (main, the failure that prompted the original jobs-API scan)

## Checklist

- [ ] PR has a **milestone** or the `no milestone` label.
