### PR TITLE
ci: gate AlwaysGreen on this run's job conclusions (stable/8.7)

### DIFF
--- a/.github/workflows/MERGE_QUEUE_HELM_TEST.yaml
+++ b/.github/workflows/MERGE_QUEUE_HELM_TEST.yaml
@@ -168,10 +168,35 @@ jobs:
       scenario: alwaysgreen
       shortname: agrn
 
+  # The failure signal for everything AlwaysGreen: the jobs API, not needs.*.result.
+  # A non-blocking SM Playwright leg, and this workflow's own merge_group
+  # continue-on-error, each hide a real failure from every `result` the gates below can
+  # read. Observed on the sibling branch as run 33727876677: the Playwright full leg
+  # failed, the run concluded `success`, and no feedback, no triage and no fix agent
+  # followed. The gate here was the same one. Full rationale in
+  # alwaysgreen-detect-failures.yml.
+  #
+  # Pinned to @main like alwaysgreen-triage.yml below, for the same reason: the
+  # AlwaysGreen workflows and their .github/scripts/alwaysgreen tooling live on main
+  # only, and this scan has to agree with the ref normalisation and the supported-ref
+  # list they enforce. Nothing is backported as a result -- updating main is enough.
+  #
+  # run-ai-agent-cpt is deliberately absent from `needs`: it does not exist on this
+  # branch, and naming it would make the whole workflow invalid.
+  detect-failures:
+    name: AlwaysGreen failure detection
+    needs: [ build-image, trigger-sm-e2e, trigger-saas-e2e ]
+    if: always()
+    permissions:
+      actions: read
+    uses: camunda/connectors/.github/workflows/alwaysgreen-detect-failures.yml@main
+
   sm-e2e-debug-summary:
     name: AlwaysGreen failure feedback (SM E2E)
-    needs: trigger-sm-e2e
-    if: always() && needs.trigger-sm-e2e.result == 'failure'
+    needs: [ trigger-sm-e2e, detect-failures ]
+    # Not needs.trigger-sm-e2e.result: a non-blocking SM leg failing leaves that at
+    # `success`, which produced no SM feedback at all in run 33727876677.
+    if: always() && needs.detect-failures.outputs.sm_failed == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     continue-on-error: ${{ github.event_name == 'merge_group' }}
@@ -524,10 +549,16 @@ jobs:
   # docker-build-helm-integration.yml). Nothing under alwaysgreen needs backporting to
   # this branch as a result -- updating main is enough, by construction.
   #
-  # push only, for now. Half the failing jobs come from merge_group, but those belong
-  # to the PR under test -- its author is already looking at it, and a fix PR in the
-  # e2e repository would not unblock that queue entry. Same gate as
-  # connectors-streak-detector.yml.
+  # Every event this workflow runs on, not push only. merge_group failures were held
+  # back on the reasoning that they belong to the PR under test -- but a merge-queue
+  # entry runs the same SM and SaaS suites against the same clusters, so a red one is
+  # the same e2e regression seen ~10 minutes earlier, and holding it back lost the
+  # majority of the signal. It is also safe to let through: this workflow is not a
+  # required check for the queue -- there is no required_status_checks rule on this
+  # branch -- so a triage failure cannot block a queue entry. Dedupe is unchanged: the
+  # queue ref normalises to its base branch, so a merge_group run and the push run that
+  # follows it derive the same dispatch key, and the second is suppressed by the
+  # in-flight / open-fix-PR layers.
   alwaysgreen-triage:
     name: AlwaysGreen triage and fix dispatch
     # run-ai-agent-cpt is deliberately absent: it exists only on main, and a `needs`
@@ -540,9 +571,17 @@ jobs:
       - sm-e2e-debug-summary
       - trigger-saas-e2e
       - saas-e2e-debug-summary
+      - detect-failures
+    # detect-failures, not contains(needs.*.result, 'failure'): continue-on-error --
+    # here and on the non-blocking SM Playwright leg -- keeps a real failure out of
+    # every `result` this job can see. See the comment on that job.
+    #
+    # base_ref_supported keeps a manual dispatch from an arbitrary ref out: triage
+    # hard-errors on a base_ref outside main|stable/8.7-8.9, so calling it for one
+    # would only add a red job. detect-failures annotates and summarises that case.
     if: >-
-      always() && github.event_name == 'push' &&
-      contains(needs.*.result, 'failure')
+      always() && needs.detect-failures.outputs.any_failed == 'true' &&
+      needs.detect-failures.outputs.base_ref_supported == 'true'
     permissions:
       contents: read
       actions: write
@@ -550,7 +589,9 @@ jobs:
     uses: camunda/connectors/.github/workflows/alwaysgreen-triage.yml@main
     secrets: inherit
     with:
-      base_ref: ${{ github.ref_name }}
+      # Normalised by detect-failures: on merge_group github.ref_name is the
+      # per-PR queue ref, which triage rejects as an unsupported base_ref.
+      base_ref: ${{ needs.detect-failures.outputs.base_ref }}
       tooling_ref: main
       # Reply in whichever feedback message was posted, so one failure stays one
       # Slack thread. Empty when neither stage failed or Slack was unavailable.


### PR DESCRIPTION
## Description

The AlwaysGreen gates on this branch read `needs.*.result`, which cannot see two of the
ways a job here fails:

* the SM Playwright matrix in camunda-platform-helm runs its `full` leg with
  `continue-on-error: ${{ !matrix.blocking }}`, so a `full`-only failure leaves
  `needs.trigger-sm-e2e.result == 'success'`;
* this workflow is itself `continue-on-error` on `merge_group`, which does the same one
  level up.

Run [33727876677](https://github.com/camunda/connectors/actions/runs/33727876677) on stable/8.9 is the case, against the identical gate: the Playwright `full` leg failed, the run concluded
`success`, and `AlwaysGreen failure feedback (SM E2E)` and `AlwaysGreen triage and fix
dispatch` were both `skipped` — no Slack alert, no PR comment, no fix agent for a real
e2e failure.

Gate on this run's job conclusions instead, read from the jobs API — the same evidence
`.github/scripts/alwaysgreen/discover.py` reads, so the gate and the classifier can no
longer disagree. The scan itself is the reusable workflow added on main in #8619, called
`@main` exactly like `alwaysgreen-triage.yml`, so future changes to detection stay
main-only.

Triage also stops being push-only, matching main: a merge-queue entry runs the same SM
and SaaS suites against the same clusters, so a red one is the same regression seen ~10
minutes earlier. Safe to let through — there is no `required_status_checks` rule on this
branch, so a triage failure cannot block a queue entry — and dedupe is unchanged,
because the queue ref normalises to its base branch and the follow-up push run derives
the same dispatch key.

Authored per branch rather than backported: main's copy of this file has diverged, so
the patch does not apply. Verified with `actionlint`.

**Merge #8619 first** — this calls a workflow that does not exist on main yet.

## Related issues

Detected on: https://github.com/camunda/connectors/actions/runs/33727876677

Companion PRs: #8619 (main, the shared workflow) and the sibling stable branches.

## Checklist

- [ ] PR has a **milestone** or the `no milestone` label.
