### PR TITLE
ci: release an idle PR's hold on the spec files it touches

### DIFF
--- a/.github/scripts/alwaysgreen/discover.py
+++ b/.github/scripts/alwaysgreen/discover.py
@@ -48,23 +48,36 @@ KEY_LABEL_PREFIX = planning.KEY_LABEL_PREFIX
 #: two lookups below fail closed, a repository the token cannot reach would wedge every
 #: dispatch shut rather than merely returning nothing.
 FIX_PR_REPOS = [REPO, E2E_REPO]
+
+
+def _ttl_hours(env_var: str, default: int) -> int:
+    """An overridable TTL dial, read defensively.
+
+    Matches the degrade-don't-crash bias of everything else here: an unreadable
+    timestamp keeps the lock and a failed lookup suppresses, so a malformed dial must
+    not raise at import and take down every entry point in this module. Set to 0 to
+    restore the old never-expiring lock.
+    """
+    try:
+        return int(os.environ.get(env_var, "").strip() or default)
+    except ValueError:
+        print(
+            f"::warning::unparseable {env_var}; using the default ({default}h).",
+            file=sys.stderr,
+        )
+        return default
+
+
 #: How long an open fix PR keeps holding its dispatch key; see
-#: planning.PR_LOCK_TTL_HOURS. Set to 0 to restore the old never-expiring lock.
-#: Read defensively, matching the degrade-don't-crash bias of everything else here: an
-#: unreadable `createdAt` keeps the lock and a failed lookup suppresses, so a malformed
-#: dial must not raise at import and take down every entry point in this module.
-try:
-    PR_LOCK_TTL_HOURS = int(
-        os.environ.get("ALWAYSGREEN_PR_LOCK_TTL_HOURS", "").strip()
-        or planning.PR_LOCK_TTL_HOURS
-    )
-except ValueError:
-    print(
-        "::warning::unparseable ALWAYSGREEN_PR_LOCK_TTL_HOURS; using the default "
-        f"({planning.PR_LOCK_TTL_HOURS}h).",
-        file=sys.stderr,
-    )
-    PR_LOCK_TTL_HOURS = planning.PR_LOCK_TTL_HOURS
+#: planning.PR_LOCK_TTL_HOURS.
+PR_LOCK_TTL_HOURS = _ttl_hours(
+    "ALWAYSGREEN_PR_LOCK_TTL_HOURS", planning.PR_LOCK_TTL_HOURS
+)
+#: How long an open PR keeps blocking dispatches that would edit the spec files it
+#: touches; see planning.PATH_CLAIM_TTL_HOURS.
+PATH_CLAIM_TTL_HOURS = _ttl_hours(
+    "ALWAYSGREEN_PATH_CLAIM_TTL_HOURS", planning.PATH_CLAIM_TTL_HOURS
+)
 
 
 class DiscoveryError(RuntimeError):
@@ -422,6 +435,9 @@ def paths_claimed_by_open_prs(paths: set[str]) -> tuple[dict[str, int], bool]:
     fix, and a bot PR all count. Filtering by author would reintroduce exactly the
     blindness this layer exists to close.
 
+    A PR idle for longer than PATH_CLAIM_TTL_HOURS stops claiming its files, so a
+    forgotten draft cannot hold a surface's spec files shut indefinitely.
+
     Returns (claims, ok). On any lookup failure `ok` is False and the caller
     suppresses: a missed dispatch retries on the next failing run, a duplicate PR
     editing the same lines does not un-happen.
@@ -433,7 +449,7 @@ def paths_claimed_by_open_prs(paths: set[str]) -> tuple[dict[str, int], bool]:
     prs, err = gh_json_ex(
         [
             "pr", "list", "--repo", E2E_REPO, "--state", "open",
-            "--limit", "100", "--json", "number,files",
+            "--limit", "100", "--json", "number,files,updatedAt",
         ],
         None,
     )
@@ -447,8 +463,20 @@ def paths_claimed_by_open_prs(paths: set[str]) -> tuple[dict[str, int], bool]:
         log("::warning::open PR listing hit the page limit; suppressing this run")
         return claims, False
 
+    now = datetime.now(timezone.utc)
     for pr in prs:
         number = pr.get("number")
+        # Before the truncation check below, so a stale PR large enough to truncate
+        # cannot suppress the run either — it claims nothing, so its file list does
+        # not need to be complete.
+        if planning.pr_lock_expired(
+            pr.get("updatedAt") or "", now, PATH_CLAIM_TTL_HOURS
+        ):
+            log(
+                f"path claim expired after {PATH_CLAIM_TTL_HOURS}h: {E2E_REPO}#{number} "
+                "no longer claims the spec files it touches"
+            )
+            continue
         files = pr.get("files") or []
         # gh caps the per-PR file list. A truncated list under-reports claims, which
         # would read as "nothing claimed" — the one wrong answer this layer must not

--- a/.github/scripts/alwaysgreen/plan.py
+++ b/.github/scripts/alwaysgreen/plan.py
@@ -60,10 +60,30 @@ MAX_LABEL_LENGTH = 50
 PR_LOCK_TTL_HOURS = 2
 
 
+#: How long an open PR's touched spec files keep blocking a dispatch that would edit
+#: them.
+#:
+#: The claim exists so two agents do not rewrite the same spec at the same time, and it
+#: is author-agnostic for that reason — but nothing released it either, and a claim is
+#: coarser than the key lock: it holds every failure in every file the PR touches, for
+#: whatever the PR happens to be. A draft opened on 2026-08-26 touching ten spec files
+#: still held them on 2026-09-03, and run 33727363856 reported
+#: `spec-path-claimed-by-open-pr` and dispatched nothing.
+#:
+#: Measured from last activity, not from creation, and a day rather than the key lock's
+#: two hours: a PR being written, reviewed or rebased touches its own timestamp well
+#: inside a day, so an active one never loses its files, while one nobody has touched
+#: since yesterday is not work in progress that a second agent could collide with.
+PATH_CLAIM_TTL_HOURS = 24
+
+
 def pr_lock_expired(
     created_at: str | None, now: datetime, ttl_hours: int = PR_LOCK_TTL_HOURS
 ) -> bool:
-    """Whether an open fix PR is too old to keep holding its dispatch key.
+    """Whether an open PR is too old to keep holding a lock.
+
+    Used for both locks a PR can hold: its dispatch key, from `createdAt`, and the spec
+    files it touches, from `updatedAt`. Only the timestamp and the TTL differ.
 
     A missing or unparseable timestamp keeps the lock, and `ttl_hours <= 0` disables
     expiry altogether: the bias matches the `ok` flags in discover's key lookups,

--- a/.github/scripts/alwaysgreen/test_discover.py
+++ b/.github/scripts/alwaysgreen/test_discover.py
@@ -139,3 +139,73 @@ def test_a_failed_lookup_reports_not_ok(monkeypatch):
     _stub(monkeypatch, [_pr(1, ["connectors:main:sm-smoke-e2e"], claims=["aaaaaaaa"])], ok=False)
     _covered, _keys, _per_spec, ok = discover.dedupe_inputs()
     assert ok is False
+
+
+SPEC = "tests/8.10/smoke-tests.spec.ts"
+
+
+def _stub_pr_list(monkeypatch, prs, *, err=""):
+    """Serve `prs` as the open-PR listing behind the spec-path claim lookup."""
+
+    def fake(args, default):
+        return (None, err) if err else (list(prs), "")
+
+    monkeypatch.setattr(discover, "gh_json_ex", fake)
+
+
+def _claiming_pr(number, *, idle_hours=0, files=(SPEC,)):
+    return {
+        "number": number,
+        "files": [{"path": f} for f in files],
+        "updatedAt": _ago(hours=idle_hours),
+    }
+
+
+def test_a_live_pr_claims_the_spec_files_it_touches(monkeypatch):
+    _stub_pr_list(monkeypatch, [_claiming_pr(3153)])
+    claims, ok = discover.paths_claimed_by_open_prs({SPEC})
+    assert claims == {SPEC: 3153}
+    assert ok is True
+
+
+def test_an_idle_pr_stops_claiming_its_spec_files(monkeypatch):
+    # The case that wedged run 33727363856: a draft untouched for eight days still held
+    # every spec file it touched, so every failure in those files went undispatched.
+    _stub_pr_list(monkeypatch, [_claiming_pr(3153, idle_hours=8 * 24)])
+    claims, ok = discover.paths_claimed_by_open_prs({SPEC})
+    assert claims == {}
+    assert ok is True
+
+
+def test_an_idle_pr_with_a_truncated_file_list_does_not_suppress(monkeypatch):
+    # Truncation is only a problem for a PR whose claims still count. Checking the TTL
+    # first keeps a large stale PR from failing the lookup for everyone.
+    files = [f"tests/8.10/spec-{i}.spec.ts" for i in range(120)]
+    _stub_pr_list(monkeypatch, [_claiming_pr(3153, idle_hours=8 * 24, files=files)])
+    claims, ok = discover.paths_claimed_by_open_prs({SPEC})
+    assert claims == {}
+    assert ok is True
+
+
+def test_a_live_pr_with_a_truncated_file_list_still_suppresses(monkeypatch):
+    files = [f"tests/8.10/spec-{i}.spec.ts" for i in range(120)]
+    _stub_pr_list(monkeypatch, [_claiming_pr(3153, files=files)])
+    _claims, ok = discover.paths_claimed_by_open_prs({SPEC})
+    assert ok is False
+
+
+def test_a_missing_timestamp_keeps_the_claim(monkeypatch):
+    # Same bias as the key lock: an unproven state suppresses rather than risking two
+    # agents rewriting one spec.
+    pr = _claiming_pr(3153)
+    pr["updatedAt"] = ""
+    _stub_pr_list(monkeypatch, [pr])
+    claims, ok = discover.paths_claimed_by_open_prs({SPEC})
+    assert claims == {SPEC: 3153}
+    assert ok is True
+
+
+def test_a_failed_pr_listing_suppresses(monkeypatch):
+    _stub_pr_list(monkeypatch, [], err="gh: not found")
+    _claims, ok = discover.paths_claimed_by_open_prs({SPEC})
+    assert ok is False


### PR DESCRIPTION
## Description

AlwaysGreen will not dispatch a fix for a failing spec whose file an open PR in the e2e
repository already touches, so two agents cannot rewrite one spec at the same time. That
claim is deliberately author-agnostic — another agent's branch, a human fix and a bot PR
all count — but nothing ever released it. It held for as long as the PR stayed open,
covering every file the PR touched and every failure in those files, whatever the PR was
actually for.

Run [33727363856](https://github.com/camunda/connectors/actions/runs/33727363856) is the
consequence. Triage found a real SaaS failure, and its plan reports:

```json
{"surface": "saas-smoke-e2e", "reason": "spec-path-claimed-by-open-pr",
 "detail": "tests/8.10/smoke-tests.spec.ts (#3153)"}
```

`c8-cross-component-e2e-tests#3153` is a draft opened 2026-08-26 with one commit and no
activity since. It touches ten spec files, so it had been silently holding all ten shut
for eight days.

Expire the claim after a day of inactivity, measured from the PR's last activity rather
than from when it was opened: a PR being written, reviewed or rebased touches its own
timestamp well inside a day, so an active one keeps its files, while one nobody has
touched since yesterday is not work a second agent could collide with. The coarse
dispatch-key lock already expires this way (#8604); this is the same release applied to
the finer per-file claim, and the key lock plus the in-flight check still bound duplicate
work.

The TTL is checked before the file-list truncation guard, so a stale PR large enough to
truncate `gh`'s per-PR file list no longer fails the lookup for every surface.

Overridable via `ALWAYSGREEN_PATH_CLAIM_TTL_HOURS`; `0` restores the old never-expiring
claim.

Not in scope: the SM leg of that same run was suppressed as
`tracked-by-open-product-bug` (camunda/camunda#61565), which is correct and untouched.

## Related issues

Detected on: https://github.com/camunda/connectors/actions/runs/33727363856

Follows #8604, which gave the dispatch-key lock its TTL.

## Checklist

- [ ] PR has a **milestone** or the `no milestone` label.
