### PR TITLE
feat(element-template): support non-editable properties

### DIFF
--- a/element-template-generator/annotations/README.md
+++ b/element-template-generator/annotations/README.md
@@ -66,6 +66,23 @@ You can customize the property name and label by using the `@TemplateProperty` a
 private String value;
 ```
 
+## Non-editable properties
+
+Set `editable` to `NullableBoolean.FALSE` to prevent users from changing a generated property in the
+properties panel. For example, this Boolean property is displayed as checked and read-only:
+
+```java
+@TemplateProperty(
+    type = TemplateProperty.PropertyType.Boolean,
+    defaultValue = "true",
+    defaultValueType = TemplateProperty.DefaultValueType.Boolean,
+    editable = TemplateProperty.NullableBoolean.FALSE)
+private Boolean enabled;
+```
+
+The generator emits `"editable": false` only for `NullableBoolean.FALSE`. For every other value, it
+omits `editable` because `true` is the element-template schema default.
+
 ## Nested properties
 
 The Template Generator supports nested properties. For example, if your Connector input data model looks like this:

--- a/element-template-generator/annotations/src/main/java/io/camunda/connector/generator/java/annotation/TemplateProperty.java
+++ b/element-template-generator/annotations/src/main/java/io/camunda/connector/generator/java/annotation/TemplateProperty.java
@@ -55,6 +55,13 @@ public @interface TemplateProperty {
   boolean optional() default OPTIONAL_DEFAULT;
 
   /**
+   * Whether users can edit the property in the properties panel. Set to {@link
+   * NullableBoolean#FALSE} to emit {@code "editable": false}. Other values omit the member because
+   * {@code true} is the element-template schema default.
+   */
+  NullableBoolean editable() default NullableBoolean.NULL;
+
+  /**
    * Overrides the property type. By default, the generator will use the field type to determine the
    * property type. Most primitive fields will be mapped to String properties by default.
    *

--- a/element-template-generator/core/README.md
+++ b/element-template-generator/core/README.md
@@ -66,6 +66,23 @@ You can customize the property name and label by using the `@TemplateProperty` a
 private String value;
 ```
 
+## Non-editable properties
+
+Set `editable` to `NullableBoolean.FALSE` to prevent users from changing a generated property in the
+properties panel. For example, this Boolean property is displayed as checked and read-only:
+
+```java
+@TemplateProperty(
+    type = TemplateProperty.PropertyType.Boolean,
+    defaultValue = "true",
+    defaultValueType = TemplateProperty.DefaultValueType.Boolean,
+    editable = TemplateProperty.NullableBoolean.FALSE)
+private Boolean enabled;
+```
+
+The generator emits `"editable": false` only for `NullableBoolean.FALSE`. For every other value, it
+omits `editable` because `true` is the element-template schema default.
+
 ## Nested properties
 
 The Template Generator supports nested properties. For example, if your Connector input data model looks like this:

--- a/element-template-generator/core/src/main/java/io/camunda/connector/generator/dsl/BooleanProperty.java
+++ b/element-template-generator/core/src/main/java/io/camunda/connector/generator/dsl/BooleanProperty.java
@@ -36,6 +36,7 @@ public final class BooleanProperty extends Property {
       PropertyCondition condition,
       String tooltip,
       Object exampleValue,
+      Boolean editable,
       Boolean secret) {
     super(
         name,
@@ -54,6 +55,7 @@ public final class BooleanProperty extends Property {
         exampleValue,
         null,
         TYPE,
+        editable,
         secret);
   }
 
@@ -90,6 +92,7 @@ public final class BooleanProperty extends Property {
           condition,
           tooltip,
           exampleValue,
+          editable,
           secret);
     }
   }

--- a/element-template-generator/core/src/main/java/io/camunda/connector/generator/dsl/ConfigurationProperty.java
+++ b/element-template-generator/core/src/main/java/io/camunda/connector/generator/dsl/ConfigurationProperty.java
@@ -44,6 +44,7 @@ public final class ConfigurationProperty extends Property {
       PropertyBinding binding,
       PropertyCondition condition,
       String tooltip,
+      Boolean editable,
       String configurationTemplate) {
     super(
         name,
@@ -62,6 +63,7 @@ public final class ConfigurationProperty extends Property {
         null,
         null,
         TYPE,
+        editable,
         null);
     this.configurationTemplate = configurationTemplate;
   }
@@ -109,6 +111,7 @@ public final class ConfigurationProperty extends Property {
           binding,
           condition,
           tooltip,
+          editable,
           configurationTemplate);
     }
   }

--- a/element-template-generator/core/src/main/java/io/camunda/connector/generator/dsl/DropdownProperty.java
+++ b/element-template-generator/core/src/main/java/io/camunda/connector/generator/dsl/DropdownProperty.java
@@ -40,6 +40,7 @@ public final class DropdownProperty extends Property {
       String tooltip,
       List<DropdownChoice> choices,
       Object exampleValue,
+      Boolean editable,
       Boolean secret) {
     super(
         name,
@@ -58,6 +59,7 @@ public final class DropdownProperty extends Property {
         exampleValue,
         null,
         TYPE,
+        editable,
         secret);
     this.choices = choices;
   }
@@ -107,6 +109,7 @@ public final class DropdownProperty extends Property {
           tooltip,
           choices,
           exampleValue,
+          editable,
           secret);
     }
   }

--- a/element-template-generator/core/src/main/java/io/camunda/connector/generator/dsl/HiddenProperty.java
+++ b/element-template-generator/core/src/main/java/io/camunda/connector/generator/dsl/HiddenProperty.java
@@ -34,6 +34,7 @@ public final class HiddenProperty extends Property {
       String group,
       PropertyBinding binding,
       PropertyCondition condition,
+      Boolean editable,
       Boolean secret) {
     super(
         name,
@@ -52,6 +53,7 @@ public final class HiddenProperty extends Property {
         null,
         null,
         TYPE,
+        editable,
         secret);
   }
 
@@ -85,6 +87,7 @@ public final class HiddenProperty extends Property {
           group,
           binding,
           condition,
+          editable,
           secret);
     }
   }

--- a/element-template-generator/core/src/main/java/io/camunda/connector/generator/dsl/NumberProperty.java
+++ b/element-template-generator/core/src/main/java/io/camunda/connector/generator/dsl/NumberProperty.java
@@ -36,6 +36,7 @@ public final class NumberProperty extends Property {
       PropertyCondition condition,
       String tooltip,
       Object exampleValue,
+      Boolean editable,
       Boolean secret) {
     super(
         name,
@@ -54,6 +55,7 @@ public final class NumberProperty extends Property {
         exampleValue,
         null,
         TYPE,
+        editable,
         secret);
   }
 
@@ -89,6 +91,7 @@ public final class NumberProperty extends Property {
           condition,
           tooltip,
           exampleValue,
+          editable,
           secret);
     }
   }

--- a/element-template-generator/core/src/main/java/io/camunda/connector/generator/dsl/Property.java
+++ b/element-template-generator/core/src/main/java/io/camunda/connector/generator/dsl/Property.java
@@ -47,6 +47,7 @@ public abstract sealed class Property
   protected final Object exampleValue;
   protected final String language;
   protected final String type;
+  protected final Boolean editable;
   protected final Boolean secret;
 
   public record GeneratedValue(String type) {}
@@ -68,6 +69,7 @@ public abstract sealed class Property
       Object exampleValue,
       String language,
       String type,
+      Boolean editable,
       Boolean secret) {
     this.id = id;
     this.label = label;
@@ -84,6 +86,7 @@ public abstract sealed class Property
     this.placeholder = placeholder;
     this.language = language;
     this.type = type;
+    this.editable = editable;
     this.exampleValue = exampleValue;
     this.secret = secret;
   }
@@ -133,6 +136,10 @@ public abstract sealed class Property
 
   public String getType() {
     return type;
+  }
+
+  public Boolean getEditable() {
+    return editable;
   }
 
   public PropertyCondition getCondition() {
@@ -192,7 +199,8 @@ public abstract sealed class Property
         && Objects.equals(group, property.group)
         && Objects.equals(binding, property.binding)
         && Objects.equals(language, property.language)
-        && Objects.equals(type, property.type);
+        && Objects.equals(type, property.type)
+        && Objects.equals(editable, property.editable);
   }
 
   @Override
@@ -210,6 +218,7 @@ public abstract sealed class Property
         binding,
         language,
         type,
+        editable,
         tooltip);
   }
 
@@ -245,6 +254,8 @@ public abstract sealed class Property
         + ", type='"
         + type
         + '\''
+        + ", editable="
+        + editable
         + ", condition='"
         + condition
         + '\''

--- a/element-template-generator/core/src/main/java/io/camunda/connector/generator/dsl/PropertyBuilder.java
+++ b/element-template-generator/core/src/main/java/io/camunda/connector/generator/dsl/PropertyBuilder.java
@@ -36,6 +36,7 @@ public abstract class PropertyBuilder {
   protected String placeholder;
   protected Object exampleValue;
   protected String language;
+  protected Boolean editable;
   protected Boolean secret;
 
   protected PropertyBuilder() {}
@@ -141,6 +142,11 @@ public abstract class PropertyBuilder {
     return this;
   }
 
+  public PropertyBuilder editable(Boolean editable) {
+    this.editable = editable;
+    return this;
+  }
+
   public PropertyBuilder secret(Boolean secret) {
     this.secret = secret;
     return this;
@@ -170,6 +176,7 @@ public abstract class PropertyBuilder {
     builder.placeholder = source.placeholder;
     builder.exampleValue = source.exampleValue;
     builder.language = source.language;
+    builder.editable = source.editable;
     builder.secret = source.secret;
     return builder;
   }

--- a/element-template-generator/core/src/main/java/io/camunda/connector/generator/dsl/StringProperty.java
+++ b/element-template-generator/core/src/main/java/io/camunda/connector/generator/dsl/StringProperty.java
@@ -38,6 +38,7 @@ public final class StringProperty extends Property {
       String placeholder,
       Object exampleValue,
       String language,
+      Boolean editable,
       Boolean secret) {
     super(
         name,
@@ -56,6 +57,7 @@ public final class StringProperty extends Property {
         exampleValue,
         language,
         TYPE,
+        editable,
         secret);
   }
 
@@ -96,6 +98,7 @@ public final class StringProperty extends Property {
           placeholder,
           exampleValue,
           language,
+          editable,
           secret);
     }
   }

--- a/element-template-generator/core/src/main/java/io/camunda/connector/generator/dsl/TextProperty.java
+++ b/element-template-generator/core/src/main/java/io/camunda/connector/generator/dsl/TextProperty.java
@@ -38,6 +38,7 @@ public final class TextProperty extends Property {
       String placeholder,
       Object exampleValue,
       String language,
+      Boolean editable,
       Boolean secret) {
     super(
         name,
@@ -56,6 +57,7 @@ public final class TextProperty extends Property {
         exampleValue,
         language,
         TYPE,
+        editable,
         secret);
   }
 
@@ -96,6 +98,7 @@ public final class TextProperty extends Property {
           placeholder,
           exampleValue,
           language,
+          editable,
           secret);
     }
   }

--- a/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/processor/TemplatePropertyAnnotationProcessor.java
+++ b/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/processor/TemplatePropertyAnnotationProcessor.java
@@ -148,6 +148,9 @@ public class TemplatePropertyAnnotationProcessor implements AnnotationProcessor 
       return;
     }
     builder.optional(AnnotationProcessor.isOptional(field));
+    if (annotation.editable() == NullableBoolean.FALSE) {
+      builder.editable(false);
+    }
 
     switch (builder) {
       case DropdownProperty.DropdownPropertyBuilder ignored -> {}

--- a/element-template-generator/core/src/test/java/io/camunda/connector/generator/java/EditablePropertyGenerationTest.java
+++ b/element-template-generator/core/src/test/java/io/camunda/connector/generator/java/EditablePropertyGenerationTest.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.generator.java;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.networknt.schema.JsonSchema;
+import com.networknt.schema.JsonSchemaFactory;
+import com.networknt.schema.SpecVersion.VersionFlag;
+import io.camunda.connector.api.annotation.OutboundConnector;
+import io.camunda.connector.api.outbound.OutboundConnectorContext;
+import io.camunda.connector.api.outbound.OutboundConnectorFunction;
+import io.camunda.connector.generator.dsl.BooleanProperty;
+import io.camunda.connector.generator.dsl.ElementTemplate;
+import io.camunda.connector.generator.dsl.ElementTemplateBuilder;
+import io.camunda.connector.generator.java.annotation.FeelMode;
+import io.camunda.connector.generator.java.annotation.TemplateProperty;
+import io.camunda.connector.generator.java.annotation.TemplateProperty.DefaultValueType;
+import io.camunda.connector.generator.java.annotation.TemplateProperty.NullableBoolean;
+import io.camunda.connector.generator.java.json.ElementTemplateModule;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import org.junit.jupiter.api.Test;
+
+class EditablePropertyGenerationTest {
+
+  private static final String SCHEMA_URL =
+      "https://unpkg.com/@camunda/zeebe-element-templates-json-schema@0.44.0/resources/schema.json";
+  private static final ObjectMapper MAPPER =
+      new ObjectMapper().registerModule(new ElementTemplateModule());
+
+  private final ClassBasedTemplateGenerator generator = new ClassBasedTemplateGenerator();
+
+  @Test
+  void emitsEditableOnlyForReadOnlyPropertiesAndPreservesItWhenCopied() throws Exception {
+    assertThat(NullableBoolean.NULL.toBoolean()).isNull();
+
+    var template = generator.generate(ReadOnlyBooleanConnector.class).getFirst();
+    var readOnlyProperty = (BooleanProperty) property(template, "readOnly");
+    var explicitlyEditableProperty = property(template, "explicitlyEditable");
+    var defaultEditableProperty = property(template, "defaultEditable");
+
+    assertThat(readOnlyProperty.getEditable()).isFalse();
+    assertThat(readOnlyProperty.getType()).isEqualTo("Boolean");
+    assertThat(readOnlyProperty.getValue()).isEqualTo(true);
+    assertThat(readOnlyProperty.getBinding().type()).isEqualTo("zeebe:input");
+    assertThat(readOnlyProperty.getFeel()).isEqualTo(FeelMode.staticFeel);
+    assertThat(explicitlyEditableProperty.getEditable()).isNull();
+    assertThat(defaultEditableProperty.getEditable()).isNull();
+
+    JsonNode templateJson = MAPPER.valueToTree(template);
+    JsonNode readOnlyPropertyJson = property(templateJson, "readOnly");
+    assertThat(readOnlyPropertyJson.get("editable").booleanValue()).isFalse();
+    assertThat(readOnlyPropertyJson.get("feel").textValue()).isEqualTo("static");
+    assertThat(property(templateJson, "explicitlyEditable").has("editable")).isFalse();
+    assertThat(property(templateJson, "defaultEditable").has("editable")).isFalse();
+    assertThat(schema().validate(templateJson)).isEmpty();
+
+    var copiedProperty = (BooleanProperty) readOnlyProperty.toBuilder().build();
+    assertThat(copiedProperty.getEditable()).isFalse();
+
+    var copiedTemplate = ElementTemplateBuilder.from(template).build();
+    assertThat(property(copiedTemplate, "readOnly").getEditable()).isFalse();
+  }
+
+  private static io.camunda.connector.generator.dsl.Property property(
+      ElementTemplate template, String id) {
+    return template.properties().stream()
+        .filter(property -> id.equals(property.getId()))
+        .findFirst()
+        .orElseThrow();
+  }
+
+  private static JsonNode property(JsonNode template, String id) {
+    for (JsonNode property : template.get("properties")) {
+      if (id.equals(property.path("id").textValue())) {
+        return property;
+      }
+    }
+    throw new IllegalStateException(id + " property not found");
+  }
+
+  private static JsonSchema schema() throws Exception {
+    var client =
+        HttpClient.newBuilder()
+            .followRedirects(HttpClient.Redirect.NORMAL)
+            .connectTimeout(Duration.ofSeconds(10))
+            .build();
+    var request =
+        HttpRequest.newBuilder(URI.create(SCHEMA_URL))
+            .timeout(Duration.ofSeconds(20))
+            .GET()
+            .build();
+    HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+    assertThat(response.statusCode()).isBetween(200, 299);
+    return JsonSchemaFactory.getInstance(VersionFlag.V7)
+        .getSchema(MAPPER.readTree(response.body()));
+  }
+
+  record ReadOnlyBooleanInput(
+      @TemplateProperty(
+              type = TemplateProperty.PropertyType.Boolean,
+              editable = NullableBoolean.FALSE,
+              defaultValue = "true",
+              defaultValueType = DefaultValueType.Boolean)
+          Boolean readOnly,
+      @TemplateProperty(
+              type = TemplateProperty.PropertyType.Boolean,
+              editable = NullableBoolean.TRUE,
+              defaultValue = "true",
+              defaultValueType = DefaultValueType.Boolean)
+          Boolean explicitlyEditable,
+      @TemplateProperty(
+              type = TemplateProperty.PropertyType.Boolean,
+              defaultValue = "false",
+              defaultValueType = DefaultValueType.Boolean)
+          Boolean defaultEditable) {}
+
+  @OutboundConnector(name = "Read-only Boolean", type = "test:read-only-boolean")
+  @io.camunda.connector.generator.java.annotation.ElementTemplate(
+      id = "test-read-only-boolean",
+      name = "Read-only Boolean",
+      version = 1,
+      inputDataClass = ReadOnlyBooleanInput.class)
+  static class ReadOnlyBooleanConnector implements OutboundConnectorFunction {
+
+    @Override
+    public Object execute(OutboundConnectorContext context) {
+      return null;
+    }
+  }
+}


### PR DESCRIPTION
## Description

Add native generator support for non-editable element-template properties. `@TemplateProperty(editable = NullableBoolean.FALSE)` now emits `"editable": false`, while unset and explicit `TRUE` values omit the member to preserve the schema default and existing generated output.

The shared property DSL and builders retain non-editability through copy and transformation paths. Documentation and focused tests cover Boolean rendering, checked values, omission semantics, copy behavior, and validation against the pinned element-template schema.

This lets downstream transformations preserve non-editability. It does not replace #8550's transformation that injects inert `binding.type: property` / `modeler:*` status properties, because annotation-generated host properties still use `zeebe:input` bindings.

## Related issues

closes #8607

Supports camunda/experience-pdp#25 requirement F7.

## Checklist

- [x] Backport labels are added if these code changes should be backported. No backport is needed for this feature.
- [x] Tests/Integration tests for the changes have been added if applicable.
- [x] If the change requires a documentation update, it has been added to the appropriate section in the documentation.