### PR TITLE
feat(agentic-ai): OAuth 2.0 client-credentials auth on Anthropic's compatible backend

### DIFF
--- a/connector-commons/http-client/src/main/java/io/camunda/connector/http/client/authentication/OAuthClientCredentialsTokenResolver.java
+++ b/connector-commons/http-client/src/main/java/io/camunda/connector/http/client/authentication/OAuthClientCredentialsTokenResolver.java
@@ -22,9 +22,8 @@ import io.camunda.connector.http.client.model.auth.OAuthAuthentication;
 import org.jspecify.annotations.Nullable;
 
 /**
- * Resolves an OAuth2 client-credentials access token for a {@code custom}/compatible LLM backend,
- * shared by the OpenAI and Anthropic native providers. Backed by the same {@link OAuthService} and
- * {@link OAuthTokenCache} the HTTP connector uses.
+ * Resolves an OAuth2 client-credentials access token for a {@code custom}/compatible LLM backend.
+ * Backed by the same {@link OAuthService} and {@link OAuthTokenCache} the HTTP connector uses.
  */
 public class OAuthClientCredentialsTokenResolver {
 

--- a/connector-commons/http-client/src/main/java/io/camunda/connector/http/client/authentication/OAuthClientCredentialsTokenResolver.java
+++ b/connector-commons/http-client/src/main/java/io/camunda/connector/http/client/authentication/OAuthClientCredentialsTokenResolver.java
@@ -22,8 +22,9 @@ import io.camunda.connector.http.client.model.auth.OAuthAuthentication;
 import org.jspecify.annotations.Nullable;
 
 /**
- * Resolves an OAuth2 client-credentials access token for a {@code custom}/compatible LLM backend.
- * Backed by the same {@link OAuthService} and {@link OAuthTokenCache} the HTTP connector uses.
+ * Resolves an OAuth2 client-credentials access token for a {@code custom}/compatible LLM backend,
+ * shared by the OpenAI and Anthropic native providers. Backed by the same {@link OAuthService} and
+ * {@link OAuthTokenCache} the HTTP connector uses.
  */
 public class OAuthClientCredentialsTokenResolver {
 

--- a/connector-commons/http-client/src/test/java/io/camunda/connector/http/client/authentication/OAuthClientCredentialsTokenResolverTest.java
+++ b/connector-commons/http-client/src/test/java/io/camunda/connector/http/client/authentication/OAuthClientCredentialsTokenResolverTest.java
@@ -166,6 +166,40 @@ class OAuthClientCredentialsTokenResolverTest {
   }
 
   @Test
+  void shouldNotCacheTokenWhenExpiresInIsMissing() {
+    stubFor(
+        post(urlEqualTo("/oauth/token"))
+            .willReturn(
+                aResponse()
+                    .withStatus(200)
+                    .withHeader("Content-Type", "application/json")
+                    .withBody(
+                        """
+                        {
+                          "access_token": "uncached-token",
+                          "token_type": "Bearer"
+                        }
+                        """)));
+
+    final var auth =
+        new OAuthAuthentication(
+            tokenEndpoint,
+            "my-client-id",
+            "my-client-secret",
+            null,
+            OAuthConstants.BASIC_AUTH_HEADER,
+            null);
+
+    final var token1 = resolver.resolveAccessToken(auth);
+    final var token2 = resolver.resolveAccessToken(auth);
+
+    assertThat(token1).isEqualTo("uncached-token");
+    assertThat(token2).isEqualTo("uncached-token");
+
+    verify(2, postRequestedFor(urlEqualTo("/oauth/token")));
+  }
+
+  @Test
   void shouldThrowConnectorExceptionOnHttpFailure() {
     stubFor(
         post(urlEqualTo("/oauth/token"))

--- a/connectors/agentic-ai/connector-agentic-ai/element-templates/agenticai-ai-agent-subprocess.v2.json
+++ b/connectors/agentic-ai/connector-agentic-ai/element-templates/agenticai-ai-agent-subprocess.v2.json
@@ -444,6 +444,9 @@
     }, {
       "name" : "API key",
       "value" : "apiKey"
+    }, {
+      "name" : "OAuth 2.0",
+      "value" : "oauth-client-credentials-flow"
     } ]
   }, {
     "id" : "provider.anthropic.backend.custom.authentication.apiKey",
@@ -462,6 +465,191 @@
       "allMatch" : [ {
         "property" : "provider.anthropic.backend.custom.authentication.type",
         "equals" : "apiKey",
+        "type" : "simple"
+      }, {
+        "property" : "provider.anthropic.backend.type",
+        "equals" : "custom",
+        "type" : "simple"
+      }, {
+        "property" : "provider.type",
+        "equals" : "anthropic",
+        "type" : "simple"
+      } ]
+    },
+    "type" : "String"
+  }, {
+    "id" : "provider.anthropic.backend.custom.authentication.oauthTokenEndpoint",
+    "label" : "OAuth 2.0 token endpoint",
+    "description" : "The OAuth token endpoint",
+    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true,
+      "pattern" : {
+        "value" : "^(=|(http://|https://|secrets|\\{\\{).*$)",
+        "message" : "Must be a http(s) URL"
+      }
+    },
+    "feel" : "optional",
+    "group" : "provider",
+    "binding" : {
+      "name" : "provider.anthropic.backend.custom.authentication.oauthTokenEndpoint",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "allMatch" : [ {
+        "property" : "provider.anthropic.backend.custom.authentication.type",
+        "equals" : "oauth-client-credentials-flow",
+        "type" : "simple"
+      }, {
+        "property" : "provider.anthropic.backend.type",
+        "equals" : "custom",
+        "type" : "simple"
+      }, {
+        "property" : "provider.type",
+        "equals" : "anthropic",
+        "type" : "simple"
+      } ]
+    },
+    "type" : "String"
+  }, {
+    "id" : "provider.anthropic.backend.custom.authentication.clientId",
+    "label" : "Client ID",
+    "description" : "Your application's client ID from the OAuth client",
+    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "provider",
+    "binding" : {
+      "name" : "provider.anthropic.backend.custom.authentication.clientId",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "allMatch" : [ {
+        "property" : "provider.anthropic.backend.custom.authentication.type",
+        "equals" : "oauth-client-credentials-flow",
+        "type" : "simple"
+      }, {
+        "property" : "provider.anthropic.backend.type",
+        "equals" : "custom",
+        "type" : "simple"
+      }, {
+        "property" : "provider.type",
+        "equals" : "anthropic",
+        "type" : "simple"
+      } ]
+    },
+    "type" : "String"
+  }, {
+    "id" : "provider.anthropic.backend.custom.authentication.clientSecret",
+    "label" : "Client secret",
+    "description" : "Your application's client secret from the OAuth client",
+    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "provider",
+    "binding" : {
+      "name" : "provider.anthropic.backend.custom.authentication.clientSecret",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "allMatch" : [ {
+        "property" : "provider.anthropic.backend.custom.authentication.type",
+        "equals" : "oauth-client-credentials-flow",
+        "type" : "simple"
+      }, {
+        "property" : "provider.anthropic.backend.type",
+        "equals" : "custom",
+        "type" : "simple"
+      }, {
+        "property" : "provider.type",
+        "equals" : "anthropic",
+        "type" : "simple"
+      } ]
+    },
+    "type" : "String"
+  }, {
+    "id" : "provider.anthropic.backend.custom.authentication.audience",
+    "label" : "Audience",
+    "description" : "The unique identifier of the target API you want to access",
+    "optional" : true,
+    "feel" : "optional",
+    "group" : "provider",
+    "binding" : {
+      "name" : "provider.anthropic.backend.custom.authentication.audience",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "allMatch" : [ {
+        "property" : "provider.anthropic.backend.custom.authentication.type",
+        "equals" : "oauth-client-credentials-flow",
+        "type" : "simple"
+      }, {
+        "property" : "provider.anthropic.backend.type",
+        "equals" : "custom",
+        "type" : "simple"
+      }, {
+        "property" : "provider.type",
+        "equals" : "anthropic",
+        "type" : "simple"
+      } ]
+    },
+    "type" : "String"
+  }, {
+    "id" : "provider.anthropic.backend.custom.authentication.clientAuthentication",
+    "label" : "Client authentication",
+    "description" : "Send client ID and client secret as Basic Auth request in the header, or as client credentials in the request body",
+    "optional" : false,
+    "value" : "BASIC_AUTH_HEADER",
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "group" : "provider",
+    "binding" : {
+      "name" : "provider.anthropic.backend.custom.authentication.clientAuthentication",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "allMatch" : [ {
+        "property" : "provider.anthropic.backend.custom.authentication.type",
+        "equals" : "oauth-client-credentials-flow",
+        "type" : "simple"
+      }, {
+        "property" : "provider.anthropic.backend.type",
+        "equals" : "custom",
+        "type" : "simple"
+      }, {
+        "property" : "provider.type",
+        "equals" : "anthropic",
+        "type" : "simple"
+      } ]
+    },
+    "type" : "Dropdown",
+    "choices" : [ {
+      "name" : "Send as Basic Auth header",
+      "value" : "BASIC_AUTH_HEADER"
+    }, {
+      "name" : "Send client credentials in body",
+      "value" : "CREDENTIALS_BODY"
+    } ]
+  }, {
+    "id" : "provider.anthropic.backend.custom.authentication.scopes",
+    "label" : "Scopes",
+    "description" : "The scopes which you want to request authorization for (e.g.read:contacts)",
+    "optional" : true,
+    "feel" : "optional",
+    "group" : "provider",
+    "binding" : {
+      "name" : "provider.anthropic.backend.custom.authentication.scopes",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "allMatch" : [ {
+        "property" : "provider.anthropic.backend.custom.authentication.type",
+        "equals" : "oauth-client-credentials-flow",
         "type" : "simple"
       }, {
         "property" : "provider.anthropic.backend.type",

--- a/connectors/agentic-ai/connector-agentic-ai/element-templates/agenticai-ai-agent-subprocess.v2.json
+++ b/connectors/agentic-ai/connector-agentic-ai/element-templates/agenticai-ai-agent-subprocess.v2.json
@@ -660,7 +660,7 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "The scopes which you want to request authorization for (e.g.read:contacts)",
+    "tooltip" : "The scopes which you want to request authorization for (e.g., read:contacts)",
     "type" : "String"
   }, {
     "id" : "provider.anthropic.timeouts.timeout",

--- a/connectors/agentic-ai/connector-agentic-ai/element-templates/agenticai-ai-agent-subprocess.v2.json
+++ b/connectors/agentic-ai/connector-agentic-ai/element-templates/agenticai-ai-agent-subprocess.v2.json
@@ -480,7 +480,6 @@
   }, {
     "id" : "provider.anthropic.backend.custom.authentication.oauthTokenEndpoint",
     "label" : "OAuth 2.0 token endpoint",
-    "description" : "The OAuth token endpoint",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true,
@@ -510,11 +509,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "The OAuth token endpoint",
     "type" : "String"
   }, {
     "id" : "provider.anthropic.backend.custom.authentication.clientId",
     "label" : "Client ID",
-    "description" : "Your application's client ID from the OAuth client",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -540,11 +539,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Your application's client ID from the OAuth client",
     "type" : "String"
   }, {
     "id" : "provider.anthropic.backend.custom.authentication.clientSecret",
     "label" : "Client secret",
-    "description" : "Your application's client secret from the OAuth client",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -570,11 +569,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Your application's client secret from the OAuth client",
     "type" : "String"
   }, {
     "id" : "provider.anthropic.backend.custom.authentication.audience",
     "label" : "Audience",
-    "description" : "The unique identifier of the target API you want to access",
     "optional" : true,
     "feel" : "optional",
     "group" : "provider",
@@ -597,11 +596,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "The unique identifier of the target API you want to access",
     "type" : "String"
   }, {
     "id" : "provider.anthropic.backend.custom.authentication.clientAuthentication",
     "label" : "Client authentication",
-    "description" : "Send client ID and client secret as Basic Auth request in the header, or as client credentials in the request body",
     "optional" : false,
     "value" : "BASIC_AUTH_HEADER",
     "constraints" : {
@@ -627,6 +626,7 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Send client ID and client secret as Basic Auth request in the header, or as client credentials in the request body",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "Send as Basic Auth header",
@@ -638,7 +638,6 @@
   }, {
     "id" : "provider.anthropic.backend.custom.authentication.scopes",
     "label" : "Scopes",
-    "description" : "The scopes which you want to request authorization for (e.g.read:contacts)",
     "optional" : true,
     "feel" : "optional",
     "group" : "provider",
@@ -661,6 +660,7 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "The scopes which you want to request authorization for (e.g.read:contacts)",
     "type" : "String"
   }, {
     "id" : "provider.anthropic.timeouts.timeout",

--- a/connectors/agentic-ai/connector-agentic-ai/element-templates/agenticai-ai-agent-subprocess.v2.json
+++ b/connectors/agentic-ai/connector-agentic-ai/element-templates/agenticai-ai-agent-subprocess.v2.json
@@ -570,7 +570,8 @@
       } ]
     },
     "tooltip" : "Your application's client secret from the OAuth client",
-    "type" : "String"
+    "type" : "String",
+    "secret" : true
   }, {
     "id" : "provider.anthropic.backend.custom.authentication.audience",
     "label" : "Audience",

--- a/connectors/agentic-ai/connector-agentic-ai/element-templates/agenticai-ai-agent-task.v2.json
+++ b/connectors/agentic-ai/connector-agentic-ai/element-templates/agenticai-ai-agent-task.v2.json
@@ -416,6 +416,9 @@
     }, {
       "name" : "API key",
       "value" : "apiKey"
+    }, {
+      "name" : "OAuth 2.0",
+      "value" : "oauth-client-credentials-flow"
     } ]
   }, {
     "id" : "provider.anthropic.backend.custom.authentication.apiKey",
@@ -434,6 +437,191 @@
       "allMatch" : [ {
         "property" : "provider.anthropic.backend.custom.authentication.type",
         "equals" : "apiKey",
+        "type" : "simple"
+      }, {
+        "property" : "provider.anthropic.backend.type",
+        "equals" : "custom",
+        "type" : "simple"
+      }, {
+        "property" : "provider.type",
+        "equals" : "anthropic",
+        "type" : "simple"
+      } ]
+    },
+    "type" : "String"
+  }, {
+    "id" : "provider.anthropic.backend.custom.authentication.oauthTokenEndpoint",
+    "label" : "OAuth 2.0 token endpoint",
+    "description" : "The OAuth token endpoint",
+    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true,
+      "pattern" : {
+        "value" : "^(=|(http://|https://|secrets|\\{\\{).*$)",
+        "message" : "Must be a http(s) URL"
+      }
+    },
+    "feel" : "optional",
+    "group" : "provider",
+    "binding" : {
+      "name" : "provider.anthropic.backend.custom.authentication.oauthTokenEndpoint",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "allMatch" : [ {
+        "property" : "provider.anthropic.backend.custom.authentication.type",
+        "equals" : "oauth-client-credentials-flow",
+        "type" : "simple"
+      }, {
+        "property" : "provider.anthropic.backend.type",
+        "equals" : "custom",
+        "type" : "simple"
+      }, {
+        "property" : "provider.type",
+        "equals" : "anthropic",
+        "type" : "simple"
+      } ]
+    },
+    "type" : "String"
+  }, {
+    "id" : "provider.anthropic.backend.custom.authentication.clientId",
+    "label" : "Client ID",
+    "description" : "Your application's client ID from the OAuth client",
+    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "provider",
+    "binding" : {
+      "name" : "provider.anthropic.backend.custom.authentication.clientId",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "allMatch" : [ {
+        "property" : "provider.anthropic.backend.custom.authentication.type",
+        "equals" : "oauth-client-credentials-flow",
+        "type" : "simple"
+      }, {
+        "property" : "provider.anthropic.backend.type",
+        "equals" : "custom",
+        "type" : "simple"
+      }, {
+        "property" : "provider.type",
+        "equals" : "anthropic",
+        "type" : "simple"
+      } ]
+    },
+    "type" : "String"
+  }, {
+    "id" : "provider.anthropic.backend.custom.authentication.clientSecret",
+    "label" : "Client secret",
+    "description" : "Your application's client secret from the OAuth client",
+    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "provider",
+    "binding" : {
+      "name" : "provider.anthropic.backend.custom.authentication.clientSecret",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "allMatch" : [ {
+        "property" : "provider.anthropic.backend.custom.authentication.type",
+        "equals" : "oauth-client-credentials-flow",
+        "type" : "simple"
+      }, {
+        "property" : "provider.anthropic.backend.type",
+        "equals" : "custom",
+        "type" : "simple"
+      }, {
+        "property" : "provider.type",
+        "equals" : "anthropic",
+        "type" : "simple"
+      } ]
+    },
+    "type" : "String"
+  }, {
+    "id" : "provider.anthropic.backend.custom.authentication.audience",
+    "label" : "Audience",
+    "description" : "The unique identifier of the target API you want to access",
+    "optional" : true,
+    "feel" : "optional",
+    "group" : "provider",
+    "binding" : {
+      "name" : "provider.anthropic.backend.custom.authentication.audience",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "allMatch" : [ {
+        "property" : "provider.anthropic.backend.custom.authentication.type",
+        "equals" : "oauth-client-credentials-flow",
+        "type" : "simple"
+      }, {
+        "property" : "provider.anthropic.backend.type",
+        "equals" : "custom",
+        "type" : "simple"
+      }, {
+        "property" : "provider.type",
+        "equals" : "anthropic",
+        "type" : "simple"
+      } ]
+    },
+    "type" : "String"
+  }, {
+    "id" : "provider.anthropic.backend.custom.authentication.clientAuthentication",
+    "label" : "Client authentication",
+    "description" : "Send client ID and client secret as Basic Auth request in the header, or as client credentials in the request body",
+    "optional" : false,
+    "value" : "BASIC_AUTH_HEADER",
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "group" : "provider",
+    "binding" : {
+      "name" : "provider.anthropic.backend.custom.authentication.clientAuthentication",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "allMatch" : [ {
+        "property" : "provider.anthropic.backend.custom.authentication.type",
+        "equals" : "oauth-client-credentials-flow",
+        "type" : "simple"
+      }, {
+        "property" : "provider.anthropic.backend.type",
+        "equals" : "custom",
+        "type" : "simple"
+      }, {
+        "property" : "provider.type",
+        "equals" : "anthropic",
+        "type" : "simple"
+      } ]
+    },
+    "type" : "Dropdown",
+    "choices" : [ {
+      "name" : "Send as Basic Auth header",
+      "value" : "BASIC_AUTH_HEADER"
+    }, {
+      "name" : "Send client credentials in body",
+      "value" : "CREDENTIALS_BODY"
+    } ]
+  }, {
+    "id" : "provider.anthropic.backend.custom.authentication.scopes",
+    "label" : "Scopes",
+    "description" : "The scopes which you want to request authorization for (e.g.read:contacts)",
+    "optional" : true,
+    "feel" : "optional",
+    "group" : "provider",
+    "binding" : {
+      "name" : "provider.anthropic.backend.custom.authentication.scopes",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "allMatch" : [ {
+        "property" : "provider.anthropic.backend.custom.authentication.type",
+        "equals" : "oauth-client-credentials-flow",
         "type" : "simple"
       }, {
         "property" : "provider.anthropic.backend.type",

--- a/connectors/agentic-ai/connector-agentic-ai/element-templates/agenticai-ai-agent-task.v2.json
+++ b/connectors/agentic-ai/connector-agentic-ai/element-templates/agenticai-ai-agent-task.v2.json
@@ -542,7 +542,8 @@
       } ]
     },
     "tooltip" : "Your application's client secret from the OAuth client",
-    "type" : "String"
+    "type" : "String",
+    "secret" : true
   }, {
     "id" : "provider.anthropic.backend.custom.authentication.audience",
     "label" : "Audience",

--- a/connectors/agentic-ai/connector-agentic-ai/element-templates/agenticai-ai-agent-task.v2.json
+++ b/connectors/agentic-ai/connector-agentic-ai/element-templates/agenticai-ai-agent-task.v2.json
@@ -452,7 +452,6 @@
   }, {
     "id" : "provider.anthropic.backend.custom.authentication.oauthTokenEndpoint",
     "label" : "OAuth 2.0 token endpoint",
-    "description" : "The OAuth token endpoint",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true,
@@ -482,11 +481,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "The OAuth token endpoint",
     "type" : "String"
   }, {
     "id" : "provider.anthropic.backend.custom.authentication.clientId",
     "label" : "Client ID",
-    "description" : "Your application's client ID from the OAuth client",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -512,11 +511,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Your application's client ID from the OAuth client",
     "type" : "String"
   }, {
     "id" : "provider.anthropic.backend.custom.authentication.clientSecret",
     "label" : "Client secret",
-    "description" : "Your application's client secret from the OAuth client",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -542,11 +541,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Your application's client secret from the OAuth client",
     "type" : "String"
   }, {
     "id" : "provider.anthropic.backend.custom.authentication.audience",
     "label" : "Audience",
-    "description" : "The unique identifier of the target API you want to access",
     "optional" : true,
     "feel" : "optional",
     "group" : "provider",
@@ -569,11 +568,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "The unique identifier of the target API you want to access",
     "type" : "String"
   }, {
     "id" : "provider.anthropic.backend.custom.authentication.clientAuthentication",
     "label" : "Client authentication",
-    "description" : "Send client ID and client secret as Basic Auth request in the header, or as client credentials in the request body",
     "optional" : false,
     "value" : "BASIC_AUTH_HEADER",
     "constraints" : {
@@ -599,6 +598,7 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Send client ID and client secret as Basic Auth request in the header, or as client credentials in the request body",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "Send as Basic Auth header",
@@ -610,7 +610,6 @@
   }, {
     "id" : "provider.anthropic.backend.custom.authentication.scopes",
     "label" : "Scopes",
-    "description" : "The scopes which you want to request authorization for (e.g.read:contacts)",
     "optional" : true,
     "feel" : "optional",
     "group" : "provider",
@@ -633,6 +632,7 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "The scopes which you want to request authorization for (e.g.read:contacts)",
     "type" : "String"
   }, {
     "id" : "provider.anthropic.timeouts.timeout",

--- a/connectors/agentic-ai/connector-agentic-ai/element-templates/agenticai-ai-agent-task.v2.json
+++ b/connectors/agentic-ai/connector-agentic-ai/element-templates/agenticai-ai-agent-task.v2.json
@@ -632,7 +632,7 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "The scopes which you want to request authorization for (e.g.read:contacts)",
+    "tooltip" : "The scopes which you want to request authorization for (e.g., read:contacts)",
     "type" : "String"
   }, {
     "id" : "provider.anthropic.timeouts.timeout",

--- a/connectors/agentic-ai/connector-agentic-ai/element-templates/hybrid/agenticai-ai-agent-subprocess.v2-hybrid.json
+++ b/connectors/agentic-ai/connector-agentic-ai/element-templates/hybrid/agenticai-ai-agent-subprocess.v2-hybrid.json
@@ -485,7 +485,6 @@
   }, {
     "id" : "provider.anthropic.backend.custom.authentication.oauthTokenEndpoint",
     "label" : "OAuth 2.0 token endpoint",
-    "description" : "The OAuth token endpoint",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true,
@@ -515,11 +514,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "The OAuth token endpoint",
     "type" : "String"
   }, {
     "id" : "provider.anthropic.backend.custom.authentication.clientId",
     "label" : "Client ID",
-    "description" : "Your application's client ID from the OAuth client",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -545,11 +544,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Your application's client ID from the OAuth client",
     "type" : "String"
   }, {
     "id" : "provider.anthropic.backend.custom.authentication.clientSecret",
     "label" : "Client secret",
-    "description" : "Your application's client secret from the OAuth client",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -575,11 +574,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Your application's client secret from the OAuth client",
     "type" : "String"
   }, {
     "id" : "provider.anthropic.backend.custom.authentication.audience",
     "label" : "Audience",
-    "description" : "The unique identifier of the target API you want to access",
     "optional" : true,
     "feel" : "optional",
     "group" : "provider",
@@ -602,11 +601,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "The unique identifier of the target API you want to access",
     "type" : "String"
   }, {
     "id" : "provider.anthropic.backend.custom.authentication.clientAuthentication",
     "label" : "Client authentication",
-    "description" : "Send client ID and client secret as Basic Auth request in the header, or as client credentials in the request body",
     "optional" : false,
     "value" : "BASIC_AUTH_HEADER",
     "constraints" : {
@@ -632,6 +631,7 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Send client ID and client secret as Basic Auth request in the header, or as client credentials in the request body",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "Send as Basic Auth header",
@@ -643,7 +643,6 @@
   }, {
     "id" : "provider.anthropic.backend.custom.authentication.scopes",
     "label" : "Scopes",
-    "description" : "The scopes which you want to request authorization for (e.g.read:contacts)",
     "optional" : true,
     "feel" : "optional",
     "group" : "provider",
@@ -666,6 +665,7 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "The scopes which you want to request authorization for (e.g.read:contacts)",
     "type" : "String"
   }, {
     "id" : "provider.anthropic.timeouts.timeout",

--- a/connectors/agentic-ai/connector-agentic-ai/element-templates/hybrid/agenticai-ai-agent-subprocess.v2-hybrid.json
+++ b/connectors/agentic-ai/connector-agentic-ai/element-templates/hybrid/agenticai-ai-agent-subprocess.v2-hybrid.json
@@ -575,7 +575,8 @@
       } ]
     },
     "tooltip" : "Your application's client secret from the OAuth client",
-    "type" : "String"
+    "type" : "String",
+    "secret" : true
   }, {
     "id" : "provider.anthropic.backend.custom.authentication.audience",
     "label" : "Audience",

--- a/connectors/agentic-ai/connector-agentic-ai/element-templates/hybrid/agenticai-ai-agent-subprocess.v2-hybrid.json
+++ b/connectors/agentic-ai/connector-agentic-ai/element-templates/hybrid/agenticai-ai-agent-subprocess.v2-hybrid.json
@@ -665,7 +665,7 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "The scopes which you want to request authorization for (e.g.read:contacts)",
+    "tooltip" : "The scopes which you want to request authorization for (e.g., read:contacts)",
     "type" : "String"
   }, {
     "id" : "provider.anthropic.timeouts.timeout",

--- a/connectors/agentic-ai/connector-agentic-ai/element-templates/hybrid/agenticai-ai-agent-subprocess.v2-hybrid.json
+++ b/connectors/agentic-ai/connector-agentic-ai/element-templates/hybrid/agenticai-ai-agent-subprocess.v2-hybrid.json
@@ -449,6 +449,9 @@
     }, {
       "name" : "API key",
       "value" : "apiKey"
+    }, {
+      "name" : "OAuth 2.0",
+      "value" : "oauth-client-credentials-flow"
     } ]
   }, {
     "id" : "provider.anthropic.backend.custom.authentication.apiKey",
@@ -467,6 +470,191 @@
       "allMatch" : [ {
         "property" : "provider.anthropic.backend.custom.authentication.type",
         "equals" : "apiKey",
+        "type" : "simple"
+      }, {
+        "property" : "provider.anthropic.backend.type",
+        "equals" : "custom",
+        "type" : "simple"
+      }, {
+        "property" : "provider.type",
+        "equals" : "anthropic",
+        "type" : "simple"
+      } ]
+    },
+    "type" : "String"
+  }, {
+    "id" : "provider.anthropic.backend.custom.authentication.oauthTokenEndpoint",
+    "label" : "OAuth 2.0 token endpoint",
+    "description" : "The OAuth token endpoint",
+    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true,
+      "pattern" : {
+        "value" : "^(=|(http://|https://|secrets|\\{\\{).*$)",
+        "message" : "Must be a http(s) URL"
+      }
+    },
+    "feel" : "optional",
+    "group" : "provider",
+    "binding" : {
+      "name" : "provider.anthropic.backend.custom.authentication.oauthTokenEndpoint",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "allMatch" : [ {
+        "property" : "provider.anthropic.backend.custom.authentication.type",
+        "equals" : "oauth-client-credentials-flow",
+        "type" : "simple"
+      }, {
+        "property" : "provider.anthropic.backend.type",
+        "equals" : "custom",
+        "type" : "simple"
+      }, {
+        "property" : "provider.type",
+        "equals" : "anthropic",
+        "type" : "simple"
+      } ]
+    },
+    "type" : "String"
+  }, {
+    "id" : "provider.anthropic.backend.custom.authentication.clientId",
+    "label" : "Client ID",
+    "description" : "Your application's client ID from the OAuth client",
+    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "provider",
+    "binding" : {
+      "name" : "provider.anthropic.backend.custom.authentication.clientId",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "allMatch" : [ {
+        "property" : "provider.anthropic.backend.custom.authentication.type",
+        "equals" : "oauth-client-credentials-flow",
+        "type" : "simple"
+      }, {
+        "property" : "provider.anthropic.backend.type",
+        "equals" : "custom",
+        "type" : "simple"
+      }, {
+        "property" : "provider.type",
+        "equals" : "anthropic",
+        "type" : "simple"
+      } ]
+    },
+    "type" : "String"
+  }, {
+    "id" : "provider.anthropic.backend.custom.authentication.clientSecret",
+    "label" : "Client secret",
+    "description" : "Your application's client secret from the OAuth client",
+    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "provider",
+    "binding" : {
+      "name" : "provider.anthropic.backend.custom.authentication.clientSecret",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "allMatch" : [ {
+        "property" : "provider.anthropic.backend.custom.authentication.type",
+        "equals" : "oauth-client-credentials-flow",
+        "type" : "simple"
+      }, {
+        "property" : "provider.anthropic.backend.type",
+        "equals" : "custom",
+        "type" : "simple"
+      }, {
+        "property" : "provider.type",
+        "equals" : "anthropic",
+        "type" : "simple"
+      } ]
+    },
+    "type" : "String"
+  }, {
+    "id" : "provider.anthropic.backend.custom.authentication.audience",
+    "label" : "Audience",
+    "description" : "The unique identifier of the target API you want to access",
+    "optional" : true,
+    "feel" : "optional",
+    "group" : "provider",
+    "binding" : {
+      "name" : "provider.anthropic.backend.custom.authentication.audience",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "allMatch" : [ {
+        "property" : "provider.anthropic.backend.custom.authentication.type",
+        "equals" : "oauth-client-credentials-flow",
+        "type" : "simple"
+      }, {
+        "property" : "provider.anthropic.backend.type",
+        "equals" : "custom",
+        "type" : "simple"
+      }, {
+        "property" : "provider.type",
+        "equals" : "anthropic",
+        "type" : "simple"
+      } ]
+    },
+    "type" : "String"
+  }, {
+    "id" : "provider.anthropic.backend.custom.authentication.clientAuthentication",
+    "label" : "Client authentication",
+    "description" : "Send client ID and client secret as Basic Auth request in the header, or as client credentials in the request body",
+    "optional" : false,
+    "value" : "BASIC_AUTH_HEADER",
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "group" : "provider",
+    "binding" : {
+      "name" : "provider.anthropic.backend.custom.authentication.clientAuthentication",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "allMatch" : [ {
+        "property" : "provider.anthropic.backend.custom.authentication.type",
+        "equals" : "oauth-client-credentials-flow",
+        "type" : "simple"
+      }, {
+        "property" : "provider.anthropic.backend.type",
+        "equals" : "custom",
+        "type" : "simple"
+      }, {
+        "property" : "provider.type",
+        "equals" : "anthropic",
+        "type" : "simple"
+      } ]
+    },
+    "type" : "Dropdown",
+    "choices" : [ {
+      "name" : "Send as Basic Auth header",
+      "value" : "BASIC_AUTH_HEADER"
+    }, {
+      "name" : "Send client credentials in body",
+      "value" : "CREDENTIALS_BODY"
+    } ]
+  }, {
+    "id" : "provider.anthropic.backend.custom.authentication.scopes",
+    "label" : "Scopes",
+    "description" : "The scopes which you want to request authorization for (e.g.read:contacts)",
+    "optional" : true,
+    "feel" : "optional",
+    "group" : "provider",
+    "binding" : {
+      "name" : "provider.anthropic.backend.custom.authentication.scopes",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "allMatch" : [ {
+        "property" : "provider.anthropic.backend.custom.authentication.type",
+        "equals" : "oauth-client-credentials-flow",
         "type" : "simple"
       }, {
         "property" : "provider.anthropic.backend.type",

--- a/connectors/agentic-ai/connector-agentic-ai/element-templates/hybrid/agenticai-ai-agent-task.v2-hybrid.json
+++ b/connectors/agentic-ai/connector-agentic-ai/element-templates/hybrid/agenticai-ai-agent-task.v2-hybrid.json
@@ -637,7 +637,7 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "The scopes which you want to request authorization for (e.g.read:contacts)",
+    "tooltip" : "The scopes which you want to request authorization for (e.g., read:contacts)",
     "type" : "String"
   }, {
     "id" : "provider.anthropic.timeouts.timeout",

--- a/connectors/agentic-ai/connector-agentic-ai/element-templates/hybrid/agenticai-ai-agent-task.v2-hybrid.json
+++ b/connectors/agentic-ai/connector-agentic-ai/element-templates/hybrid/agenticai-ai-agent-task.v2-hybrid.json
@@ -421,6 +421,9 @@
     }, {
       "name" : "API key",
       "value" : "apiKey"
+    }, {
+      "name" : "OAuth 2.0",
+      "value" : "oauth-client-credentials-flow"
     } ]
   }, {
     "id" : "provider.anthropic.backend.custom.authentication.apiKey",
@@ -439,6 +442,191 @@
       "allMatch" : [ {
         "property" : "provider.anthropic.backend.custom.authentication.type",
         "equals" : "apiKey",
+        "type" : "simple"
+      }, {
+        "property" : "provider.anthropic.backend.type",
+        "equals" : "custom",
+        "type" : "simple"
+      }, {
+        "property" : "provider.type",
+        "equals" : "anthropic",
+        "type" : "simple"
+      } ]
+    },
+    "type" : "String"
+  }, {
+    "id" : "provider.anthropic.backend.custom.authentication.oauthTokenEndpoint",
+    "label" : "OAuth 2.0 token endpoint",
+    "description" : "The OAuth token endpoint",
+    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true,
+      "pattern" : {
+        "value" : "^(=|(http://|https://|secrets|\\{\\{).*$)",
+        "message" : "Must be a http(s) URL"
+      }
+    },
+    "feel" : "optional",
+    "group" : "provider",
+    "binding" : {
+      "name" : "provider.anthropic.backend.custom.authentication.oauthTokenEndpoint",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "allMatch" : [ {
+        "property" : "provider.anthropic.backend.custom.authentication.type",
+        "equals" : "oauth-client-credentials-flow",
+        "type" : "simple"
+      }, {
+        "property" : "provider.anthropic.backend.type",
+        "equals" : "custom",
+        "type" : "simple"
+      }, {
+        "property" : "provider.type",
+        "equals" : "anthropic",
+        "type" : "simple"
+      } ]
+    },
+    "type" : "String"
+  }, {
+    "id" : "provider.anthropic.backend.custom.authentication.clientId",
+    "label" : "Client ID",
+    "description" : "Your application's client ID from the OAuth client",
+    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "provider",
+    "binding" : {
+      "name" : "provider.anthropic.backend.custom.authentication.clientId",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "allMatch" : [ {
+        "property" : "provider.anthropic.backend.custom.authentication.type",
+        "equals" : "oauth-client-credentials-flow",
+        "type" : "simple"
+      }, {
+        "property" : "provider.anthropic.backend.type",
+        "equals" : "custom",
+        "type" : "simple"
+      }, {
+        "property" : "provider.type",
+        "equals" : "anthropic",
+        "type" : "simple"
+      } ]
+    },
+    "type" : "String"
+  }, {
+    "id" : "provider.anthropic.backend.custom.authentication.clientSecret",
+    "label" : "Client secret",
+    "description" : "Your application's client secret from the OAuth client",
+    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "provider",
+    "binding" : {
+      "name" : "provider.anthropic.backend.custom.authentication.clientSecret",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "allMatch" : [ {
+        "property" : "provider.anthropic.backend.custom.authentication.type",
+        "equals" : "oauth-client-credentials-flow",
+        "type" : "simple"
+      }, {
+        "property" : "provider.anthropic.backend.type",
+        "equals" : "custom",
+        "type" : "simple"
+      }, {
+        "property" : "provider.type",
+        "equals" : "anthropic",
+        "type" : "simple"
+      } ]
+    },
+    "type" : "String"
+  }, {
+    "id" : "provider.anthropic.backend.custom.authentication.audience",
+    "label" : "Audience",
+    "description" : "The unique identifier of the target API you want to access",
+    "optional" : true,
+    "feel" : "optional",
+    "group" : "provider",
+    "binding" : {
+      "name" : "provider.anthropic.backend.custom.authentication.audience",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "allMatch" : [ {
+        "property" : "provider.anthropic.backend.custom.authentication.type",
+        "equals" : "oauth-client-credentials-flow",
+        "type" : "simple"
+      }, {
+        "property" : "provider.anthropic.backend.type",
+        "equals" : "custom",
+        "type" : "simple"
+      }, {
+        "property" : "provider.type",
+        "equals" : "anthropic",
+        "type" : "simple"
+      } ]
+    },
+    "type" : "String"
+  }, {
+    "id" : "provider.anthropic.backend.custom.authentication.clientAuthentication",
+    "label" : "Client authentication",
+    "description" : "Send client ID and client secret as Basic Auth request in the header, or as client credentials in the request body",
+    "optional" : false,
+    "value" : "BASIC_AUTH_HEADER",
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "group" : "provider",
+    "binding" : {
+      "name" : "provider.anthropic.backend.custom.authentication.clientAuthentication",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "allMatch" : [ {
+        "property" : "provider.anthropic.backend.custom.authentication.type",
+        "equals" : "oauth-client-credentials-flow",
+        "type" : "simple"
+      }, {
+        "property" : "provider.anthropic.backend.type",
+        "equals" : "custom",
+        "type" : "simple"
+      }, {
+        "property" : "provider.type",
+        "equals" : "anthropic",
+        "type" : "simple"
+      } ]
+    },
+    "type" : "Dropdown",
+    "choices" : [ {
+      "name" : "Send as Basic Auth header",
+      "value" : "BASIC_AUTH_HEADER"
+    }, {
+      "name" : "Send client credentials in body",
+      "value" : "CREDENTIALS_BODY"
+    } ]
+  }, {
+    "id" : "provider.anthropic.backend.custom.authentication.scopes",
+    "label" : "Scopes",
+    "description" : "The scopes which you want to request authorization for (e.g.read:contacts)",
+    "optional" : true,
+    "feel" : "optional",
+    "group" : "provider",
+    "binding" : {
+      "name" : "provider.anthropic.backend.custom.authentication.scopes",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "allMatch" : [ {
+        "property" : "provider.anthropic.backend.custom.authentication.type",
+        "equals" : "oauth-client-credentials-flow",
         "type" : "simple"
       }, {
         "property" : "provider.anthropic.backend.type",

--- a/connectors/agentic-ai/connector-agentic-ai/element-templates/hybrid/agenticai-ai-agent-task.v2-hybrid.json
+++ b/connectors/agentic-ai/connector-agentic-ai/element-templates/hybrid/agenticai-ai-agent-task.v2-hybrid.json
@@ -547,7 +547,8 @@
       } ]
     },
     "tooltip" : "Your application's client secret from the OAuth client",
-    "type" : "String"
+    "type" : "String",
+    "secret" : true
   }, {
     "id" : "provider.anthropic.backend.custom.authentication.audience",
     "label" : "Audience",

--- a/connectors/agentic-ai/connector-agentic-ai/element-templates/hybrid/agenticai-ai-agent-task.v2-hybrid.json
+++ b/connectors/agentic-ai/connector-agentic-ai/element-templates/hybrid/agenticai-ai-agent-task.v2-hybrid.json
@@ -457,7 +457,6 @@
   }, {
     "id" : "provider.anthropic.backend.custom.authentication.oauthTokenEndpoint",
     "label" : "OAuth 2.0 token endpoint",
-    "description" : "The OAuth token endpoint",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true,
@@ -487,11 +486,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "The OAuth token endpoint",
     "type" : "String"
   }, {
     "id" : "provider.anthropic.backend.custom.authentication.clientId",
     "label" : "Client ID",
-    "description" : "Your application's client ID from the OAuth client",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -517,11 +516,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Your application's client ID from the OAuth client",
     "type" : "String"
   }, {
     "id" : "provider.anthropic.backend.custom.authentication.clientSecret",
     "label" : "Client secret",
-    "description" : "Your application's client secret from the OAuth client",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -547,11 +546,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Your application's client secret from the OAuth client",
     "type" : "String"
   }, {
     "id" : "provider.anthropic.backend.custom.authentication.audience",
     "label" : "Audience",
-    "description" : "The unique identifier of the target API you want to access",
     "optional" : true,
     "feel" : "optional",
     "group" : "provider",
@@ -574,11 +573,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "The unique identifier of the target API you want to access",
     "type" : "String"
   }, {
     "id" : "provider.anthropic.backend.custom.authentication.clientAuthentication",
     "label" : "Client authentication",
-    "description" : "Send client ID and client secret as Basic Auth request in the header, or as client credentials in the request body",
     "optional" : false,
     "value" : "BASIC_AUTH_HEADER",
     "constraints" : {
@@ -604,6 +603,7 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Send client ID and client secret as Basic Auth request in the header, or as client credentials in the request body",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "Send as Basic Auth header",
@@ -615,7 +615,6 @@
   }, {
     "id" : "provider.anthropic.backend.custom.authentication.scopes",
     "label" : "Scopes",
-    "description" : "The scopes which you want to request authorization for (e.g.read:contacts)",
     "optional" : true,
     "feel" : "optional",
     "group" : "provider",
@@ -638,6 +637,7 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "The scopes which you want to request authorization for (e.g.read:contacts)",
     "type" : "String"
   }, {
     "id" : "provider.anthropic.timeouts.timeout",

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/anthropic/AnthropicChatModel.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/anthropic/AnthropicChatModel.java
@@ -111,8 +111,9 @@ public class AnthropicChatModel implements ChatModel {
           "Model call failed with HTTP %d (%s): %s"
               .formatted(e.statusCode(), errorType, e.getMessage()),
           e);
-    } catch (ChatModelRejectedException e) {
-      // thrown directly by the response converter when it recognizes a known rejection - let it
+    } catch (ConnectorException | ChatModelRejectedException e) {
+      // already coded -- a ConnectorException thrown by e.g. the OAuth token resolver, or a
+      // ChatModelRejectedException thrown by the response converter for a known rejection. Let it
       // propagate as-is rather than flattening it into a generic FAILED_MODEL_CALL below.
       throw e;
     } catch (Exception e) {

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/anthropic/AnthropicChatModelFactory.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/anthropic/AnthropicChatModelFactory.java
@@ -121,7 +121,7 @@ public class AnthropicChatModelFactory implements ChatModelFactory {
       case NoAuthentication ignored -> {}
       case OAuthClientCredentialsAuthentication oauth ->
           builder.addInterceptor(
-              new OAuthBearerTokenInterceptor(
+              OAuthBearerTokenInterceptor.create(
                   oAuthClientCredentialsTokenResolver,
                   oauth.oauthTokenEndpoint(),
                   oauth.clientId(),

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/anthropic/AnthropicChatModelFactory.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/anthropic/AnthropicChatModelFactory.java
@@ -122,19 +122,14 @@ public class AnthropicChatModelFactory implements ChatModelFactory {
       case OAuthClientCredentialsAuthentication oauth ->
           builder.addInterceptor(
               new OAuthBearerTokenInterceptor(
-                  oAuthClientCredentialsTokenResolver, toOAuthAuthentication(oauth)));
+                  oAuthClientCredentialsTokenResolver,
+                  oauth.oauthTokenEndpoint(),
+                  oauth.clientId(),
+                  oauth.clientSecret(),
+                  oauth.audience(),
+                  oauth.clientAuthentication().oauthConstant(),
+                  oauth.scopes()));
     }
-  }
-
-  private static io.camunda.connector.http.client.model.auth.OAuthAuthentication
-      toOAuthAuthentication(OAuthClientCredentialsAuthentication oauth) {
-    return new io.camunda.connector.http.client.model.auth.OAuthAuthentication(
-        oauth.oauthTokenEndpoint(),
-        oauth.clientId(),
-        oauth.clientSecret(),
-        oauth.audience(),
-        oauth.clientAuthentication().oauthConstant(),
-        oauth.scopes());
   }
 
   private static void applyAwsBedrockMantleBackend(

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/anthropic/AnthropicChatModelFactory.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/anthropic/AnthropicChatModelFactory.java
@@ -13,6 +13,7 @@ import com.anthropic.core.http.ProxyAuthenticator;
 import io.camunda.connector.agenticai.aiagent.chatmodel.ChatModel;
 import io.camunda.connector.agenticai.aiagent.chatmodel.ChatModelConfiguration;
 import io.camunda.connector.agenticai.aiagent.chatmodel.ChatModelFactory;
+import io.camunda.connector.agenticai.aiagent.chatmodel.provider.authentication.oauth.OAuthBearerTokenInterceptor;
 import io.camunda.connector.agenticai.aiagent.model.request.v2.AnthropicChatModelConfiguration;
 import io.camunda.connector.agenticai.aiagent.model.request.v2.AnthropicChatModelConfiguration.AnthropicBackend;
 import io.camunda.connector.agenticai.aiagent.model.request.v2.AnthropicChatModelConfiguration.AnthropicBackend.AnthropicApiBackend;
@@ -20,8 +21,10 @@ import io.camunda.connector.agenticai.aiagent.model.request.v2.AnthropicChatMode
 import io.camunda.connector.agenticai.aiagent.model.request.v2.AnthropicChatModelConfiguration.AnthropicBackend.AnthropicCustomBackend;
 import io.camunda.connector.agenticai.aiagent.model.request.v2.AnthropicCustomEndpointAuthentication.ApiKeyAuthentication;
 import io.camunda.connector.agenticai.aiagent.model.request.v2.AnthropicCustomEndpointAuthentication.NoAuthentication;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.AnthropicCustomEndpointAuthentication.OAuthClientCredentialsAuthentication;
 import io.camunda.connector.agenticai.aiagent.model.request.v2.AwsAuthentication;
 import io.camunda.connector.agenticai.common.AgenticAiHttpProxySupport;
+import io.camunda.connector.http.client.authentication.OAuthClientCredentialsTokenResolver;
 import io.camunda.connector.http.client.proxy.ProxyConfiguration;
 import java.net.URI;
 import java.time.Duration;
@@ -35,14 +38,17 @@ public class AnthropicChatModelFactory implements ChatModelFactory {
   private final AgenticAiHttpProxySupport httpProxySupport;
   private final AnthropicMessageRequestConverter requestConverter;
   private final AnthropicMessageResponseConverter responseConverter;
+  private final OAuthClientCredentialsTokenResolver oAuthClientCredentialsTokenResolver;
 
   public AnthropicChatModelFactory(
       AgenticAiHttpProxySupport httpProxySupport,
       AnthropicMessageRequestConverter requestConverter,
-      AnthropicMessageResponseConverter responseConverter) {
+      AnthropicMessageResponseConverter responseConverter,
+      OAuthClientCredentialsTokenResolver oAuthClientCredentialsTokenResolver) {
     this.httpProxySupport = httpProxySupport;
     this.requestConverter = requestConverter;
     this.responseConverter = responseConverter;
+    this.oAuthClientCredentialsTokenResolver = oAuthClientCredentialsTokenResolver;
   }
 
   @Override
@@ -56,21 +62,25 @@ public class AnthropicChatModelFactory implements ChatModelFactory {
     final var connection = model.anthropic();
     final var timeout = connection.timeouts() != null ? connection.timeouts().timeout() : null;
 
-    final var client = buildClient(connection.backend(), timeout, httpProxySupport);
+    final var client =
+        buildClient(
+            connection.backend(), timeout, httpProxySupport, oAuthClientCredentialsTokenResolver);
     return new AnthropicChatModel(client, model, requestConverter, responseConverter);
   }
 
   private static AnthropicClient buildClient(
       AnthropicBackend backend,
       @Nullable Duration timeout,
-      AgenticAiHttpProxySupport httpProxySupport) {
+      AgenticAiHttpProxySupport httpProxySupport,
+      OAuthClientCredentialsTokenResolver oAuthClientCredentialsTokenResolver) {
     final var builder = AnthropicOkHttpClient.builder();
 
     switch (backend) {
       case AnthropicApiBackend apiBackend -> applyApiBackend(builder, apiBackend);
       case AnthropicAwsBedrockMantleBackend awsBedrockMantleBackend ->
           applyAwsBedrockMantleBackend(builder, awsBedrockMantleBackend);
-      case AnthropicCustomBackend custom -> applyCustomBackend(builder, custom);
+      case AnthropicCustomBackend custom ->
+          applyCustomBackend(builder, custom, oAuthClientCredentialsTokenResolver);
     }
 
     if (timeout != null) {
@@ -101,13 +111,30 @@ public class AnthropicChatModelFactory implements ChatModelFactory {
   }
 
   private static void applyCustomBackend(
-      AnthropicOkHttpClient.Builder builder, AnthropicCustomBackend custom) {
+      AnthropicOkHttpClient.Builder builder,
+      AnthropicCustomBackend custom,
+      OAuthClientCredentialsTokenResolver oAuthClientCredentialsTokenResolver) {
     builder.baseUrl(custom.custom().endpoint());
 
     switch (custom.custom().authentication()) {
       case ApiKeyAuthentication apiKeyAuth -> builder.apiKey(apiKeyAuth.apiKey());
       case NoAuthentication ignored -> {}
+      case OAuthClientCredentialsAuthentication oauth ->
+          builder.addInterceptor(
+              new OAuthBearerTokenInterceptor(
+                  oAuthClientCredentialsTokenResolver, toOAuthAuthentication(oauth)));
     }
+  }
+
+  private static io.camunda.connector.http.client.model.auth.OAuthAuthentication
+      toOAuthAuthentication(OAuthClientCredentialsAuthentication oauth) {
+    return new io.camunda.connector.http.client.model.auth.OAuthAuthentication(
+        oauth.oauthTokenEndpoint(),
+        oauth.clientId(),
+        oauth.clientSecret(),
+        oauth.audience(),
+        oauth.clientAuthentication().oauthConstant(),
+        oauth.scopes());
   }
 
   private static void applyAwsBedrockMantleBackend(

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/anthropic/AnthropicChatModelFactory.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/anthropic/AnthropicChatModelFactory.java
@@ -21,8 +21,8 @@ import io.camunda.connector.agenticai.aiagent.model.request.v2.AnthropicChatMode
 import io.camunda.connector.agenticai.aiagent.model.request.v2.AnthropicChatModelConfiguration.AnthropicBackend.AnthropicCustomBackend;
 import io.camunda.connector.agenticai.aiagent.model.request.v2.AnthropicCustomEndpointAuthentication.ApiKeyAuthentication;
 import io.camunda.connector.agenticai.aiagent.model.request.v2.AnthropicCustomEndpointAuthentication.NoAuthentication;
-import io.camunda.connector.agenticai.aiagent.model.request.v2.AnthropicCustomEndpointAuthentication.OAuthClientCredentialsAuthentication;
 import io.camunda.connector.agenticai.aiagent.model.request.v2.AwsAuthentication;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.OAuthClientCredentialsAuthentication;
 import io.camunda.connector.agenticai.common.AgenticAiHttpProxySupport;
 import io.camunda.connector.http.client.authentication.OAuthClientCredentialsTokenResolver;
 import io.camunda.connector.http.client.proxy.ProxyConfiguration;

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/authentication/oauth/OAuthBearerTokenInterceptor.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/authentication/oauth/OAuthBearerTokenInterceptor.java
@@ -6,28 +6,22 @@
  */
 package io.camunda.connector.agenticai.aiagent.chatmodel.provider.authentication.oauth;
 
-import com.anthropic.core.RequestOptions;
-import com.anthropic.core.http.HttpClient;
-import com.anthropic.core.http.HttpRequest;
-import com.anthropic.core.http.HttpResponse;
 import com.anthropic.core.http.Interceptor;
 import io.camunda.connector.http.client.authentication.OAuthClientCredentialsTokenResolver;
-import io.camunda.connector.http.client.model.auth.OAuthAuthentication;
-import java.util.concurrent.CompletableFuture;
 import org.jspecify.annotations.Nullable;
 
 /**
  * Anthropic-side half of the shared OAuth2 client-credentials mechanism: the anthropic-java SDK has
  * no public dynamic-credential hook (unlike openai-java's {@code Credential}), so a bearer token is
- * instead injected per-request via the SDK's supported {@link Interceptor} hook, backed by the same
- * {@link OAuthClientCredentialsTokenResolver} the OpenAI provider uses.
+ * instead injected per-request via {@link Interceptor#syncOnly}, backed by the same {@link
+ * OAuthClientCredentialsTokenResolver} the OpenAI provider uses. Synchronous only: this provider's
+ * chat model never calls the anthropic-java async client.
  */
-public class OAuthBearerTokenInterceptor implements Interceptor {
+public final class OAuthBearerTokenInterceptor {
 
-  private final OAuthClientCredentialsTokenResolver tokenResolver;
-  private final OAuthAuthentication authentication;
+  private OAuthBearerTokenInterceptor() {}
 
-  public OAuthBearerTokenInterceptor(
+  public static Interceptor create(
       OAuthClientCredentialsTokenResolver tokenResolver,
       String oauthTokenEndpoint,
       String clientId,
@@ -35,35 +29,19 @@ public class OAuthBearerTokenInterceptor implements Interceptor {
       @Nullable String audience,
       String clientAuthentication,
       @Nullable String scopes) {
-    this.tokenResolver = tokenResolver;
-    this.authentication =
-        new OAuthAuthentication(
-            oauthTokenEndpoint, clientId, clientSecret, audience, clientAuthentication, scopes);
-  }
-
-  @Override
-  public HttpClient intercept(HttpClient httpClient) {
-    return new HttpClient() {
-      @Override
-      public HttpResponse execute(HttpRequest request, RequestOptions requestOptions) {
-        return httpClient.execute(withBearerToken(request), requestOptions);
-      }
-
-      @Override
-      public CompletableFuture<HttpResponse> executeAsync(
-          HttpRequest request, RequestOptions requestOptions) {
-        return httpClient.executeAsync(withBearerToken(request), requestOptions);
-      }
-
-      @Override
-      public void close() {
-        httpClient.close();
-      }
-    };
-  }
-
-  private HttpRequest withBearerToken(HttpRequest request) {
-    final var accessToken = tokenResolver.resolveAccessToken(authentication);
-    return request.toBuilder().putHeader("Authorization", "Bearer " + accessToken).build();
+    return Interceptor.syncOnly(
+        (client, request, requestOptions) -> {
+          final var accessToken =
+              tokenResolver.resolveAccessToken(
+                  oauthTokenEndpoint,
+                  clientId,
+                  clientSecret,
+                  audience,
+                  clientAuthentication,
+                  scopes);
+          final var authorizedRequest =
+              request.toBuilder().putHeader("Authorization", "Bearer " + accessToken).build();
+          return client.execute(authorizedRequest, requestOptions);
+        });
   }
 }

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/authentication/oauth/OAuthBearerTokenInterceptor.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/authentication/oauth/OAuthBearerTokenInterceptor.java
@@ -11,11 +11,8 @@ import io.camunda.connector.http.client.authentication.OAuthClientCredentialsTok
 import org.jspecify.annotations.Nullable;
 
 /**
- * Anthropic-side half of the shared OAuth2 client-credentials mechanism: the anthropic-java SDK has
- * no public dynamic-credential hook (unlike openai-java's {@code Credential}), so a bearer token is
- * instead injected per-request via {@link Interceptor#syncOnly}, backed by the same {@link
- * OAuthClientCredentialsTokenResolver} the OpenAI provider uses. Synchronous only: this provider's
- * chat model never calls the anthropic-java async client.
+ * Injects a resolved bearer token per-request via {@link Interceptor#syncOnly}. Synchronous only:
+ * this provider's chat model never calls the anthropic-java async client.
  */
 public final class OAuthBearerTokenInterceptor {
 

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/authentication/oauth/OAuthBearerTokenInterceptor.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/authentication/oauth/OAuthBearerTokenInterceptor.java
@@ -37,7 +37,7 @@ public final class OAuthBearerTokenInterceptor {
                   clientAuthentication,
                   scopes);
           final var authorizedRequest =
-              request.toBuilder().putHeader("Authorization", "Bearer " + accessToken).build();
+              request.toBuilder().replaceHeaders("Authorization", "Bearer " + accessToken).build();
           return client.execute(authorizedRequest, requestOptions);
         });
   }

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/authentication/oauth/OAuthBearerTokenInterceptor.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/authentication/oauth/OAuthBearerTokenInterceptor.java
@@ -14,6 +14,7 @@ import com.anthropic.core.http.Interceptor;
 import io.camunda.connector.http.client.authentication.OAuthClientCredentialsTokenResolver;
 import io.camunda.connector.http.client.model.auth.OAuthAuthentication;
 import java.util.concurrent.CompletableFuture;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Anthropic-side half of the shared OAuth2 client-credentials mechanism: the anthropic-java SDK has
@@ -27,9 +28,17 @@ public class OAuthBearerTokenInterceptor implements Interceptor {
   private final OAuthAuthentication authentication;
 
   public OAuthBearerTokenInterceptor(
-      OAuthClientCredentialsTokenResolver tokenResolver, OAuthAuthentication authentication) {
+      OAuthClientCredentialsTokenResolver tokenResolver,
+      String oauthTokenEndpoint,
+      String clientId,
+      String clientSecret,
+      @Nullable String audience,
+      String clientAuthentication,
+      @Nullable String scopes) {
     this.tokenResolver = tokenResolver;
-    this.authentication = authentication;
+    this.authentication =
+        new OAuthAuthentication(
+            oauthTokenEndpoint, clientId, clientSecret, audience, clientAuthentication, scopes);
   }
 
   @Override

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/authentication/oauth/OAuthBearerTokenInterceptor.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/authentication/oauth/OAuthBearerTokenInterceptor.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.agenticai.aiagent.chatmodel.provider.authentication.oauth;
+
+import com.anthropic.core.RequestOptions;
+import com.anthropic.core.http.HttpClient;
+import com.anthropic.core.http.HttpRequest;
+import com.anthropic.core.http.HttpResponse;
+import com.anthropic.core.http.Interceptor;
+import io.camunda.connector.http.client.authentication.OAuthClientCredentialsTokenResolver;
+import io.camunda.connector.http.client.model.auth.OAuthAuthentication;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Anthropic-side half of the shared OAuth2 client-credentials mechanism: the anthropic-java SDK has
+ * no public dynamic-credential hook (unlike openai-java's {@code Credential}), so a bearer token is
+ * instead injected per-request via the SDK's supported {@link Interceptor} hook, backed by the same
+ * {@link OAuthClientCredentialsTokenResolver} the OpenAI provider uses.
+ */
+public class OAuthBearerTokenInterceptor implements Interceptor {
+
+  private final OAuthClientCredentialsTokenResolver tokenResolver;
+  private final OAuthAuthentication authentication;
+
+  public OAuthBearerTokenInterceptor(
+      OAuthClientCredentialsTokenResolver tokenResolver, OAuthAuthentication authentication) {
+    this.tokenResolver = tokenResolver;
+    this.authentication = authentication;
+  }
+
+  @Override
+  public HttpClient intercept(HttpClient httpClient) {
+    return new HttpClient() {
+      @Override
+      public HttpResponse execute(HttpRequest request, RequestOptions requestOptions) {
+        return httpClient.execute(withBearerToken(request), requestOptions);
+      }
+
+      @Override
+      public CompletableFuture<HttpResponse> executeAsync(
+          HttpRequest request, RequestOptions requestOptions) {
+        return httpClient.executeAsync(withBearerToken(request), requestOptions);
+      }
+
+      @Override
+      public void close() {
+        httpClient.close();
+      }
+    };
+  }
+
+  private HttpRequest withBearerToken(HttpRequest request) {
+    final var accessToken = tokenResolver.resolveAccessToken(authentication);
+    return request.toBuilder().putHeader("Authorization", "Bearer " + accessToken).build();
+  }
+}

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/authentication/oauth/package-info.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/authentication/oauth/package-info.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+@NullMarked
+package io.camunda.connector.agenticai.aiagent.chatmodel.provider.authentication.oauth;
+
+import org.jspecify.annotations.NullMarked;

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/configuration/AgenticAiNativeProvidersConfiguration.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/configuration/AgenticAiNativeProvidersConfiguration.java
@@ -46,11 +46,13 @@ public class AgenticAiNativeProvidersConfiguration {
   @ConditionalOnMissingBean
   public AnthropicChatModelFactory aiAgentAnthropicChatModelFactory(
       AgenticAiHttpProxySupport httpProxySupport,
+      OAuthClientCredentialsTokenResolver oAuthClientCredentialsTokenResolver,
       @ConnectorsObjectMapper ObjectMapper objectMapper) {
     final var contentConverter = new AnthropicContentConverter(objectMapper);
     final var requestConverter = new AnthropicMessageRequestConverter(contentConverter);
     final var responseConverter = new AnthropicMessageResponseConverter(objectMapper);
-    return new AnthropicChatModelFactory(httpProxySupport, requestConverter, responseConverter);
+    return new AnthropicChatModelFactory(
+        httpProxySupport, requestConverter, responseConverter, oAuthClientCredentialsTokenResolver);
   }
 
   @Bean

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/openai/OpenAiChatModelFactory.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/openai/OpenAiChatModelFactory.java
@@ -16,6 +16,7 @@ import io.camunda.connector.agenticai.aiagent.chatmodel.ChatModel;
 import io.camunda.connector.agenticai.aiagent.chatmodel.ChatModelConfiguration;
 import io.camunda.connector.agenticai.aiagent.chatmodel.ChatModelFactory;
 import io.camunda.connector.agenticai.aiagent.chatmodel.provider.openai.family.OpenAiApiFamilyStrategy;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.OAuthClientCredentialsAuthentication;
 import io.camunda.connector.agenticai.aiagent.model.request.v2.OpenAiChatModelConfiguration;
 import io.camunda.connector.agenticai.aiagent.model.request.v2.OpenAiChatModelConfiguration.OpenAiApi.OpenAiCompletionsApi;
 import io.camunda.connector.agenticai.aiagent.model.request.v2.OpenAiChatModelConfiguration.OpenAiApi.OpenAiResponsesApi;
@@ -24,7 +25,6 @@ import io.camunda.connector.agenticai.aiagent.model.request.v2.OpenAiChatModelCo
 import io.camunda.connector.agenticai.aiagent.model.request.v2.OpenAiChatModelConfiguration.OpenAiBackend.OpenAiCustomBackend;
 import io.camunda.connector.agenticai.aiagent.model.request.v2.OpenAiChatModelConfiguration.OpenAiBackend.OpenAiFoundryBackend;
 import io.camunda.connector.agenticai.aiagent.model.request.v2.OpenAiCustomEndpointAuthentication.ApiKeyAuthentication;
-import io.camunda.connector.agenticai.aiagent.model.request.v2.OpenAiCustomEndpointAuthentication.OAuthClientCredentialsAuthentication;
 import io.camunda.connector.agenticai.common.AgenticAiHttpProxySupport;
 import io.camunda.connector.api.error.ConnectorInputException;
 import io.camunda.connector.http.client.authentication.OAuthClientCredentialsTokenResolver;

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/v2/AnthropicCustomEndpointAuthentication.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/v2/AnthropicCustomEndpointAuthentication.java
@@ -80,27 +80,27 @@ public sealed interface AnthropicCustomEndpointAuthentication {
               message = "Must be a http(s) URL")
           @TemplateProperty(
               group = "provider",
-              description = "The OAuth token endpoint",
+              tooltip = "The OAuth token endpoint",
               label = "OAuth 2.0 token endpoint")
           String oauthTokenEndpoint,
       @FEEL
           @NotEmpty
           @TemplateProperty(
               group = "provider",
-              description = "Your application's client ID from the OAuth client",
+              tooltip = "Your application's client ID from the OAuth client",
               label = "Client ID")
           String clientId,
       @FEEL
           @NotEmpty
           @TemplateProperty(
               group = "provider",
-              description = "Your application's client secret from the OAuth client",
+              tooltip = "Your application's client secret from the OAuth client",
               label = "Client secret")
           String clientSecret,
       @FEEL
           @TemplateProperty(
               group = "provider",
-              description = "The unique identifier of the target API you want to access",
+              tooltip = "The unique identifier of the target API you want to access",
               optional = true)
           String audience,
       @NotNull
@@ -116,13 +116,13 @@ public sealed interface AnthropicCustomEndpointAuthentication {
                     label = "Send client credentials in body")
               },
               defaultValue = "BASIC_AUTH_HEADER",
-              description =
+              tooltip =
                   "Send client ID and client secret as Basic Auth request in the header, or as client credentials in the request body")
           ClientAuthenticationMethod clientAuthentication,
       @FEEL
           @TemplateProperty(
               group = "provider",
-              description =
+              tooltip =
                   "The scopes which you want to request authorization for (e.g.read:contacts)",
               optional = true)
           String scopes)

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/v2/AnthropicCustomEndpointAuthentication.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/v2/AnthropicCustomEndpointAuthentication.java
@@ -8,19 +8,11 @@ package io.camunda.connector.agenticai.aiagent.model.request.v2;
 
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
-import io.camunda.connector.api.annotation.FEEL;
 import io.camunda.connector.generator.java.annotation.FeelMode;
 import io.camunda.connector.generator.java.annotation.TemplateDiscriminatorProperty;
 import io.camunda.connector.generator.java.annotation.TemplateProperty;
-import io.camunda.connector.generator.java.annotation.TemplateProperty.DropdownPropertyChoice;
-import io.camunda.connector.generator.java.annotation.TemplateProperty.PropertyType;
 import io.camunda.connector.generator.java.annotation.TemplateSubType;
-import io.camunda.connector.http.client.authentication.OAuthConstants;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotEmpty;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Pattern;
-import org.apache.commons.lang3.builder.ToStringBuilder;
 
 /**
  * Authentication strategies for Anthropic's {@code custom}-backend endpoint. Anthropic-compatible
@@ -37,8 +29,8 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
       value = AnthropicCustomEndpointAuthentication.ApiKeyAuthentication.class,
       name = "apiKey"),
   @JsonSubTypes.Type(
-      value = AnthropicCustomEndpointAuthentication.OAuthClientCredentialsAuthentication.class,
-      name = AnthropicCustomEndpointAuthentication.OAuthClientCredentialsAuthentication.TYPE)
+      value = OAuthClientCredentialsAuthentication.class,
+      name = OAuthClientCredentialsAuthentication.TYPE)
 })
 @TemplateDiscriminatorProperty(
     label = "Authentication",
@@ -46,7 +38,10 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
     name = "type",
     defaultValue = "none",
     description = "Authentication for the compatible API.")
-public sealed interface AnthropicCustomEndpointAuthentication {
+public sealed interface AnthropicCustomEndpointAuthentication
+    permits AnthropicCustomEndpointAuthentication.NoAuthentication,
+        AnthropicCustomEndpointAuthentication.ApiKeyAuthentication,
+        OAuthClientCredentialsAuthentication {
 
   @TemplateSubType(id = "none", label = "None")
   record NoAuthentication() implements AnthropicCustomEndpointAuthentication {}
@@ -66,102 +61,6 @@ public sealed interface AnthropicCustomEndpointAuthentication {
     @Override
     public String toString() {
       return "ApiKeyAuthentication{apiKey=[REDACTED]}";
-    }
-  }
-
-  @TemplateSubType(
-      id = AnthropicCustomEndpointAuthentication.OAuthClientCredentialsAuthentication.TYPE,
-      label = "OAuth 2.0")
-  record OAuthClientCredentialsAuthentication(
-      @FEEL
-          @NotEmpty
-          @Pattern(
-              regexp = "^(=|(http://|https://|secrets|\\{\\{).*$)",
-              message = "Must be a http(s) URL")
-          @TemplateProperty(
-              group = "provider",
-              tooltip = "The OAuth token endpoint",
-              label = "OAuth 2.0 token endpoint")
-          String oauthTokenEndpoint,
-      @FEEL
-          @NotEmpty
-          @TemplateProperty(
-              group = "provider",
-              tooltip = "Your application's client ID from the OAuth client",
-              label = "Client ID")
-          String clientId,
-      @FEEL
-          @NotEmpty
-          @TemplateProperty(
-              group = "provider",
-              tooltip = "Your application's client secret from the OAuth client",
-              label = "Client secret")
-          String clientSecret,
-      @FEEL
-          @TemplateProperty(
-              group = "provider",
-              tooltip = "The unique identifier of the target API you want to access",
-              optional = true)
-          String audience,
-      @NotNull
-          @TemplateProperty(
-              group = "provider",
-              type = PropertyType.Dropdown,
-              choices = {
-                @DropdownPropertyChoice(
-                    value = "BASIC_AUTH_HEADER",
-                    label = "Send as Basic Auth header"),
-                @DropdownPropertyChoice(
-                    value = "CREDENTIALS_BODY",
-                    label = "Send client credentials in body")
-              },
-              defaultValue = "BASIC_AUTH_HEADER",
-              tooltip =
-                  "Send client ID and client secret as Basic Auth request in the header, or as client credentials in the request body")
-          ClientAuthenticationMethod clientAuthentication,
-      @FEEL
-          @TemplateProperty(
-              group = "provider",
-              tooltip =
-                  "The scopes which you want to request authorization for (e.g.read:contacts)",
-              optional = true)
-          String scopes)
-      implements AnthropicCustomEndpointAuthentication {
-
-    @TemplateProperty(ignore = true)
-    public static final String TYPE = "oauth-client-credentials-flow";
-
-    public enum ClientAuthenticationMethod {
-      BASIC_AUTH_HEADER(OAuthConstants.BASIC_AUTH_HEADER),
-      CREDENTIALS_BODY(OAuthConstants.CREDENTIALS_BODY);
-
-      private final String oauthConstant;
-
-      ClientAuthenticationMethod(String oauthConstant) {
-        this.oauthConstant = oauthConstant;
-      }
-
-      public String oauthConstant() {
-        return oauthConstant;
-      }
-    }
-
-    public OAuthClientCredentialsAuthentication {
-      if (clientAuthentication == null) {
-        clientAuthentication = ClientAuthenticationMethod.BASIC_AUTH_HEADER;
-      }
-    }
-
-    @Override
-    public String toString() {
-      return new ToStringBuilder(this)
-          .append("oauthTokenEndpoint", oauthTokenEndpoint)
-          .append("clientId", "[REDACTED]")
-          .append("clientSecret", "[REDACTED]")
-          .append("audience", audience)
-          .append("clientAuthentication", clientAuthentication)
-          .append("scopes", scopes)
-          .toString();
     }
   }
 }

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/v2/AnthropicCustomEndpointAuthentication.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/v2/AnthropicCustomEndpointAuthentication.java
@@ -8,11 +8,19 @@ package io.camunda.connector.agenticai.aiagent.model.request.v2;
 
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import io.camunda.connector.api.annotation.FEEL;
 import io.camunda.connector.generator.java.annotation.FeelMode;
 import io.camunda.connector.generator.java.annotation.TemplateDiscriminatorProperty;
 import io.camunda.connector.generator.java.annotation.TemplateProperty;
+import io.camunda.connector.generator.java.annotation.TemplateProperty.DropdownPropertyChoice;
+import io.camunda.connector.generator.java.annotation.TemplateProperty.PropertyType;
 import io.camunda.connector.generator.java.annotation.TemplateSubType;
+import io.camunda.connector.http.client.authentication.OAuthConstants;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import org.apache.commons.lang3.builder.ToStringBuilder;
 
 /**
  * Authentication strategies for Anthropic's {@code custom}-backend endpoint. Anthropic-compatible
@@ -27,7 +35,10 @@ import jakarta.validation.constraints.NotBlank;
       name = "none"),
   @JsonSubTypes.Type(
       value = AnthropicCustomEndpointAuthentication.ApiKeyAuthentication.class,
-      name = "apiKey")
+      name = "apiKey"),
+  @JsonSubTypes.Type(
+      value = AnthropicCustomEndpointAuthentication.OAuthClientCredentialsAuthentication.class,
+      name = AnthropicCustomEndpointAuthentication.OAuthClientCredentialsAuthentication.TYPE)
 })
 @TemplateDiscriminatorProperty(
     label = "Authentication",
@@ -55,6 +66,102 @@ public sealed interface AnthropicCustomEndpointAuthentication {
     @Override
     public String toString() {
       return "ApiKeyAuthentication{apiKey=[REDACTED]}";
+    }
+  }
+
+  @TemplateSubType(
+      id = AnthropicCustomEndpointAuthentication.OAuthClientCredentialsAuthentication.TYPE,
+      label = "OAuth 2.0")
+  record OAuthClientCredentialsAuthentication(
+      @FEEL
+          @NotEmpty
+          @Pattern(
+              regexp = "^(=|(http://|https://|secrets|\\{\\{).*$)",
+              message = "Must be a http(s) URL")
+          @TemplateProperty(
+              group = "provider",
+              description = "The OAuth token endpoint",
+              label = "OAuth 2.0 token endpoint")
+          String oauthTokenEndpoint,
+      @FEEL
+          @NotEmpty
+          @TemplateProperty(
+              group = "provider",
+              description = "Your application's client ID from the OAuth client",
+              label = "Client ID")
+          String clientId,
+      @FEEL
+          @NotEmpty
+          @TemplateProperty(
+              group = "provider",
+              description = "Your application's client secret from the OAuth client",
+              label = "Client secret")
+          String clientSecret,
+      @FEEL
+          @TemplateProperty(
+              group = "provider",
+              description = "The unique identifier of the target API you want to access",
+              optional = true)
+          String audience,
+      @NotNull
+          @TemplateProperty(
+              group = "provider",
+              type = PropertyType.Dropdown,
+              choices = {
+                @DropdownPropertyChoice(
+                    value = "BASIC_AUTH_HEADER",
+                    label = "Send as Basic Auth header"),
+                @DropdownPropertyChoice(
+                    value = "CREDENTIALS_BODY",
+                    label = "Send client credentials in body")
+              },
+              defaultValue = "BASIC_AUTH_HEADER",
+              description =
+                  "Send client ID and client secret as Basic Auth request in the header, or as client credentials in the request body")
+          ClientAuthenticationMethod clientAuthentication,
+      @FEEL
+          @TemplateProperty(
+              group = "provider",
+              description =
+                  "The scopes which you want to request authorization for (e.g.read:contacts)",
+              optional = true)
+          String scopes)
+      implements AnthropicCustomEndpointAuthentication {
+
+    @TemplateProperty(ignore = true)
+    public static final String TYPE = "oauth-client-credentials-flow";
+
+    public enum ClientAuthenticationMethod {
+      BASIC_AUTH_HEADER(OAuthConstants.BASIC_AUTH_HEADER),
+      CREDENTIALS_BODY(OAuthConstants.CREDENTIALS_BODY);
+
+      private final String oauthConstant;
+
+      ClientAuthenticationMethod(String oauthConstant) {
+        this.oauthConstant = oauthConstant;
+      }
+
+      public String oauthConstant() {
+        return oauthConstant;
+      }
+    }
+
+    public OAuthClientCredentialsAuthentication {
+      if (clientAuthentication == null) {
+        clientAuthentication = ClientAuthenticationMethod.BASIC_AUTH_HEADER;
+      }
+    }
+
+    @Override
+    public String toString() {
+      return new ToStringBuilder(this)
+          .append("oauthTokenEndpoint", oauthTokenEndpoint)
+          .append("clientId", "[REDACTED]")
+          .append("clientSecret", "[REDACTED]")
+          .append("audience", audience)
+          .append("clientAuthentication", clientAuthentication)
+          .append("scopes", scopes)
+          .toString();
     }
   }
 }

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/v2/OAuthClientCredentialsAuthentication.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/v2/OAuthClientCredentialsAuthentication.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.agenticai.aiagent.model.request.v2;
+
+import io.camunda.connector.api.annotation.FEEL;
+import io.camunda.connector.generator.java.annotation.TemplateProperty;
+import io.camunda.connector.generator.java.annotation.TemplateProperty.DropdownPropertyChoice;
+import io.camunda.connector.generator.java.annotation.TemplateProperty.PropertyType;
+import io.camunda.connector.generator.java.annotation.TemplateSubType;
+import io.camunda.connector.http.client.authentication.OAuthConstants;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * OAuth 2.0 client-credentials authentication for a {@code custom}-backend endpoint, shared between
+ * {@link OpenAiCustomEndpointAuthentication} and {@link AnthropicCustomEndpointAuthentication}:
+ * both target an OAuth 2.0 authorization server the same way, unlike {@code ApiKeyAuthentication},
+ * which is provider-specific.
+ */
+@TemplateSubType(id = OAuthClientCredentialsAuthentication.TYPE, label = "OAuth 2.0")
+public record OAuthClientCredentialsAuthentication(
+    @FEEL
+        @NotEmpty
+        @Pattern(
+            regexp = "^(=|(http://|https://|secrets|\\{\\{).*$)",
+            message = "Must be a http(s) URL")
+        @TemplateProperty(
+            group = "provider",
+            tooltip = "The OAuth token endpoint",
+            label = "OAuth 2.0 token endpoint")
+        String oauthTokenEndpoint,
+    @FEEL
+        @NotEmpty
+        @TemplateProperty(
+            group = "provider",
+            tooltip = "Your application's client ID from the OAuth client",
+            label = "Client ID")
+        String clientId,
+    @FEEL
+        @NotEmpty
+        @TemplateProperty(
+            group = "provider",
+            tooltip = "Your application's client secret from the OAuth client",
+            label = "Client secret",
+            secret = true)
+        String clientSecret,
+    @FEEL
+        @Nullable
+        @TemplateProperty(
+            group = "provider",
+            tooltip = "The unique identifier of the target API you want to access",
+            optional = true)
+        String audience,
+    @NotNull
+        @TemplateProperty(
+            group = "provider",
+            type = PropertyType.Dropdown,
+            choices = {
+              @DropdownPropertyChoice(
+                  value = "BASIC_AUTH_HEADER",
+                  label = "Send as Basic Auth header"),
+              @DropdownPropertyChoice(
+                  value = "CREDENTIALS_BODY",
+                  label = "Send client credentials in body")
+            },
+            defaultValue = "BASIC_AUTH_HEADER",
+            tooltip =
+                "Send client ID and client secret as Basic Auth request in the header, or as client credentials in the request body")
+        ClientAuthenticationMethod clientAuthentication,
+    @FEEL
+        @Nullable
+        @TemplateProperty(
+            group = "provider",
+            tooltip = "The scopes which you want to request authorization for (e.g., read:contacts)",
+            optional = true)
+        String scopes)
+    implements OpenAiCustomEndpointAuthentication, AnthropicCustomEndpointAuthentication {
+
+  @TemplateProperty(ignore = true)
+  public static final String TYPE = "oauth-client-credentials-flow";
+
+  public enum ClientAuthenticationMethod {
+    BASIC_AUTH_HEADER(OAuthConstants.BASIC_AUTH_HEADER),
+    CREDENTIALS_BODY(OAuthConstants.CREDENTIALS_BODY);
+
+    private final String oauthConstant;
+
+    ClientAuthenticationMethod(String oauthConstant) {
+      this.oauthConstant = oauthConstant;
+    }
+
+    public String oauthConstant() {
+      return oauthConstant;
+    }
+  }
+
+  public OAuthClientCredentialsAuthentication {
+    if (clientAuthentication == null) {
+      clientAuthentication = ClientAuthenticationMethod.BASIC_AUTH_HEADER;
+    }
+  }
+
+  @Override
+  public String toString() {
+    return new ToStringBuilder(this)
+        .append("oauthTokenEndpoint", oauthTokenEndpoint)
+        .append("clientId", "[REDACTED]")
+        .append("clientSecret", "[REDACTED]")
+        .append("audience", audience)
+        .append("clientAuthentication", clientAuthentication)
+        .append("scopes", scopes)
+        .toString();
+  }
+}

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/v2/OAuthClientCredentialsAuthentication.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/v2/OAuthClientCredentialsAuthentication.java
@@ -78,7 +78,8 @@ public record OAuthClientCredentialsAuthentication(
         @Nullable
         @TemplateProperty(
             group = "provider",
-            tooltip = "The scopes which you want to request authorization for (e.g., read:contacts)",
+            tooltip =
+                "The scopes which you want to request authorization for (e.g., read:contacts)",
             optional = true)
         String scopes)
     implements OpenAiCustomEndpointAuthentication, AnthropicCustomEndpointAuthentication {

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/v2/OpenAiCustomEndpointAuthentication.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/v2/OpenAiCustomEndpointAuthentication.java
@@ -8,20 +8,11 @@ package io.camunda.connector.agenticai.aiagent.model.request.v2;
 
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
-import io.camunda.connector.api.annotation.FEEL;
 import io.camunda.connector.generator.java.annotation.FeelMode;
 import io.camunda.connector.generator.java.annotation.TemplateDiscriminatorProperty;
 import io.camunda.connector.generator.java.annotation.TemplateProperty;
-import io.camunda.connector.generator.java.annotation.TemplateProperty.DropdownPropertyChoice;
-import io.camunda.connector.generator.java.annotation.TemplateProperty.PropertyType;
 import io.camunda.connector.generator.java.annotation.TemplateSubType;
-import io.camunda.connector.http.client.authentication.OAuthConstants;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotEmpty;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Pattern;
-import org.apache.commons.lang3.builder.ToStringBuilder;
-import org.jspecify.annotations.Nullable;
 
 /**
  * Authentication strategies for OpenAI's {@code custom}-backend endpoint. Unlike Anthropic, there
@@ -37,8 +28,8 @@ import org.jspecify.annotations.Nullable;
       value = OpenAiCustomEndpointAuthentication.ApiKeyAuthentication.class,
       name = "apiKey"),
   @JsonSubTypes.Type(
-      value = OpenAiCustomEndpointAuthentication.OAuthClientCredentialsAuthentication.class,
-      name = OpenAiCustomEndpointAuthentication.OAuthClientCredentialsAuthentication.TYPE)
+      value = OAuthClientCredentialsAuthentication.class,
+      name = OAuthClientCredentialsAuthentication.TYPE)
 })
 @TemplateDiscriminatorProperty(
     label = "Authentication",
@@ -46,7 +37,9 @@ import org.jspecify.annotations.Nullable;
     name = "type",
     defaultValue = "apiKey",
     description = "Authentication for the compatible API.")
-public sealed interface OpenAiCustomEndpointAuthentication {
+public sealed interface OpenAiCustomEndpointAuthentication
+    permits OpenAiCustomEndpointAuthentication.ApiKeyAuthentication,
+        OAuthClientCredentialsAuthentication {
 
   @TemplateSubType(id = "apiKey", label = "API key")
   record ApiKeyAuthentication(
@@ -63,105 +56,6 @@ public sealed interface OpenAiCustomEndpointAuthentication {
     @Override
     public String toString() {
       return "ApiKeyAuthentication{apiKey=[REDACTED]}";
-    }
-  }
-
-  @TemplateSubType(
-      id = OpenAiCustomEndpointAuthentication.OAuthClientCredentialsAuthentication.TYPE,
-      label = "OAuth 2.0")
-  record OAuthClientCredentialsAuthentication(
-      @FEEL
-          @NotEmpty
-          @Pattern(
-              regexp = "^(=|(http://|https://|secrets|\\{\\{).*$)",
-              message = "Must be a http(s) URL")
-          @TemplateProperty(
-              group = "provider",
-              tooltip = "The OAuth token endpoint",
-              label = "OAuth 2.0 token endpoint")
-          String oauthTokenEndpoint,
-      @FEEL
-          @NotEmpty
-          @TemplateProperty(
-              group = "provider",
-              tooltip = "Your application's client ID from the OAuth client",
-              label = "Client ID")
-          String clientId,
-      @FEEL
-          @NotEmpty
-          @TemplateProperty(
-              group = "provider",
-              tooltip = "Your application's client secret from the OAuth client",
-              label = "Client secret",
-              secret = true)
-          String clientSecret,
-      @FEEL
-          @Nullable
-          @TemplateProperty(
-              group = "provider",
-              tooltip = "The unique identifier of the target API you want to access",
-              optional = true)
-          String audience,
-      @NotNull
-          @TemplateProperty(
-              group = "provider",
-              type = PropertyType.Dropdown,
-              choices = {
-                @DropdownPropertyChoice(
-                    value = "BASIC_AUTH_HEADER",
-                    label = "Send as Basic Auth header"),
-                @DropdownPropertyChoice(
-                    value = "CREDENTIALS_BODY",
-                    label = "Send client credentials in body")
-              },
-              defaultValue = "BASIC_AUTH_HEADER",
-              tooltip =
-                  "Send client ID and client secret as Basic Auth request in the header, or as client credentials in the request body")
-          ClientAuthenticationMethod clientAuthentication,
-      @FEEL
-          @Nullable
-          @TemplateProperty(
-              group = "provider",
-              tooltip =
-                  "The scopes which you want to request authorization for (e.g., read:contacts)",
-              optional = true)
-          String scopes)
-      implements OpenAiCustomEndpointAuthentication {
-
-    @TemplateProperty(ignore = true)
-    public static final String TYPE = "oauth-client-credentials-flow";
-
-    public enum ClientAuthenticationMethod {
-      BASIC_AUTH_HEADER(OAuthConstants.BASIC_AUTH_HEADER),
-      CREDENTIALS_BODY(OAuthConstants.CREDENTIALS_BODY);
-
-      private final String oauthConstant;
-
-      ClientAuthenticationMethod(String oauthConstant) {
-        this.oauthConstant = oauthConstant;
-      }
-
-      public String oauthConstant() {
-        return oauthConstant;
-      }
-    }
-
-    public OAuthClientCredentialsAuthentication {
-      if (clientAuthentication == null) {
-        clientAuthentication = ClientAuthenticationMethod.BASIC_AUTH_HEADER;
-      }
-    }
-
-    @Override
-    public String toString() {
-      return new ToStringBuilder(this)
-          .append("oauthTokenEndpoint", oauthTokenEndpoint)
-          .append("clientId", "[REDACTED]")
-          .append("clientSecret", "[REDACTED]")
-          .append("audience", audience)
-          .append("clientAuthentication", clientAuthentication)
-          .append("scopes", scopes)
-          .toString();
     }
   }
 }

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/anthropic/AnthropicChatModelFactoryClientTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/anthropic/AnthropicChatModelFactoryClientTest.java
@@ -40,8 +40,10 @@ import io.camunda.connector.agenticai.aiagent.model.request.v2.AnthropicChatMode
 import io.camunda.connector.agenticai.aiagent.model.request.v2.AnthropicChatModelConfiguration.AnthropicModel;
 import io.camunda.connector.agenticai.aiagent.model.request.v2.AnthropicCustomEndpointAuthentication.ApiKeyAuthentication;
 import io.camunda.connector.agenticai.aiagent.model.request.v2.AnthropicCustomEndpointAuthentication.NoAuthentication;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.AnthropicCustomEndpointAuthentication.OAuthClientCredentialsAuthentication;
 import io.camunda.connector.agenticai.aiagent.model.request.v2.AwsAuthentication;
 import io.camunda.connector.agenticai.common.AgenticAiHttpProxySupport;
+import io.camunda.connector.http.client.authentication.OAuthClientCredentialsTokenResolver;
 import io.camunda.connector.http.client.proxy.ProxyConfiguration;
 import java.io.IOException;
 import java.io.InputStream;
@@ -173,6 +175,44 @@ class AnthropicChatModelFactoryClientTest {
   }
 
   @Test
+  void customBackendResolvesOAuthClientCredentialsBearerToken(WireMockRuntimeInfo wireMock) {
+    stubFor(
+        post(urlPathEqualTo("/oauth/token"))
+            .willReturn(
+                aResponse()
+                    .withStatus(200)
+                    .withHeader("Content-Type", "application/json")
+                    .withBody(
+                        """
+                        {
+                          "access_token": "oauth-access-token",
+                          "expires_in": 3600
+                        }
+                        """)));
+
+    executeAgainst(
+        new AnthropicCustomBackend(
+            new AnthropicCustomBackend.CustomBackend(
+                wireMock.getHttpBaseUrl(),
+                null,
+                null,
+                null,
+                new OAuthClientCredentialsAuthentication(
+                    wireMock.getHttpBaseUrl() + "/oauth/token",
+                    "client-123",
+                    "secret-123",
+                    null,
+                    OAuthClientCredentialsAuthentication.ClientAuthenticationMethod
+                        .BASIC_AUTH_HEADER,
+                    null))));
+
+    verify(
+        postRequestedFor(urlPathEqualTo("/v1/messages"))
+            .withHeader("Authorization", equalTo("Bearer oauth-access-token"))
+            .withoutHeader("x-api-key"));
+  }
+
+  @Test
   void bedrockBackendWithStaticCredentialsSignsRequestWithSigV4(WireMockRuntimeInfo wireMock) {
     executeAgainstBedrock(
         wireMock,
@@ -257,6 +297,13 @@ class AnthropicChatModelFactoryClientTest {
     }
   }
 
+  private static OAuthClientCredentialsTokenResolver oAuthClientCredentialsTokenResolver() {
+    return new OAuthClientCredentialsTokenResolver(
+        new io.camunda.connector.http.client.authentication.OAuthService(),
+        new io.camunda.connector.http.client.authentication.cacheimpl.CaffeineOAuthTokenCache(),
+        new io.camunda.connector.http.client.client.apache.CustomApacheHttpClient());
+  }
+
   private void executeAgainst(AnthropicBackend backend) {
     executeAgainst(httpProxySupport, backend);
   }
@@ -267,7 +314,8 @@ class AnthropicChatModelFactoryClientTest {
         new AnthropicChatModelFactory(
             httpProxySupport,
             new AnthropicMessageRequestConverter(new AnthropicContentConverter(objectMapper)),
-            new AnthropicMessageResponseConverter(objectMapper));
+            new AnthropicMessageResponseConverter(objectMapper),
+            oAuthClientCredentialsTokenResolver());
     final var configuration =
         new AnthropicChatModelConfiguration(
             new AnthropicConnection(backend, new AnthropicModel(MODEL_ID, null), null));

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/anthropic/AnthropicChatModelFactoryClientTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/anthropic/AnthropicChatModelFactoryClientTest.java
@@ -40,8 +40,8 @@ import io.camunda.connector.agenticai.aiagent.model.request.v2.AnthropicChatMode
 import io.camunda.connector.agenticai.aiagent.model.request.v2.AnthropicChatModelConfiguration.AnthropicModel;
 import io.camunda.connector.agenticai.aiagent.model.request.v2.AnthropicCustomEndpointAuthentication.ApiKeyAuthentication;
 import io.camunda.connector.agenticai.aiagent.model.request.v2.AnthropicCustomEndpointAuthentication.NoAuthentication;
-import io.camunda.connector.agenticai.aiagent.model.request.v2.AnthropicCustomEndpointAuthentication.OAuthClientCredentialsAuthentication;
 import io.camunda.connector.agenticai.aiagent.model.request.v2.AwsAuthentication;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.OAuthClientCredentialsAuthentication;
 import io.camunda.connector.agenticai.common.AgenticAiHttpProxySupport;
 import io.camunda.connector.http.client.authentication.OAuthClientCredentialsTokenResolver;
 import io.camunda.connector.http.client.proxy.ProxyConfiguration;

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/anthropic/AnthropicChatModelFactoryTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/anthropic/AnthropicChatModelFactoryTest.java
@@ -23,6 +23,7 @@ import io.camunda.connector.agenticai.aiagent.model.request.v2.AnthropicCustomEn
 import io.camunda.connector.agenticai.aiagent.model.request.v2.AwsAuthentication;
 import io.camunda.connector.agenticai.aiagent.model.request.v2.CustomProviderConfiguration;
 import io.camunda.connector.agenticai.common.AgenticAiHttpProxySupport;
+import io.camunda.connector.http.client.authentication.OAuthClientCredentialsTokenResolver;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Stream;
@@ -40,6 +41,7 @@ class AnthropicChatModelFactoryTest {
   private static final String MODEL_ID = "claude-sonnet-4-6";
 
   @Mock private AgenticAiHttpProxySupport httpProxySupport;
+  @Mock private OAuthClientCredentialsTokenResolver oAuthClientCredentialsTokenResolver;
 
   private final ObjectMapper objectMapper = new ObjectMapper();
 
@@ -51,7 +53,8 @@ class AnthropicChatModelFactoryTest {
         new AnthropicChatModelFactory(
             httpProxySupport,
             new AnthropicMessageRequestConverter(new AnthropicContentConverter(objectMapper)),
-            new AnthropicMessageResponseConverter(objectMapper));
+            new AnthropicMessageResponseConverter(objectMapper),
+            oAuthClientCredentialsTokenResolver);
   }
 
   @ParameterizedTest

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/anthropic/AnthropicChatModelTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/anthropic/AnthropicChatModelTest.java
@@ -212,6 +212,21 @@ class AnthropicChatModelTest {
   }
 
   @Test
+  void propagatesConnectorExceptionFromFailedTokenExchangeUnwrapped() {
+    final var tokenExchangeFailure =
+        new ConnectorException("OAUTH_TOKEN_EXCHANGE_FAILED", "invalid_client");
+
+    when(requestConverter.toMessageCreateParams(any(), any(), any()))
+        .thenReturn(mock(MessageCreateParams.class));
+    when(client.messages()).thenThrow(tokenExchangeFailure);
+
+    // must escape execute() as-is - a plain catch (Exception) would flatten the OAuth interceptor's
+    // ConnectorException (with its own error code and response variables) into a generic
+    // FAILED_MODEL_CALL, losing the token-exchange diagnostics.
+    assertThatThrownBy(() -> api.execute(request)).isSameAs(tokenExchangeFailure);
+  }
+
+  @Test
   void closesUnderlyingClient() {
     api.close();
 

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/authentication/oauth/OAuthBearerTokenInterceptorTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/authentication/oauth/OAuthBearerTokenInterceptorTest.java
@@ -68,6 +68,28 @@ class OAuthBearerTokenInterceptorTest {
   }
 
   @Test
+  void replacesExistingAuthorizationHeaderRatherThanAppending() {
+    when(tokenResolver.resolveAccessToken(any(), any(), any(), any(), any(), any()))
+        .thenReturn("resolved-token");
+    when(delegate.execute(any(), any())).thenReturn(response);
+
+    final var wrapped = interceptor.intercept(delegate);
+    final var request =
+        HttpRequest.builder()
+            .method(HttpMethod.GET)
+            .baseUrl("https://api.example.com")
+            .putHeader("Authorization", "Bearer stale-token")
+            .build();
+
+    wrapped.execute(request);
+
+    final var captor = ArgumentCaptor.forClass(HttpRequest.class);
+    verify(delegate).execute(captor.capture(), any());
+    assertThat(captor.getValue().headers().values("Authorization"))
+        .containsExactly("Bearer resolved-token");
+  }
+
+  @Test
   void resolvesTokenAgainOnEachRequest() {
     when(tokenResolver.resolveAccessToken(any(), any(), any(), any(), any(), any()))
         .thenReturn("token-1", "token-2");

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/authentication/oauth/OAuthBearerTokenInterceptorTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/authentication/oauth/OAuthBearerTokenInterceptorTest.java
@@ -7,7 +7,9 @@
 package io.camunda.connector.agenticai.aiagent.chatmodel.provider.authentication.oauth;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -15,9 +17,9 @@ import com.anthropic.core.http.HttpClient;
 import com.anthropic.core.http.HttpMethod;
 import com.anthropic.core.http.HttpRequest;
 import com.anthropic.core.http.HttpResponse;
+import com.anthropic.core.http.Interceptor;
 import io.camunda.connector.http.client.authentication.OAuthClientCredentialsTokenResolver;
 import io.camunda.connector.http.client.authentication.OAuthConstants;
-import io.camunda.connector.http.client.model.auth.OAuthAuthentication;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -32,33 +34,25 @@ class OAuthBearerTokenInterceptorTest {
   @Mock private HttpClient delegate;
   @Mock private HttpResponse response;
 
-  private OAuthAuthentication authentication;
-  private OAuthBearerTokenInterceptor interceptor;
+  private Interceptor interceptor;
 
   @BeforeEach
   void setUp() {
-    authentication =
-        new OAuthAuthentication(
+    interceptor =
+        OAuthBearerTokenInterceptor.create(
+            tokenResolver,
             "https://auth.example.com/oauth/token",
             "my-client-id",
             "my-client-secret",
             null,
             OAuthConstants.BASIC_AUTH_HEADER,
             null);
-    interceptor =
-        new OAuthBearerTokenInterceptor(
-            tokenResolver,
-            authentication.oauthTokenEndpoint(),
-            authentication.clientId(),
-            authentication.clientSecret(),
-            authentication.audience(),
-            authentication.clientAuthentication(),
-            authentication.scopes());
   }
 
   @Test
   void addsBearerAuthorizationHeaderResolvedPerRequest() {
-    when(tokenResolver.resolveAccessToken(authentication)).thenReturn("resolved-token");
+    when(tokenResolver.resolveAccessToken(any(), any(), any(), any(), any(), any()))
+        .thenReturn("resolved-token");
     when(delegate.execute(any(), any())).thenReturn(response);
 
     final var wrapped = interceptor.intercept(delegate);
@@ -75,7 +69,8 @@ class OAuthBearerTokenInterceptorTest {
 
   @Test
   void resolvesTokenAgainOnEachRequest() {
-    when(tokenResolver.resolveAccessToken(authentication)).thenReturn("token-1", "token-2");
+    when(tokenResolver.resolveAccessToken(any(), any(), any(), any(), any(), any()))
+        .thenReturn("token-1", "token-2");
     when(delegate.execute(any(), any())).thenReturn(response);
 
     final var wrapped = interceptor.intercept(delegate);
@@ -85,6 +80,23 @@ class OAuthBearerTokenInterceptorTest {
     wrapped.execute(request);
     wrapped.execute(request);
 
-    verify(tokenResolver, org.mockito.Mockito.times(2)).resolveAccessToken(authentication);
+    verify(tokenResolver, times(2))
+        .resolveAccessToken(
+            "https://auth.example.com/oauth/token",
+            "my-client-id",
+            "my-client-secret",
+            null,
+            OAuthConstants.BASIC_AUTH_HEADER,
+            null);
+  }
+
+  @Test
+  void doesNotSupportAsyncExecution() {
+    final var wrapped = interceptor.intercept(delegate);
+    final var request =
+        HttpRequest.builder().method(HttpMethod.GET).baseUrl("https://api.example.com").build();
+
+    assertThatThrownBy(() -> wrapped.executeAsync(request))
+        .isInstanceOf(UnsupportedOperationException.class);
   }
 }

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/authentication/oauth/OAuthBearerTokenInterceptorTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/authentication/oauth/OAuthBearerTokenInterceptorTest.java
@@ -45,7 +45,15 @@ class OAuthBearerTokenInterceptorTest {
             null,
             OAuthConstants.BASIC_AUTH_HEADER,
             null);
-    interceptor = new OAuthBearerTokenInterceptor(tokenResolver, authentication);
+    interceptor =
+        new OAuthBearerTokenInterceptor(
+            tokenResolver,
+            authentication.oauthTokenEndpoint(),
+            authentication.clientId(),
+            authentication.clientSecret(),
+            authentication.audience(),
+            authentication.clientAuthentication(),
+            authentication.scopes());
   }
 
   @Test

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/authentication/oauth/OAuthBearerTokenInterceptorTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/authentication/oauth/OAuthBearerTokenInterceptorTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.agenticai.aiagent.chatmodel.provider.authentication.oauth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.anthropic.core.http.HttpClient;
+import com.anthropic.core.http.HttpMethod;
+import com.anthropic.core.http.HttpRequest;
+import com.anthropic.core.http.HttpResponse;
+import io.camunda.connector.http.client.authentication.OAuthClientCredentialsTokenResolver;
+import io.camunda.connector.http.client.authentication.OAuthConstants;
+import io.camunda.connector.http.client.model.auth.OAuthAuthentication;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class OAuthBearerTokenInterceptorTest {
+
+  @Mock private OAuthClientCredentialsTokenResolver tokenResolver;
+  @Mock private HttpClient delegate;
+  @Mock private HttpResponse response;
+
+  private OAuthAuthentication authentication;
+  private OAuthBearerTokenInterceptor interceptor;
+
+  @BeforeEach
+  void setUp() {
+    authentication =
+        new OAuthAuthentication(
+            "https://auth.example.com/oauth/token",
+            "my-client-id",
+            "my-client-secret",
+            null,
+            OAuthConstants.BASIC_AUTH_HEADER,
+            null);
+    interceptor = new OAuthBearerTokenInterceptor(tokenResolver, authentication);
+  }
+
+  @Test
+  void addsBearerAuthorizationHeaderResolvedPerRequest() {
+    when(tokenResolver.resolveAccessToken(authentication)).thenReturn("resolved-token");
+    when(delegate.execute(any(), any())).thenReturn(response);
+
+    final var wrapped = interceptor.intercept(delegate);
+    final var request =
+        HttpRequest.builder().method(HttpMethod.GET).baseUrl("https://api.example.com").build();
+
+    wrapped.execute(request);
+
+    final var captor = ArgumentCaptor.forClass(HttpRequest.class);
+    verify(delegate).execute(captor.capture(), any());
+    assertThat(captor.getValue().headers().values("Authorization"))
+        .containsExactly("Bearer resolved-token");
+  }
+
+  @Test
+  void resolvesTokenAgainOnEachRequest() {
+    when(tokenResolver.resolveAccessToken(authentication)).thenReturn("token-1", "token-2");
+    when(delegate.execute(any(), any())).thenReturn(response);
+
+    final var wrapped = interceptor.intercept(delegate);
+    final var request =
+        HttpRequest.builder().method(HttpMethod.GET).baseUrl("https://api.example.com").build();
+
+    wrapped.execute(request);
+    wrapped.execute(request);
+
+    verify(tokenResolver, org.mockito.Mockito.times(2)).resolveAccessToken(authentication);
+  }
+}

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/openai/OpenAiChatModelFactoryClientTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/openai/OpenAiChatModelFactoryClientTest.java
@@ -38,6 +38,7 @@ import io.camunda.connector.agenticai.aiagent.model.AgentConfiguration;
 import io.camunda.connector.agenticai.aiagent.model.AgentExecutionContext;
 import io.camunda.connector.agenticai.aiagent.model.request.PromptConfiguration.SystemPromptConfiguration;
 import io.camunda.connector.agenticai.aiagent.model.request.PromptConfiguration.UserPromptConfiguration;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.OAuthClientCredentialsAuthentication;
 import io.camunda.connector.agenticai.aiagent.model.request.v2.OpenAiChatModelConfiguration;
 import io.camunda.connector.agenticai.aiagent.model.request.v2.OpenAiChatModelConfiguration.OpenAiApi.OpenAiCompletionsApi;
 import io.camunda.connector.agenticai.aiagent.model.request.v2.OpenAiChatModelConfiguration.OpenAiApi.OpenAiCompletionsApi.CompletionsParameters;
@@ -53,7 +54,6 @@ import io.camunda.connector.agenticai.aiagent.model.request.v2.OpenAiChatModelCo
 import io.camunda.connector.agenticai.aiagent.model.request.v2.OpenAiChatModelConfiguration.OpenAiBackend.OpenAiFoundryBackend.FoundryBackend;
 import io.camunda.connector.agenticai.aiagent.model.request.v2.OpenAiChatModelConfiguration.OpenAiModel;
 import io.camunda.connector.agenticai.aiagent.model.request.v2.OpenAiCustomEndpointAuthentication.ApiKeyAuthentication;
-import io.camunda.connector.agenticai.aiagent.model.request.v2.OpenAiCustomEndpointAuthentication.OAuthClientCredentialsAuthentication;
 import io.camunda.connector.agenticai.autoconfigure.AgenticAiConnectorsConfigurationProperties.ChatModelProperties.AzureProperties.CredentialCacheProperties;
 import io.camunda.connector.agenticai.common.AgenticAiHttpProxySupport;
 import io.camunda.connector.http.client.authentication.OAuthClientCredentialsTokenResolver;

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/model/request/v2/AnthropicChatModelConfigurationTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/model/request/v2/AnthropicChatModelConfigurationTest.java
@@ -19,6 +19,7 @@ import io.camunda.connector.agenticai.aiagent.model.request.v2.AnthropicChatMode
 import io.camunda.connector.agenticai.aiagent.model.request.v2.AnthropicChatModelConfiguration.AnthropicModel.AnthropicThinking;
 import io.camunda.connector.agenticai.aiagent.model.request.v2.AnthropicChatModelConfiguration.AnthropicModel.ThinkingMode;
 import io.camunda.connector.agenticai.aiagent.model.request.v2.AnthropicCustomEndpointAuthentication.ApiKeyAuthentication;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.AnthropicCustomEndpointAuthentication.OAuthClientCredentialsAuthentication;
 import io.camunda.connector.agenticai.aiagent.util.ConnectorUtils;
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.Validator;
@@ -156,6 +157,103 @@ class AnthropicChatModelConfigurationTest {
 
     final String reserialised = mapper.writeValueAsString(parsed);
     assertThat(mapper.readValue(reserialised, ProviderConfiguration.class)).isEqualTo(parsed);
+  }
+
+  @Test
+  void deserialisesCustomBackendWithOAuthClientCredentialsAuthAndRoundTrips() throws Exception {
+    final String json =
+        """
+        {
+          "type": "anthropic",
+          "anthropic": {
+            "backend": {
+              "type": "custom",
+              "custom": {
+                "endpoint": "https://custom.example.com",
+                "authentication": {
+                  "type": "oauth-client-credentials-flow",
+                  "oauthTokenEndpoint": "https://auth.example.com/oauth/token",
+                  "clientId": "client-123",
+                  "clientSecret": "secret-123",
+                  "scopes": "read:llm"
+                }
+              }
+            },
+            "model": { "model": "claude-sonnet-4-6" }
+          }
+        }
+        """;
+
+    final AnthropicChatModelConfiguration parsed =
+        (AnthropicChatModelConfiguration) mapper.readValue(json, ProviderConfiguration.class);
+
+    final AnthropicCustomBackend custom = (AnthropicCustomBackend) parsed.anthropic().backend();
+    assertThat(custom.custom().authentication())
+        .isEqualTo(
+            new OAuthClientCredentialsAuthentication(
+                "https://auth.example.com/oauth/token",
+                "client-123",
+                "secret-123",
+                null,
+                OAuthClientCredentialsAuthentication.ClientAuthenticationMethod.BASIC_AUTH_HEADER,
+                "read:llm"));
+
+    final String reserialised = mapper.writeValueAsString(parsed);
+    assertThat(mapper.readValue(reserialised, ProviderConfiguration.class)).isEqualTo(parsed);
+  }
+
+  @Test
+  void oAuthClientCredentialsAuthenticationRedactsSecretsInToString() {
+    final var auth =
+        new OAuthClientCredentialsAuthentication(
+            "https://auth.example.com/oauth/token",
+            "client-123",
+            "super-secret-value",
+            null,
+            OAuthClientCredentialsAuthentication.ClientAuthenticationMethod.BASIC_AUTH_HEADER,
+            null);
+
+    assertThat(auth.toString())
+        .contains("clientId=[REDACTED]", "clientSecret=[REDACTED]")
+        .doesNotContain("client-123", "super-secret-value");
+  }
+
+  @Test
+  void requiredOAuthClientCredentialsFieldsAreEnforced() {
+    final var config =
+        new AnthropicChatModelConfiguration(
+            new AnthropicConnection(
+                new AnthropicCustomBackend(
+                    new AnthropicCustomBackend.CustomBackend(
+                        "https://custom.example.com",
+                        null,
+                        null,
+                        null,
+                        new OAuthClientCredentialsAuthentication("", "", "", null, null, null))),
+                new AnthropicModel("claude-sonnet-4-6", null),
+                null));
+
+    final var violations = validator.validate(config);
+
+    assertThat(violations)
+        .anySatisfy(
+            v -> {
+              assertThat(v.getPropertyPath().toString())
+                  .isEqualTo("anthropic.backend.custom.authentication.oauthTokenEndpoint");
+              assertThat(v.getMessage()).isEqualTo("must not be empty");
+            })
+        .anySatisfy(
+            v -> {
+              assertThat(v.getPropertyPath().toString())
+                  .isEqualTo("anthropic.backend.custom.authentication.clientId");
+              assertThat(v.getMessage()).isEqualTo("must not be empty");
+            })
+        .anySatisfy(
+            v -> {
+              assertThat(v.getPropertyPath().toString())
+                  .isEqualTo("anthropic.backend.custom.authentication.clientSecret");
+              assertThat(v.getMessage()).isEqualTo("must not be empty");
+            });
   }
 
   @Test

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/model/request/v2/AnthropicChatModelConfigurationTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/model/request/v2/AnthropicChatModelConfigurationTest.java
@@ -19,7 +19,6 @@ import io.camunda.connector.agenticai.aiagent.model.request.v2.AnthropicChatMode
 import io.camunda.connector.agenticai.aiagent.model.request.v2.AnthropicChatModelConfiguration.AnthropicModel.AnthropicThinking;
 import io.camunda.connector.agenticai.aiagent.model.request.v2.AnthropicChatModelConfiguration.AnthropicModel.ThinkingMode;
 import io.camunda.connector.agenticai.aiagent.model.request.v2.AnthropicCustomEndpointAuthentication.ApiKeyAuthentication;
-import io.camunda.connector.agenticai.aiagent.model.request.v2.AnthropicCustomEndpointAuthentication.OAuthClientCredentialsAuthentication;
 import io.camunda.connector.agenticai.aiagent.util.ConnectorUtils;
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.Validator;

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/model/request/v2/OpenAiChatModelConfigurationTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/model/request/v2/OpenAiChatModelConfigurationTest.java
@@ -26,7 +26,6 @@ import io.camunda.connector.agenticai.aiagent.model.request.v2.OpenAiChatModelCo
 import io.camunda.connector.agenticai.aiagent.model.request.v2.OpenAiChatModelConfiguration.OpenAiEffort;
 import io.camunda.connector.agenticai.aiagent.model.request.v2.OpenAiChatModelConfiguration.OpenAiModel;
 import io.camunda.connector.agenticai.aiagent.model.request.v2.OpenAiCustomEndpointAuthentication.ApiKeyAuthentication;
-import io.camunda.connector.agenticai.aiagent.model.request.v2.OpenAiCustomEndpointAuthentication.OAuthClientCredentialsAuthentication;
 import io.camunda.connector.agenticai.aiagent.util.ConnectorUtils;
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.Validator;

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/autoconfigure/AgenticAiConnectorsAutoConfigurationTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/autoconfigure/AgenticAiConnectorsAutoConfigurationTest.java
@@ -759,7 +759,8 @@ class AgenticAiConnectorsAutoConfigurationTest {
           super(
               mock(AgenticAiHttpProxySupport.class),
               mock(AnthropicMessageRequestConverter.class),
-              mock(AnthropicMessageResponseConverter.class));
+              mock(AnthropicMessageResponseConverter.class),
+              mock(OAuthClientCredentialsTokenResolver.class));
         }
 
         @Override

--- a/connectors/agentic-ai/docs/reference/native-providers.md
+++ b/connectors/agentic-ai/docs/reference/native-providers.md
@@ -16,9 +16,18 @@ One wire format (the Messages API), so a single backend axis covers everything: 
 
 `AnthropicCustomBackend` is the only variant exposing user-configurable
 `headers`/`queryParameters`/`bodyProperties`, and the only one supporting genuine no-auth
-(`AnthropicCustomEndpointAuthentication.NoAuthentication`) alongside API-key auth. Overrides merge
+(`AnthropicCustomEndpointAuthentication.NoAuthentication`) alongside `apiKey` and
+`OAuthClientCredentialsAuthentication` (OAuth 2.0 client-credentials flow). Overrides merge
 additively per-key onto the SDK request builder (`AnthropicMessageRequestConverter
 .applyRequestCustomizations`), never a wholesale replace.
+
+Unlike openai-java, the anthropic-java SDK's client builder has no public dynamic-credential hook
+(its `AccessTokenProvider`/`credentials()` path is Kotlin-`internal`). `AnthropicChatModelFactory`
+instead adds an `OAuthBearerTokenInterceptor` (`com.anthropic.core.http.Interceptor`, a supported
+public hook) via `builder.addInterceptor(...)`: it wraps the transport `HttpClient` and rewrites
+each outgoing `HttpRequest` with a fresh `Authorization: Bearer` header, resolved per request from
+the same shared `OAuthClientCredentialsTokenResolver` the OpenAI provider uses
+(`provider/authentication/oauth/`).
 
 ### Reasoning
 

--- a/connectors/agentic-ai/docs/reference/native-providers.md
+++ b/connectors/agentic-ai/docs/reference/native-providers.md
@@ -21,10 +21,8 @@ One wire format (the Messages API), so a single backend axis covers everything: 
 additively per-key onto the SDK request builder (`AnthropicMessageRequestConverter
 .applyRequestCustomizations`), never a wholesale replace.
 
-Unlike openai-java, the anthropic-java SDK's client builder has no public dynamic-credential hook
-(its `AccessTokenProvider`/`credentials()` path is Kotlin-`internal`). `AnthropicChatModelFactory`
-instead adds an `OAuthBearerTokenInterceptor` (`com.anthropic.core.http.Interceptor`, a supported
-public hook) via `builder.addInterceptor(...)`: it wraps the transport `HttpClient` and rewrites
+`AnthropicChatModelFactory` adds an `OAuthBearerTokenInterceptor` (`com.anthropic.core.http.Interceptor`,
+a supported public hook) via `builder.addInterceptor(...)`: it wraps the transport `HttpClient` and rewrites
 each outgoing `HttpRequest` with a fresh `Authorization: Bearer` header, resolved per request from
 the same shared `OAuthClientCredentialsTokenResolver` the OpenAI provider uses
 (`provider/authentication/oauth/`).


### PR DESCRIPTION
## Description

Adds the same OAuth 2.0 client-credentials authentication to the Anthropic native provider's `custom/compatible` backend.

- New `OAuthClientCredentialsAuthentication` option on `AnthropicCustomEndpointAuthentication`, mirroring OpenAI's.
- The anthropic-java SDK has no public dynamic-credential hook (unlike openai-java's `Credential`), so the bearer token is injected per request via the SDK's supported `Interceptor` hook instead, backed by the same shared `OAuthClientCredentialsTokenResolver` introduced in #8626.

## Related issues

closes #8056

## Checklist

- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest
  release, as this branch will be rebased onto main before the next release. Example backport labels:
    - `backport stable/8.8`: for changes that should be included in the next 8.8.x release.
    - **or** `backport release-8.8.7`: for changes that should be included in the specific release 8.8.7, and this
      *release has already been created*. The release branch will be merged back into stable/8.8 later, so the change
      will be included in future 8.8.x releases as well.
- [x] Tests/Integration tests for the changes have been added if applicable.
- [x] If the change requires a documentation update, it has been added to the appropriate section in the documentation.