### PR TITLE
fix: scope testcontainers and wiremock to test in rabbitmq and email connectors

### DIFF
--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretUtil.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretUtil.java
@@ -103,10 +103,10 @@ public class SecretUtil {
    * Names are trimmed, because that is the name {@link #resolveSecretValue} looks up: the
    * parentheses pattern's capture reaches past the name to the closing braces, so {@code {{
    * secrets.FOO }}} declares {@code FOO}, not {@code "FOO "}. Returning the untrimmed form also
-   * breaks consumers that do not normalize again. For example, exception redaction filters extracted
-   * names against the allow-list before fetching their values; a colon-bearing name has no independent
-   * bare-pattern match, so the untrimmed name is filtered out and its value cannot be redacted from an
-   * exception message.
+   * breaks consumers that do not normalize again. For example, exception redaction filters
+   * extracted names against the allow-list before fetching their values; a colon-bearing name has
+   * no independent bare-pattern match, so the untrimmed name is filtered out and its value cannot
+   * be redacted from an exception message.
    */
   public static List<String> retrieveSecretKeysInInput(String input) {
     return Objects.isNull(input)

--- a/connectors-e2e-test/connectors-e2e-test-rabbitmq/pom.xml
+++ b/connectors-e2e-test/connectors-e2e-test-rabbitmq/pom.xml
@@ -47,5 +47,12 @@
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>testcontainers-rabbitmq</artifactId>
+      <version>${version.testcontainers}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/connectors/email/pom.xml
+++ b/connectors/email/pom.xml
@@ -34,6 +34,7 @@
         <dependency>
             <groupId>org.wiremock</groupId>
             <artifactId>wiremock-standalone</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.icegreen</groupId>

--- a/connectors/rabbitmq/pom.xml
+++ b/connectors/rabbitmq/pom.xml
@@ -33,6 +33,7 @@
       <groupId>org.testcontainers</groupId>
       <artifactId>testcontainers-rabbitmq</artifactId>
       <version>${version.testcontainers}</version>
+      <scope>test</scope>
     </dependency>
 
     <!-- This dependency will be removed after camunda/zeebe#9859 is resolved. -->


### PR DESCRIPTION
## Summary

Adds `<scope>test</scope>` to two dependency declarations on `stable/8.7`, matching what 8.8+
already have:

- `connectors/rabbitmq/pom.xml` — `org.testcontainers:testcontainers-rabbitmq` (used only from `src/test`)
- `connectors/email/pom.xml` — `org.wiremock:wiremock-standalone` (not referenced from `src/main` or `src/test`; the declaration does not exist on 8.8+)

Without the scope, both resolve at compile scope and are therefore packaged into
`connector-runtime-bundle*-with-dependencies.jar` by `maven-shade-plugin`, so test-harness
libraries and their transitive dependencies ship inside the bundle images.

## Verification

`mvn -pl bundle/default-bundle -am dependency:tree` before and after:

- before — `connector-runtime-bundle` resolved `testcontainers-rabbitmq:compile` (and its
  `com.github.docker-java` transitives) plus `wiremock-standalone:compile`
- after — none of `org.testcontainers`, `org.wiremock` or `com.github.docker-java` remains on the
  module's compile/runtime classpath

Security fix. Details in the internal tracking issue: camunda/team-connectors#1275
