### PR TITLE
feat(runtime): extend secret filtering to inbound connectors

### DIFF
--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/DefaultInboundConnectorContextFactory.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/DefaultInboundConnectorContextFactory.java
@@ -38,6 +38,7 @@ public class DefaultInboundConnectorContextFactory implements InboundConnectorCo
   private final ValidationProvider validationProvider;
   private final OperateClientAdapter operateClientAdapter;
   private final DocumentFactory documentFactory;
+  private final boolean secretFilterEnabled;
 
   public DefaultInboundConnectorContextFactory(
       final ObjectMapper mapper,
@@ -46,6 +47,25 @@ public class DefaultInboundConnectorContextFactory implements InboundConnectorCo
       final ValidationProvider validationProvider,
       final OperateClientAdapter operateClientAdapter,
       final DocumentFactory documentFactory) {
+    this(
+        mapper,
+        correlationHandler,
+        secretProviderAggregator,
+        validationProvider,
+        operateClientAdapter,
+        documentFactory,
+        false);
+  }
+
+  public DefaultInboundConnectorContextFactory(
+      final ObjectMapper mapper,
+      final InboundCorrelationHandler correlationHandler,
+      final SecretProviderAggregator secretProviderAggregator,
+      final ValidationProvider validationProvider,
+      final OperateClientAdapter operateClientAdapter,
+      final DocumentFactory documentFactory,
+      final boolean secretFilterEnabled) {
+    this.secretFilterEnabled = secretFilterEnabled;
     this.objectMapper = mapper;
     this.correlationHandler = correlationHandler;
     this.secretProviderAggregator = secretProviderAggregator;
@@ -70,7 +90,8 @@ public class DefaultInboundConnectorContextFactory implements InboundConnectorCo
             correlationHandler,
             cancellationCallback,
             objectMapper,
-            queue);
+            queue,
+            secretFilterEnabled);
 
     if (isIntermediateContext(executableClass)) {
       inboundContext =

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/DefaultProcessElementContext.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/DefaultProcessElementContext.java
@@ -24,6 +24,7 @@ import io.camunda.connector.api.secret.SecretProvider;
 import io.camunda.connector.api.validation.ValidationProvider;
 import io.camunda.connector.runtime.core.AbstractConnectorContext;
 import io.camunda.connector.runtime.core.secret.SecretFilter;
+import io.camunda.connector.runtime.core.secret.SecretUtil;
 import java.util.Map;
 
 public class DefaultProcessElementContext extends AbstractConnectorContext
@@ -41,11 +42,51 @@ public class DefaultProcessElementContext extends AbstractConnectorContext
       ValidationProvider validationProvider,
       SecretProvider secretProvider,
       ObjectMapper objectMapper) {
-    super(secretProvider, SecretFilter.allowAll(), validationProvider);
+    this(connectorElement, validationProvider, secretProvider, objectMapper, false);
+  }
+
+  /**
+   * @param secretFilterEnabled when {@code true}, restricts secret resolution to the names this
+   *     element's own deployed {@code zeebe:property} text declares (#7730).
+   */
+  public DefaultProcessElementContext(
+      InboundConnectorElement connectorElement,
+      ValidationProvider validationProvider,
+      SecretProvider secretProvider,
+      ObjectMapper objectMapper,
+      boolean secretFilterEnabled) {
+    super(secretProvider, secretFilter(connectorElement, secretFilterEnabled), validationProvider);
     this.connectorElement = connectorElement;
     this.objectMapper = objectMapper;
     this.properties =
         InboundPropertyHandler.readWrappedProperties(connectorElement.rawProperties());
+  }
+
+  /**
+   * Scoped to this one element's {@code rawProperties} — the exact text {@link
+   * #getPropertiesWithSecrets} filters — rather than to every element of the executable. A name
+   * only a sibling element declares is therefore refused here, matching the per-call scoping #8538
+   * settled on upstream after a union across siblings proved too wide.
+   *
+   * <p>This context is a second inbound resolution path, distinct from {@code
+   * InboundConnectorContextImpl}: {@code canActivate} hands it to connectors as {@code
+   * ActivationCheckResult.Success.CanActivate#activatedElement()}, and every successful {@code
+   * CorrelationResult} carries one, so its public {@code getProperties()} and {@code
+   * bindProperties()} resolve secrets too. It is the analogue of main's {@code
+   * BindableProcessElement}, which is why upstream filters that and this filters here.
+   *
+   * <p>Static because it feeds the {@code super(...)} call, before any field is assigned.
+   */
+  private static SecretFilter secretFilter(
+      InboundConnectorElement connectorElement, boolean secretFilterEnabled) {
+    if (!secretFilterEnabled) {
+      return SecretFilter.allowAll();
+    }
+    return SecretFilter.allowOnly(
+        connectorElement.rawProperties().values().stream()
+            .flatMap(value -> SecretUtil.retrieveSecretKeysInInput(value).stream())
+            .distinct()
+            .toList());
   }
 
   @Override

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/DefaultProcessElementContextFactory.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/DefaultProcessElementContextFactory.java
@@ -26,19 +26,29 @@ public class DefaultProcessElementContextFactory implements ProcessElementContex
   private final SecretProvider secretProvider;
   private final ValidationProvider validationProvider;
   private final ObjectMapper objectMapper;
+  private final boolean secretFilterEnabled;
 
   public DefaultProcessElementContextFactory(
       SecretProvider secretProvider,
       ValidationProvider validationProvider,
       ObjectMapper objectMapper) {
+    this(secretProvider, validationProvider, objectMapper, false);
+  }
+
+  public DefaultProcessElementContextFactory(
+      SecretProvider secretProvider,
+      ValidationProvider validationProvider,
+      ObjectMapper objectMapper,
+      boolean secretFilterEnabled) {
     this.secretProvider = secretProvider;
     this.validationProvider = validationProvider;
     this.objectMapper = objectMapper;
+    this.secretFilterEnabled = secretFilterEnabled;
   }
 
   @Override
   public ProcessElementContext createContext(InboundConnectorElement connectorElement) {
     return new DefaultProcessElementContext(
-        connectorElement, validationProvider, secretProvider, objectMapper);
+        connectorElement, validationProvider, secretProvider, objectMapper, secretFilterEnabled);
   }
 }

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextImpl.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextImpl.java
@@ -29,6 +29,7 @@ import io.camunda.connector.runtime.core.inbound.correlation.InboundCorrelationH
 import io.camunda.connector.runtime.core.inbound.details.InboundConnectorDetails;
 import io.camunda.connector.runtime.core.inbound.details.InboundConnectorDetails.ValidInboundConnectorDetails;
 import io.camunda.connector.runtime.core.secret.SecretFilter;
+import io.camunda.connector.runtime.core.secret.SecretUtil;
 import io.camunda.document.Document;
 import io.camunda.document.factory.DocumentFactory;
 import io.camunda.document.factory.DocumentFactoryImpl;
@@ -70,7 +71,33 @@ public class InboundConnectorContextImpl extends AbstractConnectorContext
       Consumer<Throwable> cancellationCallback,
       ObjectMapper objectMapper,
       EvictingQueue<Activity> logs) {
-    super(secretProvider, SecretFilter.allowAll(), validationProvider);
+    this(
+        secretProvider,
+        validationProvider,
+        documentFactory,
+        connectorDetails,
+        correlationHandler,
+        cancellationCallback,
+        objectMapper,
+        logs,
+        false);
+  }
+
+  /**
+   * @param secretFilterEnabled when {@code true}, restricts secret resolution to the names declared
+   *     by the deployed {@code zeebe:property} text replacement runs over (#7730).
+   */
+  public InboundConnectorContextImpl(
+      SecretProvider secretProvider,
+      ValidationProvider validationProvider,
+      DocumentFactory documentFactory,
+      ValidInboundConnectorDetails connectorDetails,
+      InboundCorrelationHandler correlationHandler,
+      Consumer<Throwable> cancellationCallback,
+      ObjectMapper objectMapper,
+      EvictingQueue<Activity> logs,
+      boolean secretFilterEnabled) {
+    super(secretProvider, secretFilter(connectorDetails, secretFilterEnabled), validationProvider);
     this.documentFactory = documentFactory;
     this.correlationHandler = correlationHandler;
     this.connectorDetails = connectorDetails;
@@ -147,6 +174,41 @@ public class InboundConnectorContextImpl extends AbstractConnectorContext
     } catch (Throwable e) {
       LOG.error("Failed to deliver the cancellation signal to the runtime", e);
     }
+  }
+
+  /**
+   * The allow-list is drawn from the same {@code rawPropertiesWithoutKeywords} map that {@link
+   * #properties} is built from, so the names permitted and the text filtered always come from one
+   * read. Both are fixed at construction on this branch — {@code connectorDetails} and {@code
+   * properties} are final and there is no {@code updateConnectorDetails} — so the hot-swap and
+   * torn-read failure directions main had to close are not representable here.
+   *
+   * <p>This is what the filter stops: {@link SecretUtil#replaceSecrets} runs the brace pass and
+   * then runs the bare pass over that pass's output, so a resolved value containing
+   * reference-shaped text otherwise produces a lookup for a name no model declares. Confirmed
+   * present on this branch before backporting: a secret whose value is the literal {@code
+   * secrets.CHAINED} resolved {@code CHAINED} under the previous allow-all filter.
+   *
+   * <p>Narrower than the equivalent on 8.8/8.9, and deliberately so for now. This branch's {@code
+   * SecretUtil} has neither their nested-match exclusion in {@code retrieveSecretKeysInInput} nor
+   * their denied-bracket exclusion in {@code replaceSecretsWithoutParentheses} (#8592, #8593), so a
+   * model declaring {@code {{secrets.FOO:BAR}}} also admits the truncated {@code FOO}. That is a
+   * pre-existing property of this branch, unchanged by this filter in either direction; porting
+   * that hardening is separate work, because {@code SecretUtil} here is shared with the outbound
+   * allow-list and with exception redaction.
+   *
+   * <p>Static because it feeds the {@code super(...)} call, before any field is assigned.
+   */
+  private static SecretFilter secretFilter(
+      ValidInboundConnectorDetails connectorDetails, boolean secretFilterEnabled) {
+    if (!secretFilterEnabled) {
+      return SecretFilter.allowAll();
+    }
+    return SecretFilter.allowOnly(
+        connectorDetails.rawPropertiesWithoutKeywords().values().stream()
+            .flatMap(value -> SecretUtil.retrieveSecretKeysInInput(value).stream())
+            .distinct()
+            .toList());
   }
 
   @Override

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretUtil.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretUtil.java
@@ -103,10 +103,10 @@ public class SecretUtil {
    * Names are trimmed, because that is the name {@link #resolveSecretValue} looks up: the
    * parentheses pattern's capture reaches past the name to the closing braces, so {@code {{
    * secrets.FOO }}} declares {@code FOO}, not {@code "FOO "}. Returning the untrimmed form also
-   * breaks consumers that do not normalize again. For example, exception redaction filters extracted
-   * names against the allow-list before fetching their values; a colon-bearing name has no independent
-   * bare-pattern match, so the untrimmed name is filtered out and its value cannot be redacted from an
-   * exception message.
+   * breaks consumers that do not normalize again. For example, exception redaction filters
+   * extracted names against the allow-list before fetching their values; a colon-bearing name has
+   * no independent bare-pattern match, so the untrimmed name is filtered out and its value cannot
+   * be redacted from an exception message.
    */
   public static List<String> retrieveSecretKeysInInput(String input) {
     return Objects.isNull(input)

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextImplTest.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextImplTest.java
@@ -18,11 +18,18 @@ package io.camunda.connector.runtime.core.inbound;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.EvictingQueue;
 import io.camunda.connector.api.inbound.ProcessElement;
 import io.camunda.connector.api.json.ConnectorsObjectMapperSupplier;
+import io.camunda.connector.api.secret.SecretContext;
 import io.camunda.connector.api.secret.SecretProvider;
 import io.camunda.connector.feel.annotation.FEEL;
 import io.camunda.connector.runtime.core.FooBarSecretProvider;
@@ -105,6 +112,100 @@ class InboundConnectorContextImplTest {
     // then
     assertThat(propertiesAsType.getMapWithStringListWithNumbers().get("key").getFirst())
         .isInstanceOf(String.class);
+  }
+
+  // #7730: inbound secret resolution is restricted to the names the element's own deployed
+  // zeebe:property text declares. The allow-list is a superset of what a correctly-authored model
+  // names, so what it actually stops is a second-order lookup: replaceSecrets runs the brace pass
+  // and then runs the bare pass over that pass's output, letting a resolved value that contains
+  // reference-shaped text reach a secret no model ever declared. Confirmed present on this branch
+  // before backporting: under the previous allow-all filter, a secret whose value is the literal
+  // "secrets.CHAINED" resolved CHAINED.
+  //
+  // Main's suite also covers a hot swap, a sibling element's names, and the new
+  // camunda.secrets.<name> form. None are representable on this branch: connectorDetails and
+  // properties are both final and there is no updateConnectorDetails at all, there is a single
+  // connector-level text rather than a per-element one, and the new form does not exist here.
+
+  private InboundConnectorContextImpl filteringContext(
+      ValidInboundConnectorDetails details, SecretProvider provider) {
+    return new InboundConnectorContextImpl(
+        provider,
+        (e) -> {},
+        null,
+        details,
+        null,
+        (e) -> {},
+        mapper,
+        EvictingQueue.create(10),
+        true);
+  }
+
+  private static String replace(InboundConnectorContextImpl context, String input) {
+    return context.getSecretHandler().replaceSecrets(input, new SecretContext("t"));
+  }
+
+  @Test
+  void secretFilterEnabled_resolvesADeclaredSecret() {
+    var provider = mock(SecretProvider.class);
+    when(provider.getSecret(eq("DECLARED"), any())).thenReturn("resolved");
+    var context =
+        filteringContext(
+            getInboundConnectorDefinition(Map.of("token", "secrets.DECLARED")), provider);
+
+    assertThat(replace(context, "secrets.DECLARED")).isEqualTo("resolved");
+  }
+
+  @Test
+  void secretFilterEnabled_resolvesADeclaredSecretInBraceSyntax() {
+    var provider = mock(SecretProvider.class);
+    when(provider.getSecret(eq("BRACED"), any())).thenReturn("resolved");
+    var context =
+        filteringContext(
+            getInboundConnectorDefinition(Map.of("token", "{{ secrets.BRACED }}")), provider);
+
+    assertThat(replace(context, "{{ secrets.BRACED }}")).isEqualTo("resolved");
+  }
+
+  @Test
+  void secretFilterEnabled_leavesAnUndeclaredSecret() {
+    var provider = mock(SecretProvider.class);
+    var context =
+        filteringContext(
+            getInboundConnectorDefinition(Map.of("token", "secrets.DECLARED")), provider);
+
+    assertThat(replace(context, "secrets.INJECTED")).isEqualTo("secrets.INJECTED");
+    verify(provider, never()).getSecret(eq("INJECTED"), any());
+  }
+
+  @Test
+  void secretFilterEnabled_leavesASecretNamedOnlyByAnotherSecretsValue() {
+    var provider = mock(SecretProvider.class);
+    when(provider.getSecret(eq("CHAIN_ROOT"), any())).thenReturn("secrets.CHAINED");
+    when(provider.getSecret(eq("CHAINED"), any())).thenReturn("leaked-value");
+    var context =
+        filteringContext(
+            getInboundConnectorDefinition(Map.of("token", "{{secrets.CHAIN_ROOT}}")), provider);
+
+    assertThat(replace(context, "{{secrets.CHAIN_ROOT}}")).isEqualTo("secrets.CHAINED");
+    verify(provider, never()).getSecret(eq("CHAINED"), any());
+  }
+
+  @Test
+  void secretFilterDisabled_resolvesAnUndeclaredSecret() {
+    var provider = mock(SecretProvider.class);
+    when(provider.getSecret(eq("INJECTED"), any())).thenReturn("resolved");
+    var context =
+        new InboundConnectorContextImpl(
+            provider,
+            (e) -> {},
+            getInboundConnectorDefinition(Map.of("token", "secrets.DECLARED")),
+            null,
+            (e) -> {},
+            mapper,
+            EvictingQueue.create(10));
+
+    assertThat(replace(context, "secrets.INJECTED")).isEqualTo("resolved");
   }
 
   private static ValidInboundConnectorDetails getInboundConnectorDefinition(

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/InboundConnectorRuntimeConfiguration.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/InboundConnectorRuntimeConfiguration.java
@@ -40,6 +40,7 @@ import io.camunda.connector.runtime.inbound.state.ProcessDefinitionInspector;
 import io.camunda.connector.runtime.inbound.state.ProcessStateStore;
 import io.camunda.connector.runtime.inbound.state.TenantAwareProcessStateStoreImpl;
 import io.camunda.connector.runtime.inbound.webhook.WebhookConnectorRegistry;
+import io.camunda.connector.runtime.outbound.job.ConfigurableSecretFilterFactory.SecretFilterMode;
 import io.camunda.document.factory.DocumentFactory;
 import io.camunda.operate.CamundaOperateClient;
 import io.camunda.zeebe.client.ZeebeClient;
@@ -95,14 +96,21 @@ public class InboundConnectorRuntimeConfiguration {
       SecretProviderAggregator secretProviderAggregator,
       @Autowired(required = false) ValidationProvider validationProvider,
       OperateClientAdapter operateClientAdapter,
-      DocumentFactory documentFactory) {
+      DocumentFactory documentFactory,
+      @Value("${camunda.connector.secret-resolver.secret-filter.mode:STRICT}")
+          SecretFilterMode secretFilterMode) {
+    // LAX vs STRICT only matters outbound, where the allow-list needs a remote BPMN lookup that can
+    // fail; the inbound allow-list is built from data already in memory, so it never fails and both
+    // modes behave identically here — only DISABLED turns this off.
+    boolean secretFilterEnabled = secretFilterMode != SecretFilterMode.DISABLED;
     return new DefaultInboundConnectorContextFactory(
         mapper,
         correlationHandler,
         secretProviderAggregator,
         validationProvider,
         operateClientAdapter,
-        documentFactory);
+        documentFactory,
+        secretFilterEnabled);
   }
 
   @Bean

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/InboundConnectorRuntimeConfiguration.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/InboundConnectorRuntimeConfiguration.java
@@ -74,9 +74,16 @@ public class InboundConnectorRuntimeConfiguration {
   public ProcessElementContextFactory processElementContextFactory(
       ObjectMapper objectMapper,
       @Autowired(required = false) ValidationProvider validationProvider,
-      SecretProviderAggregator secretProviderAggregator) {
+      SecretProviderAggregator secretProviderAggregator,
+      @Value("${camunda.connector.secret-resolver.secret-filter.mode:STRICT}")
+          SecretFilterMode secretFilterMode) {
+    // Same DISABLED-only opt-out as springInboundConnectorContextFactory: this is the second
+    // inbound resolution path, reached through canActivate and every successful CorrelationResult.
     return new DefaultProcessElementContextFactory(
-        secretProviderAggregator, validationProvider, objectMapper);
+        secretProviderAggregator,
+        validationProvider,
+        objectMapper,
+        secretFilterMode != SecretFilterMode.DISABLED);
   }
 
   @Bean

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/inbound/InboundConnectorRuntimeConfigurationTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/inbound/InboundConnectorRuntimeConfigurationTest.java
@@ -21,6 +21,7 @@ import static org.mockito.Mockito.mock;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.EvictingQueue;
+import io.camunda.connector.api.inbound.ActivationCheckResult;
 import io.camunda.connector.api.inbound.InboundConnectorContext;
 import io.camunda.connector.api.inbound.InboundConnectorExecutable;
 import io.camunda.connector.api.inbound.ProcessElement;
@@ -111,5 +112,66 @@ class InboundConnectorRuntimeConfigurationTest {
 
     @Override
     public void deactivate() {}
+  }
+
+  /**
+   * The second inbound resolution path. {@code canActivate} hands connectors a {@code
+   * ProcessElementContext} — and every successful {@code CorrelationResult} carries one — whose
+   * public {@code getProperties()}/{@code bindProperties()} resolve secrets through their own
+   * {@code SecretHandler}. Filtering only {@code springInboundConnectorContextFactory} leaves this
+   * one allow-all, so a connector holding the activated element could still resolve a chained name
+   * no model declares even under STRICT. This is the analogue of the {@code BindableProcessElement}
+   * path #8538 filters upstream.
+   *
+   * <p>The probe has to be the chained case: this context resolves the element's own property text,
+   * so any name written there is declared by definition and the allow-list is a superset of it.
+   * What it must refuse is a name that only a resolved <em>value</em> spells — CHAIN_ROOT's value
+   * is the literal {@code secrets.CHAINED}, which the bare pass then runs over.
+   */
+  @Test
+  void processElementContextFactory_refusesAChainedNameOnTheActivatedElement() {
+    assertEquals("secrets.CHAINED", resolveChainedViaActivatedElement(SecretFilterMode.STRICT));
+    assertEquals("secrets.CHAINED", resolveChainedViaActivatedElement(SecretFilterMode.LAX));
+    assertEquals("leaked-value", resolveChainedViaActivatedElement(SecretFilterMode.DISABLED));
+  }
+
+  private String resolveChainedViaActivatedElement(SecretFilterMode mode) {
+    var elementFactory =
+        configuration.processElementContextFactory(
+            new ObjectMapper(),
+            mock(ValidationProvider.class),
+            new SecretProviderAggregator(List.of(chainingProvider())),
+            mode);
+    var handler =
+        new InboundCorrelationHandler(
+            mock(io.camunda.zeebe.client.ZeebeClient.class),
+            new io.camunda.connector.feel.FeelEngineWrapper(),
+            elementFactory,
+            java.time.Duration.ofSeconds(60));
+    var result = handler.canActivate(List.of(chainRootElement()), Map.of());
+    var activated = ((ActivationCheckResult.Success.CanActivate) result).activatedElement();
+    return (String) activated.getProperties().get("token");
+  }
+
+  private static InboundConnectorElement chainRootElement() {
+    var properties =
+        Map.of("inbound.type", "io.camunda:connector:1", "token", "{{secrets.CHAIN_ROOT}}");
+    return new InboundConnectorElement(
+        properties,
+        new StandaloneMessageCorrelationPoint("", "", null, null),
+        new ProcessElement("process", 0, 0, "id", "<default>"));
+  }
+
+  private static SecretProvider chainingProvider() {
+    return new SecretProvider() {
+      @Override
+      public String getSecret(String name, SecretContext context) {
+        return switch (name.trim()) {
+          case "CHAIN_ROOT" -> "secrets.CHAINED";
+          case "CHAINED" -> "leaked-value";
+          default -> null;
+        };
+      }
+    };
   }
 }

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/inbound/InboundConnectorRuntimeConfigurationTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/inbound/InboundConnectorRuntimeConfigurationTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.runtime.inbound;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.EvictingQueue;
+import io.camunda.connector.api.inbound.InboundConnectorContext;
+import io.camunda.connector.api.inbound.InboundConnectorExecutable;
+import io.camunda.connector.api.inbound.ProcessElement;
+import io.camunda.connector.api.secret.SecretContext;
+import io.camunda.connector.api.secret.SecretProvider;
+import io.camunda.connector.api.validation.ValidationProvider;
+import io.camunda.connector.runtime.core.inbound.InboundConnectorContextImpl;
+import io.camunda.connector.runtime.core.inbound.InboundConnectorElement;
+import io.camunda.connector.runtime.core.inbound.OperateClientAdapter;
+import io.camunda.connector.runtime.core.inbound.correlation.InboundCorrelationHandler;
+import io.camunda.connector.runtime.core.inbound.correlation.MessageCorrelationPoint.StandaloneMessageCorrelationPoint;
+import io.camunda.connector.runtime.core.inbound.details.InboundConnectorDetails;
+import io.camunda.connector.runtime.core.inbound.details.InboundConnectorDetails.ValidInboundConnectorDetails;
+import io.camunda.connector.runtime.core.secret.SecretProviderAggregator;
+import io.camunda.connector.runtime.outbound.job.ConfigurableSecretFilterFactory.SecretFilterMode;
+import io.camunda.document.factory.DocumentFactory;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class InboundConnectorRuntimeConfigurationTest {
+
+  private final InboundConnectorRuntimeConfiguration configuration =
+      new InboundConnectorRuntimeConfiguration();
+
+  /**
+   * Pins the {@code SecretFilterMode} -> boolean hop: nothing else asserts that the mode reaches
+   * the context, and because {@code LAX} and {@code STRICT} behave identically on the inbound path
+   * this is the only place their equivalence — and {@code DISABLED}'s difference from both — is
+   * checked. Fails if the argument is dropped or the boolean inverted.
+   *
+   * <p>This calls the bean method directly and so bypasses Spring's {@code @Value} resolution
+   * entirely; {@code InboundSecretFilterDefaultModeWiringTest} covers the default string itself.
+   */
+  @Test
+  void springInboundConnectorContextFactory_filtersSecretsUnlessModeIsDisabled() {
+    assertEquals(
+        "secrets.UNDECLARED",
+        resolveUndeclared(contextForSecretFilterMode(SecretFilterMode.STRICT)));
+    assertEquals(
+        "secrets.UNDECLARED", resolveUndeclared(contextForSecretFilterMode(SecretFilterMode.LAX)));
+    assertEquals(
+        "resolved", resolveUndeclared(contextForSecretFilterMode(SecretFilterMode.DISABLED)));
+  }
+
+  private InboundConnectorContextImpl contextForSecretFilterMode(SecretFilterMode mode) {
+    var factory =
+        configuration.springInboundConnectorContextFactory(
+            new ObjectMapper(),
+            mock(InboundCorrelationHandler.class),
+            new SecretProviderAggregator(List.of(alwaysResolvingProvider())),
+            mock(ValidationProvider.class),
+            mock(OperateClientAdapter.class),
+            mock(DocumentFactory.class),
+            mode);
+    return (InboundConnectorContextImpl)
+        factory.createContext(
+            detailsDeclaringNoSecret(), e -> {}, TestExecutable.class, EvictingQueue.create(10));
+  }
+
+  private static ValidInboundConnectorDetails detailsDeclaringNoSecret() {
+    var properties = Map.of("inbound.type", "io.camunda:connector:1");
+    var element =
+        new InboundConnectorElement(
+            properties,
+            new StandaloneMessageCorrelationPoint("", "", null, null),
+            new ProcessElement("process", 0, 0, "id", "<default>"));
+    return (ValidInboundConnectorDetails)
+        InboundConnectorDetails.of(element.deduplicationId(List.of()), List.of(element));
+  }
+
+  private static String resolveUndeclared(InboundConnectorContextImpl context) {
+    return context.getSecretHandler().replaceSecrets("secrets.UNDECLARED", new SecretContext("t"));
+  }
+
+  private static SecretProvider alwaysResolvingProvider() {
+    return new SecretProvider() {
+      @Override
+      public String getSecret(String name, SecretContext context) {
+        return "resolved";
+      }
+    };
+  }
+
+  static class TestExecutable implements InboundConnectorExecutable<InboundConnectorContext> {
+    @Override
+    public void activate(InboundConnectorContext context) {}
+
+    @Override
+    public void deactivate() {}
+  }
+}

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/inbound/InboundSecretFilterDefaultModeWiringTest.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/inbound/InboundSecretFilterDefaultModeWiringTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.runtime.inbound;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.common.collect.EvictingQueue;
+import io.camunda.connector.api.inbound.InboundConnectorContext;
+import io.camunda.connector.api.inbound.InboundConnectorExecutable;
+import io.camunda.connector.api.inbound.ProcessElement;
+import io.camunda.connector.api.secret.SecretContext;
+import io.camunda.connector.runtime.app.TestConnectorRuntimeApplication;
+import io.camunda.connector.runtime.core.inbound.InboundConnectorContextFactory;
+import io.camunda.connector.runtime.core.inbound.InboundConnectorContextImpl;
+import io.camunda.connector.runtime.core.inbound.InboundConnectorElement;
+import io.camunda.connector.runtime.core.inbound.correlation.MessageCorrelationPoint.StandaloneMessageCorrelationPoint;
+import io.camunda.connector.runtime.core.inbound.details.InboundConnectorDetails;
+import io.camunda.connector.runtime.core.inbound.details.InboundConnectorDetails.ValidInboundConnectorDetails;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+/**
+ * No {@code camunda.connector.secret-resolver.secret-filter.mode} property is set here, so this
+ * exercises the {@code @Value} default on {@code springInboundConnectorContextFactory} itself —
+ * unlike a direct call to that bean method, which bypasses Spring's property resolution entirely
+ * and so stays green however wrong that default string is.
+ *
+ * <p>What this catches is a default that resolves to {@code DISABLED}, which turns inbound
+ * filtering off silently. It cannot distinguish {@code LAX} from {@code STRICT}, because those two
+ * behave identically inbound — {@code
+ * InboundConnectorRuntimeConfigurationTest#springInboundConnectorContextFactory_filtersSecretsUnlessModeIsDisabled}
+ * pins that equivalence, and {@code DISABLED}'s difference from both, at the bean-method level.
+ */
+@SpringBootTest(classes = TestConnectorRuntimeApplication.class)
+class InboundSecretFilterDefaultModeWiringTest {
+
+  @Autowired private InboundConnectorContextFactory contextFactory;
+
+  static class TestExecutable implements InboundConnectorExecutable<InboundConnectorContext> {
+    @Override
+    public void activate(InboundConnectorContext context) {}
+
+    @Override
+    public void deactivate() {}
+  }
+
+  @Test
+  void defaultsToFilteringSecrets() {
+    var properties = Map.of("inbound.type", "io.camunda:connector:1");
+    var element =
+        new InboundConnectorElement(
+            properties,
+            new StandaloneMessageCorrelationPoint("", "", null, null),
+            new ProcessElement("process", 0, 0, "id", "<default>"));
+    var details =
+        (ValidInboundConnectorDetails)
+            InboundConnectorDetails.of(element.deduplicationId(List.of()), List.of(element));
+
+    var context =
+        (InboundConnectorContextImpl)
+            contextFactory.createContext(
+                details, e -> {}, TestExecutable.class, EvictingQueue.create(10));
+    var result =
+        context.getSecretHandler().replaceSecrets("secrets.UNDECLARED", new SecretContext("t"));
+
+    assertThat(result).isEqualTo("secrets.UNDECLARED");
+  }
+}


### PR DESCRIPTION
## Summary

Manual backport of #8538 to `stable/8.7`. A cherry-pick is not viable here: `ADR-0007`, `InboundSecretReferenceBindingTest`, `InboundConnectorRuntimeConfigurationTest` and `ConnectorsAutoConfiguration` don't exist on this branch; `InboundConnectorContextImpl` takes an `EvictingQueue<Activity>` rather than an `ActivityLogWriter`; the factory takes an `OperateClientAdapter` rather than a `ProcessInstanceClient`; and `SecretContext` is a single-arg record.

Wires the existing `camunda.connector.secret-resolver.secret-filter.mode` property into the inbound path: secret resolution is now restricted to the names declared by the deployed `zeebe:property` text each replacement runs over, instead of always allowing every secret. `DISABLED` keeps the prior allow-all behavior; `LAX` and `STRICT` behave identically here since, unlike outbound, no remote lookup can fail.

**The `STRICT` default already applies on this branch** (since #8501), so inbound and outbound agree and no default-mode change is introduced.

## Two inbound resolution paths, both filtered

`stable/8.7` has **two** places that resolve secrets over inbound model text, and both needed filtering:

1. **`InboundConnectorContextImpl`** — the connector-level context, via `getProperties()`/`bindProperties()`.
2. **`DefaultProcessElementContext`** — an element-scoped context that `canActivate()` hands to connectors as `ActivationCheckResult.Success.CanActivate#activatedElement()`, and that **every successful `CorrelationResult` carries** (three construction sites in `InboundCorrelationHandler`: `ProcessInstanceCreated`, `MessagePublished`, `MessageAlreadyCorrelated`). Its public `getProperties()`/`bindProperties()` resolve secrets through their own `SecretHandler`.

The second path is this branch's analogue of main's `BindableProcessElement`, which #8538 filters upstream via `bindElementProperties`. **It was missed in the first push of this PR** and added in `429c150` after Copilot review — the original description wrongly claimed this branch had no correlation-scoped call site to adapt, on the strength of `BindableProcessElement` being absent by name. On 8.7 the path predates that rename.

Checked, not assumed: `DefaultProcessElementContext` exists **only on `stable/8.7`**. On 8.8, 8.9 and main, `CorrelationResult.Success` carries a plain `ProcessElement` record with no secret resolution, so the companion backports #8609 and #8600 are unaffected.

In both paths the allow-list is scoped to **exactly the text that call filters** — the connector-level `rawPropertiesWithoutKeywords` for the first, that one element's own `rawProperties` for the second — never unioned across an executable's elements. That matches the per-call scoping #8538 settled on upstream after a sibling union proved too wide (ledger row 2).

## The leak was confirmed present here, not assumed

Before writing anything, this branch's own `SecretUtil` was probed with an allow-all filter — exactly today's inbound behaviour, since both contexts pass `SecretFilter.allowAll()`:

```
A CHAIN RESULT: [LEAKED]  LEAK=true
```

A secret whose stored value is the literal `secrets.CHAINED` resolved `CHAINED` — a name no model declares. The brace pass resolved the declared name, then the bare pass ran over its own output and resolved the injected one.

## ⚠️ Known weaker than the 8.8/8.9 backports — read this before approving

This branch's `SecretUtil` has **neither** the nested-match exclusion in `retrieveSecretKeysInInput` **nor** the denied-bracket exclusion in `replaceSecretsWithoutParentheses` that #8592 (8.9) and #8593 (8.8) added. Probed here:

```
B KEYS: [FOO:BAR, FOO]                        ← the truncated prefix is admitted
B DENIED-BRACKET RESULT: [{{foo-value:BAR}}]  ← 8.8 leaves this literal
```

So a model declaring `{{secrets.FOO:BAR}}` also puts the truncated `FOO` on the allow-list, and the unhardened bare pass substitutes `FOO`'s real value *inside* the bracketed reference, corrupting it.

Two things to be clear about:

1. **This filter neither introduces nor worsens that.** It is a pre-existing property of `stable/8.7`, reproducible with no filter at all. Today inbound is allow-all, so *everything* resolves; this change is strictly an improvement, just not the full one 8.8/8.9 received.
2. **Porting the hardening is deliberately out of scope.** On this branch `SecretUtil` is shared with the outbound allow-list *and* with exception redaction (see #8618's own javadoc), so changing it carries regression risk on the oldest maintained line and should be decided coherently — main is missing the same hardening too. It does not belong inside an inbound backport.

## Changes

**5 production files, 157 added lines** (plus a format-only reflow of `SecretUtil` in the first commit, see below). Every new constructor is an additive overload whose existing signature delegates with `false`, so no existing call site changes.

| File | Change |
|---|---|
| `InboundConnectorContextImpl` | `secretFilterEnabled` overload + static `secretFilter(...)` feeding `super(...)` |
| `DefaultInboundConnectorContextFactory` | `secretFilterEnabled` overload, passed through |
| `DefaultProcessElementContext` | `secretFilterEnabled` overload + per-element `secretFilter(...)` |
| `DefaultProcessElementContextFactory` | `secretFilterEnabled` overload, passed through |
| `InboundConnectorRuntimeConfiguration` | both bean methods read the mode and map it to a boolean |

The allow-list is passed to `super(...)` at construction rather than derived per call. In both contexts the filtered text is fixed at construction — `connectorDetails`, `properties` and `connectorElement` are all `final`, and there is **no `updateConnectorDetails` at all** on this branch — so the hot-swap and torn-read failure directions main had to close (ledger rows 3 and 4) are not representable here.

## First commit is an unrelated format fix

`3a7b2e8` reflows three javadoc lines that #8618 landed over the wrap width. `spotless:check` fails on `stable/8.7`'s own HEAD because of it — the post-merge branch build is already red — and `check-format` here cannot pass without it. It is pure `spotless:apply` output with the comment text unchanged, kept as its own commit so it can be split out or landed separately if you'd rather.

## Test plan

- [x] Four applicable cases from main's suite on the connector-level path: a declared secret resolves, in brace syntax too, an undeclared name is left as a placeholder and never reaches the `SecretProvider`, and a name that only another secret's *value* spells is refused.
- [x] A control asserting allow-all still resolves an undeclared name when the filter is off.
- [x] `processElementContextFactory_refusesAChainedNameOnTheActivatedElement`: goes through the **real second path** — `canActivate()` → `activatedElement().getProperties()` — asserting `STRICT` and `LAX` refuse a chained name while `DISABLED` resolves it. That third assertion is itself the evidence the path was unfiltered before `429c150`.
- [x] `springInboundConnectorContextFactory_filtersSecretsUnlessModeIsDisabled`: pins the `SecretFilterMode` → boolean hop across all three modes.
- [x] `InboundSecretFilterDefaultModeWiringTest`: a `@SpringBootTest` with the property omitted, the only test that evaluates the `@Value` default string itself.
- [x] 401 tests green: `connector-runtime-core` (215), `connector-runtime-spring` (128), `spring-boot-starter-camunda-connectors` (58).
- [x] `spotless:check` clean.

### Verified by falsification, not just green runs

#8538's ledger records that two of its tests initially passed vacuously, so a green test is not treated as evidence. Each protection was re-broken and the named test observed to fail:

| Falsification | Observed |
|---|---|
| Connector-context filter forced off | `secretFilterEnabled_leavesASecretNamedOnlyByAnotherSecretsValue` fails — `expected "secrets.CHAINED"`; `secretFilterEnabled_leavesAnUndeclaredSecret` errors, the name reached the provider |
| Element-context filter forced off | `processElementContextFactory_refusesAChainedNameOnTheActivatedElement` fails — `expected <secrets.CHAINED> but was <leaked-value>` |
| Mode boolean inverted | `springInboundConnectorContextFactory_filtersSecretsUnlessModeIsDisabled` fails — `expected <secrets.UNDECLARED> but was <resolved>` |
| `@Value` default flipped to `DISABLED` | `InboundSecretFilterDefaultModeWiringTest` fails with `Secret with name 'UNDECLARED' is not available`, while the bean-method test stays green |

An earlier version of the element-path test asserted on an "undeclared" name written into the element's own properties, and failed — correctly, since that context resolves the element's own text, so any name written there is declared by definition and the allow-list is a superset of it. The chained case is the only thing that path can refuse.

## Scope note

This branch has no `LegacySecretMode`/`FALLBACK` and no `CentralStoreSecretProvider` (#8368 never reached it), so a chained reference here can only reach **locally configured** providers — env vars, Spring properties, SPI, custom aggregators — not the cluster secret store. Still a real exfiltration path for any locally-configured secret it names, but a narrower blast radius than main or `stable/8.9`.

## Deliberately omitted

Main's hot-swap, sibling-element and new-form tests are structurally inapplicable on this branch, and are omitted with an in-file comment saying why.

Companion backports: #8600 (`stable/8.9`), #8609 (`stable/8.8`).

Relates to #7730
