### PR TITLE
fix: retry and report an unreadable outbound secret allow-list

### DIFF
--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/ConfigurableSecretFilterFactory.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/ConfigurableSecretFilterFactory.java
@@ -68,7 +68,7 @@ public class ConfigurableSecretFilterFactory implements SecretFilterFactory {
                   context.elementId(),
                   context.processDefinitionKey(),
                   realCause.getClass().getName());
-              throw new IllegalArgumentException(
+              throw new SecretAllowListUnavailableException(
                   "Error retrieving secret keys for element '"
                       + context.elementId()
                       + "' in process definition key "

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/OutboundConnectorExceptionHandler.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/OutboundConnectorExceptionHandler.java
@@ -358,7 +358,7 @@ public class OutboundConnectorExceptionHandler {
 
   private static Duration retryBackoffFor(Exception failure, Duration configured) {
     return failure instanceof SecretAllowListUnavailableException
-        ? Objects.requireNonNullElse(configured, ALLOW_LIST_RETRY_BACKOFF)
+        ? ALLOW_LIST_RETRY_BACKOFF
         : configured;
   }
 

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/OutboundConnectorExceptionHandler.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/OutboundConnectorExceptionHandler.java
@@ -356,18 +356,23 @@ public class OutboundConnectorExceptionHandler {
     return e instanceof ConnectorInputException || e.getCause() instanceof ConnectorInputException;
   }
 
+  /**
+   * The allow-list lookup reads the process definition from secondary storage, which a
+   * just-deployed definition has yet to reach, so a failure to read it is backed off rather than
+   * retried at once — remaining attempts would otherwise all be spent inside that window.
+   */
+  private static Duration retryBackoffFor(Exception failure, Duration configured) {
+    return failure instanceof SecretAllowListUnavailableException
+        ? Objects.requireNonNullElse(configured, ALLOW_LIST_RETRY_BACKOFF)
+        : configured;
+  }
+
   public ConnectorResult.ErrorResult manageConnectorJobHandlerException(
       Exception e, ActivatedJob job, Duration retryBackoffDuration, SecretFilter secretFilter) {
     if (e instanceof SecretAllowListUnavailableException) {
       // Nothing to redact: every substitution goes through the allow-list, so one that could not
-      // be read means no secret value ever reached the input. Backed off rather than failed
-      // outright — the lookup reads the process definition from secondary storage, which a
-      // just-deployed definition has yet to reach.
-      return handleGenericException(
-          job,
-          e,
-          List.of(),
-          Objects.requireNonNullElse(retryBackoffDuration, ALLOW_LIST_RETRY_BACKOFF));
+      // be read means no secret value ever reached the input.
+      return handleGenericException(job, e, List.of(), retryBackoffFor(e, retryBackoffDuration));
     }
     var masking = fetchSecretsForMasking(job, secretFilter, e);
     if (masking.unavailable()) {
@@ -382,7 +387,10 @@ public class OutboundConnectorExceptionHandler {
           isFatalInputError(masking.failure()) || isFatalInputError(e) ? 0 : job.getRetries() - 1;
       return new ConnectorResult.ErrorResult(
           // secrets could not be fetched, so there is nothing to mask with
-          Map.of("error", exceptionToMap(wrappedException, List.of())), wrappedException, retries);
+          Map.of("error", exceptionToMap(wrappedException, List.of())),
+          wrappedException,
+          retries,
+          retryBackoffFor(masking.failure(), retryBackoffDuration));
     }
     List<String> secrets = masking.secrets();
     return switch (e) {

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/OutboundConnectorExceptionHandler.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/OutboundConnectorExceptionHandler.java
@@ -44,6 +44,8 @@ public class OutboundConnectorExceptionHandler {
   /** Stands in for a container that (transitively) contains itself, so masking cannot loop. */
   private static final String CIRCULAR_REFERENCE = "[circular reference]";
 
+  private static final Duration ALLOW_LIST_RETRY_BACKOFF = Duration.ofSeconds(5);
+
   private final SecretProvider secretProvider;
 
   public OutboundConnectorExceptionHandler(SecretProvider secretProvider) {
@@ -356,6 +358,17 @@ public class OutboundConnectorExceptionHandler {
 
   public ConnectorResult.ErrorResult manageConnectorJobHandlerException(
       Exception e, ActivatedJob job, Duration retryBackoffDuration, SecretFilter secretFilter) {
+    if (e instanceof SecretAllowListUnavailableException) {
+      // Nothing to redact: every substitution goes through the allow-list, so one that could not
+      // be read means no secret value ever reached the input. Backed off rather than failed
+      // outright — the lookup reads the process definition from secondary storage, which a
+      // just-deployed definition has yet to reach.
+      return handleGenericException(
+          job,
+          e,
+          List.of(),
+          Objects.requireNonNullElse(retryBackoffDuration, ALLOW_LIST_RETRY_BACKOFF));
+    }
     var masking = fetchSecretsForMasking(job, secretFilter, e);
     if (masking.unavailable()) {
       var wrappedException = unmaskableError(masking.failure());

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/OutboundConnectorExceptionHandler.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/OutboundConnectorExceptionHandler.java
@@ -356,11 +356,6 @@ public class OutboundConnectorExceptionHandler {
     return e instanceof ConnectorInputException || e.getCause() instanceof ConnectorInputException;
   }
 
-  /**
-   * The allow-list lookup reads the process definition from secondary storage, which a
-   * just-deployed definition has yet to reach, so a failure to read it is backed off rather than
-   * retried at once — remaining attempts would otherwise all be spent inside that window.
-   */
   private static Duration retryBackoffFor(Exception failure, Duration configured) {
     return failure instanceof SecretAllowListUnavailableException
         ? Objects.requireNonNullElse(configured, ALLOW_LIST_RETRY_BACKOFF)
@@ -370,8 +365,6 @@ public class OutboundConnectorExceptionHandler {
   public ConnectorResult.ErrorResult manageConnectorJobHandlerException(
       Exception e, ActivatedJob job, Duration retryBackoffDuration, SecretFilter secretFilter) {
     if (e instanceof SecretAllowListUnavailableException) {
-      // Nothing to redact: every substitution goes through the allow-list, so one that could not
-      // be read means no secret value ever reached the input.
       return handleGenericException(job, e, List.of(), retryBackoffFor(e, retryBackoffDuration));
     }
     var masking = fetchSecretsForMasking(job, secretFilter, e);

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/SecretAllowListUnavailableException.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/SecretAllowListUnavailableException.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.runtime.outbound.job;
+
+import io.camunda.connector.runtime.core.secret.SecretFailureDiagnostic;
+
+/**
+ * Raised when the allow-list of secret names an element may resolve could not be read. The message
+ * is the runtime's own throughout — an element ID, a process definition key and an exception class
+ * name — so it is safe to publish verbatim.
+ */
+class SecretAllowListUnavailableException extends RuntimeException
+    implements SecretFailureDiagnostic {
+
+  SecretAllowListUnavailableException(String message) {
+    super(message);
+  }
+
+  @Override
+  public String publishableMessage() {
+    return getMessage();
+  }
+}

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/SecretAllowListUnavailableException.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/SecretAllowListUnavailableException.java
@@ -18,11 +18,6 @@ package io.camunda.connector.runtime.outbound.job;
 
 import io.camunda.connector.runtime.core.secret.SecretFailureDiagnostic;
 
-/**
- * Raised when the allow-list of secret names an element may resolve could not be read. The message
- * is the runtime's own throughout — an element ID, a process definition key and an exception class
- * name — so it is safe to publish verbatim.
- */
 class SecretAllowListUnavailableException extends RuntimeException
     implements SecretFailureDiagnostic {
 

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/job/ConfigurableSecretFilterFactoryTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/job/ConfigurableSecretFilterFactoryTest.java
@@ -97,14 +97,14 @@ class ConfigurableSecretFilterFactoryTest {
   }
 
   @Test
-  void create_strict_whenCacheThrows_throwsIllegalArgumentException() {
+  void create_strict_whenCacheThrows_throwsSecretAllowListUnavailableException() {
     when(secretKeyCache.getSecretKeys(any())).thenThrow(new RuntimeException("fetch failed"));
     var factory = new ConfigurableSecretFilterFactory(SecretFilterMode.STRICT, secretKeyCache);
 
     var filter = factory.create(CONTEXT);
 
     assertThatThrownBy(() -> filter.isAllowed("ANY_SECRET"))
-        .isInstanceOf(IllegalArgumentException.class)
+        .isInstanceOf(SecretAllowListUnavailableException.class)
         .hasMessageContaining("Error retrieving secret keys");
   }
 
@@ -161,7 +161,7 @@ class ConfigurableSecretFilterFactoryTest {
     var filter = factory.create(CONTEXT);
 
     assertThatThrownBy(() -> filter.isAllowed("ANY_SECRET"))
-        .isInstanceOf(IllegalArgumentException.class);
+        .isInstanceOf(SecretAllowListUnavailableException.class);
   }
 
   @Test

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/job/OutboundConnectorExceptionHandlerTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/job/OutboundConnectorExceptionHandlerTest.java
@@ -208,6 +208,8 @@ class OutboundConnectorExceptionHandlerTest {
             new RuntimeException("boom"), job, null, unreadableAllowList);
 
     assertThat(result.exception()).hasMessageContaining("Activity_1");
+    assertThat(result.retries()).isEqualTo(2);
+    assertThat(result.retryBackoff()).isEqualTo(Duration.ofSeconds(5));
   }
 
   @Test

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/job/OutboundConnectorExceptionHandlerTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/job/OutboundConnectorExceptionHandlerTest.java
@@ -42,7 +42,10 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.ArgumentCaptor;
 import org.slf4j.LoggerFactory;
 
@@ -178,8 +181,10 @@ class OutboundConnectorExceptionHandlerTest {
     verifyNoInteractions(secretProvider);
   }
 
-  @Test
-  void manageConnectorJobHandlerException_prefersTheModelsBackoffWhenTheAllowListCouldNotBeRead() {
+  @ParameterizedTest
+  @MethodSource("modelBackoffs")
+  void manageConnectorJobHandlerException_backsOffTheAllowListReadWhateverTheModelAsksFor(
+      Duration modelBackoff) {
     var job = jobOnEngine("engine-1");
     when(job.getRetries()).thenReturn(3);
 
@@ -187,10 +192,29 @@ class OutboundConnectorExceptionHandlerTest {
         handler.manageConnectorJobHandlerException(
             new SecretAllowListUnavailableException("lookup failed"),
             job,
-            Duration.ofMinutes(1),
+            modelBackoff,
             SecretFilter.allowAll());
 
-    assertThat(result.retryBackoff()).isEqualTo(Duration.ofMinutes(1));
+    assertThat(result.retryBackoff()).isEqualTo(Duration.ofSeconds(5));
+    assertThat(result.retries()).isEqualTo(2);
+  }
+
+  private static Stream<Duration> modelBackoffs() {
+    return Stream.of(
+        null, Duration.ZERO, Duration.ofSeconds(-1), Duration.ofSeconds(30), Duration.ofMinutes(1));
+  }
+
+  @Test
+  void manageConnectorJobHandlerException_keepsTheModelsBackoffForOtherMaskingFailures() {
+    var job = jobOnEngine("engine-1");
+    when(job.getRetries()).thenReturn(3);
+    when(secretProvider.fetchAll(any(), any())).thenThrow(new RuntimeException("timed out"));
+
+    var result =
+        handler.manageConnectorJobHandlerException(
+            new RuntimeException("boom"), job, Duration.ofSeconds(30), SecretFilter.allowAll());
+
+    assertThat(result.retryBackoff()).isEqualTo(Duration.ofSeconds(30));
   }
 
   @Test

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/job/OutboundConnectorExceptionHandlerTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/job/OutboundConnectorExceptionHandlerTest.java
@@ -21,6 +21,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import ch.qos.logback.classic.Logger;
@@ -153,6 +154,60 @@ class OutboundConnectorExceptionHandlerTest {
             SecretFilter.allowAll());
 
     assertThat(result.retries()).isZero();
+  }
+
+  @Test
+  void manageConnectorJobHandlerException_publishesTheReasonTheAllowListCouldNotBeRead() {
+    var job = jobOnEngine("engine-1");
+    when(job.getRetries()).thenReturn(3);
+
+    var result =
+        handler.manageConnectorJobHandlerException(
+            new SecretAllowListUnavailableException(
+                "Error retrieving secret keys for element 'Activity_1' in process definition key 42"
+                    + " (io.camunda.client.api.command.ProblemException)"),
+            job,
+            null,
+            SecretFilter.allowAll());
+
+    assertThat(result.exception())
+        .hasMessageContaining("Activity_1")
+        .hasMessageContaining("ProblemException");
+    assertThat(result.retries()).isEqualTo(2);
+    assertThat(result.retryBackoff()).isEqualTo(Duration.ofSeconds(5));
+    verifyNoInteractions(secretProvider);
+  }
+
+  @Test
+  void manageConnectorJobHandlerException_prefersTheModelsBackoffWhenTheAllowListCouldNotBeRead() {
+    var job = jobOnEngine("engine-1");
+    when(job.getRetries()).thenReturn(3);
+
+    var result =
+        handler.manageConnectorJobHandlerException(
+            new SecretAllowListUnavailableException("lookup failed"),
+            job,
+            Duration.ofMinutes(1),
+            SecretFilter.allowAll());
+
+    assertThat(result.retryBackoff()).isEqualTo(Duration.ofMinutes(1));
+  }
+
+  @Test
+  void manageConnectorJobHandlerException_publishesTheAllowListFailureRaisedByTheMaskingRead() {
+    var job = jobOnEngine("engine-1");
+    when(job.getRetries()).thenReturn(3);
+    SecretFilter unreadableAllowList =
+        name -> {
+          throw new SecretAllowListUnavailableException(
+              "Error retrieving secret keys for element 'Activity_1'");
+        };
+
+    var result =
+        handler.manageConnectorJobHandlerException(
+            new RuntimeException("boom"), job, null, unreadableAllowList);
+
+    assertThat(result.exception()).hasMessageContaining("Activity_1");
   }
 
   @Test


### PR DESCRIPTION
## Description

With STRICT outbound secret filtering, a connector element that references secrets first has to
read the allow-list of secret names that element is permitted to resolve. When that read failed,
the job ended permanently and the operator got no usable error.

Two things went wrong at once:

- **The message was withheld.** Error messages are redacted by re-reading the secret values to
  redact with, and that re-read consults the same allow-list — so it failed the same way, and the
  incident degraded to a bare exception type with no element, no process definition, and no
  indication that the allow-list rather than a secret store was what failed.
- **The attempts were spent instantly.** The failure carried no backoff, so all remaining attempts
  were used within milliseconds and the job ended as *no retries left*.

An allow-list that could not be read means no secret value ever reached the input — every
substitution goes through it — so there is nothing to redact and the failure can be reported as it
is. It is now also reported with a backoff, because the lookup reads the process definition from
secondary storage, which a just-deployed definition has yet to reach: that race is what made this
permanent in practice, and it resolves on the next attempt.

STRICT is not relaxed. The job still fails; it just fails legibly and with its attempts intact.

Alternatives considered: retrying inside the lookup (blocks the worker and hides the failure);
telling apart *not yet indexed* from *not permitted* by the client's status code (couples the
runtime to transport details — the job's own retries already bound both, and a permanent
permission problem now surfaces a named incident once they are spent); serving an empty allow-list
on failure (would silently drop secrets).

## Related issues

closes #8500

Blocks removal of the E2E skips in camunda/c8-cross-component-e2e-tests#3254 and
camunda/c8-cross-component-e2e-tests#3281 — those need a ping once this reaches SaaS INT.

## Checklist

- [x] Backport labels are added if these code changes should be backported.
- [x] Tests/Integration tests for the changes have been added if applicable.
- [x] If the change requires a documentation update, it has been added to the appropriate section in the documentation. — no user-facing behaviour or configuration change; nothing to document.

🤖 Generated with [Claude Code](https://claude.com/claude-code)