### PR TITLE
fix: redact secrets from jobError and bpmnError incidents

### DIFF
--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/OutboundConnectorExceptionHandler.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/OutboundConnectorExceptionHandler.java
@@ -418,11 +418,22 @@ public class OutboundConnectorExceptionHandler {
     };
   }
 
+  /** Redacts expression-chosen variables that are about to be published as a diagnostic. */
+  public Map<String, Object> maskDiagnosticVariables(
+      Map<String, Object> variables, ActivatedJob job, SecretFilter secretFilter) {
+    if (variables == null || variables.isEmpty()) {
+      return variables;
+    }
+    var masking = fetchSecretsForMasking(job, secretFilter, null);
+    return masking.unavailable() ? Map.of() : maskVariables(variables, masking.secrets());
+  }
+
   /** Redacts an error an error expression produced; {@code failJob}/{@code throwError} do not. */
   public ConnectorError maskConnectorError(
       ConnectorError error, ActivatedJob job, SecretFilter secretFilter) {
     return switch (error) {
-      // ignoreError completes the job with business variables, which are never redacted
+      // business output on the branch that completes the job; the branch that raises an incident
+      // instead redacts them itself, via maskDiagnosticVariables
       case IgnoreError ignoreError -> ignoreError;
       case BpmnError bpmnError -> {
         if (nothingToRedact(bpmnError.errorMessage(), bpmnError.variables())) {

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/OutboundConnectorExceptionHandler.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/OutboundConnectorExceptionHandler.java
@@ -206,22 +206,28 @@ public class OutboundConnectorExceptionHandler {
   private MaskingSecrets fetchSecretsForMasking(
       ActivatedJob job, SecretFilter secretFilter, Exception jobFailure) {
     try {
-      var context =
-          new SecretContext(job.getTenantId(), job.getBpmnProcessId(), job.getPhysicalTenantId());
       var legacyKeys =
           allowedKeys(SecretUtil.retrieveLegacySecretKeysInInput(job.getVariables()), secretFilter);
-      var legacyValues = this.secretProvider.fetchAll(legacyKeys, context);
+      var referenceKeys =
+          allowedKeys(SecretUtil.retrieveSecretKeysInInput(job.getVariables()), secretFilter)
+              .stream()
+              .filter(key -> !legacyKeys.contains(key))
+              .toList();
+      // A job that declares no secret has nothing to redact, so no provider is asked for anything:
+      // a custom fetchAll that refuses every batch must not withhold such a job's error message.
+      if (legacyKeys.isEmpty() && referenceKeys.isEmpty()) {
+        return new MaskingSecrets(List.of(), null);
+      }
+      var context =
+          new SecretContext(job.getTenantId(), job.getBpmnProcessId(), job.getPhysicalTenantId());
+      List<String> legacyValues =
+          legacyKeys.isEmpty() ? List.of() : this.secretProvider.fetchAll(legacyKeys, context);
       if (legacyValues.size() < legacyKeys.size() && !reportsAnUnavailableSecret(jobFailure)) {
         return new MaskingSecrets(
             List.of(),
             new MaskingSecretsIncompleteException(
                 legacyKeys.size() - legacyValues.size(), legacyKeys.size()));
       }
-      var referenceKeys =
-          allowedKeys(SecretUtil.retrieveSecretKeysInInput(job.getVariables()), secretFilter)
-              .stream()
-              .filter(key -> !legacyKeys.contains(key))
-              .toList();
       if (referenceKeys.isEmpty()) {
         return new MaskingSecrets(legacyValues, null);
       }
@@ -233,7 +239,7 @@ public class OutboundConnectorExceptionHandler {
           "Initial error for job: {} for tenant: {} can't be displayed because fetching secrets failed: {}",
           job.getKey(),
           job.getTenantId(),
-          ex.getMessage());
+          safeDiagnostic(ex));
       return new MaskingSecrets(List.of(), ex);
     }
   }
@@ -267,11 +273,10 @@ public class OutboundConnectorExceptionHandler {
     } catch (Exception ex) {
       LOGGER.warn(
           "Reading the values behind the camunda.secrets references named by job: {} for tenant: {}"
-              + " failed with {}: {}. Its error message is redacted with the legacy secrets alone.",
+              + " failed with {}. Its error message is redacted with the legacy secrets alone.",
           job.getKey(),
           job.getTenantId(),
-          ex.getClass().getName(),
-          ex.getMessage());
+          safeDiagnostic(ex));
       return List.of();
     }
   }
@@ -339,6 +344,14 @@ public class OutboundConnectorExceptionHandler {
    * charset a name has to fit. Withholding arbitrary provider text is not a reason to withhold text
    * written to be read.
    */
+  // A provider's own message can carry secret material - a bundle that parses as a non-object puts
+  // the value into Jackson's coercion error - so only what SecretReferenceResolver keeps is logged.
+  private static String safeDiagnostic(Exception fetchFailure) {
+    return fetchFailure instanceof SecretFailureDiagnostic diagnosable
+        ? fetchFailure.getClass().getName() + ": " + diagnosable.publishableMessage()
+        : fetchFailure.getClass().getName();
+  }
+
   private static RuntimeException unmaskableError(Exception fetchFailure) {
     return new SecretsUnavailableException(
         fetchFailure.getClass().getName(),
@@ -459,6 +472,11 @@ public class OutboundConnectorExceptionHandler {
   private static String hideSecretsFromMessage(String message, List<String> secrets) {
     if (!Objects.isNull(message))
       return secrets.stream()
+          // a provider may answer with an empty value, and replacing that matches everywhere
+          .filter(secret -> !secret.isEmpty())
+          // longest first: masking a secret that prefixes another would destroy the longer match
+          // and publish its remainder, e.g. "x" before "xSUPERSECRET" leaves "***SUPERSECRET"
+          .sorted(Comparator.comparingInt(String::length).reversed())
           .reduce(message, (newMessage, nextSecret) -> newMessage.replace(nextSecret, "***"));
     else return "";
   }

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/OutboundConnectorExceptionHandler.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/OutboundConnectorExceptionHandler.java
@@ -24,8 +24,12 @@ import io.camunda.connector.api.error.ConnectorInputException;
 import io.camunda.connector.api.error.ConnectorRetryException;
 import io.camunda.connector.api.secret.SecretContext;
 import io.camunda.connector.api.secret.SecretProvider;
+import io.camunda.connector.runtime.core.error.BpmnError;
+import io.camunda.connector.runtime.core.error.ConnectorError;
+import io.camunda.connector.runtime.core.error.IgnoreError;
 import io.camunda.connector.runtime.core.error.InvalidBackOffDurationException;
 import io.camunda.connector.runtime.core.error.InvalidJobTimeoutException;
+import io.camunda.connector.runtime.core.error.JobError;
 import io.camunda.connector.runtime.core.outbound.ConnectorResult;
 import io.camunda.connector.runtime.core.secret.SecretFailureDiagnostic;
 import io.camunda.connector.runtime.core.secret.SecretFilter;
@@ -108,14 +112,7 @@ public class OutboundConnectorExceptionHandler {
           yield CIRCULAR_REFERENCE;
         }
         try {
-          // keys are masked too, and collapsed keys simply overwrite rather than fail
-          var masked = new LinkedHashMap<String, Object>();
-          map.forEach(
-              (key, entry) ->
-                  masked.put(
-                      hideSecretsFromMessage(String.valueOf(key), secrets),
-                      maskSecrets(entry, secrets, enclosing)));
-          yield masked;
+          yield maskMap(map, secrets, enclosing);
         } finally {
           enclosing.remove(map);
         }
@@ -132,6 +129,29 @@ public class OutboundConnectorExceptionHandler {
       }
       default -> value;
     };
+  }
+
+  private static Map<String, Object> maskMap(
+      Map<?, ?> map, List<String> secrets, Set<Object> enclosing) {
+    // keys are masked too, and collapsed keys simply overwrite rather than fail
+    var masked = new LinkedHashMap<String, Object>();
+    map.forEach(
+        (key, entry) ->
+            masked.put(
+                hideSecretsFromMessage(String.valueOf(key), secrets),
+                maskSecrets(entry, secrets, enclosing)));
+    return masked;
+  }
+
+  /** Typed variant of {@link #maskSecrets}, which returns {@link Object} to allow a sentinel. */
+  private static Map<String, Object> maskVariables(
+      Map<String, Object> variables, List<String> secrets) {
+    if (variables == null) {
+      return null;
+    }
+    Set<Object> enclosing = Collections.newSetFromMap(new IdentityHashMap<>());
+    enclosing.add(variables);
+    return maskMap(variables, secrets, enclosing);
   }
 
   /**
@@ -267,7 +287,7 @@ public class OutboundConnectorExceptionHandler {
    */
   private static boolean reportsAnUnavailableSecret(Exception jobFailure) {
     return jobFailure instanceof SecretNotAvailableException
-        || jobFailure.getCause() instanceof SecretNotAvailableException;
+        || (jobFailure != null && jobFailure.getCause() instanceof SecretNotAvailableException);
   }
 
   /**
@@ -383,6 +403,57 @@ public class OutboundConnectorExceptionHandler {
       case Exception exception ->
           handleGenericException(job, exception, secrets, retryBackoffDuration);
     };
+  }
+
+  /** Redacts an error an error expression produced; {@code failJob}/{@code throwError} do not. */
+  public ConnectorError maskConnectorError(
+      ConnectorError error, ActivatedJob job, SecretFilter secretFilter) {
+    return switch (error) {
+      // ignoreError completes the job with business variables, which are never redacted
+      case IgnoreError ignoreError -> ignoreError;
+      case BpmnError bpmnError -> {
+        if (nothingToRedact(bpmnError.errorMessage(), bpmnError.variables())) {
+          yield bpmnError;
+        }
+        var masking = fetchSecretsForMasking(job, secretFilter, null);
+        // the error code is never redacted: boundary events match on it
+        yield masking.unavailable()
+            ? new BpmnError(
+                bpmnError.errorCode(), unmaskableError(masking.failure()).getMessage(), Map.of())
+            : new BpmnError(
+                bpmnError.errorCode(),
+                redactNullable(bpmnError.errorMessage(), masking.secrets()),
+                maskVariables(bpmnError.variables(), masking.secrets()));
+      }
+      case JobError jobError -> {
+        if (nothingToRedact(jobError.errorMessage(), jobError.variables())) {
+          yield jobError;
+        }
+        var masking = fetchSecretsForMasking(job, secretFilter, null);
+        yield masking.unavailable()
+            ? new JobError(
+                unmaskableError(masking.failure()).getMessage(),
+                Map.of(),
+                jobError.retries(),
+                jobError.retryBackoff())
+            : new JobError(
+                redactNullable(jobError.errorMessage(), masking.secrets()),
+                maskVariables(jobError.variables(), masking.secrets()),
+                jobError.retries(),
+                jobError.retryBackoff());
+      }
+    };
+  }
+
+  // A JobError egresses variablesWithErrorMessage(), which adds only the message checked here.
+  private static boolean nothingToRedact(String errorMessage, Map<String, Object> variables) {
+    return (errorMessage == null || errorMessage.isEmpty())
+        && (variables == null || variables.isEmpty());
+  }
+
+  /** Unlike {@link #hideSecretsFromMessage}, keeps a null message null rather than "". */
+  private static String redactNullable(String message, List<String> secrets) {
+    return message == null ? null : hideSecretsFromMessage(message, secrets);
   }
 
   private static String hideSecretsFromMessage(String message, List<String> secrets) {

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/SpringConnectorJobHandler.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/SpringConnectorJobHandler.java
@@ -436,7 +436,14 @@ public class SpringConnectorJobHandler implements JobHandler {
       optionalConnectorError.ifPresentOrElse(
           error ->
               handleConnectorError(
-                  client, job, context, finalResult, error, counterMetricsContext, deadline),
+                  client,
+                  job,
+                  context,
+                  finalResult,
+                  error,
+                  counterMetricsContext,
+                  secretFilter,
+                  deadline),
           () ->
               handleFinalResult(
                   client, job, context, finalResult, counterMetricsContext, deadline));
@@ -511,10 +518,13 @@ public class SpringConnectorJobHandler implements JobHandler {
       ActivatedJob job,
       OutboundConnectorContext context,
       ConnectorResult finalResult,
-      ConnectorError error,
+      ConnectorError rawError,
       CounterMetricsContext counterMetricsContext,
+      SecretFilter secretFilter,
       long deadline) {
     var response = connectorResponseOrNull(finalResult);
+    // redacted before the Zeebe command and the listener payload are built from it
+    var error = outboundConnectorExceptionHandler.maskConnectorError(rawError, job, secretFilter);
 
     switch (error) {
       case BpmnError bpmnError -> {

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/SpringConnectorJobHandler.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/SpringConnectorJobHandler.java
@@ -529,8 +529,9 @@ public class SpringConnectorJobHandler implements JobHandler {
     switch (error) {
       case BpmnError bpmnError -> {
         checkVariablesSize(bpmnError.variables());
-        LOGGER.debug(
-            "Throwing BPMN error for job {} with code {}", job.getKey(), bpmnError.errorCode());
+        // the code is not redacted, so it stays out of the log: unlike the command and the error
+        // variables that carry it, pod logs are shipped to systems with their own access controls
+        LOGGER.debug("Throwing BPMN error for job {}", job.getKey());
         CompletableFuture<CommandOutcome> throwBpmnErrorRequest =
             throwBpmnError(client, job, bpmnError, counterMetricsContext, deadline);
         notifyFailureOnCommandOutcome(

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/SpringConnectorJobHandler.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/SpringConnectorJobHandler.java
@@ -577,6 +577,7 @@ public class SpringConnectorJobHandler implements JobHandler {
               response,
               ignoreError,
               counterMetricsContext,
+              secretFilter,
               deadline);
     }
   }
@@ -589,6 +590,7 @@ public class SpringConnectorJobHandler implements JobHandler {
       ConnectorResponse response,
       IgnoreError ignoreError,
       CounterMetricsContext counterMetricsContext,
+      SecretFilter secretFilter,
       long deadline) {
     if (finalResult instanceof ConnectorResult.SuccessResult successResult
         && successResult.connectorResponse() instanceof AdHocSubProcessConnectorResponse) {
@@ -596,11 +598,17 @@ public class SpringConnectorJobHandler implements JobHandler {
           "IgnoreError not supported for AdHocSubProcessConnectorResponse, job {}", job.getKey());
       var cause =
           new UnsupportedOperationException("IgnoreError is not supported for this connector");
+      // this branch raises an incident rather than completing the job, so the variables the
+      // expression chose become diagnostic output and prepareFailJobCommand appends them to its
+      // message - redacted here, unlike on the completion branch below
+      var variables =
+          outboundConnectorExceptionHandler.maskDiagnosticVariables(
+              ignoreError.variables(), job, secretFilter);
       CompletableFuture<CommandOutcome> failJobRequest =
           failJob(
               client,
               job,
-              new ConnectorResult.ErrorResult(ignoreError.variables(), cause, 0, null),
+              new ConnectorResult.ErrorResult(variables, cause, 0, null),
               counterMetricsContext,
               deadline);
 

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/job/OutboundConnectorExceptionHandlerTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/job/OutboundConnectorExceptionHandlerTest.java
@@ -21,6 +21,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import ch.qos.logback.classic.Logger;
@@ -240,6 +241,112 @@ class OutboundConnectorExceptionHandlerTest {
 
     assertThat(logged).noneMatch(message -> message.contains("super-secret"));
     assertThat(logged).anyMatch(message -> message.contains("java.lang.RuntimeException"));
+  }
+
+  @Test
+  void aFailedMaskingFetchIsNeverLoggedEither() {
+    // A provider writes its own message, and it can carry secret material: AbstractSecretProvider
+    // folds a Jackson failure into one, and a bundle that parses as a non-object puts the value it
+    // could not coerce into the coercion error.
+    var job = jobOnEngine("engine-1");
+    when(job.getRetries()).thenReturn(3);
+    when(secretProvider.fetchAll(any(), any()))
+        .thenThrow(
+            new RuntimeException(
+                "Could not resolve secrets: MismatchedInputException: Cannot construct instance of"
+                    + " `java.util.LinkedHashMap` from String value ('super-secret')"));
+
+    var logged =
+        logsOf(
+            () ->
+                handler.manageConnectorJobHandlerException(
+                    new RuntimeException("boom"),
+                    job,
+                    Duration.ofSeconds(1),
+                    SecretFilter.allowAll()));
+
+    assertThat(logged).noneMatch(message -> message.contains("super-secret"));
+    assertThat(logged).anyMatch(message -> message.contains("java.lang.RuntimeException"));
+  }
+
+  @Test
+  void aRefusalTheRuntimeWroteItselfKeepsItsMessageInTheLog() {
+    // Withholding arbitrary provider text is not a reason to withhold text written to be read: a
+    // refusal names the setting an operator has to change, and a type name alone does not.
+    var job = jobOnEngine("engine-1");
+    when(job.getRetries()).thenReturn(3);
+    when(secretProvider.fetchAll(any(), any()))
+        .thenThrow(new SecretLookupRefusedException("Legacy secret resolution is switched off"));
+
+    var logged =
+        logsOf(
+            () ->
+                handler.manageConnectorJobHandlerException(
+                    new RuntimeException("boom"),
+                    job,
+                    Duration.ofSeconds(1),
+                    SecretFilter.allowAll()));
+
+    assertThat(logged)
+        .anyMatch(message -> message.contains("Legacy secret resolution is switched off"));
+  }
+
+  @Test
+  void masksALongerSecretThatStartsWithAShorterOne() {
+    // Replacing the shorter value first would leave the longer one unmatched and publish its
+    // remainder: "x" before "xSUPERSECRET" turns the message into "***SUPERSECRET".
+    var job = jobNaming("{\"a\": \"{{secrets.SHORT}}\", \"b\": \"{{secrets.LONG}}\"}");
+    when(job.getRetries()).thenReturn(3);
+    holdingOnly(Map.of("SHORT", "x", "LONG", "xSUPERSECRET"));
+
+    var result =
+        handler.manageConnectorJobHandlerException(
+            new RuntimeException("api rejected xSUPERSECRET"),
+            job,
+            Duration.ofSeconds(1),
+            SecretFilter.allowAll());
+
+    assertThat(requestedKeys).containsExactly("SHORT", "LONG");
+    assertThat(result.exception().getMessage()).isEqualTo("api rejected ***");
+  }
+
+  @Test
+  void anEmptySecretValueDoesNotCorruptTheMessage() {
+    // Replacing "" matches at every position, so a provider answering with one would rewrite the
+    // whole message into separators rather than redact anything.
+    var job = jobNaming("{\"a\": \"{{secrets.BLANK}}\"}");
+    when(job.getRetries()).thenReturn(3);
+    holdingOnly(Map.of("BLANK", ""));
+
+    var result =
+        handler.manageConnectorJobHandlerException(
+            new RuntimeException("api rejected the request"),
+            job,
+            Duration.ofSeconds(1),
+            SecretFilter.allowAll());
+
+    assertThat(result.exception().getMessage()).isEqualTo("api rejected the request");
+  }
+
+  @Test
+  void aJobDeclaringNoSecretNeverReachesAProvider() {
+    // fetchAll is overridable, and one that refuses every batch would otherwise withhold the error
+    // message of a job that had nothing to redact in the first place.
+    var job = jobNaming("{\"a\": \"nothing to resolve here\"}");
+    when(job.getRetries()).thenReturn(3);
+    when(secretProvider.fetchAll(any(), any()))
+        .thenThrow(new RuntimeException("store unavailable"));
+
+    var result =
+        handler.manageConnectorJobHandlerException(
+            new RuntimeException("api rejected the request"),
+            job,
+            Duration.ofSeconds(1),
+            SecretFilter.allowAll());
+
+    verifyNoInteractions(secretProvider);
+    assertThat(result.exception().getMessage()).isEqualTo("api rejected the request");
+    assertThat(result.retries()).isEqualTo(2);
   }
 
   /**

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/job/SpringConnectorJobHandlerTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/job/SpringConnectorJobHandlerTest.java
@@ -2144,15 +2144,29 @@ class SpringConnectorJobHandlerTest {
 
     @Test
     void jobErrorKeepsTheRetriesAndBackoffTheExpressionAsked() throws Exception {
-      var result =
-          JobBuilder.create()
-              .withVariables(INPUT_DECLARING_A_SECRET)
-              .withErrorExpressionHeader(
-                  "=jobError(\"Request failed: \" + response.body, {}, 7, duration(\"PT5M\"))")
-              .executeAndCaptureResult(echoingConnector(), false, false);
+      var failCommand = mock(FailJobCommandStep1.class);
+      var failCommandStep2 =
+          mock(FailJobCommandStep1.FailJobCommandStep2.class, RETURNS_DEEP_STUBS);
+      var jobClient = mock(JobClient.class);
+      when(jobClient.newFailCommand(any())).thenReturn(failCommand);
+      when(failCommand.retries(anyInt())).thenReturn(failCommandStep2);
+      when(failCommandStep2.errorMessage(any())).thenReturn(failCommandStep2);
+      when(failCommandStep2.retryBackoff(any())).thenReturn(failCommandStep2);
+      when(failCommandStep2.variables(anyMap())).thenReturn(failCommandStep2);
+      when(failCommandStep2.variables(any(Object.class))).thenReturn(failCommandStep2);
 
-      assertThat(result.getErrorMessage()).doesNotContain(ECHOED);
-      assertThat(result.getRetries()).isEqualTo(7);
+      JobBuilder.create()
+          .useJobClient(jobClient)
+          .withVariables(INPUT_DECLARING_A_SECRET)
+          .withErrorExpressionHeader(
+              "=jobError(\"Request failed: \" + response.body, {}, 7, duration(\"PT5M\"))")
+          .execute(echoingConnector());
+
+      var messageCaptor = ArgumentCaptor.forClass(String.class);
+      verify(failCommandStep2).errorMessage(messageCaptor.capture());
+      assertThat(messageCaptor.getValue()).doesNotContain(ECHOED);
+      verify(failCommand).retries(7);
+      verify(failCommandStep2).retryBackoff(Duration.ofMinutes(5));
     }
 
     @Test

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/job/SpringConnectorJobHandlerTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/job/SpringConnectorJobHandlerTest.java
@@ -2272,6 +2272,28 @@ class SpringConnectorJobHandlerTest {
     }
 
     @Test
+    void ignoreErrorIsRedactedOnTheBranchThatRaisesAnIncident() throws Exception {
+      // ignoreError is unsupported for an ad-hoc sub-process response, so this branch fails the job
+      // instead of completing it - the variables become diagnostic output, and
+      // prepareFailJobCommand appends them to the incident message.
+      var ahspResponse =
+          new TestAdHocSubProcessResponse(
+              Map.of("body", "rejected token " + ECHOED), Map.of(), List.of(), false, false);
+      var handler = newConnectorJobHandler(context -> ahspResponse);
+
+      var result =
+          JobBuilder.create()
+              .withVariables(INPUT_DECLARING_A_SECRET)
+              .withErrorExpressionHeader("=ignoreError({detail: response.body})")
+              .executeAndCaptureResult(handler, false);
+
+      assertThat(result.getErrorMessage())
+          .startsWith("IgnoreError is not supported for this connector")
+          .doesNotContain(ECHOED);
+      assertThat(result.getVariables()).containsEntry("detail", "rejected token ***");
+    }
+
+    @Test
     void ignoreErrorIsNotRedacted() throws Exception {
       // the boundary of this fix: ignoreError completes the job with unredacted business variables
       var result =

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/job/SpringConnectorJobHandlerTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/job/SpringConnectorJobHandlerTest.java
@@ -2091,6 +2091,268 @@ class SpringConnectorJobHandlerTest {
         .contains("message=HTTP request failed");
   }
 
+  /** The job's input declares {{secrets.FOO}}, and the called API echoes that value back. */
+  @Nested
+  class ErrorExpressionSecretMaskingTests {
+
+    private static final String ECHOED = FooBarSecretProvider.SECRET_VALUE;
+    private static final String INPUT_DECLARING_A_SECRET = "{ \"token\" : \"{{secrets.FOO}}\" }";
+
+    private SpringConnectorJobHandler echoingConnector() {
+      return newConnectorJobHandler(context -> Map.of("body", "rejected token " + ECHOED));
+    }
+
+    private SpringConnectorJobHandler echoingConnectorWithUnreadableSecrets() {
+      return newConnectorJobHandler(
+          context -> Map.of("body", "rejected token " + ECHOED),
+          new SecretProviderAggregator(List.of(new FooBarSecretProvider())) {
+            @Override
+            public List<String> fetchAll(List<String> keys, SecretContext context) {
+              throw new RuntimeException("Network error while fetching secrets");
+            }
+          });
+    }
+
+    @Test
+    void jobErrorMessageCopyingAResponseIsRedacted() throws Exception {
+      var result =
+          JobBuilder.create()
+              .withVariables(INPUT_DECLARING_A_SECRET)
+              .withErrorExpressionHeader("=jobError(\"Request failed: \" + response.body, {}, 0)")
+              .executeAndCaptureResult(echoingConnector(), false, false);
+
+      assertThat(result.getErrorMessage())
+          .startsWith("Request failed: rejected token ***")
+          .doesNotContain(ECHOED);
+    }
+
+    @Test
+    void jobErrorVariablesCopyingAResponseAreRedacted() throws Exception {
+      var result =
+          JobBuilder.create()
+              .withVariables(INPUT_DECLARING_A_SECRET)
+              .withErrorExpressionHeader(
+                  "=jobError(\"failed\", {detail: response.body, code: 401}, 0)")
+              .executeAndCaptureResult(echoingConnector(), false, false);
+
+      assertThat(result.getVariables()).containsEntry("detail", "rejected token ***");
+      // scalars keep their type, since a process resolving the incident may branch on them
+      assertThat(result.getVariables()).containsEntry("code", 401);
+      // prepareFailJobCommand appends the variables to the message, so they reach it too
+      assertThat(result.getErrorMessage()).doesNotContain(ECHOED);
+    }
+
+    @Test
+    void jobErrorKeepsTheRetriesAndBackoffTheExpressionAsked() throws Exception {
+      var result =
+          JobBuilder.create()
+              .withVariables(INPUT_DECLARING_A_SECRET)
+              .withErrorExpressionHeader(
+                  "=jobError(\"Request failed: \" + response.body, {}, 7, duration(\"PT5M\"))")
+              .executeAndCaptureResult(echoingConnector(), false, false);
+
+      assertThat(result.getErrorMessage()).doesNotContain(ECHOED);
+      assertThat(result.getRetries()).isEqualTo(7);
+    }
+
+    @Test
+    void bpmnErrorMessageCopyingAResponseIsRedacted() throws Exception {
+      var result =
+          JobBuilder.create()
+              .withVariables(INPUT_DECLARING_A_SECRET)
+              .withErrorExpressionHeader(
+                  "=bpmnError(\"AUTH_FAILED\", \"Request failed: \" + response.body)")
+              .executeAndCaptureResult(echoingConnector(), false, true);
+
+      assertThat(result.getErrorMessage())
+          .isEqualTo("Request failed: rejected token ***")
+          .doesNotContain(ECHOED);
+    }
+
+    @Test
+    void bpmnErrorVariablesCopyingAResponseAreRedacted() throws Exception {
+      var result =
+          JobBuilder.create()
+              .withVariables(INPUT_DECLARING_A_SECRET)
+              .withErrorExpressionHeader(
+                  "=bpmnError(\"AUTH_FAILED\", \"failed\", {detail: response.body})")
+              .executeAndCaptureResult(echoingConnector(), false, true);
+
+      assertThat(result.getVariables()).containsEntry("detail", "rejected token ***");
+    }
+
+    @Test
+    void bpmnErrorCodeIsNotRedacted() throws Exception {
+      // boundary events match on the code, so it keeps a value equal to the secret's
+      var result =
+          JobBuilder.create()
+              .withVariables(INPUT_DECLARING_A_SECRET)
+              .withErrorExpressionHeader(
+                  "=bpmnError(\"" + ECHOED + "\", \"Request failed: \" + response.body)")
+              .executeAndCaptureResult(echoingConnector(), false, true);
+
+      assertThat(result.getErrorCode()).isEqualTo(ECHOED);
+      assertThat(result.getErrorMessage()).doesNotContain(ECHOED);
+    }
+
+    @Test
+    void bpmnErrorWithoutAMessageStaysWithoutOne() throws Exception {
+      // throwError omits a null message but would set an empty one
+      var result =
+          JobBuilder.create()
+              .withVariables(INPUT_DECLARING_A_SECRET)
+              .withErrorExpressionHeader(
+                  "={ \"errorType\": \"bpmnError\", \"errorCode\": \"AUTH_FAILED\","
+                      + " \"variables\": {\"detail\": response.body} }")
+              .executeAndCaptureResult(echoingConnector(), false, true);
+
+      assertThat(result.getErrorMessage()).isNull();
+      assertThat(result.getVariables()).containsEntry("detail", "rejected token ***");
+    }
+
+    @Test
+    void jobErrorIsWithheldWhenItCannotBeRedacted() throws Exception {
+      var result =
+          JobBuilder.create()
+              .withVariables(INPUT_DECLARING_A_SECRET)
+              .withErrorExpressionHeader("=jobError(\"Request failed: \" + response.body, {}, 0)")
+              .executeAndCaptureResult(echoingConnectorWithUnreadableSecrets(), false, false);
+
+      // the fetch failure's own message is withheld too: a provider error can echo the store's body
+      assertThat(result.getErrorMessage())
+          .startsWith("Fetching secrets failed, so the original error cannot be displayed")
+          .contains("java.lang.RuntimeException")
+          .doesNotContain("Network error while fetching secrets")
+          .doesNotContain(ECHOED);
+      assertThat(result.getRetries()).isZero();
+    }
+
+    @Test
+    void bpmnErrorKeepsItsCodeWhenItCannotBeRedacted() throws Exception {
+      var result =
+          JobBuilder.create()
+              .withVariables(INPUT_DECLARING_A_SECRET)
+              .withErrorExpressionHeader(
+                  "=bpmnError(\"AUTH_FAILED\", \"Request failed: \" + response.body,"
+                      + " {detail: response.body})")
+              .executeAndCaptureResult(echoingConnectorWithUnreadableSecrets(), false, true);
+
+      assertThat(result.getErrorCode()).isEqualTo("AUTH_FAILED");
+      assertThat(result.getErrorMessage())
+          .startsWith("Fetching secrets failed, so the original error cannot be displayed")
+          .doesNotContain(ECHOED);
+      assertThat(result.getVariables()).isEmpty();
+    }
+
+    @Test
+    void anErrorCarryingNothingToRedactIsLeftAlone() throws Exception {
+      // no message and no variables, so the read is skipped and the unreadable store costs nothing
+      var result =
+          JobBuilder.create()
+              .withVariables(INPUT_DECLARING_A_SECRET)
+              .withErrorExpressionHeader("=bpmnError(\"AUTH_FAILED\")")
+              .executeAndCaptureResult(echoingConnectorWithUnreadableSecrets(), false, true);
+
+      assertThat(result.getErrorCode()).isEqualTo("AUTH_FAILED");
+      assertThat(result.getErrorMessage()).isNull();
+    }
+
+    @Test
+    void ignoreErrorIsNotRedacted() throws Exception {
+      // the boundary of this fix: ignoreError completes the job with unredacted business variables
+      var result =
+          JobBuilder.create()
+              .withVariables(INPUT_DECLARING_A_SECRET)
+              .withErrorExpressionHeader("=ignoreError({detail: response.body})")
+              .executeAndCaptureResult(echoingConnector(), true);
+
+      assertThat(result.getVariables()).containsEntry("detail", "rejected token " + ECHOED);
+    }
+
+    @Test
+    void listenerIsNotifiedWithARedactedJobError() throws Exception {
+      // redacting the Zeebe command alone would leave this second sink open
+      var listener = mock(JobCompletionListener.class);
+      var handler =
+          newConnectorJobHandler(
+              new MaskingListenerFunction(Map.of("body", "rejected token " + ECHOED), listener),
+              CompletableFuture.completedFuture(new CommandOutcome.Completed(null, 1)));
+
+      JobBuilder.create()
+          .withVariables(INPUT_DECLARING_A_SECRET)
+          .withErrorExpressionHeader(
+              "=jobError(\"Request failed: \" + response.body, {detail: response.body}, 0)")
+          .executeAndCaptureResult(handler, false, false);
+
+      var captor = ArgumentCaptor.forClass(JobCompletionFailure.class);
+      verify(listener).onJobCompletionFailed(any(), any(ConnectorResponse.class), captor.capture());
+      assertThat(captor.getValue())
+          .isInstanceOfSatisfying(
+              JobCompletionFailure.JobErrorRaised.class,
+              failure -> {
+                assertThat(failure.errorMessage()).isEqualTo("Request failed: rejected token ***");
+                assertThat(failure.variables()).containsEntry("detail", "rejected token ***");
+              });
+    }
+
+    @Test
+    void listenerIsNotifiedWithARedactedBpmnError() throws Exception {
+      var listener = mock(JobCompletionListener.class);
+      var handler =
+          newConnectorJobHandler(
+              new MaskingListenerFunction(Map.of("body", "rejected token " + ECHOED), listener),
+              CompletableFuture.completedFuture(new CommandOutcome.Completed(null, 1)));
+
+      JobBuilder.create()
+          .withVariables(INPUT_DECLARING_A_SECRET)
+          .withErrorExpressionHeader(
+              "=bpmnError(\"AUTH_FAILED\", \"Request failed: \" + response.body,"
+                  + " {detail: response.body})")
+          .executeAndCaptureResult(handler, false, true);
+
+      var captor = ArgumentCaptor.forClass(JobCompletionFailure.class);
+      verify(listener).onJobCompletionFailed(any(), any(ConnectorResponse.class), captor.capture());
+      assertThat(captor.getValue())
+          .isInstanceOfSatisfying(
+              JobCompletionFailure.BpmnErrorThrown.class,
+              failure -> {
+                assertThat(failure.errorCode()).isEqualTo("AUTH_FAILED");
+                assertThat(failure.errorMessage()).isEqualTo("Request failed: rejected token ***");
+                assertThat(failure.variables()).containsEntry("detail", "rejected token ***");
+              });
+    }
+
+    private static final class MaskingListenerFunction
+        implements OutboundConnectorFunction, JobCompletionListener {
+
+      private final Object response;
+      private final JobCompletionListener delegate;
+
+      MaskingListenerFunction(Object response, JobCompletionListener delegate) {
+        this.response = response;
+        this.delegate = delegate;
+      }
+
+      @Override
+      public Object execute(OutboundConnectorContext context) {
+        return response;
+      }
+
+      @Override
+      public void onJobCompleted(OutboundConnectorContext context, ConnectorResponse response) {
+        delegate.onJobCompleted(context, response);
+      }
+
+      @Override
+      public void onJobCompletionFailed(
+          OutboundConnectorContext context,
+          ConnectorResponse response,
+          JobCompletionFailure failure) {
+        delegate.onJobCompletionFailed(context, response, failure);
+      }
+    }
+  }
+
   @Nested
   class ConnectorResponseTests {
 


### PR DESCRIPTION
## Description

An `errorExpression` that copies a response into its message published a credential the called API echoed back, in the clear, into the incident — visible in Operate to anyone who can see the process instance.

Every other outbound error is redacted by `OutboundConnectorExceptionHandler` before `failJob` is called, and neither `failJob` nor `throwError` masks anything of its own. The `jobError(...)` and `bpmnError(...)` branches of `handleConnectorError` built their Zeebe command directly, so they bypassed that entirely. The contract was "callers must sanitize before calling `failJob`" — and these two callers did not.

The realistic shape of the leak is not the filed repro (`jobError(response.body.secret, ...)`, where the author names the field) but the ordinary one:

```
jobError("Request failed: " + string(response.body), {}, 0)
```

The author names nothing secret; the endpoint echoes the credential back.

### The fix

Redact the whole `ConnectorError` once, at the top of `handleConnectorError`. Both sinks are then built from the masked object:

- the Zeebe fail/throw command, and
- the `JobErrorRaised`/`BpmnErrorThrown` payloads handed to `JobCompletionListener` subscribers.

Redacting inside the command builders instead — which looks more structural — would have left the listeners exposed, and would also have masked *after* truncation, where a secret straddling the 6000-character cut leaves behind a prefix `String#replace` no longer sees.

This can only ever be a value comparison, not provenance: the echoed credential arrives as response bytes with nothing marking it as a secret, so the only way to recognize it is against the value the job's own input resolved. A holder type that refuses to stringify would protect a resolved *input* value, but not this. The gap ADR-0007 already documents for engine-substituted references is unchanged — those names never reach this runtime.

### Deliberate boundaries

- **`bpmnError`'s `errorCode` is never redacted** — boundary events match on it, so redacting would stop the error being caught rather than hide anything.
- **`jobError`'s `retries`/`retryBackoff` survive redaction.** They are the author's decision about this error, which is why this cannot delegate to `manageConnectorJobHandlerException`: that recomputes both.
- **`ignoreError` is untouched.** It completes the job with business variables the process branches on. Diagnostic output (incident messages, error variables) is redacted; business output is not — the same reason a `resultExpression` can put a response value into a process variable unmasked. Pinned by a test so it doesn't read as an oversight.
- **An unreadable secret store fails closed**, matching the existing exception path: the message is withheld rather than published unredacted. This is a behaviour change on a path that previously always succeeded, limited to jobs that actually declare secrets.

### Verification

Reverting just the masking call fails 11 of the 12 new tests, printing the actual leak:

```
expected: "Request failed: rejected token ***"
 but was: "Request failed: rejected token bar"
```

The one that still passes is the skip-path test, correctly. 526 tests green in the module.

### Not addressed here

- **Memoizing the masking fetch per job.** This adds a secret read on a path that previously did none, and `bpmnError` is ordinary business routing rather than a failure. An error carrying neither a message nor variables skips the read, and a job declaring no secrets asks its providers for nothing. What memoization would recover is the case where the connector throws *and* the error expression maps it to a `bpmnError`: one fetch today, two now. Threading a per-job memo through would change two public signatures and ~25 test call sites, which isn't worth folding into a security fix.
- **`prepareFailJobCommand` unboxing `Integer retries`** via `Math.max(retries, 0)`. The `jobError` FEEL function always defaults it to `0`, but the raw JSON error form (`{"errorType": "jobError", ...}`) can omit it. Pre-existing and untouched.
- **The success path.** `prepareCompleteJobCommand` passes `result.variables()` through unredacted, by design — processes branch on those values. An author who wants to leak already can, via `resultExpression`; this fix is about accidental leaks.

## Also fixed, from review

Three further masking gaps, all pre-existing, all on paths this PR newly routes error-expression content through. Each was verified by reverting the fix and watching the new test fail.

**A provider's own failure message reached the pod log.** `AbstractSecretProvider` folds a Jackson failure into its message, and a secrets bundle that parses as valid JSON but not an object puts the value it could not coerce into the coercion error — `...from String value ('super-secret')`. Jackson's `[Source: ...]` redaction does not cover that; the coercion error embeds the value itself. `fetchSecretsForMasking`'s catch then logged it at ERROR. Now logs the exception class, plus `publishableMessage()` where the failure is a `SecretFailureDiagnostic`, so operators keep the diagnostics they can act on and lose only arbitrary provider text. This mirrors `SecretReferenceResolver:125-130`, which already refuses to log or wrap its own client errors for exactly this reason. Applied to the sibling log in `fetchReferencedSecrets` too, which had the same leak and was not flagged.

**A secret that prefixes another was only partly masked.** `hideSecretsFromMessage` reduced over the values in provider order, so masking the shorter value first destroyed the longer match and published its remainder. With `x` and `xSUPERSECRET`, the message came out `api rejected ***SUPERSECRET`. Now sorts longest-first, and skips an empty value — which otherwise matches at every position and rewrote the whole message into separators (`***a***p***i***...`).

**Fail-closed could fire for a job that declared no secret.** `fetchSecretsForMasking` called `fetchAll` before checking whether any key existed, so an overriding implementation that refuses every batch withheld the error message of a job with nothing to redact. This is what makes the "limited to jobs that actually declare secrets" boundary above actually true, rather than merely true for well-behaved providers — thanks to the reviewer for catching that the claim was load-bearing and unenforced.

### Note on the issue's addendum

The reported untrimmed-`group("secret")` gap (`{{secrets.DECLARED_A }}` resolving but escaping the masking allow-list) is **already fixed on main** and needs no change here. `SecretUtil.keysIn` trims, landed in #8368 on 2026-08-26 — before the issue was filed on 2026-09-01, against a `#8496` branch cut earlier. There is an existing passing regression test named for it: `masksAReferenceWrittenWithSpaceInsideTheBraces`. #8537 closed the sibling `{{secrets.A:SUB}}` prefix hole. That section of the issue can be struck.

## Related issues

closes #8543

## Checklist

- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest
  release, as this branch will be rebased onto main before the next release. Example backport labels:
    - `backport stable/8.8`: for changes that should be included in the next 8.8.x release.
    - **or** `backport release-8.8.7`: for changes that should be included in the specific release 8.8.7, and this
      *release has already been created*. The release branch will be merged back into stable/8.8 later, so the change
      will be included in future 8.8.x releases as well.
- [x] Tests/Integration tests for the changes have been added if applicable.
- [ ] If the change requires a documentation update, it has been added to the appropriate section in the documentation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
