### PR TITLE
feat(runtime): extend secret filtering to inbound connectors

### DIFF
--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/DefaultInboundConnectorContextFactory.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/DefaultInboundConnectorContextFactory.java
@@ -35,6 +35,7 @@ public class DefaultInboundConnectorContextFactory implements InboundConnectorCo
   private final SecretProviderAggregator secretProviderAggregator;
   private final ValidationProvider validationProvider;
   private final OperateClientAdapter operateClientAdapter;
+  private final boolean secretFilterEnabled;
 
   public DefaultInboundConnectorContextFactory(
       final ObjectMapper mapper,
@@ -42,6 +43,23 @@ public class DefaultInboundConnectorContextFactory implements InboundConnectorCo
       final SecretProviderAggregator secretProviderAggregator,
       final ValidationProvider validationProvider,
       final OperateClientAdapter operateClientAdapter) {
+    this(
+        mapper,
+        correlationHandler,
+        secretProviderAggregator,
+        validationProvider,
+        operateClientAdapter,
+        false);
+  }
+
+  public DefaultInboundConnectorContextFactory(
+      final ObjectMapper mapper,
+      final InboundCorrelationHandler correlationHandler,
+      final SecretProviderAggregator secretProviderAggregator,
+      final ValidationProvider validationProvider,
+      final OperateClientAdapter operateClientAdapter,
+      final boolean secretFilterEnabled) {
+    this.secretFilterEnabled = secretFilterEnabled;
     this.objectMapper = mapper;
     this.correlationHandler = correlationHandler;
     this.secretProviderAggregator = secretProviderAggregator;
@@ -64,7 +82,8 @@ public class DefaultInboundConnectorContextFactory implements InboundConnectorCo
             correlationHandler,
             cancellationCallback,
             objectMapper,
-            queue);
+            queue,
+            secretFilterEnabled);
 
     if (isIntermediateContext(executableClass)) {
       inboundContext =

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/DefaultProcessElementContext.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/DefaultProcessElementContext.java
@@ -23,6 +23,7 @@ import io.camunda.connector.api.secret.SecretProvider;
 import io.camunda.connector.api.validation.ValidationProvider;
 import io.camunda.connector.runtime.core.AbstractConnectorContext;
 import io.camunda.connector.runtime.core.secret.SecretFilter;
+import io.camunda.connector.runtime.core.secret.SecretUtil;
 import java.util.Map;
 
 public class DefaultProcessElementContext extends AbstractConnectorContext
@@ -40,11 +41,52 @@ public class DefaultProcessElementContext extends AbstractConnectorContext
       ValidationProvider validationProvider,
       SecretProvider secretProvider,
       ObjectMapper objectMapper) {
-    super(secretProvider, SecretFilter.allowAll(), validationProvider);
+    this(connectorElement, validationProvider, secretProvider, objectMapper, false);
+  }
+
+  /**
+   * @param secretFilterEnabled when {@code true}, restricts secret resolution to the names this
+   *     element's own deployed {@code zeebe:property} text declares (#7730).
+   */
+  public DefaultProcessElementContext(
+      InboundConnectorElement connectorElement,
+      ValidationProvider validationProvider,
+      SecretProvider secretProvider,
+      ObjectMapper objectMapper,
+      boolean secretFilterEnabled) {
+    super(secretProvider, secretFilter(connectorElement, secretFilterEnabled), validationProvider);
     this.connectorElement = connectorElement;
     this.objectMapper = objectMapper;
     this.properties =
         InboundPropertyHandler.readWrappedProperties(connectorElement.rawProperties());
+  }
+
+  /**
+   * Scoped to this one element's {@code rawProperties} — the exact text {@link
+   * #getPropertiesWithSecrets} filters — rather than to every element of the executable, matching
+   * the per-call scoping #8538 settled on upstream after a union across siblings proved too wide.
+   *
+   * <p>This context is a second inbound resolution path, distinct from {@code
+   * InboundConnectorContextImpl}: every successful {@code CorrelationResult} carries one as its
+   * {@code activatedElement} — {@code ProcessInstanceCreated}, {@code MessagePublished} and {@code
+   * MessageAlreadyCorrelated}, built at three sites in {@code InboundCorrelationHandler} — and its
+   * public {@code getProperties()} and {@code bindProperties()} resolve secrets too. It is the
+   * analogue of main's {@code BindableProcessElement}, which is why upstream filters that and this
+   * filters here. (Later branches also expose it through {@code canActivate}; that entry point does
+   * not exist here.)
+   *
+   * <p>Static because it feeds the {@code super(...)} call, before any field is assigned.
+   */
+  private static SecretFilter secretFilter(
+      InboundConnectorElement connectorElement, boolean secretFilterEnabled) {
+    if (!secretFilterEnabled) {
+      return SecretFilter.allowAll();
+    }
+    return SecretFilter.allowOnly(
+        connectorElement.rawProperties().values().stream()
+            .flatMap(value -> SecretUtil.retrieveSecretKeysInInput(value).stream())
+            .distinct()
+            .toList());
   }
 
   @Override

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/DefaultProcessElementContextFactory.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/DefaultProcessElementContextFactory.java
@@ -26,19 +26,29 @@ public class DefaultProcessElementContextFactory implements ProcessElementContex
   private final SecretProvider secretProvider;
   private final ValidationProvider validationProvider;
   private final ObjectMapper objectMapper;
+  private final boolean secretFilterEnabled;
 
   public DefaultProcessElementContextFactory(
       SecretProvider secretProvider,
       ValidationProvider validationProvider,
       ObjectMapper objectMapper) {
+    this(secretProvider, validationProvider, objectMapper, false);
+  }
+
+  public DefaultProcessElementContextFactory(
+      SecretProvider secretProvider,
+      ValidationProvider validationProvider,
+      ObjectMapper objectMapper,
+      boolean secretFilterEnabled) {
     this.secretProvider = secretProvider;
     this.validationProvider = validationProvider;
     this.objectMapper = objectMapper;
+    this.secretFilterEnabled = secretFilterEnabled;
   }
 
   @Override
   public ProcessElementContext createContext(InboundConnectorElement connectorElement) {
     return new DefaultProcessElementContext(
-        connectorElement, validationProvider, secretProvider, objectMapper);
+        connectorElement, validationProvider, secretProvider, objectMapper, secretFilterEnabled);
   }
 }

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextImpl.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextImpl.java
@@ -32,6 +32,7 @@ import io.camunda.connector.runtime.core.inbound.correlation.InboundCorrelationH
 import io.camunda.connector.runtime.core.inbound.details.InboundConnectorDetails;
 import io.camunda.connector.runtime.core.inbound.details.InboundConnectorDetails.ValidInboundConnectorDetails;
 import io.camunda.connector.runtime.core.secret.SecretFilter;
+import io.camunda.connector.runtime.core.secret.SecretUtil;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -65,7 +66,31 @@ public class InboundConnectorContextImpl extends AbstractConnectorContext
       Consumer<Throwable> cancellationCallback,
       ObjectMapper objectMapper,
       EvictingQueue logs) {
-    super(secretProvider, SecretFilter.allowAll(), validationProvider);
+    this(
+        secretProvider,
+        validationProvider,
+        connectorDetails,
+        correlationHandler,
+        cancellationCallback,
+        objectMapper,
+        logs,
+        false);
+  }
+
+  /**
+   * @param secretFilterEnabled when {@code true}, restricts secret resolution to the names declared
+   *     by the deployed {@code zeebe:property} text replacement runs over (#7730).
+   */
+  public InboundConnectorContextImpl(
+      SecretProvider secretProvider,
+      ValidationProvider validationProvider,
+      ValidInboundConnectorDetails connectorDetails,
+      InboundCorrelationHandler correlationHandler,
+      Consumer<Throwable> cancellationCallback,
+      ObjectMapper objectMapper,
+      EvictingQueue logs,
+      boolean secretFilterEnabled) {
+    super(secretProvider, secretFilter(connectorDetails, secretFilterEnabled), validationProvider);
     this.correlationHandler = correlationHandler;
     this.connectorDetails = connectorDetails;
     this.properties =
@@ -100,6 +125,39 @@ public class InboundConnectorContextImpl extends AbstractConnectorContext
     } catch (Throwable e) {
       LOG.error("Failed to deliver the cancellation signal to the runtime", e);
     }
+  }
+
+  /**
+   * The allow-list is drawn from the same {@code rawPropertiesWithoutKeywords} map that {@link
+   * #properties} is built from, so the names permitted and the text filtered always come from one
+   * read. Both are fixed at construction on this branch — {@code connectorDetails} and {@code
+   * properties} are final and there is no {@code updateConnectorDetails} — so the hot-swap and
+   * torn-read failure directions main had to close are not representable here.
+   *
+   * <p>This is what the filter stops: {@link SecretUtil#replaceSecrets} runs the brace pass and
+   * then runs the bare pass over that pass's output, so a resolved value containing
+   * reference-shaped text otherwise produces a lookup for a name no model declares. Confirmed
+   * present on this branch before backporting: a secret whose value is the literal {@code
+   * secrets.CHAINED} resolved {@code CHAINED} under the previous allow-all filter.
+   *
+   * <p>Narrower than the equivalent on 8.8/8.9, and deliberately so. This branch's {@code
+   * SecretUtil} has neither their nested-match exclusion in {@code retrieveSecretKeysInInput} nor
+   * their denied-bracket exclusion in {@code replaceSecretsWithoutParentheses} (#8592, #8593), so a
+   * model declaring {@code {{secrets.FOO:BAR}}} also admits the truncated {@code FOO}. That is a
+   * pre-existing property of this branch, unchanged by this filter in either direction.
+   *
+   * <p>Static because it feeds the {@code super(...)} call, before any field is assigned.
+   */
+  private static SecretFilter secretFilter(
+      ValidInboundConnectorDetails connectorDetails, boolean secretFilterEnabled) {
+    if (!secretFilterEnabled) {
+      return SecretFilter.allowAll();
+    }
+    return SecretFilter.allowOnly(
+        connectorDetails.rawPropertiesWithoutKeywords().values().stream()
+            .flatMap(value -> SecretUtil.retrieveSecretKeysInInput(value).stream())
+            .distinct()
+            .toList());
   }
 
   @Override

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextImplTest.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextImplTest.java
@@ -112,8 +112,6 @@ class InboundConnectorContextImplTest {
         .isInstanceOf(String.class);
   }
 
-  @NotNull
-
   // #7730: inbound secret resolution is restricted to the names the element's own deployed
   // zeebe:property text declares. The allow-list is a superset of what a correctly-authored model
   // names, so what it actually stops is a second-order lookup: replaceSecrets runs the brace pass
@@ -200,6 +198,7 @@ class InboundConnectorContextImplTest {
     assertThat(replace(context, "secrets.INJECTED")).isEqualTo("resolved");
   }
 
+  @NotNull
   private static ValidInboundConnectorDetails getInboundConnectorDefinition(
       Map<String, String> properties) {
     properties = new HashMap<>(properties);

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextImplTest.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextImplTest.java
@@ -18,6 +18,10 @@ package io.camunda.connector.runtime.core.inbound;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.EvictingQueue;
@@ -109,6 +113,93 @@ class InboundConnectorContextImplTest {
   }
 
   @NotNull
+
+  // #7730: inbound secret resolution is restricted to the names the element's own deployed
+  // zeebe:property text declares. The allow-list is a superset of what a correctly-authored model
+  // names, so what it actually stops is a second-order lookup: replaceSecrets runs the brace pass
+  // and then runs the bare pass over that pass's output, letting a resolved value that contains
+  // reference-shaped text reach a secret no model ever declared. Confirmed present on this branch
+  // before backporting: under the previous allow-all filter, a secret whose value is the literal
+  // "secrets.CHAINED" resolved CHAINED.
+  //
+  // Main's suite also covers a hot swap, a sibling element's names, and the new
+  // camunda.secrets.<name> form. None are representable on this branch: connectorDetails and
+  // properties are both final and there is no updateConnectorDetails at all, there is a single
+  // connector-level text rather than a per-element one, and the new form does not exist here.
+
+  private InboundConnectorContextImpl filteringContext(
+      ValidInboundConnectorDetails details, SecretProvider provider) {
+    return new InboundConnectorContextImpl(
+        provider, (e) -> {}, details, null, (e) -> {}, mapper, EvictingQueue.create(10), true);
+  }
+
+  private static String replace(InboundConnectorContextImpl context, String input) {
+    return context.getSecretHandler().replaceSecrets(input);
+  }
+
+  @Test
+  void secretFilterEnabled_resolvesADeclaredSecret() {
+    var provider = mock(SecretProvider.class);
+    when(provider.getSecret("DECLARED")).thenReturn("resolved");
+    var context =
+        filteringContext(
+            getInboundConnectorDefinition(Map.of("token", "secrets.DECLARED")), provider);
+
+    assertThat(replace(context, "secrets.DECLARED")).isEqualTo("resolved");
+  }
+
+  @Test
+  void secretFilterEnabled_resolvesADeclaredSecretInBraceSyntax() {
+    var provider = mock(SecretProvider.class);
+    when(provider.getSecret("BRACED")).thenReturn("resolved");
+    var context =
+        filteringContext(
+            getInboundConnectorDefinition(Map.of("token", "{{ secrets.BRACED }}")), provider);
+
+    assertThat(replace(context, "{{ secrets.BRACED }}")).isEqualTo("resolved");
+  }
+
+  @Test
+  void secretFilterEnabled_leavesAnUndeclaredSecret() {
+    var provider = mock(SecretProvider.class);
+    var context =
+        filteringContext(
+            getInboundConnectorDefinition(Map.of("token", "secrets.DECLARED")), provider);
+
+    assertThat(replace(context, "secrets.INJECTED")).isEqualTo("secrets.INJECTED");
+    verify(provider, never()).getSecret("INJECTED");
+  }
+
+  @Test
+  void secretFilterEnabled_leavesASecretNamedOnlyByAnotherSecretsValue() {
+    var provider = mock(SecretProvider.class);
+    when(provider.getSecret("CHAIN_ROOT")).thenReturn("secrets.CHAINED");
+    when(provider.getSecret("CHAINED")).thenReturn("leaked-value");
+    var context =
+        filteringContext(
+            getInboundConnectorDefinition(Map.of("token", "{{secrets.CHAIN_ROOT}}")), provider);
+
+    assertThat(replace(context, "{{secrets.CHAIN_ROOT}}")).isEqualTo("secrets.CHAINED");
+    verify(provider, never()).getSecret("CHAINED");
+  }
+
+  @Test
+  void secretFilterDisabled_resolvesAnUndeclaredSecret() {
+    var provider = mock(SecretProvider.class);
+    when(provider.getSecret("INJECTED")).thenReturn("resolved");
+    var context =
+        new InboundConnectorContextImpl(
+            provider,
+            (e) -> {},
+            getInboundConnectorDefinition(Map.of("token", "secrets.DECLARED")),
+            null,
+            (e) -> {},
+            mapper,
+            EvictingQueue.create(10));
+
+    assertThat(replace(context, "secrets.INJECTED")).isEqualTo("resolved");
+  }
+
   private static ValidInboundConnectorDetails getInboundConnectorDefinition(
       Map<String, String> properties) {
     properties = new HashMap<>(properties);

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/InboundConnectorRuntimeConfiguration.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/InboundConnectorRuntimeConfiguration.java
@@ -38,6 +38,7 @@ import io.camunda.connector.runtime.inbound.state.ProcessDefinitionInspector;
 import io.camunda.connector.runtime.inbound.state.ProcessStateStore;
 import io.camunda.connector.runtime.inbound.state.TenantAwareProcessStateStoreImpl;
 import io.camunda.connector.runtime.inbound.webhook.WebhookConnectorRegistry;
+import io.camunda.connector.runtime.outbound.job.ConfigurableSecretFilterFactory.SecretFilterMode;
 import io.camunda.operate.CamundaOperateClient;
 import io.camunda.zeebe.client.ZeebeClient;
 import io.camunda.zeebe.spring.client.metrics.MetricsRecorder;
@@ -62,9 +63,17 @@ public class InboundConnectorRuntimeConfiguration {
   public ProcessElementContextFactory processElementContextFactory(
       ObjectMapper objectMapper,
       @Autowired(required = false) ValidationProvider validationProvider,
-      SecretProviderAggregator secretProviderAggregator) {
+      SecretProviderAggregator secretProviderAggregator,
+      @Value("${camunda.connector.secret-resolver.secret-filter.mode:STRICT}")
+          SecretFilterMode secretFilterMode) {
+    // Same DISABLED-only opt-out as springInboundConnectorContextFactory: this is the second
+    // inbound resolution path, carried as the activatedElement of every successful
+    // CorrelationResult.
     return new DefaultProcessElementContextFactory(
-        secretProviderAggregator, validationProvider, objectMapper);
+        secretProviderAggregator,
+        validationProvider,
+        objectMapper,
+        secretFilterMode != SecretFilterMode.DISABLED);
   }
 
   @Bean
@@ -88,13 +97,20 @@ public class InboundConnectorRuntimeConfiguration {
       InboundCorrelationHandler correlationHandler,
       SecretProviderAggregator secretProviderAggregator,
       @Autowired(required = false) ValidationProvider validationProvider,
-      OperateClientAdapter operateClientAdapter) {
+      OperateClientAdapter operateClientAdapter,
+      @Value("${camunda.connector.secret-resolver.secret-filter.mode:STRICT}")
+          SecretFilterMode secretFilterMode) {
+    // LAX vs STRICT only matters outbound, where the allow-list needs a remote BPMN lookup that can
+    // fail; the inbound allow-list is built from data already in memory, so it never fails and both
+    // modes behave identically here — only DISABLED turns this off.
+    boolean secretFilterEnabled = secretFilterMode != SecretFilterMode.DISABLED;
     return new DefaultInboundConnectorContextFactory(
         mapper,
         correlationHandler,
         secretProviderAggregator,
         validationProvider,
-        operateClientAdapter);
+        operateClientAdapter,
+        secretFilterEnabled);
   }
 
   @Bean

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/inbound/InboundConnectorRuntimeConfigurationTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/inbound/InboundConnectorRuntimeConfigurationTest.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.runtime.inbound;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.EvictingQueue;
+import io.camunda.connector.api.inbound.InboundConnectorContext;
+import io.camunda.connector.api.inbound.InboundConnectorExecutable;
+import io.camunda.connector.api.inbound.ProcessElement;
+import io.camunda.connector.api.secret.SecretProvider;
+import io.camunda.connector.api.validation.ValidationProvider;
+import io.camunda.connector.runtime.core.inbound.InboundConnectorContextImpl;
+import io.camunda.connector.runtime.core.inbound.InboundConnectorElement;
+import io.camunda.connector.runtime.core.inbound.OperateClientAdapter;
+import io.camunda.connector.runtime.core.inbound.correlation.InboundCorrelationHandler;
+import io.camunda.connector.runtime.core.inbound.correlation.MessageCorrelationPoint.StandaloneMessageCorrelationPoint;
+import io.camunda.connector.runtime.core.inbound.details.InboundConnectorDetails;
+import io.camunda.connector.runtime.core.inbound.details.InboundConnectorDetails.ValidInboundConnectorDetails;
+import io.camunda.connector.runtime.core.secret.SecretProviderAggregator;
+import io.camunda.connector.runtime.outbound.job.ConfigurableSecretFilterFactory.SecretFilterMode;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class InboundConnectorRuntimeConfigurationTest {
+
+  private final InboundConnectorRuntimeConfiguration configuration =
+      new InboundConnectorRuntimeConfiguration();
+
+  /**
+   * Pins the {@code SecretFilterMode} -> boolean hop on the connector-level path: nothing else
+   * asserts that the mode reaches the context, and because {@code LAX} and {@code STRICT} behave
+   * identically inbound this is the only place their equivalence — and {@code DISABLED}'s
+   * difference from both — is checked. Fails if the argument is dropped or the boolean inverted.
+   */
+  @Test
+  void springInboundConnectorContextFactory_filtersSecretsUnlessModeIsDisabled() {
+    assertEquals("secrets.UNDECLARED", resolveUndeclared(SecretFilterMode.STRICT));
+    assertEquals("secrets.UNDECLARED", resolveUndeclared(SecretFilterMode.LAX));
+    assertEquals("resolved", resolveUndeclared(SecretFilterMode.DISABLED));
+  }
+
+  /**
+   * The second inbound resolution path. Every successful {@code CorrelationResult} carries a {@code
+   * ProcessElementContext} as its {@code activatedElement} — built at three sites in {@code
+   * InboundCorrelationHandler} — and its public {@code getProperties()}/{@code bindProperties()}
+   * resolve secrets through their own {@code SecretHandler}. Filtering only {@code
+   * springInboundConnectorContextFactory} would leave this one allow-all. It is the analogue of the
+   * {@code BindableProcessElement} path #8538 filters upstream.
+   *
+   * <p>Exercised at the factory rather than through {@code correlate()}, which would need the whole
+   * Zeebe publish/create round trip mocked to reach a {@code Success}; what needs pinning here is
+   * that the mode reaches the context the correlation handler hands out, and that is this factory.
+   *
+   * <p>The probe has to be the chained case: this context resolves the element's own property text,
+   * so any name written there is declared by definition and the allow-list is a superset of it.
+   */
+  @Test
+  void processElementContextFactory_refusesAChainedNameOnTheActivatedElement() {
+    assertEquals("secrets.CHAINED", resolveChainedViaElementContext(SecretFilterMode.STRICT));
+    assertEquals("secrets.CHAINED", resolveChainedViaElementContext(SecretFilterMode.LAX));
+    assertEquals("leaked-value", resolveChainedViaElementContext(SecretFilterMode.DISABLED));
+  }
+
+  private String resolveUndeclared(SecretFilterMode mode) {
+    var factory =
+        configuration.springInboundConnectorContextFactory(
+            new ObjectMapper(),
+            mock(InboundCorrelationHandler.class),
+            new SecretProviderAggregator(List.of(alwaysResolvingProvider())),
+            mock(ValidationProvider.class),
+            mock(OperateClientAdapter.class),
+            mode);
+    var context =
+        (InboundConnectorContextImpl)
+            factory.createContext(
+                detailsDeclaringOnly("token", "secrets.DECLARED"),
+                e -> {},
+                TestExecutable.class,
+                EvictingQueue.create(10));
+    return context.getSecretHandler().replaceSecrets("secrets.UNDECLARED");
+  }
+
+  private String resolveChainedViaElementContext(SecretFilterMode mode) {
+    var elementFactory =
+        configuration.processElementContextFactory(
+            new ObjectMapper(),
+            mock(ValidationProvider.class),
+            new SecretProviderAggregator(List.of(chainingProvider())),
+            mode);
+    var elementContext = elementFactory.createContext(chainRootElement());
+    return (String) elementContext.getProperties().get("token");
+  }
+
+  private static ValidInboundConnectorDetails detailsDeclaringOnly(String key, String value) {
+    var element = element(Map.of("inbound.type", "io.camunda:connector:1", key, value));
+    return (ValidInboundConnectorDetails)
+        InboundConnectorDetails.of(element.deduplicationId(List.of()), List.of(element));
+  }
+
+  private static InboundConnectorElement chainRootElement() {
+    return element(
+        Map.of("inbound.type", "io.camunda:connector:1", "token", "{{secrets.CHAIN_ROOT}}"));
+  }
+
+  private static InboundConnectorElement element(Map<String, String> properties) {
+    return new InboundConnectorElement(
+        properties,
+        new StandaloneMessageCorrelationPoint("", "", null, null),
+        new ProcessElement("process", 0, 0, "id", "<default>"));
+  }
+
+  private static SecretProvider alwaysResolvingProvider() {
+    return name -> "resolved";
+  }
+
+  private static SecretProvider chainingProvider() {
+    return name ->
+        switch (name.trim()) {
+          case "CHAIN_ROOT" -> "secrets.CHAINED";
+          case "CHAINED" -> "leaked-value";
+          default -> null;
+        };
+  }
+
+  static class TestExecutable implements InboundConnectorExecutable<InboundConnectorContext> {
+    @Override
+    public void activate(InboundConnectorContext context) {}
+
+    @Override
+    public void deactivate() {}
+  }
+}

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/inbound/InboundSecretFilterDefaultModeWiringTest.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/inbound/InboundSecretFilterDefaultModeWiringTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.runtime.inbound;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.common.collect.EvictingQueue;
+import io.camunda.connector.api.inbound.InboundConnectorContext;
+import io.camunda.connector.api.inbound.InboundConnectorExecutable;
+import io.camunda.connector.api.inbound.ProcessElement;
+import io.camunda.connector.runtime.app.TestConnectorRuntimeApplication;
+import io.camunda.connector.runtime.core.inbound.InboundConnectorContextFactory;
+import io.camunda.connector.runtime.core.inbound.InboundConnectorContextImpl;
+import io.camunda.connector.runtime.core.inbound.InboundConnectorElement;
+import io.camunda.connector.runtime.core.inbound.correlation.MessageCorrelationPoint.StandaloneMessageCorrelationPoint;
+import io.camunda.connector.runtime.core.inbound.details.InboundConnectorDetails;
+import io.camunda.connector.runtime.core.inbound.details.InboundConnectorDetails.ValidInboundConnectorDetails;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+/**
+ * No {@code camunda.connector.secret-resolver.secret-filter.mode} property is set here, so this
+ * exercises the {@code @Value} default on {@code springInboundConnectorContextFactory} itself —
+ * unlike a direct call to that bean method, which bypasses Spring's property resolution entirely
+ * and so stays green however wrong that default string is.
+ *
+ * <p>What this catches is a default that resolves to {@code DISABLED}, which turns inbound
+ * filtering off silently. It cannot distinguish {@code LAX} from {@code STRICT}, because those two
+ * behave identically inbound — {@code InboundConnectorRuntimeConfigurationTest} pins that
+ * equivalence, and {@code DISABLED}'s difference from both, at the bean-method level for both
+ * inbound paths.
+ */
+@SpringBootTest(classes = TestConnectorRuntimeApplication.class)
+class InboundSecretFilterDefaultModeWiringTest {
+
+  @Autowired private InboundConnectorContextFactory contextFactory;
+
+  static class TestExecutable implements InboundConnectorExecutable<InboundConnectorContext> {
+    @Override
+    public void activate(InboundConnectorContext context) {}
+
+    @Override
+    public void deactivate() {}
+  }
+
+  @Test
+  void defaultsToFilteringSecrets() {
+    var properties = Map.of("inbound.type", "io.camunda:connector:1");
+    var element =
+        new InboundConnectorElement(
+            properties,
+            new StandaloneMessageCorrelationPoint("", "", null, null),
+            new ProcessElement("process", 0, 0, "id", "<default>"));
+    var details =
+        (ValidInboundConnectorDetails)
+            InboundConnectorDetails.of(element.deduplicationId(List.of()), List.of(element));
+
+    var context =
+        (InboundConnectorContextImpl)
+            contextFactory.createContext(
+                details, e -> {}, TestExecutable.class, EvictingQueue.create(10));
+
+    assertThat(context.getSecretHandler().replaceSecrets("secrets.UNDECLARED"))
+        .isEqualTo("secrets.UNDECLARED");
+  }
+}


### PR DESCRIPTION
## Summary

Manual backport of #8538 to `stable/8.6`, building on #8505 which landed #7568 here earlier today. A cherry-pick is not viable: `ADR-0007`, `InboundSecretReferenceBindingTest`, `InboundConnectorRuntimeConfigurationTest` and `ConnectorsAutoConfiguration` don't exist on this branch; **`SecretContext` does not exist at all**, so `replaceSecrets` and `SecretProvider.getSecret` are single-argument; `InboundConnectorContextImpl` takes a raw `EvictingQueue` and no `DocumentFactory`; and there is no `BindableProcessElement`.

Wires the existing `camunda.connector.secret-resolver.secret-filter.mode` property into the inbound path: secret resolution is restricted to the names declared by the deployed `zeebe:property` text each replacement runs over, instead of always allowing every secret. `DISABLED` keeps the prior allow-all behavior; `LAX` and `STRICT` behave identically here since, unlike outbound, no remote lookup can fail.

**The `STRICT` default already applies** (via #8505), so inbound and outbound agree and no default-mode change is introduced.

## Both inbound resolution paths are filtered

`stable/8.6` has two places that resolve secrets over inbound model text. Both are wired:

1. **`InboundConnectorContextImpl`** — the connector-level context.
2. **`DefaultProcessElementContext`** — carried as the `activatedElement` of **every successful `CorrelationResult`** (`ProcessInstanceCreated`, `MessagePublished`, `MessageAlreadyCorrelated` — three construction sites in `InboundCorrelationHandler`). Its public `getProperties()`/`bindProperties()` resolve secrets through their own `SecretHandler`. This is the analogue of main's `BindableProcessElement`, which #8538 filters upstream.

The second path was found by Copilot review on the `stable/8.7` backport (#8630) after being missed there. On this branch it was caught up front by enumerating every subclass of `AbstractConnectorContext` and every `SecretFilter.allowAll()` call site, rather than grepping for `BindableProcessElement` by name — which is what caused the 8.7 miss.

**One difference from 8.7 worth noting:** this branch has no `canActivate`/`ActivationCheckResult`, so the element context is reachable *only* through correlation results. The javadoc says exactly that rather than repeating 8.7's wording.

In both paths the allow-list is scoped to **exactly the text that call filters** — the connector-level `rawPropertiesWithoutKeywords`, and that one element's own `rawProperties` — never unioned across an executable's elements, matching the per-call scoping #8538 settled on upstream after a sibling union proved too wide.

## The leak was confirmed present here, not assumed

Probed against this branch's own `SecretUtil` with an allow-all filter — exactly today's inbound behaviour, since both contexts pass `SecretFilter.allowAll()`:

```
A CHAIN: [LEAKED]  LEAK=true
```

A secret whose stored value is the literal `secrets.CHAINED` resolved `CHAINED` — a name no model declares.

## ⚠️ Known weaker than the 8.8/8.9 backports — same caveat as 8.7

This branch's `SecretUtil` has **neither** the nested-match exclusion in `retrieveSecretKeysInInput` **nor** the denied-bracket exclusion in `replaceSecretsWithoutParentheses` that #8592 (8.9) and #8593 (8.8) added. Probed here:

```
B KEYS: [FOO:BAR, FOO]                     ← the truncated prefix is admitted
B DENIED-BRACKET: [{{foo-value:BAR}}]      ← 8.8 leaves this literal
```

So a model declaring `{{secrets.FOO:BAR}}` also puts the truncated `FOO` on the allow-list, and the unhardened bare pass substitutes `FOO`'s real value *inside* the bracketed reference, corrupting it.

1. **This filter neither introduces nor worsens that.** It is pre-existing, reproducible with no filter at all. Today inbound is allow-all, so *everything* resolves; this is strictly an improvement, just not the full one 8.8/8.9 received.
2. **Porting the hardening is deliberately out of scope** — `SecretUtil` here is shared with the outbound allow-list, and main is missing the same hardening, so it should be decided coherently rather than inside an inbound backport.

## Changes

**5 production files, 153 added lines.** Every new constructor is an additive overload whose existing signature delegates with `false`, so no existing call site changes.

| File | Change |
|---|---|
| `InboundConnectorContextImpl` | `secretFilterEnabled` overload + static `secretFilter(...)` feeding `super(...)` |
| `DefaultInboundConnectorContextFactory` | `secretFilterEnabled` overload, passed through |
| `DefaultProcessElementContext` | `secretFilterEnabled` overload + per-element `secretFilter(...)` |
| `DefaultProcessElementContextFactory` | `secretFilterEnabled` overload, passed through |
| `InboundConnectorRuntimeConfiguration` | both bean methods read the mode and map it to a boolean |

The allow-list is passed to `super(...)` at construction. `connectorDetails`, `properties` and `connectorElement` are all `final` and there is **no `updateConnectorDetails`** on this branch, so the hot-swap and torn-read failure directions main had to close (ledger rows 3 and 4) are not representable here.

Extraction uses this branch's `retrieveSecretKeysInInput` rather than main's `retrieveLegacySecretKeysInInput`, because the new `camunda.secrets.<name>` form does not exist anywhere on `stable/8.6`, so the method here is already legacy-only.

## Test plan

- [x] Four applicable cases from main's suite on the connector path: a declared secret resolves, in brace syntax too, an undeclared name is left as a placeholder and never reaches the `SecretProvider`, and a name that only another secret's *value* spells is refused.
- [x] A control asserting allow-all still resolves an undeclared name when the filter is off.
- [x] `InboundConnectorRuntimeConfigurationTest` (new file): pins the `SecretFilterMode` → boolean hop across all three modes, **for both paths**.
- [x] `InboundSecretFilterDefaultModeWiringTest` (new file): a `@SpringBootTest` with the property omitted, the only test that evaluates the `@Value` default string itself.
- [x] 317 tests green: `connector-runtime-core` (195), `connector-runtime-spring` (92), `spring-boot-starter-camunda-connectors` (30).
- [x] `spotless:apply` clean.

### Verified by falsification, not just green runs

#8538's ledger records that two of its tests initially passed vacuously, so a green test is not treated as evidence. Each protection was re-broken and the named test observed to fail:

| Falsification | Observed |
|---|---|
| Connector-context filter forced off | `secretFilterEnabled_leavesASecretNamedOnlyByAnotherSecretsValue` fails — `expected "secrets.CHAINED"`; `secretFilterEnabled_leavesAnUndeclaredSecret` errors, the name reached the provider |
| Element-context filter forced off | `processElementContextFactory_refusesAChainedNameOnTheActivatedElement` fails — `expected <secrets.CHAINED> but was <leaked-value>` |
| Mode boolean inverted | **both** bean-method assertions fail — `<secrets.CHAINED>` → `<leaked-value>` and `<secrets.UNDECLARED>` → `<resolved>` |
| `@Value` default flipped to `DISABLED` | `InboundSecretFilterDefaultModeWiringTest` fails |

The element-path test is exercised at the factory rather than through `correlate()`, which would need the whole Zeebe publish/create round trip mocked to reach a `Success`. What needs pinning is that the mode reaches the context the correlation handler hands out, and that is this factory — noted in the test's javadoc.

## Scope note

This branch has no `LegacySecretMode`/`FALLBACK` and no `CentralStoreSecretProvider`, so a chained reference can only reach **locally configured** providers — env vars, Spring properties, SPI, custom aggregators — not the cluster secret store. Still a real exfiltration path for any locally-configured secret it names, but a narrower blast radius than main or `stable/8.9`.

## For maintainers: is 8.6 in scope at all?

#8505's head branch was named `backport-7568-to-end-of-life/8.6`, and `stable/8.6` was absent from `origin` earlier today. If 8.6 is genuinely end-of-life, whether this should ship is a release-policy call rather than a technical one — the code is ready either way. Flagging rather than assuming.

## Deliberately omitted

Main's hot-swap, sibling-element and new-form tests are structurally inapplicable on this branch, and are omitted with an in-file comment saying why.

Companion backports: #8600 (`stable/8.9`), #8609 (`stable/8.8`), #8630 (`stable/8.7`).

Relates to #7730
