### PR TITLE
refactor: share the secret-masking string primitive via SecretUtil

### DIFF
--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretUtil.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretUtil.java
@@ -18,6 +18,7 @@ package io.camunda.connector.runtime.core.secret;
 
 import com.fasterxml.jackson.core.io.JsonStringEncoder;
 import io.camunda.connector.api.secret.SecretContext;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
 import java.util.function.Function;
@@ -155,5 +156,17 @@ public class SecretUtil {
             .map(matchResult -> matchResult.group("secret").trim())
             .distinct()
             .toList();
+  }
+
+  // Longest secret first: masking a shorter secret that prefixes a longer one would destroy the
+  // longer match and publish its remainder, e.g. "x" before "xSUPERSECRET" leaves "***SUPERSECRET".
+  public static String hideSecretsFromMessage(String message, List<String> secrets) {
+    if (message == null) {
+      return "";
+    }
+    return secrets.stream()
+        .filter(secret -> !secret.isEmpty())
+        .sorted(Comparator.comparingInt(String::length).reversed())
+        .reduce(message, (newMessage, nextSecret) -> newMessage.replace(nextSecret, "***"));
   }
 }

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/OutboundConnectorExceptionHandler.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/OutboundConnectorExceptionHandler.java
@@ -105,7 +105,7 @@ public class OutboundConnectorExceptionHandler {
   private static Object maskSecrets(Object value, List<String> secrets, Set<Object> enclosing) {
     return switch (value) {
       case null -> null;
-      case String string -> hideSecretsFromMessage(string, secrets);
+      case String string -> SecretUtil.hideSecretsFromMessage(string, secrets);
       case Map<?, ?> map -> {
         // error variables are user-supplied, so a container may contain itself
         if (!enclosing.add(map)) {
@@ -138,7 +138,7 @@ public class OutboundConnectorExceptionHandler {
     map.forEach(
         (key, entry) ->
             masked.put(
-                hideSecretsFromMessage(String.valueOf(key), secrets),
+                SecretUtil.hideSecretsFromMessage(String.valueOf(key), secrets),
                 maskSecrets(entry, secrets, enclosing)));
     return masked;
   }
@@ -475,32 +475,22 @@ public class OutboundConnectorExceptionHandler {
         && (variables == null || variables.isEmpty());
   }
 
-  /** Unlike {@link #hideSecretsFromMessage}, keeps a null message null rather than "". */
+  /** Unlike {@link SecretUtil#hideSecretsFromMessage}, keeps a null message null rather than "". */
   private static String redactNullable(String message, List<String> secrets) {
-    return message == null ? null : hideSecretsFromMessage(message, secrets);
-  }
-
-  private static String hideSecretsFromMessage(String message, List<String> secrets) {
-    if (!Objects.isNull(message))
-      return secrets.stream()
-          // a provider may answer with an empty value, and replacing that matches everywhere
-          .filter(secret -> !secret.isEmpty())
-          // longest first: masking a secret that prefixes another would destroy the longer match
-          // and publish its remainder, e.g. "x" before "xSUPERSECRET" leaves "***SUPERSECRET"
-          .sorted(Comparator.comparingInt(String::length).reversed())
-          .reduce(message, (newMessage, nextSecret) -> newMessage.replace(nextSecret, "***"));
-    else return "";
+    return message == null ? null : SecretUtil.hideSecretsFromMessage(message, secrets);
   }
 
   private ConnectorResult.ErrorResult handleBackOffException(Exception e, List<String> secrets) {
-    Exception newException = new Exception(hideSecretsFromMessage(e.getMessage(), secrets), e);
+    Exception newException =
+        new Exception(SecretUtil.hideSecretsFromMessage(e.getMessage(), secrets), e);
     return new ConnectorResult.ErrorResult(
         Map.of("error", exceptionToMap(newException, secrets)), newException, 0);
   }
 
   private ConnectorResult.ErrorResult handleConnectorRetryException(
       ActivatedJob job, ConnectorRetryException ex, List<String> secrets, Duration retryBackoff) {
-    Exception newException = new Exception(hideSecretsFromMessage(ex.getMessage(), secrets), ex);
+    Exception newException =
+        new Exception(SecretUtil.hideSecretsFromMessage(ex.getMessage(), secrets), ex);
     LOGGER.debug(
         "ConnectorRetryException while processing job: {} for tenant: {}, error message: {}",
         job.getKey(),
@@ -537,7 +527,8 @@ public class OutboundConnectorExceptionHandler {
 
   private ConnectorResult.ErrorResult handleGenericException(
       ActivatedJob job, Exception ex, List<String> secrets, Duration retryBackoff) {
-    Exception newException = new Exception(hideSecretsFromMessage(ex.getMessage(), secrets), ex);
+    Exception newException =
+        new Exception(SecretUtil.hideSecretsFromMessage(ex.getMessage(), secrets), ex);
     LOGGER.debug(
         "Exception while processing job: {} for tenant: {}, message: {}",
         job.getKey(),
@@ -593,7 +584,8 @@ public class OutboundConnectorExceptionHandler {
           Map.of("error", exceptionToMap(wrappedException, List.of())), wrappedException, 0);
     }
     List<String> secrets = masking.secrets();
-    Exception newException = new Exception(hideSecretsFromMessage(ex.getMessage(), secrets), ex);
+    Exception newException =
+        new Exception(SecretUtil.hideSecretsFromMessage(ex.getMessage(), secrets), ex);
     LOGGER.error(
         "Exception while processing job: {} for tenant: {}, message: {}",
         job.getKey(),


### PR DESCRIPTION
## Description

Pure relocation: `hideSecretsFromMessage(String, List<String>)` moved from `OutboundConnectorExceptionHandler` (connector-runtime-spring) to `SecretUtil` (connector-runtime-core, which spring already depends on). No behavior change — outbound now delegates to the shared method instead of keeping its own copy.

This is prep for #8638: inbound redaction (next PR in the stack) needs the same longest-first, empty-skip masking logic. Sharing it means one implementation to keep correct instead of two copies that can drift apart over time.

### Verification

All existing outbound tests pass unchanged, confirming this is behavior-preserving:
- `OutboundConnectorExceptionHandlerTest`: 31/31 passing
- `SpringConnectorJobHandlerTest`: 140/140 passing

## Related issues

Stacked on #8634. Part of #8638.

## Checklist

- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest
  release, as this branch will be rebased onto main before the next release. Example backport labels:
    - `backport stable/8.8`: for changes that should be included in the next 8.8.x release.
    - **or** `backport release-8.8.7`: for changes that should be included in the specific release 8.8.7, and this
      *release has already been created*. The release branch will be merged back into stable/8.8 later, so the change
      will be included in future 8.8.x releases as well.
- [x] Tests/Integration tests for the changes have been added if applicable.
- [ ] If the change requires a documentation update, it has been added to the appropriate section in the documentation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)