### PR TITLE
fix: redact secrets from inbound logs and outbound rotation, share masking primitive

### DIFF
--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextImpl.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextImpl.java
@@ -542,11 +542,11 @@ public class InboundConnectorContextImpl extends AbstractConnectorContext
             redact(builder.build())));
   }
 
-  // every value a SecretHandler this context built ever substituted, immune to a later rotation
+  // captures are only ever unioned into a successful, complete re-read, never a substitute for one
   private @Nullable List<String> secretValuesForRedaction() {
     var reRead = reReadSecretValues();
     if (reRead == null) {
-      return capturedSecretValues.isEmpty() ? null : List.copyOf(capturedSecretValues);
+      return null;
     }
     if (capturedSecretValues.isEmpty()) {
       return reRead;
@@ -692,6 +692,7 @@ public class InboundConnectorContextImpl extends AbstractConnectorContext
               + message);
     }
     connectorDetails = newDetails;
+    reReadSecrets = null;
     logRuntime(
         builder ->
             builder

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextImpl.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextImpl.java
@@ -423,17 +423,21 @@ public class InboundConnectorContextImpl extends AbstractConnectorContext
 
   private <T> T bindElementProperties(
       ValidInboundConnectorDetails details, Map<String, String> rawProperties, Class<T> cls) {
+    var handler = secretHandler(rawProperties);
     try {
       var wrapped = InboundPropertyHandler.readWrappedProperties(rawProperties);
-      var handler = secretHandler(rawProperties);
-      var withSecrets =
-          InboundPropertyHandler.getPropertiesWithSecrets(
-              handler,
-              objectMapper,
-              wrapped,
-              new SecretContext(
-                  details.tenantId(), details.processDefinitionId(), physicalTenantId()));
-      capturedSecretValues.addAll(handler.getResolvedValues());
+      Map<String, Object> withSecrets;
+      try {
+        withSecrets =
+            InboundPropertyHandler.getPropertiesWithSecrets(
+                handler,
+                objectMapper,
+                wrapped,
+                new SecretContext(
+                    details.tenantId(), details.processDefinitionId(), physicalTenantId()));
+      } finally {
+        capturedSecretValues.addAll(handler.getResolvedValues());
+      }
       var propertiesJson = objectMapper.valueToTree(withSecrets);
       var result =
           FeelContextAwareObjectReader.of(objectMapper)
@@ -609,7 +613,8 @@ public class InboundConnectorContextImpl extends AbstractConnectorContext
       return health;
     }
     var error = health.getError();
-    return health.withError(new Health.Error(error.code(), redactMessage(error.message())));
+    return health.withError(
+        new Health.Error(redactMessage(error.code()), redactMessage(error.message())));
   }
 
   private Activity redact(Activity activity) {
@@ -635,16 +640,19 @@ public class InboundConnectorContextImpl extends AbstractConnectorContext
   private Map<String, Object> getPropertiesWithSecrets(Map<String, Object> properties) {
     if (propertiesWithSecrets == null) {
       var handler = getSecretHandler();
-      propertiesWithSecrets =
-          InboundPropertyHandler.getPropertiesWithSecrets(
-              handler,
-              objectMapper,
-              properties,
-              new SecretContext(
-                  connectorDetails.tenantId(),
-                  connectorDetails.processDefinitionId(),
-                  physicalTenantId()));
-      capturedSecretValues.addAll(handler.getResolvedValues());
+      try {
+        propertiesWithSecrets =
+            InboundPropertyHandler.getPropertiesWithSecrets(
+                handler,
+                objectMapper,
+                properties,
+                new SecretContext(
+                    connectorDetails.tenantId(),
+                    connectorDetails.processDefinitionId(),
+                    physicalTenantId()));
+      } finally {
+        capturedSecretValues.addAll(handler.getResolvedValues());
+      }
     }
     return propertiesWithSecrets;
   }

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextImpl.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextImpl.java
@@ -82,6 +82,10 @@ public class InboundConnectorContextImpl extends AbstractConnectorContext
   private volatile ValidInboundConnectorDetails connectorDetails;
   private Health health = Health.unknown();
   private @Nullable Map<String, Object> propertiesWithSecrets;
+  private volatile @Nullable List<String> redactionSecrets;
+
+  private static final String REDACTION_UNAVAILABLE_MESSAGE =
+      "Message withheld: could not verify it does not contain a secret value";
 
   public InboundConnectorContextImpl(
       SecretProvider secretProvider,
@@ -471,7 +475,8 @@ public class InboundConnectorContextImpl extends AbstractConnectorContext
     if (health == null) {
       throw new IllegalArgumentException("Health must not be null");
     }
-    if (health.equals(this.health)) {
+    var masked = redactHealth(health);
+    if (masked.equals(this.health)) {
       return;
     }
     var activityLog =
@@ -480,9 +485,9 @@ public class InboundConnectorContextImpl extends AbstractConnectorContext
             .withMessage(
                 String.format(
                     "Health status changed to %s, details: %s",
-                    health.getStatus(), health.getDetails()))
-            .withSeverity(health.getStatus() == Health.Status.UP ? Severity.INFO : Severity.ERROR)
-            .andReportHealth(health)
+                    masked.getStatus(), masked.getDetails()))
+            .withSeverity(masked.getStatus() == Health.Status.UP ? Severity.INFO : Severity.ERROR)
+            .andReportHealth(masked)
             .build();
     // append the activity log to store the health status change history
     activityLogWriter.log(
@@ -490,7 +495,7 @@ public class InboundConnectorContextImpl extends AbstractConnectorContext
             ExecutableId.fromDeduplicationId(connectorDetails.deduplicationId()),
             ActivitySource.CONNECTOR,
             activityLog));
-    this.health = health;
+    this.health = masked;
   }
 
   @Override
@@ -500,14 +505,15 @@ public class InboundConnectorContextImpl extends AbstractConnectorContext
 
   @Override
   public void log(Activity log) {
-    if (log.healthChange() != null) {
-      this.health = log.healthChange();
+    var masked = redact(log);
+    if (masked.healthChange() != null) {
+      this.health = masked.healthChange();
     }
     activityLogWriter.log(
         new ActivityLogEntry(
             ExecutableId.fromDeduplicationId(connectorDetails.deduplicationId()),
             ActivitySource.CONNECTOR,
-            log));
+            masked));
   }
 
   @Override
@@ -527,7 +533,67 @@ public class InboundConnectorContextImpl extends AbstractConnectorContext
         new ActivityLogEntry(
             ExecutableId.fromDeduplicationId(connectorDetails.deduplicationId()),
             ActivitySource.RUNTIME,
-            builder.build()));
+            redact(builder.build())));
+  }
+
+  // legacy names only, matching the scope of secretFilterEnabled's own allow-list (#7730 tracks
+  // the new camunda.secrets.<name> form for inbound)
+  private List<String> secretValuesForRedaction() {
+    var cached = redactionSecrets;
+    if (cached != null) {
+      return cached;
+    }
+    var values = fetchSecretValuesForRedaction();
+    if (values != null) {
+      redactionSecrets = values;
+    }
+    return values;
+  }
+
+  private @Nullable List<String> fetchSecretValuesForRedaction() {
+    var names = declaredSecretNames(connectorDetails.rawPropertiesWithoutKeywords());
+    if (names.isEmpty()) {
+      return List.of();
+    }
+    try {
+      return secretProvider.fetchAll(names, redactionSecretContext());
+    } catch (Exception e) {
+      LOG.warn("Could not fetch secret values to redact activity log: {}", e.getClass().getName());
+      return null;
+    }
+  }
+
+  private SecretContext redactionSecretContext() {
+    return new SecretContext(
+        connectorDetails.tenantId(), connectorDetails.processDefinitionId(), physicalTenantId());
+  }
+
+  private @Nullable String redactMessage(@Nullable String message) {
+    if (message == null) {
+      return null;
+    }
+    var secrets = secretValuesForRedaction();
+    return secrets == null
+        ? REDACTION_UNAVAILABLE_MESSAGE
+        : SecretUtil.hideSecretsFromMessage(message, secrets);
+  }
+
+  private @Nullable Health redactHealth(@Nullable Health health) {
+    if (health == null || health.getError() == null) {
+      return health;
+    }
+    var error = health.getError();
+    return health.withError(new Health.Error(error.code(), redactMessage(error.message())));
+  }
+
+  private Activity redact(Activity activity) {
+    return new Activity(
+        activity.severity(),
+        activity.tag(),
+        activity.timestamp(),
+        redactMessage(activity.message()),
+        activity.data(),
+        redactHealth(activity.healthChange()));
   }
 
   @Override

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextImpl.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextImpl.java
@@ -56,9 +56,12 @@ import io.camunda.connector.runtime.core.secret.SecretReferenceResolver;
 import io.camunda.connector.runtime.core.secret.SecretResolvingResultProcessor;
 import io.camunda.connector.runtime.core.secret.SecretUtil;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import org.jspecify.annotations.Nullable;
@@ -82,7 +85,8 @@ public class InboundConnectorContextImpl extends AbstractConnectorContext
   private volatile ValidInboundConnectorDetails connectorDetails;
   private Health health = Health.unknown();
   private @Nullable Map<String, Object> propertiesWithSecrets;
-  private volatile @Nullable List<String> redactionSecrets;
+  private volatile @Nullable List<String> reReadSecrets;
+  private final Set<String> capturedSecretValues = ConcurrentHashMap.newKeySet();
 
   private static final String REDACTION_UNAVAILABLE_MESSAGE =
       "Message withheld: could not verify it does not contain a secret value";
@@ -421,13 +425,15 @@ public class InboundConnectorContextImpl extends AbstractConnectorContext
       ValidInboundConnectorDetails details, Map<String, String> rawProperties, Class<T> cls) {
     try {
       var wrapped = InboundPropertyHandler.readWrappedProperties(rawProperties);
+      var handler = secretHandler(rawProperties);
       var withSecrets =
           InboundPropertyHandler.getPropertiesWithSecrets(
-              secretHandler(rawProperties),
+              handler,
               objectMapper,
               wrapped,
               new SecretContext(
                   details.tenantId(), details.processDefinitionId(), physicalTenantId()));
+      capturedSecretValues.addAll(handler.getResolvedValues());
       var propertiesJson = objectMapper.valueToTree(withSecrets);
       var result =
           FeelContextAwareObjectReader.of(objectMapper)
@@ -536,27 +542,47 @@ public class InboundConnectorContextImpl extends AbstractConnectorContext
             redact(builder.build())));
   }
 
-  // legacy names only, matching the scope of secretFilterEnabled's own allow-list (#7730 tracks
-  // the new camunda.secrets.<name> form for inbound)
-  private List<String> secretValuesForRedaction() {
-    var cached = redactionSecrets;
+  // every value a SecretHandler this context built ever substituted, immune to a later rotation
+  private @Nullable List<String> secretValuesForRedaction() {
+    var reRead = reReadSecretValues();
+    if (reRead == null) {
+      return capturedSecretValues.isEmpty() ? null : List.copyOf(capturedSecretValues);
+    }
+    if (capturedSecretValues.isEmpty()) {
+      return reRead;
+    }
+    var union = new ArrayList<>(reRead);
+    union.addAll(capturedSecretValues);
+    return union;
+  }
+
+  private @Nullable List<String> reReadSecretValues() {
+    var cached = reReadSecrets;
     if (cached != null) {
       return cached;
     }
     var values = fetchSecretValuesForRedaction();
     if (values != null) {
-      redactionSecrets = values;
+      reReadSecrets = values;
     }
     return values;
   }
 
+  // legacy names across every grouped element, not just this context's representative one
   private @Nullable List<String> fetchSecretValuesForRedaction() {
-    var names = declaredSecretNames(connectorDetails.rawPropertiesWithoutKeywords());
+    var names =
+        connectorDetails.connectorElements().stream()
+            .flatMap(element -> element.rawProperties().values().stream())
+            .flatMap(value -> SecretUtil.retrieveLegacySecretKeysInInput(value).stream())
+            .distinct()
+            .toList();
     if (names.isEmpty()) {
       return List.of();
     }
     try {
-      return secretProvider.fetchAll(names, redactionSecretContext());
+      var values = secretProvider.fetchAll(names, redactionSecretContext());
+      // fewer values than names means a partial read, treated the same as a failed one
+      return values.size() < names.size() ? null : values;
     } catch (Exception e) {
       LOG.warn("Could not fetch secret values to redact activity log: {}", e.getClass().getName());
       return null;
@@ -608,15 +634,17 @@ public class InboundConnectorContextImpl extends AbstractConnectorContext
 
   private Map<String, Object> getPropertiesWithSecrets(Map<String, Object> properties) {
     if (propertiesWithSecrets == null) {
+      var handler = getSecretHandler();
       propertiesWithSecrets =
           InboundPropertyHandler.getPropertiesWithSecrets(
-              getSecretHandler(),
+              handler,
               objectMapper,
               properties,
               new SecretContext(
                   connectorDetails.tenantId(),
                   connectorDetails.processDefinitionId(),
                   physicalTenantId()));
+      capturedSecretValues.addAll(handler.getResolvedValues());
     }
     return propertiesWithSecrets;
   }

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextImpl.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextImpl.java
@@ -486,7 +486,7 @@ public class InboundConnectorContextImpl extends AbstractConnectorContext
       throw new IllegalArgumentException("Health must not be null");
     }
     var masked = redactHealth(health);
-    if (masked.equals(this.health)) {
+    if (!isWithheld(masked) && masked.equals(this.health)) {
       return;
     }
     var activityLog =
@@ -606,6 +606,12 @@ public class InboundConnectorContextImpl extends AbstractConnectorContext
     return secrets == null
         ? REDACTION_UNAVAILABLE_MESSAGE
         : SecretUtil.hideSecretsFromMessage(message, secrets);
+  }
+
+  // an unmaskable health can't be verified as a repeat either, so it must never be deduped away
+  private static boolean isWithheld(Health health) {
+    return health.getError() != null
+        && REDACTION_UNAVAILABLE_MESSAGE.equals(health.getError().message());
   }
 
   private @Nullable Health redactHealth(@Nullable Health health) {

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretHandler.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretHandler.java
@@ -20,7 +20,8 @@ import io.camunda.connector.api.secret.SecretContext;
 import io.camunda.connector.api.secret.SecretProvider;
 import java.util.List;
 import java.util.Optional;
-import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -33,7 +34,7 @@ public class SecretHandler {
   protected SecretReplacer secretReplacer;
 
   // values this instance substituted, so a caller can redact against a rotated re-read
-  private final List<String> resolvedValues = new CopyOnWriteArrayList<>();
+  private final Set<String> resolvedValues = ConcurrentHashMap.newKeySet();
 
   public SecretHandler(final SecretProvider secretProvider, SecretFilter secretFilter) {
     this.secretProvider = secretProvider;

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretHandler.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretHandler.java
@@ -18,7 +18,9 @@ package io.camunda.connector.runtime.core.secret;
 
 import io.camunda.connector.api.secret.SecretContext;
 import io.camunda.connector.api.secret.SecretProvider;
+import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.CopyOnWriteArrayList;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -30,13 +32,19 @@ public class SecretHandler {
 
   protected SecretReplacer secretReplacer;
 
+  // values this instance substituted, so a caller can redact against a rotated re-read
+  private final List<String> resolvedValues = new CopyOnWriteArrayList<>();
+
   public SecretHandler(final SecretProvider secretProvider, SecretFilter secretFilter) {
     this.secretProvider = secretProvider;
     secretReplacer =
         (name, context) -> {
           if (secretFilter.isAllowed(name)) {
-            return Optional.ofNullable(secretProvider.getSecret(name, context))
-                .orElseThrow(() -> new SecretNotAvailableException(name));
+            var value =
+                Optional.ofNullable(secretProvider.getSecret(name, context))
+                    .orElseThrow(() -> new SecretNotAvailableException(name));
+            resolvedValues.add(value);
+            return value;
           }
           LOG.debug("Secret '{}' not in allow-list — placeholder left unreplaced", name);
           return null;
@@ -45,5 +53,9 @@ public class SecretHandler {
 
   public String replaceSecrets(String input, SecretContext context) {
     return SecretUtil.replaceSecrets(input, context, secretReplacer);
+  }
+
+  public List<String> getResolvedValues() {
+    return List.copyOf(resolvedValues);
   }
 }

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretHandler.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretHandler.java
@@ -44,6 +44,8 @@ public class SecretHandler {
                 Optional.ofNullable(secretProvider.getSecret(name, context))
                     .orElseThrow(() -> new SecretNotAvailableException(name));
             resolvedValues.add(value);
+            // the substituted JSON carries this form, not the raw value, when it differs
+            resolvedValues.add(SecretUtil.jsonEscape(value));
             return value;
           }
           LOG.debug("Secret '{}' not in allow-list — placeholder left unreplaced", name);

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretUtil.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretUtil.java
@@ -18,6 +18,7 @@ package io.camunda.connector.runtime.core.secret;
 
 import com.fasterxml.jackson.core.io.JsonStringEncoder;
 import io.camunda.connector.api.secret.SecretContext;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -128,5 +129,17 @@ public class SecretUtil {
             .flatMap(match -> Stream.of(groups).map(match::group))
             .filter(Objects::nonNull)
             .distinct();
+  }
+
+  // Longest secret first: masking a shorter secret that prefixes a longer one would destroy the
+  // longer match and publish its remainder, e.g. "x" before "xSUPERSECRET" leaves "***SUPERSECRET".
+  public static String hideSecretsFromMessage(String message, List<String> secrets) {
+    if (message == null) {
+      return "";
+    }
+    return secrets.stream()
+        .filter(secret -> !secret.isEmpty())
+        .sorted(Comparator.comparingInt(String::length).reversed())
+        .reduce(message, (newMessage, nextSecret) -> newMessage.replace(nextSecret, "***"));
   }
 }

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretUtil.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretUtil.java
@@ -54,8 +54,13 @@ public class SecretUtil {
         REFERENCE,
         matcher -> {
           String value = resolve(legacyName(matcher), context, secretReplacer, resolutions);
-          return value == null ? matcher.group() : new String(encoder.quoteAsString(value));
+          return value == null ? matcher.group() : jsonEscape(value);
         });
+  }
+
+  // the form actually spliced into the substituted JSON, which a raw-value capture would miss
+  public static String jsonEscape(String value) {
+    return new String(encoder.quoteAsString(value));
   }
 
   public static String replaceTokens(

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextImplTest.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextImplTest.java
@@ -622,6 +622,117 @@ class InboundConnectorContextImplTest {
   }
 
   @Test
+  void log_masksASecretResolvedForThisConnector() {
+    // given a connector declaring a legacy secret this context can resolve
+    var definition = getInboundConnectorDefinition(Map.of("token", "secrets.FOO"));
+    var context =
+        new InboundConnectorContextImpl(
+            secretProvider,
+            (e) -> {},
+            definition,
+            null,
+            (e) -> {},
+            mapper,
+            activityLogRegistry,
+            camundaClient);
+
+    // when an activity's message happens to carry the resolved value
+    context.log(activity -> activity.withSeverity(Severity.ERROR).withMessage("token was bar"));
+
+    // then the logged message has the value masked
+    var logs =
+        activityLogRegistry.getLogs(ExecutableId.fromDeduplicationId(definition.deduplicationId()));
+    assertThat(logs)
+        .singleElement()
+        .satisfies(log -> assertThat(log.message()).isEqualTo("token was ***"));
+  }
+
+  @Test
+  void log_withholdsMessageWhenSecretValuesCannotBeFetched() {
+    // given a provider that fails to resolve the declared secret
+    var definition = getInboundConnectorDefinition(Map.of("token", "secrets.FOO"));
+    var failingProvider = mock(SecretProvider.class);
+    when(failingProvider.fetchAll(any(), any())).thenThrow(new RuntimeException("down"));
+    var context =
+        new InboundConnectorContextImpl(
+            failingProvider,
+            (e) -> {},
+            definition,
+            null,
+            (e) -> {},
+            mapper,
+            activityLogRegistry,
+            camundaClient);
+
+    // when
+    context.log(activity -> activity.withSeverity(Severity.ERROR).withMessage("token was bar"));
+
+    // then the raw message is withheld rather than published unmasked
+    var logs =
+        activityLogRegistry.getLogs(ExecutableId.fromDeduplicationId(definition.deduplicationId()));
+    assertThat(logs)
+        .singleElement()
+        .satisfies(
+            log -> {
+              assertThat(log.message()).doesNotContain("bar");
+              assertThat(log.message()).contains("withheld");
+            });
+  }
+
+  @Test
+  void reportHealth_masksASecretInTheErrorMessage() {
+    // given
+    var definition = getInboundConnectorDefinition(Map.of("token", "secrets.FOO"));
+    var context =
+        new InboundConnectorContextImpl(
+            secretProvider,
+            (e) -> {},
+            definition,
+            null,
+            (e) -> {},
+            mapper,
+            activityLogRegistry,
+            camundaClient);
+
+    // when the reported health carries the resolved value in its error
+    context.reportHealth(Health.down(new RuntimeException("token was bar")));
+
+    // then it is masked both in the stored health and in the activity log
+    assertThat(context.getHealth().getError().message()).doesNotContain("bar");
+    var logs =
+        activityLogRegistry.getLogs(ExecutableId.fromDeduplicationId(definition.deduplicationId()));
+    assertThat(logs)
+        .singleElement()
+        .satisfies(
+            log -> assertThat(log.healthChange().getError().message()).doesNotContain("bar"));
+  }
+
+  @Test
+  void reportHealth_dedupesIdenticalHealthAfterMasking() {
+    // given
+    var definition = getInboundConnectorDefinition(Map.of("token", "secrets.FOO"));
+    var context =
+        new InboundConnectorContextImpl(
+            secretProvider,
+            (e) -> {},
+            definition,
+            null,
+            (e) -> {},
+            mapper,
+            activityLogRegistry,
+            camundaClient);
+
+    // when the same failure is reported twice
+    context.reportHealth(Health.down(new RuntimeException("token was bar")));
+    context.reportHealth(Health.down(new RuntimeException("token was bar")));
+
+    // then the second report is deduped against the masked, not the raw, health
+    var logs =
+        activityLogRegistry.getLogs(ExecutableId.fromDeduplicationId(definition.deduplicationId()));
+    assertThat(logs).hasSize(1);
+  }
+
+  @Test
   void bindProperties_shouldForwardClusterVariableExpressionToCluster() {
     // given a property referencing a cluster-scoped variable (e.g. camunda.vars.env.*)
     var definition =

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextImplTest.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextImplTest.java
@@ -733,6 +733,104 @@ class InboundConnectorContextImplTest {
   }
 
   @Test
+  void log_masksASecretThatRotatedAfterItWasBound() {
+    // given a provider that resolves FOO to one value at bind time and a different one on re-read
+    var definition = getInboundConnectorDefinition(Map.of("token", "secrets.FOO"));
+    var rotatingProvider = mock(SecretProvider.class);
+    when(rotatingProvider.getSecret(eq("FOO"), any())).thenReturn("old-value");
+    when(rotatingProvider.fetchAll(any(), any())).thenReturn(List.of("new-value"));
+    var context =
+        new InboundConnectorContextImpl(
+            rotatingProvider,
+            (e) -> {},
+            definition,
+            null,
+            (e) -> {},
+            mapper,
+            activityLogRegistry,
+            camundaClient);
+
+    // when the bound value is used, binding first so it is actually substituted and captured
+    context.getProperties();
+    context.log(
+        activity -> activity.withSeverity(Severity.ERROR).withMessage("token was old-value"));
+
+    // then the bound value is redacted even though a re-read would return a different one
+    var logs =
+        activityLogRegistry.getLogs(ExecutableId.fromDeduplicationId(definition.deduplicationId()));
+    assertThat(logs).last().satisfies(log -> assertThat(log.message()).isEqualTo("token was ***"));
+  }
+
+  @Test
+  void log_withholdsMessageWhenTheReReadComesBackShort() {
+    // given a provider declaring two secrets but only resolving one of them on re-read
+    var definition = getInboundConnectorDefinition(Map.of("a", "secrets.FOO", "b", "secrets.BAR"));
+    var partialProvider = mock(SecretProvider.class);
+    when(partialProvider.fetchAll(any(), any())).thenReturn(List.of("only-one-value"));
+    var context =
+        new InboundConnectorContextImpl(
+            partialProvider,
+            (e) -> {},
+            definition,
+            null,
+            (e) -> {},
+            mapper,
+            activityLogRegistry,
+            camundaClient);
+
+    // when nothing was ever bound, so only the (incomplete) re-read is available
+    context.log(activity -> activity.withSeverity(Severity.ERROR).withMessage("token was leaked"));
+
+    // then the message is withheld rather than published with only one of the two values masked
+    var logs =
+        activityLogRegistry.getLogs(ExecutableId.fromDeduplicationId(definition.deduplicationId()));
+    assertThat(logs)
+        .singleElement()
+        .satisfies(log -> assertThat(log.message()).contains("withheld"));
+  }
+
+  @Test
+  void log_masksASecretDeclaredOnlyByAGroupedSiblingElement() {
+    // given a group where only the sibling element (not this context's representative one)
+    // declares a secret
+    var scope = List.of("shared");
+    var representative = elementWithProperties("a", Map.of("shared", "x"));
+    var sibling = elementWithProperties("b", Map.of("shared", "x", "token", "secrets.FOO"));
+    var correlationHandler = mock(InboundCorrelationHandler.class);
+    when(correlationHandler.correlate(any(), any()))
+        .thenReturn(
+            new CorrelationResult.Success.ProcessInstanceCreated(
+                sibling.element(), 1L, "<default>"));
+    var context =
+        new InboundConnectorContextImpl(
+            secretProvider,
+            (e) -> {},
+            mock(DocumentFactory.class),
+            detailsOf(scope, representative, sibling),
+            correlationHandler,
+            (e) -> {},
+            mapper,
+            activityLogRegistry,
+            camundaClient);
+
+    // when the sibling is the one activated and bound
+    var success =
+        (CorrelationResult.Success)
+            context.correlate(CorrelationRequest.builder().variables(Map.of()).build());
+    success.bindProperties(TokenHolder.class);
+    context.log(activity -> activity.withSeverity(Severity.ERROR).withMessage("token was bar"));
+
+    // then its secret is still redacted, even though it is absent from the representative
+    // element's own properties
+    var logs =
+        activityLogRegistry.getLogs(
+            ExecutableId.fromDeduplicationId(context.getDefinition().deduplicationId()));
+    assertThat(logs).last().satisfies(log -> assertThat(log.message()).isEqualTo("token was ***"));
+  }
+
+  private record TokenHolder(String token) {}
+
+  @Test
   void bindProperties_shouldForwardClusterVariableExpressionToCluster() {
     // given a property referencing a cluster-scoped variable (e.g. camunda.vars.env.*)
     var definition =

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextImplTest.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextImplTest.java
@@ -733,6 +733,33 @@ class InboundConnectorContextImplTest {
   }
 
   @Test
+  void reportHealth_doesNotDedupeTwoDifferentUnmaskableFailures() {
+    // given a provider that is down, so every health report is withheld
+    var definition = getInboundConnectorDefinition(Map.of("token", "secrets.FOO"));
+    var downProvider = mock(SecretProvider.class);
+    when(downProvider.fetchAll(any(), any())).thenThrow(new RuntimeException("down"));
+    var context =
+        new InboundConnectorContextImpl(
+            downProvider,
+            (e) -> {},
+            definition,
+            null,
+            (e) -> {},
+            mapper,
+            activityLogRegistry,
+            camundaClient);
+
+    // when two distinct failures are reported during the outage
+    context.reportHealth(Health.down(new RuntimeException("kafka broker unreachable")));
+    context.reportHealth(Health.down(new RuntimeException("deserialization failed")));
+
+    // then both are logged rather than the second being deduped against the first
+    var logs =
+        activityLogRegistry.getLogs(ExecutableId.fromDeduplicationId(definition.deduplicationId()));
+    assertThat(logs).hasSize(2);
+  }
+
+  @Test
   void log_masksASecretThatRotatedAfterItWasBound() {
     // given a provider that resolves FOO to one value at bind time and a different one on re-read
     var definition = getInboundConnectorDefinition(Map.of("token", "secrets.FOO"));

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/OutboundConnectorExceptionHandler.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/OutboundConnectorExceptionHandler.java
@@ -107,7 +107,7 @@ public class OutboundConnectorExceptionHandler {
   private static Object maskSecrets(Object value, List<String> secrets, Set<Object> enclosing) {
     return switch (value) {
       case null -> null;
-      case String string -> hideSecretsFromMessage(string, secrets);
+      case String string -> SecretUtil.hideSecretsFromMessage(string, secrets);
       case Map<?, ?> map -> {
         // error variables are user-supplied, so a container may contain itself
         if (!enclosing.add(map)) {
@@ -140,7 +140,7 @@ public class OutboundConnectorExceptionHandler {
     map.forEach(
         (key, entry) ->
             masked.put(
-                hideSecretsFromMessage(String.valueOf(key), secrets),
+                SecretUtil.hideSecretsFromMessage(String.valueOf(key), secrets),
                 maskSecrets(entry, secrets, enclosing)));
     return masked;
   }
@@ -489,32 +489,22 @@ public class OutboundConnectorExceptionHandler {
         && (variables == null || variables.isEmpty());
   }
 
-  /** Unlike {@link #hideSecretsFromMessage}, keeps a null message null rather than "". */
+  /** Unlike {@link SecretUtil#hideSecretsFromMessage}, keeps a null message null rather than "". */
   private static String redactNullable(String message, List<String> secrets) {
-    return message == null ? null : hideSecretsFromMessage(message, secrets);
-  }
-
-  private static String hideSecretsFromMessage(String message, List<String> secrets) {
-    if (!Objects.isNull(message))
-      return secrets.stream()
-          // a provider may answer with an empty value, and replacing that matches everywhere
-          .filter(secret -> !secret.isEmpty())
-          // longest first: masking a secret that prefixes another would destroy the longer match
-          // and publish its remainder, e.g. "x" before "xSUPERSECRET" leaves "***SUPERSECRET"
-          .sorted(Comparator.comparingInt(String::length).reversed())
-          .reduce(message, (newMessage, nextSecret) -> newMessage.replace(nextSecret, "***"));
-    else return "";
+    return message == null ? null : SecretUtil.hideSecretsFromMessage(message, secrets);
   }
 
   private ConnectorResult.ErrorResult handleBackOffException(Exception e, List<String> secrets) {
-    Exception newException = new Exception(hideSecretsFromMessage(e.getMessage(), secrets), e);
+    Exception newException =
+        new Exception(SecretUtil.hideSecretsFromMessage(e.getMessage(), secrets), e);
     return new ConnectorResult.ErrorResult(
         Map.of("error", exceptionToMap(newException, secrets)), newException, 0);
   }
 
   private ConnectorResult.ErrorResult handleConnectorRetryException(
       ActivatedJob job, ConnectorRetryException ex, List<String> secrets, Duration retryBackoff) {
-    Exception newException = new Exception(hideSecretsFromMessage(ex.getMessage(), secrets), ex);
+    Exception newException =
+        new Exception(SecretUtil.hideSecretsFromMessage(ex.getMessage(), secrets), ex);
     LOGGER.debug(
         "ConnectorRetryException while processing job: {} for tenant: {}, error message: {}",
         job.getKey(),
@@ -551,7 +541,8 @@ public class OutboundConnectorExceptionHandler {
 
   private ConnectorResult.ErrorResult handleGenericException(
       ActivatedJob job, Exception ex, List<String> secrets, Duration retryBackoff) {
-    Exception newException = new Exception(hideSecretsFromMessage(ex.getMessage(), secrets), ex);
+    Exception newException =
+        new Exception(SecretUtil.hideSecretsFromMessage(ex.getMessage(), secrets), ex);
     LOGGER.debug(
         "Exception while processing job: {} for tenant: {}, message: {}",
         job.getKey(),
@@ -607,7 +598,8 @@ public class OutboundConnectorExceptionHandler {
           Map.of("error", exceptionToMap(wrappedException, List.of())), wrappedException, 0);
     }
     List<String> secrets = masking.secrets();
-    Exception newException = new Exception(hideSecretsFromMessage(ex.getMessage(), secrets), ex);
+    Exception newException =
+        new Exception(SecretUtil.hideSecretsFromMessage(ex.getMessage(), secrets), ex);
     LOGGER.error(
         "Exception while processing job: {} for tenant: {}, message: {}",
         job.getKey(),

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/OutboundConnectorExceptionHandler.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/OutboundConnectorExceptionHandler.java
@@ -170,6 +170,16 @@ public class OutboundConnectorExceptionHandler {
     }
   }
 
+  // unions bind-time captures into a successful re-read, so a rotated secret is still redacted
+  private static List<String> withCaptured(MaskingSecrets masking, List<String> captured) {
+    if (captured.isEmpty()) {
+      return masking.secrets();
+    }
+    var union = new ArrayList<String>(masking.secrets());
+    union.addAll(captured);
+    return union;
+  }
+
   /**
    * Reads the values to redact. A provider may refuse a key outright — legacy resolution switched
    * off, a name that cannot be migrated — and it throws here for keys this fetch only ever wanted
@@ -396,7 +406,11 @@ public class OutboundConnectorExceptionHandler {
   }
 
   public ConnectorResult.ErrorResult manageConnectorJobHandlerException(
-      Exception e, ActivatedJob job, Duration retryBackoffDuration, SecretFilter secretFilter) {
+      Exception e,
+      ActivatedJob job,
+      Duration retryBackoffDuration,
+      SecretFilter secretFilter,
+      List<String> capturedSecrets) {
     if (e instanceof SecretAllowListUnavailableException) {
       return handleGenericException(job, e, List.of(), retryBackoffFor(e, retryBackoffDuration));
     }
@@ -418,7 +432,7 @@ public class OutboundConnectorExceptionHandler {
           retries,
           retryBackoffFor(masking.failure(), retryBackoffDuration));
     }
-    List<String> secrets = masking.secrets();
+    List<String> secrets = withCaptured(masking, capturedSecrets);
     return switch (e) {
       case InvalidBackOffDurationException invalidBackOffDurationException ->
           handleBackOffException(invalidBackOffDurationException, secrets);
@@ -434,17 +448,25 @@ public class OutboundConnectorExceptionHandler {
 
   /** Redacts expression-chosen variables that are about to be published as a diagnostic. */
   public Map<String, Object> maskDiagnosticVariables(
-      Map<String, Object> variables, ActivatedJob job, SecretFilter secretFilter) {
+      Map<String, Object> variables,
+      ActivatedJob job,
+      SecretFilter secretFilter,
+      List<String> capturedSecrets) {
     if (variables == null || variables.isEmpty()) {
       return variables;
     }
     var masking = fetchSecretsForMasking(job, secretFilter, null);
-    return masking.unavailable() ? Map.of() : maskVariables(variables, masking.secrets());
+    return masking.unavailable()
+        ? Map.of()
+        : maskVariables(variables, withCaptured(masking, capturedSecrets));
   }
 
   /** Redacts an error an error expression produced; {@code failJob}/{@code throwError} do not. */
   public ConnectorError maskConnectorError(
-      ConnectorError error, ActivatedJob job, SecretFilter secretFilter) {
+      ConnectorError error,
+      ActivatedJob job,
+      SecretFilter secretFilter,
+      List<String> capturedSecrets) {
     return switch (error) {
       // business output on the branch that completes the job; the branch that raises an incident
       // instead redacts them itself, via maskDiagnosticVariables
@@ -455,30 +477,34 @@ public class OutboundConnectorExceptionHandler {
         }
         var masking = fetchSecretsForMasking(job, secretFilter, null);
         // the error code is never redacted: boundary events match on it
-        yield masking.unavailable()
-            ? new BpmnError(
-                bpmnError.errorCode(), unmaskableError(masking.failure()).getMessage(), Map.of())
-            : new BpmnError(
-                bpmnError.errorCode(),
-                redactNullable(bpmnError.errorMessage(), masking.secrets()),
-                maskVariables(bpmnError.variables(), masking.secrets()));
+        if (masking.unavailable()) {
+          yield new BpmnError(
+              bpmnError.errorCode(), unmaskableError(masking.failure()).getMessage(), Map.of());
+        }
+        var secrets = withCaptured(masking, capturedSecrets);
+        yield new BpmnError(
+            bpmnError.errorCode(),
+            redactNullable(bpmnError.errorMessage(), secrets),
+            maskVariables(bpmnError.variables(), secrets));
       }
       case JobError jobError -> {
         if (nothingToRedact(jobError.errorMessage(), jobError.variables())) {
           yield jobError;
         }
         var masking = fetchSecretsForMasking(job, secretFilter, null);
-        yield masking.unavailable()
-            ? new JobError(
-                unmaskableError(masking.failure()).getMessage(),
-                Map.of(),
-                jobError.retries(),
-                jobError.retryBackoff())
-            : new JobError(
-                redactNullable(jobError.errorMessage(), masking.secrets()),
-                maskVariables(jobError.variables(), masking.secrets()),
-                jobError.retries(),
-                jobError.retryBackoff());
+        if (masking.unavailable()) {
+          yield new JobError(
+              unmaskableError(masking.failure()).getMessage(),
+              Map.of(),
+              jobError.retries(),
+              jobError.retryBackoff());
+        }
+        var secrets = withCaptured(masking, capturedSecrets);
+        yield new JobError(
+            redactNullable(jobError.errorMessage(), secrets),
+            maskVariables(jobError.variables(), secrets),
+            jobError.retries(),
+            jobError.retryBackoff());
       }
     };
   }
@@ -584,7 +610,7 @@ public class OutboundConnectorExceptionHandler {
    * withholding it there would leave the runtime silent about why.
    */
   public ConnectorResult.ErrorResult handleFinalResultException(
-      Exception ex, ActivatedJob job, SecretFilter secretFilter) {
+      Exception ex, ActivatedJob job, SecretFilter secretFilter, List<String> capturedSecrets) {
     var masking = fetchSecretsForMasking(job, secretFilter, ex);
     if (masking.unavailable()) {
       LOGGER.error(
@@ -597,7 +623,7 @@ public class OutboundConnectorExceptionHandler {
       return new ConnectorResult.ErrorResult(
           Map.of("error", exceptionToMap(wrappedException, List.of())), wrappedException, 0);
     }
-    List<String> secrets = masking.secrets();
+    List<String> secrets = withCaptured(masking, capturedSecrets);
     Exception newException =
         new Exception(SecretUtil.hideSecretsFromMessage(ex.getMessage(), secrets), ex);
     LOGGER.error(

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/SpringConnectorJobHandler.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/SpringConnectorJobHandler.java
@@ -228,7 +228,7 @@ public class SpringConnectorJobHandler implements JobHandler {
   private record ResultWithDeadline(ConnectorResult result, long deadline) {}
 
   private ResultWithDeadline getConnectorResult(
-      ActivatedJob job, OutboundConnectorContext context, SecretFilter secretFilter) {
+      ActivatedJob job, JobHandlerContext context, SecretFilter secretFilter) {
     Duration retryBackoff = null;
     long deadline = job.getDeadline();
     try {
@@ -271,7 +271,7 @@ public class SpringConnectorJobHandler implements JobHandler {
     } catch (Exception e) {
       return new ResultWithDeadline(
           outboundConnectorExceptionHandler.manageConnectorJobHandlerException(
-              e, job, retryBackoff, secretFilter),
+              e, job, retryBackoff, secretFilter, context.getSecretHandler().getResolvedValues()),
           deadline);
     }
   }
@@ -420,7 +420,7 @@ public class SpringConnectorJobHandler implements JobHandler {
   private void processFinalResult(
       JobClient client,
       ActivatedJob job,
-      OutboundConnectorContext context,
+      JobHandlerContext context,
       ConnectorResult finalResult,
       CounterMetricsContext counterMetricsContext,
       SecretFilter secretFilter,
@@ -471,7 +471,7 @@ public class SpringConnectorJobHandler implements JobHandler {
               client,
               job,
               this.outboundConnectorExceptionHandler.handleFinalResultException(
-                  ex, job, secretFilter),
+                  ex, job, secretFilter, context.getSecretHandler().getResolvedValues()),
               counterMetricsContext,
               deadline);
       notifyFailureOnCommandOutcome(
@@ -516,7 +516,7 @@ public class SpringConnectorJobHandler implements JobHandler {
   private void handleConnectorError(
       JobClient client,
       ActivatedJob job,
-      OutboundConnectorContext context,
+      JobHandlerContext context,
       ConnectorResult finalResult,
       ConnectorError rawError,
       CounterMetricsContext counterMetricsContext,
@@ -524,7 +524,9 @@ public class SpringConnectorJobHandler implements JobHandler {
       long deadline) {
     var response = connectorResponseOrNull(finalResult);
     // redacted before the Zeebe command and the listener payload are built from it
-    var error = outboundConnectorExceptionHandler.maskConnectorError(rawError, job, secretFilter);
+    var error =
+        outboundConnectorExceptionHandler.maskConnectorError(
+            rawError, job, secretFilter, context.getSecretHandler().getResolvedValues());
 
     switch (error) {
       case BpmnError bpmnError -> {
@@ -586,7 +588,7 @@ public class SpringConnectorJobHandler implements JobHandler {
   private void handleIgnoreError(
       JobClient client,
       ActivatedJob job,
-      OutboundConnectorContext context,
+      JobHandlerContext context,
       ConnectorResult finalResult,
       ConnectorResponse response,
       IgnoreError ignoreError,
@@ -604,7 +606,10 @@ public class SpringConnectorJobHandler implements JobHandler {
       // message - redacted here, unlike on the completion branch below
       var variables =
           outboundConnectorExceptionHandler.maskDiagnosticVariables(
-              ignoreError.variables(), job, secretFilter);
+              ignoreError.variables(),
+              job,
+              secretFilter,
+              context.getSecretHandler().getResolvedValues());
       CompletableFuture<CommandOutcome> failJobRequest =
           failJob(
               client,

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/job/OutboundConnectorExceptionHandlerTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/job/OutboundConnectorExceptionHandlerTest.java
@@ -87,7 +87,11 @@ class OutboundConnectorExceptionHandlerTest {
     when(secretProvider.fetchAll(any(), any())).thenReturn(List.of("secret-value"));
 
     handler.manageConnectorJobHandlerException(
-        new RuntimeException("boom"), job, Duration.ofSeconds(1), SecretFilter.allowAll());
+        new RuntimeException("boom"),
+        job,
+        Duration.ofSeconds(1),
+        SecretFilter.allowAll(),
+        List.of());
 
     assertThat(captureSecretContext())
         .isEqualTo(new SecretContext("my-tenant", "my-process", "engine-1"));
@@ -104,7 +108,11 @@ class OutboundConnectorExceptionHandlerTest {
 
     var result =
         handler.manageConnectorJobHandlerException(
-            new RuntimeException("boom"), job, Duration.ofSeconds(1), SecretFilter.allowAll());
+            new RuntimeException("boom"),
+            job,
+            Duration.ofSeconds(1),
+            SecretFilter.allowAll(),
+            List.of());
 
     assertThat(result.retries()).isZero();
   }
@@ -117,7 +125,11 @@ class OutboundConnectorExceptionHandlerTest {
 
     var result =
         handler.manageConnectorJobHandlerException(
-            new RuntimeException("boom"), job, Duration.ofSeconds(1), SecretFilter.allowAll());
+            new RuntimeException("boom"),
+            job,
+            Duration.ofSeconds(1),
+            SecretFilter.allowAll(),
+            List.of());
 
     assertThat(result.retries()).isEqualTo(2);
   }
@@ -135,7 +147,11 @@ class OutboundConnectorExceptionHandlerTest {
 
     var result =
         handler.manageConnectorJobHandlerException(
-            new RuntimeException("boom"), job, Duration.ofSeconds(1), SecretFilter.allowAll());
+            new RuntimeException("boom"),
+            job,
+            Duration.ofSeconds(1),
+            SecretFilter.allowAll(),
+            List.of());
 
     assertThat(result.retries()).isEqualTo(2);
   }
@@ -154,7 +170,8 @@ class OutboundConnectorExceptionHandlerTest {
             new ConnectorInputException("secret 'FOO' is not available"),
             job,
             Duration.ofSeconds(1),
-            SecretFilter.allowAll());
+            SecretFilter.allowAll(),
+            List.of());
 
     assertThat(result.retries()).isZero();
   }
@@ -171,7 +188,8 @@ class OutboundConnectorExceptionHandlerTest {
                     + " (io.camunda.client.api.command.ProblemException)"),
             job,
             null,
-            SecretFilter.allowAll());
+            SecretFilter.allowAll(),
+            List.of());
 
     assertThat(result.exception())
         .hasMessageContaining("Activity_1")
@@ -193,7 +211,8 @@ class OutboundConnectorExceptionHandlerTest {
             new SecretAllowListUnavailableException("lookup failed"),
             job,
             modelBackoff,
-            SecretFilter.allowAll());
+            SecretFilter.allowAll(),
+            List.of());
 
     assertThat(result.retryBackoff()).isEqualTo(Duration.ofSeconds(5));
     assertThat(result.retries()).isEqualTo(2);
@@ -212,7 +231,11 @@ class OutboundConnectorExceptionHandlerTest {
 
     var result =
         handler.manageConnectorJobHandlerException(
-            new RuntimeException("boom"), job, Duration.ofSeconds(30), SecretFilter.allowAll());
+            new RuntimeException("boom"),
+            job,
+            Duration.ofSeconds(30),
+            SecretFilter.allowAll(),
+            List.of());
 
     assertThat(result.retryBackoff()).isEqualTo(Duration.ofSeconds(30));
   }
@@ -229,7 +252,7 @@ class OutboundConnectorExceptionHandlerTest {
 
     var result =
         handler.manageConnectorJobHandlerException(
-            new RuntimeException("boom"), job, null, unreadableAllowList);
+            new RuntimeException("boom"), job, null, unreadableAllowList, List.of());
 
     assertThat(result.exception()).hasMessageContaining("Activity_1");
     assertThat(result.retries()).isEqualTo(2);
@@ -242,7 +265,8 @@ class OutboundConnectorExceptionHandlerTest {
     when(job.getRetries()).thenReturn(1);
     when(secretProvider.fetchAll(any(), any())).thenReturn(List.of("secret-value"));
 
-    handler.handleFinalResultException(new RuntimeException("boom"), job, SecretFilter.allowAll());
+    handler.handleFinalResultException(
+        new RuntimeException("boom"), job, SecretFilter.allowAll(), List.of());
 
     assertThat(captureSecretContext())
         .isEqualTo(new SecretContext("my-tenant", "my-process", "engine-1"));
@@ -261,7 +285,7 @@ class OutboundConnectorExceptionHandlerTest {
 
     var result =
         handler.handleFinalResultException(
-            new RuntimeException("boom"), job, SecretFilter.allowAll());
+            new RuntimeException("boom"), job, SecretFilter.allowAll(), List.of());
 
     assertThat(result).isNotNull();
     assertThat(result.retries()).isZero();
@@ -279,7 +303,8 @@ class OutboundConnectorExceptionHandlerTest {
         handler.handleFinalResultException(
             new RuntimeException("failed talking to https://api?key=super-secret"),
             job,
-            SecretFilter.allowAll());
+            SecretFilter.allowAll(),
+            List.of());
 
     assertThat(result.responseValue().toString()).doesNotContain("super-secret");
   }
@@ -299,7 +324,8 @@ class OutboundConnectorExceptionHandlerTest {
                 handler.handleFinalResultException(
                     new RuntimeException("failed talking to https://api?key=super-secret"),
                     job,
-                    SecretFilter.allowAll()));
+                    SecretFilter.allowAll(),
+                    List.of()));
 
     assertThat(logged).noneMatch(message -> message.contains("super-secret"));
     assertThat(logged).anyMatch(message -> message.contains("***"));
@@ -317,7 +343,8 @@ class OutboundConnectorExceptionHandlerTest {
                 handler.handleFinalResultException(
                     new RuntimeException("failed talking to https://api?key=super-secret"),
                     job,
-                    SecretFilter.allowAll()));
+                    SecretFilter.allowAll(),
+                    List.of()));
 
     assertThat(logged).noneMatch(message -> message.contains("super-secret"));
     assertThat(logged).anyMatch(message -> message.contains("java.lang.RuntimeException"));
@@ -343,7 +370,8 @@ class OutboundConnectorExceptionHandlerTest {
                     new RuntimeException("boom"),
                     job,
                     Duration.ofSeconds(1),
-                    SecretFilter.allowAll()));
+                    SecretFilter.allowAll(),
+                    List.of()));
 
     assertThat(logged).noneMatch(message -> message.contains("super-secret"));
     assertThat(logged).anyMatch(message -> message.contains("java.lang.RuntimeException"));
@@ -365,7 +393,8 @@ class OutboundConnectorExceptionHandlerTest {
                     new RuntimeException("boom"),
                     job,
                     Duration.ofSeconds(1),
-                    SecretFilter.allowAll()));
+                    SecretFilter.allowAll(),
+                    List.of()));
 
     assertThat(logged)
         .anyMatch(message -> message.contains("Legacy secret resolution is switched off"));
@@ -384,7 +413,8 @@ class OutboundConnectorExceptionHandlerTest {
             new RuntimeException("api rejected xSUPERSECRET"),
             job,
             Duration.ofSeconds(1),
-            SecretFilter.allowAll());
+            SecretFilter.allowAll(),
+            List.of());
 
     assertThat(requestedKeys).containsExactly("SHORT", "LONG");
     assertThat(result.exception().getMessage()).isEqualTo("api rejected ***");
@@ -403,7 +433,8 @@ class OutboundConnectorExceptionHandlerTest {
             new RuntimeException("api rejected the request"),
             job,
             Duration.ofSeconds(1),
-            SecretFilter.allowAll());
+            SecretFilter.allowAll(),
+            List.of());
 
     assertThat(result.exception().getMessage()).isEqualTo("api rejected the request");
   }
@@ -422,7 +453,8 @@ class OutboundConnectorExceptionHandlerTest {
             new RuntimeException("api rejected the request"),
             job,
             Duration.ofSeconds(1),
-            SecretFilter.allowAll());
+            SecretFilter.allowAll(),
+            List.of());
 
     verifyNoInteractions(secretProvider);
     assertThat(result.exception().getMessage()).isEqualTo("api rejected the request");
@@ -462,7 +494,8 @@ class OutboundConnectorExceptionHandlerTest {
             new RuntimeException("api rejected bar-value and foo-value"),
             job,
             Duration.ofSeconds(1),
-            SecretFilter.allowAll());
+            SecretFilter.allowAll(),
+            List.of());
 
     assertThat(result.responseValue().toString()).doesNotContain("bar-value");
     assertThat(result.exception().getMessage()).doesNotContain("bar-value");
@@ -487,7 +520,8 @@ class OutboundConnectorExceptionHandlerTest {
             new SecretNotAvailableException("BAR"),
             job,
             Duration.ofSeconds(1),
-            SecretFilter.allowAll());
+            SecretFilter.allowAll(),
+            List.of());
 
     assertThat(result.exception().getMessage())
         .isEqualTo("Secret with name 'BAR' is not available");
@@ -505,7 +539,8 @@ class OutboundConnectorExceptionHandlerTest {
             new RuntimeException("api rejected bar-value and foo-value"),
             job,
             Duration.ofSeconds(1),
-            SecretFilter.allowAll());
+            SecretFilter.allowAll(),
+            List.of());
 
     assertThat(result.exception().getMessage()).isEqualTo("api rejected *** and ***");
   }
@@ -527,7 +562,8 @@ class OutboundConnectorExceptionHandlerTest {
             new RuntimeException("api rejected foo-value"),
             job,
             Duration.ofSeconds(1),
-            SecretFilter.allowAll());
+            SecretFilter.allowAll(),
+            List.of());
 
     assertThat(result.exception().getMessage()).isEqualTo("api rejected ***");
   }
@@ -555,7 +591,8 @@ class OutboundConnectorExceptionHandlerTest {
             new RuntimeException("api rejected foo-value"),
             job,
             Duration.ofSeconds(1),
-            SecretFilter.allowAll());
+            SecretFilter.allowAll(),
+            List.of());
 
     assertThat(result.exception().getMessage()).isEqualTo("api rejected ***");
     assertThat(result.retries()).isEqualTo(2);
@@ -586,7 +623,8 @@ class OutboundConnectorExceptionHandlerTest {
             new RuntimeException("api rejected the request"),
             job,
             Duration.ofSeconds(1),
-            SecretFilter.allowAll());
+            SecretFilter.allowAll(),
+            List.of());
 
     assertThat(result.exception().getMessage()).isEqualTo("api rejected the request");
     assertThat(result.retries()).isEqualTo(2);
@@ -605,7 +643,8 @@ class OutboundConnectorExceptionHandlerTest {
             new RuntimeException("api rejected foo-value"),
             job,
             Duration.ofSeconds(1),
-            SecretFilter.allowAll());
+            SecretFilter.allowAll(),
+            List.of());
 
     assertThat(requestedKeys).containsExactly("FOO");
     assertThat(result.exception().getMessage()).isEqualTo("api rejected ***");
@@ -645,7 +684,11 @@ class OutboundConnectorExceptionHandlerTest {
 
     var result =
         handler.manageConnectorJobHandlerException(
-            new RuntimeException("boom"), job, Duration.ofSeconds(1), SecretFilter.allowAll());
+            new RuntimeException("boom"),
+            job,
+            Duration.ofSeconds(1),
+            SecretFilter.allowAll(),
+            List.of());
 
     // Both channels: the payload becomes process variables, and the message becomes the incident
     // message that prepareFailJobCommand sends to Zeebe.
@@ -671,7 +714,11 @@ class OutboundConnectorExceptionHandlerTest {
 
     var result =
         handler.manageConnectorJobHandlerException(
-            new RuntimeException("boom"), job, Duration.ofSeconds(1), SecretFilter.allowAll());
+            new RuntimeException("boom"),
+            job,
+            Duration.ofSeconds(1),
+            SecretFilter.allowAll(),
+            List.of());
 
     assertThat(result.exception().getMessage())
         .contains("camunda.connector.secret-resolver.legacy.mode=OFF")
@@ -697,7 +744,11 @@ class OutboundConnectorExceptionHandlerTest {
 
     var result =
         handler.manageConnectorJobHandlerException(
-            new RuntimeException("boom"), job, Duration.ofSeconds(1), SecretFilter.allowAll());
+            new RuntimeException("boom"),
+            job,
+            Duration.ofSeconds(1),
+            SecretFilter.allowAll(),
+            List.of());
 
     assertThat(result.responseValue().toString())
         .doesNotContain("super-secret")
@@ -725,7 +776,8 @@ class OutboundConnectorExceptionHandlerTest {
             .handleFinalResultException(
                 new RuntimeException("failed talking to https://api?key=super-secret"),
                 job,
-                SecretFilter.allowAll());
+                SecretFilter.allowAll(),
+                List.of());
 
     assertThat(result.responseValue().toString()).doesNotContain("super-secret");
   }
@@ -800,7 +852,7 @@ class OutboundConnectorExceptionHandlerTest {
 
     var result =
         handler.handleFinalResultException(
-            new ConnectorException("401", "Unauthorized"), job, SecretFilter.allowAll());
+            new ConnectorException("401", "Unauthorized"), job, SecretFilter.allowAll(), List.of());
 
     assertThat(error(result)).containsEntry("code", "401");
   }
@@ -815,7 +867,8 @@ class OutboundConnectorExceptionHandlerTest {
         handler.handleFinalResultException(
             new ConnectorException("401", "Unauthorized", null, errorVariables),
             job,
-            SecretFilter.allowAll());
+            SecretFilter.allowAll(),
+            List.of());
 
     return (Map<String, Object>) error(result).get("variables");
   }

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/job/SpringConnectorJobHandlerTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/job/SpringConnectorJobHandlerTest.java
@@ -2389,6 +2389,67 @@ class SpringConnectorJobHandlerTest {
     }
   }
 
+  // the value bound at execution time can differ from what a later re-read returns if it rotated
+  @Nested
+  class RotationRaceSecretMaskingTests {
+
+    private record TokenHolder(String token) {}
+
+    private static final String INPUT_DECLARING_A_SECRET = "{ \"token\" : \"{{secrets.FOO}}\" }";
+
+    private SecretProviderAggregator rotatingSecretProvider(
+        String boundValue, String rotatedValue) {
+      return new SecretProviderAggregator(List.of()) {
+        @Override
+        public String getSecret(String secretName, SecretContext context) {
+          return boundValue;
+        }
+
+        @Override
+        public List<String> fetchAll(List<String> keys, SecretContext context) {
+          return keys.stream().map(key -> rotatedValue).toList();
+        }
+      };
+    }
+
+    private SpringConnectorJobHandler connectorThrowingTheBoundToken(
+        SecretProviderAggregator secretProviderAggregator) {
+      return newConnectorJobHandler(
+          context -> {
+            var bound = context.bindVariables(TokenHolder.class);
+            throw new RuntimeException("api rejected " + bound.token());
+          },
+          secretProviderAggregator);
+    }
+
+    @Test
+    void aSecretThatRotatedBetweenBindAndMaskingIsStillRedacted() throws Exception {
+      var jobHandler =
+          connectorThrowingTheBoundToken(rotatingSecretProvider("old-value", "new-value"));
+
+      var result =
+          JobBuilder.create()
+              .withVariables(INPUT_DECLARING_A_SECRET)
+              .executeAndCaptureResult(jobHandler, false, false);
+
+      assertThat(result.getErrorMessage()).doesNotContain("old-value");
+    }
+
+    @Test
+    void aStableSecretIsStillRedactedTheOrdinaryWay() throws Exception {
+      // the union must not depend on rotation happening: an unrotated secret is redacted too
+      var jobHandler =
+          connectorThrowingTheBoundToken(rotatingSecretProvider("stable-value", "stable-value"));
+
+      var result =
+          JobBuilder.create()
+              .withVariables(INPUT_DECLARING_A_SECRET)
+              .executeAndCaptureResult(jobHandler, false, false);
+
+      assertThat(result.getErrorMessage()).doesNotContain("stable-value");
+    }
+  }
+
   @Nested
   class ConnectorResponseTests {
 

--- a/connector-sdk/core/src/main/java/io/camunda/connector/api/inbound/Health.java
+++ b/connector-sdk/core/src/main/java/io/camunda/connector/api/inbound/Health.java
@@ -190,6 +190,11 @@ public class Health {
     return new Health(this.status, this.error, details, this.lastUpdatedAt);
   }
 
+  // preserves lastUpdatedAt, mirroring withDetails
+  public Health withError(Error error) {
+    return new Health(this.status, error, this.details, this.lastUpdatedAt);
+  }
+
   private Health() {
     this(Status.UNKNOWN, null, null);
   }

--- a/connector-sdk/core/src/main/java/io/camunda/connector/api/inbound/Health.java
+++ b/connector-sdk/core/src/main/java/io/camunda/connector/api/inbound/Health.java
@@ -190,7 +190,13 @@ public class Health {
     return new Health(this.status, this.error, details, this.lastUpdatedAt);
   }
 
-  // preserves lastUpdatedAt, mirroring withDetails
+  /**
+   * Returns a new {@link Health} with the given error, preserving the original {@link
+   * #getLastUpdatedAt() lastUpdatedAt} timestamp.
+   *
+   * @param error the error for the new instance
+   * @return a new Health with the same status, details, and timestamp but the supplied error
+   */
   public Health withError(Error error) {
     return new Health(this.status, error, this.details, this.lastUpdatedAt);
   }


### PR DESCRIPTION
## Description

Addresses both halves of #8638:

1. **Inbound had no secret redaction at all.** `context.log(...)` and `context.reportHealth(...)` publish exception messages and stack traces verbatim to `ActivityLogRegistry` (operator-visible, e.g. webhook/Kafka/polling/A2A/Slack/SQS connectors logging a caught exception) and to `Health.error` (surfaced via the connector health API), including any resolved legacy secret an exception happens to echo back.
2. **Outbound masking re-reads the secret store instead of reusing the value substituted at bind time.** If a secret rotates in between, the re-read gets the new value and has nothing to match the old value still sitting in the error message — a silent leak, not an exception.

Plus a small prep refactor: `hideSecretsFromMessage` moved from `OutboundConnectorExceptionHandler` to `SecretUtil` so both the inbound and outbound fixes share one masking implementation instead of two copies that can drift.

### 1. Inbound redaction

Masks `Activity.message` and `Health.error` using the same declared-name scope `InboundConnectorContextImpl` already uses for its secret-filter allow-list (legacy `{{secrets.X}}`/`secrets.X` forms). Values are fetched once per context and cached on first success, so a transient provider failure fails closed for just that one message instead of poisoning every later log.

`Health` is masked *before* the existing `equals()`-based dedup check runs. Masking after would compare a freshly-masked `Health` against a previously-stored raw one, which never compares equal when an error message carries a secret — so a connector failing the same way every retry would re-log an activity entry every single time instead of deduping. Caught by writing the regression test first, reverting the ordering, and watching it fail (`Expected size: 1 but was: 2`).

Explicitly out of scope, with reasons: the new `camunda.secrets.<name>` form for inbound (tracked in #7730 — redaction is scoped to match `secretFilterEnabled`'s existing allow-list), and `Activity.data`/`Health.details` (checked every production call site — Zeebe keys, Kafka consumer group info, process counts, processId/tenantId/type enrichment — none carry exception-derived content).

### 2. Outbound rotation race

The issue's own proposed fix — capture every resolved value at substitution time, stop re-reading — was already attempted and backed out in #8634: it broke 17 tests, because a defensive re-read masks every secret the input *names*, while a precise capture only masks what was actually *substituted*, and telling those apart needs test-by-test confirmation the issue flags as its own workstream.

This does the smaller, additive version instead: `SecretHandler` now records every value it resolves. The existing re-read is untouched; the captured values are **unioned** into its result, so a rotated secret is still redacted by the value the message actually carries, on top of whatever the re-read comes back with. Since masking is just "replace these strings if present," adding more candidates can only mask more — it can't regress any of the 17 tests the replace-based approach broke, because the re-read path they depend on is unchanged.

`manageConnectorJobHandlerException`, `maskDiagnosticVariables`, `maskConnectorError`, and `handleFinalResultException` take the captured list alongside the existing `job`/`secretFilter` params. `SpringConnectorJobHandler` already held the concrete `JobHandlerContext` at every call site that needs it; narrowing those four private parameter types from `OutboundConnectorContext` to `JobHandlerContext` exposes `getSecretHandler()` there without touching the public SDK.

### Verification

- New tests for both halves, each verified by reverting the relevant fix and watching the test fail first:
  - Inbound: secret masked in `log(...)` messages, message withheld (not leaked) when the secret provider fails, secret masked in `reportHealth(...)`'s stored `Health.error` and activity log, and the dedup-after-masking regression.
  - Outbound: a secret bound as `old-value` and rotated to `new-value` before the masking re-read is still redacted (`SpringConnectorJobHandlerTest$RotationRaceSecretMaskingTests`), plus a stable (non-rotated) secret redacts the ordinary way.
- All existing outbound tests pass unchanged with the captured-list parameter as `List.of()`, confirming the union is a no-op when nothing was captured — `OutboundConnectorExceptionHandlerTest` (31), `SpringConnectorJobHandlerTest` (143 across nested classes).
- Targeted runs green: `connector-runtime-core` (`InboundConnectorContextImplTest` 29, `LegacySecretCharacterizationTest` 30), `connector-sdk/core`.
- `spotless:check` clean.

## Related issues

Closes #8638.

## Checklist

- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest
  release, as this branch will be rebased onto main before the next release. Example backport labels:
    - `backport stable/8.8`: for changes that should be included in the next 8.8.x release.
    - **or** `backport release-8.8.7`: for changes that should be included in the specific release 8.8.7, and this
      *release has already been created*. The release branch will be merged back into stable/8.8 later, so the change
      will be included in future 8.8.x releases as well.
- [x] Tests/Integration tests for the changes have been added if applicable.
- [ ] If the change requires a documentation update, it has been added to the appropriate section in the documentation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)