### PR TITLE
fix(logging): update condition for stackdriver log appender in logback configuration (#7704)

### DIFF
--- a/connector-runtime/connector-runtime-application/src/main/resources/logback-spring.xml
+++ b/connector-runtime/connector-runtime-application/src/main/resources/logback-spring.xml
@@ -3,7 +3,11 @@
     <springProperty name="connectorsLogAppender" source="connectors.log.appender"
                     defaultValue="default"/>
     <springProfile name="!test">
-        <if condition='property("connectorsLogAppender").equalsIgnoreCase("stackdriver")'>
+        <condition class="ch.qos.logback.core.boolex.PropertyEqualityCondition">
+            <key>connectorsLogAppender</key>
+            <value>stackdriver</value>
+        </condition>
+        <if>
             <then>
                 <springProperty name="serviceName" source="log.stackdriver.serviceName"
                                 defaultValue="connectors"/>


### PR DESCRIPTION
Backport of #7704 to `stable/8.7`. The fix was backported to `stable/8.9` (#8247) and `stable/8.8` (#8338), but `stable/8.7` and `stable/8.6` were skipped. Companion PR for 8.6: #8645.

## Problem

The runtime on `stable/8.7` logs **nothing at all**, and has done so since **2026-07-23**.

`logback-spring.xml` used the deprecated Janino-backed `condition` attribute:

```xml
<if condition='property("connectorsLogAppender").equalsIgnoreCase("stackdriver")'>
```

Logback 1.6.0 **removed `ch.qos.logback.core.joran.conditional.PropertyEvalScriptBuilder`**, the class that compiles that expression. Verified against the jars — present in `logback-core-1.5.32`, gone from `1.6.0` onward.

On 1.6.x, `IfModelHandler.handle()` reads the `condition` attribute only to emit a deprecation warning, then sets a branch state solely if a nested `<condition>` element pushed one. `ThenModelHandler`/`ElseModelHandler` gate their subtrees on `branchState == IF_BRANCH`/`ELSE_BRANCH`, so **both branches are skipped**, no appender is attached to the root logger, and the process is silent.

There is no error — only a `WARN` in logback's own status output, which is itself not visible. That is why this passed CI: the affected config is `connector-runtime-application`'s, while the starter's `logback-spring.xml` has no `<if>` at all.

### Impact on this branch

`stable/8.7` took logback `1.6.0` in #8049 on **2026-07-23** and never received the config fix. The runtime has therefore been silent on this branch for roughly six weeks, spanning the `8.7.13` .. `8.7.23-rc1` releases.

For contrast, `stable/8.8` took the same bump on 2026-07-27 and was silent until the fix landed on 2026-08-17 (#8338).

### Reproduced

Identical config, same JVM, logback swapped:

| logback | output |
|---|---|
| 1.5.32 | `PLAIN >>> THIS LINE SHOULD APPEAR <<<` |
| 1.6.3 | *(nothing)* |

## Fix

Use the `<condition>` element, which `PropertyEqualityCondition` backs in **both** 1.5.x and 1.6.x:

```xml
<condition class="ch.qos.logback.core.boolex.PropertyEqualityCondition">
    <key>connectorsLogAppender</key>
    <value>stackdriver</value>
</condition>
<if>
```

Verified logging works on 1.5.32, 1.5.34 and 1.6.3 with no warnings.

## Verification

- Confirmed `PropertyEqualityCondition` is present in both `logback-core-1.5.32` and `1.6.3`, so the change is version-agnostic.
- The resulting file is **byte-identical** to `stable/8.8`, `stable/8.9`, `stable/8.10` and `main` (`sha1 964aab81c7bc4454e1fea7c7c60017d8b055e02b`).
- No other logback config on this branch uses the Janino `condition` attribute.

🤖 Generated with [Claude Code](https://claude.com/claude-code)