### PR TITLE
[Backport stable/8.9] fix: retry and report an unreadable outbound secret allow-list

### DIFF
--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/ConfigurableSecretFilterFactory.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/ConfigurableSecretFilterFactory.java
@@ -67,7 +67,7 @@ public class ConfigurableSecretFilterFactory implements SecretFilterFactory {
                   context.elementId(),
                   context.processDefinitionKey(),
                   realCause.getClass().getName());
-              throw new IllegalArgumentException(
+              throw new SecretAllowListUnavailableException(
                   "Error retrieving secret keys for element '"
                       + context.elementId()
                       + "' in process definition key "

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/OutboundConnectorExceptionHandler.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/OutboundConnectorExceptionHandler.java
@@ -37,6 +37,9 @@ public class OutboundConnectorExceptionHandler {
 
   private static final Logger LOGGER =
       LoggerFactory.getLogger(OutboundConnectorExceptionHandler.class);
+
+  private static final Duration ALLOW_LIST_RETRY_BACKOFF = Duration.ofSeconds(5);
+
   private final SecretProvider secretProvider;
 
   public OutboundConnectorExceptionHandler(SecretProvider secretProvider) {
@@ -67,8 +70,17 @@ public class OutboundConnectorExceptionHandler {
     return Map.copyOf(result);
   }
 
+  private static Duration retryBackoffFor(Exception failure, Duration configured) {
+    return failure instanceof SecretAllowListUnavailableException
+        ? ALLOW_LIST_RETRY_BACKOFF
+        : configured;
+  }
+
   public ConnectorResult.ErrorResult manageConnectorJobHandlerException(
       Exception e, ActivatedJob job, Duration retryBackoffDuration, SecretFilter secretFilter) {
+    if (e instanceof SecretAllowListUnavailableException) {
+      return handleGenericException(job, e, List.of(), retryBackoffFor(e, retryBackoffDuration));
+    }
     List<String> secrets;
     try {
       var allowedKeys =
@@ -92,7 +104,8 @@ public class OutboundConnectorExceptionHandler {
       return new ConnectorResult.ErrorResult(
           Map.of("error", exceptionToMap(wrappedException)),
           wrappedException,
-          job.getRetries() - 1);
+          job.getRetries() - 1,
+          retryBackoffFor(ex, retryBackoffDuration));
     }
     return switch (e) {
       case InvalidBackOffDurationException invalidBackOffDurationException ->

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/SecretAllowListUnavailableException.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/SecretAllowListUnavailableException.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.runtime.outbound.job;
+
+/**
+ * Thrown when the allow-list of secret names an element may resolve could not be read, so no secret
+ * value ever reached the input. The lookup reads the process definition from secondary storage,
+ * which a just-deployed definition has yet to reach, so this failure is worth another attempt after
+ * a backoff rather than immediately.
+ */
+class SecretAllowListUnavailableException extends RuntimeException {
+
+  SecretAllowListUnavailableException(String message) {
+    super(message);
+  }
+}

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/job/ConfigurableSecretFilterFactoryTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/job/ConfigurableSecretFilterFactoryTest.java
@@ -98,14 +98,14 @@ class ConfigurableSecretFilterFactoryTest {
   }
 
   @Test
-  void create_strict_whenCacheThrows_throwsIllegalArgumentException() {
+  void create_strict_whenCacheThrows_throwsSecretAllowListUnavailableException() {
     when(secretKeyCache.getSecretKeys(any())).thenThrow(new RuntimeException("fetch failed"));
     var factory = new ConfigurableSecretFilterFactory(SecretFilterMode.STRICT, secretKeyCache);
 
     var filter = factory.create(CONTEXT);
 
     assertThatThrownBy(() -> filter.isAllowed("ANY_SECRET"))
-        .isInstanceOf(IllegalArgumentException.class)
+        .isInstanceOf(SecretAllowListUnavailableException.class)
         .hasMessageContaining("Error retrieving secret keys");
   }
 
@@ -162,7 +162,7 @@ class ConfigurableSecretFilterFactoryTest {
     var filter = factory.create(CONTEXT);
 
     assertThatThrownBy(() -> filter.isAllowed("ANY_SECRET"))
-        .isInstanceOf(IllegalArgumentException.class);
+        .isInstanceOf(SecretAllowListUnavailableException.class);
   }
 
   @Test

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/job/OutboundConnectorExceptionHandlerTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/job/OutboundConnectorExceptionHandlerTest.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.runtime.outbound.job;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.camunda.client.api.response.ActivatedJob;
+import io.camunda.connector.api.secret.SecretProvider;
+import io.camunda.connector.runtime.core.secret.SecretFilter;
+import io.camunda.connector.runtime.secret.FooBarSecretProvider;
+import java.time.Duration;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class OutboundConnectorExceptionHandlerTest {
+
+  private final OutboundConnectorExceptionHandler handler =
+      new OutboundConnectorExceptionHandler(new FooBarSecretProvider());
+
+  private static ActivatedJob jobWithSecretReference() {
+    var job = mock(ActivatedJob.class);
+    when(job.getVariables()).thenReturn("{\"value\":\"{{secrets.FOO}}\"}");
+    when(job.getKey()).thenReturn(1L);
+    when(job.getTenantId()).thenReturn("tenant");
+    when(job.getRetries()).thenReturn(3);
+    return job;
+  }
+
+  @Test
+  void manageConnectorJobHandlerException_publishesTheReasonTheAllowListCouldNotBeRead() {
+    var job = jobWithSecretReference();
+    SecretProvider providerThatMustNotBeCalled =
+        mock(
+            SecretProvider.class,
+            invocation -> {
+              throw new AssertionError(
+                  "an unreadable allow-list means no secret ever reached the input, so there is"
+                      + " nothing to resolve for masking");
+            });
+    var handlerWithGuard = new OutboundConnectorExceptionHandler(providerThatMustNotBeCalled);
+
+    var result =
+        handlerWithGuard.manageConnectorJobHandlerException(
+            new SecretAllowListUnavailableException(
+                "Error retrieving secret keys for element 'Activity_1' in process definition key 42"
+                    + " (io.camunda.client.api.command.ProblemException)"),
+            job,
+            null,
+            SecretFilter.allowAll());
+
+    assertThat(result.exception())
+        .hasMessageContaining("Activity_1")
+        .hasMessageContaining("ProblemException");
+    assertThat(result.retries()).isEqualTo(2);
+    assertThat(result.retryBackoff()).isEqualTo(Duration.ofSeconds(5));
+  }
+
+  @ParameterizedTest
+  @MethodSource("modelBackoffs")
+  void manageConnectorJobHandlerException_backsOffTheAllowListReadWhateverTheModelAsksFor(
+      Duration modelBackoff) {
+    var job = jobWithSecretReference();
+
+    var result =
+        handler.manageConnectorJobHandlerException(
+            new SecretAllowListUnavailableException("lookup failed"),
+            job,
+            modelBackoff,
+            SecretFilter.allowAll());
+
+    assertThat(result.retryBackoff()).isEqualTo(Duration.ofSeconds(5));
+    assertThat(result.retries()).isEqualTo(2);
+  }
+
+  private static Stream<Duration> modelBackoffs() {
+    return Stream.of(
+        null, Duration.ZERO, Duration.ofSeconds(-1), Duration.ofSeconds(30), Duration.ofMinutes(1));
+  }
+
+  @Test
+  void manageConnectorJobHandlerException_keepsTheModelsBackoffForOtherMaskingFailures() {
+    var job = jobWithSecretReference();
+    SecretProvider throwingProvider =
+        mock(
+            SecretProvider.class,
+            invocation -> {
+              throw new IllegalStateException("timed out");
+            });
+    var handlerWithThrowingProvider = new OutboundConnectorExceptionHandler(throwingProvider);
+
+    var result =
+        handlerWithThrowingProvider.manageConnectorJobHandlerException(
+            new RuntimeException("boom"), job, Duration.ofSeconds(30), SecretFilter.allowAll());
+
+    assertThat(result.retryBackoff()).isEqualTo(Duration.ofSeconds(30));
+  }
+
+  @Test
+  void manageConnectorJobHandlerException_publishesTheAllowListFailureRaisedByTheMaskingRead() {
+    var job = jobWithSecretReference();
+    SecretFilter unreadableAllowList =
+        name -> {
+          throw new SecretAllowListUnavailableException(
+              "Error retrieving secret keys for element 'Activity_1'");
+        };
+
+    var result =
+        handler.manageConnectorJobHandlerException(
+            new RuntimeException("boom"), job, null, unreadableAllowList);
+
+    assertThat(result.exception()).hasMessageContaining("Activity_1");
+    assertThat(result.retries()).isEqualTo(2);
+    assertThat(result.retryBackoff()).isEqualTo(Duration.ofSeconds(5));
+  }
+}


### PR DESCRIPTION
# Description

Backport of #8633 to `stable/8.9`. The automatic backport could not apply — the outbound error-handling path has moved and changed shape since this branch, so this is written by hand rather than cherry-picked.

## What is ported, and what is not

#8633 fixed two things. Only one of them exists on this branch.

- **The missing backoff — ported.** The allow-list read failure carried no backoff of its own, so all remaining attempts were spent within milliseconds and the job ended as *no retries left*. It now always uses its own 5s backoff, regardless of what the model asks for (zero, in 50 older element template versions).
- **The withheld message — not applicable.** `main` deliberately withholds unmaskable error messages, which is why #8633 needed `SecretFailureDiagnostic` to carve out an exception. This branch does not withhold: the allow-list failure's message (element ID, process-definition key, cause class) already reaches the incident. Porting that machinery would add it for nothing.

## Branch-specific notes

This branch keeps `OutboundConnectorExceptionHandler` in `connector-runtime-spring`, in the pre-`fetchSecretsForMasking` shape, so the change is written against that: an early return for the exception, and the masking-failure branch switched to the four-argument `ErrorResult` so it carries a backoff.

`SecretAllowListUnavailableException` is a plain `RuntimeException` here — `SecretFailureDiagnostic` does not exist on this branch, and it is not needed, because this branch never withholds the message in the first place.

This branch had no `OutboundConnectorExceptionHandlerTest`, so one is added covering just this fix.

## Checklist

- [x] Backport labels are added if these code changes should be backported. — n/a, this *is* the backport.
- [x] Tests/Integration tests for the changes have been added if applicable.
- [x] If the change requires a documentation update, it has been added to the appropriate section in the documentation. — no user-facing behaviour or configuration change; nothing to document.

🤖 Generated with [Claude Code](https://claude.com/claude-code)