### PR TITLE
[Backport stable/8.6] fix: retry and report an unreadable outbound secret allow-list

### DIFF
--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/outbound/ConnectorJobHandler.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/outbound/ConnectorJobHandler.java
@@ -31,6 +31,7 @@ import io.camunda.connector.runtime.core.error.JobError;
 import io.camunda.connector.runtime.core.outbound.ConnectorResult.ErrorResult;
 import io.camunda.connector.runtime.core.outbound.ConnectorResult.SuccessResult;
 import io.camunda.connector.runtime.core.outbound.ErrorExpressionJobContext.ErrorExpressionJob;
+import io.camunda.connector.runtime.core.secret.SecretAllowListUnavailableException;
 import io.camunda.connector.runtime.core.secret.SecretFilter;
 import io.camunda.connector.runtime.core.secret.SecretFilterFactory;
 import io.camunda.connector.runtime.core.secret.SecretFilterFactory.SecretFilterContext;
@@ -56,6 +57,9 @@ public class ConnectorJobHandler implements JobHandler {
   // Protects Zeebe from enormously large messages it cannot handle
   public static final int MAX_ERROR_MESSAGE_LENGTH = 6000;
   private static final Logger LOGGER = LoggerFactory.getLogger(ConnectorJobHandler.class);
+
+  private static final Duration ALLOW_LIST_RETRY_BACKOFF = Duration.ofSeconds(5);
+
   protected final OutboundConnectorFunction call;
   protected SecretProvider secretProvider;
 
@@ -205,7 +209,9 @@ public class ConnectorJobHandler implements JobHandler {
       if (ex instanceof ConnectorException connectorException) {
         errorCode = connectorException.getErrorCode();
       }
-      result = handleSDKException(job, ex, job.getRetries() - 1, errorCode, retryBackoff);
+      result =
+          handleSDKException(
+              job, ex, job.getRetries() - 1, errorCode, retryBackoffFor(ex, retryBackoff));
     }
 
     try {
@@ -252,6 +258,20 @@ public class ConnectorJobHandler implements JobHandler {
               jobError.retries(),
               jobError.retryBackoff()));
     }
+  }
+
+  /**
+   * An allow-list that could not be read means no secret value ever reached the input, and the
+   * lookup behind it reads the process definition from secondary storage, which a just-deployed
+   * definition has yet to reach. That race resolves on the next attempt, so the read gets its own
+   * backoff rather than the model's: the model's paces calls to the target system, which this
+   * failure never reached, and it is zero in older element template versions -- which spent every
+   * remaining attempt within milliseconds.
+   */
+  private static Duration retryBackoffFor(Exception failure, Duration configured) {
+    return failure instanceof SecretAllowListUnavailableException
+        ? ALLOW_LIST_RETRY_BACKOFF
+        : configured;
   }
 
   private ConnectorResult handleSDKException(

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretAllowListUnavailableException.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretAllowListUnavailableException.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.runtime.core.secret;
+
+/**
+ * Thrown when the allow-list of secret names an element may resolve could not be read, so no secret
+ * value ever reached the input. The lookup reads the process definition from secondary storage,
+ * which a just-deployed definition has yet to reach, so this failure is worth another attempt after
+ * a backoff rather than immediately.
+ *
+ * <p>It lives here rather than beside the filter factory that throws it because the runtime that
+ * has to recognise it on the failure path is in this module.
+ */
+public class SecretAllowListUnavailableException extends RuntimeException {
+
+  public SecretAllowListUnavailableException(String message) {
+    super(message);
+  }
+}

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/outbound/ConnectorJobHandlerTest.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/outbound/ConnectorJobHandlerTest.java
@@ -39,6 +39,7 @@ import io.camunda.connector.api.error.ConnectorRetryExceptionBuilder;
 import io.camunda.connector.api.outbound.OutboundConnectorFunction;
 import io.camunda.connector.runtime.core.ConnectorHelper;
 import io.camunda.connector.runtime.core.Keywords;
+import io.camunda.connector.runtime.core.secret.SecretAllowListUnavailableException;
 import io.camunda.connector.runtime.core.secret.SecretFilterFactory;
 import io.camunda.zeebe.client.api.command.FailJobCommandStep1;
 import io.camunda.zeebe.client.api.command.FailJobCommandStep1.FailJobCommandStep2;
@@ -635,6 +636,55 @@ class ConnectorJobHandlerTest {
       verify(secondStepMock).errorMessage(any());
       verify(secondStepMock, times(0)).retryBackoff(any()); // not set
       verify(secondStepMock).send();
+    }
+
+    @Test
+    void shouldBackOffUnreadableSecretAllowList_WhenNoRetryBackoffHeaderIsSet() {
+      // given -- no retry backoff header, which is what 50 older element template versions ship:
+      // every remaining attempt was previously spent within milliseconds
+      int initialRetries = 3;
+      var jobBuilder = JobBuilder.create().useJobClient(jobClient).withRetries(initialRetries);
+      var jobHandler =
+          newConnectorJobHandler(
+              context -> {
+                throw new SecretAllowListUnavailableException(
+                    "Error retrieving secret keys for element 'Activity_1' in process definition"
+                        + " key 42 (io.camunda.operate.exception.OperateException)");
+              });
+
+      // when
+      jobBuilder.execute(jobHandler);
+
+      // then
+      verify(firstStepMock).retries(initialRetries - 1);
+      verify(secondStepMock).retryBackoff(Duration.ofSeconds(5));
+      verify(secondStepMock).errorMessage(contains("Activity_1"));
+      verify(secondStepMock).send();
+    }
+
+    @Test
+    void shouldBackOffUnreadableSecretAllowList_WhateverTheModelAsksFor() {
+      // given -- the model's backoff paces calls to the target system, which this failure never
+      // reached, so the allow-list read uses its own regardless
+      int initialRetries = 3;
+      var jobBuilder =
+          JobBuilder.create()
+              .useJobClient(jobClient)
+              .withRetries(initialRetries)
+              .withHeaders(Map.of(Keywords.RETRY_BACKOFF_KEYWORD, "PT1M"));
+      var jobHandler =
+          newConnectorJobHandler(
+              context -> {
+                throw new SecretAllowListUnavailableException("lookup failed");
+              });
+
+      // when
+      jobBuilder.execute(jobHandler);
+
+      // then
+      verify(firstStepMock).retries(initialRetries - 1);
+      verify(secondStepMock).retryBackoff(Duration.ofSeconds(5));
+      verify(secondStepMock, times(0)).retryBackoff(Duration.ofMinutes(1));
     }
   }
 

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/ConfigurableSecretFilterFactory.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/ConfigurableSecretFilterFactory.java
@@ -16,6 +16,7 @@
  */
 package io.camunda.connector.runtime.outbound.job;
 
+import io.camunda.connector.runtime.core.secret.SecretAllowListUnavailableException;
 import io.camunda.connector.runtime.core.secret.SecretFilter;
 import io.camunda.connector.runtime.core.secret.SecretFilterFactory;
 import io.camunda.connector.runtime.core.secret.SecretFilterFactory.SecretFilterContext;
@@ -88,7 +89,7 @@ public class ConfigurableSecretFilterFactory implements SecretFilterFactory {
                   context.elementId(),
                   context.processDefinitionKey(),
                   realCause.getClass().getName());
-              throw new IllegalArgumentException(
+              throw new SecretAllowListUnavailableException(
                   "Error retrieving secret keys for element '"
                       + context.elementId()
                       + "' in process definition key "

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/job/ConfigurableSecretFilterFactoryTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/job/ConfigurableSecretFilterFactoryTest.java
@@ -25,6 +25,7 @@ import static org.mockito.Mockito.when;
 
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
+import io.camunda.connector.runtime.core.secret.SecretAllowListUnavailableException;
 import io.camunda.connector.runtime.core.secret.SecretFilterFactory.SecretFilterContext;
 import io.camunda.connector.runtime.outbound.job.ConfigurableSecretFilterFactory.SecretFilterMode;
 import io.camunda.connector.runtime.outbound.secret.ProcessDefinitionSecretKeyCache;
@@ -96,14 +97,14 @@ class ConfigurableSecretFilterFactoryTest {
   }
 
   @Test
-  void create_strict_whenCacheThrows_throwsIllegalArgumentException() {
+  void create_strict_whenCacheThrows_throwsSecretAllowListUnavailableException() {
     when(secretKeyCache.getSecretKeys(any())).thenThrow(new RuntimeException("fetch failed"));
     var factory = new ConfigurableSecretFilterFactory(SecretFilterMode.STRICT, secretKeyCache);
 
     var filter = factory.create(CONTEXT);
 
     assertThatThrownBy(() -> filter.isAllowed("ANY_SECRET"))
-        .isInstanceOf(IllegalArgumentException.class)
+        .isInstanceOf(SecretAllowListUnavailableException.class)
         .hasMessageContaining("Error retrieving secret keys");
   }
 
@@ -196,7 +197,7 @@ class ConfigurableSecretFilterFactoryTest {
     var filter = factory.create(CONTEXT);
 
     assertThatThrownBy(() -> filter.isAllowed("ANY_SECRET"))
-        .isInstanceOf(IllegalArgumentException.class);
+        .isInstanceOf(SecretAllowListUnavailableException.class);
   }
 
   private void assertMessageIdentifiesTheFailureWithoutLeakingTheCauseText(


### PR DESCRIPTION
# Description

Backport of #8633 to `stable/8.6`. The automatic backport could not apply — the outbound error-handling path has moved and changed shape since this branch, so this is written by hand rather than cherry-picked.

## What is ported, and what is not

#8633 fixed two things. Only one of them exists on this branch.

- **The missing backoff — ported.** The allow-list read failure carried no backoff of its own, so all remaining attempts were spent within milliseconds and the job ended as *no retries left*. It now always uses its own 5s backoff, regardless of what the model asks for (zero, in 50 older element template versions).
- **The withheld message — not applicable.** `main` deliberately withholds unmaskable error messages, which is why #8633 needed `SecretFailureDiagnostic` to carve out an exception. This branch does not withhold: the allow-list failure's message (element ID, process-definition key, cause class) already reaches the incident. Porting that machinery would add it for nothing.

## Branch-specific notes

This branch has no `OutboundConnectorExceptionHandler` at all — outbound error handling is inline in `connector-runtime-core`'s `ConnectorJobHandler`, and it does no secret masking, so the exception reaches the generic catch with its message intact. The fix is therefore just the backoff, applied where that catch builds its result. `SecretAllowListUnavailableException` goes in `connector-runtime-core`'s `secret` package so both the factory (spring) and the handler (core) can see it.

`retryBackoffFor` only ever changes behaviour for `SecretAllowListUnavailableException`, which nothing but the STRICT filter factory throws — every other exception reaching that catch keeps the model's backoff exactly as before. The helper carries a short javadoc here because, unlike on the other branches, it sits in a class shared by every outbound runtime.

The factory's separate `SecretFilterUnavailableException` catch (no `CamundaOperateClient` bean) is deliberately left throwing `IllegalArgumentException`: that is a permanent misconfiguration, not the secondary-storage race, and retrying it with a backoff would be wrong.

## Checklist

- [x] Backport labels are added if these code changes should be backported. — n/a, this *is* the backport.
- [x] Tests/Integration tests for the changes have been added if applicable.
- [x] If the change requires a documentation update, it has been added to the appropriate section in the documentation. — no user-facing behaviour or configuration change; nothing to document.

🤖 Generated with [Claude Code](https://claude.com/claude-code)