### PR TITLE
fix: read every secret reference in a single scan (#8641) [stable/8.8]

### DIFF
--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextImpl.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextImpl.java
@@ -280,16 +280,19 @@ public class InboundConnectorContextImpl extends AbstractConnectorContext
    * properties} are final and there is no {@code updateConnectorDetails} — so the hot-swap and
    * torn-read failure directions the outbound path had to close are not representable here.
    *
-   * <p>This is what the filter stops: {@link SecretUtil#replaceSecrets} runs the brace pass and
-   * then runs the bare pass over that pass's output, so a resolved value containing
-   * reference-shaped text otherwise produces a lookup for a name no model declares. Verified
-   * present on this branch before backporting: a secret whose value is the literal {@code
-   * secrets.CHAINED} resolved {@code CHAINED} under the previous allow-all filter.
+   * <p>This is what the filter still stops: a name only a sibling element declares, and any name in
+   * text a caller supplies rather than the element's own properties. The escalation it was written
+   * for -- {@link SecretUtil#replaceSecrets} running the bare pass over the brace pass's output, so
+   * that a resolved value containing reference-shaped text reached a secret no model declares --
+   * was verified present on this branch before backporting: a secret whose value is the literal
+   * {@code secrets.CHAINED} resolved {@code CHAINED} under the previous allow-all filter. It is now
+   * closed at its source: the single scan consumes each reference whole and never re-reads what it
+   * resolved.
    *
-   * <p>Distinct from the denied-bracket exclusion in {@code replaceSecretsWithoutParentheses}
-   * (#8593), which stops the bare pass re-litigating a truncated prefix of a bracketed name the
-   * bracket pass already refused. The two are complementary: that one guards a name the text still
-   * spells, this one a name only a resolved value spells.
+   * <p>The denied-bracket exclusion in {@code replaceSecretsWithoutParentheses} (#8593) this was
+   * described as complementary to is gone with the same change. It stopped the bare pass
+   * re-litigating a truncated prefix of a bracketed name the bracket pass had already refused;
+   * there is no second pass left to re-litigate anything.
    *
    * <p>Static because it feeds the {@code super(...)} call, before any field is assigned.
    */

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretUtil.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretUtil.java
@@ -18,90 +18,39 @@ package io.camunda.connector.runtime.core.secret;
 
 import com.fasterxml.jackson.core.io.JsonStringEncoder;
 import io.camunda.connector.api.secret.SecretContext;
+import java.util.HashMap;
 import java.util.List;
-import java.util.Objects;
+import java.util.Map;
 import java.util.function.Function;
 import java.util.regex.MatchResult;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import java.util.stream.Stream;
 
 /** Utility class to replace secrets in strings. */
 public class SecretUtil {
 
   private static final JsonStringEncoder encoder = JsonStringEncoder.getInstance();
 
-  private static final Pattern SECRET_PATTERN_SECRETS =
-      Pattern.compile("secrets\\.(?<secret>([a-zA-Z0-9]+[\\/._-])*[a-zA-Z0-9]+)");
-
-  private static final Pattern SECRET_PATTERN_PARENTHESES =
-      Pattern.compile("\\{\\{\\s*secrets\\.(?<secret>\\S+?\\s*)}}");
+  // One pattern, so that one scan consumes each reference whole: scanning per form or per caller
+  // lets a narrower alternative re-read the inside of a wider match, as a name never declared.
+  private static final Pattern REFERENCE =
+      Pattern.compile(
+          "\\{\\{\\s*secrets\\.(?<braced>\\S+?)\\s*}}"
+              + "|secrets\\.(?<bare>([a-zA-Z0-9]+[\\/._-])*[a-zA-Z0-9]+)");
 
   public static String replaceSecrets(
       String input, SecretContext context, SecretReplacer secretReplacer) {
     if (input == null) {
       throw new IllegalStateException("input cant be null.");
     }
-    input = replaceSecretsWithParentheses(input, context, secretReplacer);
-    input = replaceSecretsWithoutParentheses(input, context, secretReplacer);
-    return input;
-  }
-
-  private static String replaceSecretsWithParentheses(
-      String input, SecretContext context, SecretReplacer secretReplacer) {
-    var secretVariableNameWithParenthesesMatcher = SECRET_PATTERN_PARENTHESES.matcher(input);
-    while (secretVariableNameWithParenthesesMatcher.find()) {
-      input =
-          replaceTokens(
-              input,
-              SECRET_PATTERN_PARENTHESES,
-              matcher -> resolveSecretValue(context, secretReplacer, matcher));
-    }
-    return input;
-  }
-
-  /**
-   * A denied bracketed reference — e.g. {@code {{secrets.FOO:BAR}}} when only {@code FOO} is
-   * allowed — is left untouched by the parentheses pass, but its own text still contains {@code
-   * secrets.FOO}, which the bare pattern would happily match and resolve on its own since {@code
-   * FOO} genuinely is allowed. Excluding bare matches nested in a still-literal bracketed reference
-   * closes that: the bracket pass already ruled on that name, and the bare pass must not
-   * re-litigate a truncated prefix of it. The exclusion is recomputed on every iteration, against
-   * whatever {@code input} that iteration is about to scan, so a still-denied reference stays
-   * excluded across the bounded rescan below that lets a resolved value chain into a further
-   * replacement.
-   */
-  private static String replaceSecretsWithoutParentheses(
-      String input, SecretContext context, SecretReplacer secretReplacer) {
-    var secretVariableNameWithParenthesesMatcher = SECRET_PATTERN_SECRETS.matcher(input);
-    while (secretVariableNameWithParenthesesMatcher.find()) {
-      List<MatchResult> deniedBracketedReferences =
-          SECRET_PATTERN_PARENTHESES.matcher(input).results().toList();
-      input =
-          replaceTokens(
-              input,
-              SECRET_PATTERN_SECRETS,
-              matcher ->
-                  isNotNestedInAny(matcher, deniedBracketedReferences)
-                      ? resolveSecretValue(context, secretReplacer, matcher)
-                      : matcher.group());
-    }
-    return input;
-  }
-
-  private static String resolveSecretValue(
-      SecretContext context, SecretReplacer secretReplacer, Matcher matcher) {
-    var secretName = matcher.group("secret").trim();
-    if (!secretName.isBlank()) {
-      var result = secretReplacer.replaceSecrets(secretName, context);
-      if (result != null) {
-        return new String(encoder.quoteAsString(result));
-      } else {
-        return matcher.group();
-      }
-    } else {
-      return null;
-    }
+    Map<String, String> resolutions = new HashMap<>();
+    return replaceTokens(
+        input,
+        REFERENCE,
+        matcher -> {
+          String value = resolve(name(matcher), context, secretReplacer, resolutions);
+          return value == null ? matcher.group() : new String(encoder.quoteAsString(value));
+        });
   }
 
   public static String replaceTokens(
@@ -119,37 +68,31 @@ public class SecretUtil {
     return output.toString();
   }
 
-  public static List<String> retrieveSecretKeysInInput(String input) {
-    if (Objects.isNull(input)) {
-      return List.of();
+  /** Asks the replacer at most once per name, for providers that meter or charge per lookup. */
+  private static String resolve(
+      String name,
+      SecretContext context,
+      SecretReplacer secretReplacer,
+      Map<String, String> resolutions) {
+    if (!resolutions.containsKey(name)) {
+      resolutions.put(name, secretReplacer.replaceSecrets(name, context));
     }
-    List<MatchResult> bracketedReferences =
-        SECRET_PATTERN_PARENTHESES.matcher(input).results().toList();
-    return Stream.of(SECRET_PATTERN_PARENTHESES, SECRET_PATTERN_SECRETS)
-        .flatMap(
-            pattern ->
-                pattern
-                    .matcher(input)
-                    .results()
-                    .filter(
-                        result ->
-                            pattern != SECRET_PATTERN_SECRETS
-                                || isNotNestedInAny(result, bracketedReferences)))
-        .map(matchResult -> matchResult.group("secret").trim())
-        .distinct()
-        .toList();
+    return resolutions.get(name);
+  }
+
+  private static String name(MatchResult match) {
+    var braced = match.group("braced");
+    return braced != null ? braced : match.group("bare");
   }
 
   /**
-   * A bare {@code secrets.NAME} match nested inside a {@code {{secrets.NAME}}} occurrence is not a
-   * second, independent declaration — it is the bare pattern's narrower character class re-reading
-   * the same literal text and stopping short at a character the bracket form tolerates (e.g. {@code
-   * :}). Left in, a model declaring only {@code {{secrets.LONG:SUFFIX}}} would also admit the
-   * truncated "LONG" into the allow-list, letting a runtime value spell that shorter name and
-   * resolve a secret the model never declared.
+   * Every secret name the given text declares, in either form, read by the same scan {@link
+   * #replaceSecrets} uses: a name that method asks a provider for appears here spelled exactly as
+   * it asks for it, and no name appears that the scan never read.
    */
-  private static boolean isNotNestedInAny(MatchResult candidate, List<MatchResult> outerMatches) {
-    return outerMatches.stream()
-        .noneMatch(outer -> candidate.start() >= outer.start() && candidate.end() <= outer.end());
+  public static List<String> retrieveSecretKeysInInput(String input) {
+    return input == null
+        ? List.of()
+        : REFERENCE.matcher(input).results().map(SecretUtil::name).distinct().toList();
   }
 }

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/SecretUtilTests.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/SecretUtilTests.java
@@ -25,8 +25,11 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import io.camunda.connector.api.secret.SecretContext;
 import io.camunda.connector.runtime.core.secret.SecretReplacer;
 import io.camunda.connector.runtime.core.secret.SecretUtil;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
@@ -119,11 +122,13 @@ public class SecretUtilTests {
   }
 
   @Test
-  void shouldNotResolveADeniedBracketedReferenceDuringAChainedRescan() {
-    // The bare pass reruns once per match in the original text, so a resolved value that itself
-    // looks like a secret reference can chain into a further replacement. A still-denied bracketed
-    // reference elsewhere in the same text must stay excluded across every one of those reruns, not
-    // just the first.
+  void shouldNotChainAResolvedValueIntoAFurtherReplacement() {
+    // This pinned the opposite: the bare pass used to rerun once per match in the original text, so
+    // a resolved value that itself looked like a reference chained into a further replacement, and
+    // the point was that a denied bracketed reference stayed denied across every rerun. The single
+    // scan removes the reruns, so it removes the chain with them -- A resolves to the literal text
+    // "secrets.FOO" and the scan moves past it, never asking for FOO. The denied reference is still
+    // denied, now because the scan consumed it whole rather than because it was excluded.
     SecretReplacer secretReplacer =
         (name, context) -> {
           if ("A".equals(name)) return "secrets.FOO";
@@ -134,7 +139,7 @@ public class SecretUtilTests {
     String result =
         SecretUtil.replaceSecrets("secrets.A and {{secrets.FOO:BAR}}", null, secretReplacer);
 
-    assertThat(result).isEqualTo("REAL_VALUE and {{secrets.FOO:BAR}}");
+    assertThat(result).isEqualTo("secrets.FOO and {{secrets.FOO:BAR}}");
   }
 
   @Test
@@ -160,5 +165,95 @@ public class SecretUtilTests {
     SecretContext secretContext = new SecretContext("tenantId");
     String replacedContent = SecretUtil.replaceSecrets(content, secretContext, secretReplacer);
     assertThat(replacedContent).isEqualTo("Hello VALUE1 and VALUE2 and {{secrets.KEY3}}");
+  }
+
+  @Test
+  void shouldNotResolveABarePrefixOfADeniedBracketedName() {
+    var asked = new ArrayList<String>();
+
+    assertThat(
+            SecretUtil.replaceSecrets(
+                "{{secrets.PROD:API}}", null, recording(asked, Map.of("PROD", "p4ssw0rd"))))
+        .isEqualTo("{{secrets.PROD:API}}");
+    assertThat(asked).containsExactly("PROD:API");
+  }
+
+  @Test
+  void shouldNotResolveABracketedReferenceAResolvedValueIntroduces() {
+    var asked = new ArrayList<String>();
+    var secrets = Map.of("A", "{{secrets.PROD:API}}", "PROD", "p4ssw0rd");
+
+    assertThat(SecretUtil.replaceSecrets("{{secrets.A}}", null, recording(asked, secrets)))
+        .isEqualTo("{{secrets.PROD:API}}");
+    assertThat(asked).containsExactly("A");
+  }
+
+  @Test
+  void shouldNotResolveABareReferenceAResolvedValueIntroduces() {
+    var asked = new ArrayList<String>();
+    var secrets = Map.of("NOTE", "see secrets.OTHER", "OTHER", "TOP_SECRET");
+
+    assertThat(SecretUtil.replaceSecrets("{{secrets.NOTE}}", null, recording(asked, secrets)))
+        .isEqualTo("see secrets.OTHER");
+    assertThat(asked).containsExactly("NOTE");
+  }
+
+  @Test
+  void shouldReportOnlyTheNameABracketedReferenceDeclares() {
+    assertThat(SecretUtil.retrieveSecretKeysInInput("{{secrets.PROD:API}}"))
+        .containsExactly("PROD:API");
+    assertThat(SecretUtil.retrieveSecretKeysInInput("{{secrets.camunda.secrets.FOO}}"))
+        .containsExactly("camunda.secrets.FOO");
+  }
+
+  @Test
+  void shouldAskForEveryNameAtMostOnce() {
+    var asked = new ArrayList<String>();
+
+    assertThat(
+            SecretUtil.replaceSecrets(
+                "secrets.K secrets.K {{secrets.K}}", null, recording(asked, Map.of("K", "V"))))
+        .isEqualTo("V V V");
+    assertThat(asked).containsExactly("K");
+  }
+
+  @Test
+  void shouldAskForEveryDeniedNameAtMostOnce() {
+    var asked = new ArrayList<String>();
+    var input = "{{secrets.DENIED}} secrets.DENIED {{secrets.DENIED}}";
+
+    assertThat(SecretUtil.replaceSecrets(input, null, recording(asked, Map.of()))).isEqualTo(input);
+    assertThat(asked).containsExactly("DENIED");
+  }
+
+  @Test
+  void shouldScanAPayloadOfDeniedReferencesOnce() {
+    var asked = new ArrayList<String>();
+    var payload =
+        IntStream.range(0, 5000)
+            .mapToObj(i -> "{{secrets.DENIED" + i + ":X}}")
+            .collect(Collectors.joining(" "));
+
+    assertThat(SecretUtil.replaceSecrets(payload, null, recording(asked, Map.of())))
+        .isEqualTo(payload);
+    assertThat(asked).hasSize(5000);
+  }
+
+  @Test
+  void shouldNotWriteTheTextNullWhereANameIsAllWhitespace() {
+    // The NUL is written as an escape rather than as a raw byte: a raw NUL makes git treat the
+    // whole file as binary, which hides every later change to it from review.
+    var asked = new ArrayList<String>();
+    var input = "{\"pw\":\"{{secrets.\0}}\"}";
+
+    assertThat(SecretUtil.replaceSecrets(input, null, recording(asked, Map.of()))).isEqualTo(input);
+    assertThat(asked).containsExactly("\0");
+  }
+
+  private static SecretReplacer recording(List<String> asked, Map<String, String> secrets) {
+    return (name, context) -> {
+      asked.add(name);
+      return secrets.get(name);
+    };
   }
 }


### PR DESCRIPTION
Backport of #8641 to `stable/8.8`. The automatic backport could not cherry-pick it.

fix: read every secret reference in a single scan (#8641)

Backport of #8641. Not a cherry-pick: this branch has neither the
camunda.secrets.<name> form nor containsLegacySecretReference, and there
is no ADR here to amend, so the port is main's rewrite minus those three.

SecretUtil read the same text several times with patterns that disagree
about what a secret name is: two replacement passes plus one scan per
pattern in the key extractor. The bare form's character class stops at
':', so every extra read could recover a truncated prefix of a name the
text never declared. This branch closed that leak with isNotNestedInAny,
excluding a bare match nested inside a bracketed one (#8496) -- a guard
the single scan makes unnecessary, because a match now consumes its
whole span and the scan resumes past it, so a narrower alternative can
never re-read the inside of a wider match at all. The extractor and the
resolver consume the same scan, so an allow-list can no longer admit or
deny a name the resolver reads differently.

Two things the guard did not fix and this does:

- Each replacement pass re-ran a whole-string replacement once per match
  in its original input, so denied references cost O(n^2) -- worse here
  than on main, since this branch also recomputes the bracketed-match
  list on every iteration. A per-call memo now asks the replacer at most
  once per name, for metered providers.
- A name that trimmed to blank made the converter return null, which
  StringBuilder.append writes as the literal text "null" into the
  payload.

Behaviour change, as on main: a resolved value is no longer rescanned,
so a secret whose value spells another reference is no longer treated as
a template. Main had no test on this; this branch did, because that guard had
to reason about the rescan to keep a denied reference denied across it.
shouldNotResolveADeniedBracketedReferenceDuringAChainedRescan is
rewritten rather than deleted, so the removal is pinned: the reference
stays denied, now because the scan consumed it whole. The secretFilter
javadoc, whose stated reason for existing was that same rescan, is
corrected to what the filter still stops.

Deviations from main, both because this branch has one key method
instead of three: keysIn collapses into retrieveSecretKeysInInput, and
resolve drops the null-name guard, which only the camunda form could
trigger.

connector-runtime-core and connector-runtime-spring both green.

(cherry picked from commit eb406fe4ec608c53929cfe65b9f5eb316351ff67)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)