### PR TITLE
fix: read every secret reference in a single scan (#8641) [stable/8.7]

### DIFF
--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextImpl.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextImpl.java
@@ -183,19 +183,22 @@ public class InboundConnectorContextImpl extends AbstractConnectorContext
    * properties} are final and there is no {@code updateConnectorDetails} — so the hot-swap and
    * torn-read failure directions main had to close are not representable here.
    *
-   * <p>This is what the filter stops: {@link SecretUtil#replaceSecrets} runs the brace pass and
-   * then runs the bare pass over that pass's output, so a resolved value containing
-   * reference-shaped text otherwise produces a lookup for a name no model declares. Confirmed
-   * present on this branch before backporting: a secret whose value is the literal {@code
-   * secrets.CHAINED} resolved {@code CHAINED} under the previous allow-all filter.
+   * <p>This is what the filter still stops: a name only a sibling element declares, and any name in
+   * text a caller supplies rather than the element's own properties. The escalation it was written
+   * for -- {@link SecretUtil#replaceSecrets} running the bare pass over the brace pass's output, so
+   * that a resolved value containing reference-shaped text reached a secret no model declares --
+   * was confirmed present on this branch before backporting: a secret whose value is the literal
+   * {@code secrets.CHAINED} resolved {@code CHAINED} under the previous allow-all filter. It is now
+   * closed at its source: the single scan consumes each reference whole and never re-reads what it
+   * resolved.
    *
-   * <p>Narrower than the equivalent on 8.8/8.9, and deliberately so for now. This branch's {@code
-   * SecretUtil} has neither their nested-match exclusion in {@code retrieveSecretKeysInInput} nor
+   * <p>This paragraph used to record that the filter was narrower here than on 8.8/8.9, because
+   * this branch had neither their nested-match exclusion in {@code retrieveSecretKeysInInput} nor
    * their denied-bracket exclusion in {@code replaceSecretsWithoutParentheses} (#8592, #8593), so a
-   * model declaring {@code {{secrets.FOO:BAR}}} also admits the truncated {@code FOO}. That is a
-   * pre-existing property of this branch, unchanged by this filter in either direction; porting
-   * that hardening is separate work, because {@code SecretUtil} here is shared with the outbound
-   * allow-list and with exception redaction.
+   * model declaring {@code {{secrets.FOO:BAR}}} also admitted the truncated {@code FOO}. That is
+   * the hardening it called separate work, and it is done: the single scan closes the same gap for
+   * every {@code SecretUtil} caller at once, which is what made the shared use by the outbound
+   * allow-list and by exception redaction safe to change.
    *
    * <p>Static because it feeds the {@code super(...)} call, before any field is assigned.
    */

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretUtil.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretUtil.java
@@ -17,71 +17,37 @@
 package io.camunda.connector.runtime.core.secret;
 
 import io.camunda.connector.api.secret.SecretContext;
+import java.util.HashMap;
 import java.util.List;
-import java.util.Objects;
+import java.util.Map;
 import java.util.function.Function;
+import java.util.regex.MatchResult;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import java.util.stream.Stream;
 
 /** Utility class to replace secrets in strings. */
 public class SecretUtil {
 
-  private static final Pattern SECRET_PATTERN_SECRETS =
-      Pattern.compile("secrets\\.(?<secret>([a-zA-Z0-9]+[\\/._-])*[a-zA-Z0-9]+)");
-
-  private static final Pattern SECRET_PATTERN_PARENTHESES =
-      Pattern.compile("\\{\\{\\s*secrets\\.(?<secret>\\S+?\\s*)}}");
+  // One pattern, so that one scan consumes each reference whole: scanning per form or per caller
+  // lets a narrower alternative re-read the inside of a wider match, as a name never declared.
+  private static final Pattern REFERENCE =
+      Pattern.compile(
+          "\\{\\{\\s*secrets\\.(?<braced>\\S+?)\\s*}}"
+              + "|secrets\\.(?<bare>([a-zA-Z0-9]+[\\/._-])*[a-zA-Z0-9]+)");
 
   public static String replaceSecrets(
       String input, SecretContext context, SecretReplacer secretReplacer) {
     if (input == null) {
       throw new IllegalStateException("input cant be null.");
     }
-    input = replaceSecretsWithParentheses(input, context, secretReplacer);
-    input = replaceSecretsWithoutParentheses(input, context, secretReplacer);
-    return input;
-  }
-
-  private static String replaceSecretsWithParentheses(
-      String input, SecretContext context, SecretReplacer secretReplacer) {
-    var secretVariableNameWithParenthesesMatcher = SECRET_PATTERN_PARENTHESES.matcher(input);
-    while (secretVariableNameWithParenthesesMatcher.find()) {
-      input =
-          replaceTokens(
-              input,
-              SECRET_PATTERN_PARENTHESES,
-              matcher -> resolveSecretValue(context, secretReplacer, matcher));
-    }
-    return input;
-  }
-
-  private static String replaceSecretsWithoutParentheses(
-      String input, SecretContext context, SecretReplacer secretReplacer) {
-    var secretVariableNameWithParenthesesMatcher = SECRET_PATTERN_SECRETS.matcher(input);
-    while (secretVariableNameWithParenthesesMatcher.find()) {
-      input =
-          replaceTokens(
-              input,
-              SECRET_PATTERN_SECRETS,
-              matcher -> resolveSecretValue(context, secretReplacer, matcher));
-    }
-    return input;
-  }
-
-  private static String resolveSecretValue(
-      SecretContext context, SecretReplacer secretReplacer, Matcher matcher) {
-    var secretName = matcher.group("secret").trim();
-    if (!secretName.isBlank()) {
-      var result = secretReplacer.replaceSecrets(secretName, context);
-      if (result != null) {
-        return result;
-      } else {
-        return matcher.group();
-      }
-    } else {
-      return null;
-    }
+    Map<String, String> resolutions = new HashMap<>();
+    return replaceTokens(
+        input,
+        REFERENCE,
+        matcher -> {
+          String value = resolve(name(matcher), context, secretReplacer, resolutions);
+          return value == null ? matcher.group() : value;
+        });
   }
 
   public static String replaceTokens(
@@ -99,23 +65,32 @@ public class SecretUtil {
     return output.toString();
   }
 
+  /** Asks the replacer at most once per name, for providers that meter or charge per lookup. */
+  private static String resolve(
+      String name,
+      SecretContext context,
+      SecretReplacer secretReplacer,
+      Map<String, String> resolutions) {
+    if (!resolutions.containsKey(name)) {
+      resolutions.put(name, secretReplacer.replaceSecrets(name, context));
+    }
+    return resolutions.get(name);
+  }
+
+  private static String name(MatchResult match) {
+    var braced = match.group("braced");
+    return braced != null ? braced : match.group("bare");
+  }
+
   /**
-   * Names are trimmed, because that is the name {@link #resolveSecretValue} looks up: the
-   * parentheses pattern's capture reaches past the name to the closing braces, so {@code {{
-   * secrets.FOO }}} declares {@code FOO}, not {@code "FOO "}. Returning the untrimmed form also
-   * breaks consumers that do not normalize again. For example, exception redaction filters
-   * extracted names against the allow-list before fetching their values; a colon-bearing name has
-   * no independent bare-pattern match, so the untrimmed name is filtered out and its value cannot
-   * be redacted from an exception message.
+   * Every secret name the given text declares, in either form, read by the same scan {@link
+   * #replaceSecrets} uses: a name that method asks a provider for appears here spelled exactly as
+   * it asks for it, and no name appears that the scan never read. Feeding both from one scan is
+   * what keeps the outbound allow-list and exception redaction agreeing with resolution.
    */
   public static List<String> retrieveSecretKeysInInput(String input) {
-    return Objects.isNull(input)
+    return input == null
         ? List.of()
-        : Stream.of(SECRET_PATTERN_PARENTHESES, SECRET_PATTERN_SECRETS)
-            .map(pattern -> pattern.matcher(input))
-            .flatMap(Matcher::results)
-            .map(matchResult -> matchResult.group("secret").trim())
-            .distinct()
-            .toList();
+        : REFERENCE.matcher(input).results().map(SecretUtil::name).distinct().toList();
   }
 }

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/SecretUtilTests.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/SecretUtilTests.java
@@ -24,7 +24,11 @@ import static org.mockito.Mockito.verifyNoInteractions;
 
 import io.camunda.connector.runtime.core.secret.SecretReplacer;
 import io.camunda.connector.runtime.core.secret.SecretUtil;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
@@ -88,5 +92,95 @@ public class SecretUtilTests {
   void shouldTrimSecretKeyExtractedFromBracketedReference() {
     var keys = SecretUtil.retrieveSecretKeysInInput("{{ secrets.FOO:BAR }}");
     assertThat(keys).contains("FOO:BAR");
+  }
+
+  @Test
+  void shouldNotResolveABarePrefixOfADeniedBracketedName() {
+    var asked = new ArrayList<String>();
+
+    assertThat(
+            SecretUtil.replaceSecrets(
+                "{{secrets.PROD:API}}", null, recording(asked, Map.of("PROD", "p4ssw0rd"))))
+        .isEqualTo("{{secrets.PROD:API}}");
+    assertThat(asked).containsExactly("PROD:API");
+  }
+
+  @Test
+  void shouldNotResolveABracketedReferenceAResolvedValueIntroduces() {
+    var asked = new ArrayList<String>();
+    var secrets = Map.of("A", "{{secrets.PROD:API}}", "PROD", "p4ssw0rd");
+
+    assertThat(SecretUtil.replaceSecrets("{{secrets.A}}", null, recording(asked, secrets)))
+        .isEqualTo("{{secrets.PROD:API}}");
+    assertThat(asked).containsExactly("A");
+  }
+
+  @Test
+  void shouldNotResolveABareReferenceAResolvedValueIntroduces() {
+    var asked = new ArrayList<String>();
+    var secrets = Map.of("NOTE", "see secrets.OTHER", "OTHER", "TOP_SECRET");
+
+    assertThat(SecretUtil.replaceSecrets("{{secrets.NOTE}}", null, recording(asked, secrets)))
+        .isEqualTo("see secrets.OTHER");
+    assertThat(asked).containsExactly("NOTE");
+  }
+
+  @Test
+  void shouldReportOnlyTheNameABracketedReferenceDeclares() {
+    assertThat(SecretUtil.retrieveSecretKeysInInput("{{secrets.PROD:API}}"))
+        .containsExactly("PROD:API");
+    assertThat(SecretUtil.retrieveSecretKeysInInput("{{secrets.camunda.secrets.FOO}}"))
+        .containsExactly("camunda.secrets.FOO");
+  }
+
+  @Test
+  void shouldAskForEveryNameAtMostOnce() {
+    var asked = new ArrayList<String>();
+
+    assertThat(
+            SecretUtil.replaceSecrets(
+                "secrets.K secrets.K {{secrets.K}}", null, recording(asked, Map.of("K", "V"))))
+        .isEqualTo("V V V");
+    assertThat(asked).containsExactly("K");
+  }
+
+  @Test
+  void shouldAskForEveryDeniedNameAtMostOnce() {
+    var asked = new ArrayList<String>();
+    var input = "{{secrets.DENIED}} secrets.DENIED {{secrets.DENIED}}";
+
+    assertThat(SecretUtil.replaceSecrets(input, null, recording(asked, Map.of()))).isEqualTo(input);
+    assertThat(asked).containsExactly("DENIED");
+  }
+
+  @Test
+  void shouldScanAPayloadOfDeniedReferencesOnce() {
+    var asked = new ArrayList<String>();
+    var payload =
+        IntStream.range(0, 5000)
+            .mapToObj(i -> "{{secrets.DENIED" + i + ":X}}")
+            .collect(Collectors.joining(" "));
+
+    assertThat(SecretUtil.replaceSecrets(payload, null, recording(asked, Map.of())))
+        .isEqualTo(payload);
+    assertThat(asked).hasSize(5000);
+  }
+
+  @Test
+  void shouldNotWriteTheTextNullWhereANameIsAllWhitespace() {
+    // The NUL is written as an escape rather than as a raw byte: a raw NUL makes git treat the
+    // whole file as binary, which hides every later change to it from review.
+    var asked = new ArrayList<String>();
+    var input = "{\"pw\":\"{{secrets.\0}}\"}";
+
+    assertThat(SecretUtil.replaceSecrets(input, null, recording(asked, Map.of()))).isEqualTo(input);
+    assertThat(asked).containsExactly("\0");
+  }
+
+  private static SecretReplacer recording(List<String> asked, Map<String, String> secrets) {
+    return (name, context) -> {
+      asked.add(name);
+      return secrets.get(name);
+    };
   }
 }

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/inbound/InboundConnectorRuntimeConfigurationTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/inbound/InboundConnectorRuntimeConfigurationTest.java
@@ -126,13 +126,22 @@ class InboundConnectorRuntimeConfigurationTest {
    * <p>The probe has to be the chained case: this context resolves the element's own property text,
    * so any name written there is declared by definition and the allow-list is a superset of it.
    * What it must refuse is a name that only a resolved <em>value</em> spells — CHAIN_ROOT's value
-   * is the literal {@code secrets.CHAINED}, which the bare pass then runs over.
+   * is the literal {@code secrets.CHAINED}.
+   *
+   * <p>DISABLED used to resolve that to {@code leaked-value}, because the bare pass ran over the
+   * brace pass's output and the filter was the only thing standing in the way. The single scan
+   * removes the second pass, so the chain is closed at its source and all three modes refuse the
+   * name. The probe no longer discriminates between modes, and there is no longer a way to
+   * construct an undeclared name on this path: what the filter here guards against is a resolution
+   * step that no longer exists. The filter itself stays, and {@link
+   * #springInboundConnectorContextFactory_filtersSecretsUnlessModeIsDisabled} still exercises it on
+   * the path where a caller supplies the text.
    */
   @Test
   void processElementContextFactory_refusesAChainedNameOnTheActivatedElement() {
     assertEquals("secrets.CHAINED", resolveChainedViaActivatedElement(SecretFilterMode.STRICT));
     assertEquals("secrets.CHAINED", resolveChainedViaActivatedElement(SecretFilterMode.LAX));
-    assertEquals("leaked-value", resolveChainedViaActivatedElement(SecretFilterMode.DISABLED));
+    assertEquals("secrets.CHAINED", resolveChainedViaActivatedElement(SecretFilterMode.DISABLED));
   }
 
   private String resolveChainedViaActivatedElement(SecretFilterMode mode) {


### PR DESCRIPTION
Backport of #8641 to `stable/8.7`. The automatic backport could not cherry-pick it.

fix: read every secret reference in a single scan (#8641)

Backport of #8641. Not a cherry-pick: this branch has neither the
camunda.secrets.<name> form nor containsLegacySecretReference, there is
no ADR here to amend, and resolved values are not JSON-escaped on this
branch, so the port is main's rewrite minus those four.

Unlike 8.8/8.9, this branch never received the nested-match exclusion
(#8592, #8593), so every bug #8641 describes is live here. Verified by
adding the tests first, against this branch's SecretUtil: all 8 failed.

SecretUtil read the same text several times with patterns that disagree
about what a secret name is: two replacement passes plus one scan per
pattern in the key extractor. The bare form's character class stops at
':', so every extra read could recover a truncated prefix of a name the
text never declared, and each consumer drew a different conclusion:

- retrieveSecretKeysInInput("{{secrets.PROD:API}}") returned
  [PROD:API, PROD], admitting the undeclared PROD onto the STRICT
  outbound allow-list.
- "{{secrets.PROD:API}}" with PROD:API denied and PROD allowed resolved
  to p4ssw0rd:API -- the bare pass resolving a prefix of a name the
  bracketed pass had just denied.
- Each replacement pass re-ran a whole-string replacement once per match
  in its original input, so denied references cost O(n^2). The 5000
  denied references in the new payload test took 11.5 s of this module's
  suite before the change and 0.5 s after.
- A name that trimmed to blank made the converter return null, which
  StringBuilder.append writes as the literal text "null" into the
  payload.

Replace all of it with one pattern holding both reference forms and one
left-to-right scan: a match consumes its whole span and the scan resumes
past it, so a narrower alternative can never re-read the inside of a
wider match. The extractor and the resolver consume the same scan, so an
allow-list can no longer admit or deny a name the resolver reads
differently -- which is what makes this safe to change for the outbound
allow-list and exception redaction at the same time, the shared use that
#8630 named as the reason to defer this hardening. A per-call memo asks
the replacer at most once per name, for metered providers.

Behaviour change, as on main: a resolved value is no longer rescanned,
so a secret whose value spells another reference is no longer treated as
a template. Two things on this branch documented that rescan and are
corrected rather than deleted:

- The secretFilter javadoc, whose stated reason for existing was that
  rescan, and whose closing paragraph recorded this hardening as work
  deferred. It now says what the filter still stops, and that the
  deferred work is done.
- processElementContextFactory_refusesAChainedNameOnTheActivatedElement,
  whose DISABLED case asserted the leak as the baseline. All three modes
  now refuse the chained name, because it is closed at its source rather
  than by the filter. Its javadoc records that the probe no longer
  discriminates between modes, and which test still covers the filter.

connector-runtime-core and connector-runtime-spring both green.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)