### PR TITLE
fix: avoid logging unredacted exception causes

### DIFF
--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/SpringConnectorJobHandler.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/SpringConnectorJobHandler.java
@@ -495,11 +495,11 @@ public class SpringConnectorJobHandler implements JobHandler {
     } else if (finalResult instanceof ConnectorResult.ErrorResult errorResult) {
       // Handle Java error, e.g. ConnectorException
       // these errors won't be handled ConnectorHelper.examineErrorExpression
+      // The wrapper message is redacted, but its cause is not, so do not log the throwable.
       LOGGER.error(
           "Exception while completing job: {}, message: {}",
           JobForLog.from(job),
-          errorResult.exception().getMessage(),
-          errorResult.exception());
+          errorResult.exception().getMessage());
 
       // pre-response failure path: function threw before returning a response, so notify with a
       // null response (subscribers to JobCompletionListener can still react)

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/job/SpringConnectorJobHandlerTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/job/SpringConnectorJobHandlerTest.java
@@ -35,6 +35,9 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.command.ClientStatusException;
 import io.camunda.client.api.command.FailJobCommandStep1;
@@ -98,6 +101,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.*;
 import org.mockito.ArgumentCaptor;
+import org.slf4j.LoggerFactory;
 
 class SpringConnectorJobHandlerTest {
 
@@ -2433,6 +2437,34 @@ class SpringConnectorJobHandlerTest {
               .executeAndCaptureResult(jobHandler, false, false);
 
       assertThat(result.getErrorMessage()).doesNotContain("old-value");
+    }
+
+    @Test
+    void aSecretThatRotatedBetweenBindAndMaskingIsNotLoggedFromTheCause() throws Exception {
+      var jobHandler =
+          connectorThrowingTheBoundToken(rotatingSecretProvider("old-value", "new-value"));
+      var logger = (Logger) LoggerFactory.getLogger(SpringConnectorJobHandler.class);
+      var appender = new ListAppender<ILoggingEvent>();
+      appender.start();
+      logger.addAppender(appender);
+      try {
+        JobBuilder.create()
+            .withVariables(INPUT_DECLARING_A_SECRET)
+            .executeAndCaptureResult(jobHandler, false, false);
+      } finally {
+        logger.detachAppender(appender);
+        appender.stop();
+      }
+
+      assertThat(appender.list)
+          .filteredOn(
+              event -> event.getFormattedMessage().startsWith("Exception while completing job"))
+          .singleElement()
+          .satisfies(
+              event -> {
+                assertThat(event.getFormattedMessage()).doesNotContain("old-value");
+                assertThat(event.getThrowableProxy()).isNull();
+              });
     }
 
     @Test


### PR DESCRIPTION
## Description

Connector failures keep their original exception cause so error expressions can inspect error codes and variables. Although the wrapper message is redacted, logging that wrapper as a throwable also prints the raw cause and can expose a resolved secret.

This keeps the existing exception and error-expression behavior unchanged, but logs only the redacted wrapper message. A regression test covers a secret that rotates between input binding and error handling.

## Related issues

Follow-up to #8643 and the review finding on #8661. Related to #8638.

## Checklist

- [x] No backport label is added because this fix will be folded into the existing combined backport #8661.
- [x] Tests for the changes have been added.
- [x] No documentation update is required.
