### PR TITLE
[Backport stable/8.9] fix: redact secrets from connector errors and logs

### DIFF
--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextImpl.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextImpl.java
@@ -46,6 +46,7 @@ import io.camunda.connector.runtime.core.inbound.correlation.InboundCorrelationH
 import io.camunda.connector.runtime.core.inbound.details.InboundConnectorDetails.ValidInboundConnectorDetails;
 import io.camunda.connector.runtime.core.secret.SecretFilter;
 import io.camunda.connector.runtime.core.secret.SecretUtil;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -70,6 +71,10 @@ public class InboundConnectorContextImpl extends AbstractConnectorContext
   private final Long activationTimestamp;
   private Health health = Health.unknown();
   private Map<String, Object> propertiesWithSecrets;
+  private volatile List<String> reReadSecrets;
+
+  private static final String REDACTION_UNAVAILABLE_MESSAGE =
+      "Message withheld: could not verify it does not contain a secret value";
 
   public InboundConnectorContextImpl(
       SecretProvider secretProvider,
@@ -352,7 +357,8 @@ public class InboundConnectorContextImpl extends AbstractConnectorContext
     if (health == null) {
       throw new IllegalArgumentException("Health must not be null");
     }
-    if (health.equals(this.health)) {
+    var masked = redactHealth(health);
+    if (!isWithheld(masked) && masked.equals(this.health)) {
       return;
     }
     var activityLog =
@@ -361,9 +367,9 @@ public class InboundConnectorContextImpl extends AbstractConnectorContext
             .withMessage(
                 String.format(
                     "Health status changed to %s, details: %s",
-                    health.getStatus(), health.getDetails()))
-            .withSeverity(health.getStatus() == Health.Status.UP ? Severity.INFO : Severity.ERROR)
-            .andReportHealth(health)
+                    masked.getStatus(), masked.getDetails()))
+            .withSeverity(masked.getStatus() == Health.Status.UP ? Severity.INFO : Severity.ERROR)
+            .andReportHealth(masked)
             .build();
     // append the activity log to store the health status change history
     activityLogWriter.log(
@@ -371,7 +377,7 @@ public class InboundConnectorContextImpl extends AbstractConnectorContext
             ExecutableId.fromDeduplicationId(connectorDetails.deduplicationId()),
             ActivitySource.CONNECTOR,
             activityLog));
-    this.health = health;
+    this.health = masked;
   }
 
   @Override
@@ -381,14 +387,15 @@ public class InboundConnectorContextImpl extends AbstractConnectorContext
 
   @Override
   public void log(Activity log) {
-    if (log.healthChange() != null) {
-      this.health = log.healthChange();
+    var masked = redact(log);
+    if (masked.healthChange() != null) {
+      this.health = masked.healthChange();
     }
     activityLogWriter.log(
         new ActivityLogEntry(
             ExecutableId.fromDeduplicationId(connectorDetails.deduplicationId()),
             ActivitySource.CONNECTOR,
-            log));
+            masked));
   }
 
   @Override
@@ -408,7 +415,102 @@ public class InboundConnectorContextImpl extends AbstractConnectorContext
         new ActivityLogEntry(
             ExecutableId.fromDeduplicationId(connectorDetails.deduplicationId()),
             ActivitySource.RUNTIME,
-            builder.build()));
+            redact(builder.build())));
+  }
+
+  /**
+   * The values to redact from a message, or {@code null} when they could not all be read.
+   *
+   * <p>The values this context substituted are only ever unioned into a successful, complete
+   * re-read, never a substitute for one: a connector can declare a secret it never got around to
+   * binding before the provider went down.
+   */
+  private List<String> secretValuesForRedaction() {
+    var reRead = reReadSecretValues();
+    if (reRead == null) {
+      return null;
+    }
+    // what this context substituted, so a secret that rotated since is redacted by the value the
+    // message actually carries rather than by the one the re-read came back with
+    var captured = getSecretHandler().getResolvedValues();
+    if (captured.isEmpty()) {
+      return reRead;
+    }
+    var union = new ArrayList<>(reRead);
+    union.addAll(captured);
+    return union;
+  }
+
+  private List<String> reReadSecretValues() {
+    var cached = reReadSecrets;
+    if (cached != null) {
+      return cached;
+    }
+    var values = fetchSecretValuesForRedaction();
+    if (values != null) {
+      reReadSecrets = values;
+    }
+    return values;
+  }
+
+  // names across every grouped element, not just this context's representative one
+  private List<String> fetchSecretValuesForRedaction() {
+    var names =
+        connectorDetails.connectorElements().stream()
+            .flatMap(element -> element.rawProperties().values().stream())
+            .flatMap(value -> SecretUtil.retrieveSecretKeysInInput(value).stream())
+            .distinct()
+            .toList();
+    if (names.isEmpty()) {
+      return List.of();
+    }
+    try {
+      var values = secretProvider.fetchAll(names, redactionSecretContext());
+      // fewer values than names means a partial read, treated the same as a failed one
+      return values.size() < names.size() ? null : values;
+    } catch (Exception e) {
+      LOG.warn("Could not fetch secret values to redact activity log: {}", e.getClass().getName());
+      return null;
+    }
+  }
+
+  private SecretContext redactionSecretContext() {
+    return new SecretContext(connectorDetails.tenantId(), connectorDetails.processDefinitionId());
+  }
+
+  private String redactMessage(String message) {
+    if (message == null) {
+      return null;
+    }
+    var secrets = secretValuesForRedaction();
+    return secrets == null
+        ? REDACTION_UNAVAILABLE_MESSAGE
+        : SecretUtil.hideSecretsFromMessage(message, secrets);
+  }
+
+  // an unmaskable health can't be verified as a repeat either, so it must never be deduped away
+  private static boolean isWithheld(Health health) {
+    return health.getError() != null
+        && REDACTION_UNAVAILABLE_MESSAGE.equals(health.getError().message());
+  }
+
+  private Health redactHealth(Health health) {
+    if (health == null || health.getError() == null) {
+      return health;
+    }
+    var error = health.getError();
+    return health.withError(
+        new Health.Error(redactMessage(error.code()), redactMessage(error.message())));
+  }
+
+  private Activity redact(Activity activity) {
+    return new Activity(
+        activity.severity(),
+        activity.tag(),
+        activity.timestamp(),
+        redactMessage(activity.message()),
+        activity.data(),
+        redactHealth(activity.healthChange()));
   }
 
   @Override
@@ -477,6 +579,7 @@ public class InboundConnectorContextImpl extends AbstractConnectorContext
               + message);
     }
     connectorDetails = newDetails;
+    reReadSecrets = null;
     logRuntime(
         builder ->
             builder

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextImpl.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextImpl.java
@@ -490,8 +490,12 @@ public class InboundConnectorContextImpl extends AbstractConnectorContext
 
   // an unmaskable health can't be verified as a repeat either, so it must never be deduped away
   private static boolean isWithheld(Health health) {
-    return health.getError() != null
-        && REDACTION_UNAVAILABLE_MESSAGE.equals(health.getError().message());
+    var error = health.getError();
+    // the code is redacted as well, and an error may carry only a code, in which case the sentinel
+    // is the only place the withholding shows
+    return error != null
+        && (REDACTION_UNAVAILABLE_MESSAGE.equals(error.message())
+            || REDACTION_UNAVAILABLE_MESSAGE.equals(error.code()));
   }
 
   private Health redactHealth(Health health) {

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextImpl.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextImpl.java
@@ -490,12 +490,8 @@ public class InboundConnectorContextImpl extends AbstractConnectorContext
 
   // an unmaskable health can't be verified as a repeat either, so it must never be deduped away
   private static boolean isWithheld(Health health) {
-    var error = health.getError();
-    // the code is redacted as well, and an error may carry only a code, in which case the sentinel
-    // is the only place the withholding shows
-    return error != null
-        && (REDACTION_UNAVAILABLE_MESSAGE.equals(error.message())
-            || REDACTION_UNAVAILABLE_MESSAGE.equals(error.code()));
+    return health.getError() != null
+        && REDACTION_UNAVAILABLE_MESSAGE.equals(health.getError().message());
   }
 
   private Health redactHealth(Health health) {

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretHandler.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretHandler.java
@@ -16,7 +16,6 @@
  */
 package io.camunda.connector.runtime.core.secret;
 
-import io.camunda.connector.api.error.ConnectorInputException;
 import io.camunda.connector.api.secret.SecretContext;
 import io.camunda.connector.api.secret.SecretProvider;
 import java.util.List;
@@ -44,11 +43,7 @@ public class SecretHandler {
           if (secretFilter.isAllowed(name)) {
             var value =
                 Optional.ofNullable(secretProvider.getSecret(name, context))
-                    .orElseThrow(
-                        () ->
-                            new ConnectorInputException(
-                                String.format("Secret with name '%s' is not available", name),
-                                null));
+                    .orElseThrow(() -> new SecretNotAvailableException(name));
             resolvedValues.add(value);
             // the substituted JSON carries this form, not the raw value, when it differs
             resolvedValues.add(SecretUtil.jsonEscape(value));

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretHandler.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretHandler.java
@@ -19,7 +19,10 @@ package io.camunda.connector.runtime.core.secret;
 import io.camunda.connector.api.error.ConnectorInputException;
 import io.camunda.connector.api.secret.SecretContext;
 import io.camunda.connector.api.secret.SecretProvider;
+import java.util.List;
 import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -31,16 +34,25 @@ public class SecretHandler {
 
   protected SecretReplacer secretReplacer;
 
+  // values this instance substituted, so a caller can redact against a rotated re-read
+  private final Set<String> resolvedValues = ConcurrentHashMap.newKeySet();
+
   public SecretHandler(final SecretProvider secretProvider, SecretFilter secretFilter) {
     this.secretProvider = secretProvider;
     secretReplacer =
         (name, context) -> {
           if (secretFilter.isAllowed(name)) {
-            return Optional.ofNullable(secretProvider.getSecret(name, context))
-                .orElseThrow(
-                    () ->
-                        new ConnectorInputException(
-                            String.format("Secret with name '%s' is not available", name), null));
+            var value =
+                Optional.ofNullable(secretProvider.getSecret(name, context))
+                    .orElseThrow(
+                        () ->
+                            new ConnectorInputException(
+                                String.format("Secret with name '%s' is not available", name),
+                                null));
+            resolvedValues.add(value);
+            // the substituted JSON carries this form, not the raw value, when it differs
+            resolvedValues.add(SecretUtil.jsonEscape(value));
+            return value;
           }
           LOG.debug("Secret '{}' not in allow-list — placeholder left unreplaced", name);
           return null;
@@ -49,5 +61,9 @@ public class SecretHandler {
 
   public String replaceSecrets(String input, SecretContext context) {
     return SecretUtil.replaceSecrets(input, context, secretReplacer);
+  }
+
+  public List<String> getResolvedValues() {
+    return List.copyOf(resolvedValues);
   }
 }

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretNotAvailableException.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretNotAvailableException.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.runtime.core.secret;
+
+import io.camunda.connector.api.error.ConnectorInputException;
+
+/**
+ * A secret reference the filter allowed, for which no configured provider held a value. The
+ * reference cannot be substituted, so the input cannot be bound; the model or the secret store has
+ * to change, which is why this is a {@link ConnectorInputException} and the job is not retried.
+ *
+ * <p>A type of its own, rather than a bare {@code ConnectorInputException}, because error masking
+ * has to tell this failure apart from every other one: it is the single case where a name the input
+ * declares is expected to come back empty on the masking re-read. Everywhere else that would mean a
+ * secret has been removed since the connector ran, with its value possibly still in the message.
+ */
+public class SecretNotAvailableException extends ConnectorInputException {
+
+  public SecretNotAvailableException(String secretName) {
+    super(String.format("Secret with name '%s' is not available", secretName));
+  }
+}

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretUtil.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretUtil.java
@@ -18,6 +18,7 @@ package io.camunda.connector.runtime.core.secret;
 
 import com.fasterxml.jackson.core.io.JsonStringEncoder;
 import io.camunda.connector.api.secret.SecretContext;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -49,8 +50,13 @@ public class SecretUtil {
         REFERENCE,
         matcher -> {
           String value = resolve(name(matcher), context, secretReplacer, resolutions);
-          return value == null ? matcher.group() : new String(encoder.quoteAsString(value));
+          return value == null ? matcher.group() : jsonEscape(value);
         });
+  }
+
+  // the form actually spliced into the substituted JSON, which a raw-value capture would miss
+  public static String jsonEscape(String value) {
+    return new String(encoder.quoteAsString(value));
   }
 
   public static String replaceTokens(
@@ -94,5 +100,17 @@ public class SecretUtil {
     return input == null
         ? List.of()
         : REFERENCE.matcher(input).results().map(SecretUtil::name).distinct().toList();
+  }
+
+  // Longest secret first: masking a shorter secret that prefixes a longer one would destroy the
+  // longer match and publish its remainder, e.g. "x" before "xSUPERSECRET" leaves "***SUPERSECRET".
+  public static String hideSecretsFromMessage(String message, List<String> secrets) {
+    if (message == null) {
+      return "";
+    }
+    return secrets.stream()
+        .filter(secret -> !secret.isEmpty())
+        .sorted(Comparator.comparingInt(String::length).reversed())
+        .reduce(message, (newMessage, nextSecret) -> newMessage.replace(nextSecret, "***"));
   }
 }

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextImplTest.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextImplTest.java
@@ -415,27 +415,6 @@ class InboundConnectorContextImplTest {
   }
 
   @Test
-  void reportHealth_doesNotDedupeTwoWithheldErrorsThatCarryOnlyACode() {
-    // given a provider that is down, so every health report is withheld
-    var definition = getInboundConnectorDefinition(Map.of("token", "secrets.FOO"));
-    var downProvider = mock(SecretProvider.class);
-    when(downProvider.fetchAll(any(), any())).thenThrow(new RuntimeException("down"));
-    var context =
-        new InboundConnectorContextImpl(
-            downProvider, (e) -> {}, definition, null, (e) -> {}, mapper, activityLogRegistry);
-
-    // when two distinct failures are reported that carry a code and no message: a code is redacted
-    // like any other text, so the withholding shows there and nowhere else
-    context.reportHealth(Health.down(new Health.Error("kafka broker unreachable", null)));
-    context.reportHealth(Health.down(new Health.Error("deserialization failed", null)));
-
-    // then both are logged rather than the second being deduped against the first
-    var logs =
-        activityLogRegistry.getLogs(ExecutableId.fromDeduplicationId(definition.deduplicationId()));
-    assertThat(logs).hasSize(2);
-  }
-
-  @Test
   void log_masksASecretThatRotatedAfterItWasBound() {
     // given a provider that resolves FOO to one value at bind time and a different one on re-read
     var definition = getInboundConnectorDefinition(Map.of("token", "secrets.FOO"));

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextImplTest.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextImplTest.java
@@ -415,6 +415,27 @@ class InboundConnectorContextImplTest {
   }
 
   @Test
+  void reportHealth_doesNotDedupeTwoWithheldErrorsThatCarryOnlyACode() {
+    // given a provider that is down, so every health report is withheld
+    var definition = getInboundConnectorDefinition(Map.of("token", "secrets.FOO"));
+    var downProvider = mock(SecretProvider.class);
+    when(downProvider.fetchAll(any(), any())).thenThrow(new RuntimeException("down"));
+    var context =
+        new InboundConnectorContextImpl(
+            downProvider, (e) -> {}, definition, null, (e) -> {}, mapper, activityLogRegistry);
+
+    // when two distinct failures are reported that carry a code and no message: a code is redacted
+    // like any other text, so the withholding shows there and nowhere else
+    context.reportHealth(Health.down(new Health.Error("kafka broker unreachable", null)));
+    context.reportHealth(Health.down(new Health.Error("deserialization failed", null)));
+
+    // then both are logged rather than the second being deduped against the first
+    var logs =
+        activityLogRegistry.getLogs(ExecutableId.fromDeduplicationId(definition.deduplicationId()));
+    assertThat(logs).hasSize(2);
+  }
+
+  @Test
   void log_masksASecretThatRotatedAfterItWasBound() {
     // given a provider that resolves FOO to one value at bind time and a different one on re-read
     var definition = getInboundConnectorDefinition(Map.of("token", "secrets.FOO"));

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextImplTest.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextImplTest.java
@@ -33,6 +33,7 @@ import io.camunda.connector.api.inbound.Severity;
 import io.camunda.connector.api.secret.SecretContext;
 import io.camunda.connector.api.secret.SecretProvider;
 import io.camunda.connector.runtime.core.FooBarSecretProvider;
+import io.camunda.connector.runtime.core.Keywords;
 import io.camunda.connector.runtime.core.TestObjectMapperSupplier;
 import io.camunda.connector.runtime.core.document.DocumentFactoryImpl;
 import io.camunda.connector.runtime.core.document.store.InMemoryDocumentStore;
@@ -308,6 +309,193 @@ class InboundConnectorContextImplTest {
               assertThat(log.healthChange()).isEqualTo(health);
               assertThat(log.severity()).isEqualTo(Severity.ERROR);
             });
+  }
+
+  @Test
+  void log_masksASecretResolvedForThisConnector() {
+    // given a connector declaring a secret this context can resolve
+    var definition = getInboundConnectorDefinition(Map.of("token", "secrets.FOO"));
+    var context =
+        new InboundConnectorContextImpl(
+            secretProvider, (e) -> {}, definition, null, (e) -> {}, mapper, activityLogRegistry);
+
+    // when an activity's message happens to carry the resolved value
+    context.log(activity -> activity.withSeverity(Severity.ERROR).withMessage("token was bar"));
+
+    // then the logged message has the value masked
+    var logs =
+        activityLogRegistry.getLogs(ExecutableId.fromDeduplicationId(definition.deduplicationId()));
+    assertThat(logs)
+        .singleElement()
+        .satisfies(log -> assertThat(log.message()).isEqualTo("token was ***"));
+  }
+
+  @Test
+  void log_withholdsMessageWhenSecretValuesCannotBeFetched() {
+    // given a provider that fails to resolve the declared secret
+    var definition = getInboundConnectorDefinition(Map.of("token", "secrets.FOO"));
+    var failingProvider = mock(SecretProvider.class);
+    when(failingProvider.fetchAll(any(), any())).thenThrow(new RuntimeException("down"));
+    var context =
+        new InboundConnectorContextImpl(
+            failingProvider, (e) -> {}, definition, null, (e) -> {}, mapper, activityLogRegistry);
+
+    // when
+    context.log(activity -> activity.withSeverity(Severity.ERROR).withMessage("token was bar"));
+
+    // then the raw message is withheld rather than published unmasked
+    var logs =
+        activityLogRegistry.getLogs(ExecutableId.fromDeduplicationId(definition.deduplicationId()));
+    assertThat(logs)
+        .singleElement()
+        .satisfies(
+            log -> {
+              assertThat(log.message()).doesNotContain("bar");
+              assertThat(log.message()).contains("withheld");
+            });
+  }
+
+  @Test
+  void reportHealth_masksASecretInTheErrorMessage() {
+    // given
+    var definition = getInboundConnectorDefinition(Map.of("token", "secrets.FOO"));
+    var context =
+        new InboundConnectorContextImpl(
+            secretProvider, (e) -> {}, definition, null, (e) -> {}, mapper, activityLogRegistry);
+
+    // when the reported health carries the resolved value in its error
+    context.reportHealth(Health.down(new RuntimeException("token was bar")));
+
+    // then it is masked both in the stored health and in the activity log
+    assertThat(context.getHealth().getError().message()).doesNotContain("bar");
+    var logs =
+        activityLogRegistry.getLogs(ExecutableId.fromDeduplicationId(definition.deduplicationId()));
+    assertThat(logs)
+        .singleElement()
+        .satisfies(
+            log -> assertThat(log.healthChange().getError().message()).doesNotContain("bar"));
+  }
+
+  @Test
+  void reportHealth_dedupesIdenticalHealthAfterMasking() {
+    // given
+    var definition = getInboundConnectorDefinition(Map.of("token", "secrets.FOO"));
+    var context =
+        new InboundConnectorContextImpl(
+            secretProvider, (e) -> {}, definition, null, (e) -> {}, mapper, activityLogRegistry);
+
+    // when the same failure is reported twice
+    context.reportHealth(Health.down(new RuntimeException("token was bar")));
+    context.reportHealth(Health.down(new RuntimeException("token was bar")));
+
+    // then the second report is deduped against the masked, not the raw, health
+    var logs =
+        activityLogRegistry.getLogs(ExecutableId.fromDeduplicationId(definition.deduplicationId()));
+    assertThat(logs).hasSize(1);
+  }
+
+  @Test
+  void reportHealth_doesNotDedupeTwoDifferentUnmaskableFailures() {
+    // given a provider that is down, so every health report is withheld
+    var definition = getInboundConnectorDefinition(Map.of("token", "secrets.FOO"));
+    var downProvider = mock(SecretProvider.class);
+    when(downProvider.fetchAll(any(), any())).thenThrow(new RuntimeException("down"));
+    var context =
+        new InboundConnectorContextImpl(
+            downProvider, (e) -> {}, definition, null, (e) -> {}, mapper, activityLogRegistry);
+
+    // when two distinct failures are reported during the outage
+    context.reportHealth(Health.down(new RuntimeException("kafka broker unreachable")));
+    context.reportHealth(Health.down(new RuntimeException("deserialization failed")));
+
+    // then both are logged rather than the second being deduped against the first
+    var logs =
+        activityLogRegistry.getLogs(ExecutableId.fromDeduplicationId(definition.deduplicationId()));
+    assertThat(logs).hasSize(2);
+  }
+
+  @Test
+  void log_masksASecretThatRotatedAfterItWasBound() {
+    // given a provider that resolves FOO to one value at bind time and a different one on re-read
+    var definition = getInboundConnectorDefinition(Map.of("token", "secrets.FOO"));
+    var rotatingProvider = mock(SecretProvider.class);
+    when(rotatingProvider.getSecret(eq("FOO"), any())).thenReturn("old-value");
+    when(rotatingProvider.fetchAll(any(), any())).thenReturn(List.of("new-value"));
+    var context =
+        new InboundConnectorContextImpl(
+            rotatingProvider, (e) -> {}, definition, null, (e) -> {}, mapper, activityLogRegistry);
+
+    // when the bound value is used, binding first so it is actually substituted and captured
+    context.getProperties();
+    context.log(
+        activity -> activity.withSeverity(Severity.ERROR).withMessage("token was old-value"));
+
+    // then the bound value is redacted even though a re-read would return a different one
+    var logs =
+        activityLogRegistry.getLogs(ExecutableId.fromDeduplicationId(definition.deduplicationId()));
+    assertThat(logs).last().satisfies(log -> assertThat(log.message()).isEqualTo("token was ***"));
+  }
+
+  @Test
+  void log_withholdsMessageWhenTheReReadComesBackShort() {
+    // given a connector declaring two secrets but only one of them resolving on re-read
+    var definition = getInboundConnectorDefinition(Map.of("a", "secrets.FOO", "b", "secrets.BAR"));
+    var partialProvider = mock(SecretProvider.class);
+    when(partialProvider.fetchAll(any(), any())).thenReturn(List.of("only-one-value"));
+    var context =
+        new InboundConnectorContextImpl(
+            partialProvider, (e) -> {}, definition, null, (e) -> {}, mapper, activityLogRegistry);
+
+    // when nothing was ever bound, so only the (incomplete) re-read is available
+    context.log(activity -> activity.withSeverity(Severity.ERROR).withMessage("token was leaked"));
+
+    // then the message is withheld rather than published with only one of the two values masked
+    var logs =
+        activityLogRegistry.getLogs(ExecutableId.fromDeduplicationId(definition.deduplicationId()));
+    assertThat(logs)
+        .singleElement()
+        .satisfies(log -> assertThat(log.message()).contains("withheld"));
+  }
+
+  @Test
+  void log_masksASecretDeclaredOnlyByAGroupedSiblingElement() {
+    // given a group whose elements agree on everything the grouping compares, and where only the
+    // sibling names a secret - in a property excluded from that comparison, which is the only way
+    // an element of a group can name one the representative element's properties do not carry.
+    // (Main's version has the sibling declare it in an ordinary property and bind it through
+    // bindElementProperties; neither is representable here, where a group's elements must share
+    // their properties and there is a single connector-level binding.)
+    var representative =
+        elementWithProperties("a", Map.of(Keywords.RESULT_EXPRESSION_KEYWORD, "="));
+    var sibling =
+        elementWithProperties("b", Map.of(Keywords.RESULT_EXPRESSION_KEYWORD, "=\"secrets.FOO\""));
+    var details =
+        (ValidInboundConnectorDetails)
+            InboundConnectorDetails.of(
+                representative.deduplicationId(List.of()), List.of(representative, sibling));
+    var context =
+        new InboundConnectorContextImpl(
+            secretProvider, (e) -> {}, details, null, (e) -> {}, mapper, activityLogRegistry);
+
+    // when a message carries the value that only the sibling names
+    context.log(activity -> activity.withSeverity(Severity.ERROR).withMessage("token was bar"));
+
+    // then it is still redacted, even though it is absent from the representative element's
+    // own properties
+    var logs =
+        activityLogRegistry.getLogs(ExecutableId.fromDeduplicationId(details.deduplicationId()));
+    assertThat(logs).last().satisfies(log -> assertThat(log.message()).isEqualTo("token was ***"));
+  }
+
+  private static InboundConnectorElement elementWithProperties(
+      String elementId, Map<String, String> properties) {
+    var rawProperties = new HashMap<>(properties);
+    rawProperties.put("inbound.type", "io.camunda:connector:1");
+    rawProperties.put("shared", "x");
+    return new InboundConnectorElement(
+        rawProperties,
+        new StandaloneMessageCorrelationPoint("", "", null, null),
+        new ProcessElementWithRuntimeData("bool", 0, 0, elementId, "<default>"));
   }
 
   private TestPropertiesClass createTestClass() {

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/OutboundConnectorExceptionHandler.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/OutboundConnectorExceptionHandler.java
@@ -305,6 +305,20 @@ public class OutboundConnectorExceptionHandler {
         : configured;
   }
 
+  /**
+   * @deprecated retained for callers compiled against earlier 8.9 patch releases. Without the
+   *     values the input binding substituted, an error raised after a secret rotated between
+   *     binding and this call is redacted with the new value only, leaving the one the connector
+   *     actually saw in the message. Prefer {@link #manageConnectorJobHandlerException(Exception,
+   *     ActivatedJob, Duration, SecretFilter, List)}.
+   */
+  @Deprecated
+  public ConnectorResult.ErrorResult manageConnectorJobHandlerException(
+      Exception e, ActivatedJob job, Duration retryBackoffDuration, SecretFilter secretFilter) {
+    return manageConnectorJobHandlerException(
+        e, job, retryBackoffDuration, secretFilter, List.of());
+  }
+
   public ConnectorResult.ErrorResult manageConnectorJobHandlerException(
       Exception e,
       ActivatedJob job,
@@ -481,6 +495,17 @@ public class OutboundConnectorExceptionHandler {
    * evaluate on the next attempt, and reaching here at all means the connector has already run, so
    * a retry would repeat its side effects.
    */
+  /**
+   * @deprecated retained for callers compiled against earlier 8.9 patch releases. See {@link
+   *     #manageConnectorJobHandlerException(Exception, ActivatedJob, Duration, SecretFilter)} for
+   *     what passing no captured values costs.
+   */
+  @Deprecated
+  public ConnectorResult.ErrorResult handleFinalResultException(
+      Exception ex, ActivatedJob job, SecretFilter secretFilter) {
+    return handleFinalResultException(ex, job, secretFilter, List.of());
+  }
+
   public ConnectorResult.ErrorResult handleFinalResultException(
       Exception ex, ActivatedJob job, SecretFilter secretFilter, List<String> capturedSecrets) {
     var masking = fetchSecretsForMasking(job, secretFilter, ex);

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/OutboundConnectorExceptionHandler.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/OutboundConnectorExceptionHandler.java
@@ -31,6 +31,7 @@ import io.camunda.connector.runtime.core.error.InvalidBackOffDurationException;
 import io.camunda.connector.runtime.core.error.JobError;
 import io.camunda.connector.runtime.core.outbound.ConnectorResult;
 import io.camunda.connector.runtime.core.secret.SecretFilter;
+import io.camunda.connector.runtime.core.secret.SecretNotAvailableException;
 import io.camunda.connector.runtime.core.secret.SecretUtil;
 import java.time.Duration;
 import java.util.*;
@@ -53,9 +54,13 @@ public class OutboundConnectorExceptionHandler {
     this.secretProvider = secretProvider;
   }
 
-  private static Map<String, Object> exceptionToMap(Exception wrappedException) {
+  private static Map<String, Object> exceptionToMap(
+      Exception wrappedException, List<String> secrets) {
     Map<String, Object> result = new HashMap<>();
-    Throwable originalCause = wrappedException.getCause();
+    // Every wrapper built here carries the failure it reports as its cause, except the one that
+    // deliberately withholds it — that one reports itself, rather than dereferencing a null.
+    Throwable originalCause =
+        wrappedException.getCause() != null ? wrappedException.getCause() : wrappedException;
     result.put("type", originalCause.getClass().getName());
     var message = wrappedException.getMessage();
     if (message != null) {
@@ -67,11 +72,16 @@ public class OutboundConnectorExceptionHandler {
       var variables = connectorException.getErrorVariables();
 
       if (code != null) {
+        // deliberately not masked: BPMN error boundary events match on this value, so altering it
+        // would stop the error from being caught
         result.put("code", code);
       }
 
       if (variables != null) {
-        result.put("variables", variables);
+        // the message is masked by the callers, but these are copied straight off the original
+        // exception: for HTTP connectors they carry the whole response body and headers, so an API
+        // that echoes a rejected credential back would publish the resolved secret as a variable
+        result.put("variables", maskSecrets(variables, secrets));
       }
     }
     return Map.copyOf(result);
@@ -85,6 +95,10 @@ public class OutboundConnectorExceptionHandler {
    * String} are passed through untouched — a secret held in a field of a custom object is not
    * reached.
    */
+  private static Object maskSecrets(Object value, List<String> secrets) {
+    return maskSecrets(value, secrets, Collections.newSetFromMap(new IdentityHashMap<>()));
+  }
+
   private static Object maskSecrets(Object value, List<String> secrets, Set<Object> enclosing) {
     return switch (value) {
       case null -> null;
@@ -165,7 +179,8 @@ public class OutboundConnectorExceptionHandler {
    * Reads the values to redact. A provider may refuse a key outright, and it throws here for keys
    * this fetch only ever wanted for masking, so the failure is returned rather than raised.
    */
-  private MaskingSecrets fetchSecretsForMasking(ActivatedJob job, SecretFilter secretFilter) {
+  private MaskingSecrets fetchSecretsForMasking(
+      ActivatedJob job, SecretFilter secretFilter, Exception jobFailure) {
     try {
       var allowedKeys =
           SecretUtil.retrieveSecretKeysInInput(job.getVariables()).stream()
@@ -176,10 +191,20 @@ public class OutboundConnectorExceptionHandler {
       if (allowedKeys.isEmpty()) {
         return new MaskingSecrets(List.of(), null);
       }
-      return new MaskingSecrets(
+      var values =
           this.secretProvider.fetchAll(
-              allowedKeys, new SecretContext(job.getTenantId(), job.getBpmnProcessId())),
-          null);
+              allowedKeys, new SecretContext(job.getTenantId(), job.getBpmnProcessId()));
+      // fetchAll drops the names it cannot resolve, so a short read is a silent one: a name the
+      // input declares resolved when it was bound, so one missing now means the secret was removed,
+      // or access revoked, while the connector ran. Redacting with what did come back would publish
+      // the one that did not in the clear.
+      if (values.size() < allowedKeys.size() && !reportsAnUnavailableSecret(jobFailure)) {
+        return new MaskingSecrets(
+            List.of(),
+            new MaskingSecretsIncompleteException(
+                allowedKeys.size() - values.size(), allowedKeys.size()));
+      }
+      return new MaskingSecrets(values, null);
     } catch (Exception ex) {
       LOGGER.error(
           "Initial error for job: {} for tenant: {} can't be displayed because fetching secrets failed: {}",
@@ -191,16 +216,57 @@ public class OutboundConnectorExceptionHandler {
   }
 
   /**
+   * Whether the job failed because a secret it names has no value. A re-read that comes back short
+   * then says the same thing the job's own failure already says, rather than reporting a value that
+   * has gone missing since the connector ran.
+   */
+  private static boolean reportsAnUnavailableSecret(Exception jobFailure) {
+    return jobFailure instanceof SecretNotAvailableException
+        || (jobFailure != null && jobFailure.getCause() instanceof SecretNotAvailableException);
+  }
+
+  /**
+   * Reported when the masking re-read comes back short of the names the job's input declares.
+   * Carries a count and nothing else: how many values are missing is enough for an operator to act
+   * on, and is not something a secret store told this runtime.
+   */
+  private static class MaskingSecretsIncompleteException extends RuntimeException {
+
+    private MaskingSecretsIncompleteException(int missing, int expected) {
+      super(
+          missing
+              + " of the "
+              + expected
+              + " secrets this job's input names could not be read back, so the error message could"
+              + " not be redacted. A secret that resolved when the input was bound has since been"
+              + " removed, or access to it revoked.");
+    }
+  }
+
+  /**
    * What may be said about a failed secret read. A provider's own message can carry secret material
    * — a bundle that parses as a non-object puts the value it could not coerce into Jackson's
-   * coercion error — so only the exception's class name is reported, plus the text of the one
-   * refusal this runtime writes itself: an unreadable allow-list names the element an operator has
-   * to look at, and a type name alone does not.
+   * coercion error — so only the exception's class name is reported, plus the text of the refusals
+   * this runtime writes itself: an unreadable allow-list names the element an operator has to look
+   * at, and a short re-read a count to act on, and a type name alone does neither.
    */
   private static String safeDiagnostic(Exception fetchFailure) {
-    return fetchFailure instanceof SecretAllowListUnavailableException
+    return runtimeAuthored(fetchFailure)
         ? fetchFailure.getClass().getName() + ": " + fetchFailure.getMessage()
         : fetchFailure.getClass().getName();
+  }
+
+  private static boolean runtimeAuthored(Exception fetchFailure) {
+    return fetchFailure instanceof SecretAllowListUnavailableException
+        || fetchFailure instanceof MaskingSecretsIncompleteException;
+  }
+
+  /**
+   * Whether an exception says the input can never bind, whoever raised it. Such a job is not worth
+   * another attempt; anything else — an unreachable cluster, a timeout — is.
+   */
+  private static boolean isFatalInputError(Throwable e) {
+    return e instanceof ConnectorInputException || e.getCause() instanceof ConnectorInputException;
   }
 
   /**
@@ -248,19 +314,21 @@ public class OutboundConnectorExceptionHandler {
     if (e instanceof SecretAllowListUnavailableException) {
       return handleGenericException(job, e, List.of(), retryBackoffFor(e, retryBackoffDuration));
     }
-    var masking = fetchSecretsForMasking(job, secretFilter);
+    var masking = fetchSecretsForMasking(job, secretFilter, e);
     if (masking.unavailable()) {
-      var ex = masking.failure();
-      var wrappedException =
-          new RuntimeException(
-              "Fetching secrets failed, original error can't be displayed as the error message might contain secrets: "
-                  + ex.getMessage(),
-              ex);
+      var wrappedException = unmaskableError(masking.failure());
+      // Either failure can be the permanent one, so both are consulted. A provider that refuses to
+      // resolve at all throws for every key, including the ones this fetch only needed for masking;
+      // and the job's own failure is still whatever it was, so an input error that will never bind
+      // must not become retryable just because reading the values to redact it happened to fail.
+      int retries =
+          isFatalInputError(masking.failure()) || isFatalInputError(e) ? 0 : job.getRetries() - 1;
       return new ConnectorResult.ErrorResult(
-          Map.of("error", exceptionToMap(wrappedException)),
+          // secrets could not be fetched, so there is nothing to mask with
+          Map.of("error", exceptionToMap(wrappedException, List.of())),
           wrappedException,
-          job.getRetries() - 1,
-          retryBackoffFor(ex, retryBackoffDuration));
+          retries,
+          retryBackoffFor(masking.failure(), retryBackoffDuration));
     }
     List<String> secrets = withCaptured(masking, capturedSecrets);
     return switch (e) {
@@ -287,7 +355,7 @@ public class OutboundConnectorExceptionHandler {
         if (nothingToRedact(bpmnError.errorMessage(), bpmnError.variables())) {
           yield bpmnError;
         }
-        var masking = fetchSecretsForMasking(job, secretFilter);
+        var masking = fetchSecretsForMasking(job, secretFilter, null);
         // the error code is never redacted: boundary events match on it
         if (masking.unavailable()) {
           yield new BpmnError(
@@ -303,7 +371,7 @@ public class OutboundConnectorExceptionHandler {
         if (nothingToRedact(jobError.errorMessage(), jobError.variables())) {
           yield jobError;
         }
-        var masking = fetchSecretsForMasking(job, secretFilter);
+        var masking = fetchSecretsForMasking(job, secretFilter, null);
         if (masking.unavailable()) {
           yield new JobError(
               unmaskableError(masking.failure()).getMessage(),
@@ -336,7 +404,7 @@ public class OutboundConnectorExceptionHandler {
     Exception newException =
         new Exception(SecretUtil.hideSecretsFromMessage(e.getMessage(), secrets), e);
     return new ConnectorResult.ErrorResult(
-        Map.of("error", exceptionToMap(newException)), newException, 0);
+        Map.of("error", exceptionToMap(newException, secrets)), newException, 0);
   }
 
   private ConnectorResult.ErrorResult handleConnectorRetryException(
@@ -354,11 +422,17 @@ public class OutboundConnectorExceptionHandler {
         newException,
         Optional.ofNullable(ex.getRetries()).orElse(job.getRetries() - 1),
         errorCode,
-        Optional.ofNullable(ex.getBackoffDuration()).orElse(retryBackoff));
+        Optional.ofNullable(ex.getBackoffDuration()).orElse(retryBackoff),
+        secrets);
   }
 
   private ConnectorResult.ErrorResult handleSDKException(
-      ActivatedJob job, Exception ex, Integer retries, String errorCode, Duration backoffDuration) {
+      ActivatedJob job,
+      Exception ex,
+      Integer retries,
+      String errorCode,
+      Duration backoffDuration,
+      List<String> secrets) {
     LOGGER.debug(
         "Failing job with retry config => job: {} for tenant: {} with error code: {}, retries: {} and remaining backoffDuration: {}",
         job.getKey(),
@@ -368,7 +442,7 @@ public class OutboundConnectorExceptionHandler {
         backoffDuration);
 
     return new ConnectorResult.ErrorResult(
-        Map.of("error", exceptionToMap(ex)), ex, retries, backoffDuration);
+        Map.of("error", exceptionToMap(ex, secrets)), ex, retries, backoffDuration);
   }
 
   private ConnectorResult.ErrorResult handleGenericException(
@@ -387,23 +461,41 @@ public class OutboundConnectorExceptionHandler {
     if (ex instanceof ConnectorException connectorException) {
       errorCode = connectorException.getErrorCode();
     }
-    if (ex instanceof ConnectorInputException || ex.getCause() instanceof ConnectorInputException) {
+    if (isFatalInputError(ex)) {
       retries = 0;
     }
-    return handleSDKException(job, newException, retries, errorCode, retryBackoff);
+    return handleSDKException(job, newException, retries, errorCode, retryBackoff, secrets);
   }
 
+  /**
+   * Reports a failure raised while processing a connector's final result — its result or error
+   * expression.
+   *
+   * <p>This must not throw. Its only caller is already handling the failure it is being told about,
+   * and an exception leaving here escapes that handler entirely: the job is then neither completed
+   * nor failed, and stays put until its activation timeout hands it to another worker, which
+   * re-runs the connector. So a masking fetch that fails costs the original message — which cannot
+   * be shown unredacted — and nothing else.
+   *
+   * <p>The result is unretryable either way. A result expression that does not evaluate will not
+   * evaluate on the next attempt, and reaching here at all means the connector has already run, so
+   * a retry would repeat its side effects.
+   */
   public ConnectorResult.ErrorResult handleFinalResultException(
       Exception ex, ActivatedJob job, SecretFilter secretFilter, List<String> capturedSecrets) {
-    var allowedKeys =
-        SecretUtil.retrieveSecretKeysInInput(job.getVariables()).stream()
-            .filter(secretFilter::isAllowed)
-            .toList();
-    List<String> secrets =
-        new ArrayList<>(
-            this.secretProvider.fetchAll(
-                allowedKeys, new SecretContext(job.getTenantId(), job.getBpmnProcessId())));
-    secrets.addAll(capturedSecrets);
+    var masking = fetchSecretsForMasking(job, secretFilter, ex);
+    if (masking.unavailable()) {
+      LOGGER.error(
+          "Exception while processing job: {} for tenant: {}, type: {}. Its message is withheld:"
+              + " the values to redact it with could not be read.",
+          job.getKey(),
+          job.getTenantId(),
+          ex.getClass().getName());
+      var wrappedException = unmaskableError(masking.failure());
+      return new ConnectorResult.ErrorResult(
+          Map.of("error", exceptionToMap(wrappedException, List.of())), wrappedException, 0);
+    }
+    List<String> secrets = withCaptured(masking, capturedSecrets);
     Exception newException =
         new Exception(SecretUtil.hideSecretsFromMessage(ex.getMessage(), secrets), ex);
     LOGGER.error(
@@ -412,6 +504,6 @@ public class OutboundConnectorExceptionHandler {
         job.getTenantId(),
         newException.getMessage());
     return new ConnectorResult.ErrorResult(
-        Map.of("error", exceptionToMap(newException)), newException, 0);
+        Map.of("error", exceptionToMap(newException, secrets)), newException, 0);
   }
 }

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/OutboundConnectorExceptionHandler.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/OutboundConnectorExceptionHandler.java
@@ -305,20 +305,6 @@ public class OutboundConnectorExceptionHandler {
         : configured;
   }
 
-  /**
-   * @deprecated retained for callers compiled against earlier 8.9 patch releases. Without the
-   *     values the input binding substituted, an error raised after a secret rotated between
-   *     binding and this call is redacted with the new value only, leaving the one the connector
-   *     actually saw in the message. Prefer {@link #manageConnectorJobHandlerException(Exception,
-   *     ActivatedJob, Duration, SecretFilter, List)}.
-   */
-  @Deprecated
-  public ConnectorResult.ErrorResult manageConnectorJobHandlerException(
-      Exception e, ActivatedJob job, Duration retryBackoffDuration, SecretFilter secretFilter) {
-    return manageConnectorJobHandlerException(
-        e, job, retryBackoffDuration, secretFilter, List.of());
-  }
-
   public ConnectorResult.ErrorResult manageConnectorJobHandlerException(
       Exception e,
       ActivatedJob job,
@@ -495,17 +481,6 @@ public class OutboundConnectorExceptionHandler {
    * evaluate on the next attempt, and reaching here at all means the connector has already run, so
    * a retry would repeat its side effects.
    */
-  /**
-   * @deprecated retained for callers compiled against earlier 8.9 patch releases. See {@link
-   *     #manageConnectorJobHandlerException(Exception, ActivatedJob, Duration, SecretFilter)} for
-   *     what passing no captured values costs.
-   */
-  @Deprecated
-  public ConnectorResult.ErrorResult handleFinalResultException(
-      Exception ex, ActivatedJob job, SecretFilter secretFilter) {
-    return handleFinalResultException(ex, job, secretFilter, List.of());
-  }
-
   public ConnectorResult.ErrorResult handleFinalResultException(
       Exception ex, ActivatedJob job, SecretFilter secretFilter, List<String> capturedSecrets) {
     var masking = fetchSecretsForMasking(job, secretFilter, ex);

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/OutboundConnectorExceptionHandler.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/OutboundConnectorExceptionHandler.java
@@ -88,7 +88,7 @@ public class OutboundConnectorExceptionHandler {
   private static Object maskSecrets(Object value, List<String> secrets, Set<Object> enclosing) {
     return switch (value) {
       case null -> null;
-      case String string -> hideSecretsFromMessage(string, secrets);
+      case String string -> SecretUtil.hideSecretsFromMessage(string, secrets);
       case Map<?, ?> map -> {
         // error variables are user-supplied, so a container may contain itself
         if (!enclosing.add(map)) {
@@ -121,7 +121,7 @@ public class OutboundConnectorExceptionHandler {
     map.forEach(
         (key, entry) ->
             masked.put(
-                hideSecretsFromMessage(String.valueOf(key), secrets),
+                SecretUtil.hideSecretsFromMessage(String.valueOf(key), secrets),
                 maskSecrets(entry, secrets, enclosing)));
     return masked;
   }
@@ -135,6 +135,16 @@ public class OutboundConnectorExceptionHandler {
     Set<Object> enclosing = Collections.newSetFromMap(new IdentityHashMap<>());
     enclosing.add(variables);
     return maskMap(variables, secrets, enclosing);
+  }
+
+  // unions bind-time captures into a successful re-read, so a rotated secret is still redacted
+  private static List<String> withCaptured(MaskingSecrets masking, List<String> captured) {
+    if (captured.isEmpty()) {
+      return masking.secrets();
+    }
+    var union = new ArrayList<String>(masking.secrets());
+    union.addAll(captured);
+    return union;
   }
 
   /**
@@ -230,7 +240,11 @@ public class OutboundConnectorExceptionHandler {
   }
 
   public ConnectorResult.ErrorResult manageConnectorJobHandlerException(
-      Exception e, ActivatedJob job, Duration retryBackoffDuration, SecretFilter secretFilter) {
+      Exception e,
+      ActivatedJob job,
+      Duration retryBackoffDuration,
+      SecretFilter secretFilter,
+      List<String> capturedSecrets) {
     if (e instanceof SecretAllowListUnavailableException) {
       return handleGenericException(job, e, List.of(), retryBackoffFor(e, retryBackoffDuration));
     }
@@ -248,7 +262,7 @@ public class OutboundConnectorExceptionHandler {
           job.getRetries() - 1,
           retryBackoffFor(ex, retryBackoffDuration));
     }
-    List<String> secrets = masking.secrets();
+    List<String> secrets = withCaptured(masking, capturedSecrets);
     return switch (e) {
       case InvalidBackOffDurationException invalidBackOffDurationException ->
           handleBackOffException(invalidBackOffDurationException, secrets);
@@ -262,7 +276,10 @@ public class OutboundConnectorExceptionHandler {
 
   /** Redacts an error an error expression produced; {@code failJob}/{@code throwError} do not. */
   public ConnectorError maskConnectorError(
-      ConnectorError error, ActivatedJob job, SecretFilter secretFilter) {
+      ConnectorError error,
+      ActivatedJob job,
+      SecretFilter secretFilter,
+      List<String> capturedSecrets) {
     return switch (error) {
       // business output: this branch completes the job with the variables the process branches on
       case IgnoreError ignoreError -> ignoreError;
@@ -272,30 +289,34 @@ public class OutboundConnectorExceptionHandler {
         }
         var masking = fetchSecretsForMasking(job, secretFilter);
         // the error code is never redacted: boundary events match on it
-        yield masking.unavailable()
-            ? new BpmnError(
-                bpmnError.errorCode(), unmaskableError(masking.failure()).getMessage(), Map.of())
-            : new BpmnError(
-                bpmnError.errorCode(),
-                redactNullable(bpmnError.errorMessage(), masking.secrets()),
-                maskVariables(bpmnError.variables(), masking.secrets()));
+        if (masking.unavailable()) {
+          yield new BpmnError(
+              bpmnError.errorCode(), unmaskableError(masking.failure()).getMessage(), Map.of());
+        }
+        var secrets = withCaptured(masking, capturedSecrets);
+        yield new BpmnError(
+            bpmnError.errorCode(),
+            redactNullable(bpmnError.errorMessage(), secrets),
+            maskVariables(bpmnError.variables(), secrets));
       }
       case JobError jobError -> {
         if (nothingToRedact(jobError.errorMessage(), jobError.variables())) {
           yield jobError;
         }
         var masking = fetchSecretsForMasking(job, secretFilter);
-        yield masking.unavailable()
-            ? new JobError(
-                unmaskableError(masking.failure()).getMessage(),
-                Map.of(),
-                jobError.retries(),
-                jobError.retryBackoff())
-            : new JobError(
-                redactNullable(jobError.errorMessage(), masking.secrets()),
-                maskVariables(jobError.variables(), masking.secrets()),
-                jobError.retries(),
-                jobError.retryBackoff());
+        if (masking.unavailable()) {
+          yield new JobError(
+              unmaskableError(masking.failure()).getMessage(),
+              Map.of(),
+              jobError.retries(),
+              jobError.retryBackoff());
+        }
+        var secrets = withCaptured(masking, capturedSecrets);
+        yield new JobError(
+            redactNullable(jobError.errorMessage(), secrets),
+            maskVariables(jobError.variables(), secrets),
+            jobError.retries(),
+            jobError.retryBackoff());
       }
     };
   }
@@ -306,32 +327,22 @@ public class OutboundConnectorExceptionHandler {
         && (variables == null || variables.isEmpty());
   }
 
-  /** Unlike {@link #hideSecretsFromMessage}, keeps a null message null rather than "". */
+  /** Unlike {@link SecretUtil#hideSecretsFromMessage}, keeps a null message null rather than "". */
   private static String redactNullable(String message, List<String> secrets) {
-    return message == null ? null : hideSecretsFromMessage(message, secrets);
-  }
-
-  private static String hideSecretsFromMessage(String message, List<String> secrets) {
-    if (!Objects.isNull(message))
-      return secrets.stream()
-          // a provider may answer with an empty value, and replacing that matches everywhere
-          .filter(secret -> !secret.isEmpty())
-          // longest first: masking a secret that prefixes another would destroy the longer match
-          // and publish its remainder, e.g. "x" before "xSUPERSECRET" leaves "***SUPERSECRET"
-          .sorted(Comparator.comparingInt(String::length).reversed())
-          .reduce(message, (newMessage, nextSecret) -> newMessage.replace(nextSecret, "***"));
-    else return "";
+    return message == null ? null : SecretUtil.hideSecretsFromMessage(message, secrets);
   }
 
   private ConnectorResult.ErrorResult handleBackOffException(Exception e, List<String> secrets) {
-    Exception newException = new Exception(hideSecretsFromMessage(e.getMessage(), secrets), e);
+    Exception newException =
+        new Exception(SecretUtil.hideSecretsFromMessage(e.getMessage(), secrets), e);
     return new ConnectorResult.ErrorResult(
         Map.of("error", exceptionToMap(newException)), newException, 0);
   }
 
   private ConnectorResult.ErrorResult handleConnectorRetryException(
       ActivatedJob job, ConnectorRetryException ex, List<String> secrets, Duration retryBackoff) {
-    Exception newException = new Exception(hideSecretsFromMessage(ex.getMessage(), secrets), ex);
+    Exception newException =
+        new Exception(SecretUtil.hideSecretsFromMessage(ex.getMessage(), secrets), ex);
     LOGGER.debug(
         "ConnectorRetryException while processing job: {} for tenant: {}, error message: {}",
         job.getKey(),
@@ -362,7 +373,8 @@ public class OutboundConnectorExceptionHandler {
 
   private ConnectorResult.ErrorResult handleGenericException(
       ActivatedJob job, Exception ex, List<String> secrets, Duration retryBackoff) {
-    Exception newException = new Exception(hideSecretsFromMessage(ex.getMessage(), secrets), ex);
+    Exception newException =
+        new Exception(SecretUtil.hideSecretsFromMessage(ex.getMessage(), secrets), ex);
     LOGGER.debug(
         "Exception while processing job: {} for tenant: {}, message: {}",
         job.getKey(),
@@ -382,15 +394,18 @@ public class OutboundConnectorExceptionHandler {
   }
 
   public ConnectorResult.ErrorResult handleFinalResultException(
-      Exception ex, ActivatedJob job, SecretFilter secretFilter) {
+      Exception ex, ActivatedJob job, SecretFilter secretFilter, List<String> capturedSecrets) {
     var allowedKeys =
         SecretUtil.retrieveSecretKeysInInput(job.getVariables()).stream()
             .filter(secretFilter::isAllowed)
             .toList();
     List<String> secrets =
-        this.secretProvider.fetchAll(
-            allowedKeys, new SecretContext(job.getTenantId(), job.getBpmnProcessId()));
-    Exception newException = new Exception(hideSecretsFromMessage(ex.getMessage(), secrets), ex);
+        new ArrayList<>(
+            this.secretProvider.fetchAll(
+                allowedKeys, new SecretContext(job.getTenantId(), job.getBpmnProcessId())));
+    secrets.addAll(capturedSecrets);
+    Exception newException =
+        new Exception(SecretUtil.hideSecretsFromMessage(ex.getMessage(), secrets), ex);
     LOGGER.error(
         "Exception while processing job: {} for tenant: {}, message: {}",
         job.getKey(),

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/OutboundConnectorExceptionHandler.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/OutboundConnectorExceptionHandler.java
@@ -24,7 +24,11 @@ import io.camunda.connector.api.error.ConnectorInputException;
 import io.camunda.connector.api.error.ConnectorRetryException;
 import io.camunda.connector.api.secret.SecretContext;
 import io.camunda.connector.api.secret.SecretProvider;
+import io.camunda.connector.runtime.core.error.BpmnError;
+import io.camunda.connector.runtime.core.error.ConnectorError;
+import io.camunda.connector.runtime.core.error.IgnoreError;
 import io.camunda.connector.runtime.core.error.InvalidBackOffDurationException;
+import io.camunda.connector.runtime.core.error.JobError;
 import io.camunda.connector.runtime.core.outbound.ConnectorResult;
 import io.camunda.connector.runtime.core.secret.SecretFilter;
 import io.camunda.connector.runtime.core.secret.SecretUtil;
@@ -37,6 +41,9 @@ public class OutboundConnectorExceptionHandler {
 
   private static final Logger LOGGER =
       LoggerFactory.getLogger(OutboundConnectorExceptionHandler.class);
+
+  /** Stands in for a container that (transitively) contains itself, so masking cannot loop. */
+  private static final String CIRCULAR_REFERENCE = "[circular reference]";
 
   private static final Duration ALLOW_LIST_RETRY_BACKOFF = Duration.ofSeconds(5);
 
@@ -70,6 +77,152 @@ public class OutboundConnectorExceptionHandler {
     return Map.copyOf(result);
   }
 
+  /**
+   * Masks every secret occurrence in {@code value}, recursing through maps and collections.
+   *
+   * <p>Only strings are rewritten; numbers, booleans and other scalars keep their type, since
+   * processes may branch on them. Values of types other than {@link Map}/{@link Collection}/{@link
+   * String} are passed through untouched — a secret held in a field of a custom object is not
+   * reached.
+   */
+  private static Object maskSecrets(Object value, List<String> secrets, Set<Object> enclosing) {
+    return switch (value) {
+      case null -> null;
+      case String string -> hideSecretsFromMessage(string, secrets);
+      case Map<?, ?> map -> {
+        // error variables are user-supplied, so a container may contain itself
+        if (!enclosing.add(map)) {
+          yield CIRCULAR_REFERENCE;
+        }
+        try {
+          yield maskMap(map, secrets, enclosing);
+        } finally {
+          enclosing.remove(map);
+        }
+      }
+      case Collection<?> collection -> {
+        if (!enclosing.add(collection)) {
+          yield CIRCULAR_REFERENCE;
+        }
+        try {
+          yield collection.stream().map(item -> maskSecrets(item, secrets, enclosing)).toList();
+        } finally {
+          enclosing.remove(collection);
+        }
+      }
+      default -> value;
+    };
+  }
+
+  private static Map<String, Object> maskMap(
+      Map<?, ?> map, List<String> secrets, Set<Object> enclosing) {
+    // keys are masked too, and collapsed keys simply overwrite rather than fail
+    var masked = new LinkedHashMap<String, Object>();
+    map.forEach(
+        (key, entry) ->
+            masked.put(
+                hideSecretsFromMessage(String.valueOf(key), secrets),
+                maskSecrets(entry, secrets, enclosing)));
+    return masked;
+  }
+
+  /** Typed variant of {@link #maskSecrets}, which returns {@link Object} to allow a sentinel. */
+  private static Map<String, Object> maskVariables(
+      Map<String, Object> variables, List<String> secrets) {
+    if (variables == null) {
+      return null;
+    }
+    Set<Object> enclosing = Collections.newSetFromMap(new IdentityHashMap<>());
+    enclosing.add(variables);
+    return maskMap(variables, secrets, enclosing);
+  }
+
+  /**
+   * The values to redact from an error message, or the failure that prevented reading them.
+   *
+   * <p>Every call site needs the values before it can report anything, and none of them may let a
+   * failure to read them escape: one would replace a classified result with an unclassified throw,
+   * and another is already inside a catch block whose escape route abandons the job.
+   */
+  private record MaskingSecrets(List<String> secrets, Exception failure) {
+
+    boolean unavailable() {
+      return failure != null;
+    }
+  }
+
+  /**
+   * Reads the values to redact. A provider may refuse a key outright, and it throws here for keys
+   * this fetch only ever wanted for masking, so the failure is returned rather than raised.
+   */
+  private MaskingSecrets fetchSecretsForMasking(ActivatedJob job, SecretFilter secretFilter) {
+    try {
+      var allowedKeys =
+          SecretUtil.retrieveSecretKeysInInput(job.getVariables()).stream()
+              .filter(secretFilter::isAllowed)
+              .toList();
+      // A job that declares no secret has nothing to redact, so no provider is asked for anything:
+      // a custom fetchAll that refuses every batch must not withhold such a job's error message.
+      if (allowedKeys.isEmpty()) {
+        return new MaskingSecrets(List.of(), null);
+      }
+      return new MaskingSecrets(
+          this.secretProvider.fetchAll(
+              allowedKeys, new SecretContext(job.getTenantId(), job.getBpmnProcessId())),
+          null);
+    } catch (Exception ex) {
+      LOGGER.error(
+          "Initial error for job: {} for tenant: {} can't be displayed because fetching secrets failed: {}",
+          job.getKey(),
+          job.getTenantId(),
+          safeDiagnostic(ex));
+      return new MaskingSecrets(List.of(), ex);
+    }
+  }
+
+  /**
+   * What may be said about a failed secret read. A provider's own message can carry secret material
+   * — a bundle that parses as a non-object puts the value it could not coerce into Jackson's
+   * coercion error — so only the exception's class name is reported, plus the text of the one
+   * refusal this runtime writes itself: an unreadable allow-list names the element an operator has
+   * to look at, and a type name alone does not.
+   */
+  private static String safeDiagnostic(Exception fetchFailure) {
+    return fetchFailure instanceof SecretAllowListUnavailableException
+        ? fetchFailure.getClass().getName() + ": " + fetchFailure.getMessage()
+        : fetchFailure.getClass().getName();
+  }
+
+  /**
+   * Stands in for an error that cannot be shown. With no values to redact with, the original
+   * message has to be dropped rather than reported unmasked — it may hold a resolved secret.
+   *
+   * <p>The failure that prevented masking is dropped with it, and for the same reason: a provider
+   * or client error can echo a response body from the secret store, so its message is no safer to
+   * publish than the message it was supposed to help redact.
+   */
+  private static RuntimeException unmaskableError(Exception fetchFailure) {
+    return new SecretsUnavailableException(safeDiagnostic(fetchFailure));
+  }
+
+  /**
+   * Reported in place of an error whose message could not be redacted.
+   *
+   * <p>Deliberately not a {@link ConnectorException}: {@link #exceptionToMap} copies a {@code
+   * ConnectorException}'s error variables and error code into the payload, and on this path it
+   * would copy them with no redaction list at all — publishing unmasked exactly the data this
+   * branch exists to withhold.
+   */
+  private static class SecretsUnavailableException extends RuntimeException {
+
+    private SecretsUnavailableException(String failureType) {
+      super(
+          "Fetching secrets failed, so the original error cannot be displayed: with nothing to"
+              + " redact with it might reveal a secret. Fetching failed with: "
+              + failureType);
+    }
+  }
+
   private static Duration retryBackoffFor(Exception failure, Duration configured) {
     return failure instanceof SecretAllowListUnavailableException
         ? ALLOW_LIST_RETRY_BACKOFF
@@ -81,21 +234,9 @@ public class OutboundConnectorExceptionHandler {
     if (e instanceof SecretAllowListUnavailableException) {
       return handleGenericException(job, e, List.of(), retryBackoffFor(e, retryBackoffDuration));
     }
-    List<String> secrets;
-    try {
-      var allowedKeys =
-          SecretUtil.retrieveSecretKeysInInput(job.getVariables()).stream()
-              .filter(secretFilter::isAllowed)
-              .toList();
-      secrets =
-          this.secretProvider.fetchAll(
-              allowedKeys, new SecretContext(job.getTenantId(), job.getBpmnProcessId()));
-    } catch (Exception ex) {
-      LOGGER.error(
-          "Initial error for job: {} for tenant: {} can't be displayed because fetching secrets failed: {}",
-          job.getKey(),
-          job.getTenantId(),
-          ex.getMessage());
+    var masking = fetchSecretsForMasking(job, secretFilter);
+    if (masking.unavailable()) {
+      var ex = masking.failure();
       var wrappedException =
           new RuntimeException(
               "Fetching secrets failed, original error can't be displayed as the error message might contain secrets: "
@@ -107,6 +248,7 @@ public class OutboundConnectorExceptionHandler {
           job.getRetries() - 1,
           retryBackoffFor(ex, retryBackoffDuration));
     }
+    List<String> secrets = masking.secrets();
     return switch (e) {
       case InvalidBackOffDurationException invalidBackOffDurationException ->
           handleBackOffException(invalidBackOffDurationException, secrets);
@@ -118,9 +260,65 @@ public class OutboundConnectorExceptionHandler {
     };
   }
 
-  private String hideSecretsFromMessage(String message, List<String> secrets) {
+  /** Redacts an error an error expression produced; {@code failJob}/{@code throwError} do not. */
+  public ConnectorError maskConnectorError(
+      ConnectorError error, ActivatedJob job, SecretFilter secretFilter) {
+    return switch (error) {
+      // business output: this branch completes the job with the variables the process branches on
+      case IgnoreError ignoreError -> ignoreError;
+      case BpmnError bpmnError -> {
+        if (nothingToRedact(bpmnError.errorMessage(), bpmnError.variables())) {
+          yield bpmnError;
+        }
+        var masking = fetchSecretsForMasking(job, secretFilter);
+        // the error code is never redacted: boundary events match on it
+        yield masking.unavailable()
+            ? new BpmnError(
+                bpmnError.errorCode(), unmaskableError(masking.failure()).getMessage(), Map.of())
+            : new BpmnError(
+                bpmnError.errorCode(),
+                redactNullable(bpmnError.errorMessage(), masking.secrets()),
+                maskVariables(bpmnError.variables(), masking.secrets()));
+      }
+      case JobError jobError -> {
+        if (nothingToRedact(jobError.errorMessage(), jobError.variables())) {
+          yield jobError;
+        }
+        var masking = fetchSecretsForMasking(job, secretFilter);
+        yield masking.unavailable()
+            ? new JobError(
+                unmaskableError(masking.failure()).getMessage(),
+                Map.of(),
+                jobError.retries(),
+                jobError.retryBackoff())
+            : new JobError(
+                redactNullable(jobError.errorMessage(), masking.secrets()),
+                maskVariables(jobError.variables(), masking.secrets()),
+                jobError.retries(),
+                jobError.retryBackoff());
+      }
+    };
+  }
+
+  // A JobError egresses variablesWithErrorMessage(), which adds only the message checked here.
+  private static boolean nothingToRedact(String errorMessage, Map<String, Object> variables) {
+    return (errorMessage == null || errorMessage.isEmpty())
+        && (variables == null || variables.isEmpty());
+  }
+
+  /** Unlike {@link #hideSecretsFromMessage}, keeps a null message null rather than "". */
+  private static String redactNullable(String message, List<String> secrets) {
+    return message == null ? null : hideSecretsFromMessage(message, secrets);
+  }
+
+  private static String hideSecretsFromMessage(String message, List<String> secrets) {
     if (!Objects.isNull(message))
       return secrets.stream()
+          // a provider may answer with an empty value, and replacing that matches everywhere
+          .filter(secret -> !secret.isEmpty())
+          // longest first: masking a secret that prefixes another would destroy the longer match
+          // and publish its remainder, e.g. "x" before "xSUPERSECRET" leaves "***SUPERSECRET"
+          .sorted(Comparator.comparingInt(String::length).reversed())
           .reduce(message, (newMessage, nextSecret) -> newMessage.replace(nextSecret, "***"));
     else return "";
   }

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/SpringConnectorJobHandler.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/SpringConnectorJobHandler.java
@@ -191,22 +191,23 @@ public class SpringConnectorJobHandler implements JobHandler {
         job.getKey(),
         job.getType(),
         job.getTenantId());
-    ConnectorResult result = getConnectorResult(job, secretFilter);
-    processFinalResult(client, job, result, counterMetricsContext, secretFilter);
+    var context =
+        new JobHandlerContext(
+            job,
+            getSecretProvider(),
+            validationProvider,
+            documentFactory,
+            objectMapper,
+            secretFilter);
+    ConnectorResult result = getConnectorResult(job, context, secretFilter);
+    processFinalResult(client, job, context, result, counterMetricsContext, secretFilter);
   }
 
-  private ConnectorResult getConnectorResult(ActivatedJob job, SecretFilter secretFilter) {
+  private ConnectorResult getConnectorResult(
+      ActivatedJob job, JobHandlerContext context, SecretFilter secretFilter) {
     Duration retryBackoff = null;
     try {
       retryBackoff = getBackoffDuration(job);
-      var context =
-          new JobHandlerContext(
-              job,
-              getSecretProvider(),
-              validationProvider,
-              documentFactory,
-              objectMapper,
-              secretFilter);
       var response = call.execute(context);
       var responseVariables =
           connectorResultHandler.createOutputVariables(
@@ -219,13 +220,14 @@ public class SpringConnectorJobHandler implements JobHandler {
       return new ConnectorResult.SuccessResult(response, responseVariables);
     } catch (Exception e) {
       return outboundConnectorExceptionHandler.manageConnectorJobHandlerException(
-          e, job, retryBackoff, secretFilter);
+          e, job, retryBackoff, secretFilter, context.getSecretHandler().getResolvedValues());
     }
   }
 
   private void processFinalResult(
       JobClient client,
       ActivatedJob job,
+      JobHandlerContext context,
       ConnectorResult finalResult,
       CounterMetricsContext counterMetricsContext,
       SecretFilter secretFilter) {
@@ -237,7 +239,8 @@ public class SpringConnectorJobHandler implements JobHandler {
               new ErrorExpressionJobContext(
                   new ErrorExpressionJobContext.ErrorExpressionJob(job.getRetries())));
       optionalConnectorError.ifPresentOrElse(
-          error -> handleBPMNError(client, job, error, counterMetricsContext, secretFilter),
+          error ->
+              handleBPMNError(client, job, context, error, counterMetricsContext, secretFilter),
           () -> handleSuccessResult(client, job, finalResult, counterMetricsContext));
     } catch (Exception ex) {
       if (Thread.currentThread().isInterrupted()) {
@@ -261,7 +264,8 @@ public class SpringConnectorJobHandler implements JobHandler {
       failJob(
           client,
           job,
-          this.outboundConnectorExceptionHandler.handleFinalResultException(ex, job, secretFilter),
+          this.outboundConnectorExceptionHandler.handleFinalResultException(
+              ex, job, secretFilter, context.getSecretHandler().getResolvedValues()),
           counterMetricsContext);
     }
   }
@@ -289,11 +293,14 @@ public class SpringConnectorJobHandler implements JobHandler {
   private void handleBPMNError(
       JobClient client,
       ActivatedJob job,
+      JobHandlerContext context,
       ConnectorError rawError,
       CounterMetricsContext counterMetricsContext,
       SecretFilter secretFilter) {
     // redacted before the Zeebe command is built from it
-    var error = outboundConnectorExceptionHandler.maskConnectorError(rawError, job, secretFilter);
+    var error =
+        outboundConnectorExceptionHandler.maskConnectorError(
+            rawError, job, secretFilter, context.getSecretHandler().getResolvedValues());
 
     switch (error) {
       case BpmnError bpmnError -> {

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/SpringConnectorJobHandler.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/SpringConnectorJobHandler.java
@@ -237,7 +237,7 @@ public class SpringConnectorJobHandler implements JobHandler {
               new ErrorExpressionJobContext(
                   new ErrorExpressionJobContext.ErrorExpressionJob(job.getRetries())));
       optionalConnectorError.ifPresentOrElse(
-          error -> handleBPMNError(client, job, error, counterMetricsContext),
+          error -> handleBPMNError(client, job, error, counterMetricsContext, secretFilter),
           () -> handleSuccessResult(client, job, finalResult, counterMetricsContext));
     } catch (Exception ex) {
       if (Thread.currentThread().isInterrupted()) {
@@ -289,13 +289,18 @@ public class SpringConnectorJobHandler implements JobHandler {
   private void handleBPMNError(
       JobClient client,
       ActivatedJob job,
-      ConnectorError error,
-      CounterMetricsContext counterMetricsContext) {
+      ConnectorError rawError,
+      CounterMetricsContext counterMetricsContext,
+      SecretFilter secretFilter) {
+    // redacted before the Zeebe command is built from it
+    var error = outboundConnectorExceptionHandler.maskConnectorError(rawError, job, secretFilter);
+
     switch (error) {
       case BpmnError bpmnError -> {
         checkVariablesSize(bpmnError.variables());
-        LOGGER.debug(
-            "Throwing BPMN error for job {} with code {}", job.getKey(), bpmnError.errorCode());
+        // the code is not redacted, so it stays out of the log: unlike the command and the error
+        // variables that carry it, pod logs are shipped to systems with their own access controls
+        LOGGER.debug("Throwing BPMN error for job {}", job.getKey());
         throwBpmnError(client, job, bpmnError, counterMetricsContext);
       }
       case JobError jobError -> {

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/SpringConnectorJobHandler.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/SpringConnectorJobHandler.java
@@ -281,11 +281,11 @@ public class SpringConnectorJobHandler implements JobHandler {
     } else if (finalResult instanceof ConnectorResult.ErrorResult errorResult) {
       // Handle Java error, e.g. ConnectorException
       // these errors won't be handled ConnectorHelper.examineErrorExpression
+      // The wrapper message is redacted, but its cause is not, so do not log the throwable.
       LOGGER.error(
           "Exception while completing job: {}, message: {}",
           JobForLog.from(job),
-          errorResult.exception().getMessage(),
-          errorResult.exception());
+          errorResult.exception().getMessage());
       failJob(jobClient, job, errorResult, counterMetricsContext);
     }
   }

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/job/OutboundConnectorExceptionHandlerTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/job/OutboundConnectorExceptionHandlerTest.java
@@ -562,39 +562,6 @@ class OutboundConnectorExceptionHandlerTest {
     assertThat(error(result)).containsEntry("code", "401");
   }
 
-  /**
-   * Callers compiled against an earlier 8.9 patch release call the signatures that predate the
-   * captured values, and they still link and still redact with what the re-read returns.
-   */
-  @Test
-  @SuppressWarnings("deprecation")
-  void manageConnectorJobHandlerException_redactsForCallersThatPassNoCapturedValues() {
-    var job = jobWithSecretReference();
-    when(secretProvider.fetchAll(any(), any())).thenReturn(List.of("bar-value"));
-
-    var result =
-        handlerOverStore.manageConnectorJobHandlerException(
-            new RuntimeException("api rejected bar-value"),
-            job,
-            Duration.ofSeconds(1),
-            SecretFilter.allowAll());
-
-    assertThat(result.exception().getMessage()).isEqualTo("api rejected ***");
-  }
-
-  @Test
-  @SuppressWarnings("deprecation")
-  void handleFinalResultException_redactsForCallersThatPassNoCapturedValues() {
-    var job = jobWithSecretReference();
-    when(secretProvider.fetchAll(any(), any())).thenReturn(List.of("bar-value"));
-
-    var result =
-        handlerOverStore.handleFinalResultException(
-            new RuntimeException("api rejected bar-value"), job, SecretFilter.allowAll());
-
-    assertThat(result.exception().getMessage()).isEqualTo("api rejected ***");
-  }
-
   @SuppressWarnings("unchecked")
   private Map<String, Object> maskedErrorVariables(Map<String, Object> errorVariables) {
     var job = jobWithSecretReference();

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/job/OutboundConnectorExceptionHandlerTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/job/OutboundConnectorExceptionHandlerTest.java
@@ -562,6 +562,39 @@ class OutboundConnectorExceptionHandlerTest {
     assertThat(error(result)).containsEntry("code", "401");
   }
 
+  /**
+   * Callers compiled against an earlier 8.9 patch release call the signatures that predate the
+   * captured values, and they still link and still redact with what the re-read returns.
+   */
+  @Test
+  @SuppressWarnings("deprecation")
+  void manageConnectorJobHandlerException_redactsForCallersThatPassNoCapturedValues() {
+    var job = jobWithSecretReference();
+    when(secretProvider.fetchAll(any(), any())).thenReturn(List.of("bar-value"));
+
+    var result =
+        handlerOverStore.manageConnectorJobHandlerException(
+            new RuntimeException("api rejected bar-value"),
+            job,
+            Duration.ofSeconds(1),
+            SecretFilter.allowAll());
+
+    assertThat(result.exception().getMessage()).isEqualTo("api rejected ***");
+  }
+
+  @Test
+  @SuppressWarnings("deprecation")
+  void handleFinalResultException_redactsForCallersThatPassNoCapturedValues() {
+    var job = jobWithSecretReference();
+    when(secretProvider.fetchAll(any(), any())).thenReturn(List.of("bar-value"));
+
+    var result =
+        handlerOverStore.handleFinalResultException(
+            new RuntimeException("api rejected bar-value"), job, SecretFilter.allowAll());
+
+    assertThat(result.exception().getMessage()).isEqualTo("api rejected ***");
+  }
+
   @SuppressWarnings("unchecked")
   private Map<String, Object> maskedErrorVariables(Map<String, Object> errorVariables) {
     var job = jobWithSecretReference();

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/job/OutboundConnectorExceptionHandlerTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/job/OutboundConnectorExceptionHandlerTest.java
@@ -113,7 +113,8 @@ class OutboundConnectorExceptionHandlerTest {
                     + " (io.camunda.client.api.command.ProblemException)"),
             job,
             null,
-            SecretFilter.allowAll());
+            SecretFilter.allowAll(),
+            List.of());
 
     assertThat(result.exception())
         .hasMessageContaining("Activity_1")
@@ -133,7 +134,8 @@ class OutboundConnectorExceptionHandlerTest {
             new SecretAllowListUnavailableException("lookup failed"),
             job,
             modelBackoff,
-            SecretFilter.allowAll());
+            SecretFilter.allowAll(),
+            List.of());
 
     assertThat(result.retryBackoff()).isEqualTo(Duration.ofSeconds(5));
     assertThat(result.retries()).isEqualTo(2);
@@ -157,7 +159,11 @@ class OutboundConnectorExceptionHandlerTest {
 
     var result =
         handlerWithThrowingProvider.manageConnectorJobHandlerException(
-            new RuntimeException("boom"), job, Duration.ofSeconds(30), SecretFilter.allowAll());
+            new RuntimeException("boom"),
+            job,
+            Duration.ofSeconds(30),
+            SecretFilter.allowAll(),
+            List.of());
 
     assertThat(result.retryBackoff()).isEqualTo(Duration.ofSeconds(30));
   }
@@ -173,7 +179,7 @@ class OutboundConnectorExceptionHandlerTest {
 
     var result =
         handler.manageConnectorJobHandlerException(
-            new RuntimeException("boom"), job, null, unreadableAllowList);
+            new RuntimeException("boom"), job, null, unreadableAllowList, List.of());
 
     assertThat(result.exception()).hasMessageContaining("Activity_1");
     assertThat(result.retries()).isEqualTo(2);
@@ -199,7 +205,8 @@ class OutboundConnectorExceptionHandlerTest {
                     new RuntimeException("boom"),
                     job,
                     Duration.ofSeconds(1),
-                    SecretFilter.allowAll()));
+                    SecretFilter.allowAll(),
+                    List.of()));
 
     assertThat(logged).noneMatch(message -> message.contains("super-secret"));
     assertThat(logged).anyMatch(message -> message.contains("java.lang.RuntimeException"));
@@ -220,7 +227,11 @@ class OutboundConnectorExceptionHandlerTest {
         logsOf(
             () ->
                 handler.manageConnectorJobHandlerException(
-                    new RuntimeException("boom"), job, Duration.ofSeconds(1), unreadableAllowList));
+                    new RuntimeException("boom"),
+                    job,
+                    Duration.ofSeconds(1),
+                    unreadableAllowList,
+                    List.of()));
 
     assertThat(logged).anyMatch(message -> message.contains("Activity_1"));
   }
@@ -237,7 +248,8 @@ class OutboundConnectorExceptionHandlerTest {
             new RuntimeException("api rejected xSUPERSECRET"),
             job,
             Duration.ofSeconds(1),
-            SecretFilter.allowAll());
+            SecretFilter.allowAll(),
+            List.of());
 
     assertThat(requestedKeys).containsExactly("SHORT", "LONG");
     assertThat(result.exception().getMessage()).isEqualTo("api rejected ***");
@@ -255,7 +267,8 @@ class OutboundConnectorExceptionHandlerTest {
             new RuntimeException("api rejected the request"),
             job,
             Duration.ofSeconds(1),
-            SecretFilter.allowAll());
+            SecretFilter.allowAll(),
+            List.of());
 
     assertThat(result.exception().getMessage()).isEqualTo("api rejected the request");
   }
@@ -273,7 +286,8 @@ class OutboundConnectorExceptionHandlerTest {
             new RuntimeException("api rejected the request"),
             job,
             Duration.ofSeconds(1),
-            SecretFilter.allowAll());
+            SecretFilter.allowAll(),
+            List.of());
 
     verifyNoInteractions(secretProvider);
     assertThat(result.exception().getMessage()).isEqualTo("api rejected the request");

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/job/OutboundConnectorExceptionHandlerTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/job/OutboundConnectorExceptionHandlerTest.java
@@ -17,31 +17,80 @@
 package io.camunda.connector.runtime.outbound.job;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
 import io.camunda.client.api.response.ActivatedJob;
 import io.camunda.connector.api.secret.SecretProvider;
 import io.camunda.connector.runtime.core.secret.SecretFilter;
 import io.camunda.connector.runtime.secret.FooBarSecretProvider;
 import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.slf4j.LoggerFactory;
 
 class OutboundConnectorExceptionHandlerTest {
 
   private final OutboundConnectorExceptionHandler handler =
       new OutboundConnectorExceptionHandler(new FooBarSecretProvider());
 
+  private final SecretProvider secretProvider = mock(SecretProvider.class);
+  private final List<String> requestedKeys = new ArrayList<>();
+  private final OutboundConnectorExceptionHandler handlerOverStore =
+      new OutboundConnectorExceptionHandler(secretProvider);
+
   private static ActivatedJob jobWithSecretReference() {
+    return jobNaming("{\"value\":\"{{secrets.FOO}}\"}");
+  }
+
+  private static ActivatedJob jobNaming(String variables) {
     var job = mock(ActivatedJob.class);
-    when(job.getVariables()).thenReturn("{\"value\":\"{{secrets.FOO}}\"}");
+    when(job.getVariables()).thenReturn(variables);
     when(job.getKey()).thenReturn(1L);
     when(job.getTenantId()).thenReturn("tenant");
     when(job.getRetries()).thenReturn(3);
     return job;
+  }
+
+  /**
+   * Answers like the {@link SecretProvider#fetchAll} default over a store holding {@code values}.
+   */
+  private void holdingOnly(Map<String, String> values) {
+    when(secretProvider.fetchAll(any(), any()))
+        .thenAnswer(
+            invocation -> {
+              List<String> keys = invocation.getArgument(0);
+              requestedKeys.addAll(keys);
+              return keys.stream().map(values::get).filter(Objects::nonNull).toList();
+            });
+  }
+
+  /**
+   * Every message this handler logs while {@code action} runs, formatted as it would be written.
+   */
+  private static List<String> logsOf(Runnable action) {
+    var logger = (Logger) LoggerFactory.getLogger(OutboundConnectorExceptionHandler.class);
+    var appender = new ListAppender<ILoggingEvent>();
+    appender.start();
+    logger.addAppender(appender);
+    try {
+      action.run();
+    } finally {
+      logger.detachAppender(appender);
+      appender.stop();
+    }
+    return appender.list.stream().map(ILoggingEvent::getFormattedMessage).toList();
   }
 
   @Test
@@ -129,5 +178,105 @@ class OutboundConnectorExceptionHandlerTest {
     assertThat(result.exception()).hasMessageContaining("Activity_1");
     assertThat(result.retries()).isEqualTo(2);
     assertThat(result.retryBackoff()).isEqualTo(Duration.ofSeconds(5));
+  }
+
+  @Test
+  void aFailedMaskingFetchIsNeverLogged() {
+    // A provider writes its own message, and it can carry secret material: AbstractSecretProvider
+    // folds a Jackson failure into one, and a bundle that parses as a non-object puts the value it
+    // could not coerce into the coercion error.
+    var job = jobWithSecretReference();
+    when(secretProvider.fetchAll(any(), any()))
+        .thenThrow(
+            new RuntimeException(
+                "Could not resolve secrets: MismatchedInputException: Cannot construct instance of"
+                    + " `java.util.LinkedHashMap` from String value ('super-secret')"));
+
+    var logged =
+        logsOf(
+            () ->
+                handlerOverStore.manageConnectorJobHandlerException(
+                    new RuntimeException("boom"),
+                    job,
+                    Duration.ofSeconds(1),
+                    SecretFilter.allowAll()));
+
+    assertThat(logged).noneMatch(message -> message.contains("super-secret"));
+    assertThat(logged).anyMatch(message -> message.contains("java.lang.RuntimeException"));
+  }
+
+  @Test
+  void aRefusalTheRuntimeWroteItselfKeepsItsMessageInTheLog() {
+    // Withholding arbitrary provider text is not a reason to withhold text written to be read: an
+    // unreadable allow-list names the element an operator has to look at, and a type name does not.
+    var job = jobWithSecretReference();
+    SecretFilter unreadableAllowList =
+        name -> {
+          throw new SecretAllowListUnavailableException(
+              "Error retrieving secret keys for element 'Activity_1'");
+        };
+
+    var logged =
+        logsOf(
+            () ->
+                handler.manageConnectorJobHandlerException(
+                    new RuntimeException("boom"), job, Duration.ofSeconds(1), unreadableAllowList));
+
+    assertThat(logged).anyMatch(message -> message.contains("Activity_1"));
+  }
+
+  @Test
+  void masksALongerSecretThatStartsWithAShorterOne() {
+    // Replacing the shorter value first would leave the longer one unmatched and publish its
+    // remainder: "x" before "xSUPERSECRET" turns the message into "***SUPERSECRET".
+    var job = jobNaming("{\"a\": \"{{secrets.SHORT}}\", \"b\": \"{{secrets.LONG}}\"}");
+    holdingOnly(Map.of("SHORT", "x", "LONG", "xSUPERSECRET"));
+
+    var result =
+        handlerOverStore.manageConnectorJobHandlerException(
+            new RuntimeException("api rejected xSUPERSECRET"),
+            job,
+            Duration.ofSeconds(1),
+            SecretFilter.allowAll());
+
+    assertThat(requestedKeys).containsExactly("SHORT", "LONG");
+    assertThat(result.exception().getMessage()).isEqualTo("api rejected ***");
+  }
+
+  @Test
+  void anEmptySecretValueDoesNotCorruptTheMessage() {
+    // Replacing "" matches at every position, so a provider answering with one would rewrite the
+    // whole message into separators rather than redact anything.
+    var job = jobNaming("{\"a\": \"{{secrets.BLANK}}\"}");
+    holdingOnly(Map.of("BLANK", ""));
+
+    var result =
+        handlerOverStore.manageConnectorJobHandlerException(
+            new RuntimeException("api rejected the request"),
+            job,
+            Duration.ofSeconds(1),
+            SecretFilter.allowAll());
+
+    assertThat(result.exception().getMessage()).isEqualTo("api rejected the request");
+  }
+
+  @Test
+  void aJobDeclaringNoSecretNeverReachesAProvider() {
+    // fetchAll is overridable, and one that refuses every batch would otherwise withhold the error
+    // message of a job that had nothing to redact in the first place.
+    var job = jobNaming("{\"a\": \"nothing to resolve here\"}");
+    when(secretProvider.fetchAll(any(), any()))
+        .thenThrow(new RuntimeException("store unavailable"));
+
+    var result =
+        handlerOverStore.manageConnectorJobHandlerException(
+            new RuntimeException("api rejected the request"),
+            job,
+            Duration.ofSeconds(1),
+            SecretFilter.allowAll());
+
+    verifyNoInteractions(secretProvider);
+    assertThat(result.exception().getMessage()).isEqualTo("api rejected the request");
+    assertThat(result.retries()).isEqualTo(2);
   }
 }

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/job/OutboundConnectorExceptionHandlerTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/job/OutboundConnectorExceptionHandlerTest.java
@@ -26,11 +26,15 @@ import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.read.ListAppender;
 import io.camunda.client.api.response.ActivatedJob;
+import io.camunda.connector.api.error.ConnectorException;
 import io.camunda.connector.api.secret.SecretProvider;
+import io.camunda.connector.runtime.core.outbound.ConnectorResult;
 import io.camunda.connector.runtime.core.secret.SecretFilter;
+import io.camunda.connector.runtime.core.secret.SecretNotAvailableException;
 import io.camunda.connector.runtime.secret.FooBarSecretProvider;
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -292,5 +296,289 @@ class OutboundConnectorExceptionHandlerTest {
     verifyNoInteractions(secretProvider);
     assertThat(result.exception().getMessage()).isEqualTo("api rejected the request");
     assertThat(result.retries()).isEqualTo(2);
+  }
+
+  @Test
+  void withholdsTheMessageWhenTheMaskingReReadComesBackShort() {
+    // A name the input declares must have resolved when the input was bound — SecretHandler's
+    // replacer throws otherwise — so one missing now means the secret was removed, or access
+    // revoked, while the connector ran. fetchAll drops what it cannot resolve, so redacting with
+    // what did come back would publish the one that did not in the clear.
+    var job = jobNaming("{\"a\": \"{{secrets.FOO}}\", \"b\": \"secrets.BAR\"}");
+    holdingOnly(Map.of("FOO", "foo-value"));
+
+    var result =
+        handlerOverStore.manageConnectorJobHandlerException(
+            new RuntimeException("api rejected bar-value and foo-value"),
+            job,
+            Duration.ofSeconds(1),
+            SecretFilter.allowAll(),
+            List.of());
+
+    assertThat(result.responseValue().toString()).doesNotContain("bar-value");
+    assertThat(result.exception().getMessage()).doesNotContain("bar-value");
+    // Not the input's fault, so the job keeps its remaining attempts.
+    assertThat(result.retries()).isEqualTo(2);
+    // A count is publishable; it is not something a secret store told this runtime.
+    assertThat(result.exception().getMessage()).contains("1 of the 2 secrets");
+  }
+
+  @Test
+  void publishesTheMessageWhenTheJobFailedBecauseThatSecretHasNoValue() {
+    // The one case where a name the input declares is expected back empty: substitution itself
+    // threw, so the input never carried BAR's value and there is nothing of it to redact. The
+    // message is the replacer's own and names the secret an operator has to go and create —
+    // withholding it would replace the answer with a description of the question.
+    var job = jobNaming("{\"a\": \"{{secrets.FOO}}\", \"b\": \"secrets.BAR\"}");
+    holdingOnly(Map.of("FOO", "foo-value"));
+
+    var result =
+        handlerOverStore.manageConnectorJobHandlerException(
+            new SecretNotAvailableException("BAR"),
+            job,
+            Duration.ofSeconds(1),
+            SecretFilter.allowAll(),
+            List.of());
+
+    assertThat(result.exception().getMessage())
+        .isEqualTo("Secret with name 'BAR' is not available");
+    assertThat(result.retries()).isZero();
+  }
+
+  @Test
+  void redactsEveryValueWhenTheMaskingReReadIsComplete() {
+    var job = jobNaming("{\"a\": \"{{secrets.FOO}}\", \"b\": \"secrets.BAR\"}");
+    holdingOnly(Map.of("FOO", "foo-value", "BAR", "bar-value"));
+
+    var result =
+        handlerOverStore.manageConnectorJobHandlerException(
+            new RuntimeException("api rejected bar-value and foo-value"),
+            job,
+            Duration.ofSeconds(1),
+            SecretFilter.allowAll(),
+            List.of());
+
+    assertThat(result.exception().getMessage()).isEqualTo("api rejected *** and ***");
+  }
+
+  @Test
+  void aFailedMaskingFetchIsNeverItselfPublished() {
+    // The fetch failure is no safer to publish than the message it was meant to help redact: a
+    // provider or client error can echo a response body from the secret store. Nothing built from
+    // it can be masked either, since the redaction list is empty by definition on this path.
+    var job = jobWithSecretReference();
+    when(secretProvider.fetchAll(any(), any()))
+        .thenThrow(new RuntimeException("store replied: {\"token\":\"super-secret\"}"));
+
+    var result =
+        handlerOverStore.manageConnectorJobHandlerException(
+            new RuntimeException("boom"),
+            job,
+            Duration.ofSeconds(1),
+            SecretFilter.allowAll(),
+            List.of());
+
+    // Both channels: the payload becomes process variables, and the message becomes the incident
+    // message that prepareFailJobCommand sends to Zeebe.
+    assertThat(result.responseValue().toString()).doesNotContain("super-secret");
+    assertThat(result.exception().getMessage()).doesNotContain("super-secret");
+    // The class name is what an operator needs, and carries no request or response data.
+    assertThat(result.exception().getMessage()).contains("java.lang.RuntimeException");
+  }
+
+  @Test
+  void aFailedMaskingFetchDoesNotPublishItsOwnErrorVariables() {
+    // exceptionToMap copies a ConnectorException's variables and code into the payload. On this
+    // path it would copy them with an empty redaction list, publishing unmasked exactly the data
+    // the branch exists to withhold.
+    var job = jobWithSecretReference();
+    when(secretProvider.fetchAll(any(), any()))
+        .thenThrow(
+            new ConnectorException(
+                "PROVIDER_CODE",
+                "lookup rejected",
+                null,
+                Map.of("response", "credential super-secret was rejected")));
+
+    var result =
+        handlerOverStore.manageConnectorJobHandlerException(
+            new RuntimeException("boom"),
+            job,
+            Duration.ofSeconds(1),
+            SecretFilter.allowAll(),
+            List.of());
+
+    assertThat(result.responseValue().toString())
+        .doesNotContain("super-secret")
+        .doesNotContain("PROVIDER_CODE");
+  }
+
+  @Test
+  void handleFinalResultException_reportsAnErrorWhenTheMaskingFetchFails() {
+    // The only caller is already inside a catch block, and an exception leaving here escapes it:
+    // the job would then be neither completed nor failed, sitting until its activation timeout
+    // hands it to another worker, which re-runs a connector that has already run. So a masking
+    // fetch that fails has to come back as a result, not as a throw.
+    var job = jobWithSecretReference();
+    when(secretProvider.fetchAll(any(), any()))
+        .thenThrow(new RuntimeException("store unavailable"));
+
+    var result =
+        handlerOverStore.handleFinalResultException(
+            new RuntimeException("boom"), job, SecretFilter.allowAll(), List.of());
+
+    assertThat(result).isNotNull();
+    assertThat(result.retries()).isZero();
+  }
+
+  @Test
+  void handleFinalResultException_withholdsTheOriginalMessageWhenItCannotBeMasked() {
+    // Nothing to mask with means the original message cannot be shown: it may hold a resolved
+    // secret, and these variables are visible to anyone who can see the process instance.
+    var job = jobWithSecretReference();
+    when(secretProvider.fetchAll(any(), any())).thenThrow(new RuntimeException("timed out"));
+
+    var result =
+        handlerOverStore.handleFinalResultException(
+            new RuntimeException("failed talking to https://api?key=super-secret"),
+            job,
+            SecretFilter.allowAll(),
+            List.of());
+
+    assertThat(result.responseValue().toString()).doesNotContain("super-secret");
+    assertThat(result.exception().getMessage()).doesNotContain("super-secret");
+  }
+
+  @Test
+  void handleFinalResultException_logsTheFailureOnlyAfterRedaction() {
+    // The runtime log is a third channel, alongside the payload and the incident message. A
+    // connector was handed resolved secrets, so its error message can carry one back; logging it
+    // on the way in would put in the log exactly what the other two channels redact.
+    var job = jobWithSecretReference();
+    when(secretProvider.fetchAll(any(), any())).thenReturn(List.of("super-secret"));
+
+    var logged =
+        logsOf(
+            () ->
+                handlerOverStore.handleFinalResultException(
+                    new RuntimeException("failed talking to https://api?key=super-secret"),
+                    job,
+                    SecretFilter.allowAll(),
+                    List.of()));
+
+    assertThat(logged).noneMatch(message -> message.contains("super-secret"));
+    assertThat(logged).anyMatch(message -> message.contains("***"));
+  }
+
+  @Test
+  void handleFinalResultException_logsOnlyTheTypeWhenTheMessageCannotBeRedacted() {
+    var job = jobWithSecretReference();
+    when(secretProvider.fetchAll(any(), any())).thenThrow(new RuntimeException("timed out"));
+
+    var logged =
+        logsOf(
+            () ->
+                handlerOverStore.handleFinalResultException(
+                    new RuntimeException("failed talking to https://api?key=super-secret"),
+                    job,
+                    SecretFilter.allowAll(),
+                    List.of()));
+
+    assertThat(logged).noneMatch(message -> message.contains("super-secret"));
+    assertThat(logged).anyMatch(message -> message.contains("java.lang.RuntimeException"));
+  }
+
+  /**
+   * The error message was already masked, but the error variables are copied straight off the
+   * original exception. For HTTP connectors those carry the whole response body and headers, so an
+   * API that echoes a rejected credential back used to publish the resolved secret as a process
+   * variable.
+   */
+  @Test
+  void errorVariables_maskSecretsNestedInAnHttpResponseBody() {
+    var errorVariables =
+        Map.<String, Object>of(
+            "response",
+            Map.of(
+                "headers",
+                Map.of("www-authenticate", "Bearer error=\"invalid_token super-secret\""),
+                "body",
+                Map.of("errors", List.of(Map.of("detail", "token super-secret is not valid")))));
+
+    var masked = maskedErrorVariables(errorVariables);
+
+    assertThat(masked.toString()).doesNotContain("super-secret").contains("***");
+  }
+
+  @Test
+  void errorVariables_maskSecretsUsedAsMapKeys() {
+    var masked = maskedErrorVariables(Map.of("super-secret", "harmless"));
+
+    assertThat(masked).containsOnlyKeys("***");
+  }
+
+  /** Processes branch on these, so rewriting them into strings would change behaviour. */
+  @Test
+  void errorVariables_leaveNonStringLeavesUntouched() {
+    var errorVariables = new HashMap<String, Object>();
+    errorVariables.put("status", 401);
+    errorVariables.put("retryable", false);
+    errorVariables.put("body", null);
+
+    var masked = maskedErrorVariables(errorVariables);
+
+    assertThat(masked).containsEntry("status", 401).containsEntry("retryable", false);
+    assertThat(masked).containsKey("body");
+    assertThat(masked.get("body")).isNull();
+  }
+
+  /** Error variables are supplied by connector authors, so a container may contain itself. */
+  @Test
+  void errorVariables_terminateOnSelfReferencingContainers() {
+    var errorVariables = new HashMap<String, Object>();
+    errorVariables.put("detail", "token super-secret rejected");
+    errorVariables.put("self", errorVariables);
+
+    var masked = maskedErrorVariables(errorVariables);
+
+    assertThat(masked).containsEntry("detail", "token *** rejected");
+    assertThat(masked).containsEntry("self", "[circular reference]");
+  }
+
+  /**
+   * BPMN error boundary events match on the error code, so masking it would silently stop the error
+   * from being caught. Codes come from HTTP statuses and connector-authored constants, not from
+   * remote payloads.
+   */
+  @Test
+  void errorCode_isNotMasked() {
+    var job = jobWithSecretReference();
+    when(secretProvider.fetchAll(any(), any())).thenReturn(List.of("401"));
+
+    var result =
+        handlerOverStore.handleFinalResultException(
+            new ConnectorException("401", "Unauthorized"), job, SecretFilter.allowAll(), List.of());
+
+    assertThat(error(result)).containsEntry("code", "401");
+  }
+
+  @SuppressWarnings("unchecked")
+  private Map<String, Object> maskedErrorVariables(Map<String, Object> errorVariables) {
+    var job = jobWithSecretReference();
+    when(secretProvider.fetchAll(any(), any())).thenReturn(List.of("super-secret"));
+
+    var result =
+        handlerOverStore.handleFinalResultException(
+            new ConnectorException("401", "Unauthorized", null, errorVariables),
+            job,
+            SecretFilter.allowAll(),
+            List.of());
+
+    return (Map<String, Object>) error(result).get("variables");
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Map<String, Object> error(ConnectorResult.ErrorResult result) {
+    return (Map<String, Object>) ((Map<String, Object>) result.responseValue()).get("error");
   }
 }

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/job/SpringConnectorJobHandlerTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/job/SpringConnectorJobHandlerTest.java
@@ -33,6 +33,9 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
 import io.camunda.client.api.command.FailJobCommandStep1;
 import io.camunda.client.api.worker.BackoffSupplier;
 import io.camunda.client.api.worker.JobClient;
@@ -68,6 +71,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.*;
 import org.mockito.ArgumentCaptor;
+import org.slf4j.LoggerFactory;
 
 class SpringConnectorJobHandlerTest {
 
@@ -1832,6 +1836,34 @@ class SpringConnectorJobHandlerTest {
               .executeAndCaptureResult(jobHandler, false, false);
 
       assertThat(result.getErrorMessage()).doesNotContain("old-value");
+    }
+
+    @Test
+    void aSecretThatRotatedBetweenBindAndMaskingIsNotLoggedFromTheCause() throws Exception {
+      var jobHandler =
+          connectorThrowingTheBoundToken(rotatingSecretProvider("old-value", "new-value"));
+      var logger = (Logger) LoggerFactory.getLogger(SpringConnectorJobHandler.class);
+      var appender = new ListAppender<ILoggingEvent>();
+      appender.start();
+      logger.addAppender(appender);
+      try {
+        JobBuilder.create()
+            .withVariables(INPUT_DECLARING_A_SECRET)
+            .executeAndCaptureResult(jobHandler, false, false);
+      } finally {
+        logger.detachAppender(appender);
+        appender.stop();
+      }
+
+      assertThat(appender.list)
+          .filteredOn(
+              event -> event.getFormattedMessage().startsWith("Exception while completing job"))
+          .singleElement()
+          .satisfies(
+              event -> {
+                assertThat(event.getFormattedMessage()).doesNotContain("old-value");
+                assertThat(event.getThrowableProxy()).isNull();
+              });
     }
 
     @Test

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/job/SpringConnectorJobHandlerTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/job/SpringConnectorJobHandlerTest.java
@@ -1594,4 +1594,198 @@ class SpringConnectorJobHandlerTest {
         .contains("type=io.camunda.connector.api.error.ConnectorException")
         .contains("message=HTTP request failed");
   }
+
+  /** The job's input declares {{secrets.FOO}}, and the called API echoes that value back. */
+  @Nested
+  class ErrorExpressionSecretMaskingTests {
+
+    private static final String ECHOED = FooBarSecretProvider.SECRET_VALUE;
+    private static final String INPUT_DECLARING_A_SECRET = "{ \"token\" : \"{{secrets.FOO}}\" }";
+
+    private SpringConnectorJobHandler echoingConnector() {
+      return newConnectorJobHandler(context -> Map.of("body", "rejected token " + ECHOED));
+    }
+
+    private SpringConnectorJobHandler echoingConnectorWithUnreadableSecrets() {
+      return newConnectorJobHandler(
+          context -> Map.of("body", "rejected token " + ECHOED),
+          new SecretProviderAggregator(List.of(new FooBarSecretProvider())) {
+            @Override
+            public List<String> fetchAll(List<String> keys, SecretContext context) {
+              throw new RuntimeException("Network error while fetching secrets");
+            }
+          });
+    }
+
+    @Test
+    void jobErrorMessageCopyingAResponseIsRedacted() throws Exception {
+      var result =
+          JobBuilder.create()
+              .withVariables(INPUT_DECLARING_A_SECRET)
+              .withErrorExpressionHeader("=jobError(\"Request failed: \" + response.body, {}, 0)")
+              .executeAndCaptureResult(echoingConnector(), false, false);
+
+      assertThat(result.getErrorMessage())
+          .startsWith("Request failed: rejected token ***")
+          .doesNotContain(ECHOED);
+    }
+
+    @Test
+    void jobErrorVariablesCopyingAResponseAreRedacted() throws Exception {
+      var result =
+          JobBuilder.create()
+              .withVariables(INPUT_DECLARING_A_SECRET)
+              .withErrorExpressionHeader(
+                  "=jobError(\"failed\", {detail: response.body, code: 401}, 0)")
+              .executeAndCaptureResult(echoingConnector(), false, false);
+
+      assertThat(result.getVariables()).containsEntry("detail", "rejected token ***");
+      // scalars keep their type, since a process resolving the incident may branch on them
+      assertThat(result.getVariables()).containsEntry("code", 401);
+      // prepareFailJobCommand appends the variables to the message, so they reach it too
+      assertThat(result.getErrorMessage()).doesNotContain(ECHOED);
+    }
+
+    @Test
+    void jobErrorKeepsTheRetriesAndBackoffTheExpressionAsked() throws Exception {
+      var failCommand = mock(FailJobCommandStep1.class);
+      var failCommandStep2 =
+          mock(FailJobCommandStep1.FailJobCommandStep2.class, RETURNS_DEEP_STUBS);
+      var jobClient = mock(JobClient.class);
+      when(jobClient.newFailCommand(any())).thenReturn(failCommand);
+      when(failCommand.retries(anyInt())).thenReturn(failCommandStep2);
+      when(failCommandStep2.errorMessage(any())).thenReturn(failCommandStep2);
+      when(failCommandStep2.retryBackoff(any())).thenReturn(failCommandStep2);
+      when(failCommandStep2.variables(anyMap())).thenReturn(failCommandStep2);
+      when(failCommandStep2.variables(any(Object.class))).thenReturn(failCommandStep2);
+
+      JobBuilder.create()
+          .useJobClient(jobClient)
+          .withVariables(INPUT_DECLARING_A_SECRET)
+          .withErrorExpressionHeader(
+              "=jobError(\"Request failed: \" + response.body, {}, 7, duration(\"PT5M\"))")
+          .execute(echoingConnector());
+
+      var messageCaptor = ArgumentCaptor.forClass(String.class);
+      verify(failCommandStep2).errorMessage(messageCaptor.capture());
+      assertThat(messageCaptor.getValue()).doesNotContain(ECHOED);
+      verify(failCommand).retries(7);
+      verify(failCommandStep2).retryBackoff(Duration.ofMinutes(5));
+    }
+
+    @Test
+    void bpmnErrorMessageCopyingAResponseIsRedacted() throws Exception {
+      var result =
+          JobBuilder.create()
+              .withVariables(INPUT_DECLARING_A_SECRET)
+              .withErrorExpressionHeader(
+                  "=bpmnError(\"AUTH_FAILED\", \"Request failed: \" + response.body)")
+              .executeAndCaptureResult(echoingConnector(), false, true);
+
+      assertThat(result.getErrorMessage())
+          .isEqualTo("Request failed: rejected token ***")
+          .doesNotContain(ECHOED);
+    }
+
+    @Test
+    void bpmnErrorVariablesCopyingAResponseAreRedacted() throws Exception {
+      var result =
+          JobBuilder.create()
+              .withVariables(INPUT_DECLARING_A_SECRET)
+              .withErrorExpressionHeader(
+                  "=bpmnError(\"AUTH_FAILED\", \"failed\", {detail: response.body})")
+              .executeAndCaptureResult(echoingConnector(), false, true);
+
+      assertThat(result.getVariables()).containsEntry("detail", "rejected token ***");
+    }
+
+    @Test
+    void bpmnErrorCodeIsNotRedacted() throws Exception {
+      // boundary events match on the code, so it keeps a value equal to the secret's
+      var result =
+          JobBuilder.create()
+              .withVariables(INPUT_DECLARING_A_SECRET)
+              .withErrorExpressionHeader(
+                  "=bpmnError(\"" + ECHOED + "\", \"Request failed: \" + response.body)")
+              .executeAndCaptureResult(echoingConnector(), false, true);
+
+      assertThat(result.getErrorCode()).isEqualTo(ECHOED);
+      assertThat(result.getErrorMessage()).doesNotContain(ECHOED);
+    }
+
+    @Test
+    void bpmnErrorWithoutAMessageStaysWithoutOne() throws Exception {
+      // throwError omits a null message but would set an empty one
+      var result =
+          JobBuilder.create()
+              .withVariables(INPUT_DECLARING_A_SECRET)
+              .withErrorExpressionHeader(
+                  "={ \"errorType\": \"bpmnError\", \"errorCode\": \"AUTH_FAILED\","
+                      + " \"variables\": {\"detail\": response.body} }")
+              .executeAndCaptureResult(echoingConnector(), false, true);
+
+      assertThat(result.getErrorMessage()).isNull();
+      assertThat(result.getVariables()).containsEntry("detail", "rejected token ***");
+    }
+
+    @Test
+    void jobErrorIsWithheldWhenItCannotBeRedacted() throws Exception {
+      var result =
+          JobBuilder.create()
+              .withVariables(INPUT_DECLARING_A_SECRET)
+              .withErrorExpressionHeader("=jobError(\"Request failed: \" + response.body, {}, 0)")
+              .executeAndCaptureResult(echoingConnectorWithUnreadableSecrets(), false, false);
+
+      // the fetch failure's own message is withheld too: a provider error can echo the store's body
+      assertThat(result.getErrorMessage())
+          .startsWith("Fetching secrets failed, so the original error cannot be displayed")
+          .contains("java.lang.RuntimeException")
+          .doesNotContain("Network error while fetching secrets")
+          .doesNotContain(ECHOED);
+      assertThat(result.getRetries()).isZero();
+    }
+
+    @Test
+    void bpmnErrorKeepsItsCodeWhenItCannotBeRedacted() throws Exception {
+      var result =
+          JobBuilder.create()
+              .withVariables(INPUT_DECLARING_A_SECRET)
+              .withErrorExpressionHeader(
+                  "=bpmnError(\"AUTH_FAILED\", \"Request failed: \" + response.body,"
+                      + " {detail: response.body})")
+              .executeAndCaptureResult(echoingConnectorWithUnreadableSecrets(), false, true);
+
+      assertThat(result.getErrorCode()).isEqualTo("AUTH_FAILED");
+      assertThat(result.getErrorMessage())
+          .startsWith("Fetching secrets failed, so the original error cannot be displayed")
+          .doesNotContain(ECHOED);
+      assertThat(result.getVariables()).isEmpty();
+    }
+
+    @Test
+    void anErrorCarryingNothingToRedactIsLeftAlone() throws Exception {
+      // no message and no variables, so the read is skipped and the unreadable store costs nothing
+      var result =
+          JobBuilder.create()
+              .withVariables(INPUT_DECLARING_A_SECRET)
+              .withErrorExpressionHeader(
+                  "={ \"errorType\": \"bpmnError\", \"errorCode\": \"AUTH_FAILED\" }")
+              .executeAndCaptureResult(echoingConnectorWithUnreadableSecrets(), false, true);
+
+      assertThat(result.getErrorCode()).isEqualTo("AUTH_FAILED");
+      assertThat(result.getErrorMessage()).isNull();
+    }
+
+    @Test
+    void ignoreErrorIsNotRedacted() throws Exception {
+      // the boundary of this fix: ignoreError completes the job with unredacted business variables
+      var result =
+          JobBuilder.create()
+              .withVariables(INPUT_DECLARING_A_SECRET)
+              .withErrorExpressionHeader("=ignoreError({detail: response.body})")
+              .executeAndCaptureResult(echoingConnector(), true);
+
+      assertThat(result.getVariables()).containsEntry("detail", "rejected token " + ECHOED);
+    }
+  }
 }

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/job/SpringConnectorJobHandlerTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/job/SpringConnectorJobHandlerTest.java
@@ -1509,12 +1509,19 @@ class SpringConnectorJobHandlerTest {
             .executeAndCaptureResult(jobHandlerRaisingException, false);
 
     // then
+    // The incident message says why nothing can be shown and names the type that failed, and
+    // withholds two messages: the connector's own, which is what there is nothing to redact from,
+    // and the fetch failure's, which is no safer — a provider or client error can echo a response
+    // body from the secret store.
     assertThat(resultForMissingSecret.getErrorMessage())
-        .startsWith(
-            "Fetching secrets failed, original error can't be displayed as the error message might contain secrets: Network error while fetching secrets");
+        .startsWith("Fetching secrets failed, so the original error cannot be displayed")
+        .contains("java.lang.RuntimeException")
+        .doesNotContain("Network error while fetching secrets");
     assertThat(resultForRaisingException.getErrorMessage())
-        .startsWith(
-            "Fetching secrets failed, original error can't be displayed as the error message might contain secrets: Network error while fetching secrets");
+        .startsWith("Fetching secrets failed, so the original error cannot be displayed")
+        .contains("java.lang.RuntimeException")
+        .doesNotContain("Network error while fetching secrets")
+        .doesNotContain("Crazy error something with bar");
   }
 
   @Test

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/job/SpringConnectorJobHandlerTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/job/SpringConnectorJobHandlerTest.java
@@ -1788,4 +1788,64 @@ class SpringConnectorJobHandlerTest {
       assertThat(result.getVariables()).containsEntry("detail", "rejected token " + ECHOED);
     }
   }
+
+  @Nested
+  class RotationRaceSecretMaskingTests {
+
+    private record TokenHolder(String token) {}
+
+    private static final String INPUT_DECLARING_A_SECRET = "{ \"token\" : \"{{secrets.FOO}}\" }";
+
+    private SecretProviderAggregator rotatingSecretProvider(
+        String boundValue, String rotatedValue) {
+      return new SecretProviderAggregator(List.of()) {
+        @Override
+        public String getSecret(String secretName, SecretContext context) {
+          return boundValue;
+        }
+
+        @Override
+        public List<String> fetchAll(List<String> keys, SecretContext context) {
+          return keys.stream().map(key -> rotatedValue).toList();
+        }
+      };
+    }
+
+    private SpringConnectorJobHandler connectorThrowingTheBoundToken(
+        SecretProviderAggregator secretProviderAggregator) {
+      return newConnectorJobHandler(
+          context -> {
+            var bound = context.bindVariables(TokenHolder.class);
+            throw new RuntimeException("api rejected " + bound.token());
+          },
+          secretProviderAggregator);
+    }
+
+    @Test
+    void aSecretThatRotatedBetweenBindAndMaskingIsStillRedacted() throws Exception {
+      var jobHandler =
+          connectorThrowingTheBoundToken(rotatingSecretProvider("old-value", "new-value"));
+
+      var result =
+          JobBuilder.create()
+              .withVariables(INPUT_DECLARING_A_SECRET)
+              .executeAndCaptureResult(jobHandler, false, false);
+
+      assertThat(result.getErrorMessage()).doesNotContain("old-value");
+    }
+
+    @Test
+    void aStableSecretIsStillRedactedTheOrdinaryWay() throws Exception {
+      // the union must not depend on rotation happening: an unrotated secret is redacted too
+      var jobHandler =
+          connectorThrowingTheBoundToken(rotatingSecretProvider("stable-value", "stable-value"));
+
+      var result =
+          JobBuilder.create()
+              .withVariables(INPUT_DECLARING_A_SECRET)
+              .executeAndCaptureResult(jobHandler, false, false);
+
+      assertThat(result.getErrorMessage()).doesNotContain("stable-value");
+    }
+  }
 }

--- a/connector-sdk/core/src/main/java/io/camunda/connector/api/inbound/Health.java
+++ b/connector-sdk/core/src/main/java/io/camunda/connector/api/inbound/Health.java
@@ -159,6 +159,16 @@ public class Health {
     return new Health(this.status, this.error, details);
   }
 
+  /**
+   * Returns a new {@link Health} with the given error, preserving the original status and details.
+   *
+   * @param error the error for the new instance
+   * @return a new Health with the same status and details but the supplied error
+   */
+  public Health withError(Error error) {
+    return new Health(this.status, error, this.details);
+  }
+
   private Health() {
     this(Status.UNKNOWN, null, null);
   }

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/jobworker/AiAgentJobWorkerHandlerImpl.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/jobworker/AiAgentJobWorkerHandlerImpl.java
@@ -36,6 +36,7 @@ import io.camunda.connector.runtime.metrics.ConnectorMetrics;
 import io.camunda.connector.runtime.outbound.job.OutboundConnectorExceptionHandler;
 import java.time.Duration;
 import java.time.format.DateTimeParseException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -92,7 +93,10 @@ public class AiAgentJobWorkerHandlerImpl implements AiAgentJobWorkerHandler {
     final SecretFilter secretFilter =
         secretFilterFactory.create(
             new SecretFilterContext(job.getProcessDefinitionKey(), job.getElementId()));
-    final var agentResult = getAgentResult(jobClient, job, secretFilter);
+    // the values this job's input binding substituted, so an error raised after one of them rotates
+    // is still redacted with what the agent was handed
+    final List<String> capturedSecrets = new ArrayList<>();
+    final var agentResult = getAgentResult(jobClient, job, secretFilter, capturedSecrets);
 
     try {
       Optional<ConnectorError> optionalConnectorError =
@@ -103,7 +107,13 @@ public class AiAgentJobWorkerHandlerImpl implements AiAgentJobWorkerHandler {
 
       optionalConnectorError.ifPresentOrElse(
           connectorError ->
-              handleConnectorError(jobClient, job, connectorError, counterMetricsContext),
+              handleConnectorError(
+                  jobClient,
+                  job,
+                  connectorError,
+                  counterMetricsContext,
+                  secretFilter,
+                  capturedSecrets),
           () -> {
             switch (agentResult) {
               case AgentSuccessResult successResult ->
@@ -116,29 +126,30 @@ public class AiAgentJobWorkerHandlerImpl implements AiAgentJobWorkerHandler {
       failJob(
           jobClient,
           job,
-          // the context that bound this job's input, and with it the values it substituted, is
-          // created and discarded inside the execution context factory, so masking here rests on
-          // the re-read alone
           this.outboundConnectorExceptionHandler.handleFinalResultException(
-              e, job, secretFilter, List.of()),
+              e, job, secretFilter, capturedSecrets),
           counterMetricsContext);
     }
   }
 
   private JobWorkerAgentResult getAgentResult(
-      final JobClient jobClient, final ActivatedJob job, final SecretFilter secretFilter) {
+      final JobClient jobClient,
+      final ActivatedJob job,
+      final SecretFilter secretFilter,
+      final List<String> capturedSecrets) {
     Duration retryBackoff = null;
     try {
       retryBackoff = getBackoffDuration(job);
 
-      final var executionContext = executionContextFactory.createExecutionContext(jobClient, job);
+      final var executionContext =
+          executionContextFactory.createExecutionContext(jobClient, job, capturedSecrets);
       final var completion = agentRequestHandler.handleRequest(executionContext);
 
       return new AgentSuccessResult(completion);
     } catch (Exception e) {
       final var errorResult =
           outboundConnectorExceptionHandler.manageConnectorJobHandlerException(
-              e, job, retryBackoff, secretFilter, List.of());
+              e, job, retryBackoff, secretFilter, capturedSecrets);
       return new AgentErrorResult(errorResult);
     }
   }
@@ -146,8 +157,16 @@ public class AiAgentJobWorkerHandlerImpl implements AiAgentJobWorkerHandler {
   private void handleConnectorError(
       final JobClient jobClient,
       final ActivatedJob job,
-      final ConnectorError connectorError,
-      final CounterMetricsContext counterMetricsContext) {
+      final ConnectorError rawError,
+      final CounterMetricsContext counterMetricsContext,
+      final SecretFilter secretFilter,
+      final List<String> capturedSecrets) {
+    // an error expression builds its message and variables from the agent's response, which a
+    // provider can echo a resolved secret back into; redacted before the Zeebe command is built
+    final var connectorError =
+        outboundConnectorExceptionHandler.maskConnectorError(
+            rawError, job, secretFilter, capturedSecrets);
+
     switch (connectorError) {
       case BpmnError bpmnError -> throwBpmnError(jobClient, job, bpmnError, counterMetricsContext);
       case JobError jobError ->
@@ -243,9 +262,11 @@ public class AiAgentJobWorkerHandlerImpl implements AiAgentJobWorkerHandler {
       final ActivatedJob job,
       final ErrorResult errorResult,
       final CounterMetricsContext counterMetricsContext) {
+    // the wrapper message is redacted, but its cause is not, so the throwable is not logged
     LOGGER.error(
-        "Exception while completing AI Agent job with key %s".formatted(job.getKey()),
-        errorResult.exception());
+        "Exception while completing AI Agent job with key {}, message: {}",
+        job.getKey(),
+        errorResult.exception().getMessage());
 
     final var failCommand = prepareFailJobCommand(jobClient, job, errorResult);
     executeCommandAsync(failCommand, job, counterMetricsContext);

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/jobworker/AiAgentJobWorkerHandlerImpl.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/jobworker/AiAgentJobWorkerHandlerImpl.java
@@ -36,6 +36,7 @@ import io.camunda.connector.runtime.metrics.ConnectorMetrics;
 import io.camunda.connector.runtime.outbound.job.OutboundConnectorExceptionHandler;
 import java.time.Duration;
 import java.time.format.DateTimeParseException;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import org.slf4j.Logger;
@@ -115,7 +116,11 @@ public class AiAgentJobWorkerHandlerImpl implements AiAgentJobWorkerHandler {
       failJob(
           jobClient,
           job,
-          this.outboundConnectorExceptionHandler.handleFinalResultException(e, job, secretFilter),
+          // the context that bound this job's input, and with it the values it substituted, is
+          // created and discarded inside the execution context factory, so masking here rests on
+          // the re-read alone
+          this.outboundConnectorExceptionHandler.handleFinalResultException(
+              e, job, secretFilter, List.of()),
           counterMetricsContext);
     }
   }
@@ -133,7 +138,7 @@ public class AiAgentJobWorkerHandlerImpl implements AiAgentJobWorkerHandler {
     } catch (Exception e) {
       final var errorResult =
           outboundConnectorExceptionHandler.manageConnectorJobHandlerException(
-              e, job, retryBackoff, secretFilter);
+              e, job, retryBackoff, secretFilter, List.of());
       return new AgentErrorResult(errorResult);
     }
   }

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/jobworker/JobWorkerAgentExecutionContextFactory.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/jobworker/JobWorkerAgentExecutionContextFactory.java
@@ -12,17 +12,12 @@ import io.camunda.connector.agenticai.aiagent.model.JobWorkerAgentExecutionConte
 import java.util.List;
 
 public interface JobWorkerAgentExecutionContextFactory {
-  JobWorkerAgentExecutionContext createExecutionContext(
-      final JobClient jobClient, final ActivatedJob job);
-
   /**
    * Collects into {@code capturedSecretValues} every value substituted into the job's input,
    * whether the binding then succeeds or fails, so that an error reported for this job can be
    * redacted with the values the agent was actually handed rather than with whatever the secret
    * store holds by the time the error is built.
    */
-  default JobWorkerAgentExecutionContext createExecutionContext(
-      final JobClient jobClient, final ActivatedJob job, final List<String> capturedSecretValues) {
-    return createExecutionContext(jobClient, job);
-  }
+  JobWorkerAgentExecutionContext createExecutionContext(
+      final JobClient jobClient, final ActivatedJob job, final List<String> capturedSecretValues);
 }

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/jobworker/JobWorkerAgentExecutionContextFactory.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/jobworker/JobWorkerAgentExecutionContextFactory.java
@@ -9,8 +9,20 @@ package io.camunda.connector.agenticai.aiagent.jobworker;
 import io.camunda.client.api.response.ActivatedJob;
 import io.camunda.client.api.worker.JobClient;
 import io.camunda.connector.agenticai.aiagent.model.JobWorkerAgentExecutionContext;
+import java.util.List;
 
 public interface JobWorkerAgentExecutionContextFactory {
   JobWorkerAgentExecutionContext createExecutionContext(
       final JobClient jobClient, final ActivatedJob job);
+
+  /**
+   * Collects into {@code capturedSecretValues} every value substituted into the job's input,
+   * whether the binding then succeeds or fails, so that an error reported for this job can be
+   * redacted with the values the agent was actually handed rather than with whatever the secret
+   * store holds by the time the error is built.
+   */
+  default JobWorkerAgentExecutionContext createExecutionContext(
+      final JobClient jobClient, final ActivatedJob job, final List<String> capturedSecretValues) {
+    return createExecutionContext(jobClient, job);
+  }
 }

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/jobworker/JobWorkerAgentExecutionContextFactoryImpl.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/jobworker/JobWorkerAgentExecutionContextFactoryImpl.java
@@ -12,13 +12,14 @@ import io.camunda.client.api.worker.JobClient;
 import io.camunda.connector.agenticai.aiagent.model.JobWorkerAgentExecutionContext;
 import io.camunda.connector.agenticai.aiagent.model.request.JobWorkerAgentRequest;
 import io.camunda.connector.api.document.DocumentFactory;
-import io.camunda.connector.api.outbound.OutboundConnectorContext;
 import io.camunda.connector.api.secret.SecretProvider;
 import io.camunda.connector.api.validation.ValidationProvider;
 import io.camunda.connector.runtime.core.outbound.JobHandlerContext;
 import io.camunda.connector.runtime.core.secret.SecretFilter;
 import io.camunda.connector.runtime.core.secret.SecretFilterFactory;
 import io.camunda.connector.runtime.core.secret.SecretFilterFactory.SecretFilterContext;
+import java.util.ArrayList;
+import java.util.List;
 
 public class JobWorkerAgentExecutionContextFactoryImpl
     implements JobWorkerAgentExecutionContextFactory {
@@ -44,13 +45,25 @@ public class JobWorkerAgentExecutionContextFactoryImpl
   @Override
   public JobWorkerAgentExecutionContext createExecutionContext(
       final JobClient jobClient, final ActivatedJob job) {
+    return createExecutionContext(jobClient, job, new ArrayList<>());
+  }
+
+  @Override
+  public JobWorkerAgentExecutionContext createExecutionContext(
+      final JobClient jobClient, final ActivatedJob job, final List<String> capturedSecretValues) {
     final SecretFilter secretFilter =
         secretFilterFactory.create(
             new SecretFilterContext(job.getProcessDefinitionKey(), job.getElementId()));
-    final OutboundConnectorContext context =
+    final JobHandlerContext context =
         new JobHandlerContext(
             job, secretProvider, validationProvider, documentFactory, objectMapper, secretFilter);
-    final var request = context.bindVariables(JobWorkerAgentRequest.class);
-    return new JobWorkerAgentExecutionContext(jobClient, job, request);
+    try {
+      final var request = context.bindVariables(JobWorkerAgentRequest.class);
+      return new JobWorkerAgentExecutionContext(jobClient, job, request);
+    } finally {
+      // a binding that fails part-way has still substituted values, and the failure reported for it
+      // is redacted with them
+      capturedSecretValues.addAll(context.getSecretHandler().getResolvedValues());
+    }
   }
 }

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/jobworker/JobWorkerAgentExecutionContextFactoryImpl.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/jobworker/JobWorkerAgentExecutionContextFactoryImpl.java
@@ -18,7 +18,6 @@ import io.camunda.connector.runtime.core.outbound.JobHandlerContext;
 import io.camunda.connector.runtime.core.secret.SecretFilter;
 import io.camunda.connector.runtime.core.secret.SecretFilterFactory;
 import io.camunda.connector.runtime.core.secret.SecretFilterFactory.SecretFilterContext;
-import java.util.ArrayList;
 import java.util.List;
 
 public class JobWorkerAgentExecutionContextFactoryImpl
@@ -40,12 +39,6 @@ public class JobWorkerAgentExecutionContextFactoryImpl
     this.documentFactory = documentFactory;
     this.objectMapper = objectMapper;
     this.secretFilterFactory = secretFilterFactory;
-  }
-
-  @Override
-  public JobWorkerAgentExecutionContext createExecutionContext(
-      final JobClient jobClient, final ActivatedJob job) {
-    return createExecutionContext(jobClient, job, new ArrayList<>());
   }
 
   @Override

--- a/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/jobworker/AiAgentJobWorkerHandlerTest.java
+++ b/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/jobworker/AiAgentJobWorkerHandlerTest.java
@@ -20,6 +20,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
 import static org.assertj.core.api.Assertions.tuple;
 import static org.awaitility.Awaitility.await;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
@@ -89,6 +92,22 @@ class AiAgentJobWorkerHandlerTest {
         null
       """;
 
+  private static final String RESPONSE_ECHO_ERROR_EXPRESSION =
+      """
+      =if response.responseText != null then
+        jobError("agent replied: " + response.responseText)
+      else
+        null
+      """;
+
+  private static final String RESPONSE_ECHO_BPMN_ERROR_EXPRESSION =
+      """
+      =if response.responseText != null then
+        bpmnError("AGENT_REPLY_CODE", "agent replied: " + response.responseText)
+      else
+        null
+      """;
+
   private static final JobWorkerAgentResponse AGENT_RESPONSE_VARIABLE =
       JobWorkerAgentResponse.builder().responseText("Dummy response").build();
 
@@ -104,6 +123,10 @@ class AiAgentJobWorkerHandlerTest {
   private ActivatedJob job;
 
   private Map<String, String> jobHeaders;
+
+  // what the input binding substituted into this job's variables, as the execution context factory
+  // reports it back
+  private final List<String> valuesSubstitutedIntoTheJobsInput = new ArrayList<>();
 
   private AiAgentJobWorkerHandler handler;
   private CamundaClient camundaClient;
@@ -122,8 +145,12 @@ class AiAgentJobWorkerHandlerTest {
     when(job.getType()).thenReturn(AiAgentJobWorker.JOB_WORKER_TYPE);
     when(job.getCustomHeaders()).thenReturn(jobHeaders);
 
-    when(executionContextFactory.createExecutionContext(camundaClient, job))
-        .thenReturn(executionContext);
+    when(executionContextFactory.createExecutionContext(eq(camundaClient), eq(job), anyList()))
+        .thenAnswer(
+            invocation -> {
+              invocation.<List<String>>getArgument(2).addAll(valuesSubstitutedIntoTheJobsInput);
+              return executionContext;
+            });
 
     final var outboundConnectorExceptionHandler =
         new OutboundConnectorExceptionHandler(secretProvider);
@@ -571,6 +598,87 @@ class AiAgentJobWorkerHandlerTest {
               .isEqualTo(
                   Map.of(
                       "type", "java.lang.RuntimeException", "message", expectedExceptionMessage));
+        });
+  }
+
+  @Test
+  void redactsSecretsFromAJobErrorTheErrorExpressionBuiltFromTheAgentResponse() throws Exception {
+    // The agent ran successfully, so nothing has masked its response yet: a model or tool that
+    // echoes a resolved credential back puts it into the error expression's output, and from there
+    // into the incident message and the process variables.
+    jobHeaders.put("errorExpression", RESPONSE_ECHO_ERROR_EXPRESSION);
+    when(job.getVariables()).thenReturn("{\"token\":\"{{secrets.TOKEN}}\"}");
+    when(secretProvider.fetchAll(anyList(), any())).thenReturn(List.of("s3cr3t"));
+
+    when(agentRequestHandler.handleRequest(executionContext))
+        .thenReturn(
+            JobWorkerAgentCompletion.builder()
+                .completionConditionFulfilled(true)
+                .cancelRemainingInstances(false)
+                .agentResponse(
+                    AgentResponse.builder()
+                        .context(AgentContext.empty())
+                        .responseText("the token s3cr3t was rejected")
+                        .build())
+                .build());
+
+    handler.handle(camundaClient, job);
+
+    assertJobFailRequest(
+        request -> {
+          assertThat(request.getErrorMessage())
+              .isEqualTo("agent replied: the token *** was rejected");
+          assertThat(request.getVariables())
+              .containsExactly(entry("error", "agent replied: the token *** was rejected"));
+        });
+  }
+
+  @Test
+  void redactsABpmnErrorFromTheErrorExpressionWithoutTouchingItsCode() throws Exception {
+    // Boundary events match on the code, so redacting it would stop the error being caught, even
+    // when the code happens to read like a secret value.
+    jobHeaders.put("errorExpression", RESPONSE_ECHO_BPMN_ERROR_EXPRESSION);
+    when(job.getVariables()).thenReturn("{\"token\":\"{{secrets.TOKEN}}\"}");
+    when(secretProvider.fetchAll(anyList(), any())).thenReturn(List.of("AGENT_REPLY_CODE"));
+
+    when(agentRequestHandler.handleRequest(executionContext))
+        .thenReturn(
+            JobWorkerAgentCompletion.builder()
+                .completionConditionFulfilled(true)
+                .cancelRemainingInstances(false)
+                .agentResponse(
+                    AgentResponse.builder()
+                        .context(AgentContext.empty())
+                        .responseText("AGENT_REPLY_CODE is not a valid credential")
+                        .build())
+                .build());
+
+    handler.handle(camundaClient, job);
+
+    assertJobErrorRequest(
+        request -> {
+          assertThat(request.getErrorCode()).isEqualTo("AGENT_REPLY_CODE");
+          assertThat(request.getErrorMessage())
+              .isEqualTo("agent replied: *** is not a valid credential");
+        });
+  }
+
+  @Test
+  void redactsWithTheValueTheAgentWasHandedAfterTheSecretRotates() throws Exception {
+    // The store returns the rotated value on the masking re-read, so redacting with that alone
+    // leaves the value the agent was actually given in the message.
+    valuesSubstitutedIntoTheJobsInput.add("the-old-value");
+    when(job.getVariables()).thenReturn("{\"token\":\"{{secrets.TOKEN}}\"}");
+    when(secretProvider.fetchAll(anyList(), any())).thenReturn(List.of("the-new-value"));
+
+    when(agentRequestHandler.handleRequest(executionContext))
+        .thenThrow(new RuntimeException("rejected credential the-old-value"));
+
+    handler.handle(camundaClient, job);
+
+    assertJobFailRequest(
+        request -> {
+          assertThat(request.getErrorMessage()).doesNotContain("the-old-value").contains("***");
         });
   }
 

--- a/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/jobworker/JobWorkerAgentExecutionContextFactoryImplTest.java
+++ b/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/jobworker/JobWorkerAgentExecutionContextFactoryImplTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.agenticai.aiagent.jobworker;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.camunda.client.api.response.ActivatedJob;
+import io.camunda.client.api.worker.JobClient;
+import io.camunda.connector.api.document.DocumentFactory;
+import io.camunda.connector.api.secret.SecretProvider;
+import io.camunda.connector.api.validation.ValidationProvider;
+import io.camunda.connector.jackson.ConnectorsObjectMapperSupplier;
+import io.camunda.connector.runtime.core.secret.SecretFilter;
+import io.camunda.connector.runtime.core.secret.SecretFilterFactory;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class JobWorkerAgentExecutionContextFactoryImplTest {
+
+  private static final SecretProvider SECRET_PROVIDER =
+      new SecretProvider() {
+        @Override
+        public String getSecret(
+            String name, io.camunda.connector.api.secret.SecretContext context) {
+          return "s3cr3t";
+        }
+      };
+
+  private final SecretFilterFactory secretFilterFactory = context -> SecretFilter.allowAll();
+
+  private final JobWorkerAgentExecutionContextFactoryImpl factory =
+      new JobWorkerAgentExecutionContextFactoryImpl(
+          SECRET_PROVIDER,
+          mock(ValidationProvider.class),
+          mock(DocumentFactory.class),
+          ConnectorsObjectMapperSupplier.getCopy(),
+          secretFilterFactory);
+
+  /**
+   * The binding is where a secret reference becomes a value, so a failure raised anywhere after it
+   * — including by the binding itself — can carry that value. Reporting it means redacting it, and
+   * the store may hold a different value by then.
+   */
+  @Test
+  void reportsTheValuesItSubstitutedEvenWhenTheBindingFails() {
+    var job = mock(ActivatedJob.class);
+    // resolves, then fails to map: provider is an object, not a string
+    when(job.getVariables()).thenReturn("{\"provider\":\"{{secrets.TOKEN}}\"}");
+
+    List<String> captured = new ArrayList<>();
+
+    assertThatThrownBy(() -> factory.createExecutionContext(mock(JobClient.class), job, captured))
+        .isInstanceOf(Exception.class);
+
+    assertThat(captured).contains("s3cr3t");
+  }
+}


### PR DESCRIPTION
## Description

Backports #8634 and #8643 together to `stable/8.9`. They form one secret-redaction change and are intentionally combined so the fixes reach this older stable branch atomically. This is ported from the combined reference backport #8661.

The change prevents resolved secrets from being exposed through outbound job and BPMN error incidents, inbound activity logs and health errors, and errors emitted after a secret rotates between input binding and masking. It also includes the approved follow-up #8662, which prevents the unredacted exception cause from being printed to runtime logs.

The required secret-reference handling from #8641 is already present on the target branch through #8657.

## Related issues

Related to #8638.

Source PRs: #8634, #8643, and follow-up #8662.

## Checklist

- [x] No further backport labels are added; the older stable branches are being ported explicitly from the combined change.
- [x] Tests for the changes are included and the focused runtime test suite passes.
- [x] No documentation update is required for this backport.
