### PR TITLE
[Backport stable/8.7] fix: redact secrets from connector errors and logs

### DIFF
--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/DefaultProcessElementContext.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/DefaultProcessElementContext.java
@@ -25,6 +25,7 @@ import io.camunda.connector.api.validation.ValidationProvider;
 import io.camunda.connector.runtime.core.AbstractConnectorContext;
 import io.camunda.connector.runtime.core.secret.SecretFilter;
 import io.camunda.connector.runtime.core.secret.SecretUtil;
+import java.util.List;
 import java.util.Map;
 
 public class DefaultProcessElementContext extends AbstractConnectorContext
@@ -104,6 +105,16 @@ public class DefaultProcessElementContext extends AbstractConnectorContext
   @Override
   public Map<String, Object> getProperties() {
     return getPropertiesWithSecrets(properties);
+  }
+
+  /**
+   * The secret values resolved through this element context so far. The connector-level context
+   * that handed this element to the connector adds them to what it redacts: a value bound here and
+   * rotated afterwards can no longer be re-read from the provider, so nothing else would recognise
+   * it in an activity log or a health error.
+   */
+  List<String> resolvedSecretValues() {
+    return getSecretHandler().getResolvedValues();
   }
 
   private Map<String, Object> getPropertiesWithSecrets(Map<String, Object> properties) {

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextImpl.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextImpl.java
@@ -19,6 +19,7 @@ package io.camunda.connector.runtime.core.inbound;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.EvictingQueue;
 import io.camunda.connector.api.error.ConnectorInputException;
+import io.camunda.connector.api.error.ConnectorRetryException;
 import io.camunda.connector.api.inbound.*;
 import io.camunda.connector.api.secret.SecretContext;
 import io.camunda.connector.api.secret.SecretProvider;
@@ -177,9 +178,48 @@ public class InboundConnectorContextImpl extends AbstractConnectorContext
   @Override
   public void cancel(Throwable exception) {
     try {
-      cancellationCallback.accept(exception);
+      cancellationCallback.accept(redactCancellationError(exception));
     } catch (Throwable e) {
       LOG.error("Failed to deliver the cancellation signal to the runtime", e);
+    }
+  }
+
+  /**
+   * Redacts what a connector cancels with, because the runtime publishes it: the executable
+   * registry turns it into {@code Health.down(exceptionThrown)}, which reports the throwable's type
+   * and its {@link Throwable#toString()} through the health endpoint. A connector that cancels with
+   * an API's rejection carries that API's text, and a rejected credential is often echoed in it, so
+   * this needs the same redaction reported health and activity log entries already get.
+   *
+   * <p>A retry request keeps its type and its retry metadata: the registry restarts the executable
+   * from them, so anything else would silently change whether it comes back, how often, and how
+   * soon. Anything else is reported as a type of its own, naming the type it replaced, since the
+   * message a throwable carries cannot be rewritten in place.
+   */
+  private Throwable redactCancellationError(Throwable exception) {
+    if (exception == null || exception.getMessage() == null) {
+      return exception;
+    }
+    var redacted = redactMessage(exception.getMessage());
+    if (redacted.equals(exception.getMessage())) {
+      return exception;
+    }
+    if (exception instanceof ConnectorRetryException retry) {
+      return ConnectorRetryException.builder()
+          .errorCode(retry.getErrorCode())
+          .message(redacted)
+          .retries(retry.getRetries())
+          .backoffDuration(retry.getBackoffDuration())
+          .build();
+    }
+    return new RedactedCancellationError(exception.getClass().getName() + ": " + redacted);
+  }
+
+  /** Stands in for a cancellation error whose message had to be rewritten to redact a secret. */
+  private static final class RedactedCancellationError extends RuntimeException {
+
+    private RedactedCancellationError(String message) {
+      super(message);
     }
   }
 

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextImpl.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextImpl.java
@@ -26,7 +26,6 @@ import io.camunda.connector.api.validation.ValidationProvider;
 import io.camunda.connector.feel.FeelEngineWrapperException;
 import io.camunda.connector.runtime.core.AbstractConnectorContext;
 import io.camunda.connector.runtime.core.inbound.correlation.InboundCorrelationHandler;
-import io.camunda.connector.runtime.core.inbound.details.InboundConnectorDetails;
 import io.camunda.connector.runtime.core.inbound.details.InboundConnectorDetails.ValidInboundConnectorDetails;
 import io.camunda.connector.runtime.core.secret.SecretFilter;
 import io.camunda.connector.runtime.core.secret.SecretUtil;
@@ -36,10 +35,13 @@ import io.camunda.document.factory.DocumentFactoryImpl;
 import io.camunda.document.reference.DocumentReference;
 import io.camunda.document.store.DocumentCreationRequest;
 import io.camunda.document.store.InMemoryDocumentStore;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Queue;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
@@ -49,7 +51,7 @@ public class InboundConnectorContextImpl extends AbstractConnectorContext
     implements InboundConnectorContext, InboundConnectorReportingContext {
 
   private final Logger LOG = LoggerFactory.getLogger(InboundConnectorContextImpl.class);
-  private final InboundConnectorDetails connectorDetails;
+  private final ValidInboundConnectorDetails connectorDetails;
   private final Map<String, Object> properties;
 
   private final InboundCorrelationHandler correlationHandler;
@@ -61,6 +63,11 @@ public class InboundConnectorContextImpl extends AbstractConnectorContext
   private final Long activationTimestamp;
   private Health health = Health.unknown();
   private Map<String, Object> propertiesWithSecrets;
+  private volatile List<String> reReadSecrets;
+  private final Set<String> capturedSecretValues = ConcurrentHashMap.newKeySet();
+
+  private static final String REDACTION_UNAVAILABLE_MESSAGE =
+      "Message withheld: could not verify it does not contain a secret value";
 
   public InboundConnectorContextImpl(
       SecretProvider secretProvider,
@@ -239,7 +246,7 @@ public class InboundConnectorContextImpl extends AbstractConnectorContext
 
   @Override
   public void reportHealth(Health health) {
-    this.health = health;
+    this.health = redactHealth(health);
   }
 
   @Override
@@ -249,13 +256,14 @@ public class InboundConnectorContextImpl extends AbstractConnectorContext
 
   @Override
   public void log(Activity log) {
-    switch (log.severity()) {
-      case DEBUG -> LOG.debug(log.toString());
-      case ERROR -> LOG.error(log.toString());
-      case INFO -> LOG.info(log.toString());
-      case WARNING -> LOG.warn(log.toString());
+    var masked = redact(log);
+    switch (masked.severity()) {
+      case DEBUG -> LOG.debug(masked.toString());
+      case ERROR -> LOG.error(masked.toString());
+      case INFO -> LOG.info(masked.toString());
+      case WARNING -> LOG.warn(masked.toString());
     }
-    this.logs.add(log);
+    this.logs.add(masked);
   }
 
   @Override
@@ -275,14 +283,90 @@ public class InboundConnectorContextImpl extends AbstractConnectorContext
 
   private Map<String, Object> getPropertiesWithSecrets(Map<String, Object> properties) {
     if (propertiesWithSecrets == null) {
-      propertiesWithSecrets =
-          InboundPropertyHandler.getPropertiesWithSecrets(
-              getSecretHandler(),
-              objectMapper,
-              properties,
-              new SecretContext(connectorDetails.tenantId()));
+      var handler = getSecretHandler();
+      try {
+        propertiesWithSecrets =
+            InboundPropertyHandler.getPropertiesWithSecrets(
+                handler, objectMapper, properties, new SecretContext(connectorDetails.tenantId()));
+      } finally {
+        capturedSecretValues.addAll(handler.getResolvedValues());
+      }
     }
     return propertiesWithSecrets;
+  }
+
+  // captures are only ever unioned into a successful, complete re-read, never a substitute for one
+  private List<String> secretValuesForRedaction() {
+    var reRead = reReadSecretValues();
+    if (reRead == null) {
+      return null;
+    }
+    if (capturedSecretValues.isEmpty()) {
+      return reRead;
+    }
+    var union = new ArrayList<>(reRead);
+    union.addAll(capturedSecretValues);
+    return union;
+  }
+
+  private List<String> reReadSecretValues() {
+    var cached = reReadSecrets;
+    if (cached != null) {
+      return cached;
+    }
+    var values = fetchSecretValuesForRedaction();
+    if (values != null) {
+      reReadSecrets = values;
+    }
+    return values;
+  }
+
+  private List<String> fetchSecretValuesForRedaction() {
+    var names =
+        connectorDetails.rawPropertiesWithoutKeywords().values().stream()
+            .flatMap(value -> SecretUtil.retrieveSecretKeysInInput(value).stream())
+            .distinct()
+            .toList();
+    if (names.isEmpty()) {
+      return List.of();
+    }
+    try {
+      var values = secretProvider.fetchAll(names, new SecretContext(connectorDetails.tenantId()));
+      // fewer values than names means a partial read, treated the same as a failed one
+      return values.size() < names.size() ? null : values;
+    } catch (Exception e) {
+      LOG.warn("Could not fetch secret values to redact activity log: {}", e.getClass().getName());
+      return null;
+    }
+  }
+
+  private String redactMessage(String message) {
+    if (message == null) {
+      return null;
+    }
+    var secrets = secretValuesForRedaction();
+    return secrets == null
+        ? REDACTION_UNAVAILABLE_MESSAGE
+        : SecretUtil.hideSecretsFromMessage(message, secrets);
+  }
+
+  private Health redactHealth(Health health) {
+    if (health == null || health.getError() == null) {
+      return health;
+    }
+    var error = health.getError();
+    // an error is only ever set through Health.down(...), so rebuilding as down keeps the status
+    return Health.down(
+        new Health.Error(redactMessage(error.code()), redactMessage(error.message())),
+        health.getDetails());
+  }
+
+  private Activity redact(Activity activity) {
+    return new Activity(
+        activity.severity(),
+        activity.tag(),
+        activity.timestamp(),
+        redactMessage(activity.message()));
   }
 
   @Override

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextImpl.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextImpl.java
@@ -139,7 +139,8 @@ public class InboundConnectorContextImpl extends AbstractConnectorContext
 
   @Override
   public ActivationCheckResult canActivate(Object variables) {
-    return correlationHandler.canActivate(connectorDetails.connectorElements(), variables);
+    return capturing(
+        correlationHandler.canActivate(connectorDetails.connectorElements(), variables));
   }
 
   @Override
@@ -155,7 +156,8 @@ public class InboundConnectorContextImpl extends AbstractConnectorContext
 
   private CorrelationResult correlateWithResultInternal(CorrelationRequest correlationRequest) {
     try {
-      return correlationHandler.correlate(connectorDetails.connectorElements(), correlationRequest);
+      return capturing(
+          correlationHandler.correlate(connectorDetails.connectorElements(), correlationRequest));
     } catch (ConnectorInputException connectorInputException) {
       return new CorrelationResult.Failure.InvalidInput(
           connectorInputException.getMessage(), connectorInputException);
@@ -172,6 +174,83 @@ public class InboundConnectorContextImpl extends AbstractConnectorContext
               .message("Failed to correlate inbound event " + exception.getMessage()));
       LOG.error("Failed to correlate inbound event", exception);
       return new CorrelationResult.Failure.Other(exception);
+    }
+  }
+
+  /**
+   * Every successful activation check and correlation hands the connector a context for the element
+   * that matched, and that context resolves its own element's raw properties through a secret
+   * handler of its own. What it resolves has to reach this context's captured values: a value the
+   * connector binds through the activated element and that rotates before the connector reports an
+   * error is no longer re-readable, so nothing else would recognise it in the activity log or the
+   * health error that follows.
+   *
+   * <p>Upstream binds element properties on the connector-level context itself, so its captures
+   * land there directly. Here the element context is a separate object built by a shared factory,
+   * with no reference back to this one, so it is drained as the connector reads it instead.
+   */
+  private ActivationCheckResult capturing(ActivationCheckResult result) {
+    if (result instanceof ActivationCheckResult.Success.CanActivate canActivate) {
+      return new ActivationCheckResult.Success.CanActivate(
+          capturing(canActivate.activatedElement()));
+    }
+    return result;
+  }
+
+  private CorrelationResult capturing(CorrelationResult result) {
+    return switch (result) {
+      case CorrelationResult.Success.ProcessInstanceCreated created ->
+          new CorrelationResult.Success.ProcessInstanceCreated(
+              capturing(created.activatedElement()),
+              created.processInstanceKey(),
+              created.tenantId());
+      case CorrelationResult.Success.MessagePublished published ->
+          new CorrelationResult.Success.MessagePublished(
+              capturing(published.activatedElement()),
+              published.messageKey(),
+              published.tenantId());
+      case CorrelationResult.Success.MessageAlreadyCorrelated correlated ->
+          new CorrelationResult.Success.MessageAlreadyCorrelated(
+              capturing(correlated.activatedElement()));
+      default -> result;
+    };
+  }
+
+  private ProcessElementContext capturing(ProcessElementContext element) {
+    return element instanceof DefaultProcessElementContext resolving
+        ? new CapturingProcessElementContext(resolving, capturedSecretValues)
+        : element;
+  }
+
+  /**
+   * Adds what an element context resolves to the connector-level captured values, at the point the
+   * connector reads it and so before it can report anything derived from it.
+   */
+  private record CapturingProcessElementContext(
+      DefaultProcessElementContext delegate, Set<String> capturedSecretValues)
+      implements ProcessElementContext {
+
+    @Override
+    public ProcessElement getElement() {
+      return delegate.getElement();
+    }
+
+    @Override
+    public <T> T bindProperties(Class<T> cls) {
+      try {
+        return delegate.bindProperties(cls);
+      } finally {
+        capturedSecretValues.addAll(delegate.resolvedSecretValues());
+      }
+    }
+
+    @Override
+    public Map<String, Object> getProperties() {
+      try {
+        return delegate.getProperties();
+      } finally {
+        capturedSecretValues.addAll(delegate.resolvedSecretValues());
+      }
     }
   }
 
@@ -361,9 +440,15 @@ public class InboundConnectorContextImpl extends AbstractConnectorContext
     return values;
   }
 
+  // names across every grouped element, not just the representative one this context binds from:
+  // elements are grouped on the properties deduplication hashes, and PROPERTIES_EXCLUDED_FROM_
+  // DEDUPLICATION lets siblings still differ in resultExpression, activationCondition,
+  // correlationKeyExpression and the rest, so a sibling can declare a secret of its own and resolve
+  // it through the element context correlation hands the connector
   private List<String> fetchSecretValuesForRedaction() {
     var names =
-        connectorDetails.rawPropertiesWithoutKeywords().values().stream()
+        connectorDetails.connectorElements().stream()
+            .flatMap(element -> element.rawProperties().values().stream())
             .flatMap(value -> SecretUtil.retrieveSecretKeysInInput(value).stream())
             .distinct()
             .toList();

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/outbound/ConnectorJobHandler.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/outbound/ConnectorJobHandler.java
@@ -214,6 +214,7 @@ public class ConnectorJobHandler implements JobHandler {
     } else if (finalResult instanceof ErrorResult errorResult) {
       // Handle Java error, e.g. ConnectorException
       // these errors won't be handled ConnectorHelper.examineErrorExpression
+      // The wrapper message is redacted, but its cause is not, so do not log the throwable.
       LOGGER.error(
           "Exception while completing job: {} for tenant: {}, message: {}",
           job.getKey(),

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/outbound/ConnectorJobHandler.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/outbound/ConnectorJobHandler.java
@@ -36,6 +36,7 @@ import io.camunda.connector.runtime.core.outbound.ErrorExpressionJobContext.Erro
 import io.camunda.connector.runtime.core.secret.SecretFilter;
 import io.camunda.connector.runtime.core.secret.SecretFilterFactory;
 import io.camunda.connector.runtime.core.secret.SecretFilterFactory.SecretFilterContext;
+import io.camunda.connector.runtime.core.secret.SecretHandler;
 import io.camunda.connector.runtime.core.secret.SecretProviderAggregator;
 import io.camunda.connector.runtime.core.secret.SecretProviderDiscovery;
 import io.camunda.document.factory.DocumentFactory;
@@ -129,22 +130,26 @@ public class ConnectorJobHandler implements JobHandler {
     SecretFilter secretFilter =
         secretFilterFactory.create(
             new SecretFilterContext(job.getProcessDefinitionKey(), job.getElementId()));
-    ConnectorResult result = getConnectorResult(job, secretFilter);
-    processFinalResult(client, job, result, secretFilter);
+    // built here rather than inside the call, so the values it substituted are still available to
+    // redact with afterwards: a secret rotated in the store since then no longer re-reads to what
+    // this job actually sent, and the error it provoked would publish the value it did send
+    var context =
+        new JobHandlerContext(
+            job,
+            getSecretProvider(),
+            validationProvider,
+            documentFactory,
+            objectMapper,
+            secretFilter);
+    ConnectorResult result = getConnectorResult(job, context, secretFilter);
+    processFinalResult(client, job, result, secretFilter, context.getSecretHandler());
   }
 
-  private ConnectorResult getConnectorResult(ActivatedJob job, SecretFilter secretFilter) {
+  private ConnectorResult getConnectorResult(
+      ActivatedJob job, JobHandlerContext context, SecretFilter secretFilter) {
     Duration retryBackoff = null;
     try {
       retryBackoff = getBackoffDuration(job);
-      var context =
-          new JobHandlerContext(
-              job,
-              getSecretProvider(),
-              validationProvider,
-              documentFactory,
-              objectMapper,
-              secretFilter);
       var response = call.execute(context);
       var responseVariables =
           ConnectorHelper.createOutputVariables(
@@ -157,7 +162,7 @@ public class ConnectorJobHandler implements JobHandler {
       return new SuccessResult(response, responseVariables);
     } catch (Exception e) {
       return outboundConnectorExceptionHandler.manageConnectorJobHandlerException(
-          e, job, retryBackoff, secretFilter);
+          e, job, retryBackoff, secretFilter, context.getSecretHandler().getResolvedValues());
     }
   }
 
@@ -178,7 +183,11 @@ public class ConnectorJobHandler implements JobHandler {
   }
 
   private void processFinalResult(
-      JobClient client, ActivatedJob job, ConnectorResult finalResult, SecretFilter secretFilter) {
+      JobClient client,
+      ActivatedJob job,
+      ConnectorResult finalResult,
+      SecretFilter secretFilter,
+      SecretHandler secretHandler) {
     try {
       Optional<ConnectorError> optionalConnectorError =
           ConnectorHelper.examineErrorExpression(
@@ -186,13 +195,14 @@ public class ConnectorJobHandler implements JobHandler {
               job.getCustomHeaders(),
               new ErrorExpressionJobContext(new ErrorExpressionJob(job.getRetries())));
       optionalConnectorError.ifPresentOrElse(
-          error -> handleBPMNError(client, job, error, secretFilter),
+          error -> handleBPMNError(client, job, error, secretFilter, secretHandler),
           () -> handleSuccessResult(client, job, finalResult));
     } catch (Exception ex) {
       failJob(
           client,
           job,
-          this.outboundConnectorExceptionHandler.handleFinalResultException(ex, job, secretFilter));
+          this.outboundConnectorExceptionHandler.handleFinalResultException(
+              ex, job, secretFilter, secretHandler.getResolvedValues()));
     }
   }
 
@@ -214,10 +224,16 @@ public class ConnectorJobHandler implements JobHandler {
   }
 
   private void handleBPMNError(
-      JobClient client, ActivatedJob job, ConnectorError rawError, SecretFilter secretFilter) {
+      JobClient client,
+      ActivatedJob job,
+      ConnectorError rawError,
+      SecretFilter secretFilter,
+      SecretHandler secretHandler) {
     // redacted before the Zeebe command is built from it: neither throwError nor failJob masks
     // anything of its own, and an error expression can copy a response that echoes a secret back
-    var error = outboundConnectorExceptionHandler.maskConnectorError(rawError, job, secretFilter);
+    var error =
+        outboundConnectorExceptionHandler.maskConnectorError(
+            rawError, job, secretFilter, secretHandler.getResolvedValues());
     if (error instanceof BpmnError bpmnError) {
       checkVariablesSize(bpmnError.variables());
       // the code is not redacted, so it stays out of the log: unlike the command and the error

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/outbound/ConnectorJobHandler.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/outbound/ConnectorJobHandler.java
@@ -186,7 +186,7 @@ public class ConnectorJobHandler implements JobHandler {
               job.getCustomHeaders(),
               new ErrorExpressionJobContext(new ErrorExpressionJob(job.getRetries())));
       optionalConnectorError.ifPresentOrElse(
-          error -> handleBPMNError(client, job, error),
+          error -> handleBPMNError(client, job, error, secretFilter),
           () -> handleSuccessResult(client, job, finalResult));
     } catch (Exception ex) {
       failJob(
@@ -213,10 +213,16 @@ public class ConnectorJobHandler implements JobHandler {
     }
   }
 
-  private void handleBPMNError(JobClient client, ActivatedJob job, ConnectorError error) {
+  private void handleBPMNError(
+      JobClient client, ActivatedJob job, ConnectorError rawError, SecretFilter secretFilter) {
+    // redacted before the Zeebe command is built from it: neither throwError nor failJob masks
+    // anything of its own, and an error expression can copy a response that echoes a secret back
+    var error = outboundConnectorExceptionHandler.maskConnectorError(rawError, job, secretFilter);
     if (error instanceof BpmnError bpmnError) {
       checkVariablesSize(bpmnError.variables());
-      LOGGER.debug("Throwing BPMN error for job {} with code {}", job.getKey(), bpmnError.code());
+      // the code is not redacted, so it stays out of the log: unlike the command and the error
+      // variables that carry it, pod logs are shipped to systems with their own access controls
+      LOGGER.debug("Throwing BPMN error for job {}", job.getKey());
       throwBpmnError(client, job, bpmnError);
     } else if (error instanceof JobError jobError) {
       LOGGER.debug("Throwing incident for job {}", job.getKey());

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/outbound/OutboundConnectorExceptionHandler.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/outbound/OutboundConnectorExceptionHandler.java
@@ -62,6 +62,19 @@ public class OutboundConnectorExceptionHandler {
    */
   private static final class SecretFilterUnavailableException extends RuntimeException {}
 
+  /**
+   * The type name published in the {@code error} payload, which deployed models read and can match
+   * on. A missing secret is reported under the type this branch has always reported it under: the
+   * distinct class is a marker {@link #reportsAnUnavailableSecret} needs internally to tell that
+   * one failure apart on the masking re-read, and giving it a published name of its own would break
+   * a process that switches on the old one.
+   */
+  private static String publishedTypeOf(Throwable cause) {
+    return cause instanceof SecretNotAvailableException
+        ? ConnectorInputException.class.getName()
+        : cause.getClass().getName();
+  }
+
   private static Map<String, Object> exceptionToMap(
       Exception wrappedException, List<String> secrets) {
     Map<String, Object> result = new HashMap<>();
@@ -69,7 +82,7 @@ public class OutboundConnectorExceptionHandler {
     // deliberately withholds it — that one reports itself, rather than dereferencing a null.
     Throwable originalCause =
         wrappedException.getCause() != null ? wrappedException.getCause() : wrappedException;
-    result.put("type", originalCause.getClass().getName());
+    result.put("type", publishedTypeOf(originalCause));
     var message = wrappedException.getMessage();
     if (message != null) {
       result.put(
@@ -107,7 +120,7 @@ public class OutboundConnectorExceptionHandler {
   private static Map<String, Object> withheldExceptionToMap(
       Exception e, Exception wrappedException) {
     Map<String, Object> result = new HashMap<>();
-    result.put("type", e.getClass().getName());
+    result.put("type", publishedTypeOf(e));
     var message = wrappedException.getMessage();
     if (message != null) {
       result.put(

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/outbound/OutboundConnectorExceptionHandler.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/outbound/OutboundConnectorExceptionHandler.java
@@ -379,6 +379,14 @@ public class OutboundConnectorExceptionHandler {
     }
   }
 
+  /**
+   * Whether an exception says the input can never bind, whoever raised it. Such a job is not worth
+   * another attempt; anything else — an unreachable cluster, a timeout — is.
+   */
+  private static boolean isFatalInputError(Throwable e) {
+    return e instanceof ConnectorInputException || e.getCause() instanceof ConnectorInputException;
+  }
+
   public ConnectorResult.ErrorResult manageConnectorJobHandlerException(
       Exception e,
       ActivatedJob job,
@@ -391,11 +399,18 @@ public class OutboundConnectorExceptionHandler {
     var masking = fetchSecretsForMasking(job, secretFilter, e);
     if (masking.unavailable()) {
       var wrappedException = unmaskableError(masking.failure());
+      // Either failure can be the permanent one, so both are consulted. A provider that refuses to
+      // resolve at all throws for every key, including the ones this fetch only needed for masking;
+      // and the job's own failure is still whatever it was, so an input error that will never bind
+      // must not become retryable just because reading the values to redact it happened to fail.
+      // Only when neither says the input is at fault does the job keep its remaining attempts.
+      int retries =
+          isFatalInputError(masking.failure()) || isFatalInputError(e) ? 0 : job.getRetries() - 1;
       return new ConnectorResult.ErrorResult(
           // secrets could not be fetched, so there is nothing to mask with
           Map.of("error", exceptionToMap(wrappedException, List.of())),
           wrappedException,
-          job.getRetries() - 1,
+          retries,
           retryBackoffFor(masking.failure(), retryBackoffDuration));
     }
     List<String> secrets = withCaptured(masking, capturedSecrets);
@@ -533,7 +548,7 @@ public class OutboundConnectorExceptionHandler {
     if (ex instanceof ConnectorException connectorException) {
       errorCode = connectorException.getErrorCode();
     }
-    if (ex instanceof ConnectorInputException || ex.getCause() instanceof ConnectorInputException) {
+    if (isFatalInputError(ex)) {
       retries = 0;
     }
     return handleSDKException(job, newException, retries, errorCode, retryBackoff, secrets);
@@ -577,12 +592,17 @@ public class OutboundConnectorExceptionHandler {
       Exception ex, ActivatedJob job, SecretFilter secretFilter, List<String> capturedSecrets) {
     var masking = fetchSecretsForMasking(job, secretFilter, ex);
     if (masking.unavailable()) {
+      LOGGER.error(
+          "Exception while processing job: {} for tenant: {}, type: {}. Its message is withheld:"
+              + " the values to redact it with could not be read.",
+          job.getKey(),
+          job.getTenantId(),
+          ex.getClass().getName());
       var wrappedException = unmaskableError(masking.failure());
+      // zero, as on every other path out of here: the connector has already run, so there is
+      // nothing left for another attempt to do
       return new ConnectorResult.ErrorResult(
-          // secrets could not be fetched, so there is nothing to mask with
-          Map.of("error", exceptionToMap(wrappedException, List.of())),
-          wrappedException,
-          job.getRetries() - 1);
+          Map.of("error", exceptionToMap(wrappedException, List.of())), wrappedException, 0);
     }
     List<String> secrets = withCaptured(masking, capturedSecrets);
     Exception newException =

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/outbound/OutboundConnectorExceptionHandler.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/outbound/OutboundConnectorExceptionHandler.java
@@ -28,7 +28,9 @@ import io.camunda.connector.runtime.core.error.ConnectorError;
 import io.camunda.connector.runtime.core.error.InvalidBackOffDurationException;
 import io.camunda.connector.runtime.core.error.JobError;
 import io.camunda.connector.runtime.core.secret.SecretAllowListUnavailableException;
+import io.camunda.connector.runtime.core.secret.SecretFailureDiagnostic;
 import io.camunda.connector.runtime.core.secret.SecretFilter;
+import io.camunda.connector.runtime.core.secret.SecretNotAvailableException;
 import io.camunda.connector.runtime.core.secret.SecretUtil;
 import io.camunda.zeebe.client.api.response.ActivatedJob;
 import java.time.Duration;
@@ -60,9 +62,13 @@ public class OutboundConnectorExceptionHandler {
    */
   private static final class SecretFilterUnavailableException extends RuntimeException {}
 
-  private static Map<String, Object> exceptionToMap(Exception wrappedException) {
+  private static Map<String, Object> exceptionToMap(
+      Exception wrappedException, List<String> secrets) {
     Map<String, Object> result = new HashMap<>();
-    Throwable originalCause = wrappedException.getCause();
+    // Every wrapper built here carries the failure it reports as its cause, except the one that
+    // deliberately withholds it — that one reports itself, rather than dereferencing a null.
+    Throwable originalCause =
+        wrappedException.getCause() != null ? wrappedException.getCause() : wrappedException;
     result.put("type", originalCause.getClass().getName());
     var message = wrappedException.getMessage();
     if (message != null) {
@@ -74,11 +80,16 @@ public class OutboundConnectorExceptionHandler {
       var variables = connectorException.getErrorVariables();
 
       if (code != null) {
+        // deliberately not masked: BPMN error boundary events match on this value, so altering it
+        // would stop the error from being caught
         result.put("code", code);
       }
 
       if (variables != null) {
-        result.put("variables", variables);
+        // the message is masked by the callers, but these are copied straight off the original
+        // exception: for HTTP connectors they carry the whole response body and headers, so an API
+        // that echoes a rejected credential back would publish the resolved secret as a variable
+        result.put("variables", maskSecrets(variables, secrets));
       }
     }
     return Map.copyOf(result);
@@ -158,11 +169,21 @@ public class OutboundConnectorExceptionHandler {
   /**
    * Masks every secret occurrence in {@code value}, recursing through maps and collections.
    *
+   * <p>The error message is masked by the callers, but the error variables are copied straight off
+   * the original exception, and for HTTP connectors they carry the full response body and headers
+   * (see {@code ConnectorExceptionMapper}). An API that echoes a rejected credential back would
+   * otherwise put the resolved secret into process variables, which are visible to anyone who can
+   * see the process instance.
+   *
    * <p>Only strings are rewritten; numbers, booleans and other scalars keep their type, since
    * processes may branch on them. Values of types other than {@link Map}/{@link Collection}/{@link
    * String} are passed through untouched — a secret held in a field of a custom object is not
    * reached.
    */
+  private static Object maskSecrets(Object value, List<String> secrets) {
+    return maskSecrets(value, secrets, Collections.newSetFromMap(new IdentityHashMap<>()));
+  }
+
   private static Object maskSecrets(Object value, List<String> secrets, Set<Object> enclosing) {
     return switch (value) {
       case null -> null;
@@ -230,8 +251,12 @@ public class OutboundConnectorExceptionHandler {
    * Reads the values to redact an error with. A job that declares no secret is never handed to the
    * provider at all: {@code fetchAll} is overridable, and one that refuses every batch would
    * otherwise withhold the error message of a job that had nothing to redact in the first place.
+   *
+   * @param jobFailure the failure being reported, or {@code null} where the caller is redacting
+   *     something other than a failure
    */
-  private MaskingSecrets fetchSecretsForMasking(ActivatedJob job, SecretFilter secretFilter) {
+  private MaskingSecrets fetchSecretsForMasking(
+      ActivatedJob job, SecretFilter secretFilter, Exception jobFailure) {
     try {
       var allowedKeys =
           SecretUtil.retrieveSecretKeysInInput(job.getVariables()).stream()
@@ -240,8 +265,18 @@ public class OutboundConnectorExceptionHandler {
       if (allowedKeys.isEmpty()) {
         return new MaskingSecrets(List.of(), null);
       }
-      return new MaskingSecrets(
-          this.secretProvider.fetchAll(allowedKeys, new SecretContext(job.getTenantId())), null);
+      var values = this.secretProvider.fetchAll(allowedKeys, new SecretContext(job.getTenantId()));
+      // fetchAll drops the names it cannot resolve, so a short read is a silent one: a name the
+      // input declares resolved when it was bound, so one missing now means the secret was removed,
+      // or access revoked, while the connector ran. Redacting with what did come back would publish
+      // the one that did not in the clear.
+      if (values.size() < allowedKeys.size() && !reportsAnUnavailableSecret(jobFailure)) {
+        return new MaskingSecrets(
+            List.of(),
+            new MaskingSecretsIncompleteException(
+                allowedKeys.size() - values.size(), allowedKeys.size()));
+      }
+      return new MaskingSecrets(values, null);
     } catch (Exception ex) {
       LOGGER.error(
           "Initial error for job: {} for tenant: {} can't be displayed because fetching secrets failed: {}",
@@ -253,12 +288,49 @@ public class OutboundConnectorExceptionHandler {
   }
 
   /**
+   * Whether the job failed because a secret it names has no value. A re-read that comes back short
+   * then says the same thing the job's own failure already says, rather than reporting a value that
+   * has gone missing since the connector ran.
+   */
+  private static boolean reportsAnUnavailableSecret(Exception jobFailure) {
+    return jobFailure instanceof SecretNotAvailableException
+        || (jobFailure != null && jobFailure.getCause() instanceof SecretNotAvailableException);
+  }
+
+  /**
+   * Reported when the masking re-read comes back short of the names the job's input declares.
+   * Carries a count and nothing else: how many values are missing is enough for an operator to act
+   * on, and is not something a secret store told this runtime.
+   */
+  private static final class MaskingSecretsIncompleteException extends RuntimeException
+      implements SecretFailureDiagnostic {
+
+    private MaskingSecretsIncompleteException(int missing, int expected) {
+      super(
+          missing
+              + " of the "
+              + expected
+              + " secrets this job's input names could not be read back. One that resolved when the"
+              + " input was bound has since been removed, or access to it revoked.");
+    }
+
+    @Override
+    public String publishableMessage() {
+      return getMessage();
+    }
+  }
+
+  /**
    * A provider's own message can carry secret material — {@code AbstractSecretProvider} folds a
    * Jackson failure into its message, and a secrets bundle that parses as a non-object puts the
-   * value it could not coerce into the coercion error — so only the failure's type is logged.
+   * value it could not coerce into the coercion error — so only the failure's type is reported. The
+   * exception is a {@link SecretFailureDiagnostic}, whose message this runtime wrote itself and
+   * which names what an operator has to act on.
    */
   private static String safeDiagnostic(Exception fetchFailure) {
-    return fetchFailure.getClass().getName();
+    return fetchFailure instanceof SecretFailureDiagnostic diagnosable
+        ? fetchFailure.getClass().getName() + ": " + diagnosable.publishableMessage()
+        : fetchFailure.getClass().getName();
   }
 
   // unions bind-time captures into a successful re-read, so a rotated secret is still redacted
@@ -272,14 +344,39 @@ public class OutboundConnectorExceptionHandler {
   }
 
   /**
-   * Reported in place of an error whose message could not be redacted. Carries the type of the
-   * fetch failure and nothing the provider wrote itself, for the same reason {@link
-   * #safeDiagnostic} withholds it from the log.
+   * Stands in for an error that cannot be shown. With no values to redact with, the original
+   * message has to be dropped rather than reported unmasked — it may hold a resolved secret.
+   *
+   * <p>The failure that prevented masking is dropped with it, and for the same reason: a provider
+   * or client error can echo a response body from the secret store, so its message is no safer to
+   * publish than the message it was supposed to help redact. It is not attached as a cause either,
+   * since anything walking the chain would reach that message again.
    */
-  private static String unmaskableErrorMessage(Exception fetchFailure) {
-    return "Fetching secrets failed, so the original error cannot be displayed: with nothing to"
-        + " redact with it might reveal a secret. Fetching failed with: "
-        + safeDiagnostic(fetchFailure);
+  private static RuntimeException unmaskableError(Exception fetchFailure) {
+    return new SecretsUnavailableException(
+        fetchFailure.getClass().getName(),
+        fetchFailure instanceof SecretFailureDiagnostic diagnosable
+            ? diagnosable.publishableMessage()
+            : null);
+  }
+
+  /**
+   * Reported in place of an error whose message could not be redacted.
+   *
+   * <p>Deliberately not a {@link ConnectorException}: {@link #exceptionToMap} copies a {@code
+   * ConnectorException}'s error variables and error code into the payload, and on this path it
+   * would copy them with no redaction list at all — publishing unmasked exactly the data this
+   * branch exists to withhold.
+   */
+  private static final class SecretsUnavailableException extends RuntimeException {
+
+    private SecretsUnavailableException(String failureType, String publishableMessage) {
+      super(
+          "Fetching secrets failed, so the original error cannot be displayed: with nothing to"
+              + " redact with it might reveal a secret. Fetching failed with: "
+              + failureType
+              + (publishableMessage == null ? "" : ": " + publishableMessage));
+    }
   }
 
   public ConnectorResult.ErrorResult manageConnectorJobHandlerException(
@@ -291,15 +388,12 @@ public class OutboundConnectorExceptionHandler {
     if (e instanceof SecretAllowListUnavailableException) {
       return handleGenericException(job, e, List.of(), retryBackoffFor(e, retryBackoffDuration));
     }
-    var masking = fetchSecretsForMasking(job, secretFilter);
+    var masking = fetchSecretsForMasking(job, secretFilter, e);
     if (masking.unavailable()) {
-      var wrappedException =
-          new RuntimeException(
-              "Fetching secrets failed, original error can't be displayed as the error message might contain secrets: "
-                  + masking.failure().getMessage(),
-              masking.failure());
+      var wrappedException = unmaskableError(masking.failure());
       return new ConnectorResult.ErrorResult(
-          Map.of("error", exceptionToMap(wrappedException)),
+          // secrets could not be fetched, so there is nothing to mask with
+          Map.of("error", exceptionToMap(wrappedException, List.of())),
           wrappedException,
           job.getRetries() - 1,
           retryBackoffFor(masking.failure(), retryBackoffDuration));
@@ -333,11 +427,11 @@ public class OutboundConnectorExceptionHandler {
         if (nothingToRedact(bpmnError.message(), bpmnError.variables())) {
           yield bpmnError;
         }
-        var masking = fetchSecretsForMasking(job, secretFilter);
+        var masking = fetchSecretsForMasking(job, secretFilter, null);
         // the error code is never redacted: boundary events match on it
         if (masking.unavailable()) {
           yield new BpmnError(
-              bpmnError.code(), unmaskableErrorMessage(masking.failure()), Map.of());
+              bpmnError.code(), unmaskableError(masking.failure()).getMessage(), Map.of());
         }
         var secrets = withCaptured(masking, capturedSecrets);
         yield new BpmnError(
@@ -349,11 +443,11 @@ public class OutboundConnectorExceptionHandler {
         if (nothingToRedact(jobError.message(), jobError.variables())) {
           yield jobError;
         }
-        var masking = fetchSecretsForMasking(job, secretFilter);
+        var masking = fetchSecretsForMasking(job, secretFilter, null);
         // the retries and the backoff are the expression author's decision, so they survive
         if (masking.unavailable()) {
           yield new JobError(
-              unmaskableErrorMessage(masking.failure()),
+              unmaskableError(masking.failure()).getMessage(),
               Map.of(),
               jobError.retries(),
               jobError.retryBackoff());
@@ -382,7 +476,7 @@ public class OutboundConnectorExceptionHandler {
     Exception newException =
         new Exception(SecretUtil.hideSecretsFromMessage(e.getMessage(), secrets), e);
     return new ConnectorResult.ErrorResult(
-        Map.of("error", exceptionToMap(newException)), newException, 0);
+        Map.of("error", exceptionToMap(newException, secrets)), newException, 0);
   }
 
   private ConnectorResult.ErrorResult handleConnectorRetryException(
@@ -400,11 +494,17 @@ public class OutboundConnectorExceptionHandler {
         newException,
         Optional.ofNullable(ex.getRetries()).orElse(job.getRetries() - 1),
         errorCode,
-        Optional.ofNullable(ex.getBackoffDuration()).orElse(retryBackoff));
+        Optional.ofNullable(ex.getBackoffDuration()).orElse(retryBackoff),
+        secrets);
   }
 
   private ConnectorResult.ErrorResult handleSDKException(
-      ActivatedJob job, Exception ex, Integer retries, String errorCode, Duration backoffDuration) {
+      ActivatedJob job,
+      Exception ex,
+      Integer retries,
+      String errorCode,
+      Duration backoffDuration,
+      List<String> secrets) {
     LOGGER.debug(
         "Failing job with retry config => job: {} for tenant: {} with error code: {}, retries: {} and remaining backoffDuration: {}",
         job.getKey(),
@@ -414,7 +514,7 @@ public class OutboundConnectorExceptionHandler {
         backoffDuration);
 
     return new ConnectorResult.ErrorResult(
-        Map.of("error", exceptionToMap(ex)), ex, retries, backoffDuration);
+        Map.of("error", exceptionToMap(ex, secrets)), ex, retries, backoffDuration);
   }
 
   private ConnectorResult.ErrorResult handleGenericException(
@@ -436,7 +536,7 @@ public class OutboundConnectorExceptionHandler {
     if (ex instanceof ConnectorInputException || ex.getCause() instanceof ConnectorInputException) {
       retries = 0;
     }
-    return handleSDKException(job, newException, retries, errorCode, retryBackoff);
+    return handleSDKException(job, newException, retries, errorCode, retryBackoff, secrets);
   }
 
   /**
@@ -475,15 +575,12 @@ public class OutboundConnectorExceptionHandler {
    */
   public ConnectorResult.ErrorResult handleFinalResultException(
       Exception ex, ActivatedJob job, SecretFilter secretFilter, List<String> capturedSecrets) {
-    var masking = fetchSecretsForMasking(job, secretFilter);
+    var masking = fetchSecretsForMasking(job, secretFilter, ex);
     if (masking.unavailable()) {
-      var wrappedException =
-          new RuntimeException(
-              "Fetching secrets failed, original error can't be displayed as the error message might contain secrets: "
-                  + masking.failure().getMessage(),
-              masking.failure());
+      var wrappedException = unmaskableError(masking.failure());
       return new ConnectorResult.ErrorResult(
-          Map.of("error", exceptionToMap(wrappedException)),
+          // secrets could not be fetched, so there is nothing to mask with
+          Map.of("error", exceptionToMap(wrappedException, List.of())),
           wrappedException,
           job.getRetries() - 1);
     }
@@ -496,6 +593,6 @@ public class OutboundConnectorExceptionHandler {
         job.getTenantId(),
         newException.getMessage());
     return new ConnectorResult.ErrorResult(
-        Map.of("error", exceptionToMap(newException)), newException, 0);
+        Map.of("error", exceptionToMap(newException, secrets)), newException, 0);
   }
 }

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/outbound/OutboundConnectorExceptionHandler.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/outbound/OutboundConnectorExceptionHandler.java
@@ -23,7 +23,10 @@ import io.camunda.connector.api.error.ConnectorInputException;
 import io.camunda.connector.api.error.ConnectorRetryException;
 import io.camunda.connector.api.secret.SecretContext;
 import io.camunda.connector.api.secret.SecretProvider;
+import io.camunda.connector.runtime.core.error.BpmnError;
+import io.camunda.connector.runtime.core.error.ConnectorError;
 import io.camunda.connector.runtime.core.error.InvalidBackOffDurationException;
+import io.camunda.connector.runtime.core.error.JobError;
 import io.camunda.connector.runtime.core.secret.SecretAllowListUnavailableException;
 import io.camunda.connector.runtime.core.secret.SecretFilter;
 import io.camunda.connector.runtime.core.secret.SecretUtil;
@@ -39,6 +42,8 @@ public class OutboundConnectorExceptionHandler {
       LoggerFactory.getLogger(OutboundConnectorExceptionHandler.class);
 
   private static final Duration ALLOW_LIST_RETRY_BACKOFF = Duration.ofSeconds(5);
+
+  private static final String CIRCULAR_REFERENCE = "[circular reference]";
 
   private final SecretProvider secretProvider;
 
@@ -150,35 +155,142 @@ public class OutboundConnectorExceptionHandler {
         : configured;
   }
 
-  public ConnectorResult.ErrorResult manageConnectorJobHandlerException(
-      Exception e, ActivatedJob job, Duration retryBackoffDuration, SecretFilter secretFilter) {
-    if (e instanceof SecretAllowListUnavailableException) {
-      return handleGenericException(job, e, List.of(), retryBackoffFor(e, retryBackoffDuration));
+  /**
+   * Masks every secret occurrence in {@code value}, recursing through maps and collections.
+   *
+   * <p>Only strings are rewritten; numbers, booleans and other scalars keep their type, since
+   * processes may branch on them. Values of types other than {@link Map}/{@link Collection}/{@link
+   * String} are passed through untouched — a secret held in a field of a custom object is not
+   * reached.
+   */
+  private static Object maskSecrets(Object value, List<String> secrets, Set<Object> enclosing) {
+    return switch (value) {
+      case null -> null;
+      case String string -> hideSecretsFromMessage(string, secrets);
+      case Map<?, ?> map -> {
+        // error variables are user-supplied, so a container may contain itself
+        if (!enclosing.add(map)) {
+          yield CIRCULAR_REFERENCE;
+        }
+        try {
+          yield maskMap(map, secrets, enclosing);
+        } finally {
+          enclosing.remove(map);
+        }
+      }
+      case Collection<?> collection -> {
+        if (!enclosing.add(collection)) {
+          yield CIRCULAR_REFERENCE;
+        }
+        try {
+          yield collection.stream().map(item -> maskSecrets(item, secrets, enclosing)).toList();
+        } finally {
+          enclosing.remove(collection);
+        }
+      }
+      default -> value;
+    };
+  }
+
+  private static Map<String, Object> maskMap(
+      Map<?, ?> map, List<String> secrets, Set<Object> enclosing) {
+    // keys are masked too, and collapsed keys simply overwrite rather than fail
+    var masked = new LinkedHashMap<String, Object>();
+    map.forEach(
+        (key, entry) ->
+            masked.put(
+                hideSecretsFromMessage(String.valueOf(key), secrets),
+                maskSecrets(entry, secrets, enclosing)));
+    return masked;
+  }
+
+  /** Typed variant of {@link #maskSecrets}, which returns {@link Object} to allow a sentinel. */
+  private static Map<String, Object> maskVariables(
+      Map<String, Object> variables, List<String> secrets) {
+    if (variables == null) {
+      return null;
     }
-    List<String> secrets;
+    Set<Object> enclosing = Collections.newSetFromMap(new IdentityHashMap<>());
+    enclosing.add(variables);
+    return maskMap(variables, secrets, enclosing);
+  }
+
+  /**
+   * The values to redact from an error message, or the failure that prevented reading them. An
+   * empty list with no failure means the job declares nothing to redact, which is not the same as
+   * being unable to tell.
+   */
+  private record MaskingSecrets(List<String> secrets, Exception failure) {
+    boolean unavailable() {
+      return failure != null;
+    }
+  }
+
+  /**
+   * Reads the values to redact an error with. A job that declares no secret is never handed to the
+   * provider at all: {@code fetchAll} is overridable, and one that refuses every batch would
+   * otherwise withhold the error message of a job that had nothing to redact in the first place.
+   */
+  private MaskingSecrets fetchSecretsForMasking(ActivatedJob job, SecretFilter secretFilter) {
     try {
       var allowedKeys =
           SecretUtil.retrieveSecretKeysInInput(job.getVariables()).stream()
               .filter(secretFilter::isAllowed)
               .toList();
-      secrets = this.secretProvider.fetchAll(allowedKeys, new SecretContext(job.getTenantId()));
+      if (allowedKeys.isEmpty()) {
+        return new MaskingSecrets(List.of(), null);
+      }
+      return new MaskingSecrets(
+          this.secretProvider.fetchAll(allowedKeys, new SecretContext(job.getTenantId())), null);
     } catch (Exception ex) {
       LOGGER.error(
           "Initial error for job: {} for tenant: {} can't be displayed because fetching secrets failed: {}",
           job.getKey(),
           job.getTenantId(),
-          ex.getMessage());
+          safeDiagnostic(ex));
+      return new MaskingSecrets(List.of(), ex);
+    }
+  }
+
+  /**
+   * A provider's own message can carry secret material — {@code AbstractSecretProvider} folds a
+   * Jackson failure into its message, and a secrets bundle that parses as a non-object puts the
+   * value it could not coerce into the coercion error — so only the failure's type is logged.
+   */
+  private static String safeDiagnostic(Exception fetchFailure) {
+    return fetchFailure.getClass().getName();
+  }
+
+  /**
+   * Reported in place of an error whose message could not be redacted. Carries the type of the
+   * fetch failure and nothing the provider wrote itself, for the same reason {@link
+   * #safeDiagnostic} withholds it from the log.
+   */
+  private static String unmaskableErrorMessage(Exception fetchFailure) {
+    return "Fetching secrets failed, so the original error cannot be displayed: with nothing to"
+        + " redact with it might reveal a secret. Fetching failed with: "
+        + safeDiagnostic(fetchFailure);
+  }
+
+  public ConnectorResult.ErrorResult manageConnectorJobHandlerException(
+      Exception e, ActivatedJob job, Duration retryBackoffDuration, SecretFilter secretFilter) {
+    if (e instanceof SecretAllowListUnavailableException) {
+      return handleGenericException(job, e, List.of(), retryBackoffFor(e, retryBackoffDuration));
+    }
+    var masking = fetchSecretsForMasking(job, secretFilter);
+    if (masking.unavailable()) {
       var wrappedException =
           new RuntimeException(
               "Fetching secrets failed, original error can't be displayed as the error message might contain secrets: "
-                  + ex.getMessage(),
-              ex);
+                  + masking.failure().getMessage(),
+              masking.failure());
       return new ConnectorResult.ErrorResult(
           Map.of("error", exceptionToMap(wrappedException)),
           wrappedException,
           job.getRetries() - 1,
-          retryBackoffFor(ex, retryBackoffDuration));
+          retryBackoffFor(masking.failure(), retryBackoffDuration));
     }
+    List<String> secrets = masking.secrets();
     return switch (e) {
       case InvalidBackOffDurationException invalidBackOffDurationException ->
           handleBackOffException(invalidBackOffDurationException, secrets);
@@ -190,9 +302,68 @@ public class OutboundConnectorExceptionHandler {
     };
   }
 
-  private String hideSecretsFromMessage(String message, List<String> secrets) {
+  /**
+   * Redacts an error an error expression produced; {@code failJob}/{@code throwError} do not.
+   *
+   * <p>Redacting here rather than in the command builders keeps the redaction ahead of the 6000
+   * character truncation, where a secret straddling the cut would leave a prefix {@link
+   * String#replace} no longer sees.
+   */
+  public ConnectorError maskConnectorError(
+      ConnectorError error, ActivatedJob job, SecretFilter secretFilter) {
+    return switch (error) {
+      case BpmnError bpmnError -> {
+        if (nothingToRedact(bpmnError.message(), bpmnError.variables())) {
+          yield bpmnError;
+        }
+        var masking = fetchSecretsForMasking(job, secretFilter);
+        // the error code is never redacted: boundary events match on it
+        yield masking.unavailable()
+            ? new BpmnError(bpmnError.code(), unmaskableErrorMessage(masking.failure()), Map.of())
+            : new BpmnError(
+                bpmnError.code(),
+                redactNullable(bpmnError.message(), masking.secrets()),
+                maskVariables(bpmnError.variables(), masking.secrets()));
+      }
+      case JobError jobError -> {
+        if (nothingToRedact(jobError.message(), jobError.variables())) {
+          yield jobError;
+        }
+        var masking = fetchSecretsForMasking(job, secretFilter);
+        // the retries and the backoff are the expression author's decision, so they survive
+        yield masking.unavailable()
+            ? new JobError(
+                unmaskableErrorMessage(masking.failure()),
+                Map.of(),
+                jobError.retries(),
+                jobError.retryBackoff())
+            : new JobError(
+                redactNullable(jobError.message(), masking.secrets()),
+                maskVariables(jobError.variables(), masking.secrets()),
+                jobError.retries(),
+                jobError.retryBackoff());
+      }
+    };
+  }
+
+  private static boolean nothingToRedact(String errorMessage, Map<String, Object> variables) {
+    return (errorMessage == null || errorMessage.isEmpty())
+        && (variables == null || variables.isEmpty());
+  }
+
+  /** Unlike {@link #hideSecretsFromMessage}, keeps a null message null rather than "". */
+  private static String redactNullable(String message, List<String> secrets) {
+    return message == null ? null : hideSecretsFromMessage(message, secrets);
+  }
+
+  private static String hideSecretsFromMessage(String message, List<String> secrets) {
     if (!Objects.isNull(message))
       return secrets.stream()
+          // a provider may answer with an empty value, and replacing that matches everywhere
+          .filter(secret -> !secret.isEmpty())
+          // longest first: masking a secret that prefixes another would destroy the longer match
+          // and publish its remainder, e.g. "x" before "xSUPERSECRET" leaves "***SUPERSECRET"
+          .sorted(Comparator.comparingInt(String::length).reversed())
           .reduce(message, (newMessage, nextSecret) -> newMessage.replace(nextSecret, "***"));
     else return "";
   }
@@ -291,29 +462,19 @@ public class OutboundConnectorExceptionHandler {
    */
   public ConnectorResult.ErrorResult handleFinalResultException(
       Exception ex, ActivatedJob job, SecretFilter secretFilter) {
-    List<String> secrets;
-    try {
-      var allowedKeys =
-          SecretUtil.retrieveSecretKeysInInput(job.getVariables()).stream()
-              .filter(secretFilter::isAllowed)
-              .toList();
-      secrets = this.secretProvider.fetchAll(allowedKeys, new SecretContext(job.getTenantId()));
-    } catch (Exception fetchException) {
-      LOGGER.error(
-          "Exception while processing job: {} for tenant: {} can't be displayed because fetching secrets failed: {}",
-          job.getKey(),
-          job.getTenantId(),
-          fetchException.getMessage());
+    var masking = fetchSecretsForMasking(job, secretFilter);
+    if (masking.unavailable()) {
       var wrappedException =
           new RuntimeException(
               "Fetching secrets failed, original error can't be displayed as the error message might contain secrets: "
-                  + fetchException.getMessage(),
-              fetchException);
+                  + masking.failure().getMessage(),
+              masking.failure());
       return new ConnectorResult.ErrorResult(
           Map.of("error", exceptionToMap(wrappedException)),
           wrappedException,
           job.getRetries() - 1);
     }
+    List<String> secrets = masking.secrets();
     Exception newException = new Exception(hideSecretsFromMessage(ex.getMessage(), secrets), ex);
     LOGGER.error(
         "Exception while processing job: {} for tenant: {}, message: {}",

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/outbound/OutboundConnectorExceptionHandler.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/outbound/OutboundConnectorExceptionHandler.java
@@ -166,7 +166,7 @@ public class OutboundConnectorExceptionHandler {
   private static Object maskSecrets(Object value, List<String> secrets, Set<Object> enclosing) {
     return switch (value) {
       case null -> null;
-      case String string -> hideSecretsFromMessage(string, secrets);
+      case String string -> SecretUtil.hideSecretsFromMessage(string, secrets);
       case Map<?, ?> map -> {
         // error variables are user-supplied, so a container may contain itself
         if (!enclosing.add(map)) {
@@ -199,7 +199,7 @@ public class OutboundConnectorExceptionHandler {
     map.forEach(
         (key, entry) ->
             masked.put(
-                hideSecretsFromMessage(String.valueOf(key), secrets),
+                SecretUtil.hideSecretsFromMessage(String.valueOf(key), secrets),
                 maskSecrets(entry, secrets, enclosing)));
     return masked;
   }
@@ -261,6 +261,16 @@ public class OutboundConnectorExceptionHandler {
     return fetchFailure.getClass().getName();
   }
 
+  // unions bind-time captures into a successful re-read, so a rotated secret is still redacted
+  private static List<String> withCaptured(MaskingSecrets masking, List<String> captured) {
+    if (captured == null || captured.isEmpty()) {
+      return masking.secrets();
+    }
+    var union = new ArrayList<String>(masking.secrets());
+    union.addAll(captured);
+    return union;
+  }
+
   /**
    * Reported in place of an error whose message could not be redacted. Carries the type of the
    * fetch failure and nothing the provider wrote itself, for the same reason {@link
@@ -273,7 +283,11 @@ public class OutboundConnectorExceptionHandler {
   }
 
   public ConnectorResult.ErrorResult manageConnectorJobHandlerException(
-      Exception e, ActivatedJob job, Duration retryBackoffDuration, SecretFilter secretFilter) {
+      Exception e,
+      ActivatedJob job,
+      Duration retryBackoffDuration,
+      SecretFilter secretFilter,
+      List<String> capturedSecrets) {
     if (e instanceof SecretAllowListUnavailableException) {
       return handleGenericException(job, e, List.of(), retryBackoffFor(e, retryBackoffDuration));
     }
@@ -290,7 +304,7 @@ public class OutboundConnectorExceptionHandler {
           job.getRetries() - 1,
           retryBackoffFor(masking.failure(), retryBackoffDuration));
     }
-    List<String> secrets = masking.secrets();
+    List<String> secrets = withCaptured(masking, capturedSecrets);
     return switch (e) {
       case InvalidBackOffDurationException invalidBackOffDurationException ->
           handleBackOffException(invalidBackOffDurationException, secrets);
@@ -310,7 +324,10 @@ public class OutboundConnectorExceptionHandler {
    * String#replace} no longer sees.
    */
   public ConnectorError maskConnectorError(
-      ConnectorError error, ActivatedJob job, SecretFilter secretFilter) {
+      ConnectorError error,
+      ActivatedJob job,
+      SecretFilter secretFilter,
+      List<String> capturedSecrets) {
     return switch (error) {
       case BpmnError bpmnError -> {
         if (nothingToRedact(bpmnError.message(), bpmnError.variables())) {
@@ -318,12 +335,15 @@ public class OutboundConnectorExceptionHandler {
         }
         var masking = fetchSecretsForMasking(job, secretFilter);
         // the error code is never redacted: boundary events match on it
-        yield masking.unavailable()
-            ? new BpmnError(bpmnError.code(), unmaskableErrorMessage(masking.failure()), Map.of())
-            : new BpmnError(
-                bpmnError.code(),
-                redactNullable(bpmnError.message(), masking.secrets()),
-                maskVariables(bpmnError.variables(), masking.secrets()));
+        if (masking.unavailable()) {
+          yield new BpmnError(
+              bpmnError.code(), unmaskableErrorMessage(masking.failure()), Map.of());
+        }
+        var secrets = withCaptured(masking, capturedSecrets);
+        yield new BpmnError(
+            bpmnError.code(),
+            redactNullable(bpmnError.message(), secrets),
+            maskVariables(bpmnError.variables(), secrets));
       }
       case JobError jobError -> {
         if (nothingToRedact(jobError.message(), jobError.variables())) {
@@ -331,17 +351,19 @@ public class OutboundConnectorExceptionHandler {
         }
         var masking = fetchSecretsForMasking(job, secretFilter);
         // the retries and the backoff are the expression author's decision, so they survive
-        yield masking.unavailable()
-            ? new JobError(
-                unmaskableErrorMessage(masking.failure()),
-                Map.of(),
-                jobError.retries(),
-                jobError.retryBackoff())
-            : new JobError(
-                redactNullable(jobError.message(), masking.secrets()),
-                maskVariables(jobError.variables(), masking.secrets()),
-                jobError.retries(),
-                jobError.retryBackoff());
+        if (masking.unavailable()) {
+          yield new JobError(
+              unmaskableErrorMessage(masking.failure()),
+              Map.of(),
+              jobError.retries(),
+              jobError.retryBackoff());
+        }
+        var secrets = withCaptured(masking, capturedSecrets);
+        yield new JobError(
+            redactNullable(jobError.message(), secrets),
+            maskVariables(jobError.variables(), secrets),
+            jobError.retries(),
+            jobError.retryBackoff());
       }
     };
   }
@@ -351,32 +373,22 @@ public class OutboundConnectorExceptionHandler {
         && (variables == null || variables.isEmpty());
   }
 
-  /** Unlike {@link #hideSecretsFromMessage}, keeps a null message null rather than "". */
+  /** Unlike {@link SecretUtil#hideSecretsFromMessage}, keeps a null message null rather than "". */
   private static String redactNullable(String message, List<String> secrets) {
-    return message == null ? null : hideSecretsFromMessage(message, secrets);
-  }
-
-  private static String hideSecretsFromMessage(String message, List<String> secrets) {
-    if (!Objects.isNull(message))
-      return secrets.stream()
-          // a provider may answer with an empty value, and replacing that matches everywhere
-          .filter(secret -> !secret.isEmpty())
-          // longest first: masking a secret that prefixes another would destroy the longer match
-          // and publish its remainder, e.g. "x" before "xSUPERSECRET" leaves "***SUPERSECRET"
-          .sorted(Comparator.comparingInt(String::length).reversed())
-          .reduce(message, (newMessage, nextSecret) -> newMessage.replace(nextSecret, "***"));
-    else return "";
+    return message == null ? null : SecretUtil.hideSecretsFromMessage(message, secrets);
   }
 
   private ConnectorResult.ErrorResult handleBackOffException(Exception e, List<String> secrets) {
-    Exception newException = new Exception(hideSecretsFromMessage(e.getMessage(), secrets), e);
+    Exception newException =
+        new Exception(SecretUtil.hideSecretsFromMessage(e.getMessage(), secrets), e);
     return new ConnectorResult.ErrorResult(
         Map.of("error", exceptionToMap(newException)), newException, 0);
   }
 
   private ConnectorResult.ErrorResult handleConnectorRetryException(
       ActivatedJob job, ConnectorRetryException ex, List<String> secrets, Duration retryBackoff) {
-    Exception newException = new Exception(hideSecretsFromMessage(ex.getMessage(), secrets), ex);
+    Exception newException =
+        new Exception(SecretUtil.hideSecretsFromMessage(ex.getMessage(), secrets), ex);
     LOGGER.debug(
         "ConnectorRetryException while processing job: {} for tenant: {}, error message: {}",
         job.getKey(),
@@ -407,7 +419,8 @@ public class OutboundConnectorExceptionHandler {
 
   private ConnectorResult.ErrorResult handleGenericException(
       ActivatedJob job, Exception ex, List<String> secrets, Duration retryBackoff) {
-    Exception newException = new Exception(hideSecretsFromMessage(ex.getMessage(), secrets), ex);
+    Exception newException =
+        new Exception(SecretUtil.hideSecretsFromMessage(ex.getMessage(), secrets), ex);
     LOGGER.debug(
         "Exception while processing job: {} for tenant: {}, message: {}",
         job.getKey(),
@@ -461,7 +474,7 @@ public class OutboundConnectorExceptionHandler {
    * being allowed to propagate.
    */
   public ConnectorResult.ErrorResult handleFinalResultException(
-      Exception ex, ActivatedJob job, SecretFilter secretFilter) {
+      Exception ex, ActivatedJob job, SecretFilter secretFilter, List<String> capturedSecrets) {
     var masking = fetchSecretsForMasking(job, secretFilter);
     if (masking.unavailable()) {
       var wrappedException =
@@ -474,8 +487,9 @@ public class OutboundConnectorExceptionHandler {
           wrappedException,
           job.getRetries() - 1);
     }
-    List<String> secrets = masking.secrets();
-    Exception newException = new Exception(hideSecretsFromMessage(ex.getMessage(), secrets), ex);
+    List<String> secrets = withCaptured(masking, capturedSecrets);
+    Exception newException =
+        new Exception(SecretUtil.hideSecretsFromMessage(ex.getMessage(), secrets), ex);
     LOGGER.error(
         "Exception while processing job: {} for tenant: {}, message: {}",
         job.getKey(),

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretAllowListUnavailableException.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretAllowListUnavailableException.java
@@ -24,10 +24,19 @@ package io.camunda.connector.runtime.core.secret;
  *
  * <p>It lives here rather than beside the filter factory that throws it because the runtime that
  * has to recognise it on the failure path is in this module.
+ *
+ * <p>Its message is written by this runtime and names only the element and the type of the lookup
+ * failure, so it is publishable where an arbitrary provider's message is not.
  */
-public class SecretAllowListUnavailableException extends RuntimeException {
+public class SecretAllowListUnavailableException extends RuntimeException
+    implements SecretFailureDiagnostic {
 
   public SecretAllowListUnavailableException(String message) {
     super(message);
+  }
+
+  @Override
+  public String publishableMessage() {
+    return getMessage();
   }
 }

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretFailureDiagnostic.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretFailureDiagnostic.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.runtime.core.secret;
+
+/**
+ * A secret lookup failure that can say why in text safe to show an operator.
+ *
+ * <p>Most failures cannot. A secret provider or its client may put anything in a message — a
+ * response body from the secret store, a credential echoed back by a rejecting API — so where a
+ * failure is reported without the values needed to redact it, the message has to be withheld. That
+ * withholding is what this interface makes an exception to.
+ *
+ * <p>Implement it only where the runtime authors the whole message itself, and keep it that way: a
+ * provider's or client's own text must never be interpolated into what {@link
+ * #publishableMessage()} returns. A secret's <em>name</em> is fine — it is written in the model
+ * that a reader of the incident can already see — but a secret's value, or any part of a store's
+ * response, is not.
+ */
+public interface SecretFailureDiagnostic {
+
+  /**
+   * Why the lookup failed, in text the runtime wrote and may publish verbatim — to an incident
+   * message, or to process variables.
+   */
+  String publishableMessage();
+}

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretHandler.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretHandler.java
@@ -16,7 +16,6 @@
  */
 package io.camunda.connector.runtime.core.secret;
 
-import io.camunda.connector.api.error.ConnectorInputException;
 import io.camunda.connector.api.secret.SecretContext;
 import io.camunda.connector.api.secret.SecretProvider;
 import java.util.List;
@@ -44,11 +43,7 @@ public class SecretHandler {
           if (secretFilter.isAllowed(name)) {
             var value =
                 Optional.ofNullable(secretProvider.getSecret(name, context))
-                    .orElseThrow(
-                        () ->
-                            new ConnectorInputException(
-                                String.format("Secret with name '%s' is not available", name),
-                                null));
+                    .orElseThrow(() -> new SecretNotAvailableException(name));
             resolvedValues.add(value);
             return value;
           }

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretHandler.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretHandler.java
@@ -19,7 +19,10 @@ package io.camunda.connector.runtime.core.secret;
 import io.camunda.connector.api.error.ConnectorInputException;
 import io.camunda.connector.api.secret.SecretContext;
 import io.camunda.connector.api.secret.SecretProvider;
+import java.util.List;
 import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -31,16 +34,23 @@ public class SecretHandler {
 
   protected SecretReplacer secretReplacer;
 
+  // values this instance substituted, so a caller can redact against a rotated re-read
+  private final Set<String> resolvedValues = ConcurrentHashMap.newKeySet();
+
   public SecretHandler(final SecretProvider secretProvider, SecretFilter secretFilter) {
     this.secretProvider = secretProvider;
     secretReplacer =
         (name, context) -> {
           if (secretFilter.isAllowed(name)) {
-            return Optional.ofNullable(secretProvider.getSecret(name, context))
-                .orElseThrow(
-                    () ->
-                        new ConnectorInputException(
-                            String.format("Secret with name '%s' is not available", name), null));
+            var value =
+                Optional.ofNullable(secretProvider.getSecret(name, context))
+                    .orElseThrow(
+                        () ->
+                            new ConnectorInputException(
+                                String.format("Secret with name '%s' is not available", name),
+                                null));
+            resolvedValues.add(value);
+            return value;
           }
           LOG.debug("Secret '{}' not in allow-list — placeholder left unreplaced", name);
           return null;
@@ -49,5 +59,9 @@ public class SecretHandler {
 
   public String replaceSecrets(String input, SecretContext context) {
     return SecretUtil.replaceSecrets(input, context, secretReplacer);
+  }
+
+  public List<String> getResolvedValues() {
+    return List.copyOf(resolvedValues);
   }
 }

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretNotAvailableException.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretNotAvailableException.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.runtime.core.secret;
+
+import io.camunda.connector.api.error.ConnectorInputException;
+
+/**
+ * A secret reference the filter allowed, for which no configured provider held a value. The
+ * reference cannot be substituted, so the input cannot be bound; the model or the secret store has
+ * to change, which is why this is a {@link ConnectorInputException} and the job is not retried.
+ *
+ * <p>A type of its own, rather than a bare {@code ConnectorInputException}, because error masking
+ * has to tell this failure apart from every other one: it is the single case where a name the input
+ * declares is expected to come back empty on the masking re-read. Everywhere else that would mean a
+ * secret has been removed since the connector ran, with its value possibly still in the message.
+ */
+public class SecretNotAvailableException extends ConnectorInputException {
+
+  public SecretNotAvailableException(String secretName) {
+    super(String.format("Secret with name '%s' is not available", secretName), null);
+  }
+}

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretUtil.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretUtil.java
@@ -17,6 +17,7 @@
 package io.camunda.connector.runtime.core.secret;
 
 import io.camunda.connector.api.secret.SecretContext;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -92,5 +93,18 @@ public class SecretUtil {
     return input == null
         ? List.of()
         : REFERENCE.matcher(input).results().map(SecretUtil::name).distinct().toList();
+  }
+
+  // Longest secret first: masking a shorter secret that prefixes a longer one would destroy the
+  // longer match and publish its remainder, e.g. "x" before "xSUPERSECRET" leaves "***SUPERSECRET".
+  public static String hideSecretsFromMessage(String message, List<String> secrets) {
+    if (message == null) {
+      return "";
+    }
+    return secrets.stream()
+        // a provider may answer with an empty value, and replacing that matches everywhere
+        .filter(secret -> !secret.isEmpty())
+        .sorted(Comparator.comparingInt(String::length).reversed())
+        .reduce(message, (newMessage, nextSecret) -> newMessage.replace(nextSecret, "***"));
   }
 }

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextImplTest.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextImplTest.java
@@ -27,6 +27,7 @@ import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.EvictingQueue;
+import io.camunda.connector.api.error.ConnectorRetryException;
 import io.camunda.connector.api.inbound.Activity;
 import io.camunda.connector.api.inbound.Health;
 import io.camunda.connector.api.inbound.ProcessElement;
@@ -40,6 +41,8 @@ import io.camunda.connector.runtime.core.inbound.InboundConnectorContextImplTest
 import io.camunda.connector.runtime.core.inbound.correlation.MessageCorrelationPoint.StandaloneMessageCorrelationPoint;
 import io.camunda.connector.runtime.core.inbound.details.InboundConnectorDetails;
 import io.camunda.connector.runtime.core.inbound.details.InboundConnectorDetails.ValidInboundConnectorDetails;
+import java.time.Duration;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -239,8 +242,99 @@ class InboundConnectorContextImplTest {
         provider, (e) -> {}, details, null, (e) -> {}, mapper, EvictingQueue.create(10));
   }
 
+  private InboundConnectorContextImpl cancellingContext(
+      ValidInboundConnectorDetails details,
+      SecretProvider provider,
+      List<Throwable> cancellations) {
+    return new InboundConnectorContextImpl(
+        provider, (e) -> {}, details, null, cancellations::add, mapper, EvictingQueue.create(10));
+  }
+
   private static Activity errorSaying(String message) {
     return Activity.level(Severity.ERROR).tag("test").message(message);
+  }
+
+  @Test
+  void cancel_masksASecretInTheErrorTheRuntimePublishesAsHealth() {
+    // the executable registry reports what a connector cancels with as
+    // Health.down(exceptionThrown),
+    // which publishes the throwable's toString() through the health endpoint
+    var cancellations = new ArrayList<Throwable>();
+    var context =
+        cancellingContext(
+            getInboundConnectorDefinition(Map.of("token", "secrets.FOO")),
+            secretProvider,
+            cancellations);
+
+    context.cancel(new IllegalStateException("api rejected bar"));
+
+    assertThat(cancellations).singleElement();
+    var published = Health.down(cancellations.getFirst());
+    assertThat(published.getError().message()).doesNotContain("bar").contains("api rejected ***");
+    // the type it replaced is still named, so the report stays diagnosable
+    assertThat(published.getError().message()).contains("IllegalStateException");
+  }
+
+  @Test
+  void cancel_keepsRetryMetadataWhileMaskingTheMessage() {
+    // the registry restarts the executable from these, so redaction may not change them
+    var cancellations = new ArrayList<Throwable>();
+    var context =
+        cancellingContext(
+            getInboundConnectorDefinition(Map.of("token", "secrets.FOO")),
+            secretProvider,
+            cancellations);
+
+    context.cancel(
+        ConnectorRetryException.builder()
+            .errorCode("AUTH-401")
+            .message("api rejected bar")
+            .retries(4)
+            .backoffDuration(Duration.ofSeconds(30))
+            .build());
+
+    assertThat(cancellations)
+        .singleElement()
+        .isInstanceOfSatisfying(
+            ConnectorRetryException.class,
+            retry -> {
+              assertThat(retry.getMessage()).isEqualTo("api rejected ***");
+              assertThat(retry.getRetries()).isEqualTo(4);
+              assertThat(retry.getBackoffDuration()).isEqualTo(Duration.ofSeconds(30));
+              assertThat(retry.getErrorCode()).isEqualTo("AUTH-401");
+            });
+  }
+
+  @Test
+  void cancel_withholdsTheMessageWhenSecretValuesCannotBeFetched() {
+    var failingProvider = mock(SecretProvider.class);
+    when(failingProvider.fetchAll(any(), any())).thenThrow(new RuntimeException("down"));
+    var cancellations = new ArrayList<Throwable>();
+    var context =
+        cancellingContext(
+            getInboundConnectorDefinition(Map.of("token", "secrets.FOO")),
+            failingProvider,
+            cancellations);
+
+    context.cancel(new IllegalStateException("api rejected bar"));
+
+    assertThat(cancellations).singleElement();
+    assertThat(cancellations.getFirst().getMessage()).doesNotContain("bar");
+  }
+
+  @Test
+  void cancel_passesTheErrorThroughWhenThereIsNothingToRedact() {
+    var cancellations = new ArrayList<Throwable>();
+    var context =
+        cancellingContext(
+            getInboundConnectorDefinition(Map.of("token", "secrets.FOO")),
+            secretProvider,
+            cancellations);
+    var original = new IllegalStateException("the broker closed the connection");
+
+    context.cancel(original);
+
+    assertThat(cancellations).singleElement().isSameAs(original);
   }
 
   @Test

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextImplTest.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextImplTest.java
@@ -27,7 +27,10 @@ import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.EvictingQueue;
+import io.camunda.connector.api.inbound.Activity;
+import io.camunda.connector.api.inbound.Health;
 import io.camunda.connector.api.inbound.ProcessElement;
+import io.camunda.connector.api.inbound.Severity;
 import io.camunda.connector.api.json.ConnectorsObjectMapperSupplier;
 import io.camunda.connector.api.secret.SecretContext;
 import io.camunda.connector.api.secret.SecretProvider;
@@ -220,6 +223,112 @@ class InboundConnectorContextImplTest {
     var details = InboundConnectorDetails.of(element.deduplicationId(List.of()), List.of(element));
     assertThat(details).isInstanceOf(ValidInboundConnectorDetails.class);
     return (ValidInboundConnectorDetails) details;
+  }
+
+  // An activity log and a health error are both connector-authored text that routinely quotes an
+  // API response, and both are read by anyone who can see the connector in Operate.
+  //
+  // Main's suite also covers health dedup (against the masked value, and the two-distinct-outage
+  // case) and a secret declared only by a grouped sibling element. Neither is representable on this
+  // branch: reportHealth does not dedup here and writes no activity log of its own, and there is a
+  // single connector-level property text rather than a per-element one that a sibling could extend.
+
+  private InboundConnectorContextImpl contextOf(
+      ValidInboundConnectorDetails details, SecretProvider provider) {
+    return new InboundConnectorContextImpl(
+        provider, (e) -> {}, details, null, (e) -> {}, mapper, EvictingQueue.create(10));
+  }
+
+  private static Activity errorSaying(String message) {
+    return Activity.level(Severity.ERROR).tag("test").message(message);
+  }
+
+  @Test
+  void log_masksASecretResolvedForThisConnector() {
+    // given a connector declaring a secret this context can resolve
+    var context =
+        contextOf(getInboundConnectorDefinition(Map.of("token", "secrets.FOO")), secretProvider);
+
+    // when an activity's message happens to carry the resolved value
+    context.log(errorSaying("token was bar"));
+
+    // then the logged message has the value masked
+    assertThat(context.getLogs())
+        .singleElement()
+        .satisfies(log -> assertThat(log.message()).isEqualTo("token was ***"));
+  }
+
+  @Test
+  void log_withholdsMessageWhenSecretValuesCannotBeFetched() {
+    // given a provider that fails to resolve the declared secret
+    var failingProvider = mock(SecretProvider.class);
+    when(failingProvider.fetchAll(any(), any())).thenThrow(new RuntimeException("down"));
+    var context =
+        contextOf(getInboundConnectorDefinition(Map.of("token", "secrets.FOO")), failingProvider);
+
+    // when
+    context.log(errorSaying("token was bar"));
+
+    // then the raw message is withheld rather than published unmasked
+    assertThat(context.getLogs())
+        .singleElement()
+        .satisfies(
+            log -> {
+              assertThat(log.message()).doesNotContain("bar");
+              assertThat(log.message()).contains("withheld");
+            });
+  }
+
+  @Test
+  void reportHealth_masksASecretInTheErrorMessage() {
+    // given
+    var context =
+        contextOf(getInboundConnectorDefinition(Map.of("token", "secrets.FOO")), secretProvider);
+
+    // when the reported health carries the resolved value in its error
+    context.reportHealth(Health.down(new RuntimeException("token was bar")));
+
+    // then it is masked in the stored health, which is what the status endpoint serves
+    assertThat(context.getHealth().getStatus()).isEqualTo(Health.Status.DOWN);
+    assertThat(context.getHealth().getError().message()).doesNotContain("bar");
+  }
+
+  @Test
+  void log_masksASecretThatRotatedAfterItWasBound() {
+    // given a provider that resolves FOO to one value at bind time and a different one on re-read
+    var rotatingProvider = mock(SecretProvider.class);
+    when(rotatingProvider.getSecret(eq("FOO"), any())).thenReturn("old-value");
+    when(rotatingProvider.fetchAll(any(), any())).thenReturn(List.of("new-value"));
+    var context =
+        contextOf(getInboundConnectorDefinition(Map.of("token", "secrets.FOO")), rotatingProvider);
+
+    // when the bound value is used, binding first so it is actually substituted and captured
+    context.getProperties();
+    context.log(errorSaying("token was old-value"));
+
+    // then the bound value is redacted even though a re-read would return a different one
+    assertThat(context.getLogs())
+        .last()
+        .satisfies(log -> assertThat(log.message()).isEqualTo("token was ***"));
+  }
+
+  @Test
+  void log_withholdsMessageWhenTheReReadComesBackShort() {
+    // given a connector declaring two secrets of which only one resolves on re-read
+    var partialProvider = mock(SecretProvider.class);
+    when(partialProvider.fetchAll(any(), any())).thenReturn(List.of("only-one-value"));
+    var context =
+        contextOf(
+            getInboundConnectorDefinition(Map.of("a", "secrets.FOO", "b", "secrets.BAR")),
+            partialProvider);
+
+    // when nothing was ever bound, so only the (incomplete) re-read is available
+    context.log(errorSaying("token was leaked"));
+
+    // then the message is withheld rather than published with only one of the two values masked
+    assertThat(context.getLogs())
+        .singleElement()
+        .satisfies(log -> assertThat(log.message()).contains("withheld"));
   }
 
   @Test

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextImplTest.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextImplTest.java
@@ -28,7 +28,10 @@ import static org.mockito.Mockito.when;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.EvictingQueue;
 import io.camunda.connector.api.error.ConnectorRetryException;
+import io.camunda.connector.api.inbound.ActivationCheckResult;
 import io.camunda.connector.api.inbound.Activity;
+import io.camunda.connector.api.inbound.CorrelationRequest;
+import io.camunda.connector.api.inbound.CorrelationResult;
 import io.camunda.connector.api.inbound.Health;
 import io.camunda.connector.api.inbound.ProcessElement;
 import io.camunda.connector.api.inbound.Severity;
@@ -38,6 +41,7 @@ import io.camunda.connector.api.secret.SecretProvider;
 import io.camunda.connector.feel.annotation.FEEL;
 import io.camunda.connector.runtime.core.FooBarSecretProvider;
 import io.camunda.connector.runtime.core.inbound.InboundConnectorContextImplTest.TestPropertiesClass.InnerObject;
+import io.camunda.connector.runtime.core.inbound.correlation.InboundCorrelationHandler;
 import io.camunda.connector.runtime.core.inbound.correlation.MessageCorrelationPoint.StandaloneMessageCorrelationPoint;
 import io.camunda.connector.runtime.core.inbound.details.InboundConnectorDetails;
 import io.camunda.connector.runtime.core.inbound.details.InboundConnectorDetails.ValidInboundConnectorDetails;
@@ -232,9 +236,8 @@ class InboundConnectorContextImplTest {
   // API response, and both are read by anyone who can see the connector in Operate.
   //
   // Main's suite also covers health dedup (against the masked value, and the two-distinct-outage
-  // case) and a secret declared only by a grouped sibling element. Neither is representable on this
-  // branch: reportHealth does not dedup here and writes no activity log of its own, and there is a
-  // single connector-level property text rather than a per-element one that a sibling could extend.
+  // case), which is not representable on this branch: reportHealth does not dedup here and writes
+  // no activity log of its own.
 
   private InboundConnectorContextImpl contextOf(
       ValidInboundConnectorDetails details, SecretProvider provider) {
@@ -423,6 +426,177 @@ class InboundConnectorContextImplTest {
     assertThat(context.getLogs())
         .singleElement()
         .satisfies(log -> assertThat(log.message()).contains("withheld"));
+  }
+
+  @Test
+  void log_masksASecretDeclaredOnlyByAGroupedSiblingElement() {
+    // given two elements grouped under one deduplication ID: they agree on everything the grouping
+    // compares, and differ only in resultExpression, which PROPERTIES_EXCLUDED_FROM_DEDUPLICATION
+    // allows to differ -- so only the sibling declares SIBLING, and only the first element's
+    // properties become the group's representative ones
+    var provider =
+        new SecretProvider() {
+          @Override
+          public String getSecret(String name, SecretContext context) {
+            return switch (name) {
+              case "FOO" -> "bar";
+              case "SIBLING" -> "sibling-value";
+              default -> null;
+            };
+          }
+        };
+    var context =
+        contextOf(
+            groupedInboundConnectorDefinition(
+                Map.of("token", "secrets.FOO"),
+                Map.of("resultExpression", "={token: secrets.SIBLING}")),
+            provider);
+
+    // when a message carries the value only the sibling element declares
+    context.log(errorSaying("token was sibling-value"));
+
+    // then it is masked too: the re-read covers every grouped element
+    assertThat(context.getLogs())
+        .singleElement()
+        .satisfies(log -> assertThat(log.message()).isEqualTo("token was ***"));
+  }
+
+  @Test
+  void canActivate_masksASecretTheActivatedElementResolvedBeforeItRotated() {
+    // given a provider that answers one value now and a different one on the redaction re-read
+    var rotatingProvider = mock(SecretProvider.class);
+    when(rotatingProvider.getSecret(eq("FOO"), any())).thenReturn("old-value");
+    when(rotatingProvider.fetchAll(any(), any())).thenReturn(List.of("new-value"));
+    var details = getInboundConnectorDefinition(Map.of("token", "secrets.FOO"));
+    var context = contextActivating(details, rotatingProvider);
+
+    // when the connector reads the properties of the element it was handed, resolving FOO there
+    // rather than on the connector-level context
+    var activated = (ActivationCheckResult.Success.CanActivate) context.canActivate(Map.of());
+    assertThat(activated.activatedElement().getElement())
+        .isEqualTo(details.connectorElements().getFirst().element());
+    assertThat(activated.activatedElement().getProperties()).containsEntry("token", "old-value");
+
+    // then that value is redacted from what the connector reports afterwards, even though a re-read
+    // now returns a different one
+    context.log(errorSaying("token was old-value"));
+    context.reportHealth(Health.down(new RuntimeException("token was old-value")));
+
+    assertThat(context.getLogs())
+        .last()
+        .satisfies(log -> assertThat(log.message()).isEqualTo("token was ***"));
+    assertThat(context.getHealth().getError().message()).doesNotContain("old-value");
+  }
+
+  @Test
+  void correlate_masksASecretTheActivatedElementBoundBeforeItRotated() {
+    // given the same rotation, reached through correlation rather than the activation check
+    var rotatingProvider = mock(SecretProvider.class);
+    when(rotatingProvider.getSecret(eq("FOO"), any())).thenReturn("old-value");
+    when(rotatingProvider.fetchAll(any(), any())).thenReturn(List.of("new-value"));
+    var details = getInboundConnectorDefinition(Map.of("token", "secrets.FOO"));
+    var elementContext = elementContextOf(details, rotatingProvider);
+    var correlationHandler = mock(InboundCorrelationHandler.class);
+    when(correlationHandler.correlate(any(), any(CorrelationRequest.class)))
+        .thenReturn(
+            new CorrelationResult.Success.MessagePublished(elementContext, 1L, "<default>"));
+    var context =
+        new InboundConnectorContextImpl(
+            rotatingProvider,
+            (e) -> {},
+            details,
+            correlationHandler,
+            (e) -> {},
+            mapper,
+            EvictingQueue.create(10));
+
+    // when the connector binds the activated element's properties
+    var result =
+        (CorrelationResult.Success.MessagePublished)
+            context.correlate(CorrelationRequest.builder().variables(Map.of()).build());
+    assertThat(result.messageKey()).isEqualTo(1L);
+    assertThat(result.activatedElement().bindProperties(Map.class))
+        .containsEntry("token", "old-value");
+
+    // then the bound value is redacted from the activity log
+    context.log(errorSaying("token was old-value"));
+
+    assertThat(context.getLogs())
+        .last()
+        .satisfies(log -> assertThat(log.message()).isEqualTo("token was ***"));
+  }
+
+  @Test
+  void cancel_masksASecretTheActivatedElementResolvedBeforeItRotated() {
+    // given the same rotation, reported through cancellation, which the runtime publishes as
+    // Health.down(exceptionThrown)
+    var rotatingProvider = mock(SecretProvider.class);
+    when(rotatingProvider.getSecret(eq("FOO"), any())).thenReturn("old-value");
+    when(rotatingProvider.fetchAll(any(), any())).thenReturn(List.of("new-value"));
+    var details = getInboundConnectorDefinition(Map.of("token", "secrets.FOO"));
+    List<Throwable> cancellations = new ArrayList<>();
+    var context = contextActivating(details, rotatingProvider, cancellations);
+
+    // when the connector resolves the secret through the element it was handed and then cancels
+    // with an error quoting it
+    var activated = (ActivationCheckResult.Success.CanActivate) context.canActivate(Map.of());
+    activated.activatedElement().getProperties();
+    context.cancel(new RuntimeException("token was old-value"));
+
+    // then the value is redacted from what the runtime publishes
+    assertThat(cancellations)
+        .singleElement()
+        .satisfies(error -> assertThat(error.getMessage()).doesNotContain("old-value"));
+  }
+
+  private InboundConnectorContextImpl contextActivating(
+      ValidInboundConnectorDetails details, SecretProvider provider) {
+    return contextActivating(details, provider, new ArrayList<>());
+  }
+
+  private InboundConnectorContextImpl contextActivating(
+      ValidInboundConnectorDetails details,
+      SecretProvider provider,
+      List<Throwable> cancellations) {
+    var correlationHandler = mock(InboundCorrelationHandler.class);
+    when(correlationHandler.canActivate(any(), any()))
+        .thenReturn(
+            new ActivationCheckResult.Success.CanActivate(elementContextOf(details, provider)));
+    return new InboundConnectorContextImpl(
+        provider,
+        (e) -> {},
+        details,
+        correlationHandler,
+        cancellations::add,
+        mapper,
+        EvictingQueue.create(10));
+  }
+
+  private DefaultProcessElementContext elementContextOf(
+      ValidInboundConnectorDetails details, SecretProvider provider) {
+    return new DefaultProcessElementContext(
+        details.connectorElements().getFirst(), (e) -> {}, provider, mapper);
+  }
+
+  private static ValidInboundConnectorDetails groupedInboundConnectorDefinition(
+      Map<String, String> sharedProperties, Map<String, String> siblingOnlyProperties) {
+    var shared = new HashMap<>(sharedProperties);
+    shared.put("inbound.type", "io.camunda:connector:1");
+    var siblingProperties = new HashMap<>(shared);
+    siblingProperties.putAll(siblingOnlyProperties);
+    var first =
+        new InboundConnectorElement(
+            shared,
+            new StandaloneMessageCorrelationPoint("", "", null, null),
+            new ProcessElement("bool", 0, 0, "first", "<default>"));
+    var sibling =
+        new InboundConnectorElement(
+            siblingProperties,
+            new StandaloneMessageCorrelationPoint("", "", null, null),
+            new ProcessElement("bool", 0, 0, "sibling", "<default>"));
+    var details = InboundConnectorDetails.of("grouped", List.of(first, sibling));
+    assertThat(details).isInstanceOf(ValidInboundConnectorDetails.class);
+    return (ValidInboundConnectorDetails) details;
   }
 
   @Test

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/outbound/ConnectorJobHandlerTest.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/outbound/ConnectorJobHandlerTest.java
@@ -38,8 +38,10 @@ import io.camunda.connector.api.error.ConnectorException;
 import io.camunda.connector.api.error.ConnectorExceptionBuilder;
 import io.camunda.connector.api.error.ConnectorInputException;
 import io.camunda.connector.api.error.ConnectorRetryExceptionBuilder;
+import io.camunda.connector.api.json.ConnectorsObjectMapperSupplier;
 import io.camunda.connector.api.outbound.OutboundConnectorFunction;
 import io.camunda.connector.api.secret.SecretContext;
+import io.camunda.connector.api.secret.SecretProvider;
 import io.camunda.connector.runtime.core.ConnectorHelper;
 import io.camunda.connector.runtime.core.FooBarSecretProvider;
 import io.camunda.connector.runtime.core.Keywords;
@@ -1469,4 +1471,67 @@ class ConnectorJobHandlerTest {
       assertThat(result.getErrorMessage()).isNull();
     }
   }
+
+  /** The value bound at execution time can differ from what a later re-read returns. */
+  @Nested
+  class RotationRaceSecretMaskingTests {
+
+    private static final String INPUT_DECLARING_A_SECRET = "{ \"token\" : \"{{secrets.FOO}}\" }";
+
+    private SecretProvider rotatingSecretProvider(String boundValue, String rotatedValue) {
+      return new SecretProvider() {
+        @Override
+        public String getSecret(String secretName, SecretContext context) {
+          return boundValue;
+        }
+
+        @Override
+        public List<String> fetchAll(List<String> keys, SecretContext context) {
+          return keys.stream().map(key -> rotatedValue).toList();
+        }
+      };
+    }
+
+    private ConnectorJobHandler connectorThrowingTheBoundToken(SecretProvider secretProvider) {
+      return new ConnectorJobHandler(
+          context -> {
+            var bound = context.bindVariables(TokenHolder.class);
+            throw new RuntimeException("api rejected " + bound.token());
+          },
+          secretProvider,
+          e -> {},
+          null,
+          ConnectorsObjectMapperSupplier.getCopy(),
+          SecretFilterFactory.disabled());
+    }
+
+    @Test
+    void aSecretThatRotatedBetweenBindAndMaskingIsStillRedacted() {
+      var jobHandler =
+          connectorThrowingTheBoundToken(rotatingSecretProvider("old-value", "new-value"));
+
+      var result =
+          JobBuilder.create()
+              .withVariables(INPUT_DECLARING_A_SECRET)
+              .executeAndCaptureResult(jobHandler, false, false);
+
+      assertThat(result.getErrorMessage()).doesNotContain("old-value");
+    }
+
+    @Test
+    void aStableSecretIsStillRedactedTheOrdinaryWay() {
+      // the union must not depend on rotation happening: an unrotated secret is redacted too
+      var jobHandler =
+          connectorThrowingTheBoundToken(rotatingSecretProvider("stable-value", "stable-value"));
+
+      var result =
+          JobBuilder.create()
+              .withVariables(INPUT_DECLARING_A_SECRET)
+              .executeAndCaptureResult(jobHandler, false, false);
+
+      assertThat(result.getErrorMessage()).doesNotContain("stable-value");
+    }
+  }
+
+  private record TokenHolder(String token) {}
 }

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/outbound/ConnectorJobHandlerTest.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/outbound/ConnectorJobHandlerTest.java
@@ -39,6 +39,7 @@ import io.camunda.connector.api.error.ConnectorExceptionBuilder;
 import io.camunda.connector.api.error.ConnectorInputException;
 import io.camunda.connector.api.error.ConnectorRetryExceptionBuilder;
 import io.camunda.connector.api.outbound.OutboundConnectorFunction;
+import io.camunda.connector.api.secret.SecretContext;
 import io.camunda.connector.runtime.core.ConnectorHelper;
 import io.camunda.connector.runtime.core.FooBarSecretProvider;
 import io.camunda.connector.runtime.core.Keywords;
@@ -48,6 +49,7 @@ import io.camunda.zeebe.client.api.command.FailJobCommandStep1.FailJobCommandSte
 import io.camunda.zeebe.client.api.worker.JobClient;
 import java.time.Duration;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -1267,6 +1269,204 @@ class ConnectorJobHandlerTest {
       // then
       assertThat(result.getErrorCode()).isEqualTo("9999");
       assertThat(result.getErrorMessage()).isEqualTo("Message for foo value on test property");
+    }
+  }
+
+  /** The job's input declares {{secrets.FOO}}, and the called API echoes that value back. */
+  @Nested
+  class ErrorExpressionSecretMaskingTests {
+
+    private static final String ECHOED = FooBarSecretProvider.SECRET_VALUE;
+    private static final String INPUT_DECLARING_A_SECRET = "{ \"token\" : \"{{secrets.FOO}}\" }";
+
+    private ConnectorJobHandler echoingConnector() {
+      return newConnectorJobHandler(context -> Map.of("body", "rejected token " + ECHOED));
+    }
+
+    private ConnectorJobHandler echoingConnectorWithUnreadableSecrets() {
+      return new ConnectorJobHandler(
+          context -> Map.of("body", "rejected token " + ECHOED),
+          new FooBarSecretProvider() {
+            @Override
+            public List<String> fetchAll(List<String> keys, SecretContext context) {
+              throw new RuntimeException("Network error while fetching secrets");
+            }
+          },
+          e -> {},
+          null,
+          null,
+          SecretFilterFactory.disabled());
+    }
+
+    @Test
+    void jobErrorMessageCopyingAResponseIsRedacted() {
+      // when
+      var result =
+          JobBuilder.create()
+              .withVariables(INPUT_DECLARING_A_SECRET)
+              .withErrorExpressionHeader("jobError(\"Request failed: \" + response.body, {}, 0)")
+              .executeAndCaptureResult(echoingConnector(), false, false);
+
+      // then
+      assertThat(result.getErrorMessage())
+          .startsWith("Request failed: rejected token ***")
+          .doesNotContain(ECHOED);
+    }
+
+    @Test
+    void jobErrorVariablesCopyingAResponseAreRedacted() {
+      // the incident carries the message as its only variable on this branch: the variables the
+      // expression chose are not published, so the message is where an echoed credential lands
+      var result =
+          JobBuilder.create()
+              .withVariables(INPUT_DECLARING_A_SECRET)
+              .withErrorExpressionHeader(
+                  "jobError(\"failed: \" + response.body, {detail: response.body}, 0)")
+              .executeAndCaptureResult(echoingConnector(), false, false);
+
+      // then
+      assertThat(result.getVariables()).containsEntry("error", "failed: rejected token ***");
+      assertThat(result.getErrorMessage()).doesNotContain(ECHOED);
+    }
+
+    @Test
+    void jobErrorKeepsTheRetriesAndBackoffTheExpressionAsked() {
+      // given
+      var failCommand = mock(FailJobCommandStep1.class);
+      var failCommandStep2 = mock(FailJobCommandStep2.class, RETURNS_DEEP_STUBS);
+      var jobClient = mock(JobClient.class);
+      when(jobClient.newFailCommand(any())).thenReturn(failCommand);
+      when(failCommand.retries(anyInt())).thenReturn(failCommandStep2);
+      when(failCommandStep2.errorMessage(any())).thenReturn(failCommandStep2);
+      when(failCommandStep2.retryBackoff(any())).thenReturn(failCommandStep2);
+      when(failCommandStep2.variables(any(Object.class))).thenReturn(failCommandStep2);
+
+      // when
+      JobBuilder.create()
+          .useJobClient(jobClient)
+          .withVariables(INPUT_DECLARING_A_SECRET)
+          .withErrorExpressionHeader(
+              "jobError(\"Request failed: \" + response.body, {}, 7, duration(\"PT5M\"))")
+          .execute(echoingConnector());
+
+      // then
+      var messageCaptor = ArgumentCaptor.forClass(String.class);
+      verify(failCommandStep2).errorMessage(messageCaptor.capture());
+      assertThat(messageCaptor.getValue()).doesNotContain(ECHOED);
+      verify(failCommand).retries(7);
+      verify(failCommandStep2).retryBackoff(Duration.ofMinutes(5));
+    }
+
+    @Test
+    void bpmnErrorMessageCopyingAResponseIsRedacted() {
+      // when
+      var result =
+          JobBuilder.create()
+              .withVariables(INPUT_DECLARING_A_SECRET)
+              .withErrorExpressionHeader(
+                  "bpmnError(\"AUTH_FAILED\", \"Request failed: \" + response.body)")
+              .executeAndCaptureResult(echoingConnector(), false, true);
+
+      // then
+      assertThat(result.getErrorMessage())
+          .isEqualTo("Request failed: rejected token ***")
+          .doesNotContain(ECHOED);
+    }
+
+    @Test
+    void bpmnErrorVariablesCopyingAResponseAreRedacted() {
+      // when
+      var result =
+          JobBuilder.create()
+              .withVariables(INPUT_DECLARING_A_SECRET)
+              .withErrorExpressionHeader(
+                  "bpmnError(\"AUTH_FAILED\", \"failed\", {detail: response.body})")
+              .executeAndCaptureResult(echoingConnector(), false, true);
+
+      // then
+      assertThat(result.getVariables()).containsEntry("detail", "rejected token ***");
+    }
+
+    @Test
+    void bpmnErrorCodeIsNotRedacted() {
+      // boundary events match on the code, so it keeps a value equal to the secret's
+      var result =
+          JobBuilder.create()
+              .withVariables(INPUT_DECLARING_A_SECRET)
+              .withErrorExpressionHeader(
+                  "bpmnError(\"" + ECHOED + "\", \"Request failed: \" + response.body)")
+              .executeAndCaptureResult(echoingConnector(), false, true);
+
+      // then
+      assertThat(result.getErrorCode()).isEqualTo(ECHOED);
+      assertThat(result.getErrorMessage()).doesNotContain(ECHOED);
+    }
+
+    @Test
+    void bpmnErrorWithoutAMessageStaysWithoutOne() {
+      // throwError omits a null message but would set an empty one
+      var result =
+          JobBuilder.create()
+              .withVariables(INPUT_DECLARING_A_SECRET)
+              .withErrorExpressionHeader(
+                  "{ errorType: \"bpmnError\", code: \"AUTH_FAILED\","
+                      + " variables: {detail: response.body} }")
+              .executeAndCaptureResult(echoingConnector(), false, true);
+
+      // then
+      assertThat(result.getErrorMessage()).isNull();
+      assertThat(result.getVariables()).containsEntry("detail", "rejected token ***");
+    }
+
+    @Test
+    void jobErrorIsWithheldWhenItCannotBeRedacted() {
+      // when
+      var result =
+          JobBuilder.create()
+              .withVariables(INPUT_DECLARING_A_SECRET)
+              .withErrorExpressionHeader("jobError(\"Request failed: \" + response.body, {}, 0)")
+              .executeAndCaptureResult(echoingConnectorWithUnreadableSecrets(), false, false);
+
+      // the fetch failure's own message is withheld too: a provider error can echo the store's body
+      assertThat(result.getErrorMessage())
+          .startsWith("Fetching secrets failed, so the original error cannot be displayed")
+          .contains("java.lang.RuntimeException")
+          .doesNotContain("Network error while fetching secrets")
+          .doesNotContain(ECHOED);
+      assertThat(result.getRetries()).isZero();
+    }
+
+    @Test
+    void bpmnErrorKeepsItsCodeWhenItCannotBeRedacted() {
+      // when
+      var result =
+          JobBuilder.create()
+              .withVariables(INPUT_DECLARING_A_SECRET)
+              .withErrorExpressionHeader(
+                  "bpmnError(\"AUTH_FAILED\", \"Request failed: \" + response.body,"
+                      + " {detail: response.body})")
+              .executeAndCaptureResult(echoingConnectorWithUnreadableSecrets(), false, true);
+
+      // then
+      assertThat(result.getErrorCode()).isEqualTo("AUTH_FAILED");
+      assertThat(result.getErrorMessage())
+          .startsWith("Fetching secrets failed, so the original error cannot be displayed")
+          .doesNotContain(ECHOED);
+      assertThat(result.getVariables()).isEmpty();
+    }
+
+    @Test
+    void anErrorCarryingNothingToRedactIsLeftAlone() {
+      // no message and no variables, so the read is skipped and the unreadable store costs nothing
+      var result =
+          JobBuilder.create()
+              .withVariables(INPUT_DECLARING_A_SECRET)
+              .withErrorExpressionHeader("{ errorType: \"bpmnError\", code: \"AUTH_FAILED\" }")
+              .executeAndCaptureResult(echoingConnectorWithUnreadableSecrets(), false, true);
+
+      // then
+      assertThat(result.getErrorCode()).isEqualTo("AUTH_FAILED");
+      assertThat(result.getErrorMessage()).isNull();
     }
   }
 }

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/outbound/OutboundConnectorExceptionHandlerTest.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/outbound/OutboundConnectorExceptionHandlerTest.java
@@ -30,6 +30,7 @@ import io.camunda.connector.runtime.core.secret.SecretAllowListUnavailableExcept
 import io.camunda.connector.runtime.core.secret.SecretFilter;
 import io.camunda.zeebe.client.api.response.ActivatedJob;
 import java.time.Duration;
+import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
@@ -72,7 +73,8 @@ class OutboundConnectorExceptionHandlerTest {
         };
 
     var result =
-        handler.handleFinalResultException(new RuntimeException("boom"), job, throwingFilter);
+        handler.handleFinalResultException(
+            new RuntimeException("boom"), job, throwingFilter, List.of());
 
     assertThat(result.retries()).isEqualTo(2);
     assertThat(result.exception().getMessage()).contains("Fetching secrets failed");
@@ -92,7 +94,7 @@ class OutboundConnectorExceptionHandlerTest {
 
     var result =
         handlerWithThrowingProvider.handleFinalResultException(
-            new RuntimeException("boom"), job, SecretFilter.allowAll());
+            new RuntimeException("boom"), job, SecretFilter.allowAll(), List.of());
 
     assertThat(result.retries()).isEqualTo(2);
     assertThat(result.exception().getMessage()).contains("Fetching secrets failed");
@@ -214,7 +216,8 @@ class OutboundConnectorExceptionHandlerTest {
                     + " (io.camunda.operate.exception.OperateException)"),
             job,
             null,
-            SecretFilter.allowAll());
+            SecretFilter.allowAll(),
+            List.of());
 
     assertThat(result.exception())
         .hasMessageContaining("Activity_1")
@@ -234,7 +237,8 @@ class OutboundConnectorExceptionHandlerTest {
             new SecretAllowListUnavailableException("lookup failed"),
             job,
             modelBackoff,
-            SecretFilter.allowAll());
+            SecretFilter.allowAll(),
+            List.of());
 
     assertThat(result.retryBackoff()).isEqualTo(Duration.ofSeconds(5));
     assertThat(result.retries()).isEqualTo(2);
@@ -258,7 +262,11 @@ class OutboundConnectorExceptionHandlerTest {
 
     var result =
         handlerWithThrowingProvider.manageConnectorJobHandlerException(
-            new RuntimeException("boom"), job, Duration.ofSeconds(30), SecretFilter.allowAll());
+            new RuntimeException("boom"),
+            job,
+            Duration.ofSeconds(30),
+            SecretFilter.allowAll(),
+            List.of());
 
     assertThat(result.retryBackoff()).isEqualTo(Duration.ofSeconds(30));
   }
@@ -274,7 +282,7 @@ class OutboundConnectorExceptionHandlerTest {
 
     var result =
         handler.manageConnectorJobHandlerException(
-            new RuntimeException("boom"), job, null, unreadableAllowList);
+            new RuntimeException("boom"), job, null, unreadableAllowList, List.of());
 
     assertThat(result.exception()).hasMessageContaining("Activity_1");
     assertThat(result.retries()).isEqualTo(2);
@@ -295,7 +303,8 @@ class OutboundConnectorExceptionHandlerTest {
             new RuntimeException("api rejected xSUPERSECRET"),
             job,
             Duration.ofSeconds(1),
-            SecretFilter.allowAll());
+            SecretFilter.allowAll(),
+            List.of());
 
     assertThat(result.exception().getMessage()).isEqualTo("api rejected ***");
   }
@@ -313,7 +322,8 @@ class OutboundConnectorExceptionHandlerTest {
             new RuntimeException("api rejected the request"),
             job,
             Duration.ofSeconds(1),
-            SecretFilter.allowAll());
+            SecretFilter.allowAll(),
+            List.of());
 
     assertThat(result.exception().getMessage()).isEqualTo("api rejected the request");
   }
@@ -336,7 +346,8 @@ class OutboundConnectorExceptionHandlerTest {
             new RuntimeException("api rejected the request"),
             job,
             Duration.ofSeconds(1),
-            SecretFilter.allowAll());
+            SecretFilter.allowAll(),
+            List.of());
 
     assertThat(result.exception().getMessage()).isEqualTo("api rejected the request");
     assertThat(result.retries()).isEqualTo(2);

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/outbound/OutboundConnectorExceptionHandlerTest.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/outbound/OutboundConnectorExceptionHandlerTest.java
@@ -590,6 +590,34 @@ class OutboundConnectorExceptionHandlerTest {
     assertThat(result.exception().getMessage())
         .isEqualTo("Secret with name 'MISSING' is not available");
     assertThat(result.retries()).isZero();
+    // the type deployed models can match on is unchanged by this branch introducing a distinct
+    // class for the runtime's own use
+    assertThat(errorPayloadOf(result))
+        .containsEntry("type", ConnectorInputException.class.getName());
+  }
+
+  @Test
+  void aMissingSecretReportedThroughTheLegacyOverloadKeepsThePublishedTypeToo() {
+    var job = jobWithSecretReference();
+    var providerThatMustNotBeCalled =
+        mock(
+            SecretProvider.class,
+            invocation -> {
+              throw new AssertionError("this legacy overload must not resolve any secret");
+            });
+    var handlerWithGuard = new OutboundConnectorExceptionHandler(providerThatMustNotBeCalled);
+
+    var result =
+        handlerWithGuard.manageConnectorJobHandlerException(
+            new SecretNotAvailableException("MISSING"), job, Duration.ofSeconds(1));
+
+    assertThat(errorPayloadOf(result))
+        .containsEntry("type", ConnectorInputException.class.getName());
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Map<String, Object> errorPayloadOf(ConnectorResult.ErrorResult result) {
+    return (Map<String, Object>) ((Map<String, Object>) result.responseValue()).get("error");
   }
 
   @Test

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/outbound/OutboundConnectorExceptionHandlerTest.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/outbound/OutboundConnectorExceptionHandlerTest.java
@@ -78,7 +78,8 @@ class OutboundConnectorExceptionHandlerTest {
         handler.handleFinalResultException(
             new RuntimeException("boom"), job, throwingFilter, List.of());
 
-    assertThat(result.retries()).isEqualTo(2);
+    // zero, as on the successful path and on the legacy overload: the connector has already run
+    assertThat(result.retries()).isEqualTo(0);
     assertThat(result.exception().getMessage()).contains("Fetching secrets failed");
     assertThat(result.exception().getMessage()).doesNotContain("process-definition lookup failed");
     assertThat(result.exception()).hasNoCause();
@@ -100,7 +101,7 @@ class OutboundConnectorExceptionHandlerTest {
         handlerWithThrowingProvider.handleFinalResultException(
             new RuntimeException("boom"), job, SecretFilter.allowAll(), List.of());
 
-    assertThat(result.retries()).isEqualTo(2);
+    assertThat(result.retries()).isEqualTo(0);
     assertThat(result.exception().getMessage()).contains("Fetching secrets failed");
     assertThat(result.exception().getMessage()).doesNotContain("secret store unavailable");
     assertThat(result.exception()).hasNoCause();
@@ -369,6 +370,83 @@ class OutboundConnectorExceptionHandlerTest {
         .doesNotContain("vault said")
         .doesNotContain("api rejected");
     assertThat(result.exception()).hasNoCause();
+    // zero, as on the successful path: the connector has already run, so a retry has nothing to do
+    assertThat(result.retries()).isEqualTo(0);
+  }
+
+  @Test
+  void anUnreadableSecretKeepsTheRemainingRetriesWhenNeitherFailureIsAboutTheInput() {
+    // an unreachable secret store is a transient failure, and so is the job's own error here, so
+    // the job keeps the attempts it had left
+    var job = jobWithSecretReference();
+    var handlerWithThrowingProvider =
+        new OutboundConnectorExceptionHandler(
+            mock(
+                SecretProvider.class,
+                invocation -> {
+                  throw new IllegalStateException("secret store unreachable");
+                }));
+
+    var result =
+        handlerWithThrowingProvider.manageConnectorJobHandlerException(
+            new RuntimeException("upstream timed out"),
+            job,
+            Duration.ofSeconds(1),
+            SecretFilter.allowAll(),
+            List.of());
+
+    assertThat(result.retries()).isEqualTo(job.getRetries() - 1);
+  }
+
+  @Test
+  void anUnreadableSecretStillDoesNotRetryAJobWhoseInputCanNeverBind() {
+    // the job's own failure is unchanged by the masking read failing, so an input error that will
+    // never bind must not become retryable just because the values to redact it could not be read
+    var job = jobWithSecretReference();
+    var handlerWithThrowingProvider =
+        new OutboundConnectorExceptionHandler(
+            mock(
+                SecretProvider.class,
+                invocation -> {
+                  throw new IllegalStateException("secret store unreachable");
+                }));
+
+    var result =
+        handlerWithThrowingProvider.manageConnectorJobHandlerException(
+            new ConnectorInputException(new RuntimeException("property is not a number")),
+            job,
+            Duration.ofSeconds(1),
+            SecretFilter.allowAll(),
+            List.of());
+
+    assertThat(result.retries()).isEqualTo(0);
+    assertThat(result.exception().getMessage()).contains("Fetching secrets failed");
+  }
+
+  @Test
+  void anUnreadableSecretDoesNotRetryWhenTheMaskingReadItselfSaysTheInputIsAtFault() {
+    // a provider that refuses to resolve at all throws for every name, including the ones this
+    // fetch only needed for masking, and that refusal is permanent
+    var job = jobWithSecretReference();
+    var handlerWithRefusingProvider =
+        new OutboundConnectorExceptionHandler(
+            mock(
+                SecretProvider.class,
+                invocation -> {
+                  throw new ConnectorInputException(new RuntimeException("resolution refused"));
+                }));
+
+    var result =
+        handlerWithRefusingProvider.manageConnectorJobHandlerException(
+            new RuntimeException("upstream timed out"),
+            job,
+            Duration.ofSeconds(1),
+            SecretFilter.allowAll(),
+            List.of());
+
+    assertThat(result.retries()).isEqualTo(0);
+    assertThat(result.exception().getMessage()).contains("Fetching secrets failed");
+    assertThat(result.exception().getMessage()).doesNotContain("resolution refused");
   }
 
   @Test

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/outbound/OutboundConnectorExceptionHandlerTest.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/outbound/OutboundConnectorExceptionHandlerTest.java
@@ -23,6 +23,7 @@ import static org.mockito.Mockito.when;
 import io.camunda.connector.api.error.ConnectorExceptionBuilder;
 import io.camunda.connector.api.error.ConnectorInputException;
 import io.camunda.connector.api.error.ConnectorRetryExceptionBuilder;
+import io.camunda.connector.api.secret.SecretContext;
 import io.camunda.connector.api.secret.SecretProvider;
 import io.camunda.connector.runtime.core.FooBarSecretProvider;
 import io.camunda.connector.runtime.core.secret.SecretAllowListUnavailableException;
@@ -41,12 +42,25 @@ class OutboundConnectorExceptionHandlerTest {
       new OutboundConnectorExceptionHandler(new FooBarSecretProvider());
 
   private static ActivatedJob jobWithSecretReference() {
+    return jobNaming("{\"value\":\"{{secrets.FOO}}\"}");
+  }
+
+  private static ActivatedJob jobNaming(String variables) {
     var job = mock(ActivatedJob.class);
-    when(job.getVariables()).thenReturn("{\"value\":\"{{secrets.FOO}}\"}");
+    when(job.getVariables()).thenReturn(variables);
     when(job.getKey()).thenReturn(1L);
     when(job.getTenantId()).thenReturn("tenant");
     when(job.getRetries()).thenReturn(3);
     return job;
+  }
+
+  private static SecretProvider holdingOnly(Map<String, String> secrets) {
+    return new SecretProvider() {
+      @Override
+      public String getSecret(String name, SecretContext context) {
+        return secrets.get(name);
+      }
+    };
   }
 
   @Test
@@ -265,5 +279,66 @@ class OutboundConnectorExceptionHandlerTest {
     assertThat(result.exception()).hasMessageContaining("Activity_1");
     assertThat(result.retries()).isEqualTo(2);
     assertThat(result.retryBackoff()).isEqualTo(Duration.ofSeconds(5));
+  }
+
+  @Test
+  void masksALongerSecretThatStartsWithAShorterOne() {
+    // Replacing the shorter value first would leave the longer one unmatched and publish its
+    // remainder: "x" before "xSUPERSECRET" turns the message into "***SUPERSECRET".
+    var job = jobNaming("{\"a\": \"{{secrets.SHORT}}\", \"b\": \"{{secrets.LONG}}\"}");
+    var handlerHoldingBoth =
+        new OutboundConnectorExceptionHandler(
+            holdingOnly(Map.of("SHORT", "x", "LONG", "xSUPERSECRET")));
+
+    var result =
+        handlerHoldingBoth.manageConnectorJobHandlerException(
+            new RuntimeException("api rejected xSUPERSECRET"),
+            job,
+            Duration.ofSeconds(1),
+            SecretFilter.allowAll());
+
+    assertThat(result.exception().getMessage()).isEqualTo("api rejected ***");
+  }
+
+  @Test
+  void anEmptySecretValueDoesNotCorruptTheMessage() {
+    // Replacing "" matches at every position, so a provider answering with one would rewrite the
+    // whole message into separators rather than redact anything.
+    var job = jobNaming("{\"a\": \"{{secrets.BLANK}}\"}");
+    var handlerHoldingABlank =
+        new OutboundConnectorExceptionHandler(holdingOnly(Map.of("BLANK", "")));
+
+    var result =
+        handlerHoldingABlank.manageConnectorJobHandlerException(
+            new RuntimeException("api rejected the request"),
+            job,
+            Duration.ofSeconds(1),
+            SecretFilter.allowAll());
+
+    assertThat(result.exception().getMessage()).isEqualTo("api rejected the request");
+  }
+
+  @Test
+  void aJobDeclaringNoSecretNeverReachesAProvider() {
+    // fetchAll is overridable, and one that refuses every batch would otherwise withhold the error
+    // message of a job that had nothing to redact in the first place.
+    var job = jobNaming("{\"a\": \"nothing to resolve here\"}");
+    SecretProvider providerThatMustNotBeCalled =
+        mock(
+            SecretProvider.class,
+            invocation -> {
+              throw new AssertionError("a job declaring no secret has nothing to resolve");
+            });
+    var handlerWithGuard = new OutboundConnectorExceptionHandler(providerThatMustNotBeCalled);
+
+    var result =
+        handlerWithGuard.manageConnectorJobHandlerException(
+            new RuntimeException("api rejected the request"),
+            job,
+            Duration.ofSeconds(1),
+            SecretFilter.allowAll());
+
+    assertThat(result.exception().getMessage()).isEqualTo("api rejected the request");
+    assertThat(result.retries()).isEqualTo(2);
   }
 }

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/outbound/OutboundConnectorExceptionHandlerTest.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/outbound/OutboundConnectorExceptionHandlerTest.java
@@ -28,8 +28,10 @@ import io.camunda.connector.api.secret.SecretProvider;
 import io.camunda.connector.runtime.core.FooBarSecretProvider;
 import io.camunda.connector.runtime.core.secret.SecretAllowListUnavailableException;
 import io.camunda.connector.runtime.core.secret.SecretFilter;
+import io.camunda.connector.runtime.core.secret.SecretNotAvailableException;
 import io.camunda.zeebe.client.api.response.ActivatedJob;
 import java.time.Duration;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
@@ -78,6 +80,8 @@ class OutboundConnectorExceptionHandlerTest {
 
     assertThat(result.retries()).isEqualTo(2);
     assertThat(result.exception().getMessage()).contains("Fetching secrets failed");
+    assertThat(result.exception().getMessage()).doesNotContain("process-definition lookup failed");
+    assertThat(result.exception()).hasNoCause();
   }
 
   @Test
@@ -98,6 +102,8 @@ class OutboundConnectorExceptionHandlerTest {
 
     assertThat(result.retries()).isEqualTo(2);
     assertThat(result.exception().getMessage()).contains("Fetching secrets failed");
+    assertThat(result.exception().getMessage()).doesNotContain("secret store unavailable");
+    assertThat(result.exception()).hasNoCause();
   }
 
   @Test
@@ -287,6 +293,243 @@ class OutboundConnectorExceptionHandlerTest {
     assertThat(result.exception()).hasMessageContaining("Activity_1");
     assertThat(result.retries()).isEqualTo(2);
     assertThat(result.retryBackoff()).isEqualTo(Duration.ofSeconds(5));
+  }
+
+  @Test
+  void anUnreadableSecretPublishesNeitherTheProvidersWordsNorTheOriginalError() {
+    // The provider's own message can carry secret material, and so can the error that was supposed
+    // to be redacted: on this path neither has been masked, so neither may be published.
+    var job = jobWithSecretReference();
+    SecretProvider throwingProvider =
+        mock(
+            SecretProvider.class,
+            invocation -> {
+              throw new IllegalStateException(
+                  "vault said: {\"token\":\"" + FooBarSecretProvider.SECRET_VALUE + "\"}");
+            });
+    var handlerWithThrowingProvider = new OutboundConnectorExceptionHandler(throwingProvider);
+    var connectorException =
+        new ConnectorExceptionBuilder()
+            .errorCode("AUTH-401")
+            .message("api rejected " + FooBarSecretProvider.SECRET_VALUE)
+            .errorVariables(Map.of("responseBody", FooBarSecretProvider.SECRET_VALUE))
+            .build();
+
+    var result =
+        handlerWithThrowingProvider.manageConnectorJobHandlerException(
+            connectorException, job, Duration.ofSeconds(1), SecretFilter.allowAll(), List.of());
+
+    @SuppressWarnings("unchecked")
+    var errorPayload =
+        (Map<String, Object>) ((Map<String, Object>) result.responseValue()).get("error");
+    assertThat(errorPayload).doesNotContainKey("variables");
+    assertThat(errorPayload).doesNotContainKey("code");
+    assertThat(errorPayload.toString())
+        .doesNotContain(FooBarSecretProvider.SECRET_VALUE)
+        .doesNotContain("vault said")
+        .doesNotContain("api rejected");
+    assertThat(result.exception())
+        .hasNoCause()
+        .hasMessageContaining("Fetching secrets failed")
+        .hasMessageNotContaining("vault said")
+        .hasMessageNotContaining("api rejected");
+    // the type reported is the withheld-error stand-in, never the ConnectorException whose code and
+    // variables would otherwise be copied into the payload unmasked
+    assertThat(errorPayload.get("type").toString()).endsWith("SecretsUnavailableException");
+  }
+
+  @Test
+  void anUnreadableSecretOnTheFinalResultPathPublishesNothingUnmaskedEither() {
+    var job = jobWithSecretReference();
+    SecretProvider throwingProvider =
+        mock(
+            SecretProvider.class,
+            invocation -> {
+              throw new IllegalStateException("vault said: " + FooBarSecretProvider.SECRET_VALUE);
+            });
+    var handlerWithThrowingProvider = new OutboundConnectorExceptionHandler(throwingProvider);
+    var connectorException =
+        new ConnectorExceptionBuilder()
+            .errorCode("AUTH-401")
+            .message("api rejected " + FooBarSecretProvider.SECRET_VALUE)
+            .errorVariables(Map.of("responseBody", FooBarSecretProvider.SECRET_VALUE))
+            .build();
+
+    var result =
+        handlerWithThrowingProvider.handleFinalResultException(
+            connectorException, job, SecretFilter.allowAll(), List.of());
+
+    @SuppressWarnings("unchecked")
+    var errorPayload =
+        (Map<String, Object>) ((Map<String, Object>) result.responseValue()).get("error");
+    assertThat(errorPayload).doesNotContainKey("variables");
+    assertThat(errorPayload).doesNotContainKey("code");
+    assertThat(errorPayload.toString())
+        .doesNotContain(FooBarSecretProvider.SECRET_VALUE)
+        .doesNotContain("vault said")
+        .doesNotContain("api rejected");
+    assertThat(result.exception()).hasNoCause();
+  }
+
+  @Test
+  void aFailedMaskingFetchDoesNotPublishItsOwnErrorVariables() {
+    // exceptionToMap copies a ConnectorException's variables and code into the payload. On this
+    // path it would copy them with an empty redaction list, publishing unmasked exactly the data
+    // the branch exists to withhold.
+    var job = jobWithSecretReference();
+    SecretProvider throwingProvider =
+        mock(
+            SecretProvider.class,
+            invocation -> {
+              throw new ConnectorExceptionBuilder()
+                  .errorCode("PROVIDER_CODE")
+                  .message("lookup rejected")
+                  .errorVariables(Map.of("response", "credential super-secret was rejected"))
+                  .build();
+            });
+    var handlerWithThrowingProvider = new OutboundConnectorExceptionHandler(throwingProvider);
+
+    var result =
+        handlerWithThrowingProvider.manageConnectorJobHandlerException(
+            new RuntimeException("boom"),
+            job,
+            Duration.ofSeconds(1),
+            SecretFilter.allowAll(),
+            List.of());
+
+    assertThat(result.responseValue().toString())
+        .doesNotContain("super-secret")
+        .doesNotContain("PROVIDER_CODE");
+  }
+
+  @Test
+  void masksTheErrorVariablesCopiedOffTheOriginalException() {
+    // an API that echoes a rejected credential back would otherwise publish it as a process
+    // variable, which is visible to anyone who can see the process instance
+    var job = jobWithSecretReference();
+    var nested = new HashMap<String, Object>();
+    nested.put("body", "rejected " + FooBarSecretProvider.SECRET_VALUE);
+    nested.put("headers", List.of("Authorization: " + FooBarSecretProvider.SECRET_VALUE));
+    nested.put("status", 401);
+    var connectorException =
+        new ConnectorExceptionBuilder()
+            .errorCode("AUTH-401")
+            .message("api rejected the request")
+            .errorVariables(
+                Map.of("response", nested, FooBarSecretProvider.SECRET_VALUE + "-key", "value"))
+            .build();
+
+    var result =
+        handler.manageConnectorJobHandlerException(
+            connectorException, job, Duration.ofSeconds(1), SecretFilter.allowAll(), List.of());
+
+    @SuppressWarnings("unchecked")
+    var errorPayload =
+        (Map<String, Object>) ((Map<String, Object>) result.responseValue()).get("error");
+    @SuppressWarnings("unchecked")
+    var variables = (Map<String, Object>) errorPayload.get("variables");
+    assertThat(variables.toString()).doesNotContain(FooBarSecretProvider.SECRET_VALUE);
+    assertThat(variables).containsKey("***-key");
+    @SuppressWarnings("unchecked")
+    var maskedResponse = (Map<String, Object>) variables.get("response");
+    assertThat(maskedResponse.get("body")).isEqualTo("rejected ***");
+    assertThat(maskedResponse.get("headers")).isEqualTo(List.of("Authorization: ***"));
+    // scalars keep their type, since processes may branch on them
+    assertThat(maskedResponse.get("status")).isEqualTo(401);
+    // boundary events match on the code, so it is deliberately left alone
+    assertThat(errorPayload.get("code")).isEqualTo("AUTH-401");
+  }
+
+  @Test
+  void errorVariablesThatContainThemselvesAreReportedRatherThanRecursedForever() {
+    var job = jobWithSecretReference();
+    var cyclic = new HashMap<String, Object>();
+    cyclic.put("body", "rejected " + FooBarSecretProvider.SECRET_VALUE);
+    cyclic.put("self", cyclic);
+    var connectorException =
+        new ConnectorExceptionBuilder()
+            .errorCode("AUTH-401")
+            .message("api rejected the request")
+            .errorVariables(Map.of("response", cyclic))
+            .build();
+
+    var result =
+        handler.manageConnectorJobHandlerException(
+            connectorException, job, Duration.ofSeconds(1), SecretFilter.allowAll(), List.of());
+
+    @SuppressWarnings("unchecked")
+    var errorPayload =
+        (Map<String, Object>) ((Map<String, Object>) result.responseValue()).get("error");
+    @SuppressWarnings("unchecked")
+    var variables = (Map<String, Object>) errorPayload.get("variables");
+    @SuppressWarnings("unchecked")
+    var maskedResponse = (Map<String, Object>) variables.get("response");
+    assertThat(maskedResponse.get("self")).isEqualTo("[circular reference]");
+    assertThat(maskedResponse.get("body")).isEqualTo("rejected ***");
+  }
+
+  @Test
+  void aMaskingReadThatComesBackShortWithholdsTheMessage() {
+    // fetchAll drops the names it cannot resolve, so a short read is a silent one: redacting with
+    // what did come back would publish the value that did not in the clear.
+    var job = jobNaming("{\"a\": \"{{secrets.HELD}}\", \"b\": \"{{secrets.REVOKED}}\"}");
+    var handlerHoldingOne =
+        new OutboundConnectorExceptionHandler(holdingOnly(Map.of("HELD", "held-value")));
+
+    var result =
+        handlerHoldingOne.manageConnectorJobHandlerException(
+            new RuntimeException("api rejected revoked-value"),
+            job,
+            Duration.ofSeconds(1),
+            SecretFilter.allowAll(),
+            List.of());
+
+    assertThat(result.exception().getMessage())
+        .contains("Fetching secrets failed")
+        .doesNotContain("revoked-value")
+        // the count is written by this runtime, so it is publishable and says what to act on
+        .contains("1 of the 2 secrets this job's input names could not be read back");
+    assertThat(result.exception()).hasNoCause();
+    assertThat(result.retries()).isEqualTo(2);
+  }
+
+  @Test
+  void aJobThatFailedOnAMissingSecretStillReportsWhichSecretIsMissing() {
+    // the re-read comes back short for the very name the job failed on, which is what the job's own
+    // failure already says: withholding it would replace a useful message with a generic one
+    var job = jobNaming("{\"a\": \"{{secrets.HELD}}\", \"b\": \"{{secrets.MISSING}}\"}");
+    var handlerHoldingOne =
+        new OutboundConnectorExceptionHandler(holdingOnly(Map.of("HELD", "held-value")));
+
+    var result =
+        handlerHoldingOne.manageConnectorJobHandlerException(
+            new SecretNotAvailableException("MISSING"),
+            job,
+            Duration.ofSeconds(1),
+            SecretFilter.allowAll(),
+            List.of());
+
+    assertThat(result.exception().getMessage())
+        .isEqualTo("Secret with name 'MISSING' is not available");
+    assertThat(result.retries()).isZero();
+  }
+
+  @Test
+  void aCompleteReadStillMasksEveryValueItReturned() {
+    var job = jobNaming("{\"a\": \"{{secrets.HELD}}\", \"b\": \"{{secrets.ALSO_HELD}}\"}");
+    var handlerHoldingBoth =
+        new OutboundConnectorExceptionHandler(
+            holdingOnly(Map.of("HELD", "held-value", "ALSO_HELD", "other-value")));
+
+    var result =
+        handlerHoldingBoth.manageConnectorJobHandlerException(
+            new RuntimeException("api rejected held-value and other-value"),
+            job,
+            Duration.ofSeconds(1),
+            SecretFilter.allowAll(),
+            List.of());
+
+    assertThat(result.exception().getMessage()).isEqualTo("api rejected *** and ***");
   }
 
   @Test

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/outbound/ConnectorJobHandlerTests.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/outbound/ConnectorJobHandlerTests.java
@@ -124,11 +124,14 @@ public class ConnectorJobHandlerTests {
 
     // then
     assertThat(resultForMissingSecret.getErrorMessage())
-        .isEqualTo(
-            "Fetching secrets failed, original error can't be displayed as the error message might contain secrets: Network error while fetching secrets");
+        .startsWith("Fetching secrets failed, so the original error cannot be displayed")
+        .contains(RuntimeException.class.getName())
+        .doesNotContain("Network error while fetching secrets");
     assertThat(resultForRaisingException.getErrorMessage())
-        .isEqualTo(
-            "Fetching secrets failed, original error can't be displayed as the error message might contain secrets: Network error while fetching secrets");
+        .startsWith("Fetching secrets failed, so the original error cannot be displayed")
+        .contains(RuntimeException.class.getName())
+        .doesNotContain("Network error while fetching secrets")
+        .doesNotContain("Crazy error something with bar");
   }
 
   @Test


### PR DESCRIPTION
## Description

Backports #8634 and #8643 together to `stable/8.7`. They form one secret-redaction change and are intentionally combined so the fixes reach this older stable branch atomically. This is ported from the combined reference backport #8661.

The change prevents resolved secrets from being exposed through outbound job and BPMN error incidents, inbound activity logs and health errors, and errors emitted after a secret rotates between input binding and masking. It also includes the approved follow-up #8662, which prevents the unredacted exception cause from being printed to runtime logs.

The required secret-reference handling from #8641 is already present on the target branch through #8659.

## Related issues

Related to #8638.

Source PRs: #8634, #8643, and follow-up #8662.

## Checklist

- [x] No further backport labels are added; the older stable branches are being ported explicitly from the combined change.
- [x] Tests for the changes are included and the focused runtime test suite passes.
- [x] No documentation update is required for this backport.
