### PR TITLE
[Backport stable/8.8] fix: redact secrets from connector errors and logs

### DIFF
--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextImpl.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextImpl.java
@@ -465,7 +465,9 @@ public class InboundConnectorContextImpl extends AbstractConnectorContext
   // an unmaskable health can't be verified as a repeat either, so it must never be deduped away
   private static boolean isWithheld(Health health) {
     return health.getError() != null
-        && REDACTION_UNAVAILABLE_MESSAGE.equals(health.getError().message());
+        && (REDACTION_UNAVAILABLE_MESSAGE.equals(health.getError().message())
+            // redactMessage withholds the code too, and an error may carry only a code
+            || REDACTION_UNAVAILABLE_MESSAGE.equals(health.getError().code()));
   }
 
   private Health redactHealth(Health health) {

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextImpl.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextImpl.java
@@ -47,9 +47,12 @@ import io.camunda.connector.runtime.core.inbound.details.InboundConnectorDetails
 import io.camunda.connector.runtime.core.inbound.details.InboundConnectorDetails.ValidInboundConnectorDetails;
 import io.camunda.connector.runtime.core.secret.SecretFilter;
 import io.camunda.connector.runtime.core.secret.SecretUtil;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
@@ -71,6 +74,11 @@ public class InboundConnectorContextImpl extends AbstractConnectorContext
   private final Long activationTimestamp;
   private Health health = Health.unknown();
   private Map<String, Object> propertiesWithSecrets;
+  private volatile List<String> reReadSecrets;
+  private final Set<String> capturedSecretValues = ConcurrentHashMap.newKeySet();
+
+  private static final String REDACTION_UNAVAILABLE_MESSAGE =
+      "Message withheld: could not verify it does not contain a secret value";
 
   public InboundConnectorContextImpl(
       SecretProvider secretProvider,
@@ -336,7 +344,8 @@ public class InboundConnectorContextImpl extends AbstractConnectorContext
     if (health == null) {
       throw new IllegalArgumentException("Health must not be null");
     }
-    if (health.equals(this.health)) {
+    var masked = redactHealth(health);
+    if (!isWithheld(masked) && masked.equals(this.health)) {
       return;
     }
     var activityLog =
@@ -345,9 +354,9 @@ public class InboundConnectorContextImpl extends AbstractConnectorContext
             .withMessage(
                 String.format(
                     "Health status changed to %s, details: %s",
-                    health.getStatus(), health.getDetails()))
-            .withSeverity(health.getStatus() == Health.Status.UP ? Severity.INFO : Severity.ERROR)
-            .andReportHealth(health)
+                    masked.getStatus(), masked.getDetails()))
+            .withSeverity(masked.getStatus() == Health.Status.UP ? Severity.INFO : Severity.ERROR)
+            .andReportHealth(masked)
             .build();
     // append the activity log to store the health status change history
     activityLogWriter.log(
@@ -355,7 +364,7 @@ public class InboundConnectorContextImpl extends AbstractConnectorContext
             ExecutableId.fromDeduplicationId(connectorDetails.deduplicationId()),
             ActivitySource.CONNECTOR,
             activityLog));
-    this.health = health;
+    this.health = masked;
   }
 
   @Override
@@ -365,14 +374,15 @@ public class InboundConnectorContextImpl extends AbstractConnectorContext
 
   @Override
   public void log(Activity log) {
-    if (log.healthChange() != null) {
-      this.health = log.healthChange();
+    var masked = redact(log);
+    if (masked.healthChange() != null) {
+      this.health = masked.healthChange();
     }
     activityLogWriter.log(
         new ActivityLogEntry(
             ExecutableId.fromDeduplicationId(connectorDetails.deduplicationId()),
             ActivitySource.CONNECTOR,
-            log));
+            masked));
   }
 
   @Override
@@ -392,7 +402,89 @@ public class InboundConnectorContextImpl extends AbstractConnectorContext
         new ActivityLogEntry(
             ExecutableId.fromDeduplicationId(connectorDetails.deduplicationId()),
             ActivitySource.RUNTIME,
-            builder.build()));
+            redact(builder.build())));
+  }
+
+  // captures are only ever unioned into a successful, complete re-read, never a substitute for one
+  private List<String> secretValuesForRedaction() {
+    var reRead = reReadSecretValues();
+    if (reRead == null) {
+      return null;
+    }
+    if (capturedSecretValues.isEmpty()) {
+      return reRead;
+    }
+    var union = new ArrayList<>(reRead);
+    union.addAll(capturedSecretValues);
+    return union;
+  }
+
+  private List<String> reReadSecretValues() {
+    var cached = reReadSecrets;
+    if (cached != null) {
+      return cached;
+    }
+    var values = fetchSecretValuesForRedaction();
+    if (values != null) {
+      reReadSecrets = values;
+    }
+    return values;
+  }
+
+  // every grouped element's declared names, not just this context's representative properties
+  private List<String> fetchSecretValuesForRedaction() {
+    var names =
+        connectorDetails.connectorElements().stream()
+            .flatMap(element -> element.rawProperties().values().stream())
+            .flatMap(value -> SecretUtil.retrieveSecretKeysInInput(value).stream())
+            .distinct()
+            .toList();
+    if (names.isEmpty()) {
+      return List.of();
+    }
+    try {
+      var values = secretProvider.fetchAll(names, new SecretContext(connectorDetails.tenantId()));
+      // fewer values than names means a partial read, treated the same as a failed one
+      return values.size() < names.size() ? null : values;
+    } catch (Exception e) {
+      LOG.warn("Could not fetch secret values to redact activity log: {}", e.getClass().getName());
+      return null;
+    }
+  }
+
+  private String redactMessage(String message) {
+    if (message == null) {
+      return null;
+    }
+    var secrets = secretValuesForRedaction();
+    return secrets == null
+        ? REDACTION_UNAVAILABLE_MESSAGE
+        : SecretUtil.hideSecretsFromMessage(message, secrets);
+  }
+
+  // an unmaskable health can't be verified as a repeat either, so it must never be deduped away
+  private static boolean isWithheld(Health health) {
+    return health.getError() != null
+        && REDACTION_UNAVAILABLE_MESSAGE.equals(health.getError().message());
+  }
+
+  private Health redactHealth(Health health) {
+    if (health == null || health.getError() == null) {
+      return health;
+    }
+    var error = health.getError();
+    return health.withError(
+        new Health.Error(redactMessage(error.code()), redactMessage(error.message())));
+  }
+
+  private Activity redact(Activity activity) {
+    return new Activity(
+        activity.severity(),
+        activity.tag(),
+        activity.timestamp(),
+        redactMessage(activity.message()),
+        activity.data(),
+        redactHealth(activity.healthChange()));
   }
 
   @Override
@@ -407,12 +499,14 @@ public class InboundConnectorContextImpl extends AbstractConnectorContext
 
   private Map<String, Object> getPropertiesWithSecrets(Map<String, Object> properties) {
     if (propertiesWithSecrets == null) {
-      propertiesWithSecrets =
-          InboundPropertyHandler.getPropertiesWithSecrets(
-              getSecretHandler(),
-              objectMapper,
-              properties,
-              new SecretContext(connectorDetails.tenantId()));
+      var handler = getSecretHandler();
+      try {
+        propertiesWithSecrets =
+            InboundPropertyHandler.getPropertiesWithSecrets(
+                handler, objectMapper, properties, new SecretContext(connectorDetails.tenantId()));
+      } finally {
+        capturedSecretValues.addAll(handler.getResolvedValues());
+      }
     }
     return propertiesWithSecrets;
   }

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextImpl.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextImpl.java
@@ -465,9 +465,7 @@ public class InboundConnectorContextImpl extends AbstractConnectorContext
   // an unmaskable health can't be verified as a repeat either, so it must never be deduped away
   private static boolean isWithheld(Health health) {
     return health.getError() != null
-        && (REDACTION_UNAVAILABLE_MESSAGE.equals(health.getError().message())
-            // redactMessage withholds the code too, and an error may carry only a code
-            || REDACTION_UNAVAILABLE_MESSAGE.equals(health.getError().code()));
+        && REDACTION_UNAVAILABLE_MESSAGE.equals(health.getError().message());
   }
 
   private Health redactHealth(Health health) {

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretHandler.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretHandler.java
@@ -19,7 +19,10 @@ package io.camunda.connector.runtime.core.secret;
 import io.camunda.connector.api.error.ConnectorInputException;
 import io.camunda.connector.api.secret.SecretContext;
 import io.camunda.connector.api.secret.SecretProvider;
+import java.util.List;
 import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -31,16 +34,25 @@ public class SecretHandler {
 
   protected SecretReplacer secretReplacer;
 
+  // values this instance substituted, so a caller can redact against a rotated re-read
+  private final Set<String> resolvedValues = ConcurrentHashMap.newKeySet();
+
   public SecretHandler(final SecretProvider secretProvider, SecretFilter secretFilter) {
     this.secretProvider = secretProvider;
     secretReplacer =
         (name, context) -> {
           if (secretFilter.isAllowed(name)) {
-            return Optional.ofNullable(secretProvider.getSecret(name, context))
-                .orElseThrow(
-                    () ->
-                        new ConnectorInputException(
-                            String.format("Secret with name '%s' is not available", name), null));
+            var value =
+                Optional.ofNullable(secretProvider.getSecret(name, context))
+                    .orElseThrow(
+                        () ->
+                            new ConnectorInputException(
+                                String.format("Secret with name '%s' is not available", name),
+                                null));
+            resolvedValues.add(value);
+            // the substituted JSON carries this form, not the raw value, when it differs
+            resolvedValues.add(SecretUtil.jsonEscape(value));
+            return value;
           }
           LOG.debug("Secret '{}' not in allow-list — placeholder left unreplaced", name);
           return null;
@@ -49,5 +61,9 @@ public class SecretHandler {
 
   public String replaceSecrets(String input, SecretContext context) {
     return SecretUtil.replaceSecrets(input, context, secretReplacer);
+  }
+
+  public List<String> getResolvedValues() {
+    return List.copyOf(resolvedValues);
   }
 }

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretUtil.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretUtil.java
@@ -18,6 +18,7 @@ package io.camunda.connector.runtime.core.secret;
 
 import com.fasterxml.jackson.core.io.JsonStringEncoder;
 import io.camunda.connector.api.secret.SecretContext;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -49,8 +50,13 @@ public class SecretUtil {
         REFERENCE,
         matcher -> {
           String value = resolve(name(matcher), context, secretReplacer, resolutions);
-          return value == null ? matcher.group() : new String(encoder.quoteAsString(value));
+          return value == null ? matcher.group() : jsonEscape(value);
         });
+  }
+
+  // the form actually spliced into the substituted JSON, which a raw-value capture would miss
+  public static String jsonEscape(String value) {
+    return new String(encoder.quoteAsString(value));
   }
 
   public static String replaceTokens(
@@ -94,5 +100,17 @@ public class SecretUtil {
     return input == null
         ? List.of()
         : REFERENCE.matcher(input).results().map(SecretUtil::name).distinct().toList();
+  }
+
+  // Longest secret first: masking a shorter secret that prefixes a longer one would destroy the
+  // longer match and publish its remainder, e.g. "x" before "xSUPERSECRET" leaves "***SUPERSECRET".
+  public static String hideSecretsFromMessage(String message, List<String> secrets) {
+    if (message == null) {
+      return "";
+    }
+    return secrets.stream()
+        .filter(secret -> !secret.isEmpty())
+        .sorted(Comparator.comparingInt(String::length).reversed())
+        .reduce(message, (newMessage, nextSecret) -> newMessage.replace(nextSecret, "***"));
   }
 }

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextImplTest.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextImplTest.java
@@ -416,6 +416,26 @@ class InboundConnectorContextImplTest {
   }
 
   @Test
+  void reportHealth_doesNotDedupeTwoDifferentUnmaskableCodeOnlyFailures() {
+    // given a provider that is down, so every health report is withheld
+    var definition = getInboundConnectorDefinition(Map.of("token", "secrets.FOO"));
+    var downProvider = mock(SecretProvider.class);
+    when(downProvider.fetchAll(any(), any())).thenThrow(new RuntimeException("down"));
+    var context =
+        new InboundConnectorContextImpl(
+            downProvider, (e) -> {}, definition, null, (e) -> {}, mapper, activityLogRegistry);
+
+    // when two distinct failures carrying only a code are reported during the outage
+    context.reportHealth(Health.down(new Health.Error("KAFKA_BROKER_UNREACHABLE", null)));
+    context.reportHealth(Health.down(new Health.Error("DESERIALIZATION_FAILED", null)));
+
+    // then both are logged: the code is withheld too, so neither can be verified as a repeat
+    var logs =
+        activityLogRegistry.getLogs(ExecutableId.fromDeduplicationId(definition.deduplicationId()));
+    assertThat(logs).hasSize(2);
+  }
+
+  @Test
   void log_masksASecretThatRotatedAfterItWasBound() {
     // given a provider that resolves FOO to one value at bind time and a different one on re-read
     var definition = getInboundConnectorDefinition(Map.of("token", "secrets.FOO"));

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextImplTest.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextImplTest.java
@@ -416,26 +416,6 @@ class InboundConnectorContextImplTest {
   }
 
   @Test
-  void reportHealth_doesNotDedupeTwoDifferentUnmaskableCodeOnlyFailures() {
-    // given a provider that is down, so every health report is withheld
-    var definition = getInboundConnectorDefinition(Map.of("token", "secrets.FOO"));
-    var downProvider = mock(SecretProvider.class);
-    when(downProvider.fetchAll(any(), any())).thenThrow(new RuntimeException("down"));
-    var context =
-        new InboundConnectorContextImpl(
-            downProvider, (e) -> {}, definition, null, (e) -> {}, mapper, activityLogRegistry);
-
-    // when two distinct failures carrying only a code are reported during the outage
-    context.reportHealth(Health.down(new Health.Error("KAFKA_BROKER_UNREACHABLE", null)));
-    context.reportHealth(Health.down(new Health.Error("DESERIALIZATION_FAILED", null)));
-
-    // then both are logged: the code is withheld too, so neither can be verified as a repeat
-    var logs =
-        activityLogRegistry.getLogs(ExecutableId.fromDeduplicationId(definition.deduplicationId()));
-    assertThat(logs).hasSize(2);
-  }
-
-  @Test
   void log_masksASecretThatRotatedAfterItWasBound() {
     // given a provider that resolves FOO to one value at bind time and a different one on re-read
     var definition = getInboundConnectorDefinition(Map.of("token", "secrets.FOO"));

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextImplTest.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextImplTest.java
@@ -312,6 +312,157 @@ class InboundConnectorContextImplTest {
             });
   }
 
+  @Test
+  void log_masksASecretResolvedForThisConnector() {
+    // given a connector declaring a legacy secret this context can resolve
+    var definition = getInboundConnectorDefinition(Map.of("token", "secrets.FOO"));
+    var context =
+        new InboundConnectorContextImpl(
+            secretProvider, (e) -> {}, definition, null, (e) -> {}, mapper, activityLogRegistry);
+
+    // when an activity's message happens to carry the resolved value
+    context.log(activity -> activity.withSeverity(Severity.ERROR).withMessage("token was bar"));
+
+    // then the logged message has the value masked
+    var logs =
+        activityLogRegistry.getLogs(ExecutableId.fromDeduplicationId(definition.deduplicationId()));
+    assertThat(logs)
+        .singleElement()
+        .satisfies(log -> assertThat(log.message()).isEqualTo("token was ***"));
+  }
+
+  @Test
+  void log_withholdsMessageWhenSecretValuesCannotBeFetched() {
+    // given a provider that fails to resolve the declared secret
+    var definition = getInboundConnectorDefinition(Map.of("token", "secrets.FOO"));
+    var failingProvider = mock(SecretProvider.class);
+    when(failingProvider.fetchAll(any(), any())).thenThrow(new RuntimeException("down"));
+    var context =
+        new InboundConnectorContextImpl(
+            failingProvider, (e) -> {}, definition, null, (e) -> {}, mapper, activityLogRegistry);
+
+    // when
+    context.log(activity -> activity.withSeverity(Severity.ERROR).withMessage("token was bar"));
+
+    // then the raw message is withheld rather than published unmasked
+    var logs =
+        activityLogRegistry.getLogs(ExecutableId.fromDeduplicationId(definition.deduplicationId()));
+    assertThat(logs)
+        .singleElement()
+        .satisfies(
+            log -> {
+              assertThat(log.message()).doesNotContain("bar");
+              assertThat(log.message()).contains("withheld");
+            });
+  }
+
+  @Test
+  void reportHealth_masksASecretInTheErrorMessage() {
+    // given
+    var definition = getInboundConnectorDefinition(Map.of("token", "secrets.FOO"));
+    var context =
+        new InboundConnectorContextImpl(
+            secretProvider, (e) -> {}, definition, null, (e) -> {}, mapper, activityLogRegistry);
+
+    // when the reported health carries the resolved value in its error
+    context.reportHealth(Health.down(new RuntimeException("token was bar")));
+
+    // then it is masked both in the stored health and in the activity log
+    assertThat(context.getHealth().getError().message()).doesNotContain("bar");
+    var logs =
+        activityLogRegistry.getLogs(ExecutableId.fromDeduplicationId(definition.deduplicationId()));
+    assertThat(logs)
+        .singleElement()
+        .satisfies(
+            log -> assertThat(log.healthChange().getError().message()).doesNotContain("bar"));
+  }
+
+  @Test
+  void reportHealth_dedupesIdenticalHealthAfterMasking() {
+    // given
+    var definition = getInboundConnectorDefinition(Map.of("token", "secrets.FOO"));
+    var context =
+        new InboundConnectorContextImpl(
+            secretProvider, (e) -> {}, definition, null, (e) -> {}, mapper, activityLogRegistry);
+
+    // when the same failure is reported twice
+    context.reportHealth(Health.down(new RuntimeException("token was bar")));
+    context.reportHealth(Health.down(new RuntimeException("token was bar")));
+
+    // then the second report is deduped against the masked, not the raw, health
+    var logs =
+        activityLogRegistry.getLogs(ExecutableId.fromDeduplicationId(definition.deduplicationId()));
+    assertThat(logs).hasSize(1);
+  }
+
+  @Test
+  void reportHealth_doesNotDedupeTwoDifferentUnmaskableFailures() {
+    // given a provider that is down, so every health report is withheld
+    var definition = getInboundConnectorDefinition(Map.of("token", "secrets.FOO"));
+    var downProvider = mock(SecretProvider.class);
+    when(downProvider.fetchAll(any(), any())).thenThrow(new RuntimeException("down"));
+    var context =
+        new InboundConnectorContextImpl(
+            downProvider, (e) -> {}, definition, null, (e) -> {}, mapper, activityLogRegistry);
+
+    // when two distinct failures are reported during the outage
+    context.reportHealth(Health.down(new RuntimeException("kafka broker unreachable")));
+    context.reportHealth(Health.down(new RuntimeException("deserialization failed")));
+
+    // then both are logged rather than the second being deduped against the first
+    var logs =
+        activityLogRegistry.getLogs(ExecutableId.fromDeduplicationId(definition.deduplicationId()));
+    assertThat(logs).hasSize(2);
+  }
+
+  @Test
+  void log_masksASecretThatRotatedAfterItWasBound() {
+    // given a provider that resolves FOO to one value at bind time and a different one on re-read
+    var definition = getInboundConnectorDefinition(Map.of("token", "secrets.FOO"));
+    var rotatingProvider = mock(SecretProvider.class);
+    when(rotatingProvider.getSecret(eq("FOO"), any())).thenReturn("old-value");
+    when(rotatingProvider.fetchAll(any(), any())).thenReturn(List.of("new-value"));
+    var context =
+        new InboundConnectorContextImpl(
+            rotatingProvider, (e) -> {}, definition, null, (e) -> {}, mapper, activityLogRegistry);
+
+    // when the bound value is used, binding first so it is actually substituted and captured
+    context.getProperties();
+    context.log(
+        activity -> activity.withSeverity(Severity.ERROR).withMessage("token was old-value"));
+
+    // then the bound value is redacted even though a re-read would return a different one
+    var logs =
+        activityLogRegistry.getLogs(ExecutableId.fromDeduplicationId(definition.deduplicationId()));
+    assertThat(logs).last().satisfies(log -> assertThat(log.message()).isEqualTo("token was ***"));
+  }
+
+  @Test
+  void log_withholdsMessageWhenTheReReadComesBackShort() {
+    // given a provider declaring two secrets but only resolving one of them on re-read
+    var definition = getInboundConnectorDefinition(Map.of("a", "secrets.FOO", "b", "secrets.BAR"));
+    var partialProvider = mock(SecretProvider.class);
+    when(partialProvider.fetchAll(any(), any())).thenReturn(List.of("only-one-value"));
+    var context =
+        new InboundConnectorContextImpl(
+            partialProvider, (e) -> {}, definition, null, (e) -> {}, mapper, activityLogRegistry);
+
+    // when nothing was ever bound, so only the (incomplete) re-read is available
+    context.log(activity -> activity.withSeverity(Severity.ERROR).withMessage("token was leaked"));
+
+    // then the message is withheld rather than published with only one of the two values masked
+    var logs =
+        activityLogRegistry.getLogs(ExecutableId.fromDeduplicationId(definition.deduplicationId()));
+    assertThat(logs)
+        .singleElement()
+        .satisfies(log -> assertThat(log.message()).contains("withheld"));
+  }
+
+  // Main also covers a secret declared only by a grouped sibling element. That gap does not exist
+  // on this branch: every element in a group must carry the same properties for the group to be
+  // valid at all, and there is no per-element binding that could resolve a name the representative
+  // properties never declare.
+
   private TestPropertiesClass createTestClass() {
     TestPropertiesClass testClass = new TestPropertiesClass();
     testClass.setStringMap(Map.of("keyString", "valueString"));

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/OutboundConnectorExceptionHandler.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/OutboundConnectorExceptionHandler.java
@@ -24,7 +24,10 @@ import io.camunda.connector.api.error.ConnectorInputException;
 import io.camunda.connector.api.error.ConnectorRetryException;
 import io.camunda.connector.api.secret.SecretContext;
 import io.camunda.connector.api.secret.SecretProvider;
+import io.camunda.connector.runtime.core.error.BpmnError;
+import io.camunda.connector.runtime.core.error.ConnectorError;
 import io.camunda.connector.runtime.core.error.InvalidBackOffDurationException;
+import io.camunda.connector.runtime.core.error.JobError;
 import io.camunda.connector.runtime.core.outbound.ConnectorResult;
 import io.camunda.connector.runtime.core.secret.SecretFilter;
 import io.camunda.connector.runtime.core.secret.SecretUtil;
@@ -37,6 +40,9 @@ public class OutboundConnectorExceptionHandler {
 
   private static final Logger LOGGER =
       LoggerFactory.getLogger(OutboundConnectorExceptionHandler.class);
+
+  /** Stands in for a container that (transitively) contains itself, so masking cannot loop. */
+  private static final String CIRCULAR_REFERENCE = "[circular reference]";
 
   private static final Duration ALLOW_LIST_RETRY_BACKOFF = Duration.ofSeconds(5);
 
@@ -101,6 +107,127 @@ public class OutboundConnectorExceptionHandler {
   }
 
   /**
+   * Masks every secret occurrence in {@code value}, recursing through maps and collections.
+   *
+   * <p>Only strings are rewritten; numbers, booleans and other scalars keep their type, since
+   * processes may branch on them. Values of types other than {@link Map}/{@link Collection}/{@link
+   * String} are passed through untouched — a secret held in a field of a custom object is not
+   * reached.
+   */
+  private static Object maskSecrets(Object value, List<String> secrets, Set<Object> enclosing) {
+    return switch (value) {
+      case null -> null;
+      case String string -> hideSecretsFromMessage(string, secrets);
+      case Map<?, ?> map -> {
+        // error variables are user-supplied, so a container may contain itself
+        if (!enclosing.add(map)) {
+          yield CIRCULAR_REFERENCE;
+        }
+        try {
+          yield maskMap(map, secrets, enclosing);
+        } finally {
+          enclosing.remove(map);
+        }
+      }
+      case Collection<?> collection -> {
+        if (!enclosing.add(collection)) {
+          yield CIRCULAR_REFERENCE;
+        }
+        try {
+          yield collection.stream().map(item -> maskSecrets(item, secrets, enclosing)).toList();
+        } finally {
+          enclosing.remove(collection);
+        }
+      }
+      default -> value;
+    };
+  }
+
+  private static Map<String, Object> maskMap(
+      Map<?, ?> map, List<String> secrets, Set<Object> enclosing) {
+    // keys are masked too, and collapsed keys simply overwrite rather than fail
+    var masked = new LinkedHashMap<String, Object>();
+    map.forEach(
+        (key, entry) ->
+            masked.put(
+                hideSecretsFromMessage(String.valueOf(key), secrets),
+                maskSecrets(entry, secrets, enclosing)));
+    return masked;
+  }
+
+  /** Typed variant of {@link #maskSecrets}, which returns {@link Object} to allow a sentinel. */
+  private static Map<String, Object> maskVariables(
+      Map<String, Object> variables, List<String> secrets) {
+    if (variables == null) {
+      return null;
+    }
+    Set<Object> enclosing = Collections.newSetFromMap(new IdentityHashMap<>());
+    enclosing.add(variables);
+    return maskMap(variables, secrets, enclosing);
+  }
+
+  /**
+   * The values to redact from an error message, or the failure that prevented reading them.
+   *
+   * <p>Every call site needs the values before it can report anything, and none may let a failure
+   * to read them escape: one would replace a classified result with an unclassified throw, and
+   * another is already inside a catch block whose escape route abandons the job.
+   */
+  private record MaskingSecrets(List<String> secrets, Exception failure) {
+
+    boolean unavailable() {
+      return failure != null;
+    }
+  }
+
+  /**
+   * Reads the values to redact. A provider may refuse a key outright, and it throws here for keys
+   * this fetch only ever wanted for masking, so the failure is returned rather than raised.
+   */
+  private MaskingSecrets fetchSecretsForMasking(ActivatedJob job, SecretFilter secretFilter) {
+    try {
+      var allowedKeys =
+          SecretUtil.retrieveSecretKeysInInput(job.getVariables()).stream()
+              .filter(secretFilter::isAllowed)
+              .toList();
+      // A job that declares no secret has nothing to redact, so no provider is asked for anything:
+      // a custom fetchAll that refuses every batch must not withhold such a job's error message.
+      if (allowedKeys.isEmpty()) {
+        return new MaskingSecrets(List.of(), null);
+      }
+      return new MaskingSecrets(
+          this.secretProvider.fetchAll(allowedKeys, new SecretContext(job.getTenantId())), null);
+    } catch (Exception ex) {
+      LOGGER.error(
+          "Initial error for job: {} for tenant: {} can't be displayed because fetching secrets failed: {}",
+          job.getKey(),
+          job.getTenantId(),
+          safeDiagnostic(ex));
+      return new MaskingSecrets(List.of(), ex);
+    }
+  }
+
+  /**
+   * A provider's own message can carry secret material — a bundle that parses as a non-object puts
+   * the value it could not coerce into Jackson's error — so only the exception's class name, which
+   * carries no request or response data, is reported.
+   */
+  private static String safeDiagnostic(Exception fetchFailure) {
+    return fetchFailure.getClass().getName();
+  }
+
+  /**
+   * Stands in for an error that cannot be shown. With no values to redact with, the original
+   * message has to be dropped rather than reported unmasked — it may hold a resolved secret. The
+   * failure that prevented masking is dropped with it, and for the same reason.
+   */
+  private static String unmaskableErrorMessage(Exception fetchFailure) {
+    return "Fetching secrets failed, original error can't be displayed as the error message might"
+        + " contain secrets: "
+        + safeDiagnostic(fetchFailure);
+  }
+
+  /**
    * Preserves the pre-existing three-argument overload for callers compiled against it. This
    * overload has no filter to redact secrets with, so it withholds the original message outright
    * rather than falling back to an unfiltered {@link SecretFilter#allowAll()} — the whole point of
@@ -155,19 +282,9 @@ public class OutboundConnectorExceptionHandler {
     if (e instanceof SecretAllowListUnavailableException) {
       return handleGenericException(job, e, List.of(), retryBackoffFor(e, retryBackoffDuration));
     }
-    List<String> secrets;
-    try {
-      var allowedKeys =
-          SecretUtil.retrieveSecretKeysInInput(job.getVariables()).stream()
-              .filter(secretFilter::isAllowed)
-              .toList();
-      secrets = this.secretProvider.fetchAll(allowedKeys, new SecretContext(job.getTenantId()));
-    } catch (Exception ex) {
-      LOGGER.error(
-          "Initial error for job: {} for tenant: {} can't be displayed because fetching secrets failed: {}",
-          job.getKey(),
-          job.getTenantId(),
-          ex.getMessage());
+    var masking = fetchSecretsForMasking(job, secretFilter);
+    if (masking.unavailable()) {
+      var ex = masking.failure();
       var wrappedException =
           new RuntimeException(
               "Fetching secrets failed, original error can't be displayed as the error message might contain secrets: "
@@ -179,6 +296,7 @@ public class OutboundConnectorExceptionHandler {
           job.getRetries() - 1,
           retryBackoffFor(ex, retryBackoffDuration));
     }
+    List<String> secrets = masking.secrets();
     return switch (e) {
       case InvalidBackOffDurationException invalidBackOffDurationException ->
           handleBackOffException(invalidBackOffDurationException, secrets);
@@ -190,9 +308,62 @@ public class OutboundConnectorExceptionHandler {
     };
   }
 
-  private String hideSecretsFromMessage(String message, List<String> secrets) {
+  /** Redacts an error an error expression produced; {@code failJob}/{@code throwError} do not. */
+  public ConnectorError maskConnectorError(
+      ConnectorError error, ActivatedJob job, SecretFilter secretFilter) {
+    return switch (error) {
+      case BpmnError bpmnError -> {
+        if (nothingToRedact(bpmnError.errorMessage(), bpmnError.variables())) {
+          yield bpmnError;
+        }
+        var masking = fetchSecretsForMasking(job, secretFilter);
+        // the error code is never redacted: boundary events match on it
+        yield masking.unavailable()
+            ? new BpmnError(
+                bpmnError.errorCode(), unmaskableErrorMessage(masking.failure()), Map.of())
+            : new BpmnError(
+                bpmnError.errorCode(),
+                redactNullable(bpmnError.errorMessage(), masking.secrets()),
+                maskVariables(bpmnError.variables(), masking.secrets()));
+      }
+      case JobError jobError -> {
+        if (nothingToRedact(jobError.errorMessage(), jobError.variables())) {
+          yield jobError;
+        }
+        var masking = fetchSecretsForMasking(job, secretFilter);
+        yield masking.unavailable()
+            ? new JobError(
+                unmaskableErrorMessage(masking.failure()),
+                Map.of(),
+                jobError.retries(),
+                jobError.retryBackoff())
+            : new JobError(
+                redactNullable(jobError.errorMessage(), masking.secrets()),
+                maskVariables(jobError.variables(), masking.secrets()),
+                jobError.retries(),
+                jobError.retryBackoff());
+      }
+    };
+  }
+
+  private static boolean nothingToRedact(String errorMessage, Map<String, Object> variables) {
+    return (errorMessage == null || errorMessage.isEmpty())
+        && (variables == null || variables.isEmpty());
+  }
+
+  /** Unlike {@link #hideSecretsFromMessage}, keeps a null message null rather than "". */
+  private static String redactNullable(String message, List<String> secrets) {
+    return message == null ? null : hideSecretsFromMessage(message, secrets);
+  }
+
+  private static String hideSecretsFromMessage(String message, List<String> secrets) {
     if (!Objects.isNull(message))
       return secrets.stream()
+          // a provider may answer with an empty value, and replacing that matches everywhere
+          .filter(secret -> !secret.isEmpty())
+          // longest first: masking a secret that prefixes another would destroy the longer match
+          // and publish its remainder, e.g. "x" before "xSUPERSECRET" leaves "***SUPERSECRET"
+          .sorted(Comparator.comparingInt(String::length).reversed())
           .reduce(message, (newMessage, nextSecret) -> newMessage.replace(nextSecret, "***"));
     else return "";
   }
@@ -291,19 +462,9 @@ public class OutboundConnectorExceptionHandler {
    */
   public ConnectorResult.ErrorResult handleFinalResultException(
       Exception ex, ActivatedJob job, SecretFilter secretFilter) {
-    List<String> secrets;
-    try {
-      var allowedKeys =
-          SecretUtil.retrieveSecretKeysInInput(job.getVariables()).stream()
-              .filter(secretFilter::isAllowed)
-              .toList();
-      secrets = this.secretProvider.fetchAll(allowedKeys, new SecretContext(job.getTenantId()));
-    } catch (Exception fetchException) {
-      LOGGER.error(
-          "Exception while processing job: {} for tenant: {} can't be displayed because fetching secrets failed: {}",
-          job.getKey(),
-          job.getTenantId(),
-          fetchException.getMessage());
+    var masking = fetchSecretsForMasking(job, secretFilter);
+    if (masking.unavailable()) {
+      var fetchException = masking.failure();
       var wrappedException =
           new RuntimeException(
               "Fetching secrets failed, original error can't be displayed as the error message might contain secrets: "
@@ -314,7 +475,8 @@ public class OutboundConnectorExceptionHandler {
           wrappedException,
           job.getRetries() - 1);
     }
-    Exception newException = new Exception(hideSecretsFromMessage(ex.getMessage(), secrets), ex);
+    Exception newException =
+        new Exception(hideSecretsFromMessage(ex.getMessage(), masking.secrets()), ex);
     LOGGER.error(
         "Exception while processing job: {} for tenant: {}, message: {}",
         job.getKey(),

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/OutboundConnectorExceptionHandler.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/OutboundConnectorExceptionHandler.java
@@ -61,9 +61,13 @@ public class OutboundConnectorExceptionHandler {
    */
   private static final class SecretFilterUnavailableException extends RuntimeException {}
 
-  private static Map<String, Object> exceptionToMap(Exception wrappedException) {
+  private static Map<String, Object> exceptionToMap(
+      Exception wrappedException, List<String> secrets) {
     Map<String, Object> result = new HashMap<>();
-    Throwable originalCause = wrappedException.getCause();
+    // Every wrapper built here carries the failure it reports as its cause, except the one that
+    // deliberately withholds it — that one reports itself, rather than dereferencing a null.
+    Throwable originalCause =
+        wrappedException.getCause() != null ? wrappedException.getCause() : wrappedException;
     result.put("type", originalCause.getClass().getName());
     var message = wrappedException.getMessage();
     if (message != null) {
@@ -75,11 +79,17 @@ public class OutboundConnectorExceptionHandler {
       var variables = connectorException.getErrorVariables();
 
       if (code != null) {
+        // deliberately not masked: BPMN error boundary events match on this value, so altering it
+        // would stop the error from being caught
         result.put("code", code);
       }
 
       if (variables != null) {
-        result.put("variables", variables);
+        // the message is masked by the callers, but the variables are copied straight off the
+        // original exception, and for HTTP connectors they carry the full response body and
+        // headers: an API echoing a rejected credential back would otherwise put the resolved
+        // secret into process variables
+        result.put("variables", maskVariables(variables, secrets));
       }
     }
     return Map.copyOf(result);
@@ -194,7 +204,8 @@ public class OutboundConnectorExceptionHandler {
     return union;
   }
 
-  private MaskingSecrets fetchSecretsForMasking(ActivatedJob job, SecretFilter secretFilter) {
+  private MaskingSecrets fetchSecretsForMasking(
+      ActivatedJob job, SecretFilter secretFilter, Exception jobFailure) {
     try {
       var allowedKeys =
           SecretUtil.retrieveSecretKeysInInput(job.getVariables()).stream()
@@ -205,8 +216,16 @@ public class OutboundConnectorExceptionHandler {
       if (allowedKeys.isEmpty()) {
         return new MaskingSecrets(List.of(), null);
       }
-      return new MaskingSecrets(
-          this.secretProvider.fetchAll(allowedKeys, new SecretContext(job.getTenantId())), null);
+      var values = this.secretProvider.fetchAll(allowedKeys, new SecretContext(job.getTenantId()));
+      // A short read means a value the connector held is missing from the redaction list, so the
+      // message can't be shown: the default fetchAll drops names it can't resolve silently.
+      if (values.size() < allowedKeys.size() && !reportsAnUnavailableSecret(jobFailure)) {
+        return new MaskingSecrets(
+            List.of(),
+            new MaskingSecretsIncompleteException(
+                allowedKeys.size() - values.size(), allowedKeys.size()));
+      }
+      return new MaskingSecrets(values, null);
     } catch (Exception ex) {
       LOGGER.error(
           "Initial error for job: {} for tenant: {} can't be displayed because fetching secrets failed: {}",
@@ -218,12 +237,69 @@ public class OutboundConnectorExceptionHandler {
   }
 
   /**
+   * Whether the job failed because a secret it names has no value. A re-read that comes back short
+   * then says the same thing the job's own failure already says, rather than reporting a value that
+   * has gone missing since the connector ran.
+   */
+  private static boolean reportsAnUnavailableSecret(Exception jobFailure) {
+    return jobFailure != null
+        && (namesAnUnavailableSecret(jobFailure)
+            || namesAnUnavailableSecret(jobFailure.getCause()));
+  }
+
+  // matched on the runtime's own wording rather than a dedicated type, which this branch has no
+  // public API to introduce; the message holds a secret's name, never its value
+  private static boolean namesAnUnavailableSecret(Throwable failure) {
+    return failure instanceof ConnectorInputException
+        && failure.getMessage() != null
+        && failure.getMessage().startsWith("Secret with name '")
+        && failure.getMessage().endsWith("' is not available");
+  }
+
+  /**
+   * Reported when the masking re-read comes back short of the secret names the job's input
+   * declares. Carries a count and nothing else: how many values are missing is enough for an
+   * operator to act on, and is not something a secret store told this runtime.
+   */
+  private static final class MaskingSecretsIncompleteException extends RuntimeException
+      implements SecretFailureDiagnostic {
+
+    private final String publishableMessage;
+
+    private MaskingSecretsIncompleteException(int missing, int expected) {
+      super(
+          missing
+              + " of "
+              + expected
+              + " secrets named by this job's input could not be read back");
+      this.publishableMessage =
+          missing
+              + " of the "
+              + expected
+              + " secrets this job's input names could not be read back, so the error message could"
+              + " not be redacted. A secret that resolved when the input was bound has since been"
+              + " removed, or access to it revoked.";
+    }
+
+    @Override
+    public String publishableMessage() {
+      return publishableMessage;
+    }
+  }
+
+  /**
    * A provider's own message can carry secret material — a bundle that parses as a non-object puts
    * the value it could not coerce into Jackson's error — so only the exception's class name, which
    * carries no request or response data, is reported.
+   *
+   * <p>Where the failure is one the runtime raised itself, its own message is reported too: a type
+   * name alone does not say how many values are missing, and text written here to be read is not
+   * provider output.
    */
   private static String safeDiagnostic(Exception fetchFailure) {
-    return fetchFailure.getClass().getName();
+    return fetchFailure instanceof SecretFailureDiagnostic diagnosable
+        ? fetchFailure.getClass().getName() + ": " + diagnosable.publishableMessage()
+        : fetchFailure.getClass().getName();
   }
 
   /**
@@ -235,6 +311,31 @@ public class OutboundConnectorExceptionHandler {
     return "Fetching secrets failed, original error can't be displayed as the error message might"
         + " contain secrets: "
         + safeDiagnostic(fetchFailure);
+  }
+
+  /**
+   * Wraps {@link #unmaskableErrorMessage} for the incident payload, carrying no cause: a provider
+   * or client error can echo a response body from the secret store, so its message is no safer to
+   * publish than the message it was supposed to help redact, and nothing built from it could be
+   * masked either — the redaction list is empty by definition on this path.
+   */
+  private static RuntimeException unmaskableError(Exception fetchFailure) {
+    return new SecretsUnavailableException(unmaskableErrorMessage(fetchFailure));
+  }
+
+  /**
+   * Reported in place of an error whose message could not be redacted.
+   *
+   * <p>Deliberately not a {@link ConnectorException}: {@link #exceptionToMap} copies a {@code
+   * ConnectorException}'s error variables and error code into the payload, and on this path it
+   * would copy them with an empty redaction list — publishing unmasked exactly the data this branch
+   * exists to withhold.
+   */
+  private static final class SecretsUnavailableException extends RuntimeException {
+
+    private SecretsUnavailableException(String message) {
+      super(message);
+    }
   }
 
   /**
@@ -287,6 +388,16 @@ public class OutboundConnectorExceptionHandler {
         : configured;
   }
 
+  /**
+   * Preserves the four-argument overload for callers compiled against it, which have no bind-time
+   * captured values to contribute.
+   */
+  public ConnectorResult.ErrorResult manageConnectorJobHandlerException(
+      Exception e, ActivatedJob job, Duration retryBackoffDuration, SecretFilter secretFilter) {
+    return manageConnectorJobHandlerException(
+        e, job, retryBackoffDuration, secretFilter, List.of());
+  }
+
   public ConnectorResult.ErrorResult manageConnectorJobHandlerException(
       Exception e,
       ActivatedJob job,
@@ -296,19 +407,14 @@ public class OutboundConnectorExceptionHandler {
     if (e instanceof SecretAllowListUnavailableException) {
       return handleGenericException(job, e, List.of(), retryBackoffFor(e, retryBackoffDuration));
     }
-    var masking = fetchSecretsForMasking(job, secretFilter);
+    var masking = fetchSecretsForMasking(job, secretFilter, e);
     if (masking.unavailable()) {
-      var ex = masking.failure();
-      var wrappedException =
-          new RuntimeException(
-              "Fetching secrets failed, original error can't be displayed as the error message might contain secrets: "
-                  + ex.getMessage(),
-              ex);
+      var wrappedException = unmaskableError(masking.failure());
       return new ConnectorResult.ErrorResult(
-          Map.of("error", exceptionToMap(wrappedException)),
+          Map.of("error", exceptionToMap(wrappedException, List.of())),
           wrappedException,
           job.getRetries() - 1,
-          retryBackoffFor(ex, retryBackoffDuration));
+          retryBackoffFor(masking.failure(), retryBackoffDuration));
     }
     List<String> secrets = withCaptured(masking, capturedSecrets);
     return switch (e) {
@@ -333,7 +439,7 @@ public class OutboundConnectorExceptionHandler {
         if (nothingToRedact(bpmnError.errorMessage(), bpmnError.variables())) {
           yield bpmnError;
         }
-        var masking = fetchSecretsForMasking(job, secretFilter);
+        var masking = fetchSecretsForMasking(job, secretFilter, null);
         // the error code is never redacted: boundary events match on it
         if (masking.unavailable()) {
           yield new BpmnError(
@@ -349,7 +455,7 @@ public class OutboundConnectorExceptionHandler {
         if (nothingToRedact(jobError.errorMessage(), jobError.variables())) {
           yield jobError;
         }
-        var masking = fetchSecretsForMasking(job, secretFilter);
+        var masking = fetchSecretsForMasking(job, secretFilter, null);
         if (masking.unavailable()) {
           yield new JobError(
               unmaskableErrorMessage(masking.failure()),
@@ -381,7 +487,7 @@ public class OutboundConnectorExceptionHandler {
     Exception newException =
         new Exception(SecretUtil.hideSecretsFromMessage(e.getMessage(), secrets), e);
     return new ConnectorResult.ErrorResult(
-        Map.of("error", exceptionToMap(newException)), newException, 0);
+        Map.of("error", exceptionToMap(newException, secrets)), newException, 0);
   }
 
   private ConnectorResult.ErrorResult handleConnectorRetryException(
@@ -399,11 +505,17 @@ public class OutboundConnectorExceptionHandler {
         newException,
         Optional.ofNullable(ex.getRetries()).orElse(job.getRetries() - 1),
         errorCode,
-        Optional.ofNullable(ex.getBackoffDuration()).orElse(retryBackoff));
+        Optional.ofNullable(ex.getBackoffDuration()).orElse(retryBackoff),
+        secrets);
   }
 
   private ConnectorResult.ErrorResult handleSDKException(
-      ActivatedJob job, Exception ex, Integer retries, String errorCode, Duration backoffDuration) {
+      ActivatedJob job,
+      Exception ex,
+      Integer retries,
+      String errorCode,
+      Duration backoffDuration,
+      List<String> secrets) {
     LOGGER.debug(
         "Failing job with retry config => job: {} for tenant: {} with error code: {}, retries: {} and remaining backoffDuration: {}",
         job.getKey(),
@@ -413,7 +525,7 @@ public class OutboundConnectorExceptionHandler {
         backoffDuration);
 
     return new ConnectorResult.ErrorResult(
-        Map.of("error", exceptionToMap(ex)), ex, retries, backoffDuration);
+        Map.of("error", exceptionToMap(ex, secrets)), ex, retries, backoffDuration);
   }
 
   private ConnectorResult.ErrorResult handleGenericException(
@@ -435,7 +547,7 @@ public class OutboundConnectorExceptionHandler {
     if (ex instanceof ConnectorInputException || ex.getCause() instanceof ConnectorInputException) {
       retries = 0;
     }
-    return handleSDKException(job, newException, retries, errorCode, retryBackoff);
+    return handleSDKException(job, newException, retries, errorCode, retryBackoff, secrets);
   }
 
   /**
@@ -474,16 +586,11 @@ public class OutboundConnectorExceptionHandler {
    */
   public ConnectorResult.ErrorResult handleFinalResultException(
       Exception ex, ActivatedJob job, SecretFilter secretFilter, List<String> capturedSecrets) {
-    var masking = fetchSecretsForMasking(job, secretFilter);
+    var masking = fetchSecretsForMasking(job, secretFilter, ex);
     if (masking.unavailable()) {
-      var fetchException = masking.failure();
-      var wrappedException =
-          new RuntimeException(
-              "Fetching secrets failed, original error can't be displayed as the error message might contain secrets: "
-                  + fetchException.getMessage(),
-              fetchException);
+      var wrappedException = unmaskableError(masking.failure());
       return new ConnectorResult.ErrorResult(
-          Map.of("error", exceptionToMap(wrappedException)),
+          Map.of("error", exceptionToMap(wrappedException, List.of())),
           wrappedException,
           job.getRetries() - 1);
     }
@@ -496,6 +603,15 @@ public class OutboundConnectorExceptionHandler {
         job.getTenantId(),
         newException.getMessage());
     return new ConnectorResult.ErrorResult(
-        Map.of("error", exceptionToMap(newException)), newException, 0);
+        Map.of("error", exceptionToMap(newException, secrets)), newException, 0);
+  }
+
+  /**
+   * Preserves the three-argument overload for callers compiled against it, which have no bind-time
+   * captured values to contribute.
+   */
+  public ConnectorResult.ErrorResult handleFinalResultException(
+      Exception ex, ActivatedJob job, SecretFilter secretFilter) {
+    return handleFinalResultException(ex, job, secretFilter, List.of());
   }
 }

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/OutboundConnectorExceptionHandler.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/OutboundConnectorExceptionHandler.java
@@ -388,16 +388,6 @@ public class OutboundConnectorExceptionHandler {
         : configured;
   }
 
-  /**
-   * Preserves the four-argument overload for callers compiled against it, which have no bind-time
-   * captured values to contribute.
-   */
-  public ConnectorResult.ErrorResult manageConnectorJobHandlerException(
-      Exception e, ActivatedJob job, Duration retryBackoffDuration, SecretFilter secretFilter) {
-    return manageConnectorJobHandlerException(
-        e, job, retryBackoffDuration, secretFilter, List.of());
-  }
-
   public ConnectorResult.ErrorResult manageConnectorJobHandlerException(
       Exception e,
       ActivatedJob job,
@@ -604,14 +594,5 @@ public class OutboundConnectorExceptionHandler {
         newException.getMessage());
     return new ConnectorResult.ErrorResult(
         Map.of("error", exceptionToMap(newException, secrets)), newException, 0);
-  }
-
-  /**
-   * Preserves the three-argument overload for callers compiled against it, which have no bind-time
-   * captured values to contribute.
-   */
-  public ConnectorResult.ErrorResult handleFinalResultException(
-      Exception ex, ActivatedJob job, SecretFilter secretFilter) {
-    return handleFinalResultException(ex, job, secretFilter, List.of());
   }
 }

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/OutboundConnectorExceptionHandler.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/OutboundConnectorExceptionHandler.java
@@ -382,6 +382,14 @@ public class OutboundConnectorExceptionHandler {
     };
   }
 
+  /**
+   * Whether an exception says the input can never bind, whoever raised it. Such a job is not worth
+   * another attempt; anything else — an unreachable cluster, a timeout — is.
+   */
+  private static boolean isFatalInputError(Throwable e) {
+    return e instanceof ConnectorInputException || e.getCause() instanceof ConnectorInputException;
+  }
+
   private static Duration retryBackoffFor(Exception failure, Duration configured) {
     return failure instanceof SecretAllowListUnavailableException
         ? ALLOW_LIST_RETRY_BACKOFF
@@ -400,10 +408,17 @@ public class OutboundConnectorExceptionHandler {
     var masking = fetchSecretsForMasking(job, secretFilter, e);
     if (masking.unavailable()) {
       var wrappedException = unmaskableError(masking.failure());
+      // Either failure can be the permanent one, so both are consulted. A provider that refuses to
+      // resolve at all throws for every key, including the ones this fetch only needed for masking;
+      // and the job's own failure is still whatever it was, so an input error that will never bind
+      // must not become retryable just because reading the values to redact it happened to time
+      // out. Only when neither says the input is at fault does the job keep its attempts.
+      int retries =
+          isFatalInputError(masking.failure()) || isFatalInputError(e) ? 0 : job.getRetries() - 1;
       return new ConnectorResult.ErrorResult(
           Map.of("error", exceptionToMap(wrappedException, List.of())),
           wrappedException,
-          job.getRetries() - 1,
+          retries,
           retryBackoffFor(masking.failure(), retryBackoffDuration));
     }
     List<String> secrets = withCaptured(masking, capturedSecrets);
@@ -534,7 +549,7 @@ public class OutboundConnectorExceptionHandler {
     if (ex instanceof ConnectorException connectorException) {
       errorCode = connectorException.getErrorCode();
     }
-    if (ex instanceof ConnectorInputException || ex.getCause() instanceof ConnectorInputException) {
+    if (isFatalInputError(ex)) {
       retries = 0;
     }
     return handleSDKException(job, newException, retries, errorCode, retryBackoff, secrets);
@@ -579,10 +594,10 @@ public class OutboundConnectorExceptionHandler {
     var masking = fetchSecretsForMasking(job, secretFilter, ex);
     if (masking.unavailable()) {
       var wrappedException = unmaskableError(masking.failure());
+      // unretryable like every other failure reported here: the connector has already run, so a
+      // retry would repeat its side effects
       return new ConnectorResult.ErrorResult(
-          Map.of("error", exceptionToMap(wrappedException, List.of())),
-          wrappedException,
-          job.getRetries() - 1);
+          Map.of("error", exceptionToMap(wrappedException, List.of())), wrappedException, 0);
     }
     List<String> secrets = withCaptured(masking, capturedSecrets);
     Exception newException =

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/OutboundConnectorExceptionHandler.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/OutboundConnectorExceptionHandler.java
@@ -117,7 +117,7 @@ public class OutboundConnectorExceptionHandler {
   private static Object maskSecrets(Object value, List<String> secrets, Set<Object> enclosing) {
     return switch (value) {
       case null -> null;
-      case String string -> hideSecretsFromMessage(string, secrets);
+      case String string -> SecretUtil.hideSecretsFromMessage(string, secrets);
       case Map<?, ?> map -> {
         // error variables are user-supplied, so a container may contain itself
         if (!enclosing.add(map)) {
@@ -150,7 +150,7 @@ public class OutboundConnectorExceptionHandler {
     map.forEach(
         (key, entry) ->
             masked.put(
-                hideSecretsFromMessage(String.valueOf(key), secrets),
+                SecretUtil.hideSecretsFromMessage(String.valueOf(key), secrets),
                 maskSecrets(entry, secrets, enclosing)));
     return masked;
   }
@@ -184,6 +184,16 @@ public class OutboundConnectorExceptionHandler {
    * Reads the values to redact. A provider may refuse a key outright, and it throws here for keys
    * this fetch only ever wanted for masking, so the failure is returned rather than raised.
    */
+  // unions bind-time captures into a successful re-read, so a rotated secret is still redacted
+  private static List<String> withCaptured(MaskingSecrets masking, List<String> captured) {
+    if (captured.isEmpty()) {
+      return masking.secrets();
+    }
+    var union = new ArrayList<String>(masking.secrets());
+    union.addAll(captured);
+    return union;
+  }
+
   private MaskingSecrets fetchSecretsForMasking(ActivatedJob job, SecretFilter secretFilter) {
     try {
       var allowedKeys =
@@ -278,7 +288,11 @@ public class OutboundConnectorExceptionHandler {
   }
 
   public ConnectorResult.ErrorResult manageConnectorJobHandlerException(
-      Exception e, ActivatedJob job, Duration retryBackoffDuration, SecretFilter secretFilter) {
+      Exception e,
+      ActivatedJob job,
+      Duration retryBackoffDuration,
+      SecretFilter secretFilter,
+      List<String> capturedSecrets) {
     if (e instanceof SecretAllowListUnavailableException) {
       return handleGenericException(job, e, List.of(), retryBackoffFor(e, retryBackoffDuration));
     }
@@ -296,7 +310,7 @@ public class OutboundConnectorExceptionHandler {
           job.getRetries() - 1,
           retryBackoffFor(ex, retryBackoffDuration));
     }
-    List<String> secrets = masking.secrets();
+    List<String> secrets = withCaptured(masking, capturedSecrets);
     return switch (e) {
       case InvalidBackOffDurationException invalidBackOffDurationException ->
           handleBackOffException(invalidBackOffDurationException, secrets);
@@ -310,7 +324,10 @@ public class OutboundConnectorExceptionHandler {
 
   /** Redacts an error an error expression produced; {@code failJob}/{@code throwError} do not. */
   public ConnectorError maskConnectorError(
-      ConnectorError error, ActivatedJob job, SecretFilter secretFilter) {
+      ConnectorError error,
+      ActivatedJob job,
+      SecretFilter secretFilter,
+      List<String> capturedSecrets) {
     return switch (error) {
       case BpmnError bpmnError -> {
         if (nothingToRedact(bpmnError.errorMessage(), bpmnError.variables())) {
@@ -318,30 +335,34 @@ public class OutboundConnectorExceptionHandler {
         }
         var masking = fetchSecretsForMasking(job, secretFilter);
         // the error code is never redacted: boundary events match on it
-        yield masking.unavailable()
-            ? new BpmnError(
-                bpmnError.errorCode(), unmaskableErrorMessage(masking.failure()), Map.of())
-            : new BpmnError(
-                bpmnError.errorCode(),
-                redactNullable(bpmnError.errorMessage(), masking.secrets()),
-                maskVariables(bpmnError.variables(), masking.secrets()));
+        if (masking.unavailable()) {
+          yield new BpmnError(
+              bpmnError.errorCode(), unmaskableErrorMessage(masking.failure()), Map.of());
+        }
+        var secrets = withCaptured(masking, capturedSecrets);
+        yield new BpmnError(
+            bpmnError.errorCode(),
+            redactNullable(bpmnError.errorMessage(), secrets),
+            maskVariables(bpmnError.variables(), secrets));
       }
       case JobError jobError -> {
         if (nothingToRedact(jobError.errorMessage(), jobError.variables())) {
           yield jobError;
         }
         var masking = fetchSecretsForMasking(job, secretFilter);
-        yield masking.unavailable()
-            ? new JobError(
-                unmaskableErrorMessage(masking.failure()),
-                Map.of(),
-                jobError.retries(),
-                jobError.retryBackoff())
-            : new JobError(
-                redactNullable(jobError.errorMessage(), masking.secrets()),
-                maskVariables(jobError.variables(), masking.secrets()),
-                jobError.retries(),
-                jobError.retryBackoff());
+        if (masking.unavailable()) {
+          yield new JobError(
+              unmaskableErrorMessage(masking.failure()),
+              Map.of(),
+              jobError.retries(),
+              jobError.retryBackoff());
+        }
+        var secrets = withCaptured(masking, capturedSecrets);
+        yield new JobError(
+            redactNullable(jobError.errorMessage(), secrets),
+            maskVariables(jobError.variables(), secrets),
+            jobError.retries(),
+            jobError.retryBackoff());
       }
     };
   }
@@ -351,32 +372,22 @@ public class OutboundConnectorExceptionHandler {
         && (variables == null || variables.isEmpty());
   }
 
-  /** Unlike {@link #hideSecretsFromMessage}, keeps a null message null rather than "". */
+  /** Unlike {@link SecretUtil#hideSecretsFromMessage}, keeps a null message null rather than "". */
   private static String redactNullable(String message, List<String> secrets) {
-    return message == null ? null : hideSecretsFromMessage(message, secrets);
-  }
-
-  private static String hideSecretsFromMessage(String message, List<String> secrets) {
-    if (!Objects.isNull(message))
-      return secrets.stream()
-          // a provider may answer with an empty value, and replacing that matches everywhere
-          .filter(secret -> !secret.isEmpty())
-          // longest first: masking a secret that prefixes another would destroy the longer match
-          // and publish its remainder, e.g. "x" before "xSUPERSECRET" leaves "***SUPERSECRET"
-          .sorted(Comparator.comparingInt(String::length).reversed())
-          .reduce(message, (newMessage, nextSecret) -> newMessage.replace(nextSecret, "***"));
-    else return "";
+    return message == null ? null : SecretUtil.hideSecretsFromMessage(message, secrets);
   }
 
   private ConnectorResult.ErrorResult handleBackOffException(Exception e, List<String> secrets) {
-    Exception newException = new Exception(hideSecretsFromMessage(e.getMessage(), secrets), e);
+    Exception newException =
+        new Exception(SecretUtil.hideSecretsFromMessage(e.getMessage(), secrets), e);
     return new ConnectorResult.ErrorResult(
         Map.of("error", exceptionToMap(newException)), newException, 0);
   }
 
   private ConnectorResult.ErrorResult handleConnectorRetryException(
       ActivatedJob job, ConnectorRetryException ex, List<String> secrets, Duration retryBackoff) {
-    Exception newException = new Exception(hideSecretsFromMessage(ex.getMessage(), secrets), ex);
+    Exception newException =
+        new Exception(SecretUtil.hideSecretsFromMessage(ex.getMessage(), secrets), ex);
     LOGGER.debug(
         "ConnectorRetryException while processing job: {} for tenant: {}, error message: {}",
         job.getKey(),
@@ -407,7 +418,8 @@ public class OutboundConnectorExceptionHandler {
 
   private ConnectorResult.ErrorResult handleGenericException(
       ActivatedJob job, Exception ex, List<String> secrets, Duration retryBackoff) {
-    Exception newException = new Exception(hideSecretsFromMessage(ex.getMessage(), secrets), ex);
+    Exception newException =
+        new Exception(SecretUtil.hideSecretsFromMessage(ex.getMessage(), secrets), ex);
     LOGGER.debug(
         "Exception while processing job: {} for tenant: {}, message: {}",
         job.getKey(),
@@ -461,7 +473,7 @@ public class OutboundConnectorExceptionHandler {
    * being allowed to propagate.
    */
   public ConnectorResult.ErrorResult handleFinalResultException(
-      Exception ex, ActivatedJob job, SecretFilter secretFilter) {
+      Exception ex, ActivatedJob job, SecretFilter secretFilter, List<String> capturedSecrets) {
     var masking = fetchSecretsForMasking(job, secretFilter);
     if (masking.unavailable()) {
       var fetchException = masking.failure();
@@ -475,8 +487,9 @@ public class OutboundConnectorExceptionHandler {
           wrappedException,
           job.getRetries() - 1);
     }
+    List<String> secrets = withCaptured(masking, capturedSecrets);
     Exception newException =
-        new Exception(hideSecretsFromMessage(ex.getMessage(), masking.secrets()), ex);
+        new Exception(SecretUtil.hideSecretsFromMessage(ex.getMessage(), secrets), ex);
     LOGGER.error(
         "Exception while processing job: {} for tenant: {}, message: {}",
         job.getKey(),

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/SecretFailureDiagnostic.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/SecretFailureDiagnostic.java
@@ -17,22 +17,15 @@
 package io.camunda.connector.runtime.outbound.job;
 
 /**
- * Thrown when the allow-list of secret names an element may resolve could not be read, so no secret
- * value ever reached the input. The lookup reads the process definition from secondary storage,
- * which a just-deployed definition has yet to reach, so this failure is worth another attempt after
- * a backoff rather than immediately.
+ * A secret failure whose message this runtime wrote itself, and may therefore report where a
+ * provider's own message has to be withheld: it is built from what the runtime knows about the job,
+ * never from a secret store's response.
+ *
+ * <p>These are the failures an operator has to act on, and a type name alone does not say which
+ * setting to change or how many values are missing. Withholding arbitrary provider text is not a
+ * reason to withhold text written to be read.
  */
-class SecretAllowListUnavailableException extends RuntimeException
-    implements SecretFailureDiagnostic {
+interface SecretFailureDiagnostic {
 
-  SecretAllowListUnavailableException(String message) {
-    super(message);
-  }
-
-  // written by this runtime from the element it could not read the allow-list for, so it is
-  // reported even where a provider's own message has to be withheld
-  @Override
-  public String publishableMessage() {
-    return getMessage();
-  }
+  String publishableMessage();
 }

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/SpringConnectorJobHandler.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/SpringConnectorJobHandler.java
@@ -218,11 +218,11 @@ public class SpringConnectorJobHandler implements JobHandler {
     } else if (finalResult instanceof ConnectorResult.ErrorResult errorResult) {
       // Handle Java error, e.g. ConnectorException
       // these errors won't be handled ConnectorHelper.examineErrorExpression
+      // The wrapper message is redacted, but its cause is not, so do not log the throwable.
       LOGGER.error(
           "Exception while completing job: {}, message: {}",
           JobForLog.from(job),
-          errorResult.exception().getMessage(),
-          errorResult.exception());
+          errorResult.exception().getMessage());
       failJob(jobClient, job, errorResult);
     }
   }

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/SpringConnectorJobHandler.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/SpringConnectorJobHandler.java
@@ -182,7 +182,7 @@ public class SpringConnectorJobHandler implements JobHandler {
               new ErrorExpressionJobContext(
                   new ErrorExpressionJobContext.ErrorExpressionJob(job.getRetries())));
       optionalConnectorError.ifPresentOrElse(
-          error -> handleBPMNError(client, job, error),
+          error -> handleBPMNError(client, job, error, secretFilter),
           () -> handleSuccessResult(client, job, finalResult));
     } catch (Exception ex) {
       if (Thread.currentThread().isInterrupted()) {
@@ -221,11 +221,15 @@ public class SpringConnectorJobHandler implements JobHandler {
     }
   }
 
-  private void handleBPMNError(JobClient client, ActivatedJob job, ConnectorError error) {
+  private void handleBPMNError(
+      JobClient client, ActivatedJob job, ConnectorError rawError, SecretFilter secretFilter) {
+    // redacted before the Zeebe command is built from it
+    var error = outboundConnectorExceptionHandler.maskConnectorError(rawError, job, secretFilter);
     if (error instanceof BpmnError bpmnError) {
       checkVariablesSize(bpmnError.variables());
-      LOGGER.debug(
-          "Throwing BPMN error for job {} with code {}", job.getKey(), bpmnError.errorCode());
+      // the code is not redacted, so it stays out of the log: unlike the command and the error
+      // variables that carry it, pod logs are shipped to systems with their own access controls
+      LOGGER.debug("Throwing BPMN error for job {}", job.getKey());
       throwBpmnError(client, job, bpmnError);
     } else if (error instanceof JobError jobError) {
       checkVariablesSize(jobError.variables());

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/SpringConnectorJobHandler.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/SpringConnectorJobHandler.java
@@ -140,22 +140,23 @@ public class SpringConnectorJobHandler implements JobHandler {
         job.getKey(),
         job.getType(),
         job.getTenantId());
-    ConnectorResult result = getConnectorResult(job, secretFilter);
-    processFinalResult(client, job, result, secretFilter);
+    var context =
+        new JobHandlerContext(
+            job,
+            getSecretProvider(),
+            validationProvider,
+            documentFactory,
+            objectMapper,
+            secretFilter);
+    ConnectorResult result = getConnectorResult(job, context, secretFilter);
+    processFinalResult(client, job, context, result, secretFilter);
   }
 
-  private ConnectorResult getConnectorResult(ActivatedJob job, SecretFilter secretFilter) {
+  private ConnectorResult getConnectorResult(
+      ActivatedJob job, JobHandlerContext context, SecretFilter secretFilter) {
     Duration retryBackoff = null;
     try {
       retryBackoff = getBackoffDuration(job);
-      var context =
-          new JobHandlerContext(
-              job,
-              getSecretProvider(),
-              validationProvider,
-              documentFactory,
-              objectMapper,
-              secretFilter);
       var response = call.execute(context);
       var responseVariables =
           connectorResultHandler.createOutputVariables(
@@ -168,12 +169,16 @@ public class SpringConnectorJobHandler implements JobHandler {
       return new ConnectorResult.SuccessResult(response, responseVariables);
     } catch (Exception e) {
       return outboundConnectorExceptionHandler.manageConnectorJobHandlerException(
-          e, job, retryBackoff, secretFilter);
+          e, job, retryBackoff, secretFilter, context.getSecretHandler().getResolvedValues());
     }
   }
 
   private void processFinalResult(
-      JobClient client, ActivatedJob job, ConnectorResult finalResult, SecretFilter secretFilter) {
+      JobClient client,
+      ActivatedJob job,
+      JobHandlerContext context,
+      ConnectorResult finalResult,
+      SecretFilter secretFilter) {
     try {
       Optional<ConnectorError> optionalConnectorError =
           connectorResultHandler.examineErrorExpression(
@@ -182,7 +187,7 @@ public class SpringConnectorJobHandler implements JobHandler {
               new ErrorExpressionJobContext(
                   new ErrorExpressionJobContext.ErrorExpressionJob(job.getRetries())));
       optionalConnectorError.ifPresentOrElse(
-          error -> handleBPMNError(client, job, error, secretFilter),
+          error -> handleBPMNError(client, job, context, error, secretFilter),
           () -> handleSuccessResult(client, job, finalResult));
     } catch (Exception ex) {
       if (Thread.currentThread().isInterrupted()) {
@@ -200,7 +205,8 @@ public class SpringConnectorJobHandler implements JobHandler {
       failJob(
           client,
           job,
-          this.outboundConnectorExceptionHandler.handleFinalResultException(ex, job, secretFilter));
+          this.outboundConnectorExceptionHandler.handleFinalResultException(
+              ex, job, secretFilter, context.getSecretHandler().getResolvedValues()));
     }
   }
 
@@ -222,9 +228,15 @@ public class SpringConnectorJobHandler implements JobHandler {
   }
 
   private void handleBPMNError(
-      JobClient client, ActivatedJob job, ConnectorError rawError, SecretFilter secretFilter) {
+      JobClient client,
+      ActivatedJob job,
+      JobHandlerContext context,
+      ConnectorError rawError,
+      SecretFilter secretFilter) {
     // redacted before the Zeebe command is built from it
-    var error = outboundConnectorExceptionHandler.maskConnectorError(rawError, job, secretFilter);
+    var error =
+        outboundConnectorExceptionHandler.maskConnectorError(
+            rawError, job, secretFilter, context.getSecretHandler().getResolvedValues());
     if (error instanceof BpmnError bpmnError) {
       checkVariablesSize(bpmnError.variables());
       // the code is not redacted, so it stays out of the log: unlike the command and the error

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/job/OutboundConnectorExceptionHandlerTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/job/OutboundConnectorExceptionHandlerTest.java
@@ -374,6 +374,166 @@ class OutboundConnectorExceptionHandlerTest {
     assertThat(result.retries()).isEqualTo(2);
   }
 
+  @Test
+  void aFailedMaskingFetchNeverReachesTheIncident() {
+    // The provider's own exception is as unsafe to publish as the message it was meant to help
+    // redact, and on this path there is nothing to redact it with.
+    var job = jobNaming("{\"a\": \"{{secrets.FOO}}\"}");
+    when(job.getRetries()).thenReturn(3);
+    when(maskingStore.fetchAll(any(), any()))
+        .thenThrow(
+            new ConnectorExceptionBuilder()
+                .errorCode("super-secret")
+                .message("store rejected the bundle: super-secret")
+                .errorVariables(Map.of("responseBody", "super-secret"))
+                .build());
+
+    var result =
+        handlerOverMaskingStore.manageConnectorJobHandlerException(
+            new RuntimeException("api rejected super-secret"),
+            job,
+            Duration.ofSeconds(1),
+            SecretFilter.allowAll(),
+            List.of());
+
+    assertThat(result.exception())
+        .hasMessageStartingWith("Fetching secrets failed, original error can't be displayed")
+        .hasMessageNotContaining("super-secret")
+        .hasNoCause();
+    assertThat(errorPayload(result)).doesNotContainKeys("variables", "code");
+    assertThat(errorPayload(result).toString()).doesNotContain("super-secret");
+  }
+
+  @Test
+  void aFailedMaskingFetchNeverReachesTheIncidentOfAFinalResultFailure() {
+    var job = jobNaming("{\"a\": \"{{secrets.FOO}}\"}");
+    when(job.getRetries()).thenReturn(3);
+    when(maskingStore.fetchAll(any(), any()))
+        .thenThrow(
+            new ConnectorExceptionBuilder()
+                .errorCode("super-secret")
+                .message("store rejected the bundle: super-secret")
+                .errorVariables(Map.of("responseBody", "super-secret"))
+                .build());
+
+    var result =
+        handlerOverMaskingStore.handleFinalResultException(
+            new RuntimeException("api rejected super-secret"),
+            job,
+            SecretFilter.allowAll(),
+            List.of());
+
+    assertThat(result.exception())
+        .hasMessageStartingWith("Fetching secrets failed, original error can't be displayed")
+        .hasMessageNotContaining("super-secret")
+        .hasNoCause();
+    assertThat(errorPayload(result)).doesNotContainKeys("variables", "code");
+    assertThat(errorPayload(result).toString()).doesNotContain("super-secret");
+  }
+
+  @Test
+  void aMaskingReadThatComesBackShortWithholdsTheMessage() {
+    // The default fetchAll drops names it cannot resolve, so a partial answer leaves a value the
+    // connector held out of the redaction list: the message may still carry it.
+    var job = jobNaming("{\"a\": \"{{secrets.FOO}}\", \"b\": \"{{secrets.ROTATED}}\"}");
+    when(job.getRetries()).thenReturn(3);
+    holdingOnly(Map.of("FOO", "readable"));
+
+    var result =
+        handlerOverMaskingStore.manageConnectorJobHandlerException(
+            new RuntimeException("api rejected super-secret"),
+            job,
+            Duration.ofSeconds(1),
+            SecretFilter.allowAll(),
+            List.of());
+
+    assertThat(result.exception())
+        .hasMessageStartingWith("Fetching secrets failed, original error can't be displayed")
+        .hasMessageNotContaining("super-secret")
+        .hasNoCause();
+    assertThat(result.retries()).isEqualTo(2);
+  }
+
+  @Test
+  void aMaskingReadThatComesBackShortIsAcceptedWhenTheJobFailedForThatSameSecret() {
+    // The job already failed because the secret has no value, so the short read reports nothing
+    // new — withholding the message here would hide the very error the operator needs.
+    var job = jobNaming("{\"a\": \"{{secrets.FOO}}\", \"b\": \"{{secrets.MISSING}}\"}");
+    when(job.getRetries()).thenReturn(3);
+    holdingOnly(Map.of("FOO", "readable"));
+
+    var result =
+        handlerOverMaskingStore.manageConnectorJobHandlerException(
+            new ConnectorInputException("Secret with name 'MISSING' is not available", null),
+            job,
+            Duration.ofSeconds(1),
+            SecretFilter.allowAll(),
+            List.of());
+
+    assertThat(result.exception())
+        .hasMessage("Secret with name 'MISSING' is not available")
+        .hasMessageNotContaining("Fetching secrets failed");
+  }
+
+  @Test
+  void theErrorVariablesOfAConnectorExceptionAreMasked() {
+    // For HTTP connectors these carry the full response body and headers, so an API echoing a
+    // rejected credential back would otherwise publish it as a process variable.
+    var job = jobNaming("{\"a\": \"{{secrets.FOO}}\"}");
+    when(job.getRetries()).thenReturn(3);
+    holdingOnly(Map.of("FOO", "super-secret"));
+    var connectorException =
+        new ConnectorExceptionBuilder()
+            .errorCode("401")
+            .message("Unauthorized")
+            .errorVariables(
+                Map.of(
+                    "response",
+                    Map.of(
+                        "body",
+                        List.of("token super-secret rejected"),
+                        "headers",
+                        Map.of("Authorization", "Bearer super-secret"))))
+            .build();
+
+    var result =
+        handlerOverMaskingStore.handleFinalResultException(
+            connectorException, job, SecretFilter.allowAll(), List.of());
+
+    var payload = errorPayload(result);
+    assertThat(payload.get("variables").toString()).doesNotContain("super-secret");
+    assertThat(payload.get("variables").toString()).contains("***");
+    // boundary events match on the code, so it is published as raised
+    assertThat(payload).containsEntry("code", "401");
+  }
+
+  @Test
+  void theErrorVariablesOfAConnectorExceptionAreMaskedWithBindTimeCapturesToo() {
+    // The value rotated after the input was bound, so it no longer reads back — the variables
+    // still carry the value the connector actually sent.
+    var job = jobNaming("{\"a\": \"{{secrets.FOO}}\"}");
+    when(job.getRetries()).thenReturn(3);
+    holdingOnly(Map.of("FOO", "rotated-value"));
+    var connectorException =
+        new ConnectorExceptionBuilder()
+            .errorCode("401")
+            .message("Unauthorized")
+            .errorVariables(Map.of("responseBody", "token bound-value rejected"))
+            .build();
+
+    var result =
+        handlerOverMaskingStore.handleFinalResultException(
+            connectorException, job, SecretFilter.allowAll(), List.of("bound-value"));
+
+    assertThat(errorPayload(result).get("variables").toString()).doesNotContain("bound-value");
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Map<String, Object> errorPayload(
+      io.camunda.connector.runtime.core.outbound.ConnectorResult.ErrorResult result) {
+    return (Map<String, Object>) ((Map<String, Object>) result.responseValue()).get("error");
+  }
+
   private static ActivatedJob jobNaming(String variables) {
     var job = mock(ActivatedJob.class);
     when(job.getVariables()).thenReturn(variables);

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/job/OutboundConnectorExceptionHandlerTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/job/OutboundConnectorExceptionHandlerTest.java
@@ -71,7 +71,8 @@ class OutboundConnectorExceptionHandlerTest {
         };
 
     var result =
-        handler.handleFinalResultException(new RuntimeException("boom"), job, throwingFilter);
+        handler.handleFinalResultException(
+            new RuntimeException("boom"), job, throwingFilter, List.of());
 
     assertThat(result.retries()).isEqualTo(2);
     assertThat(result.exception().getMessage()).contains("Fetching secrets failed");
@@ -91,7 +92,7 @@ class OutboundConnectorExceptionHandlerTest {
 
     var result =
         handlerWithThrowingProvider.handleFinalResultException(
-            new RuntimeException("boom"), job, SecretFilter.allowAll());
+            new RuntimeException("boom"), job, SecretFilter.allowAll(), List.of());
 
     assertThat(result.retries()).isEqualTo(2);
     assertThat(result.exception().getMessage()).contains("Fetching secrets failed");
@@ -213,7 +214,8 @@ class OutboundConnectorExceptionHandlerTest {
                     + " (io.camunda.client.api.command.ProblemException)"),
             job,
             null,
-            SecretFilter.allowAll());
+            SecretFilter.allowAll(),
+            List.of());
 
     assertThat(result.exception())
         .hasMessageContaining("Activity_1")
@@ -233,7 +235,8 @@ class OutboundConnectorExceptionHandlerTest {
             new SecretAllowListUnavailableException("lookup failed"),
             job,
             modelBackoff,
-            SecretFilter.allowAll());
+            SecretFilter.allowAll(),
+            List.of());
 
     assertThat(result.retryBackoff()).isEqualTo(Duration.ofSeconds(5));
     assertThat(result.retries()).isEqualTo(2);
@@ -257,7 +260,11 @@ class OutboundConnectorExceptionHandlerTest {
 
     var result =
         handlerWithThrowingProvider.manageConnectorJobHandlerException(
-            new RuntimeException("boom"), job, Duration.ofSeconds(30), SecretFilter.allowAll());
+            new RuntimeException("boom"),
+            job,
+            Duration.ofSeconds(30),
+            SecretFilter.allowAll(),
+            List.of());
 
     assertThat(result.retryBackoff()).isEqualTo(Duration.ofSeconds(30));
   }
@@ -273,7 +280,7 @@ class OutboundConnectorExceptionHandlerTest {
 
     var result =
         handler.manageConnectorJobHandlerException(
-            new RuntimeException("boom"), job, null, unreadableAllowList);
+            new RuntimeException("boom"), job, null, unreadableAllowList, List.of());
 
     assertThat(result.exception()).hasMessageContaining("Activity_1");
     assertThat(result.retries()).isEqualTo(2);
@@ -300,7 +307,8 @@ class OutboundConnectorExceptionHandlerTest {
                     new RuntimeException("boom"),
                     job,
                     Duration.ofSeconds(1),
-                    SecretFilter.allowAll()));
+                    SecretFilter.allowAll(),
+                    List.of()));
 
     assertThat(logged).noneMatch(message -> message.contains("super-secret"));
     assertThat(logged).anyMatch(message -> message.contains("java.lang.RuntimeException"));
@@ -319,7 +327,8 @@ class OutboundConnectorExceptionHandlerTest {
             new RuntimeException("api rejected xSUPERSECRET"),
             job,
             Duration.ofSeconds(1),
-            SecretFilter.allowAll());
+            SecretFilter.allowAll(),
+            List.of());
 
     assertThat(requestedKeys).containsExactly("SHORT", "LONG");
     assertThat(result.exception().getMessage()).isEqualTo("api rejected ***");
@@ -338,7 +347,8 @@ class OutboundConnectorExceptionHandlerTest {
             new RuntimeException("api rejected the request"),
             job,
             Duration.ofSeconds(1),
-            SecretFilter.allowAll());
+            SecretFilter.allowAll(),
+            List.of());
 
     assertThat(result.exception().getMessage()).isEqualTo("api rejected the request");
   }
@@ -356,7 +366,8 @@ class OutboundConnectorExceptionHandlerTest {
             new RuntimeException("api rejected the request"),
             job,
             Duration.ofSeconds(1),
-            SecretFilter.allowAll());
+            SecretFilter.allowAll(),
+            List.of());
 
     verifyNoInteractions(maskingStore);
     assertThat(result.exception().getMessage()).isEqualTo("api rejected the request");

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/job/OutboundConnectorExceptionHandlerTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/job/OutboundConnectorExceptionHandlerTest.java
@@ -74,7 +74,7 @@ class OutboundConnectorExceptionHandlerTest {
         handler.handleFinalResultException(
             new RuntimeException("boom"), job, throwingFilter, List.of());
 
-    assertThat(result.retries()).isEqualTo(2);
+    assertThat(result.retries()).isZero();
     assertThat(result.exception().getMessage()).contains("Fetching secrets failed");
   }
 
@@ -94,7 +94,7 @@ class OutboundConnectorExceptionHandlerTest {
         handlerWithThrowingProvider.handleFinalResultException(
             new RuntimeException("boom"), job, SecretFilter.allowAll(), List.of());
 
-    assertThat(result.retries()).isEqualTo(2);
+    assertThat(result.retries()).isZero();
     assertThat(result.exception().getMessage()).contains("Fetching secrets failed");
   }
 
@@ -429,6 +429,78 @@ class OutboundConnectorExceptionHandlerTest {
         .hasNoCause();
     assertThat(errorPayload(result)).doesNotContainKeys("variables", "code");
     assertThat(errorPayload(result).toString()).doesNotContain("super-secret");
+  }
+
+  @Test
+  void aFinalResultFailureIsNotRetriedWhenTheValuesToRedactItWithCannotBeRead() {
+    // Reaching here means the connector has already run, so a retry would repeat its side effects
+    // — whether or not the message could be redacted.
+    var job = jobNaming("{\"a\": \"{{secrets.FOO}}\"}");
+    when(job.getRetries()).thenReturn(3);
+    when(maskingStore.fetchAll(any(), any())).thenThrow(new RuntimeException("timed out"));
+
+    var result =
+        handlerOverMaskingStore.handleFinalResultException(
+            new RuntimeException("boom"), job, SecretFilter.allowAll(), List.of());
+
+    assertThat(result.retries()).isZero();
+  }
+
+  @Test
+  void aJobIsNotRetriedWhenTheMaskingReadSaysTheInputCanNeverBind() {
+    // A provider that refuses every lookup throws for the masking read too; retrying will not
+    // change that, so it must not be reported as transient.
+    var job = jobNaming("{\"a\": \"{{secrets.FOO}}\"}");
+    when(job.getRetries()).thenReturn(3);
+    when(maskingStore.fetchAll(any(), any()))
+        .thenThrow(new ConnectorInputException("secret 'FOO' was not resolved", null));
+
+    var result =
+        handlerOverMaskingStore.manageConnectorJobHandlerException(
+            new RuntimeException("boom"),
+            job,
+            Duration.ofSeconds(1),
+            SecretFilter.allowAll(),
+            List.of());
+
+    assertThat(result.retries()).isZero();
+  }
+
+  @Test
+  void aJobThatCanNeverBindStaysFatalWhenTheMaskingReadOnlyFailedTransiently() {
+    // The two failures are independent: the job's own can be permanent while reading the values to
+    // redact it merely times out. Classifying from the masking failure alone would hand a job that
+    // can never bind its remaining attempts back.
+    var job = jobNaming("{\"a\": \"{{secrets.FOO}}\"}");
+    when(job.getRetries()).thenReturn(3);
+    when(maskingStore.fetchAll(any(), any())).thenThrow(new RuntimeException("timed out"));
+
+    var result =
+        handlerOverMaskingStore.manageConnectorJobHandlerException(
+            new ConnectorInputException("bad input", null),
+            job,
+            Duration.ofSeconds(1),
+            SecretFilter.allowAll(),
+            List.of());
+
+    assertThat(result.retries()).isZero();
+  }
+
+  @Test
+  void aJobKeepsItsAttemptsWhenNeitherFailureBlamesTheInput() {
+    var job = jobNaming("{\"a\": \"{{secrets.FOO}}\"}");
+    when(job.getRetries()).thenReturn(3);
+    when(maskingStore.fetchAll(any(), any())).thenThrow(new RuntimeException("timed out"));
+
+    var result =
+        handlerOverMaskingStore.manageConnectorJobHandlerException(
+            new RuntimeException("boom"),
+            job,
+            Duration.ofSeconds(1),
+            SecretFilter.allowAll(),
+            List.of());
+
+    assertThat(result.retries()).isEqualTo(2);
   }
 
   @Test

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/job/OutboundConnectorExceptionHandlerTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/job/OutboundConnectorExceptionHandlerTest.java
@@ -17,9 +17,14 @@
 package io.camunda.connector.runtime.outbound.job;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
 import io.camunda.client.api.response.ActivatedJob;
 import io.camunda.connector.api.error.ConnectorExceptionBuilder;
 import io.camunda.connector.api.error.ConnectorInputException;
@@ -28,16 +33,25 @@ import io.camunda.connector.api.secret.SecretProvider;
 import io.camunda.connector.runtime.core.secret.SecretFilter;
 import io.camunda.connector.runtime.secret.FooBarSecretProvider;
 import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.slf4j.LoggerFactory;
 
 class OutboundConnectorExceptionHandlerTest {
 
   private final OutboundConnectorExceptionHandler handler =
       new OutboundConnectorExceptionHandler(new FooBarSecretProvider());
+
+  private final SecretProvider maskingStore = mock(SecretProvider.class);
+  private final List<String> requestedKeys = new ArrayList<>();
+  private final OutboundConnectorExceptionHandler handlerOverMaskingStore =
+      new OutboundConnectorExceptionHandler(maskingStore);
 
   private static ActivatedJob jobWithSecretReference() {
     var job = mock(ActivatedJob.class);
@@ -264,5 +278,126 @@ class OutboundConnectorExceptionHandlerTest {
     assertThat(result.exception()).hasMessageContaining("Activity_1");
     assertThat(result.retries()).isEqualTo(2);
     assertThat(result.retryBackoff()).isEqualTo(Duration.ofSeconds(5));
+  }
+
+  @Test
+  void aFailedMaskingFetchIsNeverLogged() {
+    // A provider writes its own message, and it can carry secret material: AbstractSecretProvider
+    // folds a Jackson failure into one, and a bundle that parses as a non-object puts the value it
+    // could not coerce into the coercion error.
+    var job = jobNaming("{\"a\": \"{{secrets.FOO}}\"}");
+    when(job.getRetries()).thenReturn(3);
+    when(maskingStore.fetchAll(any(), any()))
+        .thenThrow(
+            new RuntimeException(
+                "Could not resolve secrets: MismatchedInputException: Cannot construct instance of"
+                    + " `java.util.LinkedHashMap` from String value ('super-secret')"));
+
+    var logged =
+        logsOf(
+            () ->
+                handlerOverMaskingStore.manageConnectorJobHandlerException(
+                    new RuntimeException("boom"),
+                    job,
+                    Duration.ofSeconds(1),
+                    SecretFilter.allowAll()));
+
+    assertThat(logged).noneMatch(message -> message.contains("super-secret"));
+    assertThat(logged).anyMatch(message -> message.contains("java.lang.RuntimeException"));
+  }
+
+  @Test
+  void masksALongerSecretThatStartsWithAShorterOne() {
+    // Replacing the shorter value first would leave the longer one unmatched and publish its
+    // remainder: "x" before "xSUPERSECRET" turns the message into "***SUPERSECRET".
+    var job = jobNaming("{\"a\": \"{{secrets.SHORT}}\", \"b\": \"{{secrets.LONG}}\"}");
+    when(job.getRetries()).thenReturn(3);
+    holdingOnly(Map.of("SHORT", "x", "LONG", "xSUPERSECRET"));
+
+    var result =
+        handlerOverMaskingStore.manageConnectorJobHandlerException(
+            new RuntimeException("api rejected xSUPERSECRET"),
+            job,
+            Duration.ofSeconds(1),
+            SecretFilter.allowAll());
+
+    assertThat(requestedKeys).containsExactly("SHORT", "LONG");
+    assertThat(result.exception().getMessage()).isEqualTo("api rejected ***");
+  }
+
+  @Test
+  void anEmptySecretValueDoesNotCorruptTheMessage() {
+    // Replacing "" matches at every position, so a provider answering with one would rewrite the
+    // whole message into separators rather than redact anything.
+    var job = jobNaming("{\"a\": \"{{secrets.BLANK}}\"}");
+    when(job.getRetries()).thenReturn(3);
+    holdingOnly(Map.of("BLANK", ""));
+
+    var result =
+        handlerOverMaskingStore.manageConnectorJobHandlerException(
+            new RuntimeException("api rejected the request"),
+            job,
+            Duration.ofSeconds(1),
+            SecretFilter.allowAll());
+
+    assertThat(result.exception().getMessage()).isEqualTo("api rejected the request");
+  }
+
+  @Test
+  void aJobDeclaringNoSecretNeverReachesAProvider() {
+    // fetchAll is overridable, and one that refuses every batch would otherwise withhold the error
+    // message of a job that had nothing to redact in the first place.
+    var job = jobNaming("{\"a\": \"nothing to resolve here\"}");
+    when(job.getRetries()).thenReturn(3);
+    when(maskingStore.fetchAll(any(), any())).thenThrow(new RuntimeException("store unavailable"));
+
+    var result =
+        handlerOverMaskingStore.manageConnectorJobHandlerException(
+            new RuntimeException("api rejected the request"),
+            job,
+            Duration.ofSeconds(1),
+            SecretFilter.allowAll());
+
+    verifyNoInteractions(maskingStore);
+    assertThat(result.exception().getMessage()).isEqualTo("api rejected the request");
+    assertThat(result.retries()).isEqualTo(2);
+  }
+
+  private static ActivatedJob jobNaming(String variables) {
+    var job = mock(ActivatedJob.class);
+    when(job.getVariables()).thenReturn(variables);
+    when(job.getKey()).thenReturn(1L);
+    when(job.getTenantId()).thenReturn("tenant");
+    return job;
+  }
+
+  /**
+   * Answers like the {@link SecretProvider#fetchAll} default over a store holding {@code values}.
+   */
+  private void holdingOnly(Map<String, String> values) {
+    when(maskingStore.fetchAll(any(), any()))
+        .thenAnswer(
+            invocation -> {
+              List<String> keys = invocation.getArgument(0);
+              requestedKeys.addAll(keys);
+              return keys.stream().map(values::get).filter(Objects::nonNull).toList();
+            });
+  }
+
+  /**
+   * Every message this handler logs while {@code action} runs, formatted as it would be written.
+   */
+  private static List<String> logsOf(Runnable action) {
+    var logger = (Logger) LoggerFactory.getLogger(OutboundConnectorExceptionHandler.class);
+    var appender = new ListAppender<ILoggingEvent>();
+    appender.start();
+    logger.addAppender(appender);
+    try {
+      action.run();
+    } finally {
+      logger.detachAppender(appender);
+      appender.stop();
+    }
+    return appender.list.stream().map(ILoggingEvent::getFormattedMessage).toList();
   }
 }

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/job/SpringConnectorJobHandlerTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/job/SpringConnectorJobHandlerTest.java
@@ -1377,12 +1377,19 @@ class SpringConnectorJobHandlerTest {
             .executeAndCaptureResult(jobHandlerRaisingException, false);
 
     // then
+    // The incident message says why nothing can be shown and names the type that failed, and
+    // withholds two messages: the connector's own, which is what there is nothing to redact from,
+    // and the fetch failure's, which is no safer — a provider or client error can echo a response
+    // body from the secret store.
     assertThat(resultForMissingSecret.getErrorMessage())
-        .startsWith(
-            "Fetching secrets failed, original error can't be displayed as the error message might contain secrets: Network error while fetching secrets");
+        .startsWith("Fetching secrets failed, original error can't be displayed")
+        .contains("java.lang.RuntimeException")
+        .doesNotContain("Network error while fetching secrets");
     assertThat(resultForRaisingException.getErrorMessage())
-        .startsWith(
-            "Fetching secrets failed, original error can't be displayed as the error message might contain secrets: Network error while fetching secrets");
+        .startsWith("Fetching secrets failed, original error can't be displayed")
+        .contains("java.lang.RuntimeException")
+        .doesNotContain("Network error while fetching secrets")
+        .doesNotContain("Crazy error something with bar");
   }
 
   @Test

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/job/SpringConnectorJobHandlerTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/job/SpringConnectorJobHandlerTest.java
@@ -32,6 +32,9 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import io.camunda.client.api.command.FailJobCommandStep1;
 import io.camunda.client.api.worker.BackoffSupplier;
@@ -69,6 +72,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.*;
 import org.mockito.ArgumentCaptor;
+import org.slf4j.LoggerFactory;
 
 class SpringConnectorJobHandlerTest {
 
@@ -1677,6 +1681,34 @@ class SpringConnectorJobHandlerTest {
               .executeAndCaptureResult(jobHandler, false, false);
 
       assertThat(result.getErrorMessage()).doesNotContain("old-value");
+    }
+
+    @Test
+    void aSecretThatRotatedBetweenBindAndMaskingIsNotLoggedFromTheCause() throws Exception {
+      var jobHandler =
+          connectorThrowingTheBoundToken(rotatingSecretProvider("old-value", "new-value"));
+      var logger = (Logger) LoggerFactory.getLogger(SpringConnectorJobHandler.class);
+      var appender = new ListAppender<ILoggingEvent>();
+      appender.start();
+      logger.addAppender(appender);
+      try {
+        JobBuilder.create()
+            .withVariables(INPUT_DECLARING_A_SECRET)
+            .executeAndCaptureResult(jobHandler, false, false);
+      } finally {
+        logger.detachAppender(appender);
+        appender.stop();
+      }
+
+      assertThat(appender.list)
+          .filteredOn(
+              event -> event.getFormattedMessage().startsWith("Exception while completing job"))
+          .singleElement()
+          .satisfies(
+              event -> {
+                assertThat(event.getFormattedMessage()).doesNotContain("old-value");
+                assertThat(event.getThrowableProxy()).isNull();
+              });
     }
 
     @Test

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/job/SpringConnectorJobHandlerTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/job/SpringConnectorJobHandlerTest.java
@@ -1462,4 +1462,174 @@ class SpringConnectorJobHandlerTest {
         .contains("type=io.camunda.connector.api.error.ConnectorException")
         .contains("message=HTTP request failed");
   }
+
+  /** The job's input declares {{secrets.FOO}}, and the called API echoes that value back. */
+  @Nested
+  class ErrorExpressionSecretMaskingTests {
+
+    private static final String ECHOED = FooBarSecretProvider.SECRET_VALUE;
+    private static final String INPUT_DECLARING_A_SECRET = "{ \"token\" : \"{{secrets.FOO}}\" }";
+
+    private SpringConnectorJobHandler echoingConnector() {
+      return newConnectorJobHandler(context -> Map.of("body", "rejected token " + ECHOED));
+    }
+
+    private SpringConnectorJobHandler echoingConnectorWithUnreadableSecrets() {
+      return newConnectorJobHandler(
+          context -> Map.of("body", "rejected token " + ECHOED),
+          new SecretProviderAggregator(List.of(new FooBarSecretProvider())) {
+            @Override
+            public List<String> fetchAll(List<String> keys, SecretContext context) {
+              throw new RuntimeException("Network error while fetching secrets");
+            }
+          });
+    }
+
+    @Test
+    void jobErrorMessageCopyingAResponseIsRedacted() throws Exception {
+      var result =
+          JobBuilder.create()
+              .withVariables(INPUT_DECLARING_A_SECRET)
+              .withErrorExpressionHeader("=jobError(\"Request failed: \" + response.body, {}, 0)")
+              .executeAndCaptureResult(echoingConnector(), false, false);
+
+      assertThat(result.getErrorMessage())
+          .startsWith("Request failed: rejected token ***")
+          .doesNotContain(ECHOED);
+      // prepareFailJobCommand publishes the message as an error variable too
+      assertThat(result.getVariables().toString()).doesNotContain(ECHOED);
+    }
+
+    @Test
+    void jobErrorKeepsTheRetriesAndBackoffTheExpressionAsked() throws Exception {
+      var failCommand = mock(FailJobCommandStep1.class);
+      var failCommandStep2 =
+          mock(FailJobCommandStep1.FailJobCommandStep2.class, RETURNS_DEEP_STUBS);
+      var jobClient = mock(JobClient.class);
+      when(jobClient.newFailCommand(any())).thenReturn(failCommand);
+      when(failCommand.retries(anyInt())).thenReturn(failCommandStep2);
+      when(failCommandStep2.errorMessage(any())).thenReturn(failCommandStep2);
+      when(failCommandStep2.retryBackoff(any())).thenReturn(failCommandStep2);
+      when(failCommandStep2.variables(anyMap())).thenReturn(failCommandStep2);
+      when(failCommandStep2.variables(any(Object.class))).thenReturn(failCommandStep2);
+
+      JobBuilder.create()
+          .useJobClient(jobClient)
+          .withVariables(INPUT_DECLARING_A_SECRET)
+          .withErrorExpressionHeader(
+              "=jobError(\"Request failed: \" + response.body, {}, 7, duration(\"PT5M\"))")
+          .execute(echoingConnector());
+
+      var messageCaptor = ArgumentCaptor.forClass(String.class);
+      verify(failCommandStep2).errorMessage(messageCaptor.capture());
+      assertThat(messageCaptor.getValue()).doesNotContain(ECHOED);
+      verify(failCommand).retries(7);
+      verify(failCommandStep2).retryBackoff(Duration.ofMinutes(5));
+    }
+
+    @Test
+    void bpmnErrorMessageCopyingAResponseIsRedacted() throws Exception {
+      var result =
+          JobBuilder.create()
+              .withVariables(INPUT_DECLARING_A_SECRET)
+              .withErrorExpressionHeader(
+                  "=bpmnError(\"AUTH_FAILED\", \"Request failed: \" + response.body)")
+              .executeAndCaptureResult(echoingConnector(), false, true);
+
+      assertThat(result.getErrorMessage())
+          .isEqualTo("Request failed: rejected token ***")
+          .doesNotContain(ECHOED);
+    }
+
+    @Test
+    void bpmnErrorVariablesCopyingAResponseAreRedacted() throws Exception {
+      var result =
+          JobBuilder.create()
+              .withVariables(INPUT_DECLARING_A_SECRET)
+              .withErrorExpressionHeader(
+                  "=bpmnError(\"AUTH_FAILED\", \"failed\", {detail: response.body, code: 401})")
+              .executeAndCaptureResult(echoingConnector(), false, true);
+
+      assertThat(result.getVariables()).containsEntry("detail", "rejected token ***");
+      // scalars keep their type, since a process resolving the incident may branch on them
+      assertThat(result.getVariables()).containsEntry("code", 401);
+    }
+
+    @Test
+    void bpmnErrorCodeIsNotRedacted() throws Exception {
+      // boundary events match on the code, so it keeps a value equal to the secret's
+      var result =
+          JobBuilder.create()
+              .withVariables(INPUT_DECLARING_A_SECRET)
+              .withErrorExpressionHeader(
+                  "=bpmnError(\"" + ECHOED + "\", \"Request failed: \" + response.body)")
+              .executeAndCaptureResult(echoingConnector(), false, true);
+
+      assertThat(result.getErrorCode()).isEqualTo(ECHOED);
+      assertThat(result.getErrorMessage()).doesNotContain(ECHOED);
+    }
+
+    @Test
+    void bpmnErrorWithoutAMessageStaysWithoutOne() throws Exception {
+      // throwError omits a null message but would set an empty one
+      var result =
+          JobBuilder.create()
+              .withVariables(INPUT_DECLARING_A_SECRET)
+              .withErrorExpressionHeader(
+                  "={ \"errorType\": \"bpmnError\", \"errorCode\": \"AUTH_FAILED\","
+                      + " \"variables\": {\"detail\": response.body} }")
+              .executeAndCaptureResult(echoingConnector(), false, true);
+
+      assertThat(result.getErrorMessage()).isNull();
+      assertThat(result.getVariables()).containsEntry("detail", "rejected token ***");
+    }
+
+    @Test
+    void jobErrorIsWithheldWhenItCannotBeRedacted() throws Exception {
+      var result =
+          JobBuilder.create()
+              .withVariables(INPUT_DECLARING_A_SECRET)
+              .withErrorExpressionHeader("=jobError(\"Request failed: \" + response.body, {}, 0)")
+              .executeAndCaptureResult(echoingConnectorWithUnreadableSecrets(), false, false);
+
+      // the fetch failure's own message is withheld too: a provider error can echo the store's body
+      assertThat(result.getErrorMessage())
+          .startsWith("Fetching secrets failed, original error can't be displayed")
+          .contains("java.lang.RuntimeException")
+          .doesNotContain("Network error while fetching secrets")
+          .doesNotContain(ECHOED);
+      assertThat(result.getRetries()).isZero();
+    }
+
+    @Test
+    void bpmnErrorKeepsItsCodeWhenItCannotBeRedacted() throws Exception {
+      var result =
+          JobBuilder.create()
+              .withVariables(INPUT_DECLARING_A_SECRET)
+              .withErrorExpressionHeader(
+                  "=bpmnError(\"AUTH_FAILED\", \"Request failed: \" + response.body,"
+                      + " {detail: response.body})")
+              .executeAndCaptureResult(echoingConnectorWithUnreadableSecrets(), false, true);
+
+      assertThat(result.getErrorCode()).isEqualTo("AUTH_FAILED");
+      assertThat(result.getErrorMessage())
+          .startsWith("Fetching secrets failed, original error can't be displayed")
+          .doesNotContain(ECHOED);
+      assertThat(result.getVariables()).isEmpty();
+    }
+
+    @Test
+    void anErrorCarryingNothingToRedactIsLeftAlone() throws Exception {
+      // no message and no variables, so the read is skipped and the unreadable store costs nothing
+      var result =
+          JobBuilder.create()
+              .withVariables(INPUT_DECLARING_A_SECRET)
+              .withErrorExpressionHeader(
+                  "={ \"errorType\": \"bpmnError\", \"errorCode\": \"AUTH_FAILED\" }")
+              .executeAndCaptureResult(echoingConnectorWithUnreadableSecrets(), false, true);
+
+      assertThat(result.getErrorCode()).isEqualTo("AUTH_FAILED");
+      assertThat(result.getErrorMessage()).isNull();
+    }
+  }
 }

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/job/SpringConnectorJobHandlerTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/job/SpringConnectorJobHandlerTest.java
@@ -1632,4 +1632,65 @@ class SpringConnectorJobHandlerTest {
       assertThat(result.getErrorMessage()).isNull();
     }
   }
+
+  // the value bound at execution time can differ from what a later re-read returns if it rotated
+  @Nested
+  class RotationRaceSecretMaskingTests {
+
+    private record TokenHolder(String token) {}
+
+    private static final String INPUT_DECLARING_A_SECRET = "{ \"token\" : \"{{secrets.FOO}}\" }";
+
+    private SecretProviderAggregator rotatingSecretProvider(
+        String boundValue, String rotatedValue) {
+      return new SecretProviderAggregator(List.of()) {
+        @Override
+        public String getSecret(String secretName, SecretContext context) {
+          return boundValue;
+        }
+
+        @Override
+        public List<String> fetchAll(List<String> keys, SecretContext context) {
+          return keys.stream().map(key -> rotatedValue).toList();
+        }
+      };
+    }
+
+    private SpringConnectorJobHandler connectorThrowingTheBoundToken(
+        SecretProviderAggregator secretProviderAggregator) {
+      return newConnectorJobHandler(
+          context -> {
+            var bound = context.bindVariables(TokenHolder.class);
+            throw new RuntimeException("api rejected " + bound.token());
+          },
+          secretProviderAggregator);
+    }
+
+    @Test
+    void aSecretThatRotatedBetweenBindAndMaskingIsStillRedacted() throws Exception {
+      var jobHandler =
+          connectorThrowingTheBoundToken(rotatingSecretProvider("old-value", "new-value"));
+
+      var result =
+          JobBuilder.create()
+              .withVariables(INPUT_DECLARING_A_SECRET)
+              .executeAndCaptureResult(jobHandler, false, false);
+
+      assertThat(result.getErrorMessage()).doesNotContain("old-value");
+    }
+
+    @Test
+    void aStableSecretIsStillRedactedTheOrdinaryWay() throws Exception {
+      // the union must not depend on rotation happening: an unrotated secret is redacted too
+      var jobHandler =
+          connectorThrowingTheBoundToken(rotatingSecretProvider("stable-value", "stable-value"));
+
+      var result =
+          JobBuilder.create()
+              .withVariables(INPUT_DECLARING_A_SECRET)
+              .executeAndCaptureResult(jobHandler, false, false);
+
+      assertThat(result.getErrorMessage()).doesNotContain("stable-value");
+    }
+  }
 }

--- a/connector-sdk/core/src/main/java/io/camunda/connector/api/inbound/Health.java
+++ b/connector-sdk/core/src/main/java/io/camunda/connector/api/inbound/Health.java
@@ -155,6 +155,16 @@ public class Health {
     this.details = details;
   }
 
+  /**
+   * Returns a new {@link Health} with the given error.
+   *
+   * @param error the error for the new instance
+   * @return a new Health with the same status and details but the supplied error
+   */
+  public Health withError(Error error) {
+    return new Health(this.status, error, this.details);
+  }
+
   private Health() {
     this(Status.UNKNOWN, null, null);
   }

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/jobworker/AiAgentJobWorkerHandlerImpl.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/jobworker/AiAgentJobWorkerHandlerImpl.java
@@ -38,6 +38,7 @@ import io.camunda.connector.runtime.metrics.ConnectorsOutboundMetrics;
 import io.camunda.connector.runtime.outbound.job.OutboundConnectorExceptionHandler;
 import java.time.Duration;
 import java.time.format.DateTimeParseException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -85,7 +86,10 @@ public class AiAgentJobWorkerHandlerImpl implements AiAgentJobWorkerHandler {
     final SecretFilter secretFilter =
         secretFilterFactory.create(
             new SecretFilterContext(job.getProcessDefinitionKey(), job.getElementId()));
-    final var agentResult = getAgentResult(jobClient, job, secretFilter);
+    // kept for the error paths: a secret rotated since the input was bound no longer reads back,
+    // and the value an error message carries is the one substituted then
+    final List<String> capturedSecrets = new ArrayList<>();
+    final var agentResult = getAgentResult(jobClient, job, secretFilter, capturedSecrets);
 
     try {
       Optional<ConnectorError> optionalConnectorError =
@@ -95,7 +99,8 @@ public class AiAgentJobWorkerHandlerImpl implements AiAgentJobWorkerHandler {
               new ErrorExpressionJobContext(new ErrorExpressionJob(job.getRetries())));
 
       optionalConnectorError.ifPresentOrElse(
-          connectorError -> handleConnectorError(jobClient, job, connectorError),
+          connectorError ->
+              handleConnectorError(jobClient, job, connectorError, secretFilter, capturedSecrets),
           () -> {
             switch (agentResult) {
               case AgentSuccessResult successResult ->
@@ -108,33 +113,45 @@ public class AiAgentJobWorkerHandlerImpl implements AiAgentJobWorkerHandler {
       failJob(
           jobClient,
           job,
-          // no captured values to add: the context that resolved them is not kept past binding
           this.outboundConnectorExceptionHandler.handleFinalResultException(
-              e, job, secretFilter, List.of()));
+              e, job, secretFilter, List.copyOf(capturedSecrets)));
     }
   }
 
   private JobWorkerAgentResult getAgentResult(
-      final JobClient jobClient, final ActivatedJob job, final SecretFilter secretFilter) {
+      final JobClient jobClient,
+      final ActivatedJob job,
+      final SecretFilter secretFilter,
+      final List<String> capturedSecrets) {
     Duration retryBackoff = null;
     try {
       retryBackoff = getBackoffDuration(job);
 
       final var executionContext =
-          executionContextFactory.createExecutionContext(jobClient, job, secretFilter);
+          executionContextFactory.createExecutionContext(
+              jobClient, job, secretFilter, capturedSecrets::addAll);
       final var completion = agentRequestHandler.handleRequest(executionContext);
 
       return new AgentSuccessResult(completion);
     } catch (Exception e) {
       final var errorResult =
           outboundConnectorExceptionHandler.manageConnectorJobHandlerException(
-              e, job, retryBackoff, secretFilter, List.of());
+              e, job, retryBackoff, secretFilter, List.copyOf(capturedSecrets));
       return new AgentErrorResult(errorResult);
     }
   }
 
   private void handleConnectorError(
-      final JobClient jobClient, final ActivatedJob job, final ConnectorError connectorError) {
+      final JobClient jobClient,
+      final ActivatedJob job,
+      final ConnectorError rawError,
+      final SecretFilter secretFilter,
+      final List<String> capturedSecrets) {
+    // an error expression builds its message from the response, which can carry a resolved secret,
+    // so it is redacted before the Zeebe command is built from it
+    final var connectorError =
+        outboundConnectorExceptionHandler.maskConnectorError(
+            rawError, job, secretFilter, List.copyOf(capturedSecrets));
     switch (connectorError) {
       case BpmnError bpmnError -> throwBpmnError(jobClient, job, bpmnError);
       case JobError jobError ->
@@ -215,9 +232,12 @@ public class AiAgentJobWorkerHandlerImpl implements AiAgentJobWorkerHandler {
 
   private void failJob(
       final JobClient jobClient, final ActivatedJob job, final ErrorResult errorResult) {
+    // the message is redacted, the exception it was built from is not: logging the throwable would
+    // print the original cause, secrets and all
     LOGGER.error(
-        "Exception while completing AI Agent job with key %s".formatted(job.getKey()),
-        errorResult.exception());
+        "Exception while completing AI Agent job with key {}: {}",
+        job.getKey(),
+        errorResult.exception().getMessage());
 
     try {
       connectorsOutboundMetrics.increaseFailure(job);
@@ -246,10 +266,11 @@ public class AiAgentJobWorkerHandlerImpl implements AiAgentJobWorkerHandler {
 
   private void throwBpmnError(
       final JobClient jobClient, final ActivatedJob job, final BpmnError bpmnError) {
+    // the code is not redacted, so it stays out of the log: unlike the command and the error
+    // variables that carry it, pod logs are shipped to systems with their own access controls
     LOGGER.error(
-        "BPMN error while completing AI Agent job with key {}. Code: {}. Message: {}",
+        "BPMN error while completing AI Agent job with key {}. Message: {}",
         job.getKey(),
-        bpmnError.errorCode(),
         bpmnError.errorMessage());
 
     try {

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/jobworker/AiAgentJobWorkerHandlerImpl.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/jobworker/AiAgentJobWorkerHandlerImpl.java
@@ -38,6 +38,7 @@ import io.camunda.connector.runtime.metrics.ConnectorsOutboundMetrics;
 import io.camunda.connector.runtime.outbound.job.OutboundConnectorExceptionHandler;
 import java.time.Duration;
 import java.time.format.DateTimeParseException;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import org.slf4j.Logger;
@@ -107,7 +108,9 @@ public class AiAgentJobWorkerHandlerImpl implements AiAgentJobWorkerHandler {
       failJob(
           jobClient,
           job,
-          this.outboundConnectorExceptionHandler.handleFinalResultException(e, job, secretFilter));
+          // no captured values to add: the context that resolved them is not kept past binding
+          this.outboundConnectorExceptionHandler.handleFinalResultException(
+              e, job, secretFilter, List.of()));
     }
   }
 
@@ -125,7 +128,7 @@ public class AiAgentJobWorkerHandlerImpl implements AiAgentJobWorkerHandler {
     } catch (Exception e) {
       final var errorResult =
           outboundConnectorExceptionHandler.manageConnectorJobHandlerException(
-              e, job, retryBackoff, secretFilter);
+              e, job, retryBackoff, secretFilter, List.of());
       return new AgentErrorResult(errorResult);
     }
   }

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/jobworker/JobWorkerAgentExecutionContextFactory.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/jobworker/JobWorkerAgentExecutionContextFactory.java
@@ -10,8 +10,26 @@ import io.camunda.client.api.response.ActivatedJob;
 import io.camunda.client.api.worker.JobClient;
 import io.camunda.connector.agenticai.aiagent.model.JobWorkerAgentExecutionContext;
 import io.camunda.connector.runtime.core.secret.SecretFilter;
+import java.util.List;
+import java.util.function.Consumer;
 
 public interface JobWorkerAgentExecutionContextFactory {
+
+  /** Preserved for callers compiled against it, which have nowhere to keep the resolved values. */
+  default JobWorkerAgentExecutionContext createExecutionContext(
+      final JobClient jobClient, final ActivatedJob job, final SecretFilter secretFilter) {
+    return createExecutionContext(jobClient, job, secretFilter, values -> {});
+  }
+
+  /**
+   * Binds the job's input, reporting the secret values substituted into it to {@code
+   * capturedSecrets} whether the binding succeeds or fails. A caller reporting an error has to
+   * redact it with those values: a secret rotated since the input was bound no longer reads back,
+   * and the value the message actually carries is this one.
+   */
   JobWorkerAgentExecutionContext createExecutionContext(
-      final JobClient jobClient, final ActivatedJob job, final SecretFilter secretFilter);
+      final JobClient jobClient,
+      final ActivatedJob job,
+      final SecretFilter secretFilter,
+      final Consumer<List<String>> capturedSecrets);
 }

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/jobworker/JobWorkerAgentExecutionContextFactory.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/jobworker/JobWorkerAgentExecutionContextFactory.java
@@ -15,12 +15,6 @@ import java.util.function.Consumer;
 
 public interface JobWorkerAgentExecutionContextFactory {
 
-  /** Preserved for callers compiled against it, which have nowhere to keep the resolved values. */
-  default JobWorkerAgentExecutionContext createExecutionContext(
-      final JobClient jobClient, final ActivatedJob job, final SecretFilter secretFilter) {
-    return createExecutionContext(jobClient, job, secretFilter, values -> {});
-  }
-
   /**
    * Binds the job's input, reporting the secret values substituted into it to {@code
    * capturedSecrets} whether the binding succeeds or fails. A caller reporting an error has to

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/jobworker/JobWorkerAgentExecutionContextFactoryImpl.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/jobworker/JobWorkerAgentExecutionContextFactoryImpl.java
@@ -12,11 +12,12 @@ import io.camunda.client.api.worker.JobClient;
 import io.camunda.connector.agenticai.aiagent.model.JobWorkerAgentExecutionContext;
 import io.camunda.connector.agenticai.aiagent.model.request.JobWorkerAgentRequest;
 import io.camunda.connector.api.document.DocumentFactory;
-import io.camunda.connector.api.outbound.OutboundConnectorContext;
 import io.camunda.connector.api.secret.SecretProvider;
 import io.camunda.connector.api.validation.ValidationProvider;
 import io.camunda.connector.runtime.core.outbound.JobHandlerContext;
 import io.camunda.connector.runtime.core.secret.SecretFilter;
+import java.util.List;
+import java.util.function.Consumer;
 
 public class JobWorkerAgentExecutionContextFactoryImpl
     implements JobWorkerAgentExecutionContextFactory {
@@ -38,11 +39,20 @@ public class JobWorkerAgentExecutionContextFactoryImpl
 
   @Override
   public JobWorkerAgentExecutionContext createExecutionContext(
-      final JobClient jobClient, final ActivatedJob job, final SecretFilter secretFilter) {
-    final OutboundConnectorContext context =
+      final JobClient jobClient,
+      final ActivatedJob job,
+      final SecretFilter secretFilter,
+      final Consumer<List<String>> capturedSecrets) {
+    final JobHandlerContext context =
         new JobHandlerContext(
             job, secretProvider, validationProvider, documentFactory, objectMapper, secretFilter);
-    final var request = context.bindVariables(JobWorkerAgentRequest.class);
-    return new JobWorkerAgentExecutionContext(jobClient, job, request);
+    try {
+      final var request = context.bindVariables(JobWorkerAgentRequest.class);
+      return new JobWorkerAgentExecutionContext(jobClient, job, request);
+    } finally {
+      // reported even when binding throws: the values substituted before it failed are the ones
+      // the failure's message can carry
+      capturedSecrets.accept(context.getSecretHandler().getResolvedValues());
+    }
   }
 }

--- a/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/jobworker/AiAgentJobWorkerHandlerTest.java
+++ b/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/jobworker/AiAgentJobWorkerHandlerTest.java
@@ -25,6 +25,8 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
@@ -59,6 +61,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Consumer;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -70,6 +73,7 @@ import org.mockito.Answers;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.LoggerFactory;
 
 @WireMockTest
 @ExtendWith(MockitoExtension.class)
@@ -122,8 +126,11 @@ class AiAgentJobWorkerHandlerTest {
     when(job.getType()).thenReturn(AiAgentJobWorker.JOB_WORKER_TYPE);
     when(job.getCustomHeaders()).thenReturn(jobHeaders);
 
-    when(executionContextFactory.createExecutionContext(
-            eq(camundaClient), eq(job), any(SecretFilter.class)))
+    // lenient: a test covering the bind-time capture path replaces this stubbing
+    Mockito.lenient()
+        .when(
+            executionContextFactory.createExecutionContext(
+                eq(camundaClient), eq(job), any(SecretFilter.class), any()))
         .thenReturn(executionContext);
 
     final var outboundConnectorExceptionHandler =
@@ -555,6 +562,142 @@ class AiAgentJobWorkerHandlerTest {
                   Map.of(
                       "type", "java.lang.RuntimeException", "message", expectedExceptionMessage));
         });
+  }
+
+  @Test
+  void redactsSecretsFromAJobErrorProducedByTheErrorExpression() {
+    // an error expression builds its message from the agent's response, which can echo a resolved
+    // secret straight back into the incident
+    namesSecret("super-secret");
+    jobHeaders.put("errorExpression", "=jobError(\"agent replied: \" + response.responseText)");
+
+    respondsWith("token super-secret rejected");
+
+    handler.handle(camundaClient, job);
+
+    assertJobFailRequest(
+        request -> {
+          assertThat(request.getErrorMessage())
+              .isEqualTo("agent replied: token *** rejected")
+              .doesNotContain("super-secret");
+          assertThat(request.getVariables().toString()).doesNotContain("super-secret");
+        });
+  }
+
+  @Test
+  void redactsSecretsFromABpmnErrorProducedByTheErrorExpressionAndKeepsItsCodeOutOfTheLog() {
+    namesSecret("super-secret");
+    jobHeaders.put(
+        "errorExpression", "=bpmnError(\"MY_CODE\", \"agent replied: \" + response.responseText)");
+
+    respondsWith("token super-secret rejected");
+
+    var logged = logsOf(() -> handler.handle(camundaClient, job));
+
+    assertJobErrorRequest(
+        request -> {
+          // boundary events match on the code, so it reaches the command unredacted
+          assertThat(request.getErrorCode()).isEqualTo("MY_CODE");
+          assertThat(request.getErrorMessage())
+              .isEqualTo("agent replied: token *** rejected")
+              .doesNotContain("super-secret");
+        });
+    // the code is not redacted, so it stays out of the log
+    assertThat(logged).noneMatch(message -> message.contains("MY_CODE"));
+    assertThat(logged).noneMatch(message -> message.contains("super-secret"));
+  }
+
+  @Test
+  void neverLogsTheUnredactedCauseOfAFailedJob() {
+    namesSecret("super-secret");
+    when(agentRequestHandler.handleRequest(executionContext))
+        .thenThrow(new RuntimeException("api rejected super-secret"));
+
+    var events = logEventsOf(() -> handler.handle(camundaClient, job));
+
+    // awaited so the asynchronous fail command lands before this test ends
+    assertJobFailRequest(
+        request -> assertThat(request.getErrorMessage()).isEqualTo("api rejected ***"));
+    assertThat(events)
+        .noneMatch(
+            event ->
+                event.getThrowableProxy() != null
+                    && throwableText(event.getThrowableProxy()).contains("super-secret"));
+    assertThat(events)
+        .noneMatch(event -> event.getFormattedMessage().contains("super-secret"))
+        .anyMatch(event -> event.getFormattedMessage().contains("api rejected ***"));
+  }
+
+  @Test
+  void redactsASecretThatRotatedAfterTheInputWasBound() {
+    // the value read back is no longer the one substituted into the input, so only the value
+    // captured at bind time can redact the message the connector actually produced
+    namesSecret("rotated-value");
+    when(executionContextFactory.createExecutionContext(
+            eq(camundaClient), eq(job), any(SecretFilter.class), any()))
+        .thenAnswer(
+            invocation -> {
+              invocation.<Consumer<List<String>>>getArgument(3).accept(List.of("bound-value"));
+              throw new RuntimeException("api rejected bound-value");
+            });
+
+    handler.handle(camundaClient, job);
+
+    assertJobFailRequest(
+        request -> {
+          assertThat(request.getErrorMessage())
+              .isEqualTo("api rejected ***")
+              .doesNotContain("bound-value");
+          assertThat(request.getVariables().toString()).doesNotContain("bound-value");
+        });
+  }
+
+  /** Makes the job's input name a secret the provider resolves to {@code value}. */
+  private void namesSecret(String value) {
+    when(job.getVariables()).thenReturn("{\"token\": \"{{secrets.FOO}}\"}");
+    when(secretProvider.fetchAll(any(), any())).thenReturn(List.of(value));
+  }
+
+  private void respondsWith(String responseText) {
+    when(agentRequestHandler.handleRequest(executionContext))
+        .thenReturn(
+            JobWorkerAgentCompletion.builder()
+                .completionConditionFulfilled(true)
+                .cancelRemainingInstances(false)
+                .agentResponse(
+                    AgentResponse.builder()
+                        .context(AgentContext.empty())
+                        .responseText(responseText)
+                        .build())
+                .build());
+  }
+
+  private static String throwableText(ch.qos.logback.classic.spi.IThrowableProxy proxy) {
+    var text = new StringBuilder();
+    for (var current = proxy; current != null; current = current.getCause()) {
+      text.append(current.getClassName()).append(current.getMessage());
+    }
+    return text.toString();
+  }
+
+  private static List<String> logsOf(Runnable action) {
+    return logEventsOf(action).stream().map(ILoggingEvent::getFormattedMessage).toList();
+  }
+
+  /** Every event the handler logs while {@code action} runs, throwables included. */
+  private static List<ILoggingEvent> logEventsOf(Runnable action) {
+    var logger =
+        (ch.qos.logback.classic.Logger) LoggerFactory.getLogger(AiAgentJobWorkerHandlerImpl.class);
+    var appender = new ListAppender<ILoggingEvent>();
+    appender.start();
+    logger.addAppender(appender);
+    try {
+      action.run();
+    } finally {
+      logger.detachAppender(appender);
+      appender.stop();
+    }
+    return List.copyOf(appender.list);
   }
 
   private Map<String, Object> asMap(final ToolCallProcessVariable toolCallProcessVariable) {


### PR DESCRIPTION
## Description

Backports #8634 and #8643 together to `stable/8.8`. They form one secret-redaction change and are intentionally combined so the fixes reach this older stable branch atomically. This is ported from the combined reference backport #8661.

The change prevents resolved secrets from being exposed through outbound job and BPMN error incidents, inbound activity logs and health errors, and errors emitted after a secret rotates between input binding and masking. It also includes the approved follow-up #8662, which prevents the unredacted exception cause from being printed to runtime logs.

Review follow-up: a failed masking read is now reported by type alone and without keeping the provider failure as the incident's cause, a re-read that comes back short of the names the input declares fails closed, and error variables reaching the incident payload are masked recursively. The AI Agent job worker, which on this branch dispatches and logs its errors on its own, redacts them the same way and keeps the bind-time values so a rotated secret is still covered. The error-handling entry points that take the resolved values do so consistently, and every caller passes them.

The required secret-reference handling from #8641 is already present on the target branch through #8658.

## Related issues

Related to #8638.

Source PRs: #8634, #8643, and follow-up #8662.

## Checklist

- [x] No further backport labels are added; the older stable branches are being ported explicitly from the combined change.
- [x] Tests for the changes are included and the focused runtime test suite passes.
- [x] No documentation update is required for this backport.
