### PR TITLE
[Backport stable/8.6] fix: redact secrets from connector errors and logs

### DIFF
--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextImpl.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextImpl.java
@@ -23,6 +23,7 @@ import io.camunda.connector.api.inbound.CorrelationResult;
 import io.camunda.connector.api.inbound.Health;
 import io.camunda.connector.api.inbound.InboundConnectorContext;
 import io.camunda.connector.api.inbound.InboundConnectorDefinition;
+import io.camunda.connector.api.inbound.ProcessElement;
 import io.camunda.connector.api.inbound.Severity;
 import io.camunda.connector.api.secret.SecretProvider;
 import io.camunda.connector.api.validation.ValidationProvider;
@@ -38,6 +39,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Queue;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
@@ -60,6 +63,11 @@ public class InboundConnectorContextImpl extends AbstractConnectorContext
   private final EvictingQueue<Activity> logs;
 
   private volatile List<String> reReadSecrets;
+
+  // an activated element resolves through its own SecretHandler, so its captures are pulled in here
+  private final Map<ProcessElement, AbstractConnectorContext> activatedElementContexts =
+      new ConcurrentHashMap<>();
+  private final Set<String> capturedElementSecretValues = ConcurrentHashMap.newKeySet();
 
   private static final String REDACTION_UNAVAILABLE_MESSAGE =
       "Message withheld: could not verify it does not contain a secret value";
@@ -110,7 +118,9 @@ public class InboundConnectorContextImpl extends AbstractConnectorContext
   @Override
   public CorrelationResult correlateWithResult(Object variables) {
     try {
-      return correlationHandler.correlate(connectorDetails.connectorElements(), variables);
+      var result = correlationHandler.correlate(connectorDetails.connectorElements(), variables);
+      trackActivatedElement(result);
+      return result;
     } catch (FeelEngineWrapperException e) {
       log(Activity.level(Severity.ERROR).tag("error").message(e.getMessage()));
       return new CorrelationResult.Failure.Other(e);
@@ -224,13 +234,48 @@ public class InboundConnectorContextImpl extends AbstractConnectorContext
     if (reRead == null) {
       return null;
     }
-    var captured = getSecretHandler().getResolvedValues();
+    var captured = new ArrayList<>(getSecretHandler().getResolvedValues());
+    captured.addAll(capturedElementSecretValues());
     if (captured.isEmpty()) {
       return reRead;
     }
     var union = new ArrayList<>(reRead);
     union.addAll(captured);
     return union;
+  }
+
+  /**
+   * Records the element context a correlation activated, so what it resolves can be redacted here.
+   *
+   * <p>An activated element resolves secrets through its own {@link
+   * io.camunda.connector.runtime.core.secret.SecretHandler} — {@code ProcessElementContext} is a
+   * second binding path, and every successful {@code CorrelationResult} hands the connector one —
+   * so its captures live outside this context and have to be pulled in. Without them a value the
+   * element bound and this context never did is invisible to the re-read once it rotates, and gets
+   * published in the clear.
+   *
+   * <p>Held per element, so a long-running executable keeps at most one reference per deployed
+   * element rather than one per correlation; a displaced context's values are harvested before it
+   * is dropped.
+   */
+  private void trackActivatedElement(CorrelationResult result) {
+    if (!(result instanceof CorrelationResult.Success success)
+        || !(success.activatedElement() instanceof AbstractConnectorContext elementContext)) {
+      return;
+    }
+    var displaced =
+        activatedElementContexts.put(success.activatedElement().getElement(), elementContext);
+    if (displaced != null && displaced != elementContext) {
+      capturedElementSecretValues.addAll(displaced.getSecretHandler().getResolvedValues());
+    }
+  }
+
+  private List<String> capturedElementSecretValues() {
+    var values = new ArrayList<>(capturedElementSecretValues);
+    activatedElementContexts
+        .values()
+        .forEach(context -> values.addAll(context.getSecretHandler().getResolvedValues()));
+    return values;
   }
 
   private List<String> reReadSecretValues() {

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextImpl.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextImpl.java
@@ -33,6 +33,7 @@ import io.camunda.connector.runtime.core.inbound.details.InboundConnectorDetails
 import io.camunda.connector.runtime.core.inbound.details.InboundConnectorDetails.ValidInboundConnectorDetails;
 import io.camunda.connector.runtime.core.secret.SecretFilter;
 import io.camunda.connector.runtime.core.secret.SecretUtil;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -57,6 +58,11 @@ public class InboundConnectorContextImpl extends AbstractConnectorContext
   private Health health = Health.unknown();
 
   private final EvictingQueue<Activity> logs;
+
+  private volatile List<String> reReadSecrets;
+
+  private static final String REDACTION_UNAVAILABLE_MESSAGE =
+      "Message withheld: could not verify it does not contain a secret value";
 
   public InboundConnectorContextImpl(
       SecretProvider secretProvider,
@@ -189,7 +195,7 @@ public class InboundConnectorContextImpl extends AbstractConnectorContext
 
   @Override
   public void reportHealth(Health health) {
-    this.health = health;
+    this.health = redactHealth(health);
   }
 
   @Override
@@ -199,8 +205,100 @@ public class InboundConnectorContextImpl extends AbstractConnectorContext
 
   @Override
   public void log(Activity log) {
-    LOG.debug("{}", log);
-    this.logs.add(log);
+    var masked = redact(log);
+    LOG.debug("{}", masked);
+    this.logs.add(masked);
+  }
+
+  /**
+   * The values an operator-visible message must not carry. Read once and cached on first complete
+   * success, so a transient provider failure fails closed for that one message instead of poisoning
+   * every later one. {@code null} means "could not be established", never "nothing to redact".
+   *
+   * <p>The captured values are additive to a successful, complete re-read and never a substitute
+   * for a failed one: a connector can declare a secret it never got around to binding before the
+   * provider went down.
+   */
+  private List<String> secretValuesForRedaction() {
+    var reRead = reReadSecretValues();
+    if (reRead == null) {
+      return null;
+    }
+    var captured = getSecretHandler().getResolvedValues();
+    if (captured.isEmpty()) {
+      return reRead;
+    }
+    var union = new ArrayList<>(reRead);
+    union.addAll(captured);
+    return union;
+  }
+
+  private List<String> reReadSecretValues() {
+    var cached = reReadSecrets;
+    if (cached != null) {
+      return cached;
+    }
+    var values = fetchSecretValuesForRedaction();
+    if (values != null) {
+      reReadSecrets = values;
+    }
+    return values;
+  }
+
+  /** Scans every grouped element's raw properties, not just this context's representative one. */
+  private List<String> fetchSecretValuesForRedaction() {
+    var names =
+        connectorDetails.connectorElements().stream()
+            .flatMap(element -> element.rawProperties().values().stream())
+            .flatMap(value -> SecretUtil.retrieveSecretKeysInInput(value).stream())
+            .distinct()
+            .toList();
+    if (names.isEmpty()) {
+      return List.of();
+    }
+    try {
+      var values = new ArrayList<String>(names.size());
+      for (var name : names) {
+        var value = secretProvider.getSecret(name);
+        // a name that comes back empty is a partial read, treated the same as a failed one
+        if (value == null) {
+          return null;
+        }
+        values.add(value);
+      }
+      return values;
+    } catch (Exception e) {
+      // never the provider's own message: it can echo the secret store's response
+      LOG.warn("Could not fetch secret values to redact activity log: {}", e.getClass().getName());
+      return null;
+    }
+  }
+
+  private String redactMessage(String message) {
+    if (message == null) {
+      return null;
+    }
+    var secrets = secretValuesForRedaction();
+    return secrets == null
+        ? REDACTION_UNAVAILABLE_MESSAGE
+        : SecretUtil.hideSecretsFromMessage(message, secrets);
+  }
+
+  private Health redactHealth(Health health) {
+    if (health == null || health.getError() == null) {
+      return health;
+    }
+    var error = health.getError();
+    return health.withError(
+        new Health.Error(redactMessage(error.code()), redactMessage(error.message())));
+  }
+
+  private Activity redact(Activity activity) {
+    return new Activity(
+        activity.severity(),
+        activity.tag(),
+        activity.timestamp(),
+        redactMessage(activity.message()));
   }
 
   @Override

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/outbound/ConnectorJobHandler.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/outbound/ConnectorJobHandler.java
@@ -171,16 +171,19 @@ public class ConnectorJobHandler implements JobHandler {
         secretFilterFactory.create(
             new SecretFilterContext(job.getProcessDefinitionKey(), job.getElementId()));
 
-    // one provider instance for both binding and the masking re-read
-    var jobSecretProvider = getSecretProvider();
-    var exceptionHandler = new OutboundConnectorExceptionHandler(jobSecretProvider);
-
     ConnectorResult result;
 
     // declared outside the try: what it resolved is what a rotated re-read would no longer match
     JobHandlerContext context = null;
+    // starts out with no provider, and gets one inside the try: discovering a provider can fail,
+    // and that failure has always failed the job rather than escaped this method and abandoned it
+    OutboundConnectorExceptionHandler exceptionHandler =
+        OutboundConnectorExceptionHandler.withoutSecretProvider();
 
     try {
+      // one provider instance for both binding and the masking re-read
+      var jobSecretProvider = getSecretProvider();
+      exceptionHandler = new OutboundConnectorExceptionHandler(jobSecretProvider);
       context =
           new JobHandlerContext(
               job, jobSecretProvider, validationProvider, objectMapper, secretFilter);
@@ -197,6 +200,7 @@ public class ConnectorJobHandler implements JobHandler {
               ex, job, retryBackoff, secretFilter, capturedSecrets(context));
     }
 
+    final OutboundConnectorExceptionHandler errorHandler = exceptionHandler;
     final List<String> capturedSecrets = capturedSecrets(context);
 
     try {
@@ -210,7 +214,7 @@ public class ConnectorJobHandler implements JobHandler {
                 handleBPMNError(
                     client,
                     job,
-                    exceptionHandler.maskConnectorError(error, job, secretFilter, capturedSecrets));
+                    errorHandler.maskConnectorError(error, job, secretFilter, capturedSecrets));
               },
               () -> {
                 if (finalResult instanceof SuccessResult successResult) {
@@ -229,7 +233,7 @@ public class ConnectorJobHandler implements JobHandler {
       failJob(
           client,
           job,
-          exceptionHandler.handleFinalResultException(ex, job, secretFilter, capturedSecrets));
+          errorHandler.handleFinalResultException(ex, job, secretFilter, capturedSecrets));
     }
   }
 

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/outbound/ConnectorJobHandler.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/outbound/ConnectorJobHandler.java
@@ -272,8 +272,12 @@ public class ConnectorJobHandler implements JobHandler {
   }
 
   protected void logError(ActivatedJob job, Exception ex) {
+    // The wrapper message is redacted, but its cause is not, so do not log the throwable.
     LOGGER.error(
-        "Exception while processing job: {} for tenant: {}", job.getKey(), job.getTenantId(), ex);
+        "Exception while processing job: {} for tenant: {}, message: {}",
+        job.getKey(),
+        job.getTenantId(),
+        ex.getMessage());
   }
 
   protected void completeJob(

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/outbound/ConnectorJobHandler.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/outbound/ConnectorJobHandler.java
@@ -19,7 +19,6 @@ package io.camunda.connector.runtime.core.outbound;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.connector.api.error.ConnectorException;
-import io.camunda.connector.api.error.ConnectorRetryException;
 import io.camunda.connector.api.outbound.OutboundConnectorFunction;
 import io.camunda.connector.api.secret.SecretProvider;
 import io.camunda.connector.api.validation.ValidationProvider;
@@ -31,7 +30,6 @@ import io.camunda.connector.runtime.core.error.JobError;
 import io.camunda.connector.runtime.core.outbound.ConnectorResult.ErrorResult;
 import io.camunda.connector.runtime.core.outbound.ConnectorResult.SuccessResult;
 import io.camunda.connector.runtime.core.outbound.ErrorExpressionJobContext.ErrorExpressionJob;
-import io.camunda.connector.runtime.core.secret.SecretAllowListUnavailableException;
 import io.camunda.connector.runtime.core.secret.SecretFilter;
 import io.camunda.connector.runtime.core.secret.SecretFilterFactory;
 import io.camunda.connector.runtime.core.secret.SecretFilterFactory.SecretFilterContext;
@@ -47,7 +45,6 @@ import java.time.Duration;
 import java.time.format.DateTimeParseException;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -57,8 +54,6 @@ public class ConnectorJobHandler implements JobHandler {
   // Protects Zeebe from enormously large messages it cannot handle
   public static final int MAX_ERROR_MESSAGE_LENGTH = 6000;
   private static final Logger LOGGER = LoggerFactory.getLogger(ConnectorJobHandler.class);
-
-  private static final Duration ALLOW_LIST_RETRY_BACKOFF = Duration.ofSeconds(5);
 
   protected final OutboundConnectorFunction call;
   protected SecretProvider secretProvider;
@@ -175,12 +170,16 @@ public class ConnectorJobHandler implements JobHandler {
         secretFilterFactory.create(
             new SecretFilterContext(job.getProcessDefinitionKey(), job.getElementId()));
 
+    // one provider instance for both binding and the masking re-read
+    var jobSecretProvider = getSecretProvider();
+    var exceptionHandler = new OutboundConnectorExceptionHandler(jobSecretProvider);
+
     ConnectorResult result;
 
     try {
       var context =
           new JobHandlerContext(
-              job, getSecretProvider(), validationProvider, objectMapper, secretFilter);
+              job, jobSecretProvider, validationProvider, objectMapper, secretFilter);
       var response = call.execute(context);
       var responseVariables =
           ConnectorHelper.createOutputVariables(
@@ -188,30 +187,9 @@ public class ConnectorJobHandler implements JobHandler {
               job.getCustomHeaders().get(Keywords.RESULT_VARIABLE_KEYWORD),
               job.getCustomHeaders().get(Keywords.RESULT_EXPRESSION_KEYWORD));
       result = new ConnectorResult.SuccessResult(response, responseVariables);
-    } catch (ConnectorRetryException ex) {
-      LOGGER.debug(
-          "ConnectorRetryException while processing job: {} for tenant: {}",
-          job.getKey(),
-          job.getTenantId(),
-          ex);
-      String errorCode = ex.getErrorCode();
-      result =
-          handleSDKException(
-              job,
-              ex,
-              Optional.ofNullable(ex.getRetries()).orElse(job.getRetries() - 1),
-              errorCode,
-              Optional.ofNullable(ex.getBackoffDuration()).orElse(retryBackoff));
     } catch (Exception ex) {
-      LOGGER.debug(
-          "Exception while processing job: {} for tenant: {}", job.getKey(), job.getTenantId(), ex);
-      String errorCode = null;
-      if (ex instanceof ConnectorException connectorException) {
-        errorCode = connectorException.getErrorCode();
-      }
       result =
-          handleSDKException(
-              job, ex, job.getRetries() - 1, errorCode, retryBackoffFor(ex, retryBackoff));
+          exceptionHandler.manageConnectorJobHandlerException(ex, job, retryBackoff, secretFilter);
     }
 
     try {
@@ -222,7 +200,8 @@ public class ConnectorJobHandler implements JobHandler {
               new ErrorExpressionJobContext(new ErrorExpressionJob(job.getRetries())))
           .ifPresentOrElse(
               error -> {
-                handleBPMNError(client, job, error);
+                handleBPMNError(
+                    client, job, exceptionHandler.maskConnectorError(error, job, secretFilter));
               },
               () -> {
                 if (finalResult instanceof SuccessResult successResult) {
@@ -237,15 +216,15 @@ public class ConnectorJobHandler implements JobHandler {
                 }
               });
     } catch (Exception ex) {
-      logError(job, ex);
-      // failure while parsing the error expression
-      failJob(client, job, new ErrorResult(Map.of("error", exceptionToMap(ex)), ex, 0));
+      // failure while parsing the error expression; logged by the handler once redacted
+      failJob(client, job, exceptionHandler.handleFinalResultException(ex, job, secretFilter));
     }
   }
 
   private void handleBPMNError(JobClient client, ActivatedJob job, ConnectorError error) {
     if (error instanceof BpmnError bpmnError) {
-      LOGGER.debug("Throwing BPMN error for job {} with code {}", job.getKey(), bpmnError.code());
+      // the code is deliberately never redacted, so it is not echoed into the log either
+      LOGGER.debug("Throwing BPMN error for job {}", job.getKey());
       throwBpmnError(client, job, bpmnError);
     } else if (error instanceof JobError jobError) {
       LOGGER.debug("Throwing incident for job {}", job.getKey());
@@ -258,33 +237,6 @@ public class ConnectorJobHandler implements JobHandler {
               jobError.retries(),
               jobError.retryBackoff()));
     }
-  }
-
-  /**
-   * An allow-list that could not be read means no secret value ever reached the input, and the
-   * lookup behind it reads the process definition from secondary storage, which a just-deployed
-   * definition has yet to reach. That race resolves on the next attempt, so the read gets its own
-   * backoff rather than the model's: the model's paces calls to the target system, which this
-   * failure never reached, and it is zero in older element template versions -- which spent every
-   * remaining attempt within milliseconds.
-   */
-  private static Duration retryBackoffFor(Exception failure, Duration configured) {
-    return failure instanceof SecretAllowListUnavailableException
-        ? ALLOW_LIST_RETRY_BACKOFF
-        : configured;
-  }
-
-  private ConnectorResult handleSDKException(
-      ActivatedJob job, Exception ex, Integer retries, String errorCode, Duration backoffDuration) {
-    LOGGER.debug(
-        "Failing job with retry config => job: {} for tenant: {} with error code: {}, retries: {} and remaining backoffDuration: {}",
-        job.getKey(),
-        job.getTenantId(),
-        errorCode,
-        retries,
-        backoffDuration);
-
-    return new ErrorResult(Map.of("error", exceptionToMap(ex)), ex, retries, backoffDuration);
   }
 
   protected SecretProvider getSecretProvider() {

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/outbound/ConnectorJobHandler.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/outbound/ConnectorJobHandler.java
@@ -44,6 +44,7 @@ import io.camunda.zeebe.client.api.worker.JobHandler;
 import java.time.Duration;
 import java.time.format.DateTimeParseException;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -176,8 +177,11 @@ public class ConnectorJobHandler implements JobHandler {
 
     ConnectorResult result;
 
+    // declared outside the try: what it resolved is what a rotated re-read would no longer match
+    JobHandlerContext context = null;
+
     try {
-      var context =
+      context =
           new JobHandlerContext(
               job, jobSecretProvider, validationProvider, objectMapper, secretFilter);
       var response = call.execute(context);
@@ -189,8 +193,11 @@ public class ConnectorJobHandler implements JobHandler {
       result = new ConnectorResult.SuccessResult(response, responseVariables);
     } catch (Exception ex) {
       result =
-          exceptionHandler.manageConnectorJobHandlerException(ex, job, retryBackoff, secretFilter);
+          exceptionHandler.manageConnectorJobHandlerException(
+              ex, job, retryBackoff, secretFilter, capturedSecrets(context));
     }
+
+    final List<String> capturedSecrets = capturedSecrets(context);
 
     try {
       final ConnectorResult finalResult = result;
@@ -201,7 +208,9 @@ public class ConnectorJobHandler implements JobHandler {
           .ifPresentOrElse(
               error -> {
                 handleBPMNError(
-                    client, job, exceptionHandler.maskConnectorError(error, job, secretFilter));
+                    client,
+                    job,
+                    exceptionHandler.maskConnectorError(error, job, secretFilter, capturedSecrets));
               },
               () -> {
                 if (finalResult instanceof SuccessResult successResult) {
@@ -217,8 +226,22 @@ public class ConnectorJobHandler implements JobHandler {
               });
     } catch (Exception ex) {
       // failure while parsing the error expression; logged by the handler once redacted
-      failJob(client, job, exceptionHandler.handleFinalResultException(ex, job, secretFilter));
+      failJob(
+          client,
+          job,
+          exceptionHandler.handleFinalResultException(ex, job, secretFilter, capturedSecrets));
     }
+  }
+
+  /**
+   * The values this job's input actually had substituted into it. The masking re-read asks the
+   * provider again, so a secret that rotated in between comes back as its new value, leaving the
+   * old one still in the error message with nothing to match it.
+   *
+   * <p>Null when the context itself could not be built, which is also when nothing was resolved.
+   */
+  private static List<String> capturedSecrets(JobHandlerContext context) {
+    return context == null ? List.of() : context.getSecretHandler().getResolvedValues();
   }
 
   private void handleBPMNError(JobClient client, ActivatedJob job, ConnectorError error) {

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/outbound/OutboundConnectorExceptionHandler.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/outbound/OutboundConnectorExceptionHandler.java
@@ -70,6 +70,16 @@ public class OutboundConnectorExceptionHandler {
     this.secretProvider = secretProvider;
   }
 
+  /**
+   * For a job whose secret provider could not be built at all. Discovery runs before the input is
+   * bound, so such a job resolved nothing: its failure cannot carry a secret value, and there is no
+   * provider left to ask for one either. Withholding the message here would hide a runtime failure
+   * an operator has to see, to redact values that were never substituted.
+   */
+  static OutboundConnectorExceptionHandler withoutSecretProvider() {
+    return new OutboundConnectorExceptionHandler(null);
+  }
+
   static Map<String, Object> exceptionToMap(Exception wrappedException, List<String> secrets) {
     Map<String, Object> result = new HashMap<>();
     // Every wrapper built here carries the failure it reports as its cause, except the one that
@@ -203,6 +213,10 @@ public class OutboundConnectorExceptionHandler {
    */
   private MaskingSecrets fetchSecretsForMasking(
       ActivatedJob job, SecretFilter secretFilter, Exception jobFailure) {
+    if (secretProvider == null) {
+      // see withoutSecretProvider(): nothing was resolved, so there is nothing to redact
+      return new MaskingSecrets(List.of(), null);
+    }
     try {
       var keys =
           allowedKeys(SecretUtil.retrieveSecretKeysInInput(job.getVariables()), secretFilter);

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/outbound/OutboundConnectorExceptionHandler.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/outbound/OutboundConnectorExceptionHandler.java
@@ -234,6 +234,16 @@ public class OutboundConnectorExceptionHandler {
     }
   }
 
+  // unions bind-time captures into a successful re-read, so a rotated secret is still redacted
+  private static List<String> withCaptured(MaskingSecrets masking, List<String> captured) {
+    if (captured.isEmpty()) {
+      return masking.secrets();
+    }
+    var union = new ArrayList<String>(masking.secrets());
+    union.addAll(captured);
+    return union;
+  }
+
   private static List<String> allowedKeys(List<String> keys, SecretFilter secretFilter) {
     return keys.stream().filter(secretFilter::isAllowed).toList();
   }
@@ -335,7 +345,11 @@ public class OutboundConnectorExceptionHandler {
   }
 
   public ConnectorResult.ErrorResult manageConnectorJobHandlerException(
-      Exception e, ActivatedJob job, Duration retryBackoffDuration, SecretFilter secretFilter) {
+      Exception e,
+      ActivatedJob job,
+      Duration retryBackoffDuration,
+      SecretFilter secretFilter,
+      List<String> capturedSecrets) {
     if (e instanceof SecretAllowListUnavailableException) {
       // nothing was resolved, so there is nothing to redact and no reason to ask a provider
       return handleGenericException(job, e, List.of(), retryBackoffFor(e, retryBackoffDuration));
@@ -350,7 +364,7 @@ public class OutboundConnectorExceptionHandler {
           job.getRetries() - 1,
           retryBackoffFor(masking.failure(), retryBackoffDuration));
     }
-    List<String> secrets = masking.secrets();
+    List<String> secrets = withCaptured(masking, capturedSecrets);
     if (e instanceof ConnectorRetryException connectorRetryException) {
       return handleConnectorRetryException(
           job, connectorRetryException, secrets, retryBackoffDuration);
@@ -360,7 +374,10 @@ public class OutboundConnectorExceptionHandler {
 
   /** Redacts an error an error expression produced; {@code failJob}/{@code throwError} do not. */
   public ConnectorError maskConnectorError(
-      ConnectorError error, ActivatedJob job, SecretFilter secretFilter) {
+      ConnectorError error,
+      ActivatedJob job,
+      SecretFilter secretFilter,
+      List<String> capturedSecrets) {
     return switch (error) {
       case BpmnError bpmnError -> {
         if (nothingToRedact(bpmnError.message(), bpmnError.variables())) {
@@ -372,7 +389,7 @@ public class OutboundConnectorExceptionHandler {
           yield new BpmnError(
               bpmnError.code(), unmaskableError(masking.failure()).getMessage(), Map.of());
         }
-        var secrets = masking.secrets();
+        var secrets = withCaptured(masking, capturedSecrets);
         yield new BpmnError(
             bpmnError.code(),
             redactNullable(bpmnError.message(), secrets),
@@ -390,7 +407,7 @@ public class OutboundConnectorExceptionHandler {
               jobError.retries(),
               jobError.retryBackoff());
         }
-        var secrets = masking.secrets();
+        var secrets = withCaptured(masking, capturedSecrets);
         yield new JobError(
             redactNullable(jobError.message(), secrets),
             maskVariables(jobError.variables(), secrets),
@@ -480,7 +497,7 @@ public class OutboundConnectorExceptionHandler {
    * log exactly what the incident and the process variables are redacted to keep out.
    */
   public ConnectorResult.ErrorResult handleFinalResultException(
-      Exception ex, ActivatedJob job, SecretFilter secretFilter) {
+      Exception ex, ActivatedJob job, SecretFilter secretFilter, List<String> capturedSecrets) {
     var masking = fetchSecretsForMasking(job, secretFilter, ex);
     if (masking.unavailable()) {
       LOGGER.error(
@@ -493,7 +510,7 @@ public class OutboundConnectorExceptionHandler {
       return new ConnectorResult.ErrorResult(
           Map.of("error", exceptionToMap(wrappedException, List.of())), wrappedException, 0);
     }
-    List<String> secrets = masking.secrets();
+    List<String> secrets = withCaptured(masking, capturedSecrets);
     Exception newException =
         new Exception(SecretUtil.hideSecretsFromMessage(ex.getMessage(), secrets), ex);
     LOGGER.error(

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/outbound/OutboundConnectorExceptionHandler.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/outbound/OutboundConnectorExceptionHandler.java
@@ -19,6 +19,7 @@ package io.camunda.connector.runtime.core.outbound;
 import static io.camunda.connector.runtime.core.outbound.ConnectorJobHandler.MAX_ERROR_MESSAGE_LENGTH;
 
 import io.camunda.connector.api.error.ConnectorException;
+import io.camunda.connector.api.error.ConnectorInputException;
 import io.camunda.connector.api.error.ConnectorRetryException;
 import io.camunda.connector.api.secret.SecretProvider;
 import io.camunda.connector.runtime.core.error.BpmnError;
@@ -345,6 +346,14 @@ public class OutboundConnectorExceptionHandler {
   }
 
   /**
+   * Whether an exception says the input can never bind, whoever raised it. Such a job is not worth
+   * another attempt; anything else — an unreachable cluster, a timeout — is.
+   */
+  private static boolean isFatalInputError(Throwable e) {
+    return e instanceof ConnectorInputException || e.getCause() instanceof ConnectorInputException;
+  }
+
+  /**
    * An allow-list that could not be read means no secret value ever reached the input, and the
    * lookup behind it reads the process definition from secondary storage, which a just-deployed
    * definition has yet to reach. That race resolves on the next attempt, so the read gets its own
@@ -371,11 +380,19 @@ public class OutboundConnectorExceptionHandler {
     var masking = fetchSecretsForMasking(job, secretFilter, e);
     if (masking.unavailable()) {
       var wrappedException = unmaskableError(masking.failure());
+      // Either failure can be the permanent one, so both are consulted. A provider that refuses
+      // to resolve at all (e.g. legacy resolution switched off) throws for every key, including
+      // the ones this fetch only needed for masking; and the job's own failure is still whatever
+      // it was, so an input error that will never bind must not become retryable just because
+      // reading the values to redact it happened to time out. Only when neither says the input is
+      // at fault does the job keep its remaining attempts.
+      int retries =
+          isFatalInputError(masking.failure()) || isFatalInputError(e) ? 0 : job.getRetries() - 1;
       return new ConnectorResult.ErrorResult(
           // secrets could not be fetched, so there is nothing to mask with
           Map.of("error", exceptionToMap(wrappedException, List.of())),
           wrappedException,
-          job.getRetries() - 1,
+          retries,
           retryBackoffFor(masking.failure(), retryBackoffDuration));
     }
     List<String> secrets = withCaptured(masking, capturedSecrets);

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/outbound/OutboundConnectorExceptionHandler.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/outbound/OutboundConnectorExceptionHandler.java
@@ -1,0 +1,507 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.runtime.core.outbound;
+
+import static io.camunda.connector.runtime.core.outbound.ConnectorJobHandler.MAX_ERROR_MESSAGE_LENGTH;
+
+import io.camunda.connector.api.error.ConnectorException;
+import io.camunda.connector.api.error.ConnectorRetryException;
+import io.camunda.connector.api.secret.SecretProvider;
+import io.camunda.connector.runtime.core.error.BpmnError;
+import io.camunda.connector.runtime.core.error.ConnectorError;
+import io.camunda.connector.runtime.core.error.JobError;
+import io.camunda.connector.runtime.core.secret.SecretAllowListUnavailableException;
+import io.camunda.connector.runtime.core.secret.SecretFailureDiagnostic;
+import io.camunda.connector.runtime.core.secret.SecretFilter;
+import io.camunda.connector.runtime.core.secret.SecretNotAvailableException;
+import io.camunda.connector.runtime.core.secret.SecretUtil;
+import io.camunda.zeebe.client.api.response.ActivatedJob;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.IdentityHashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Turns a failed outbound job into an {@link ConnectorResult.ErrorResult} whose message and
+ * variables carry no resolved secret.
+ *
+ * <p>A connector is handed resolved secrets, and the API it calls can echo one back: an error
+ * message or an error expression that copies a response body then publishes the value in the clear
+ * to anyone who can read the incident. Recognising it can only be a value comparison — response
+ * bytes carry nothing marking them as a secret — so the values the job's own input declares are
+ * read back and replaced.
+ */
+public class OutboundConnectorExceptionHandler {
+
+  private static final Logger LOGGER =
+      LoggerFactory.getLogger(OutboundConnectorExceptionHandler.class);
+
+  /** Stands in for a container that (transitively) contains itself, so masking cannot loop. */
+  private static final String CIRCULAR_REFERENCE = "[circular reference]";
+
+  private static final Duration ALLOW_LIST_RETRY_BACKOFF = Duration.ofSeconds(5);
+
+  private final SecretProvider secretProvider;
+
+  public OutboundConnectorExceptionHandler(SecretProvider secretProvider) {
+    this.secretProvider = secretProvider;
+  }
+
+  static Map<String, Object> exceptionToMap(Exception wrappedException, List<String> secrets) {
+    Map<String, Object> result = new HashMap<>();
+    // Every wrapper built here carries the failure it reports as its cause, except the one that
+    // deliberately withholds it — that one reports itself, rather than dereferencing a null.
+    Throwable originalCause =
+        wrappedException.getCause() != null ? wrappedException.getCause() : wrappedException;
+    result.put("type", originalCause.getClass().getName());
+    var message = wrappedException.getMessage();
+    if (message != null) {
+      result.put(
+          "message", message.substring(0, Math.min(message.length(), MAX_ERROR_MESSAGE_LENGTH)));
+    }
+    if (originalCause instanceof ConnectorException connectorException) {
+      var code = connectorException.getErrorCode();
+      var variables = connectorException.getErrorVariables();
+
+      if (code != null) {
+        // deliberately not masked: BPMN error boundary events match on this value, so altering it
+        // would stop the error from being caught
+        result.put("code", code);
+      }
+
+      if (variables != null) {
+        result.put("variables", maskSecrets(variables, secrets));
+      }
+    }
+    return Map.copyOf(result);
+  }
+
+  /**
+   * Masks every secret occurrence in {@code value}, recursing through maps and collections.
+   *
+   * <p>The error message is masked by the callers, but the error variables are copied straight off
+   * the original exception, and for HTTP connectors they carry the full response body and headers.
+   * An API that echoes a rejected credential back would otherwise put the resolved secret into
+   * process variables, which are visible to anyone who can see the process instance.
+   *
+   * <p>Only strings are rewritten; numbers, booleans and other scalars keep their type, since
+   * processes may branch on them. Values of types other than {@link Map}/{@link Collection}/{@link
+   * String} are passed through untouched — a secret held in a field of a custom object is not
+   * reached.
+   */
+  private static Object maskSecrets(Object value, List<String> secrets) {
+    return maskSecrets(value, secrets, Collections.newSetFromMap(new IdentityHashMap<>()));
+  }
+
+  private static Object maskSecrets(Object value, List<String> secrets, Set<Object> enclosing) {
+    return switch (value) {
+      case null -> null;
+      case String string -> SecretUtil.hideSecretsFromMessage(string, secrets);
+      case Map<?, ?> map -> {
+        // error variables are user-supplied, so a container may contain itself
+        if (!enclosing.add(map)) {
+          yield CIRCULAR_REFERENCE;
+        }
+        try {
+          yield maskMap(map, secrets, enclosing);
+        } finally {
+          enclosing.remove(map);
+        }
+      }
+      case Collection<?> collection -> {
+        if (!enclosing.add(collection)) {
+          yield CIRCULAR_REFERENCE;
+        }
+        try {
+          yield collection.stream().map(item -> maskSecrets(item, secrets, enclosing)).toList();
+        } finally {
+          enclosing.remove(collection);
+        }
+      }
+      default -> value;
+    };
+  }
+
+  private static Map<String, Object> maskMap(
+      Map<?, ?> map, List<String> secrets, Set<Object> enclosing) {
+    // keys are masked too, and collapsed keys simply overwrite rather than fail
+    var masked = new LinkedHashMap<String, Object>();
+    map.forEach(
+        (key, entry) ->
+            masked.put(
+                SecretUtil.hideSecretsFromMessage(String.valueOf(key), secrets),
+                maskSecrets(entry, secrets, enclosing)));
+    return masked;
+  }
+
+  /** Typed variant of {@link #maskSecrets}, which returns {@link Object} to allow a sentinel. */
+  private static Map<String, Object> maskVariables(
+      Map<String, Object> variables, List<String> secrets) {
+    if (variables == null) {
+      return null;
+    }
+    Set<Object> enclosing = Collections.newSetFromMap(new IdentityHashMap<>());
+    enclosing.add(variables);
+    return maskMap(variables, secrets, enclosing);
+  }
+
+  /**
+   * The values to redact from an error message, or the failure that prevented reading them.
+   *
+   * <p>Both call sites need the values before they can report anything, and neither may let a
+   * failure to read them escape: one would replace a classified result with an unclassified throw,
+   * and the other is already inside a catch block whose escape route abandons the job.
+   */
+  private record MaskingSecrets(List<String> secrets, Exception failure) {
+
+    boolean unavailable() {
+      return failure != null;
+    }
+  }
+
+  /**
+   * Reads the values to redact. A provider may refuse a key outright, and it throws here for keys
+   * this fetch only ever wanted for masking, so the failure is returned rather than raised.
+   *
+   * <p>A re-read that comes back short is treated as a failure too, because redacting with a
+   * partial list is what this whole path exists to prevent: the values that did come back would be
+   * redacted and the one that did not would be published in the clear. That requirement is exactly
+   * as strong as {@code SecretHandler}'s replacer, which throws when a provider returns null for a
+   * name the filter allows — so the input could not have been bound unless every name it declares
+   * resolved. One of them missing now means the secret was removed, or access to it revoked, since
+   * the connector ran.
+   *
+   * <p>Unless the job's own failure is that very thing ({@link SecretNotAvailableException}), which
+   * is the one case where a name the input declares is expected back empty. Substitution is then
+   * what threw, so the input the message describes never carried that secret's value and there is
+   * nothing of it to redact — and the message is the replacer's own, naming the secret an operator
+   * has to go and create. Withholding it would replace the answer with a description of the
+   * question.
+   */
+  private MaskingSecrets fetchSecretsForMasking(
+      ActivatedJob job, SecretFilter secretFilter, Exception jobFailure) {
+    try {
+      var keys =
+          allowedKeys(SecretUtil.retrieveSecretKeysInInput(job.getVariables()), secretFilter);
+      // A job that declares no secret has nothing to redact, so no provider is asked for anything:
+      // a custom provider that refuses every lookup must not withhold such a job's error message.
+      if (keys.isEmpty()) {
+        return new MaskingSecrets(List.of(), null);
+      }
+      var values = new ArrayList<String>(keys.size());
+      for (var key : keys) {
+        var value = secretProvider.getSecret(key);
+        if (value != null) {
+          values.add(value);
+        }
+      }
+      if (values.size() < keys.size() && !reportsAnUnavailableSecret(jobFailure)) {
+        return new MaskingSecrets(
+            List.of(),
+            new MaskingSecretsIncompleteException(keys.size() - values.size(), keys.size()));
+      }
+      return new MaskingSecrets(List.copyOf(values), null);
+    } catch (Exception ex) {
+      LOGGER.error(
+          "Initial error for job: {} for tenant: {} can't be displayed because fetching secrets failed: {}",
+          job.getKey(),
+          job.getTenantId(),
+          safeDiagnostic(ex));
+      return new MaskingSecrets(List.of(), ex);
+    }
+  }
+
+  private static List<String> allowedKeys(List<String> keys, SecretFilter secretFilter) {
+    return keys.stream().filter(secretFilter::isAllowed).toList();
+  }
+
+  /**
+   * Whether the job failed because a secret it names has no value. A re-read that comes back short
+   * then says the same thing the job's own failure already says, rather than reporting a value that
+   * has gone missing since the connector ran.
+   */
+  private static boolean reportsAnUnavailableSecret(Exception jobFailure) {
+    return jobFailure instanceof SecretNotAvailableException
+        || (jobFailure != null && jobFailure.getCause() instanceof SecretNotAvailableException);
+  }
+
+  /**
+   * Reported when the masking re-read comes back short of the names the job's input declares.
+   * Carries a count and nothing else: how many values are missing is enough for an operator to act
+   * on, and is not something a secret store told this runtime.
+   */
+  private static class MaskingSecretsIncompleteException extends RuntimeException
+      implements SecretFailureDiagnostic {
+
+    private final String publishableMessage;
+
+    private MaskingSecretsIncompleteException(int missing, int expected) {
+      super(
+          missing
+              + " of "
+              + expected
+              + " secrets named by this job's input could not be read back");
+      this.publishableMessage =
+          missing
+              + " of the "
+              + expected
+              + " secrets this job's input names could not be read back, so the error message could"
+              + " not be redacted. A secret that resolved when the input was bound has since been"
+              + " removed, or access to it revoked.";
+    }
+
+    @Override
+    public String publishableMessage() {
+      return publishableMessage;
+    }
+  }
+
+  // A provider's own message can carry secret material - a bundle that parses as a non-object puts
+  // the value into Jackson's coercion error - so only self-authored diagnostics are logged.
+  private static String safeDiagnostic(Exception fetchFailure) {
+    return fetchFailure instanceof SecretFailureDiagnostic diagnosable
+        ? fetchFailure.getClass().getName() + ": " + diagnosable.publishableMessage()
+        : fetchFailure.getClass().getName();
+  }
+
+  private static RuntimeException unmaskableError(Exception fetchFailure) {
+    return new SecretsUnavailableException(
+        fetchFailure.getClass().getName(),
+        fetchFailure instanceof SecretFailureDiagnostic diagnosable
+            ? diagnosable.publishableMessage()
+            : null);
+  }
+
+  /**
+   * Reported in place of an error whose message could not be redacted.
+   *
+   * <p>The failure that prevented masking is dropped with the original message, and for the same
+   * reason: a provider or client error can echo a response body from the secret store, so its
+   * message is no safer to publish than the message it was supposed to help redact. Only the
+   * exception's class name is reported, plus, where the runtime wrote the failure itself, its
+   * {@link SecretFailureDiagnostic#publishableMessage()}.
+   *
+   * <p>Deliberately not a {@link ConnectorException}: {@link #exceptionToMap} copies a {@code
+   * ConnectorException}'s error variables and error code into the payload, and on this path it
+   * would copy them with an empty redaction list — publishing unmasked exactly the data this branch
+   * exists to withhold.
+   */
+  private static class SecretsUnavailableException extends RuntimeException {
+
+    private SecretsUnavailableException(String failureType, String publishableMessage) {
+      super(
+          "Fetching secrets failed, so the original error cannot be displayed: with nothing to"
+              + " redact with it might reveal a secret. Fetching failed with: "
+              + failureType
+              + (publishableMessage == null ? "" : ": " + publishableMessage));
+    }
+  }
+
+  /**
+   * An allow-list that could not be read means no secret value ever reached the input, and the
+   * lookup behind it reads the process definition from secondary storage, which a just-deployed
+   * definition has yet to reach. That race resolves on the next attempt, so the read gets its own
+   * backoff rather than the model's: the model's paces calls to the target system, which this
+   * failure never reached, and it is zero in older element template versions -- which spent every
+   * remaining attempt within milliseconds.
+   */
+  private static Duration retryBackoffFor(Exception failure, Duration configured) {
+    return failure instanceof SecretAllowListUnavailableException
+        ? ALLOW_LIST_RETRY_BACKOFF
+        : configured;
+  }
+
+  public ConnectorResult.ErrorResult manageConnectorJobHandlerException(
+      Exception e, ActivatedJob job, Duration retryBackoffDuration, SecretFilter secretFilter) {
+    if (e instanceof SecretAllowListUnavailableException) {
+      // nothing was resolved, so there is nothing to redact and no reason to ask a provider
+      return handleGenericException(job, e, List.of(), retryBackoffFor(e, retryBackoffDuration));
+    }
+    var masking = fetchSecretsForMasking(job, secretFilter, e);
+    if (masking.unavailable()) {
+      var wrappedException = unmaskableError(masking.failure());
+      return new ConnectorResult.ErrorResult(
+          // secrets could not be fetched, so there is nothing to mask with
+          Map.of("error", exceptionToMap(wrappedException, List.of())),
+          wrappedException,
+          job.getRetries() - 1,
+          retryBackoffFor(masking.failure(), retryBackoffDuration));
+    }
+    List<String> secrets = masking.secrets();
+    if (e instanceof ConnectorRetryException connectorRetryException) {
+      return handleConnectorRetryException(
+          job, connectorRetryException, secrets, retryBackoffDuration);
+    }
+    return handleGenericException(job, e, secrets, retryBackoffDuration);
+  }
+
+  /** Redacts an error an error expression produced; {@code failJob}/{@code throwError} do not. */
+  public ConnectorError maskConnectorError(
+      ConnectorError error, ActivatedJob job, SecretFilter secretFilter) {
+    return switch (error) {
+      case BpmnError bpmnError -> {
+        if (nothingToRedact(bpmnError.message(), bpmnError.variables())) {
+          yield bpmnError;
+        }
+        var masking = fetchSecretsForMasking(job, secretFilter, null);
+        // the error code is never redacted: boundary events match on it
+        if (masking.unavailable()) {
+          yield new BpmnError(
+              bpmnError.code(), unmaskableError(masking.failure()).getMessage(), Map.of());
+        }
+        var secrets = masking.secrets();
+        yield new BpmnError(
+            bpmnError.code(),
+            redactNullable(bpmnError.message(), secrets),
+            maskVariables(bpmnError.variables(), secrets));
+      }
+      case JobError jobError -> {
+        if (nothingToRedact(jobError.message(), jobError.variables())) {
+          yield jobError;
+        }
+        var masking = fetchSecretsForMasking(job, secretFilter, null);
+        if (masking.unavailable()) {
+          yield new JobError(
+              unmaskableError(masking.failure()).getMessage(),
+              Map.of(),
+              jobError.retries(),
+              jobError.retryBackoff());
+        }
+        var secrets = masking.secrets();
+        yield new JobError(
+            redactNullable(jobError.message(), secrets),
+            maskVariables(jobError.variables(), secrets),
+            jobError.retries(),
+            jobError.retryBackoff());
+      }
+    };
+  }
+
+  private static boolean nothingToRedact(String errorMessage, Map<String, Object> variables) {
+    return (errorMessage == null || errorMessage.isEmpty())
+        && (variables == null || variables.isEmpty());
+  }
+
+  /** Unlike {@link SecretUtil#hideSecretsFromMessage}, keeps a null message null rather than "". */
+  private static String redactNullable(String message, List<String> secrets) {
+    return message == null ? null : SecretUtil.hideSecretsFromMessage(message, secrets);
+  }
+
+  private ConnectorResult.ErrorResult handleConnectorRetryException(
+      ActivatedJob job, ConnectorRetryException ex, List<String> secrets, Duration retryBackoff) {
+    Exception newException =
+        new Exception(SecretUtil.hideSecretsFromMessage(ex.getMessage(), secrets), ex);
+    LOGGER.debug(
+        "ConnectorRetryException while processing job: {} for tenant: {}, error message: {}",
+        job.getKey(),
+        job.getTenantId(),
+        newException.getMessage());
+    return handleSDKException(
+        job,
+        newException,
+        Optional.ofNullable(ex.getRetries()).orElse(job.getRetries() - 1),
+        ex.getErrorCode(),
+        Optional.ofNullable(ex.getBackoffDuration()).orElse(retryBackoff),
+        secrets);
+  }
+
+  private ConnectorResult.ErrorResult handleSDKException(
+      ActivatedJob job,
+      Exception ex,
+      Integer retries,
+      String errorCode,
+      Duration backoffDuration,
+      List<String> secrets) {
+    LOGGER.debug(
+        "Failing job with retry config => job: {} for tenant: {} with error code: {}, retries: {} and remaining backoffDuration: {}",
+        job.getKey(),
+        job.getTenantId(),
+        errorCode,
+        retries,
+        backoffDuration);
+
+    return new ConnectorResult.ErrorResult(
+        Map.of("error", exceptionToMap(ex, secrets)), ex, retries, backoffDuration);
+  }
+
+  private ConnectorResult.ErrorResult handleGenericException(
+      ActivatedJob job, Exception ex, List<String> secrets, Duration retryBackoff) {
+    Exception newException =
+        new Exception(SecretUtil.hideSecretsFromMessage(ex.getMessage(), secrets), ex);
+    LOGGER.debug(
+        "Exception while processing job: {} for tenant: {}, message: {}",
+        job.getKey(),
+        job.getTenantId(),
+        newException.getMessage());
+
+    String errorCode = null;
+    if (ex instanceof ConnectorException connectorException) {
+      errorCode = connectorException.getErrorCode();
+    }
+    return handleSDKException(
+        job, newException, job.getRetries() - 1, errorCode, retryBackoff, secrets);
+  }
+
+  /**
+   * Reports a failure raised while processing a connector's final result — its result or error
+   * expression.
+   *
+   * <p>This must not throw. Its only caller is already handling the failure it is being told about,
+   * and an exception leaving here escapes that handler entirely: the job is then neither completed
+   * nor failed, and stays put until its activation timeout hands it to another worker, which
+   * re-runs the connector. So a masking fetch that fails costs the original message — which cannot
+   * be shown unredacted — and nothing else.
+   *
+   * <p>The failure is logged after redaction, not before. A connector was handed resolved secrets
+   * and its error message can carry one back, so logging it on the way in would put in the runtime
+   * log exactly what the incident and the process variables are redacted to keep out.
+   */
+  public ConnectorResult.ErrorResult handleFinalResultException(
+      Exception ex, ActivatedJob job, SecretFilter secretFilter) {
+    var masking = fetchSecretsForMasking(job, secretFilter, ex);
+    if (masking.unavailable()) {
+      LOGGER.error(
+          "Exception while processing job: {} for tenant: {}, type: {}. Its message is withheld:"
+              + " the values to redact it with could not be read.",
+          job.getKey(),
+          job.getTenantId(),
+          ex.getClass().getName());
+      var wrappedException = unmaskableError(masking.failure());
+      return new ConnectorResult.ErrorResult(
+          Map.of("error", exceptionToMap(wrappedException, List.of())), wrappedException, 0);
+    }
+    List<String> secrets = masking.secrets();
+    Exception newException =
+        new Exception(SecretUtil.hideSecretsFromMessage(ex.getMessage(), secrets), ex);
+    LOGGER.error(
+        "Exception while processing job: {} for tenant: {}, message: {}",
+        job.getKey(),
+        job.getTenantId(),
+        newException.getMessage());
+    return new ConnectorResult.ErrorResult(
+        Map.of("error", exceptionToMap(newException, secrets)), newException, 0);
+  }
+}

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretFailureDiagnostic.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretFailureDiagnostic.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.runtime.core.secret;
+
+/**
+ * A secret failure whose message this runtime wrote itself, and which is therefore safe to log and
+ * to publish. A provider's own message is not: it can echo the secret store's response, so only
+ * failures implementing this interface contribute more than their type name.
+ */
+public interface SecretFailureDiagnostic {
+
+  String publishableMessage();
+}

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretHandler.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretHandler.java
@@ -16,7 +16,6 @@
  */
 package io.camunda.connector.runtime.core.secret;
 
-import io.camunda.connector.api.error.ConnectorInputException;
 import io.camunda.connector.api.secret.SecretProvider;
 import java.util.Optional;
 import java.util.function.Function;
@@ -37,10 +36,7 @@ public class SecretHandler {
         name -> {
           if (secretFilter.isAllowed(name)) {
             return Optional.ofNullable(secretProvider.getSecret(name))
-                .orElseThrow(
-                    () ->
-                        new ConnectorInputException(
-                            String.format("Secret with name '%s' is not available", name), null));
+                .orElseThrow(() -> new SecretNotAvailableException(name));
           }
           LOG.debug("Secret '{}' not in allow-list — placeholder left unreplaced", name);
           return null;

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretHandler.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretHandler.java
@@ -17,7 +17,10 @@
 package io.camunda.connector.runtime.core.secret;
 
 import io.camunda.connector.api.secret.SecretProvider;
+import java.util.List;
 import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -30,13 +33,21 @@ public class SecretHandler {
 
   protected Function<String, String> secretReplacer;
 
+  // values this instance substituted, so a caller can redact against a rotated re-read
+  private final Set<String> resolvedValues = ConcurrentHashMap.newKeySet();
+
   public SecretHandler(final SecretProvider secretProvider, SecretFilter secretFilter) {
     this.secretProvider = secretProvider;
     secretReplacer =
         name -> {
           if (secretFilter.isAllowed(name)) {
-            return Optional.ofNullable(secretProvider.getSecret(name))
-                .orElseThrow(() -> new SecretNotAvailableException(name));
+            var value =
+                Optional.ofNullable(secretProvider.getSecret(name))
+                    .orElseThrow(() -> new SecretNotAvailableException(name));
+            resolvedValues.add(value);
+            // a message that re-serializes the input carries this form, not the raw value
+            resolvedValues.add(SecretUtil.jsonEscape(value));
+            return value;
           }
           LOG.debug("Secret '{}' not in allow-list — placeholder left unreplaced", name);
           return null;
@@ -45,5 +56,9 @@ public class SecretHandler {
 
   public String replaceSecrets(String input) {
     return SecretUtil.replaceSecrets(input, secretReplacer);
+  }
+
+  public List<String> getResolvedValues() {
+    return List.copyOf(resolvedValues);
   }
 }

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretNotAvailableException.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretNotAvailableException.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.runtime.core.secret;
+
+import io.camunda.connector.api.error.ConnectorInputException;
+import java.io.Serial;
+
+/**
+ * Raised when a name an input declares has no value. A subtype rather than a bare {@link
+ * ConnectorInputException} so that the outbound masking re-read can recognise the one case where a
+ * declared name is expected to come back empty, and report the job's own failure rather than
+ * withholding it.
+ */
+public class SecretNotAvailableException extends ConnectorInputException {
+
+  @Serial private static final long serialVersionUID = 1L;
+
+  public SecretNotAvailableException(String name) {
+    super(String.format("Secret with name '%s' is not available", name), null);
+  }
+}

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretUtil.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretUtil.java
@@ -16,6 +16,7 @@
  */
 package io.camunda.connector.runtime.core.secret;
 
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -87,5 +88,18 @@ public class SecretUtil {
       output.append(original, lastIndex, original.length());
     }
     return output.toString();
+  }
+
+  // Longest secret first: masking a shorter secret that prefixes a longer one would destroy the
+  // longer match and publish its remainder, e.g. "x" before "xSUPERSECRET" leaves "***SUPERSECRET".
+  public static String hideSecretsFromMessage(String message, List<String> secrets) {
+    if (message == null) {
+      return "";
+    }
+    return secrets.stream()
+        // a provider may answer with an empty value, and replacing that matches everywhere
+        .filter(secret -> !secret.isEmpty())
+        .sorted(Comparator.comparingInt(String::length).reversed())
+        .reduce(message, (newMessage, nextSecret) -> newMessage.replace(nextSecret, "***"));
   }
 }

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretUtil.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretUtil.java
@@ -46,11 +46,11 @@ public class SecretUtil {
         REFERENCE,
         matcher -> {
           String value = resolve(name(matcher), secretReplacer, resolutions);
-          return value == null ? matcher.group() : value;
+          return value == null ? matcher.group() : jsonEscape(value);
         });
   }
 
-  // The form a value would take once spliced into JSON, which a raw-value capture would miss.
+  // The form actually spliced into the substituted JSON, which a raw-value capture would miss.
   public static String jsonEscape(String value) {
     return new String(JsonStringEncoder.getInstance().quoteAsString(value));
   }

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretUtil.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretUtil.java
@@ -16,6 +16,7 @@
  */
 package io.camunda.connector.runtime.core.secret;
 
+import com.fasterxml.jackson.core.io.JsonStringEncoder;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
@@ -47,6 +48,11 @@ public class SecretUtil {
           String value = resolve(name(matcher), secretReplacer, resolutions);
           return value == null ? matcher.group() : value;
         });
+  }
+
+  // The form a value would take once spliced into JSON, which a raw-value capture would miss.
+  public static String jsonEscape(String value) {
+    return new String(JsonStringEncoder.getInstance().quoteAsString(value));
   }
 
   /** Asks the replacer at most once per name, for providers that meter or charge per lookup. */

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/SecretUtilTests.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/SecretUtilTests.java
@@ -21,6 +21,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 
+import io.camunda.connector.api.json.ConnectorsObjectMapperSupplier;
 import io.camunda.connector.runtime.core.secret.SecretUtil;
 import java.util.ArrayList;
 import java.util.List;
@@ -205,6 +206,19 @@ public class SecretUtilTests {
 
     assertThat(SecretUtil.replaceSecrets(input, recording(asked, Map.of()))).isEqualTo(input);
     assertThat(asked).containsExactly("\0");
+  }
+
+  @Test
+  void shouldEscapeTheValueItSplicesIntoJson() throws Exception {
+    // callers substitute into a JSON document and parse the result, so the value has to survive
+    // that round trip: spliced raw, a backslash sequence would bind as whatever JSON reads it as
+    var value = "pa\\nss\"quoted\"";
+    var substituted = SecretUtil.replaceSecrets("{\"token\":\"{{secrets.FOO}}\"}", name -> value);
+
+    assertThat(substituted).isEqualTo("{\"token\":\"pa\\\\nss\\\"quoted\\\"\"}");
+    assertThat(
+            ConnectorsObjectMapperSupplier.getCopy().readTree(substituted).get("token").textValue())
+        .isEqualTo(value);
   }
 
   private static Function<String, String> recording(

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextImplTest.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextImplTest.java
@@ -18,14 +18,19 @@ package io.camunda.connector.runtime.core.inbound;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.EvictingQueue;
+import io.camunda.connector.api.inbound.Activity;
+import io.camunda.connector.api.inbound.Health;
 import io.camunda.connector.api.inbound.ProcessElement;
+import io.camunda.connector.api.inbound.Severity;
 import io.camunda.connector.api.json.ConnectorsObjectMapperSupplier;
 import io.camunda.connector.api.secret.SecretProvider;
 import io.camunda.connector.feel.annotation.FEEL;
@@ -34,6 +39,7 @@ import io.camunda.connector.runtime.core.inbound.InboundConnectorContextImplTest
 import io.camunda.connector.runtime.core.inbound.correlation.MessageCorrelationPoint.StandaloneMessageCorrelationPoint;
 import io.camunda.connector.runtime.core.inbound.details.InboundConnectorDetails;
 import io.camunda.connector.runtime.core.inbound.details.InboundConnectorDetails.ValidInboundConnectorDetails;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -196,6 +202,261 @@ class InboundConnectorContextImplTest {
             EvictingQueue.create(10));
 
     assertThat(replace(context, "secrets.INJECTED")).isEqualTo("resolved");
+  }
+
+  // Secret redaction of operator-visible output (#8643). The values are read back from the
+  // provider rather than remembered from binding, and unioned with what this context actually
+  // substituted, so a secret that rotated in between is still redacted by the value the message
+  // carries.
+  //
+  // Main additionally covers a sibling element declaring a secret the representative element does
+  // not, and a redeploy invalidating the cached re-read. Neither is representable here: grouped
+  // elements on this branch must carry identical connector-level properties -- {@code
+  // InboundConnectorDetailsUtil} rejects a group whose elements diverge -- and connectorDetails is
+  // final with no updateConnectorDetails to invalidate anything.
+
+  private InboundConnectorContextImpl loggingContext(
+      ValidInboundConnectorDetails details, SecretProvider provider, EvictingQueue<Activity> logs) {
+    return new InboundConnectorContextImpl(
+        provider, (e) -> {}, details, null, (e) -> {}, mapper, logs);
+  }
+
+  private static Activity errorActivity(String message) {
+    return Activity.level(Severity.ERROR).tag("error").message(message);
+  }
+
+  @Test
+  void log_masksASecretResolvedForThisConnector() {
+    // given a connector declaring a secret this context can resolve
+    EvictingQueue<Activity> logs = EvictingQueue.create(10);
+    var context =
+        loggingContext(
+            getInboundConnectorDefinition(Map.of("token", "secrets.FOO")), secretProvider, logs);
+
+    // when an activity's message happens to carry the resolved value
+    context.log(errorActivity("token was " + FooBarSecretProvider.SECRET_VALUE));
+
+    // then the logged message has the value masked
+    assertThat(logs)
+        .singleElement()
+        .satisfies(log -> assertThat(log.message()).isEqualTo("token was ***"));
+  }
+
+  @Test
+  void log_withholdsMessageWhenSecretValuesCannotBeFetched() {
+    // given a provider that fails to resolve the declared secret
+    EvictingQueue<Activity> logs = EvictingQueue.create(10);
+    var failingProvider = mock(SecretProvider.class);
+    when(failingProvider.getSecret("FOO")).thenThrow(new RuntimeException("secret store is down"));
+    var context =
+        loggingContext(
+            getInboundConnectorDefinition(Map.of("token", "secrets.FOO")), failingProvider, logs);
+
+    // when
+    context.log(errorActivity("token was bar"));
+
+    // then the raw message is withheld rather than published unmasked, and the provider's own
+    // message -- which can echo the secret store's response -- is not what replaces it
+    assertThat(logs)
+        .singleElement()
+        .satisfies(
+            log -> {
+              assertThat(log.message())
+                  .doesNotContain("bar")
+                  .doesNotContain("secret store is down");
+              assertThat(log.message()).contains("withheld");
+            });
+  }
+
+  @Test
+  void log_withholdsMessageWhenTheReReadComesBackShort() {
+    // given a connector declaring two secrets of which the provider only has one
+    EvictingQueue<Activity> logs = EvictingQueue.create(10);
+    var partialProvider = mock(SecretProvider.class);
+    when(partialProvider.getSecret("FOO")).thenReturn("only-one-value");
+    var context =
+        loggingContext(
+            getInboundConnectorDefinition(Map.of("a", "secrets.FOO", "b", "secrets.BAR")),
+            partialProvider,
+            logs);
+
+    // when nothing was ever bound, so only the incomplete re-read is available
+    context.log(errorActivity("token was leaked"));
+
+    // then the message is withheld rather than published with only one of the two values masked
+    assertThat(logs)
+        .singleElement()
+        .satisfies(log -> assertThat(log.message()).contains("withheld"));
+  }
+
+  @Test
+  void log_masksASecretThatRotatedAfterItWasBound() {
+    // given a provider that resolves FOO to one value at bind time and another on re-read
+    EvictingQueue<Activity> logs = EvictingQueue.create(10);
+    var rotatingProvider = mock(SecretProvider.class);
+    when(rotatingProvider.getSecret("FOO")).thenReturn("old-value", "new-value");
+    var context =
+        loggingContext(
+            getInboundConnectorDefinition(Map.of("token", "secrets.FOO")), rotatingProvider, logs);
+
+    // when the bound value is used, binding first so it is actually substituted and captured
+    context.getProperties();
+    context.log(errorActivity("token was old-value"));
+
+    // then the bound value is redacted even though a re-read returns a different one
+    assertThat(logs)
+        .singleElement()
+        .satisfies(log -> assertThat(log.message()).isEqualTo("token was ***"));
+  }
+
+  @Test
+  void log_readsTheSecretValuesOnceAndReusesThem() {
+    // given
+    EvictingQueue<Activity> logs = EvictingQueue.create(10);
+    var provider = mock(SecretProvider.class);
+    when(provider.getSecret("FOO")).thenReturn("bar");
+    var context =
+        loggingContext(
+            getInboundConnectorDefinition(Map.of("token", "secrets.FOO")), provider, logs);
+
+    // when several messages are logged
+    context.log(errorActivity("first was bar"));
+    context.log(errorActivity("second was bar"));
+
+    // then the provider is asked once: a per-message read would put the log path's cost, and a
+    // transient failure's blast radius, on every message
+    verify(provider, times(1)).getSecret("FOO");
+    assertThat(logs).allSatisfy(log -> assertThat(log.message()).endsWith("was ***"));
+  }
+
+  @Test
+  void log_masksASecretForAGroupedExecutable() {
+    // given two elements deduplicated into one executable
+    EvictingQueue<Activity> logs = EvictingQueue.create(10);
+    var context =
+        loggingContext(
+            groupedDefinition(Map.of("token", "secrets.FOO"), "first", "second"),
+            secretProvider,
+            logs);
+
+    // when
+    context.log(errorActivity("token was " + FooBarSecretProvider.SECRET_VALUE));
+
+    // then the scan across every grouped element still finds the declared name
+    assertThat(logs)
+        .singleElement()
+        .satisfies(log -> assertThat(log.message()).isEqualTo("token was ***"));
+  }
+
+  @Test
+  void log_isUnchangedWhenTheConnectorDeclaresNoSecret() {
+    // given a connector that names no secret, so no provider is asked for anything
+    EvictingQueue<Activity> logs = EvictingQueue.create(10);
+    var provider = mock(SecretProvider.class);
+    var context =
+        loggingContext(getInboundConnectorDefinition(Map.of("token", "plain")), provider, logs);
+
+    // when
+    context.log(errorActivity("nothing secret here"));
+
+    // then
+    assertThat(logs)
+        .singleElement()
+        .satisfies(log -> assertThat(log.message()).isEqualTo("nothing secret here"));
+    verify(provider, never()).getSecret(any());
+  }
+
+  @Test
+  void reportHealth_masksASecretInTheError() {
+    // given
+    var context =
+        loggingContext(
+            getInboundConnectorDefinition(Map.of("token", "secrets.FOO")),
+            secretProvider,
+            EvictingQueue.create(10));
+
+    // when the reported health carries the resolved value in its error
+    context.reportHealth(
+        Health.down(new RuntimeException("token was " + FooBarSecretProvider.SECRET_VALUE)));
+
+    // then it is masked in the stored health
+    assertThat(context.getHealth().getError().message())
+        .doesNotContain(FooBarSecretProvider.SECRET_VALUE);
+  }
+
+  @Test
+  void reportHealth_masksTheErrorCodeToo() {
+    // given
+    var context =
+        loggingContext(
+            getInboundConnectorDefinition(Map.of("token", "secrets.FOO")),
+            secretProvider,
+            EvictingQueue.create(10));
+
+    // when the value reaches the code rather than the message; unlike a BPMN error code, nothing
+    // routes on this one, so there is no reason to leave it unmasked
+    var error = new Health.Error(FooBarSecretProvider.SECRET_VALUE, "failed");
+    context.reportHealth(Health.down(error));
+
+    // then
+    assertThat(context.getHealth().getError().code()).isEqualTo("***");
+  }
+
+  @Test
+  void reportHealth_withholdsTheErrorWhenSecretValuesCannotBeFetched() {
+    // given
+    var failingProvider = mock(SecretProvider.class);
+    when(failingProvider.getSecret("FOO")).thenThrow(new RuntimeException("secret store is down"));
+    var context =
+        loggingContext(
+            getInboundConnectorDefinition(Map.of("token", "secrets.FOO")),
+            failingProvider,
+            EvictingQueue.create(10));
+
+    // when
+    context.reportHealth(Health.down(new RuntimeException("token was bar")));
+
+    // then
+    assertThat(context.getHealth().getError().message()).doesNotContain("bar").contains("withheld");
+  }
+
+  @Test
+  void reportHealth_leavesAHealthWithoutAnErrorAlone() {
+    // given
+    var provider = mock(SecretProvider.class);
+    var context =
+        loggingContext(
+            getInboundConnectorDefinition(Map.of("token", "secrets.FOO")),
+            provider,
+            EvictingQueue.create(10));
+
+    // when
+    context.reportHealth(Health.up());
+
+    // then no read is attempted for a health that carries no message to redact
+    assertThat(context.getHealth()).isEqualTo(Health.up());
+    verify(provider, never()).getSecret(any());
+  }
+
+  @NotNull
+  private static ValidInboundConnectorDetails groupedDefinition(
+      Map<String, String> properties, String... elementIds) {
+    properties = new HashMap<>(properties);
+    properties.put("inbound.type", "io.camunda:connector:1");
+    var rawProperties = Map.copyOf(properties);
+    var elements =
+        Arrays.stream(elementIds)
+            .map(
+                elementId ->
+                    new InboundConnectorElement(
+                        rawProperties,
+                        new StandaloneMessageCorrelationPoint("", "", null, null),
+                        new ProcessElement("bool", 0, 0, elementId, "<default>")))
+            .toList();
+    var details =
+        InboundConnectorDetails.of(elements.getFirst().deduplicationId(List.of()), elements);
+    assertThat(details).isInstanceOf(ValidInboundConnectorDetails.class);
+    return (ValidInboundConnectorDetails) details;
   }
 
   @NotNull

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextImplTest.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextImplTest.java
@@ -28,6 +28,7 @@ import static org.mockito.Mockito.when;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.EvictingQueue;
 import io.camunda.connector.api.inbound.Activity;
+import io.camunda.connector.api.inbound.CorrelationResult;
 import io.camunda.connector.api.inbound.Health;
 import io.camunda.connector.api.inbound.ProcessElement;
 import io.camunda.connector.api.inbound.Severity;
@@ -36,6 +37,7 @@ import io.camunda.connector.api.secret.SecretProvider;
 import io.camunda.connector.feel.annotation.FEEL;
 import io.camunda.connector.runtime.core.FooBarSecretProvider;
 import io.camunda.connector.runtime.core.inbound.InboundConnectorContextImplTest.TestPropertiesClass.InnerObject;
+import io.camunda.connector.runtime.core.inbound.correlation.InboundCorrelationHandler;
 import io.camunda.connector.runtime.core.inbound.correlation.MessageCorrelationPoint.StandaloneMessageCorrelationPoint;
 import io.camunda.connector.runtime.core.inbound.details.InboundConnectorDetails;
 import io.camunda.connector.runtime.core.inbound.details.InboundConnectorDetails.ValidInboundConnectorDetails;
@@ -436,6 +438,83 @@ class InboundConnectorContextImplTest {
     // then no read is attempted for a health that carries no message to redact
     assertThat(context.getHealth()).isEqualTo(Health.up());
     verify(provider, never()).getSecret(any());
+  }
+
+  @Test
+  void log_masksASecretAnActivatedElementBoundBeforeItRotated() {
+    // given a correlation that hands the connector an element context, which resolves through its
+    // own secret handler rather than this one
+    EvictingQueue<Activity> logs = EvictingQueue.create(10);
+    var rotatingProvider = mock(SecretProvider.class);
+    when(rotatingProvider.getSecret("FOO")).thenReturn("old-value", "new-value");
+    var details = getInboundConnectorDefinition(Map.of("token", "secrets.FOO"));
+    var context = correlatingContext(details, rotatingProvider, logs);
+
+    // when the element binds the secret and it rotates before anything is logged
+    var activatedElement =
+        ((CorrelationResult.Success) context.correlateWithResult(Map.of())).activatedElement();
+    activatedElement.getProperties();
+    context.log(errorActivity("token was old-value"));
+
+    // then the value the element bound is redacted, even though this context never bound it and a
+    // re-read now returns a different one
+    assertThat(logs)
+        .singleElement()
+        .satisfies(log -> assertThat(log.message()).isEqualTo("token was ***"));
+  }
+
+  @Test
+  void reportHealth_masksASecretAnActivatedElementBoundBeforeItRotated() {
+    // given
+    var rotatingProvider = mock(SecretProvider.class);
+    when(rotatingProvider.getSecret("FOO")).thenReturn("old-value", "new-value");
+    var details = getInboundConnectorDefinition(Map.of("token", "secrets.FOO"));
+    var context = correlatingContext(details, rotatingProvider, EvictingQueue.create(10));
+
+    // when
+    var activatedElement =
+        ((CorrelationResult.Success) context.correlateWithResult(Map.of())).activatedElement();
+    activatedElement.getProperties();
+    context.reportHealth(Health.down(new RuntimeException("token was old-value")));
+
+    // then
+    assertThat(context.getHealth().getError().message())
+        .doesNotContain("old-value")
+        .endsWith("token was ***");
+  }
+
+  @Test
+  void log_masksASecretWhoseValueCarriesAJsonEscape() {
+    // given a value that is not its own JSON representation
+    EvictingQueue<Activity> logs = EvictingQueue.create(10);
+    var value = "pa\\nss";
+    var rotatingProvider = mock(SecretProvider.class);
+    when(rotatingProvider.getSecret("FOO")).thenReturn(value, "new-value");
+    var context =
+        loggingContext(
+            getInboundConnectorDefinition(Map.of("token", "secrets.FOO")), rotatingProvider, logs);
+
+    // when it is bound and then rotates, leaving only the capture to redact with
+    assertThat(context.getProperties()).containsEntry("token", value);
+    context.log(errorActivity("token was " + value));
+
+    // then it was spliced into the properties JSON escaped, so what was bound is what was captured
+    assertThat(logs)
+        .singleElement()
+        .satisfies(log -> assertThat(log.message()).isEqualTo("token was ***"));
+  }
+
+  private InboundConnectorContextImpl correlatingContext(
+      ValidInboundConnectorDetails details, SecretProvider provider, EvictingQueue<Activity> logs) {
+    var elementContext =
+        new DefaultProcessElementContext(
+            details.connectorElements().getFirst(), (e) -> {}, provider, mapper);
+    var correlationHandler = mock(InboundCorrelationHandler.class);
+    when(correlationHandler.correlate(any(), any()))
+        .thenReturn(
+            new CorrelationResult.Success.MessagePublished(elementContext, 1L, "<default>"));
+    return new InboundConnectorContextImpl(
+        provider, (e) -> {}, details, correlationHandler, (e) -> {}, mapper, logs);
   }
 
   @NotNull

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/outbound/ConnectorJobHandlerTest.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/outbound/ConnectorJobHandlerTest.java
@@ -1381,4 +1381,54 @@ class ConnectorJobHandlerTest {
       assertThat(result.getErrorMessage()).isEmpty();
     }
   }
+
+  // the value bound at execution time can differ from what a later re-read returns if it rotated
+  @Nested
+  class RotationRaceSecretMaskingTests {
+
+    private record TokenHolder(String token) {}
+
+    private static final String INPUT_DECLARING_A_SECRET = "{ \"token\" : \"{{secrets.FOO}}\" }";
+
+    private ConnectorJobHandler connectorThrowingTheBoundToken(
+        String boundValue, String rotatedValue) {
+      var callCount = new AtomicInteger();
+      SecretProvider rotatingSecretProvider =
+          name -> callCount.getAndIncrement() == 0 ? boundValue : rotatedValue;
+      return new ConnectorJobHandler(
+          context -> {
+            var bound = context.bindVariables(TokenHolder.class);
+            throw new RuntimeException("api rejected " + bound.token());
+          },
+          rotatingSecretProvider,
+          e -> {},
+          null,
+          SecretFilterFactory.disabled());
+    }
+
+    @Test
+    void aSecretThatRotatedBetweenBindAndMaskingIsStillRedacted() {
+      var jobHandler = connectorThrowingTheBoundToken("old-value", "new-value");
+
+      var result =
+          JobBuilder.create()
+              .withVariables(INPUT_DECLARING_A_SECRET)
+              .executeAndCaptureResult(jobHandler, false, false);
+
+      assertThat(result.getErrorMessage()).doesNotContain("old-value");
+    }
+
+    @Test
+    void aStableSecretIsStillRedactedTheOrdinaryWay() {
+      // the union must not depend on rotation happening: an unrotated secret is redacted too
+      var jobHandler = connectorThrowingTheBoundToken("stable-value", "stable-value");
+
+      var result =
+          JobBuilder.create()
+              .withVariables(INPUT_DECLARING_A_SECRET)
+              .executeAndCaptureResult(jobHandler, false, false);
+
+      assertThat(result.getErrorMessage()).doesNotContain("stable-value");
+    }
+  }
 }

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/outbound/ConnectorJobHandlerTest.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/outbound/ConnectorJobHandlerTest.java
@@ -37,7 +37,9 @@ import io.camunda.connector.api.error.ConnectorException;
 import io.camunda.connector.api.error.ConnectorExceptionBuilder;
 import io.camunda.connector.api.error.ConnectorRetryExceptionBuilder;
 import io.camunda.connector.api.outbound.OutboundConnectorFunction;
+import io.camunda.connector.api.secret.SecretProvider;
 import io.camunda.connector.runtime.core.ConnectorHelper;
+import io.camunda.connector.runtime.core.FooBarSecretProvider;
 import io.camunda.connector.runtime.core.Keywords;
 import io.camunda.connector.runtime.core.secret.SecretAllowListUnavailableException;
 import io.camunda.connector.runtime.core.secret.SecretFilterFactory;
@@ -1200,6 +1202,183 @@ class ConnectorJobHandlerTest {
       // then
       assertThat(result.getErrorCode()).isEqualTo("9999");
       assertThat(result.getErrorMessage()).isEqualTo("Message for foo value on test property");
+    }
+  }
+
+  /** The job's input declares {{secrets.FOO}}, and the called API echoes that value back. */
+  @Nested
+  class ErrorExpressionSecretMaskingTests {
+
+    private static final String ECHOED = FooBarSecretProvider.SECRET_VALUE;
+    private static final String INPUT_DECLARING_A_SECRET = "{ \"token\" : \"{{secrets.FOO}}\" }";
+
+    private ConnectorJobHandler echoingConnector() {
+      return echoingConnector(new FooBarSecretProvider());
+    }
+
+    private ConnectorJobHandler echoingConnectorWithUnreadableSecrets() {
+      return echoingConnector(
+          name -> {
+            throw new RuntimeException("Network error while fetching secrets");
+          });
+    }
+
+    private ConnectorJobHandler echoingConnector(SecretProvider secretProvider) {
+      return new ConnectorJobHandler(
+          context -> Map.of("body", "rejected token " + ECHOED),
+          secretProvider,
+          e -> {},
+          null,
+          SecretFilterFactory.disabled());
+    }
+
+    @Test
+    void anExceptionMessageCopyingAResponseIsRedacted() {
+      var jobHandler =
+          new ConnectorJobHandler(
+              context -> {
+                throw new RuntimeException("rejected token " + ECHOED);
+              },
+              new FooBarSecretProvider(),
+              e -> {},
+              null,
+              SecretFilterFactory.disabled());
+
+      var result =
+          JobBuilder.create()
+              .withVariables(INPUT_DECLARING_A_SECRET)
+              .executeAndCaptureResult(jobHandler, false, false);
+
+      assertThat(result.getErrorMessage()).isEqualTo("rejected token ***");
+    }
+
+    @Test
+    void jobErrorMessageCopyingAResponseIsRedacted() {
+      var result =
+          JobBuilder.create()
+              .withVariables(INPUT_DECLARING_A_SECRET)
+              .withErrorExpressionHeader("=jobError(\"Request failed: \" + response.body, {}, 0)")
+              .executeAndCaptureResult(echoingConnector(), false, false);
+
+      assertThat(result.getErrorMessage())
+          .isEqualTo("Request failed: rejected token ***")
+          .doesNotContain(ECHOED);
+      // the incident's variables are built from the same masked message
+      assertThat(result.getVariables())
+          .containsEntry("error", "Request failed: rejected token ***");
+    }
+
+    @Test
+    void jobErrorKeepsTheRetriesAndBackoffTheExpressionAsked() {
+      var failCommand = mock(FailJobCommandStep1.class);
+      var failCommandStep2 = mock(FailJobCommandStep2.class, RETURNS_DEEP_STUBS);
+      var jobClient = mock(JobClient.class);
+      when(jobClient.newFailCommand(any())).thenReturn(failCommand);
+      when(failCommand.retries(anyInt())).thenReturn(failCommandStep2);
+      when(failCommandStep2.errorMessage(any())).thenReturn(failCommandStep2);
+      when(failCommandStep2.retryBackoff(any())).thenReturn(failCommandStep2);
+      when(failCommandStep2.variables(anyMap())).thenReturn(failCommandStep2);
+      when(failCommandStep2.variables(any(Object.class))).thenReturn(failCommandStep2);
+
+      JobBuilder.create()
+          .useJobClient(jobClient)
+          .withVariables(INPUT_DECLARING_A_SECRET)
+          .withErrorExpressionHeader(
+              "=jobError(\"Request failed: \" + response.body, {}, 7, duration(\"PT5M\"))")
+          .execute(echoingConnector());
+
+      var messageCaptor = ArgumentCaptor.forClass(String.class);
+      verify(failCommandStep2).errorMessage(messageCaptor.capture());
+      assertThat(messageCaptor.getValue()).doesNotContain(ECHOED);
+      verify(failCommand).retries(7);
+      verify(failCommandStep2).retryBackoff(Duration.ofMinutes(5));
+    }
+
+    @Test
+    void bpmnErrorMessageCopyingAResponseIsRedacted() {
+      var result =
+          JobBuilder.create()
+              .withVariables(INPUT_DECLARING_A_SECRET)
+              .withErrorExpressionHeader(
+                  "=bpmnError(\"AUTH_FAILED\", \"Request failed: \" + response.body)")
+              .executeAndCaptureResult(echoingConnector(), false, true);
+
+      assertThat(result.getErrorMessage())
+          .isEqualTo("Request failed: rejected token ***")
+          .doesNotContain(ECHOED);
+    }
+
+    @Test
+    void bpmnErrorVariablesCopyingAResponseAreRedacted() {
+      var result =
+          JobBuilder.create()
+              .withVariables(INPUT_DECLARING_A_SECRET)
+              .withErrorExpressionHeader(
+                  "=bpmnError(\"AUTH_FAILED\", \"failed\", {detail: response.body})")
+              .executeAndCaptureResult(echoingConnector(), false, true);
+
+      assertThat(result.getVariables()).containsEntry("detail", "rejected token ***");
+    }
+
+    @Test
+    void bpmnErrorCodeIsNotRedacted() {
+      // boundary events match on the code, so it keeps a value equal to the secret's
+      var result =
+          JobBuilder.create()
+              .withVariables(INPUT_DECLARING_A_SECRET)
+              .withErrorExpressionHeader(
+                  "=bpmnError(\"" + ECHOED + "\", \"Request failed: \" + response.body)")
+              .executeAndCaptureResult(echoingConnector(), false, true);
+
+      assertThat(result.getErrorCode()).isEqualTo(ECHOED);
+      assertThat(result.getErrorMessage()).doesNotContain(ECHOED);
+    }
+
+    @Test
+    void jobErrorIsWithheldWhenItCannotBeRedacted() {
+      var result =
+          JobBuilder.create()
+              .withVariables(INPUT_DECLARING_A_SECRET)
+              .withErrorExpressionHeader("=jobError(\"Request failed: \" + response.body, {}, 0)")
+              .executeAndCaptureResult(echoingConnectorWithUnreadableSecrets(), false, false);
+
+      // the fetch failure's own message is withheld too: a provider error can echo the store's body
+      assertThat(result.getErrorMessage())
+          .startsWith("Fetching secrets failed, so the original error cannot be displayed")
+          .contains("java.lang.RuntimeException")
+          .doesNotContain("Network error while fetching secrets")
+          .doesNotContain(ECHOED);
+      assertThat(result.getRetries()).isZero();
+    }
+
+    @Test
+    void bpmnErrorKeepsItsCodeWhenItCannotBeRedacted() {
+      var result =
+          JobBuilder.create()
+              .withVariables(INPUT_DECLARING_A_SECRET)
+              .withErrorExpressionHeader(
+                  "=bpmnError(\"AUTH_FAILED\", \"Request failed: \" + response.body,"
+                      + " {detail: response.body})")
+              .executeAndCaptureResult(echoingConnectorWithUnreadableSecrets(), false, true);
+
+      assertThat(result.getErrorCode()).isEqualTo("AUTH_FAILED");
+      assertThat(result.getErrorMessage())
+          .startsWith("Fetching secrets failed, so the original error cannot be displayed")
+          .doesNotContain(ECHOED);
+      assertThat(result.getVariables()).isEmpty();
+    }
+
+    @Test
+    void anErrorCarryingNothingToRedactIsLeftAlone() {
+      // no message and no variables, so the read is skipped and the unreadable store costs nothing
+      var result =
+          JobBuilder.create()
+              .withVariables(INPUT_DECLARING_A_SECRET)
+              .withErrorExpressionHeader("=bpmnError(\"AUTH_FAILED\", \"\")")
+              .executeAndCaptureResult(echoingConnectorWithUnreadableSecrets(), false, true);
+
+      assertThat(result.getErrorCode()).isEqualTo("AUTH_FAILED");
+      assertThat(result.getErrorMessage()).isEmpty();
     }
   }
 }

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/outbound/ConnectorJobHandlerTest.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/outbound/ConnectorJobHandlerTest.java
@@ -36,6 +36,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import io.camunda.connector.api.error.ConnectorException;
 import io.camunda.connector.api.error.ConnectorExceptionBuilder;
 import io.camunda.connector.api.error.ConnectorRetryExceptionBuilder;
+import io.camunda.connector.api.json.ConnectorsObjectMapperSupplier;
 import io.camunda.connector.api.outbound.OutboundConnectorFunction;
 import io.camunda.connector.api.secret.SecretProvider;
 import io.camunda.connector.runtime.core.ConnectorHelper;
@@ -1402,7 +1403,7 @@ class ConnectorJobHandlerTest {
           },
           rotatingSecretProvider,
           e -> {},
-          null,
+          ConnectorsObjectMapperSupplier.getCopy(),
           SecretFilterFactory.disabled());
     }
 
@@ -1429,6 +1430,44 @@ class ConnectorJobHandlerTest {
               .executeAndCaptureResult(jobHandler, false, false);
 
       assertThat(result.getErrorMessage()).doesNotContain("stable-value");
+    }
+
+    @Test
+    void aValueCarryingAJsonEscapeIsBoundAndRedactedUnchanged() {
+      // the value is spliced into the job's variables as JSON, so it is escaped on the way in:
+      // splicing it raw would bind "pa<newline>ss" instead, which is neither what the store holds
+      // nor what a capture or a re-read could match
+      var jobHandler = connectorThrowingTheBoundToken("pa\\nss", "new-value");
+
+      var result =
+          JobBuilder.create()
+              .withVariables(INPUT_DECLARING_A_SECRET)
+              .executeAndCaptureResult(jobHandler, false, false);
+
+      assertThat(result.getErrorMessage()).isEqualTo("api rejected ***");
+    }
+  }
+
+  @Nested
+  class SecretProviderDiscoveryFailureTests {
+
+    @Test
+    void aProviderThatCannotBeBuiltFailsTheJobRatherThanAbandoningIt() {
+      var jobHandler =
+          new ConnectorJobHandler(
+              context -> "never reached", null, e -> {}, null, SecretFilterFactory.disabled()) {
+            @Override
+            protected SecretProvider getSecretProvider() {
+              throw new IllegalStateException("no secret provider could be discovered");
+            }
+          };
+
+      var result =
+          JobBuilder.create().withVariables("{}").executeAndCaptureResult(jobHandler, false, false);
+
+      // discovery runs before anything is bound, so the failure carries no secret and is reported
+      // as it is; letting it escape would leave the job for its activation timeout instead
+      assertThat(result.getErrorMessage()).isEqualTo("no secret provider could be discovered");
     }
   }
 }

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/outbound/OutboundConnectorExceptionHandlerTest.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/outbound/OutboundConnectorExceptionHandlerTest.java
@@ -21,6 +21,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
+import io.camunda.connector.api.error.ConnectorInputException;
 import io.camunda.connector.api.secret.SecretProvider;
 import io.camunda.connector.runtime.core.error.BpmnError;
 import io.camunda.connector.runtime.core.error.JobError;
@@ -156,6 +157,59 @@ class OutboundConnectorExceptionHandlerTest {
         .startsWith("Fetching secrets failed, so the original error cannot be displayed")
         .contains("java.lang.RuntimeException")
         .doesNotContain("super-secret");
+  }
+
+  @Test
+  void aMaskingFetchThatSaysTheInputIsAtFaultSpendsNoFurtherAttempt() {
+    // A provider that refuses every lookup (e.g. legacy resolution switched off) throws for the
+    // masking fetch too; retrying will not change that, so this is not a transient failure.
+    var job = jobNaming("{\"a\": \"{{secrets.FOO}}\"}");
+    when(secretProvider.getSecret("FOO"))
+        .thenThrow(new ConnectorInputException("secret 'FOO' was not resolved", null));
+
+    var result =
+        handler.manageConnectorJobHandlerException(
+            new RuntimeException("api rejected the request"),
+            job,
+            NO_BACKOFF,
+            SecretFilter.allowAll(),
+            List.of());
+
+    assertThat(result.retries()).isZero();
+  }
+
+  @Test
+  void aJobWhoseOwnFailureSaysTheInputIsAtFaultSpendsNoFurtherAttemptEither() {
+    // The job's failure is still whatever it was: an input that will never bind must not become
+    // retryable just because reading the values to redact it happened to time out.
+    var job = jobNaming("{\"a\": \"{{secrets.FOO}}\"}");
+    when(secretProvider.getSecret("FOO")).thenThrow(new RuntimeException("timed out"));
+
+    var result =
+        handler.manageConnectorJobHandlerException(
+            new ConnectorInputException("secret 'FOO' is not available", null),
+            job,
+            NO_BACKOFF,
+            SecretFilter.allowAll(),
+            List.of());
+
+    assertThat(result.retries()).isZero();
+  }
+
+  @Test
+  void aMaskingFetchThatFailedTransientlyKeepsTheJobsRemainingAttempts() {
+    var job = jobNaming("{\"a\": \"{{secrets.FOO}}\"}");
+    when(secretProvider.getSecret("FOO")).thenThrow(new RuntimeException("timed out"));
+
+    var result =
+        handler.manageConnectorJobHandlerException(
+            new RuntimeException("api rejected the request"),
+            job,
+            NO_BACKOFF,
+            SecretFilter.allowAll(),
+            List.of());
+
+    assertThat(result.retries()).isEqualTo(2);
   }
 
   @Test

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/outbound/OutboundConnectorExceptionHandlerTest.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/outbound/OutboundConnectorExceptionHandlerTest.java
@@ -1,0 +1,251 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.runtime.core.outbound;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import io.camunda.connector.api.secret.SecretProvider;
+import io.camunda.connector.runtime.core.error.BpmnError;
+import io.camunda.connector.runtime.core.error.JobError;
+import io.camunda.connector.runtime.core.secret.SecretFilter;
+import io.camunda.connector.runtime.core.secret.SecretNotAvailableException;
+import io.camunda.zeebe.client.api.response.ActivatedJob;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class OutboundConnectorExceptionHandlerTest {
+
+  private static final Duration NO_BACKOFF = null;
+
+  private final SecretProvider secretProvider = mock(SecretProvider.class);
+  private final OutboundConnectorExceptionHandler handler =
+      new OutboundConnectorExceptionHandler(secretProvider);
+  private final List<String> requestedKeys = new ArrayList<>();
+
+  private ActivatedJob jobNaming(String variables) {
+    var job = mock(ActivatedJob.class);
+    when(job.getVariables()).thenReturn(variables);
+    when(job.getRetries()).thenReturn(3);
+    return job;
+  }
+
+  /** Answers only for the given names, and records what was asked for. */
+  private void holdingOnly(Map<String, String> secrets) {
+    when(secretProvider.getSecret(org.mockito.ArgumentMatchers.anyString()))
+        .thenAnswer(
+            invocation -> {
+              String name = invocation.getArgument(0);
+              requestedKeys.add(name);
+              return secrets.get(name);
+            });
+  }
+
+  @Test
+  void masksALongerSecretThatStartsWithAShorterOne() {
+    // Replacing the shorter value first would leave the longer one unmatched and publish its
+    // remainder: "x" before "xSUPERSECRET" turns the message into "***SUPERSECRET".
+    var job = jobNaming("{\"a\": \"{{secrets.SHORT}}\", \"b\": \"{{secrets.LONG}}\"}");
+    holdingOnly(Map.of("SHORT", "x", "LONG", "xSUPERSECRET"));
+
+    var result =
+        handler.manageConnectorJobHandlerException(
+            new RuntimeException("api rejected xSUPERSECRET"),
+            job,
+            NO_BACKOFF,
+            SecretFilter.allowAll());
+
+    assertThat(requestedKeys).containsExactly("SHORT", "LONG");
+    assertThat(result.exception().getMessage()).isEqualTo("api rejected ***");
+  }
+
+  @Test
+  void anEmptySecretValueDoesNotCorruptTheMessage() {
+    // Replacing "" matches at every position, so a provider answering with one would rewrite the
+    // whole message into separators rather than redact anything.
+    var job = jobNaming("{\"a\": \"{{secrets.BLANK}}\"}");
+    holdingOnly(Map.of("BLANK", ""));
+
+    var result =
+        handler.manageConnectorJobHandlerException(
+            new RuntimeException("api rejected the request"),
+            job,
+            NO_BACKOFF,
+            SecretFilter.allowAll());
+
+    assertThat(result.exception().getMessage()).isEqualTo("api rejected the request");
+  }
+
+  @Test
+  void aJobDeclaringNoSecretNeverReachesAProvider() {
+    // A provider that refuses every lookup would otherwise withhold the error message of a job that
+    // had nothing to redact in the first place.
+    var job = jobNaming("{\"a\": \"nothing to resolve here\"}");
+
+    var result =
+        handler.manageConnectorJobHandlerException(
+            new RuntimeException("api rejected the request"),
+            job,
+            NO_BACKOFF,
+            SecretFilter.allowAll());
+
+    verifyNoInteractions(secretProvider);
+    assertThat(result.exception().getMessage()).isEqualTo("api rejected the request");
+    assertThat(result.retries()).isEqualTo(2);
+  }
+
+  @Test
+  void onlyAllowedNamesAreReadBack() {
+    var job = jobNaming("{\"a\": \"{{secrets.ALLOWED}}\", \"b\": \"{{secrets.DENIED}}\"}");
+    holdingOnly(Map.of("ALLOWED", "allowed-value", "DENIED", "denied-value"));
+
+    var result =
+        handler.manageConnectorJobHandlerException(
+            new RuntimeException("api rejected allowed-value and denied-value"),
+            job,
+            NO_BACKOFF,
+            SecretFilter.allowOnly(List.of("ALLOWED")));
+
+    assertThat(requestedKeys).containsExactly("ALLOWED");
+    assertThat(result.exception().getMessage()).isEqualTo("api rejected *** and denied-value");
+  }
+
+  @Test
+  void aFailedMaskingFetchIsNeverPublishedEither() {
+    // A provider writes its own message, and it can carry secret material: a bundle that parses as
+    // a non-object puts the value it could not coerce into the coercion error.
+    var job = jobNaming("{\"a\": \"{{secrets.FOO}}\"}");
+    when(secretProvider.getSecret("FOO"))
+        .thenThrow(
+            new RuntimeException(
+                "Could not resolve secrets: MismatchedInputException: Cannot construct instance of"
+                    + " `java.util.LinkedHashMap` from String value ('super-secret')"));
+
+    var result =
+        handler.manageConnectorJobHandlerException(
+            new RuntimeException("api rejected super-secret"),
+            job,
+            NO_BACKOFF,
+            SecretFilter.allowAll());
+
+    assertThat(result.exception().getMessage())
+        .startsWith("Fetching secrets failed, so the original error cannot be displayed")
+        .contains("java.lang.RuntimeException")
+        .doesNotContain("super-secret");
+  }
+
+  @Test
+  void aRefusalTheRuntimeWroteItselfKeepsItsMessage() {
+    // Withholding arbitrary provider text is not a reason to withhold text written to be read: a
+    // count of unreadable secrets names what an operator has to go and check.
+    var job = jobNaming("{\"a\": \"{{secrets.FOO}}\", \"b\": \"{{secrets.BAR}}\"}");
+    holdingOnly(Map.of("FOO", "foo-value"));
+
+    var result =
+        handler.manageConnectorJobHandlerException(
+            new RuntimeException("api rejected foo-value"),
+            job,
+            NO_BACKOFF,
+            SecretFilter.allowAll());
+
+    assertThat(result.exception().getMessage())
+        .contains("1 of the 2 secrets this job's input names could not be read back")
+        .doesNotContain("foo-value");
+  }
+
+  @Test
+  void aJobThatFailedOnAMissingSecretKeepsItsOwnMessage() {
+    // The one case where a declared name is expected back empty: substitution is what threw, so
+    // nothing of that secret is in the message and the message names what an operator must create.
+    var job = jobNaming("{\"a\": \"{{secrets.FOO}}\"}");
+    holdingOnly(Map.of());
+
+    var result =
+        handler.manageConnectorJobHandlerException(
+            new SecretNotAvailableException("FOO"), job, NO_BACKOFF, SecretFilter.allowAll());
+
+    assertThat(result.exception().getMessage())
+        .isEqualTo("Secret with name 'FOO' is not available");
+  }
+
+  @Test
+  void aJobErrorsMessageAndVariablesAreRedacted() {
+    var job = jobNaming("{\"a\": \"{{secrets.FOO}}\"}");
+    holdingOnly(Map.of("FOO", "bar"));
+
+    var masked =
+        (JobError)
+            handler.maskConnectorError(
+                new JobError("rejected bar", Map.of("detail", "rejected bar"), 0, null),
+                job,
+                SecretFilter.allowAll());
+
+    assertThat(masked.message()).isEqualTo("rejected ***");
+    assertThat(masked.variables()).containsEntry("detail", "rejected ***");
+    // the author's retry decision survives redaction
+    assertThat(masked.retries()).isZero();
+  }
+
+  @Test
+  void aBpmnErrorKeepsItsCodeButLosesItsSecret() {
+    var job = jobNaming("{\"a\": \"{{secrets.FOO}}\"}");
+    holdingOnly(Map.of("FOO", "bar"));
+
+    var masked =
+        (BpmnError)
+            handler.maskConnectorError(
+                new BpmnError("bar", "rejected bar", Map.of("detail", "rejected bar")),
+                job,
+                SecretFilter.allowAll());
+
+    // boundary events match on the code, so it keeps a value equal to the secret's
+    assertThat(masked.code()).isEqualTo("bar");
+    assertThat(masked.message()).isEqualTo("rejected ***");
+    assertThat(masked.variables()).containsEntry("detail", "rejected ***");
+  }
+
+  @Test
+  void anErrorCarryingNothingToRedactIsLeftAlone() {
+    // no message and no variables, so the read is skipped and an unreadable store costs nothing
+    var job = jobNaming("{\"a\": \"{{secrets.FOO}}\"}");
+
+    var masked =
+        handler.maskConnectorError(
+            new BpmnError("AUTH_FAILED", null, null), job, SecretFilter.allowAll());
+
+    verifyNoInteractions(secretProvider);
+    assertThat(((BpmnError) masked).message()).isNull();
+  }
+
+  @Test
+  void aFinalResultFailureIsRedactedAndUnretryable() {
+    var job = jobNaming("{\"a\": \"{{secrets.FOO}}\"}");
+    holdingOnly(Map.of("FOO", "bar"));
+
+    var result =
+        handler.handleFinalResultException(
+            new RuntimeException("result expression saw bar"), job, SecretFilter.allowAll());
+
+    assertThat(result.exception().getMessage()).isEqualTo("result expression saw ***");
+    assertThat(result.retries()).isZero();
+  }
+}

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/outbound/OutboundConnectorExceptionHandlerTest.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/outbound/OutboundConnectorExceptionHandlerTest.java
@@ -72,7 +72,8 @@ class OutboundConnectorExceptionHandlerTest {
             new RuntimeException("api rejected xSUPERSECRET"),
             job,
             NO_BACKOFF,
-            SecretFilter.allowAll());
+            SecretFilter.allowAll(),
+            List.of());
 
     assertThat(requestedKeys).containsExactly("SHORT", "LONG");
     assertThat(result.exception().getMessage()).isEqualTo("api rejected ***");
@@ -90,7 +91,8 @@ class OutboundConnectorExceptionHandlerTest {
             new RuntimeException("api rejected the request"),
             job,
             NO_BACKOFF,
-            SecretFilter.allowAll());
+            SecretFilter.allowAll(),
+            List.of());
 
     assertThat(result.exception().getMessage()).isEqualTo("api rejected the request");
   }
@@ -106,7 +108,8 @@ class OutboundConnectorExceptionHandlerTest {
             new RuntimeException("api rejected the request"),
             job,
             NO_BACKOFF,
-            SecretFilter.allowAll());
+            SecretFilter.allowAll(),
+            List.of());
 
     verifyNoInteractions(secretProvider);
     assertThat(result.exception().getMessage()).isEqualTo("api rejected the request");
@@ -123,7 +126,8 @@ class OutboundConnectorExceptionHandlerTest {
             new RuntimeException("api rejected allowed-value and denied-value"),
             job,
             NO_BACKOFF,
-            SecretFilter.allowOnly(List.of("ALLOWED")));
+            SecretFilter.allowOnly(List.of("ALLOWED")),
+            List.of());
 
     assertThat(requestedKeys).containsExactly("ALLOWED");
     assertThat(result.exception().getMessage()).isEqualTo("api rejected *** and denied-value");
@@ -145,7 +149,8 @@ class OutboundConnectorExceptionHandlerTest {
             new RuntimeException("api rejected super-secret"),
             job,
             NO_BACKOFF,
-            SecretFilter.allowAll());
+            SecretFilter.allowAll(),
+            List.of());
 
     assertThat(result.exception().getMessage())
         .startsWith("Fetching secrets failed, so the original error cannot be displayed")
@@ -165,7 +170,8 @@ class OutboundConnectorExceptionHandlerTest {
             new RuntimeException("api rejected foo-value"),
             job,
             NO_BACKOFF,
-            SecretFilter.allowAll());
+            SecretFilter.allowAll(),
+            List.of());
 
     assertThat(result.exception().getMessage())
         .contains("1 of the 2 secrets this job's input names could not be read back")
@@ -181,7 +187,11 @@ class OutboundConnectorExceptionHandlerTest {
 
     var result =
         handler.manageConnectorJobHandlerException(
-            new SecretNotAvailableException("FOO"), job, NO_BACKOFF, SecretFilter.allowAll());
+            new SecretNotAvailableException("FOO"),
+            job,
+            NO_BACKOFF,
+            SecretFilter.allowAll(),
+            List.of());
 
     assertThat(result.exception().getMessage())
         .isEqualTo("Secret with name 'FOO' is not available");
@@ -197,7 +207,8 @@ class OutboundConnectorExceptionHandlerTest {
             handler.maskConnectorError(
                 new JobError("rejected bar", Map.of("detail", "rejected bar"), 0, null),
                 job,
-                SecretFilter.allowAll());
+                SecretFilter.allowAll(),
+                List.of());
 
     assertThat(masked.message()).isEqualTo("rejected ***");
     assertThat(masked.variables()).containsEntry("detail", "rejected ***");
@@ -215,7 +226,8 @@ class OutboundConnectorExceptionHandlerTest {
             handler.maskConnectorError(
                 new BpmnError("bar", "rejected bar", Map.of("detail", "rejected bar")),
                 job,
-                SecretFilter.allowAll());
+                SecretFilter.allowAll(),
+                List.of());
 
     // boundary events match on the code, so it keeps a value equal to the secret's
     assertThat(masked.code()).isEqualTo("bar");
@@ -230,10 +242,64 @@ class OutboundConnectorExceptionHandlerTest {
 
     var masked =
         handler.maskConnectorError(
-            new BpmnError("AUTH_FAILED", null, null), job, SecretFilter.allowAll());
+            new BpmnError("AUTH_FAILED", null, null), job, SecretFilter.allowAll(), List.of());
 
     verifyNoInteractions(secretProvider);
     assertThat(((BpmnError) masked).message()).isNull();
+  }
+
+  @Test
+  void aSecretThatRotatedBetweenBindAndMaskingIsStillRedacted() {
+    // the re-read returns what the store holds now, so the value the message carries is only
+    // known from what was actually substituted into the job's input
+    var job = jobNaming("{\"a\": \"{{secrets.FOO}}\"}");
+    holdingOnly(Map.of("FOO", "new-value"));
+
+    var result =
+        handler.manageConnectorJobHandlerException(
+            new RuntimeException("api rejected old-value"),
+            job,
+            NO_BACKOFF,
+            SecretFilter.allowAll(),
+            List.of("old-value"));
+
+    assertThat(result.exception().getMessage()).isEqualTo("api rejected ***");
+  }
+
+  @Test
+  void aCapturedValueDoesNotSubstituteForAFailedReRead() {
+    // a job can declare a secret it never got around to binding, so captures are additive to a
+    // complete read rather than a stand-in for one
+    var job = jobNaming("{\"a\": \"{{secrets.FOO}}\", \"b\": \"{{secrets.BAR}}\"}");
+    holdingOnly(Map.of("FOO", "foo-value"));
+
+    var result =
+        handler.manageConnectorJobHandlerException(
+            new RuntimeException("api rejected bar-value"),
+            job,
+            NO_BACKOFF,
+            SecretFilter.allowAll(),
+            List.of("foo-value"));
+
+    assertThat(result.exception().getMessage())
+        .startsWith("Fetching secrets failed, so the original error cannot be displayed")
+        .doesNotContain("bar-value");
+  }
+
+  @Test
+  void anErrorExpressionErrorRedactsARotatedSecretToo() {
+    var job = jobNaming("{\"a\": \"{{secrets.FOO}}\"}");
+    holdingOnly(Map.of("FOO", "new-value"));
+
+    var masked =
+        (JobError)
+            handler.maskConnectorError(
+                new JobError("rejected old-value", Map.of(), 0, null),
+                job,
+                SecretFilter.allowAll(),
+                List.of("old-value"));
+
+    assertThat(masked.message()).isEqualTo("rejected ***");
   }
 
   @Test
@@ -243,7 +309,10 @@ class OutboundConnectorExceptionHandlerTest {
 
     var result =
         handler.handleFinalResultException(
-            new RuntimeException("result expression saw bar"), job, SecretFilter.allowAll());
+            new RuntimeException("result expression saw bar"),
+            job,
+            SecretFilter.allowAll(),
+            List.of());
 
     assertThat(result.exception().getMessage()).isEqualTo("result expression saw ***");
     assertThat(result.retries()).isZero();

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/jobhandling/SpringConnectorJobHandlerTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/jobhandling/SpringConnectorJobHandlerTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.runtime.outbound.jobhandling;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Answers.RETURNS_DEEP_STUBS;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import io.camunda.connector.api.json.ConnectorsObjectMapperSupplier;
+import io.camunda.connector.api.secret.SecretProvider;
+import io.camunda.connector.runtime.core.config.OutboundConnectorConfiguration;
+import io.camunda.connector.runtime.core.outbound.ConnectorJobHandler;
+import io.camunda.connector.runtime.core.secret.SecretFilterFactory;
+import io.camunda.connector.runtime.core.secret.SecretProviderAggregator;
+import io.camunda.zeebe.client.api.response.ActivatedJob;
+import io.camunda.zeebe.client.api.worker.JobClient;
+import io.camunda.zeebe.spring.client.jobhandling.CommandExceptionHandlingStrategy;
+import io.camunda.zeebe.spring.client.metrics.MetricsRecorder;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The runtime log is where a connector failure would otherwise be reported unredacted, so it is
+ * asserted on here, in the module that has a logging backend on its test classpath.
+ */
+class SpringConnectorJobHandlerTest {
+
+  private static final String INPUT_DECLARING_A_SECRET = "{ \"token\" : \"{{secrets.FOO}}\" }";
+
+  private record TokenHolder(String token) {}
+
+  @Test
+  void aSecretThatRotatedBetweenBindAndMaskingIsNotLoggedFromTheCause() {
+    // given a secret that rotates between the job binding it and the masking re-read
+    var jobHandler = connectorThrowingTheBoundToken("old-value", "new-value");
+    var logger = (Logger) LoggerFactory.getLogger(ConnectorJobHandler.class);
+    var appender = new ListAppender<ILoggingEvent>();
+    appender.start();
+    logger.addAppender(appender);
+
+    // when the job fails with the bound value in its message
+    try {
+      jobHandler.handle(mock(JobClient.class, RETURNS_DEEP_STUBS), jobDeclaringASecret());
+    } finally {
+      logger.detachAppender(appender);
+      appender.stop();
+    }
+
+    // then the runtime log carries neither the value nor the unredacted cause it came from
+    assertThat(appender.list)
+        .filteredOn(event -> event.getFormattedMessage().startsWith("Exception while processing"))
+        .singleElement()
+        .satisfies(
+            event -> {
+              assertThat(event.getFormattedMessage()).doesNotContain("old-value");
+              assertThat(event.getThrowableProxy()).isNull();
+            });
+  }
+
+  private SpringConnectorJobHandler connectorThrowingTheBoundToken(
+      String boundValue, String rotatedValue) {
+    var callCount = new AtomicInteger();
+    SecretProvider rotatingSecretProvider =
+        name -> callCount.getAndIncrement() == 0 ? boundValue : rotatedValue;
+    return new SpringConnectorJobHandler(
+        immediateMetricsRecorder(),
+        mock(CommandExceptionHandlingStrategy.class),
+        new SecretProviderAggregator(List.of(rotatingSecretProvider)),
+        input -> {},
+        ConnectorsObjectMapperSupplier.getCopy(),
+        context -> {
+          var bound = context.bindVariables(TokenHolder.class);
+          throw new RuntimeException("api rejected " + bound.token());
+        },
+        new OutboundConnectorConfiguration("test", new String[0], "io.camunda:test:1", null),
+        SecretFilterFactory.disabled());
+  }
+
+  private static MetricsRecorder immediateMetricsRecorder() {
+    var metricsRecorder = mock(MetricsRecorder.class);
+    doAnswer(
+            invocation -> {
+              invocation.getArgument(2, Runnable.class).run();
+              return null;
+            })
+        .when(metricsRecorder)
+        .executeWithTimer(any(), any(), any());
+    return metricsRecorder;
+  }
+
+  private static ActivatedJob jobDeclaringASecret() {
+    var job = mock(ActivatedJob.class);
+    when(job.getVariables()).thenReturn(INPUT_DECLARING_A_SECRET);
+    when(job.getCustomHeaders()).thenReturn(Map.of());
+    when(job.getRetries()).thenReturn(3);
+    return job;
+  }
+}

--- a/connector-sdk/core/src/main/java/io/camunda/connector/api/inbound/Health.java
+++ b/connector-sdk/core/src/main/java/io/camunda/connector/api/inbound/Health.java
@@ -143,6 +143,16 @@ public class Health {
     }
   }
 
+  /**
+   * Returns a new {@link Health} with the given error, preserving the original status and details.
+   *
+   * @param error the error for the new instance
+   * @return a new Health with the same status and details but the supplied error
+   */
+  public Health withError(Error error) {
+    return new Health(this.status, error, this.details);
+  }
+
   private Health(Builder builder) {
     this.status = builder.status;
     this.error = builder.error;


### PR DESCRIPTION
## Description

Backports #8634 and #8643 together to `stable/8.6`. They form one secret-redaction change and are intentionally combined so the fixes reach this older stable branch atomically. This is ported from the combined reference backport #8661.

The change prevents resolved secrets from being exposed through outbound job and BPMN error incidents, inbound activity logs and health errors, and errors emitted after a secret rotates between input binding and masking. It also includes the approved follow-up #8662, which prevents the unredacted exception cause from being printed to runtime logs.

The required secret-reference handling from #8641 is already present on the target branch through #8660.

## Related issues

Related to #8638.

Source PRs: #8634, #8643, and follow-up #8662.

## Checklist

- [x] No further backport labels are added; the older stable branches are being ported explicitly from the combined change.
- [x] Tests for the changes are included and the focused runtime test suite passes.
- [x] No documentation update is required for this backport.
