### PR TITLE
[Backport stable/8.9] fix: redact secrets from connector errors and logs

### DIFF
--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextImpl.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextImpl.java
@@ -46,9 +46,12 @@ import io.camunda.connector.runtime.core.inbound.correlation.InboundCorrelationH
 import io.camunda.connector.runtime.core.inbound.details.InboundConnectorDetails.ValidInboundConnectorDetails;
 import io.camunda.connector.runtime.core.secret.SecretFilter;
 import io.camunda.connector.runtime.core.secret.SecretUtil;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
@@ -70,6 +73,11 @@ public class InboundConnectorContextImpl extends AbstractConnectorContext
   private final Long activationTimestamp;
   private Health health = Health.unknown();
   private Map<String, Object> propertiesWithSecrets;
+  private volatile List<String> reReadSecrets;
+  private final Set<String> capturedSecretValues = ConcurrentHashMap.newKeySet();
+
+  private static final String REDACTION_UNAVAILABLE_MESSAGE =
+      "Message withheld: could not verify it does not contain a secret value";
 
   public InboundConnectorContextImpl(
       SecretProvider secretProvider,
@@ -352,7 +360,8 @@ public class InboundConnectorContextImpl extends AbstractConnectorContext
     if (health == null) {
       throw new IllegalArgumentException("Health must not be null");
     }
-    if (health.equals(this.health)) {
+    var masked = redactHealth(health);
+    if (!isWithheld(masked) && masked.equals(this.health)) {
       return;
     }
     var activityLog =
@@ -361,9 +370,9 @@ public class InboundConnectorContextImpl extends AbstractConnectorContext
             .withMessage(
                 String.format(
                     "Health status changed to %s, details: %s",
-                    health.getStatus(), health.getDetails()))
-            .withSeverity(health.getStatus() == Health.Status.UP ? Severity.INFO : Severity.ERROR)
-            .andReportHealth(health)
+                    masked.getStatus(), masked.getDetails()))
+            .withSeverity(masked.getStatus() == Health.Status.UP ? Severity.INFO : Severity.ERROR)
+            .andReportHealth(masked)
             .build();
     // append the activity log to store the health status change history
     activityLogWriter.log(
@@ -371,7 +380,7 @@ public class InboundConnectorContextImpl extends AbstractConnectorContext
             ExecutableId.fromDeduplicationId(connectorDetails.deduplicationId()),
             ActivitySource.CONNECTOR,
             activityLog));
-    this.health = health;
+    this.health = masked;
   }
 
   @Override
@@ -381,14 +390,15 @@ public class InboundConnectorContextImpl extends AbstractConnectorContext
 
   @Override
   public void log(Activity log) {
-    if (log.healthChange() != null) {
-      this.health = log.healthChange();
+    var masked = redact(log);
+    if (masked.healthChange() != null) {
+      this.health = masked.healthChange();
     }
     activityLogWriter.log(
         new ActivityLogEntry(
             ExecutableId.fromDeduplicationId(connectorDetails.deduplicationId()),
             ActivitySource.CONNECTOR,
-            log));
+            masked));
   }
 
   @Override
@@ -408,7 +418,93 @@ public class InboundConnectorContextImpl extends AbstractConnectorContext
         new ActivityLogEntry(
             ExecutableId.fromDeduplicationId(connectorDetails.deduplicationId()),
             ActivitySource.RUNTIME,
-            builder.build()));
+            redact(builder.build())));
+  }
+
+  // captures are only ever unioned into a successful, complete re-read, never a substitute for one
+  private List<String> secretValuesForRedaction() {
+    var reRead = reReadSecretValues();
+    if (reRead == null) {
+      return null;
+    }
+    if (capturedSecretValues.isEmpty()) {
+      return reRead;
+    }
+    var union = new ArrayList<>(reRead);
+    union.addAll(capturedSecretValues);
+    return union;
+  }
+
+  private List<String> reReadSecretValues() {
+    var cached = reReadSecrets;
+    if (cached != null) {
+      return cached;
+    }
+    var values = fetchSecretValuesForRedaction();
+    if (values != null) {
+      reReadSecrets = values;
+    }
+    return values;
+  }
+
+  // legacy names across every grouped element, not just this context's representative one
+  private List<String> fetchSecretValuesForRedaction() {
+    var names =
+        connectorDetails.connectorElements().stream()
+            .flatMap(element -> element.rawProperties().values().stream())
+            .flatMap(value -> SecretUtil.retrieveSecretKeysInInput(value).stream())
+            .distinct()
+            .toList();
+    if (names.isEmpty()) {
+      return List.of();
+    }
+    try {
+      var values = secretProvider.fetchAll(names, redactionSecretContext());
+      // fewer values than names means a partial read, treated the same as a failed one
+      return values.size() < names.size() ? null : values;
+    } catch (Exception e) {
+      LOG.warn("Could not fetch secret values to redact activity log: {}", e.getClass().getName());
+      return null;
+    }
+  }
+
+  private SecretContext redactionSecretContext() {
+    return new SecretContext(connectorDetails.tenantId(), connectorDetails.processDefinitionId());
+  }
+
+  private String redactMessage(String message) {
+    if (message == null) {
+      return null;
+    }
+    var secrets = secretValuesForRedaction();
+    return secrets == null
+        ? REDACTION_UNAVAILABLE_MESSAGE
+        : SecretUtil.hideSecretsFromMessage(message, secrets);
+  }
+
+  // an unmaskable health can't be verified as a repeat either, so it must never be deduped away
+  private static boolean isWithheld(Health health) {
+    return health.getError() != null
+        && REDACTION_UNAVAILABLE_MESSAGE.equals(health.getError().message());
+  }
+
+  private Health redactHealth(Health health) {
+    if (health == null || health.getError() == null) {
+      return health;
+    }
+    var error = health.getError();
+    return health.withError(
+        new Health.Error(redactMessage(error.code()), redactMessage(error.message())));
+  }
+
+  private Activity redact(Activity activity) {
+    return new Activity(
+        activity.severity(),
+        activity.tag(),
+        activity.timestamp(),
+        redactMessage(activity.message()),
+        activity.data(),
+        redactHealth(activity.healthChange()));
   }
 
   @Override
@@ -423,13 +519,18 @@ public class InboundConnectorContextImpl extends AbstractConnectorContext
 
   private Map<String, Object> getPropertiesWithSecrets(Map<String, Object> properties) {
     if (propertiesWithSecrets == null) {
-      propertiesWithSecrets =
-          InboundPropertyHandler.getPropertiesWithSecrets(
-              getSecretHandler(),
-              objectMapper,
-              properties,
-              new SecretContext(
-                  connectorDetails.tenantId(), connectorDetails.processDefinitionId()));
+      var handler = getSecretHandler();
+      try {
+        propertiesWithSecrets =
+            InboundPropertyHandler.getPropertiesWithSecrets(
+                handler,
+                objectMapper,
+                properties,
+                new SecretContext(
+                    connectorDetails.tenantId(), connectorDetails.processDefinitionId()));
+      } finally {
+        capturedSecretValues.addAll(handler.getResolvedValues());
+      }
     }
     return propertiesWithSecrets;
   }
@@ -477,6 +578,7 @@ public class InboundConnectorContextImpl extends AbstractConnectorContext
               + message);
     }
     connectorDetails = newDetails;
+    reReadSecrets = null;
     logRuntime(
         builder ->
             builder

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretFailureDiagnostic.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretFailureDiagnostic.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.runtime.core.secret;
+
+/**
+ * A secret lookup failure that can say why in text safe to show an operator.
+ *
+ * <p>Most failures cannot. A secret provider or its client may put anything in a message — a
+ * response body from the secret store, a credential echoed back by a rejecting API — so where a
+ * failure is reported without the values needed to redact it, the message has to be withheld. That
+ * withholding is what this interface makes an exception to.
+ *
+ * <p>Implement it only where the runtime authors the whole message itself, and keep it that way: a
+ * provider's or client's own text must never be interpolated into what {@link
+ * #publishableMessage()} returns. A secret's <em>name</em> is fine — it is written in the model
+ * that a reader of the incident can already see — but a secret's value, or any part of a store's
+ * response, is not.
+ *
+ * <p>The point is that the two failures this runtime introduces are exactly the ones an operator
+ * has to act on, and neither is diagnosable from a type alone: legacy resolution being switched off
+ * is fixed by naming the setting and the form that replaced it, and a name that has no reference
+ * form is fixed by naming the charset that admits one.
+ */
+public interface SecretFailureDiagnostic {
+
+  /**
+   * Why the lookup failed, in text the runtime wrote and may publish verbatim — to an incident
+   * message, or to process variables.
+   */
+  String publishableMessage();
+}

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretFailureDiagnostic.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretFailureDiagnostic.java
@@ -30,10 +30,11 @@ package io.camunda.connector.runtime.core.secret;
  * that a reader of the incident can already see — but a secret's value, or any part of a store's
  * response, is not.
  *
- * <p>The point is that the two failures this runtime introduces are exactly the ones an operator
- * has to act on, and neither is diagnosable from a type alone: legacy resolution being switched off
- * is fixed by naming the setting and the form that replaced it, and a name that has no reference
- * form is fixed by naming the charset that admits one.
+ * <p>The point is that the failures this runtime raises itself are exactly the ones an operator has
+ * to act on, and neither is diagnosable from a type alone: an allow-list that could not be read is
+ * fixed by naming the element and the process definition whose lookup failed, and a masking re-read
+ * that came back short is fixed by saying how many of the job's secrets went missing. Both messages
+ * are built without interpolating any provider or client text.
  */
 public interface SecretFailureDiagnostic {
 

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretHandler.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretHandler.java
@@ -16,10 +16,12 @@
  */
 package io.camunda.connector.runtime.core.secret;
 
-import io.camunda.connector.api.error.ConnectorInputException;
 import io.camunda.connector.api.secret.SecretContext;
 import io.camunda.connector.api.secret.SecretProvider;
+import java.util.List;
 import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -31,16 +33,21 @@ public class SecretHandler {
 
   protected SecretReplacer secretReplacer;
 
+  // values this instance substituted, so a caller can redact against a rotated re-read
+  private final Set<String> resolvedValues = ConcurrentHashMap.newKeySet();
+
   public SecretHandler(final SecretProvider secretProvider, SecretFilter secretFilter) {
     this.secretProvider = secretProvider;
     secretReplacer =
         (name, context) -> {
           if (secretFilter.isAllowed(name)) {
-            return Optional.ofNullable(secretProvider.getSecret(name, context))
-                .orElseThrow(
-                    () ->
-                        new ConnectorInputException(
-                            String.format("Secret with name '%s' is not available", name), null));
+            var value =
+                Optional.ofNullable(secretProvider.getSecret(name, context))
+                    .orElseThrow(() -> new SecretNotAvailableException(name));
+            resolvedValues.add(value);
+            // the substituted JSON carries this form, not the raw value, when it differs
+            resolvedValues.add(SecretUtil.jsonEscape(value));
+            return value;
           }
           LOG.debug("Secret '{}' not in allow-list — placeholder left unreplaced", name);
           return null;
@@ -49,5 +56,9 @@ public class SecretHandler {
 
   public String replaceSecrets(String input, SecretContext context) {
     return SecretUtil.replaceSecrets(input, context, secretReplacer);
+  }
+
+  public List<String> getResolvedValues() {
+    return List.copyOf(resolvedValues);
   }
 }

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretNotAvailableException.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretNotAvailableException.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.runtime.core.secret;
+
+import io.camunda.connector.api.error.ConnectorInputException;
+
+/**
+ * A legacy secret reference the filter allowed, for which no configured provider held a value. The
+ * reference cannot be substituted, so the input cannot be bound; the model or the secret store has
+ * to change, which is why this is a {@link ConnectorInputException} and the job is not retried.
+ *
+ * <p>A type of its own, rather than a bare {@code ConnectorInputException}, because error masking
+ * has to tell this failure apart from every other one: it is the single case where a name the input
+ * declares is expected to come back empty on the masking re-read. Everywhere else that would mean a
+ * secret has been removed since the connector ran, with its value possibly still in the message.
+ */
+public class SecretNotAvailableException extends ConnectorInputException {
+
+  public SecretNotAvailableException(String secretName) {
+    super(String.format("Secret with name '%s' is not available", secretName));
+  }
+}

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretUtil.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretUtil.java
@@ -18,6 +18,7 @@ package io.camunda.connector.runtime.core.secret;
 
 import com.fasterxml.jackson.core.io.JsonStringEncoder;
 import io.camunda.connector.api.secret.SecretContext;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -49,8 +50,13 @@ public class SecretUtil {
         REFERENCE,
         matcher -> {
           String value = resolve(name(matcher), context, secretReplacer, resolutions);
-          return value == null ? matcher.group() : new String(encoder.quoteAsString(value));
+          return value == null ? matcher.group() : jsonEscape(value);
         });
+  }
+
+  // the form actually spliced into the substituted JSON, which a raw-value capture would miss
+  public static String jsonEscape(String value) {
+    return new String(encoder.quoteAsString(value));
   }
 
   public static String replaceTokens(
@@ -94,5 +100,17 @@ public class SecretUtil {
     return input == null
         ? List.of()
         : REFERENCE.matcher(input).results().map(SecretUtil::name).distinct().toList();
+  }
+
+  // Longest secret first: masking a shorter secret that prefixes a longer one would destroy the
+  // longer match and publish its remainder, e.g. "x" before "xSUPERSECRET" leaves "***SUPERSECRET".
+  public static String hideSecretsFromMessage(String message, List<String> secrets) {
+    if (message == null) {
+      return "";
+    }
+    return secrets.stream()
+        .filter(secret -> !secret.isEmpty())
+        .sorted(Comparator.comparingInt(String::length).reversed())
+        .reduce(message, (newMessage, nextSecret) -> newMessage.replace(nextSecret, "***"));
   }
 }

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextImplTest.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextImplTest.java
@@ -194,6 +194,152 @@ class InboundConnectorContextImplTest {
     assertThat(replace(context, "secrets.INJECTED")).isEqualTo("resolved");
   }
 
+  @Test
+  void log_masksASecretResolvedForThisConnector() {
+    // given a connector declaring a legacy secret this context can resolve
+    var definition = getInboundConnectorDefinition(Map.of("token", "secrets.FOO"));
+    var context =
+        new InboundConnectorContextImpl(
+            secretProvider, (e) -> {}, definition, null, (e) -> {}, mapper, activityLogRegistry);
+
+    // when an activity's message happens to carry the resolved value
+    context.log(activity -> activity.withSeverity(Severity.ERROR).withMessage("token was bar"));
+
+    // then the logged message has the value masked
+    var logs =
+        activityLogRegistry.getLogs(ExecutableId.fromDeduplicationId(definition.deduplicationId()));
+    assertThat(logs)
+        .singleElement()
+        .satisfies(log -> assertThat(log.message()).isEqualTo("token was ***"));
+  }
+
+  @Test
+  void log_withholdsMessageWhenSecretValuesCannotBeFetched() {
+    // given a provider that fails to resolve the declared secret
+    var definition = getInboundConnectorDefinition(Map.of("token", "secrets.FOO"));
+    var failingProvider = mock(SecretProvider.class);
+    when(failingProvider.fetchAll(any(), any())).thenThrow(new RuntimeException("down"));
+    var context =
+        new InboundConnectorContextImpl(
+            failingProvider, (e) -> {}, definition, null, (e) -> {}, mapper, activityLogRegistry);
+
+    // when
+    context.log(activity -> activity.withSeverity(Severity.ERROR).withMessage("token was bar"));
+
+    // then the raw message is withheld rather than published unmasked
+    var logs =
+        activityLogRegistry.getLogs(ExecutableId.fromDeduplicationId(definition.deduplicationId()));
+    assertThat(logs)
+        .singleElement()
+        .satisfies(
+            log -> {
+              assertThat(log.message()).doesNotContain("bar");
+              assertThat(log.message()).contains("withheld");
+            });
+  }
+
+  @Test
+  void reportHealth_masksASecretInTheErrorMessage() {
+    // given
+    var definition = getInboundConnectorDefinition(Map.of("token", "secrets.FOO"));
+    var context =
+        new InboundConnectorContextImpl(
+            secretProvider, (e) -> {}, definition, null, (e) -> {}, mapper, activityLogRegistry);
+
+    // when the reported health carries the resolved value in its error
+    context.reportHealth(Health.down(new RuntimeException("token was bar")));
+
+    // then it is masked both in the stored health and in the activity log
+    assertThat(context.getHealth().getError().message()).doesNotContain("bar");
+    var logs =
+        activityLogRegistry.getLogs(ExecutableId.fromDeduplicationId(definition.deduplicationId()));
+    assertThat(logs)
+        .singleElement()
+        .satisfies(
+            log -> assertThat(log.healthChange().getError().message()).doesNotContain("bar"));
+  }
+
+  @Test
+  void reportHealth_dedupesIdenticalHealthAfterMasking() {
+    // given
+    var definition = getInboundConnectorDefinition(Map.of("token", "secrets.FOO"));
+    var context =
+        new InboundConnectorContextImpl(
+            secretProvider, (e) -> {}, definition, null, (e) -> {}, mapper, activityLogRegistry);
+
+    // when the same failure is reported twice
+    context.reportHealth(Health.down(new RuntimeException("token was bar")));
+    context.reportHealth(Health.down(new RuntimeException("token was bar")));
+
+    // then the second report is deduped against the masked, not the raw, health
+    var logs =
+        activityLogRegistry.getLogs(ExecutableId.fromDeduplicationId(definition.deduplicationId()));
+    assertThat(logs).hasSize(1);
+  }
+
+  @Test
+  void reportHealth_doesNotDedupeTwoDifferentUnmaskableFailures() {
+    // given a provider that is down, so every health report is withheld
+    var definition = getInboundConnectorDefinition(Map.of("token", "secrets.FOO"));
+    var downProvider = mock(SecretProvider.class);
+    when(downProvider.fetchAll(any(), any())).thenThrow(new RuntimeException("down"));
+    var context =
+        new InboundConnectorContextImpl(
+            downProvider, (e) -> {}, definition, null, (e) -> {}, mapper, activityLogRegistry);
+
+    // when two distinct failures are reported during the outage
+    context.reportHealth(Health.down(new RuntimeException("kafka broker unreachable")));
+    context.reportHealth(Health.down(new RuntimeException("deserialization failed")));
+
+    // then both are logged rather than the second being deduped against the first
+    var logs =
+        activityLogRegistry.getLogs(ExecutableId.fromDeduplicationId(definition.deduplicationId()));
+    assertThat(logs).hasSize(2);
+  }
+
+  @Test
+  void log_masksASecretThatRotatedAfterItWasBound() {
+    // given a provider that resolves FOO to one value at bind time and a different one on re-read
+    var definition = getInboundConnectorDefinition(Map.of("token", "secrets.FOO"));
+    var rotatingProvider = mock(SecretProvider.class);
+    when(rotatingProvider.getSecret(eq("FOO"), any())).thenReturn("old-value");
+    when(rotatingProvider.fetchAll(any(), any())).thenReturn(List.of("new-value"));
+    var context =
+        new InboundConnectorContextImpl(
+            rotatingProvider, (e) -> {}, definition, null, (e) -> {}, mapper, activityLogRegistry);
+
+    // when the bound value is used, binding first so it is actually substituted and captured
+    context.getProperties();
+    context.log(
+        activity -> activity.withSeverity(Severity.ERROR).withMessage("token was old-value"));
+
+    // then the bound value is redacted even though a re-read would return a different one
+    var logs =
+        activityLogRegistry.getLogs(ExecutableId.fromDeduplicationId(definition.deduplicationId()));
+    assertThat(logs).last().satisfies(log -> assertThat(log.message()).isEqualTo("token was ***"));
+  }
+
+  @Test
+  void log_withholdsMessageWhenTheReReadComesBackShort() {
+    // given a connector declaring two secrets but only one resolving on re-read
+    var definition = getInboundConnectorDefinition(Map.of("a", "secrets.FOO", "b", "secrets.BAR"));
+    var partialProvider = mock(SecretProvider.class);
+    when(partialProvider.fetchAll(any(), any())).thenReturn(List.of("only-one-value"));
+    var context =
+        new InboundConnectorContextImpl(
+            partialProvider, (e) -> {}, definition, null, (e) -> {}, mapper, activityLogRegistry);
+
+    // when nothing was ever bound, so only the (incomplete) re-read is available
+    context.log(activity -> activity.withSeverity(Severity.ERROR).withMessage("token was leaked"));
+
+    // then the message is withheld rather than published with only one of the two values masked
+    var logs =
+        activityLogRegistry.getLogs(ExecutableId.fromDeduplicationId(definition.deduplicationId()));
+    assertThat(logs)
+        .singleElement()
+        .satisfies(log -> assertThat(log.message()).contains("withheld"));
+  }
+
   private static ValidInboundConnectorDetails getInboundConnectorDefinition(
       Map<String, String> properties) {
     properties = new HashMap<>(properties);

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/OutboundConnectorExceptionHandler.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/OutboundConnectorExceptionHandler.java
@@ -282,11 +282,11 @@ public class OutboundConnectorExceptionHandler {
    *
    * <p>The exception's class name is reported, which carries no request or response data. And where
    * the failure is one the runtime raised itself, so is its {@link
-   * SecretFailureDiagnostic#publishableMessage()}: the two failures this runtime introduces —
-   * legacy resolution switched off, and a name with no reference form — are precisely the ones an
-   * operator has to act on, and a type name alone does not say which setting to change or which
-   * charset a name has to fit. Withholding arbitrary provider text is not a reason to withhold text
-   * written to be read.
+   * SecretFailureDiagnostic#publishableMessage()}: the two failures this runtime raises — an
+   * allow-list that could not be read, and a masking re-read that came back short — are precisely
+   * the ones an operator has to act on, and a type name alone names neither the element whose
+   * lookup failed nor how many secrets went missing. Withholding arbitrary provider text is not a
+   * reason to withhold text written to be read.
    */
   // A provider's own message can carry secret material - a bundle that parses as a non-object puts
   // the value into Jackson's coercion error - so only what SecretReferenceResolver keeps is logged.
@@ -350,8 +350,8 @@ public class OutboundConnectorExceptionHandler {
     if (masking.unavailable()) {
       var wrappedException = unmaskableError(masking.failure());
       // Either failure can be the permanent one, so both are consulted. A provider that refuses
-      // to resolve at all (e.g. legacy resolution switched off) throws for every key, including
-      // the ones this fetch only needed for masking; and the job's own failure is still whatever
+      // to resolve at all throws for every key, including the ones this fetch only needed for
+      // masking; and the job's own failure is still whatever
       // it was, so an input error that will never bind must not become retryable just because
       // reading the values to redact it happened to time out. Only when neither says the input is
       // at fault does the job keep its remaining attempts.
@@ -383,8 +383,8 @@ public class OutboundConnectorExceptionHandler {
       SecretFilter secretFilter,
       List<String> capturedSecrets) {
     return switch (error) {
-      // business output on the branch that completes the job; the branch that raises an incident
-      // instead redacts them itself, via maskDiagnosticVariables
+      // ignoreError completes the job with business variables, which are deliberately not
+      // redacted; this branch has no incident-raising counterpart on this runtime
       case IgnoreError ignoreError -> ignoreError;
       case BpmnError bpmnError -> {
         if (nothingToRedact(bpmnError.errorMessage(), bpmnError.variables())) {

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/OutboundConnectorExceptionHandler.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/OutboundConnectorExceptionHandler.java
@@ -24,9 +24,15 @@ import io.camunda.connector.api.error.ConnectorInputException;
 import io.camunda.connector.api.error.ConnectorRetryException;
 import io.camunda.connector.api.secret.SecretContext;
 import io.camunda.connector.api.secret.SecretProvider;
+import io.camunda.connector.runtime.core.error.BpmnError;
+import io.camunda.connector.runtime.core.error.ConnectorError;
+import io.camunda.connector.runtime.core.error.IgnoreError;
 import io.camunda.connector.runtime.core.error.InvalidBackOffDurationException;
+import io.camunda.connector.runtime.core.error.JobError;
 import io.camunda.connector.runtime.core.outbound.ConnectorResult;
+import io.camunda.connector.runtime.core.secret.SecretFailureDiagnostic;
 import io.camunda.connector.runtime.core.secret.SecretFilter;
+import io.camunda.connector.runtime.core.secret.SecretNotAvailableException;
 import io.camunda.connector.runtime.core.secret.SecretUtil;
 import java.time.Duration;
 import java.util.*;
@@ -38,6 +44,9 @@ public class OutboundConnectorExceptionHandler {
   private static final Logger LOGGER =
       LoggerFactory.getLogger(OutboundConnectorExceptionHandler.class);
 
+  /** Stands in for a container that (transitively) contains itself, so masking cannot loop. */
+  private static final String CIRCULAR_REFERENCE = "[circular reference]";
+
   private static final Duration ALLOW_LIST_RETRY_BACKOFF = Duration.ofSeconds(5);
 
   private final SecretProvider secretProvider;
@@ -46,9 +55,13 @@ public class OutboundConnectorExceptionHandler {
     this.secretProvider = secretProvider;
   }
 
-  private static Map<String, Object> exceptionToMap(Exception wrappedException) {
+  private static Map<String, Object> exceptionToMap(
+      Exception wrappedException, List<String> secrets) {
     Map<String, Object> result = new HashMap<>();
-    Throwable originalCause = wrappedException.getCause();
+    // Every wrapper built here carries the failure it reports as its cause, except the one that
+    // deliberately withholds it — that one reports itself, rather than dereferencing a null.
+    Throwable originalCause =
+        wrappedException.getCause() != null ? wrappedException.getCause() : wrappedException;
     result.put("type", originalCause.getClass().getName());
     var message = wrappedException.getMessage();
     if (message != null) {
@@ -60,14 +73,262 @@ public class OutboundConnectorExceptionHandler {
       var variables = connectorException.getErrorVariables();
 
       if (code != null) {
+        // deliberately not masked: BPMN error boundary events match on this value, so altering it
+        // would stop the error from being caught
         result.put("code", code);
       }
 
       if (variables != null) {
-        result.put("variables", variables);
+        result.put("variables", maskSecrets(variables, secrets));
       }
     }
     return Map.copyOf(result);
+  }
+
+  /**
+   * Masks every secret occurrence in {@code value}, recursing through maps and collections.
+   *
+   * <p>The error message is masked by the callers, but the error variables are copied straight off
+   * the original exception, and for HTTP connectors they carry the full response body and headers
+   * (see {@code ConnectorExceptionMapper}). An API that echoes a rejected credential back would
+   * otherwise put the resolved secret into process variables, which are visible to anyone who can
+   * see the process instance.
+   *
+   * <p>Only strings are rewritten; numbers, booleans and other scalars keep their type, since
+   * processes may branch on them. Values of types other than {@link Map}/{@link Collection}/{@link
+   * String} are passed through untouched — a secret held in a field of a custom object is not
+   * reached.
+   */
+  private static Object maskSecrets(Object value, List<String> secrets) {
+    return maskSecrets(value, secrets, Collections.newSetFromMap(new IdentityHashMap<>()));
+  }
+
+  private static Object maskSecrets(Object value, List<String> secrets, Set<Object> enclosing) {
+    return switch (value) {
+      case null -> null;
+      case String string -> SecretUtil.hideSecretsFromMessage(string, secrets);
+      case Map<?, ?> map -> {
+        // error variables are user-supplied, so a container may contain itself
+        if (!enclosing.add(map)) {
+          yield CIRCULAR_REFERENCE;
+        }
+        try {
+          yield maskMap(map, secrets, enclosing);
+        } finally {
+          enclosing.remove(map);
+        }
+      }
+      case Collection<?> collection -> {
+        if (!enclosing.add(collection)) {
+          yield CIRCULAR_REFERENCE;
+        }
+        try {
+          yield collection.stream().map(item -> maskSecrets(item, secrets, enclosing)).toList();
+        } finally {
+          enclosing.remove(collection);
+        }
+      }
+      default -> value;
+    };
+  }
+
+  private static Map<String, Object> maskMap(
+      Map<?, ?> map, List<String> secrets, Set<Object> enclosing) {
+    // keys are masked too, and collapsed keys simply overwrite rather than fail
+    var masked = new LinkedHashMap<String, Object>();
+    map.forEach(
+        (key, entry) ->
+            masked.put(
+                SecretUtil.hideSecretsFromMessage(String.valueOf(key), secrets),
+                maskSecrets(entry, secrets, enclosing)));
+    return masked;
+  }
+
+  /** Typed variant of {@link #maskSecrets}, which returns {@link Object} to allow a sentinel. */
+  private static Map<String, Object> maskVariables(
+      Map<String, Object> variables, List<String> secrets) {
+    if (variables == null) {
+      return null;
+    }
+    Set<Object> enclosing = Collections.newSetFromMap(new IdentityHashMap<>());
+    enclosing.add(variables);
+    return maskMap(variables, secrets, enclosing);
+  }
+
+  /**
+   * The values to redact from an error message, or the failure that prevented reading them.
+   *
+   * <p>Both call sites need the values before they can report anything, and neither may let a
+   * failure to read them escape: one would replace a classified result with an unclassified throw,
+   * and the other is already inside a catch block whose escape route abandons the job.
+   */
+  private record MaskingSecrets(List<String> secrets, Exception failure) {
+
+    boolean unavailable() {
+      return failure != null;
+    }
+  }
+
+  // unions bind-time captures into a successful re-read, so a rotated secret is still redacted
+  private static List<String> withCaptured(MaskingSecrets masking, List<String> captured) {
+    if (captured.isEmpty()) {
+      return masking.secrets();
+    }
+    var union = new ArrayList<String>(masking.secrets());
+    union.addAll(captured);
+    return union;
+  }
+
+  /**
+   * Reads the values to redact. A provider may refuse a key outright, and it throws here for keys
+   * this fetch only ever wanted for masking, so the failure is returned rather than raised.
+   *
+   * <p>A re-read that comes back short is treated as a failure too, because redacting with a
+   * partial list is what this whole path exists to prevent: the values that did come back would be
+   * redacted and the one that did not would be published in the clear. The requirement is exactly
+   * as strong as {@code SecretHandler}'s replacer, which throws when a provider returns null for a
+   * name the filter allows — so the input could not have been bound unless every name it declares
+   * resolved. One of them missing now means the secret was removed, or access to it revoked, since
+   * the connector ran.
+   *
+   * <p>Unless the job's own failure is that very thing ({@link SecretNotAvailableException}), which
+   * is the one case where a name the input declares is expected back empty. Substitution is then
+   * what threw, so the input the message describes never carried that secret's value and there is
+   * nothing of it to redact — and the message is the replacer's own, naming the secret an operator
+   * has to go and create. Withholding it would replace the answer with a description of the
+   * question.
+   */
+  private MaskingSecrets fetchSecretsForMasking(
+      ActivatedJob job, SecretFilter secretFilter, Exception jobFailure) {
+    try {
+      var keys =
+          allowedKeys(SecretUtil.retrieveSecretKeysInInput(job.getVariables()), secretFilter);
+      if (keys.isEmpty()) {
+        return new MaskingSecrets(List.of(), null);
+      }
+      var values =
+          this.secretProvider.fetchAll(
+              keys, new SecretContext(job.getTenantId(), job.getBpmnProcessId()));
+      if (values.size() < keys.size() && !reportsAnUnavailableSecret(jobFailure)) {
+        return new MaskingSecrets(
+            List.of(),
+            new MaskingSecretsIncompleteException(keys.size() - values.size(), keys.size()));
+      }
+      return new MaskingSecrets(List.copyOf(values), null);
+    } catch (Exception ex) {
+      LOGGER.error(
+          "Initial error for job: {} for tenant: {} can't be displayed because fetching secrets failed: {}",
+          job.getKey(),
+          job.getTenantId(),
+          safeDiagnostic(ex));
+      return new MaskingSecrets(List.of(), ex);
+    }
+  }
+
+  private static List<String> allowedKeys(List<String> keys, SecretFilter secretFilter) {
+    return keys.stream().filter(secretFilter::isAllowed).toList();
+  }
+
+  /**
+   * Whether the job failed because a legacy secret it names has no value. A re-read that comes back
+   * short then says the same thing the job's own failure already says, rather than reporting a
+   * value that has gone missing since the connector ran.
+   */
+  private static boolean reportsAnUnavailableSecret(Exception jobFailure) {
+    return jobFailure instanceof SecretNotAvailableException
+        || (jobFailure != null && jobFailure.getCause() instanceof SecretNotAvailableException);
+  }
+
+  /**
+   * Reported when the masking re-read comes back short of the legacy names the job's input
+   * declares. Carries a count and nothing else: how many values are missing is enough for an
+   * operator to act on, and is not something a secret store told this runtime.
+   */
+  private static class MaskingSecretsIncompleteException extends RuntimeException
+      implements SecretFailureDiagnostic {
+
+    private final String publishableMessage;
+
+    private MaskingSecretsIncompleteException(int missing, int expected) {
+      super(
+          missing
+              + " of "
+              + expected
+              + " legacy secrets named by this job's input could not be read back");
+      this.publishableMessage =
+          missing
+              + " of the "
+              + expected
+              + " legacy secrets this job's input names could not be read back, so the error"
+              + " message could not be redacted. A secret that resolved when the input was bound"
+              + " has since been removed, or access to it revoked.";
+    }
+
+    @Override
+    public String publishableMessage() {
+      return publishableMessage;
+    }
+  }
+
+  /**
+   * Stands in for an error that cannot be shown. With no values to redact with, the original
+   * message has to be dropped rather than reported unmasked — it may hold a resolved secret.
+   *
+   * <p>The failure that prevented masking is dropped with it, and for the same reason: a provider
+   * or client error can echo a response body from the secret store, so its message is no safer to
+   * publish than the message it was supposed to help redact. Nothing built from it can be masked
+   * either — the redaction list is empty by definition on this path. It is logged where it happens
+   * and goes no further.
+   *
+   * <p>The exception's class name is reported, which carries no request or response data. And where
+   * the failure is one the runtime raised itself, so is its {@link
+   * SecretFailureDiagnostic#publishableMessage()}: the two failures this runtime introduces —
+   * legacy resolution switched off, and a name with no reference form — are precisely the ones an
+   * operator has to act on, and a type name alone does not say which setting to change or which
+   * charset a name has to fit. Withholding arbitrary provider text is not a reason to withhold text
+   * written to be read.
+   */
+  // A provider's own message can carry secret material - a bundle that parses as a non-object puts
+  // the value into Jackson's coercion error - so only what SecretReferenceResolver keeps is logged.
+  private static String safeDiagnostic(Exception fetchFailure) {
+    return fetchFailure instanceof SecretFailureDiagnostic diagnosable
+        ? fetchFailure.getClass().getName() + ": " + diagnosable.publishableMessage()
+        : fetchFailure.getClass().getName();
+  }
+
+  private static RuntimeException unmaskableError(Exception fetchFailure) {
+    return new SecretsUnavailableException(
+        fetchFailure.getClass().getName(),
+        fetchFailure instanceof SecretFailureDiagnostic diagnosable
+            ? diagnosable.publishableMessage()
+            : null);
+  }
+
+  /**
+   * Reported in place of an error whose message could not be redacted.
+   *
+   * <p>Deliberately not a {@link ConnectorException}: {@link #exceptionToMap} copies a {@code
+   * ConnectorException}'s error variables and error code into the payload, and on this path it
+   * would copy them with an empty redaction list — publishing unmasked exactly the data this branch
+   * exists to withhold.
+   */
+  private static class SecretsUnavailableException extends RuntimeException {
+
+    private SecretsUnavailableException(String failureType, String publishableMessage) {
+      super(
+          "Fetching secrets failed, so the original error cannot be displayed: with nothing to"
+              + " redact with it might reveal a secret. Fetching failed with: "
+              + failureType
+              + (publishableMessage == null ? "" : ": " + publishableMessage));
+    }
+  }
+
+  /**
+   * Whether an exception says the input can never bind, whoever raised it. Such a job is not worth
+   * another attempt; anything else — an unreachable cluster, a timeout — is.
+   */
+  private static boolean isFatalInputError(Throwable e) {
+    return e instanceof ConnectorInputException || e.getCause() instanceof ConnectorInputException;
   }
 
   private static Duration retryBackoffFor(Exception failure, Duration configured) {
@@ -77,36 +338,33 @@ public class OutboundConnectorExceptionHandler {
   }
 
   public ConnectorResult.ErrorResult manageConnectorJobHandlerException(
-      Exception e, ActivatedJob job, Duration retryBackoffDuration, SecretFilter secretFilter) {
+      Exception e,
+      ActivatedJob job,
+      Duration retryBackoffDuration,
+      SecretFilter secretFilter,
+      List<String> capturedSecrets) {
     if (e instanceof SecretAllowListUnavailableException) {
       return handleGenericException(job, e, List.of(), retryBackoffFor(e, retryBackoffDuration));
     }
-    List<String> secrets;
-    try {
-      var allowedKeys =
-          SecretUtil.retrieveSecretKeysInInput(job.getVariables()).stream()
-              .filter(secretFilter::isAllowed)
-              .toList();
-      secrets =
-          this.secretProvider.fetchAll(
-              allowedKeys, new SecretContext(job.getTenantId(), job.getBpmnProcessId()));
-    } catch (Exception ex) {
-      LOGGER.error(
-          "Initial error for job: {} for tenant: {} can't be displayed because fetching secrets failed: {}",
-          job.getKey(),
-          job.getTenantId(),
-          ex.getMessage());
-      var wrappedException =
-          new RuntimeException(
-              "Fetching secrets failed, original error can't be displayed as the error message might contain secrets: "
-                  + ex.getMessage(),
-              ex);
+    var masking = fetchSecretsForMasking(job, secretFilter, e);
+    if (masking.unavailable()) {
+      var wrappedException = unmaskableError(masking.failure());
+      // Either failure can be the permanent one, so both are consulted. A provider that refuses
+      // to resolve at all (e.g. legacy resolution switched off) throws for every key, including
+      // the ones this fetch only needed for masking; and the job's own failure is still whatever
+      // it was, so an input error that will never bind must not become retryable just because
+      // reading the values to redact it happened to time out. Only when neither says the input is
+      // at fault does the job keep its remaining attempts.
+      int retries =
+          isFatalInputError(masking.failure()) || isFatalInputError(e) ? 0 : job.getRetries() - 1;
       return new ConnectorResult.ErrorResult(
-          Map.of("error", exceptionToMap(wrappedException)),
+          // secrets could not be fetched, so there is nothing to mask with
+          Map.of("error", exceptionToMap(wrappedException, List.of())),
           wrappedException,
-          job.getRetries() - 1,
-          retryBackoffFor(ex, retryBackoffDuration));
+          retries,
+          retryBackoffFor(masking.failure(), retryBackoffDuration));
     }
+    List<String> secrets = withCaptured(masking, capturedSecrets);
     return switch (e) {
       case InvalidBackOffDurationException invalidBackOffDurationException ->
           handleBackOffException(invalidBackOffDurationException, secrets);
@@ -118,22 +376,76 @@ public class OutboundConnectorExceptionHandler {
     };
   }
 
-  private String hideSecretsFromMessage(String message, List<String> secrets) {
-    if (!Objects.isNull(message))
-      return secrets.stream()
-          .reduce(message, (newMessage, nextSecret) -> newMessage.replace(nextSecret, "***"));
-    else return "";
+  /** Redacts an error an error expression produced; {@code failJob}/{@code throwError} do not. */
+  public ConnectorError maskConnectorError(
+      ConnectorError error,
+      ActivatedJob job,
+      SecretFilter secretFilter,
+      List<String> capturedSecrets) {
+    return switch (error) {
+      // business output on the branch that completes the job; the branch that raises an incident
+      // instead redacts them itself, via maskDiagnosticVariables
+      case IgnoreError ignoreError -> ignoreError;
+      case BpmnError bpmnError -> {
+        if (nothingToRedact(bpmnError.errorMessage(), bpmnError.variables())) {
+          yield bpmnError;
+        }
+        var masking = fetchSecretsForMasking(job, secretFilter, null);
+        // the error code is never redacted: boundary events match on it
+        if (masking.unavailable()) {
+          yield new BpmnError(
+              bpmnError.errorCode(), unmaskableError(masking.failure()).getMessage(), Map.of());
+        }
+        var secrets = withCaptured(masking, capturedSecrets);
+        yield new BpmnError(
+            bpmnError.errorCode(),
+            redactNullable(bpmnError.errorMessage(), secrets),
+            maskVariables(bpmnError.variables(), secrets));
+      }
+      case JobError jobError -> {
+        if (nothingToRedact(jobError.errorMessage(), jobError.variables())) {
+          yield jobError;
+        }
+        var masking = fetchSecretsForMasking(job, secretFilter, null);
+        if (masking.unavailable()) {
+          yield new JobError(
+              unmaskableError(masking.failure()).getMessage(),
+              Map.of(),
+              jobError.retries(),
+              jobError.retryBackoff());
+        }
+        var secrets = withCaptured(masking, capturedSecrets);
+        yield new JobError(
+            redactNullable(jobError.errorMessage(), secrets),
+            maskVariables(jobError.variables(), secrets),
+            jobError.retries(),
+            jobError.retryBackoff());
+      }
+    };
+  }
+
+  // A JobError egresses variablesWithErrorMessage(), which adds only the message checked here.
+  private static boolean nothingToRedact(String errorMessage, Map<String, Object> variables) {
+    return (errorMessage == null || errorMessage.isEmpty())
+        && (variables == null || variables.isEmpty());
+  }
+
+  /** Unlike {@link SecretUtil#hideSecretsFromMessage}, keeps a null message null rather than "". */
+  private static String redactNullable(String message, List<String> secrets) {
+    return message == null ? null : SecretUtil.hideSecretsFromMessage(message, secrets);
   }
 
   private ConnectorResult.ErrorResult handleBackOffException(Exception e, List<String> secrets) {
-    Exception newException = new Exception(hideSecretsFromMessage(e.getMessage(), secrets), e);
+    Exception newException =
+        new Exception(SecretUtil.hideSecretsFromMessage(e.getMessage(), secrets), e);
     return new ConnectorResult.ErrorResult(
-        Map.of("error", exceptionToMap(newException)), newException, 0);
+        Map.of("error", exceptionToMap(newException, secrets)), newException, 0);
   }
 
   private ConnectorResult.ErrorResult handleConnectorRetryException(
       ActivatedJob job, ConnectorRetryException ex, List<String> secrets, Duration retryBackoff) {
-    Exception newException = new Exception(hideSecretsFromMessage(ex.getMessage(), secrets), ex);
+    Exception newException =
+        new Exception(SecretUtil.hideSecretsFromMessage(ex.getMessage(), secrets), ex);
     LOGGER.debug(
         "ConnectorRetryException while processing job: {} for tenant: {}, error message: {}",
         job.getKey(),
@@ -145,11 +457,17 @@ public class OutboundConnectorExceptionHandler {
         newException,
         Optional.ofNullable(ex.getRetries()).orElse(job.getRetries() - 1),
         errorCode,
-        Optional.ofNullable(ex.getBackoffDuration()).orElse(retryBackoff));
+        Optional.ofNullable(ex.getBackoffDuration()).orElse(retryBackoff),
+        secrets);
   }
 
   private ConnectorResult.ErrorResult handleSDKException(
-      ActivatedJob job, Exception ex, Integer retries, String errorCode, Duration backoffDuration) {
+      ActivatedJob job,
+      Exception ex,
+      Integer retries,
+      String errorCode,
+      Duration backoffDuration,
+      List<String> secrets) {
     LOGGER.debug(
         "Failing job with retry config => job: {} for tenant: {} with error code: {}, retries: {} and remaining backoffDuration: {}",
         job.getKey(),
@@ -159,12 +477,13 @@ public class OutboundConnectorExceptionHandler {
         backoffDuration);
 
     return new ConnectorResult.ErrorResult(
-        Map.of("error", exceptionToMap(ex)), ex, retries, backoffDuration);
+        Map.of("error", exceptionToMap(ex, secrets)), ex, retries, backoffDuration);
   }
 
   private ConnectorResult.ErrorResult handleGenericException(
       ActivatedJob job, Exception ex, List<String> secrets, Duration retryBackoff) {
-    Exception newException = new Exception(hideSecretsFromMessage(ex.getMessage(), secrets), ex);
+    Exception newException =
+        new Exception(SecretUtil.hideSecretsFromMessage(ex.getMessage(), secrets), ex);
     LOGGER.debug(
         "Exception while processing job: {} for tenant: {}, message: {}",
         job.getKey(),
@@ -177,28 +496,57 @@ public class OutboundConnectorExceptionHandler {
     if (ex instanceof ConnectorException connectorException) {
       errorCode = connectorException.getErrorCode();
     }
-    if (ex instanceof ConnectorInputException || ex.getCause() instanceof ConnectorInputException) {
+    if (isFatalInputError(ex)) {
       retries = 0;
     }
-    return handleSDKException(job, newException, retries, errorCode, retryBackoff);
+    return handleSDKException(job, newException, retries, errorCode, retryBackoff, secrets);
   }
 
+  /**
+   * Reports a failure raised while processing a connector's final result — its result or error
+   * expression.
+   *
+   * <p>This must not throw. Its only caller is already handling the failure it is being told about,
+   * and an exception leaving here escapes that handler entirely: the job is then neither completed
+   * nor failed, and stays put until its activation timeout hands it to another worker, which
+   * re-runs the connector. So a masking fetch that fails costs the original message — which cannot
+   * be shown unredacted — and nothing else.
+   *
+   * <p>The result is unretryable either way. A result expression that does not evaluate will not
+   * evaluate on the next attempt, and reaching here at all means the connector has already run, so
+   * a retry would repeat its side effects.
+   *
+   * <p>The failure is logged after redaction, not before. A connector was handed resolved secrets
+   * and its error message can carry one back, so logging it on the way in would put in the runtime
+   * log exactly what the incident and the process variables are redacted to keep out. Where the
+   * values to redact with cannot be read, the type is logged and the message is dropped, on the
+   * same reasoning that drops it from the payload. The failure that prevented redaction is the one
+   * exception, and only in the log: it is the reason an operator has nothing else to go on, and
+   * withholding it there would leave the runtime silent about why.
+   */
   public ConnectorResult.ErrorResult handleFinalResultException(
-      Exception ex, ActivatedJob job, SecretFilter secretFilter) {
-    var allowedKeys =
-        SecretUtil.retrieveSecretKeysInInput(job.getVariables()).stream()
-            .filter(secretFilter::isAllowed)
-            .toList();
-    List<String> secrets =
-        this.secretProvider.fetchAll(
-            allowedKeys, new SecretContext(job.getTenantId(), job.getBpmnProcessId()));
-    Exception newException = new Exception(hideSecretsFromMessage(ex.getMessage(), secrets), ex);
+      Exception ex, ActivatedJob job, SecretFilter secretFilter, List<String> capturedSecrets) {
+    var masking = fetchSecretsForMasking(job, secretFilter, ex);
+    if (masking.unavailable()) {
+      LOGGER.error(
+          "Exception while processing job: {} for tenant: {}, type: {}. Its message is withheld:"
+              + " the values to redact it with could not be read.",
+          job.getKey(),
+          job.getTenantId(),
+          ex.getClass().getName());
+      var wrappedException = unmaskableError(masking.failure());
+      return new ConnectorResult.ErrorResult(
+          Map.of("error", exceptionToMap(wrappedException, List.of())), wrappedException, 0);
+    }
+    List<String> secrets = withCaptured(masking, capturedSecrets);
+    Exception newException =
+        new Exception(SecretUtil.hideSecretsFromMessage(ex.getMessage(), secrets), ex);
     LOGGER.error(
         "Exception while processing job: {} for tenant: {}, message: {}",
         job.getKey(),
         job.getTenantId(),
         newException.getMessage());
     return new ConnectorResult.ErrorResult(
-        Map.of("error", exceptionToMap(newException)), newException, 0);
+        Map.of("error", exceptionToMap(newException, secrets)), newException, 0);
   }
 }

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/SecretAllowListUnavailableException.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/SecretAllowListUnavailableException.java
@@ -16,15 +16,27 @@
  */
 package io.camunda.connector.runtime.outbound.job;
 
+import io.camunda.connector.runtime.core.secret.SecretFailureDiagnostic;
+
 /**
  * Thrown when the allow-list of secret names an element may resolve could not be read, so no secret
  * value ever reached the input. The lookup reads the process definition from secondary storage,
  * which a just-deployed definition has yet to reach, so this failure is worth another attempt after
  * a backoff rather than immediately.
  */
-class SecretAllowListUnavailableException extends RuntimeException {
+class SecretAllowListUnavailableException extends RuntimeException
+    implements SecretFailureDiagnostic {
 
   SecretAllowListUnavailableException(String message) {
     super(message);
+  }
+
+  /**
+   * The runtime wrote this message itself — it names the element and the process definition, not
+   * anything a secret store echoed back — so it stays readable when an error has to be withheld.
+   */
+  @Override
+  public String publishableMessage() {
+    return getMessage();
   }
 }

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/SpringConnectorJobHandler.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/SpringConnectorJobHandler.java
@@ -191,22 +191,23 @@ public class SpringConnectorJobHandler implements JobHandler {
         job.getKey(),
         job.getType(),
         job.getTenantId());
-    ConnectorResult result = getConnectorResult(job, secretFilter);
-    processFinalResult(client, job, result, counterMetricsContext, secretFilter);
+    var context =
+        new JobHandlerContext(
+            job,
+            getSecretProvider(),
+            validationProvider,
+            documentFactory,
+            objectMapper,
+            secretFilter);
+    ConnectorResult result = getConnectorResult(job, context, secretFilter);
+    processFinalResult(client, job, context, result, counterMetricsContext, secretFilter);
   }
 
-  private ConnectorResult getConnectorResult(ActivatedJob job, SecretFilter secretFilter) {
+  private ConnectorResult getConnectorResult(
+      ActivatedJob job, JobHandlerContext context, SecretFilter secretFilter) {
     Duration retryBackoff = null;
     try {
       retryBackoff = getBackoffDuration(job);
-      var context =
-          new JobHandlerContext(
-              job,
-              getSecretProvider(),
-              validationProvider,
-              documentFactory,
-              objectMapper,
-              secretFilter);
       var response = call.execute(context);
       var responseVariables =
           connectorResultHandler.createOutputVariables(
@@ -219,13 +220,14 @@ public class SpringConnectorJobHandler implements JobHandler {
       return new ConnectorResult.SuccessResult(response, responseVariables);
     } catch (Exception e) {
       return outboundConnectorExceptionHandler.manageConnectorJobHandlerException(
-          e, job, retryBackoff, secretFilter);
+          e, job, retryBackoff, secretFilter, context.getSecretHandler().getResolvedValues());
     }
   }
 
   private void processFinalResult(
       JobClient client,
       ActivatedJob job,
+      JobHandlerContext context,
       ConnectorResult finalResult,
       CounterMetricsContext counterMetricsContext,
       SecretFilter secretFilter) {
@@ -237,7 +239,9 @@ public class SpringConnectorJobHandler implements JobHandler {
               new ErrorExpressionJobContext(
                   new ErrorExpressionJobContext.ErrorExpressionJob(job.getRetries())));
       optionalConnectorError.ifPresentOrElse(
-          error -> handleBPMNError(client, job, error, counterMetricsContext),
+          error ->
+              handleConnectorError(
+                  client, job, context, error, counterMetricsContext, secretFilter),
           () -> handleSuccessResult(client, job, finalResult, counterMetricsContext));
     } catch (Exception ex) {
       if (Thread.currentThread().isInterrupted()) {
@@ -261,7 +265,8 @@ public class SpringConnectorJobHandler implements JobHandler {
       failJob(
           client,
           job,
-          this.outboundConnectorExceptionHandler.handleFinalResultException(ex, job, secretFilter),
+          this.outboundConnectorExceptionHandler.handleFinalResultException(
+              ex, job, secretFilter, context.getSecretHandler().getResolvedValues()),
           counterMetricsContext);
     }
   }
@@ -280,22 +285,32 @@ public class SpringConnectorJobHandler implements JobHandler {
       LOGGER.error(
           "Exception while completing job: {}, message: {}",
           JobForLog.from(job),
-          errorResult.exception().getMessage(),
-          errorResult.exception());
+          errorResult.exception().getMessage());
       failJob(jobClient, job, errorResult, counterMetricsContext);
     }
   }
 
-  private void handleBPMNError(
+  private void handleConnectorError(
       JobClient client,
       ActivatedJob job,
-      ConnectorError error,
-      CounterMetricsContext counterMetricsContext) {
+      JobHandlerContext context,
+      ConnectorError rawError,
+      CounterMetricsContext counterMetricsContext,
+      SecretFilter secretFilter) {
+    // redacted before the Zeebe command is built from it: failJob and throwError mask nothing of
+    // their own, and these two branches build their command directly rather than going through
+    // manageConnectorJobHandlerException
+    var error =
+        outboundConnectorExceptionHandler.maskConnectorError(
+            rawError, job, secretFilter, context.getSecretHandler().getResolvedValues());
+
     switch (error) {
       case BpmnError bpmnError -> {
         checkVariablesSize(bpmnError.variables());
-        LOGGER.debug(
-            "Throwing BPMN error for job {} with code {}", job.getKey(), bpmnError.errorCode());
+        // the code is deliberately never redacted, since boundary events match on it, so it stays
+        // out of the log: pod logs are shipped to systems with their own retention and access
+        // controls, and the job key already identifies the line
+        LOGGER.debug("Throwing BPMN error for job {}", job.getKey());
         throwBpmnError(client, job, bpmnError, counterMetricsContext);
       }
       case JobError jobError -> {

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/job/OutboundConnectorExceptionHandlerTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/job/OutboundConnectorExceptionHandlerTest.java
@@ -20,15 +20,23 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
 import io.camunda.client.api.response.ActivatedJob;
+import io.camunda.connector.api.secret.SecretContext;
 import io.camunda.connector.api.secret.SecretProvider;
 import io.camunda.connector.runtime.core.secret.SecretFilter;
 import io.camunda.connector.runtime.secret.FooBarSecretProvider;
 import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.slf4j.LoggerFactory;
 
 class OutboundConnectorExceptionHandlerTest {
 
@@ -64,7 +72,8 @@ class OutboundConnectorExceptionHandlerTest {
                     + " (io.camunda.client.api.command.ProblemException)"),
             job,
             null,
-            SecretFilter.allowAll());
+            SecretFilter.allowAll(),
+            List.of());
 
     assertThat(result.exception())
         .hasMessageContaining("Activity_1")
@@ -84,7 +93,8 @@ class OutboundConnectorExceptionHandlerTest {
             new SecretAllowListUnavailableException("lookup failed"),
             job,
             modelBackoff,
-            SecretFilter.allowAll());
+            SecretFilter.allowAll(),
+            List.of());
 
     assertThat(result.retryBackoff()).isEqualTo(Duration.ofSeconds(5));
     assertThat(result.retries()).isEqualTo(2);
@@ -108,7 +118,11 @@ class OutboundConnectorExceptionHandlerTest {
 
     var result =
         handlerWithThrowingProvider.manageConnectorJobHandlerException(
-            new RuntimeException("boom"), job, Duration.ofSeconds(30), SecretFilter.allowAll());
+            new RuntimeException("boom"),
+            job,
+            Duration.ofSeconds(30),
+            SecretFilter.allowAll(),
+            List.of());
 
     assertThat(result.retryBackoff()).isEqualTo(Duration.ofSeconds(30));
   }
@@ -124,10 +138,168 @@ class OutboundConnectorExceptionHandlerTest {
 
     var result =
         handler.manageConnectorJobHandlerException(
-            new RuntimeException("boom"), job, null, unreadableAllowList);
+            new RuntimeException("boom"), job, null, unreadableAllowList, List.of());
 
     assertThat(result.exception()).hasMessageContaining("Activity_1");
     assertThat(result.retries()).isEqualTo(2);
     assertThat(result.retryBackoff()).isEqualTo(Duration.ofSeconds(5));
+  }
+
+  private static ActivatedJob jobNaming(String variables) {
+    var job = mock(ActivatedJob.class);
+    when(job.getVariables()).thenReturn(variables);
+    when(job.getKey()).thenReturn(1L);
+    when(job.getTenantId()).thenReturn("tenant");
+    when(job.getRetries()).thenReturn(3);
+    return job;
+  }
+
+  /** Captures what the handler's own logger wrote while the given action ran. */
+  private static List<String> logsOf(Runnable action) {
+    var logger = (Logger) LoggerFactory.getLogger(OutboundConnectorExceptionHandler.class);
+    var appender = new ListAppender<ILoggingEvent>();
+    appender.start();
+    logger.addAppender(appender);
+    try {
+      action.run();
+    } finally {
+      logger.detachAppender(appender);
+      appender.stop();
+    }
+    return appender.list.stream().map(ILoggingEvent::getFormattedMessage).toList();
+  }
+
+  @Test
+  void aFailedMaskingFetchIsNeverLoggedEither() {
+    // A provider writes its own message, and it can carry secret material: AbstractSecretProvider
+    // folds a Jackson failure into one, and a bundle that parses as a non-object puts the value it
+    // could not coerce into the coercion error.
+    var job = jobWithSecretReference();
+    SecretProvider leakyProvider =
+        mock(
+            SecretProvider.class,
+            invocation -> {
+              throw new RuntimeException(
+                  "Could not resolve secrets: MismatchedInputException: Cannot construct instance"
+                      + " of `java.util.LinkedHashMap` from String value ('super-secret')");
+            });
+    var handlerWithLeakyProvider = new OutboundConnectorExceptionHandler(leakyProvider);
+
+    var logged =
+        logsOf(
+            () ->
+                handlerWithLeakyProvider.manageConnectorJobHandlerException(
+                    new RuntimeException("boom"),
+                    job,
+                    Duration.ofSeconds(1),
+                    SecretFilter.allowAll(),
+                    List.of()));
+
+    assertThat(logged).noneMatch(message -> message.contains("super-secret"));
+    assertThat(logged).anyMatch(message -> message.contains("java.lang.RuntimeException"));
+  }
+
+  @Test
+  void aRefusalTheRuntimeWroteItselfKeepsItsMessageInTheLog() {
+    // Withholding arbitrary provider text is not a reason to withhold text written to be read: a
+    // refusal names the element an operator has to go and look at, and a type name does not.
+    var job = jobWithSecretReference();
+    SecretProvider refusingProvider =
+        mock(
+            SecretProvider.class,
+            invocation -> {
+              throw new SecretAllowListUnavailableException(
+                  "Error retrieving secret keys for element 'Activity_1'");
+            });
+    var handlerWithRefusingProvider = new OutboundConnectorExceptionHandler(refusingProvider);
+
+    var logged =
+        logsOf(
+            () ->
+                handlerWithRefusingProvider.manageConnectorJobHandlerException(
+                    new RuntimeException("boom"),
+                    job,
+                    Duration.ofSeconds(1),
+                    SecretFilter.allowAll(),
+                    List.of()));
+
+    assertThat(logged).anyMatch(message -> message.contains("Activity_1"));
+  }
+
+  @Test
+  void masksALongerSecretThatStartsWithAShorterOne() {
+    // Replacing the shorter value first would leave the longer one unmatched and publish its
+    // remainder: "x" before "xSUPERSECRET" turns the message into "***SUPERSECRET".
+    var job = jobNaming("{\"a\": \"{{secrets.SHORT}}\", \"b\": \"{{secrets.LONG}}\"}");
+    var handlerWithBoth =
+        new OutboundConnectorExceptionHandler(
+            holdingOnly(Map.of("SHORT", "x", "LONG", "xSUPERSECRET")));
+
+    var result =
+        handlerWithBoth.manageConnectorJobHandlerException(
+            new RuntimeException("api rejected xSUPERSECRET"),
+            job,
+            Duration.ofSeconds(1),
+            SecretFilter.allowAll(),
+            List.of());
+
+    assertThat(result.exception().getMessage()).isEqualTo("api rejected ***");
+  }
+
+  @Test
+  void anEmptySecretValueDoesNotCorruptTheMessage() {
+    // Replacing "" matches at every position, so a provider answering with one would rewrite the
+    // whole message into separators rather than redact anything.
+    var job = jobNaming("{\"a\": \"{{secrets.BLANK}}\"}");
+    var handlerWithBlank = new OutboundConnectorExceptionHandler(holdingOnly(Map.of("BLANK", "")));
+
+    var result =
+        handlerWithBlank.manageConnectorJobHandlerException(
+            new RuntimeException("api rejected the request"),
+            job,
+            Duration.ofSeconds(1),
+            SecretFilter.allowAll(),
+            List.of());
+
+    assertThat(result.exception().getMessage()).isEqualTo("api rejected the request");
+  }
+
+  @Test
+  void aJobDeclaringNoSecretNeverReachesAProvider() {
+    // Failing closed is limited to jobs that actually declare a secret, and that is only true if
+    // the read is skipped outright rather than delegated to a provider that may refuse every batch.
+    var job = jobNaming("{\"a\": \"nothing secret here\"}");
+    SecretProvider providerThatMustNotBeCalled =
+        mock(
+            SecretProvider.class,
+            invocation -> {
+              throw new AssertionError("a job declaring no secret has nothing to redact");
+            });
+    var handlerWithGuard = new OutboundConnectorExceptionHandler(providerThatMustNotBeCalled);
+
+    var result =
+        handlerWithGuard.manageConnectorJobHandlerException(
+            new RuntimeException("api rejected the request"),
+            job,
+            Duration.ofSeconds(1),
+            SecretFilter.allowAll(),
+            List.of());
+
+    assertThat(result.exception().getMessage()).isEqualTo("api rejected the request");
+  }
+
+  /** A provider holding exactly the given names, and answering {@code fetchAll} in key order. */
+  private static SecretProvider holdingOnly(Map<String, String> secrets) {
+    return new SecretProvider() {
+      @Override
+      public String getSecret(String name, SecretContext context) {
+        return secrets.get(name);
+      }
+
+      @Override
+      public List<String> fetchAll(List<String> keys, SecretContext context) {
+        return keys.stream().map(secrets::get).filter(Objects::nonNull).toList();
+      }
+    };
   }
 }

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/job/SpringConnectorJobHandlerTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/job/SpringConnectorJobHandlerTest.java
@@ -33,6 +33,9 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
 import io.camunda.client.api.command.FailJobCommandStep1;
 import io.camunda.client.api.worker.BackoffSupplier;
 import io.camunda.client.api.worker.JobClient;
@@ -68,6 +71,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.*;
 import org.mockito.ArgumentCaptor;
+import org.slf4j.LoggerFactory;
 
 class SpringConnectorJobHandlerTest {
 
@@ -1505,12 +1509,16 @@ class SpringConnectorJobHandlerTest {
             .executeAndCaptureResult(jobHandlerRaisingException, false);
 
     // then
+    // the provider's own message is no longer concatenated in: a provider folds the value it could
+    // not coerce into its text, so publishing it verbatim published a secret
     assertThat(resultForMissingSecret.getErrorMessage())
-        .startsWith(
-            "Fetching secrets failed, original error can't be displayed as the error message might contain secrets: Network error while fetching secrets");
+        .startsWith("Fetching secrets failed, so the original error cannot be displayed")
+        .contains("java.lang.RuntimeException")
+        .doesNotContain("Network error while fetching secrets");
     assertThat(resultForRaisingException.getErrorMessage())
-        .startsWith(
-            "Fetching secrets failed, original error can't be displayed as the error message might contain secrets: Network error while fetching secrets");
+        .startsWith("Fetching secrets failed, so the original error cannot be displayed")
+        .contains("java.lang.RuntimeException")
+        .doesNotContain("Network error while fetching secrets");
   }
 
   @Test
@@ -1593,5 +1601,312 @@ class SpringConnectorJobHandlerTest {
         .contains("status=400")
         .contains("type=io.camunda.connector.api.error.ConnectorException")
         .contains("message=HTTP request failed");
+  }
+
+  /** The job's input declares {{secrets.FOO}}, and the called API echoes that value back. */
+  @Nested
+  class ErrorExpressionSecretMaskingTests {
+
+    private static final String ECHOED = FooBarSecretProvider.SECRET_VALUE;
+    private static final String INPUT_DECLARING_A_SECRET = "{ \"token\" : \"{{secrets.FOO}}\" }";
+
+    private SpringConnectorJobHandler handlerFor(
+        OutboundConnectorFunction call, SecretProviderAggregator secretProviderAggregator) {
+      return new SpringConnectorJobHandler(
+          new MicrometerMetricsRecorder(new SimpleMeterRegistry()),
+          new DefaultCommandExceptionHandlingStrategy(
+              BackoffSupplier.newBackoffBuilder().build(),
+              Executors.newSingleThreadScheduledExecutor()),
+          secretProviderAggregator,
+          new DefaultValidationProvider(),
+          mock(DocumentFactory.class),
+          TestObjectMapperSupplier.INSTANCE,
+          call,
+          job -> SecretFilter.allowAll());
+    }
+
+    private SpringConnectorJobHandler echoingConnector() {
+      return handlerFor(
+          context -> Map.of("body", "rejected token " + ECHOED),
+          new SecretProviderAggregator(List.of(new FooBarSecretProvider())));
+    }
+
+    private SpringConnectorJobHandler echoingConnectorWithUnreadableSecrets() {
+      return handlerFor(
+          context -> Map.of("body", "rejected token " + ECHOED),
+          new SecretProviderAggregator(List.of(new FooBarSecretProvider())) {
+            @Override
+            public List<String> fetchAll(List<String> keys, SecretContext context) {
+              throw new RuntimeException("Network error while fetching secrets");
+            }
+          });
+    }
+
+    @Test
+    void jobErrorMessageCopyingAResponseIsRedacted() throws Exception {
+      var result =
+          JobBuilder.create()
+              .withVariables(INPUT_DECLARING_A_SECRET)
+              .withErrorExpressionHeader("=jobError(\"Request failed: \" + response.body, {}, 0)")
+              .executeAndCaptureResult(echoingConnector(), false, false);
+
+      assertThat(result.getErrorMessage())
+          .startsWith("Request failed: rejected token ***")
+          .doesNotContain(ECHOED);
+    }
+
+    @Test
+    void jobErrorVariablesCopyingAResponseAreRedacted() throws Exception {
+      var result =
+          JobBuilder.create()
+              .withVariables(INPUT_DECLARING_A_SECRET)
+              .withErrorExpressionHeader(
+                  "=jobError(\"failed\", {detail: response.body, code: 401}, 0)")
+              .executeAndCaptureResult(echoingConnector(), false, false);
+
+      assertThat(result.getVariables()).containsEntry("detail", "rejected token ***");
+      // scalars keep their type, since a process resolving the incident may branch on them
+      assertThat(result.getVariables()).containsEntry("code", 401);
+      // prepareFailJobCommand appends the variables to the message, so they reach it too
+      assertThat(result.getErrorMessage()).doesNotContain(ECHOED);
+    }
+
+    @Test
+    void jobErrorKeepsTheRetriesAndBackoffTheExpressionAsked() throws Exception {
+      var failCommand = mock(FailJobCommandStep1.class);
+      var failCommandStep2 =
+          mock(FailJobCommandStep1.FailJobCommandStep2.class, RETURNS_DEEP_STUBS);
+      var jobClient = mock(JobClient.class);
+      when(jobClient.newFailCommand(any())).thenReturn(failCommand);
+      when(failCommand.retries(anyInt())).thenReturn(failCommandStep2);
+      when(failCommandStep2.errorMessage(any())).thenReturn(failCommandStep2);
+      when(failCommandStep2.retryBackoff(any())).thenReturn(failCommandStep2);
+      when(failCommandStep2.variables(anyMap())).thenReturn(failCommandStep2);
+      when(failCommandStep2.variables(any(Object.class))).thenReturn(failCommandStep2);
+
+      JobBuilder.create()
+          .useJobClient(jobClient)
+          .withVariables(INPUT_DECLARING_A_SECRET)
+          .withErrorExpressionHeader(
+              "=jobError(\"Request failed: \" + response.body, {}, 7, duration(\"PT5M\"))")
+          .execute(echoingConnector());
+
+      var messageCaptor = ArgumentCaptor.forClass(String.class);
+      verify(failCommandStep2).errorMessage(messageCaptor.capture());
+      assertThat(messageCaptor.getValue()).doesNotContain(ECHOED);
+      verify(failCommand).retries(7);
+      verify(failCommandStep2).retryBackoff(Duration.ofMinutes(5));
+    }
+
+    @Test
+    void bpmnErrorMessageCopyingAResponseIsRedacted() throws Exception {
+      var result =
+          JobBuilder.create()
+              .withVariables(INPUT_DECLARING_A_SECRET)
+              .withErrorExpressionHeader(
+                  "=bpmnError(\"AUTH_FAILED\", \"Request failed: \" + response.body)")
+              .executeAndCaptureResult(echoingConnector(), false, true);
+
+      assertThat(result.getErrorMessage())
+          .isEqualTo("Request failed: rejected token ***")
+          .doesNotContain(ECHOED);
+    }
+
+    @Test
+    void bpmnErrorVariablesCopyingAResponseAreRedacted() throws Exception {
+      var result =
+          JobBuilder.create()
+              .withVariables(INPUT_DECLARING_A_SECRET)
+              .withErrorExpressionHeader(
+                  "=bpmnError(\"AUTH_FAILED\", \"failed\", {detail: response.body})")
+              .executeAndCaptureResult(echoingConnector(), false, true);
+
+      assertThat(result.getVariables()).containsEntry("detail", "rejected token ***");
+    }
+
+    @Test
+    void bpmnErrorCodeIsNotRedacted() throws Exception {
+      // boundary events match on the code, so it keeps a value equal to the secret's
+      var result =
+          JobBuilder.create()
+              .withVariables(INPUT_DECLARING_A_SECRET)
+              .withErrorExpressionHeader(
+                  "=bpmnError(\"" + ECHOED + "\", \"Request failed: \" + response.body)")
+              .executeAndCaptureResult(echoingConnector(), false, true);
+
+      assertThat(result.getErrorCode()).isEqualTo(ECHOED);
+      assertThat(result.getErrorMessage()).doesNotContain(ECHOED);
+    }
+
+    @Test
+    void bpmnErrorWithoutAMessageStaysWithoutOne() throws Exception {
+      // throwError omits a null message but would set an empty one
+      var result =
+          JobBuilder.create()
+              .withVariables(INPUT_DECLARING_A_SECRET)
+              .withErrorExpressionHeader(
+                  "={ \"errorType\": \"bpmnError\", \"errorCode\": \"AUTH_FAILED\","
+                      + " \"variables\": {\"detail\": response.body} }")
+              .executeAndCaptureResult(echoingConnector(), false, true);
+
+      assertThat(result.getErrorMessage()).isNull();
+      assertThat(result.getVariables()).containsEntry("detail", "rejected token ***");
+    }
+
+    @Test
+    void jobErrorIsWithheldWhenItCannotBeRedacted() throws Exception {
+      var result =
+          JobBuilder.create()
+              .withVariables(INPUT_DECLARING_A_SECRET)
+              .withErrorExpressionHeader("=jobError(\"Request failed: \" + response.body, {}, 0)")
+              .executeAndCaptureResult(echoingConnectorWithUnreadableSecrets(), false, false);
+
+      // the fetch failure's own message is withheld too: a provider error can echo the store's body
+      assertThat(result.getErrorMessage())
+          .startsWith("Fetching secrets failed, so the original error cannot be displayed")
+          .contains("java.lang.RuntimeException")
+          .doesNotContain("Network error while fetching secrets")
+          .doesNotContain(ECHOED);
+      assertThat(result.getRetries()).isZero();
+    }
+
+    @Test
+    void bpmnErrorKeepsItsCodeWhenItCannotBeRedacted() throws Exception {
+      var result =
+          JobBuilder.create()
+              .withVariables(INPUT_DECLARING_A_SECRET)
+              .withErrorExpressionHeader(
+                  "=bpmnError(\"AUTH_FAILED\", \"Request failed: \" + response.body,"
+                      + " {detail: response.body})")
+              .executeAndCaptureResult(echoingConnectorWithUnreadableSecrets(), false, true);
+
+      assertThat(result.getErrorCode()).isEqualTo("AUTH_FAILED");
+      assertThat(result.getErrorMessage())
+          .startsWith("Fetching secrets failed, so the original error cannot be displayed")
+          .doesNotContain(ECHOED);
+      assertThat(result.getVariables()).isEmpty();
+    }
+
+    @Test
+    void anErrorCarryingNothingToRedactIsLeftAlone() throws Exception {
+      // no message and no variables, so the read is skipped and the unreadable store costs nothing
+      var result =
+          JobBuilder.create()
+              .withVariables(INPUT_DECLARING_A_SECRET)
+              .withErrorExpressionHeader(
+                  "={ \"errorType\": \"bpmnError\", \"errorCode\": \"AUTH_FAILED\" }")
+              .executeAndCaptureResult(echoingConnectorWithUnreadableSecrets(), false, true);
+
+      assertThat(result.getErrorCode()).isEqualTo("AUTH_FAILED");
+      assertThat(result.getErrorMessage()).isNull();
+    }
+
+    @Test
+    void ignoreErrorIsNotRedacted() throws Exception {
+      // the boundary of this fix: ignoreError completes the job with unredacted business variables
+      var result =
+          JobBuilder.create()
+              .withVariables(INPUT_DECLARING_A_SECRET)
+              .withErrorExpressionHeader("=ignoreError({detail: response.body})")
+              .executeAndCaptureResult(echoingConnector(), true);
+
+      assertThat(result.getVariables()).containsEntry("detail", "rejected token " + ECHOED);
+    }
+  }
+
+  // the value bound at execution time can differ from what a later re-read returns if it rotated
+  @Nested
+  class RotationRaceSecretMaskingTests {
+
+    private static final String INPUT_DECLARING_A_SECRET = "{ \"token\" : \"{{secrets.FOO}}\" }";
+
+    private SecretProviderAggregator rotatingSecretProvider(
+        String boundValue, String rotatedValue) {
+      return new SecretProviderAggregator(List.of()) {
+        @Override
+        public String getSecret(String secretName, SecretContext context) {
+          return boundValue;
+        }
+
+        @Override
+        public List<String> fetchAll(List<String> keys, SecretContext context) {
+          return keys.stream().map(key -> rotatedValue).toList();
+        }
+      };
+    }
+
+    private SpringConnectorJobHandler connectorThrowingTheBoundToken(
+        SecretProviderAggregator secretProviderAggregator) {
+      return new SpringConnectorJobHandler(
+          new MicrometerMetricsRecorder(new SimpleMeterRegistry()),
+          new DefaultCommandExceptionHandlingStrategy(
+              BackoffSupplier.newBackoffBuilder().build(),
+              Executors.newSingleThreadScheduledExecutor()),
+          secretProviderAggregator,
+          new DefaultValidationProvider(),
+          mock(DocumentFactory.class),
+          TestObjectMapperSupplier.INSTANCE,
+          context -> {
+            var bound = context.bindVariables(TokenHolder.class);
+            throw new RuntimeException("api rejected " + bound.token());
+          },
+          job -> SecretFilter.allowAll());
+    }
+
+    @Test
+    void aSecretThatRotatedBetweenBindAndMaskingIsStillRedacted() throws Exception {
+      var jobHandler =
+          connectorThrowingTheBoundToken(rotatingSecretProvider("old-value", "new-value"));
+
+      var result =
+          JobBuilder.create()
+              .withVariables(INPUT_DECLARING_A_SECRET)
+              .executeAndCaptureResult(jobHandler, false, false);
+
+      assertThat(result.getErrorMessage()).doesNotContain("old-value");
+    }
+
+    @Test
+    void aSecretThatRotatedBetweenBindAndMaskingIsNotLoggedFromTheCause() throws Exception {
+      var jobHandler =
+          connectorThrowingTheBoundToken(rotatingSecretProvider("old-value", "new-value"));
+      var logger = (Logger) LoggerFactory.getLogger(SpringConnectorJobHandler.class);
+      var appender = new ListAppender<ILoggingEvent>();
+      appender.start();
+      logger.addAppender(appender);
+      try {
+        JobBuilder.create()
+            .withVariables(INPUT_DECLARING_A_SECRET)
+            .executeAndCaptureResult(jobHandler, false, false);
+      } finally {
+        logger.detachAppender(appender);
+        appender.stop();
+      }
+
+      assertThat(appender.list)
+          .filteredOn(
+              event -> event.getFormattedMessage().startsWith("Exception while completing job"))
+          .singleElement()
+          .satisfies(
+              event -> {
+                assertThat(event.getFormattedMessage()).doesNotContain("old-value");
+                assertThat(event.getThrowableProxy()).isNull();
+              });
+    }
+
+    @Test
+    void aStableSecretIsStillRedactedTheOrdinaryWay() throws Exception {
+      var jobHandler =
+          connectorThrowingTheBoundToken(rotatingSecretProvider("same-value", "same-value"));
+
+      var result =
+          JobBuilder.create()
+              .withVariables(INPUT_DECLARING_A_SECRET)
+              .executeAndCaptureResult(jobHandler, false, false);
+
+      assertThat(result.getErrorMessage()).doesNotContain("same-value").contains("***");
+    }
+
+    private record TokenHolder(String token) {}
   }
 }

--- a/connector-sdk/core/src/main/java/io/camunda/connector/api/inbound/Health.java
+++ b/connector-sdk/core/src/main/java/io/camunda/connector/api/inbound/Health.java
@@ -159,6 +159,16 @@ public class Health {
     return new Health(this.status, this.error, details);
   }
 
+  /**
+   * Returns a new {@link Health} with the given error, keeping this instance's status and details.
+   *
+   * @param error the error for the new instance
+   * @return a new Health with the same status and details but the supplied error
+   */
+  public Health withError(Error error) {
+    return new Health(this.status, error, this.details);
+  }
+
   private Health() {
     this(Status.UNKNOWN, null, null);
   }

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/jobworker/AiAgentJobWorkerHandlerImpl.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/jobworker/AiAgentJobWorkerHandlerImpl.java
@@ -36,6 +36,7 @@ import io.camunda.connector.runtime.metrics.ConnectorMetrics;
 import io.camunda.connector.runtime.outbound.job.OutboundConnectorExceptionHandler;
 import java.time.Duration;
 import java.time.format.DateTimeParseException;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import org.slf4j.Logger;
@@ -102,7 +103,8 @@ public class AiAgentJobWorkerHandlerImpl implements AiAgentJobWorkerHandler {
 
       optionalConnectorError.ifPresentOrElse(
           connectorError ->
-              handleConnectorError(jobClient, job, connectorError, counterMetricsContext),
+              handleConnectorError(
+                  jobClient, job, connectorError, counterMetricsContext, secretFilter),
           () -> {
             switch (agentResult) {
               case AgentSuccessResult successResult ->
@@ -115,7 +117,8 @@ public class AiAgentJobWorkerHandlerImpl implements AiAgentJobWorkerHandler {
       failJob(
           jobClient,
           job,
-          this.outboundConnectorExceptionHandler.handleFinalResultException(e, job, secretFilter),
+          this.outboundConnectorExceptionHandler.handleFinalResultException(
+              e, job, secretFilter, List.of()),
           counterMetricsContext);
     }
   }
@@ -133,7 +136,7 @@ public class AiAgentJobWorkerHandlerImpl implements AiAgentJobWorkerHandler {
     } catch (Exception e) {
       final var errorResult =
           outboundConnectorExceptionHandler.manageConnectorJobHandlerException(
-              e, job, retryBackoff, secretFilter);
+              e, job, retryBackoff, secretFilter, List.of());
       return new AgentErrorResult(errorResult);
     }
   }
@@ -141,8 +144,21 @@ public class AiAgentJobWorkerHandlerImpl implements AiAgentJobWorkerHandler {
   private void handleConnectorError(
       final JobClient jobClient,
       final ActivatedJob job,
-      final ConnectorError connectorError,
-      final CounterMetricsContext counterMetricsContext) {
+      final ConnectorError rawConnectorError,
+      final CounterMetricsContext counterMetricsContext,
+      final SecretFilter secretFilter) {
+    // This worker builds its Zeebe command straight from the error expression's result, the same
+    // way SpringConnectorJobHandler does, so it needs the same redaction: neither failJob nor
+    // throwError masks anything of its own, and an expression copying the agent's response can
+    // carry a credential the model or a tool echoed back.
+    //
+    // Redacted against the masking re-read alone: the values captured while binding live in a
+    // JobHandlerContext that JobWorkerAgentExecutionContextFactoryImpl discards, so a secret that
+    // rotated since the job was bound is not covered here.
+    final var connectorError =
+        outboundConnectorExceptionHandler.maskConnectorError(
+            rawConnectorError, job, secretFilter, List.of());
+
     switch (connectorError) {
       case BpmnError bpmnError -> throwBpmnError(jobClient, job, bpmnError, counterMetricsContext);
       case JobError jobError ->

--- a/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/jobworker/AiAgentJobWorkerHandlerTest.java
+++ b/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/jobworker/AiAgentJobWorkerHandlerTest.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
 import static org.assertj.core.api.Assertions.tuple;
 import static org.awaitility.Awaitility.await;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
@@ -261,6 +262,68 @@ class AiAgentJobWorkerHandlerTest {
                                     Map.entry("toolCall", asMap(agentResponse.toolCalls().get(1))),
                                     Map.entry("toolCallResult", ""))));
                   });
+        });
+  }
+
+  @Test
+  void redactsASecretTheErrorExpressionCopiedIntoAJobError() throws Exception {
+    // the job's input declares a secret, and the agent's response echoes its resolved value back
+    jobHeaders.put("errorExpression", ERROR_EXPRESSION);
+    when(job.getVariables()).thenReturn("{\"token\": \"{{secrets.FOO}}\"}");
+    when(secretProvider.fetchAll(any(), any())).thenReturn(List.of("Job error response"));
+
+    final var agentResponse =
+        AgentResponse.builder()
+            .context(AgentContext.empty())
+            .responseText("Job error response")
+            .build();
+
+    when(agentRequestHandler.handleRequest(executionContext))
+        .thenReturn(
+            JobWorkerAgentCompletion.builder()
+                .completionConditionFulfilled(true)
+                .cancelRemainingInstances(false)
+                .agentResponse(agentResponse)
+                .build());
+
+    handler.handle(camundaClient, job);
+
+    // nothing else redacts this path: the fail command is built straight from the expression
+    assertJobFailRequest(
+        request -> {
+          assertThat(request.getErrorMessage()).isEqualTo("The text '***' led to a job error");
+          assertThat(request.getVariables())
+              .containsExactly(entry("error", "The text '***' led to a job error"));
+        });
+  }
+
+  @Test
+  void redactsASecretTheErrorExpressionCopiedIntoABpmnError() throws Exception {
+    jobHeaders.put("errorExpression", ERROR_EXPRESSION);
+    when(job.getVariables()).thenReturn("{\"token\": \"{{secrets.FOO}}\"}");
+    when(secretProvider.fetchAll(any(), any())).thenReturn(List.of("BPMN error response"));
+
+    final var agentResponse =
+        AgentResponse.builder()
+            .context(AgentContext.empty())
+            .responseText("BPMN error response")
+            .build();
+
+    when(agentRequestHandler.handleRequest(executionContext))
+        .thenReturn(
+            JobWorkerAgentCompletion.builder()
+                .completionConditionFulfilled(true)
+                .cancelRemainingInstances(false)
+                .agentResponse(agentResponse)
+                .build());
+
+    handler.handle(camundaClient, job);
+
+    assertJobErrorRequest(
+        request -> {
+          // the code is never redacted: boundary events match on it
+          assertThat(request.getErrorCode()).isEqualTo("RESPONSE_TEXT_BPMN_ERROR_CODE");
+          assertThat(request.getErrorMessage()).isEqualTo("The text '***' led to an BPMN error");
         });
   }
 


### PR DESCRIPTION
## Description

Backport of #8661 (itself the combined backport of #8634 and #8643 plus the #8662 follow-up) to `stable/8.9`. Written by hand — a cherry-pick of the three commits conflicts in 4 files before it reaches the second one, because the outbound error path has moved and changed shape since this branch.

The change prevents resolved secrets from being exposed through outbound job and BPMN error incidents, inbound activity logs and health errors, and errors emitted after a secret rotates between input binding and masking.

## What this branch does not have, and so does not get

Each of these is an absence on `stable/8.9`, not a gap in the port:

- **No `AdHocSubProcessConnectorResponse`**, so `ignoreError` has only the branch that completes the job. The fix for the branch that raises an incident has nothing to apply to, and `maskDiagnosticVariables` has no call site — both left out.
- **No `JobCompletionListener`**, so the Zeebe command is the only sink an error expression reaches. The two listener-payload tests are dropped.
- **One legacy secret reference form only** — no `camunda.secrets.<name>` — so `fetchSecretsForMasking` is a single read rather than a legacy read plus a reference read, and `SecretUtil.retrieveSecretKeysInInput` stands in for `retrieveLegacySecretKeysInInput`.
- **Two-arg `SecretContext`** (no `physicalTenantId`), so that test is dropped.
- **`bpmnError` has no one-argument FEEL form here** (only `errorCode, errorMessage` and `+ variables`), so the "an error carrying nothing to redact" test uses the map form to express the same error.

## Three things this branch needed added

- **`SecretNotAvailableException`**, carried over verbatim. It extends `ConnectorInputException` with the same message `SecretHandler` already threw, so this is behaviour-neutral for callers — and it lets the masking re-read tell a secret that was never available apart from one removed since the job ran.
- **`SecretFailureDiagnostic`**, with `SecretAllowListUnavailableException` now implementing it. #8647 deliberately left this out because this branch never withheld an error message. It does now, and without the interface the allow-list failure's own message — element id and process-definition key, which the runtime wrote itself — would be withheld along with everything else, undoing what #8647 landed.
- **`Health.withError`**, needed by the inbound health redaction. `stable/8.9` had only `withDetails`.

## One behaviour change worth your attention

`stable/8.9` currently concatenates the secret provider's own failure message into the incident:

```java
"Fetching secrets failed, original error can't be displayed as the error message might contain secrets: " + ex.getMessage()
```

That concatenation *is* the leak — a provider folds the value it could not coerce into its own text (`...from String value ('super-secret')`). This PR replaces it with the withheld form, which names the failure type but not the provider's words. #8647 declined the withholding machinery when it was cosmetic on this branch; here it is the fix. `shouldHideExceptionMessageWhenSecretsObfuscationFails` pinned the old message and now asserts the provider's text is absent.

## Verification

`connector-sdk/core`, `connector-runtime-core` (291 tests) and `connector-runtime-spring` (291 tests) all green; `spotless:check` clean.

Each protection was falsified by reverting it:

| Reverted | Result |
| --- | --- |
| the `maskConnectorError` call in `handleConnectorError` | 9 of 11 error-expression tests fail; the 2 that pass are the ones asserting the deliberate boundaries (`ignoreError` stays unredacted, an empty error is left alone) |
| longest-first sort + empty-value skip in `hideSecretsFromMessage` | `masksALongerSecretThatStartsWithAShorterOne` and `anEmptySecretValueDoesNotCorruptTheMessage` fail |
| the `resolvedValues` capture in `SecretHandler` | `log_masksASecretThatRotatedAfterItWasBound` fails |

## Related issues

Related to #8638. Source: #8661 (#8634, #8643, #8662).

Supersedes #8664 — same target, written independently.

## Checklist

- [x] Backport labels — n/a, this *is* the backport.
- [x] Tests for the changes are included; both runtime modules pass.
- [x] No user-facing configuration change; the incident-message change is described above rather than documented.