### PR TITLE
[Backport stable/8.9] fix(secrets): field-path-scoped secret filtering over a JSON tree

### DIFF
--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextImpl.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextImpl.java
@@ -45,8 +45,10 @@ import io.camunda.connector.runtime.core.inbound.activitylog.ActivitySource;
 import io.camunda.connector.runtime.core.inbound.correlation.InboundCorrelationHandler;
 import io.camunda.connector.runtime.core.inbound.details.InboundConnectorDetails.ValidInboundConnectorDetails;
 import io.camunda.connector.runtime.core.secret.SecretFilter;
+import io.camunda.connector.runtime.core.secret.SecretFilter.Secret;
 import io.camunda.connector.runtime.core.secret.SecretUtil;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -323,8 +325,11 @@ public class InboundConnectorContextImpl extends AbstractConnectorContext
       return SecretFilter.allowAll();
     }
     return SecretFilter.allowOnly(
-        connectorDetails.rawPropertiesWithoutKeywords().values().stream()
-            .flatMap(value -> SecretUtil.retrieveSecretKeysInInput(value).stream())
+        connectorDetails.rawPropertiesWithoutKeywords().entrySet().stream()
+            .flatMap(
+                entry ->
+                    SecretUtil.retrieveSecretKeysInInput(entry.getValue()).stream()
+                        .map(name -> new Secret(name, Arrays.asList(entry.getKey().split("\\.")))))
             .distinct()
             .toList());
   }

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/InboundPropertyHandler.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/InboundPropertyHandler.java
@@ -112,10 +112,10 @@ public class InboundPropertyHandler {
       Map<String, Object> properties,
       SecretContext secretContext) {
     try {
-      var propertiesAsJsonString = objectMapper.writeValueAsString(properties);
+      var propertiesAsJsonString = objectMapper.valueToTree(properties);
       var propertiesWithSecretsJson =
           secretHandler.replaceSecrets(propertiesAsJsonString, secretContext);
-      return objectMapper.readValue(propertiesWithSecretsJson, new TypeReference<>() {});
+      return objectMapper.treeToValue(propertiesWithSecretsJson, new TypeReference<>() {});
     } catch (JsonProcessingException e) {
       throw new RuntimeException(e);
     }

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/outbound/JobHandlerContext.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/outbound/JobHandlerContext.java
@@ -16,11 +16,16 @@
  */
 package io.camunda.connector.runtime.core.outbound;
 
+import com.fasterxml.jackson.core.JsonGenerationException;
+import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.exc.*;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import io.camunda.client.api.response.ActivatedJob;
 import io.camunda.connector.api.document.Document;
 import io.camunda.connector.api.document.DocumentCreationRequest;
@@ -52,7 +57,7 @@ public class JobHandlerContext extends AbstractConnectorContext
   private final ObjectMapper objectMapper;
   private final JobContext jobContext;
   private final DocumentFactory documentFactory;
-  private String jsonWithSecrets = null;
+  private JsonNode jsonWithSecrets = null;
 
   public JobHandlerContext(
       final ActivatedJob job,
@@ -65,7 +70,7 @@ public class JobHandlerContext extends AbstractConnectorContext
     this.documentFactory = documentFactory;
     this.job = job;
     this.objectMapper = objectMapper;
-    this.jobContext = new ActivatedJobContext(job, this::getJsonReplacedWithSecrets);
+    this.jobContext = new ActivatedJobContext(job, () -> writeJson(getJsonReplacedWithSecrets()));
   }
 
   @Override
@@ -75,44 +80,114 @@ public class JobHandlerContext extends AbstractConnectorContext
     return mappedObject;
   }
 
-  private String getJsonReplacedWithSecrets() {
+  private JsonNode getJsonReplacedWithSecrets() {
     if (jsonWithSecrets == null) {
       jsonWithSecrets =
           getSecretHandler()
               .replaceSecrets(
-                  job.getVariables(), new SecretContext(job.getTenantId(), job.getBpmnProcessId()));
+                  parseVariables(), new SecretContext(job.getTenantId(), job.getBpmnProcessId()));
     }
     return jsonWithSecrets;
+  }
+
+  /**
+   * Parses via this context's own {@code objectMapper}, with {@code USE_BIG_DECIMAL_FOR_FLOATS}
+   * enabled, rather than {@code job.getVariablesAsType(JsonNode.class)} — the client's own {@code
+   * JsonMapper} parses untyped JSON numbers to {@code double} by default, which loses precision
+   * (e.g. {@code 0.1234567890123456789012345} -> {@code 0.12345678901234568}) before the value ever
+   * reaches a {@code BigDecimal}-typed connector field. Reading through an {@code ObjectReader}
+   * rather than reconfiguring the shared mapper keeps that feature scoped to this one parse. The
+   * node factory is additionally configured with {@code withExactBigDecimals(true)}: its default
+   * strips trailing zeros off the parsed {@code BigDecimal} itself at node construction (e.g.
+   * {@code 1.10} becomes scale-1 {@code 1.1}), a value change a {@code BigDecimal}-typed connector
+   * field would observe via {@code equals}, not merely a difference in how it prints.
+   */
+  private JsonNode parseVariables() {
+    JsonNode variables;
+    try {
+      variables =
+          objectMapper
+              .reader()
+              .with(DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS)
+              .with(JsonNodeFactory.withExactBigDecimals(true))
+              .forType(JsonNode.class)
+              .readValue(job.getVariables());
+    } catch (JsonProcessingException e) {
+      throw translateJsonException(e);
+    }
+    if (!variables.isObject()) {
+      throw new ConnectorInputException("This is not a JSON object");
+    }
+    return variables;
+  }
+
+  /**
+   * {@code JsonNode.toString()} serializes through Jackson's shared internal mapper, which writes a
+   * {@code DecimalNode} via plain {@code BigDecimal.toString()} — reintroducing scientific notation
+   * for small-magnitude values (e.g. {@code 0.00000001} -> {@code 1E-8}) even though the digits
+   * themselves survived parsing. {@code WRITE_BIGDECIMAL_AS_PLAIN} keeps the plain-decimal form the
+   * raw job JSON used.
+   *
+   * <p>Jackson refuses plain output for a {@code BigDecimal} whose scale falls outside ±9999 (e.g.
+   * {@code 1e-10000}, which parses fine into a {@code DecimalNode}). Such a document is written
+   * without the feature instead, i.e. in scientific notation — the same text the previous
+   * raw-string path returned — rather than failing the job.
+   */
+  private String writeJson(JsonNode node) {
+    try {
+      return objectMapper
+          .writer()
+          .with(JsonGenerator.Feature.WRITE_BIGDECIMAL_AS_PLAIN)
+          .writeValueAsString(node);
+    } catch (JsonGenerationException e) {
+      return writeJsonWithoutPlainDecimals(node);
+    } catch (JsonProcessingException e) {
+      throw translateJsonException(e);
+    }
+  }
+
+  private String writeJsonWithoutPlainDecimals(JsonNode node) {
+    try {
+      return objectMapper.writeValueAsString(node);
+    } catch (JsonProcessingException e) {
+      throw translateJsonException(e);
+    }
   }
 
   private <T> T mapJson(Class<T> cls) {
     var jsonWithSecrets = getJsonReplacedWithSecrets();
     try {
-      return objectMapper.readValue(jsonWithSecrets, cls);
-    } catch (JsonParseException e) {
-      throw new ConnectorInputException("This is not a JSON object", e);
-    } catch (InvalidFormatException
-        | InvalidNullException
-        | InvalidTypeIdException
-        | PropertyBindingException e) {
+      return objectMapper.treeToValue(jsonWithSecrets, cls);
+    } catch (JsonProcessingException e) {
+      throw translateJsonException(e);
+    }
+  }
+
+  private static ConnectorInputException translateJsonException(JsonProcessingException e) {
+    if (e instanceof JsonParseException) {
+      return new ConnectorInputException("This is not a JSON object", e);
+    }
+    if (e instanceof InvalidFormatException
+        || e instanceof InvalidNullException
+        || e instanceof InvalidTypeIdException
+        || e instanceof PropertyBindingException) {
+      MismatchedInputException mappingException = (MismatchedInputException) e;
       String errorMessage =
-          e.getPath().stream()
+          mappingException.getPath().stream()
               .map(JsonMappingException.Reference::getFieldName)
               .reduce((s, s2) -> s.concat(", ").concat(s2))
               .map("Json object contains an invalid field: "::concat)
               .map(
                   s ->
-                      e.getTargetType() == null
+                      mappingException.getTargetType() == null
                           ? s
                           : s.concat(". It Must be `")
-                              .concat(e.getTargetType().getSimpleName())
+                              .concat(mappingException.getTargetType().getSimpleName())
                               .concat("`"))
               .orElse("Unexpected Error, Further investigation is needed");
-
-      throw new ConnectorInputException(errorMessage, e);
-    } catch (JsonProcessingException e) {
-      throw new ConnectorInputException(e.getOriginalMessage(), e);
+      return new ConnectorInputException(errorMessage, e);
     }
+    return new ConnectorInputException(e.getOriginalMessage(), e);
   }
 
   @Override

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretFilter.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretFilter.java
@@ -23,34 +23,57 @@ import java.util.Set;
  * Determines whether a named secret may be resolved within a connector's context.
  *
  * <p>Use {@link #allowAll()} when no restriction applies and {@link #allowOnly(List)} to restrict
- * resolution to a declared set of names. An empty list passed to {@code allowOnly} denies all
+ * resolution to a declared set of secrets. An empty list passed to {@code allowOnly} denies all
  * secrets.
  */
 @FunctionalInterface
 public interface SecretFilter {
 
-  /**
-   * Returns {@code true} if the secret with the given name may be resolved.
-   *
-   * @param secretName the secret name to check
-   * @return {@code true} to allow resolution, {@code false} to leave the reference as-is
-   */
-  boolean isAllowed(String secretName);
-
   /** Returns a filter that permits every secret name. */
   static SecretFilter allowAll() {
-    return name -> true;
+    return context -> true;
   }
 
   /**
    * Returns a filter that permits only the secret names in {@code names}. An empty list denies all
    * secrets.
    *
-   * @param names the permitted secret names
-   * @return a filter restricted to the given names
+   * @param secrets the permitted secret contexts
+   * @return a filter restricted to the given secrets
    */
-  static SecretFilter allowOnly(List<String> names) {
-    var allowed = Set.copyOf(names);
-    return allowed::contains;
+  static SecretFilter allowOnly(List<Secret> secrets) {
+    var allowed = Set.copyOf(secrets);
+    return context ->
+        allowed.stream()
+            .filter(secret -> secret.secretName().equals(context.secretName()))
+            .filter(secret -> context.fieldPath().size() >= secret.fieldPath().size())
+            .anyMatch(
+                secret ->
+                    context
+                        .fieldPath()
+                        .subList(0, secret.fieldPath().size())
+                        .equals(secret.fieldPath()));
+  }
+
+  /**
+   * Returns {@code true} if the secret with the given name may be resolved.
+   *
+   * @param context the secret filter context
+   * @return {@code true} to allow resolution, {@code false} to leave the reference as-is
+   */
+  boolean isAllowed(Secret context);
+
+  record Secret(String secretName, List<String> fieldPath) {
+
+    /**
+     * Defensively copies {@code fieldPath}: callers such as {@code Arrays.asList(...)} return a
+     * fixed-size but still mutable (via {@code set}) list, which would otherwise let anyone holding
+     * a cached {@code Secret} reach in and change which fields it authorizes for later, unrelated
+     * jobs.
+     */
+    public Secret(String secretName, List<String> fieldPath) {
+      this.secretName = secretName;
+      this.fieldPath = List.copyOf(fieldPath);
+    }
   }
 }

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretHandler.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretHandler.java
@@ -16,6 +16,7 @@
  */
 package io.camunda.connector.runtime.core.secret;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import io.camunda.connector.api.secret.SecretContext;
 import io.camunda.connector.api.secret.SecretProvider;
 import java.util.List;
@@ -39,22 +40,25 @@ public class SecretHandler {
   public SecretHandler(final SecretProvider secretProvider, SecretFilter secretFilter) {
     this.secretProvider = secretProvider;
     secretReplacer =
-        (name, context) -> {
-          if (secretFilter.isAllowed(name)) {
+        (secretFilterContext, context) -> {
+          if (secretFilter.isAllowed(secretFilterContext)) {
             var value =
-                Optional.ofNullable(secretProvider.getSecret(name, context))
-                    .orElseThrow(() -> new SecretNotAvailableException(name));
+                Optional.ofNullable(
+                        secretProvider.getSecret(secretFilterContext.secretName(), context))
+                    .orElseThrow(() -> new SecretNotAvailableException(secretFilterContext));
             resolvedValues.add(value);
-            // the substituted JSON carries this form, not the raw value, when it differs
+            // the serialized job JSON carries this form, not the raw value, when it differs
             resolvedValues.add(SecretUtil.jsonEscape(value));
             return value;
           }
-          LOG.debug("Secret '{}' not in allow-list — placeholder left unreplaced", name);
+          LOG.debug(
+              "Secret '{}' not in allow-list — placeholder left unreplaced",
+              secretFilterContext.secretName());
           return null;
         };
   }
 
-  public String replaceSecrets(String input, SecretContext context) {
+  public JsonNode replaceSecrets(JsonNode input, SecretContext context) {
     return SecretUtil.replaceSecrets(input, context, secretReplacer);
   }
 

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretNotAvailableException.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretNotAvailableException.java
@@ -17,6 +17,7 @@
 package io.camunda.connector.runtime.core.secret;
 
 import io.camunda.connector.api.error.ConnectorInputException;
+import io.camunda.connector.runtime.core.secret.SecretFilter.Secret;
 
 /**
  * A secret reference the filter allowed, for which no configured provider held a value. The
@@ -30,7 +31,13 @@ import io.camunda.connector.api.error.ConnectorInputException;
  */
 public class SecretNotAvailableException extends ConnectorInputException {
 
-  public SecretNotAvailableException(String secretName) {
-    super(String.format("Secret with name '%s' is not available", secretName));
+  /**
+   * Omits {@code secret.fieldPath()}: it is derived from JSON property names, and {@link
+   * SecretUtil} supports resolving secrets into property names as well as values, so a path segment
+   * may itself carry a resolved secret's text — echoing it here would leak that text into an error
+   * message error masking cannot always catch.
+   */
+  public SecretNotAvailableException(Secret secret) {
+    super(String.format("Secret with name '%s' is not available", secret.secretName()));
   }
 }

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretReplacer.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretReplacer.java
@@ -17,7 +17,8 @@
 package io.camunda.connector.runtime.core.secret;
 
 import io.camunda.connector.api.secret.SecretContext;
+import io.camunda.connector.runtime.core.secret.SecretFilter.Secret;
 
 public interface SecretReplacer {
-  String replaceSecrets(String name, SecretContext secretContext);
+  String replaceSecrets(Secret secret, SecretContext secretContext);
 }

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretUtil.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretUtil.java
@@ -17,11 +17,19 @@
 package io.camunda.connector.runtime.core.secret;
 
 import com.fasterxml.jackson.core.io.JsonStringEncoder;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.node.TextNode;
 import io.camunda.connector.api.secret.SecretContext;
+import io.camunda.connector.runtime.core.secret.SecretFilter.Secret;
+import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
+import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.regex.MatchResult;
 import java.util.regex.Matcher;
@@ -39,22 +47,131 @@ public class SecretUtil {
           "\\{\\{\\s*secrets\\.(?<braced>\\S+?)\\s*}}"
               + "|secrets\\.(?<bare>([a-zA-Z0-9]+[\\/._-])*[a-zA-Z0-9]+)");
 
-  public static String replaceSecrets(
-      String input, SecretContext context, SecretReplacer secretReplacer) {
+  /**
+   * Substitutes every legacy secret reference in the tree, in place, and returns the same node.
+   *
+   * <p>One walk, one scan per string: a second pass over already-substituted text is what let a
+   * narrower form re-read the inside of a reference the first pass had consumed (and, when the walk
+   * renames a property, made the second pass iterate a reordered snapshot of the object).
+   */
+  public static JsonNode replaceSecrets(
+      JsonNode input, SecretContext context, SecretReplacer secretReplacer) {
     if (input == null) {
       throw new IllegalStateException("input cant be null.");
     }
-    Map<String, String> resolutions = new HashMap<>();
-    return replaceTokens(
+    if (!input.isObject()) {
+      throw new IllegalStateException("input must be an ObjectNode.");
+    }
+    Map<Secret, String> resolutions = new HashMap<>();
+    walkJsonNode(
         input,
-        REFERENCE,
-        matcher -> {
-          String value = resolve(name(matcher), context, secretReplacer, resolutions);
-          return value == null ? matcher.group() : jsonEscape(value);
-        });
+        (stringValue, fieldPath) ->
+            replaceTokens(
+                stringValue,
+                REFERENCE,
+                matcher -> {
+                  var value =
+                      resolve(name(matcher), fieldPath, context, secretReplacer, resolutions);
+                  return value == null ? matcher.group() : value;
+                }),
+        new ArrayList<>());
+    return input;
   }
 
-  // the form actually spliced into the substituted JSON, which a raw-value capture would miss
+  /**
+   * Asks the replacer at most once per secret <em>and field path</em>: the same name is a separate
+   * question at a different path, since that is the granularity the allow-list authorizes at.
+   */
+  private static String resolve(
+      String name,
+      List<String> fieldPath,
+      SecretContext context,
+      SecretReplacer secretReplacer,
+      Map<Secret, String> resolutions) {
+    var secret = new Secret(name, fieldPath);
+    if (!resolutions.containsKey(secret)) {
+      resolutions.put(secret, secretReplacer.replaceSecrets(secret, context));
+    }
+    return resolutions.get(secret);
+  }
+
+  private static String name(MatchResult match) {
+    var braced = match.group("braced");
+    return braced != null ? braced : match.group("bare");
+  }
+
+  private static void walkJsonNode(
+      JsonNode input, BiFunction<String, List<String>, String> converter, List<String> fieldPath) {
+    switch (input.getNodeType()) {
+      case ARRAY -> walkArray((ArrayNode) input, converter, fieldPath);
+      case OBJECT -> walkObject((ObjectNode) input, converter, fieldPath);
+      default -> {}
+    }
+  }
+
+  /**
+   * Substitutes property names as well as values: the raw-text pass this replaced matched anywhere
+   * in the document, key or value, so a placeholder written as a property name (e.g. {@code
+   * {"{{secrets.KEY}}": "value"}}) resolved just as one written as a value did. Renaming is
+   * deferred until after the entry is otherwise processed, and runs over a snapshot of the original
+   * entries, since renaming a key while iterating the node's live property view would throw.
+   */
+  private static void walkObject(
+      ObjectNode input,
+      BiFunction<String, List<String>, String> converter,
+      List<String> fieldPath) {
+    // Map.entry(...) reads each key/value pair eagerly, decoupling the snapshot from the live
+    // map: input.properties() entries are backed by the same map nodes ObjectNode#set/remove
+    // mutate, so a snapshot that merely copies the entry objects (e.g. List.copyOf(...)) would
+    // still observe later renames through entries for keys processed earlier in this same loop.
+    for (Entry<String, JsonNode> entry :
+        input.properties().stream().map(e -> Map.entry(e.getKey(), e.getValue())).toList()) {
+      String key = entry.getKey();
+      JsonNode value = entry.getValue();
+      List<String> extendedFieldPath = new ArrayList<>(fieldPath);
+      extendedFieldPath.add(key);
+
+      if (value instanceof TextNode stringValue) {
+        input.set(key, new TextNode(converter.apply(stringValue.asText(), extendedFieldPath)));
+      } else {
+        walkJsonNode(value, converter, extendedFieldPath);
+        // Reinserts this entry's own (possibly object/array-mutated-in-place, otherwise
+        // untouched) value at its own original key, in snapshot order. Without this, a key
+        // rename earlier in this same loop that happens to collide with this entry's still
+        // unprocessed key would silently overwrite this entry before its own turn came, and this
+        // entry's non-text value — having no put/set of its own — would never overwrite it back.
+        input.set(key, value);
+      }
+
+      String newKey = converter.apply(key, extendedFieldPath);
+      if (!newKey.equals(key)) {
+        input.set(newKey, input.get(key));
+        input.remove(key);
+      }
+    }
+  }
+
+  /** Recurses into array elements at arbitrary depth, mirroring {@link #walkJsonNode}. */
+  private static void walkArray(
+      ArrayNode arrayNode,
+      BiFunction<String, List<String>, String> converter,
+      List<String> fieldPath) {
+    for (int i = 0; i < arrayNode.size(); i++) {
+      JsonNode item = arrayNode.get(i);
+      if (item instanceof TextNode stringValue) {
+        arrayNode.set(i, new TextNode(converter.apply(stringValue.asText(), fieldPath)));
+      } else {
+        walkJsonNode(item, converter, fieldPath);
+      }
+    }
+  }
+
+  /**
+   * The form a resolved value takes once the substituted tree is serialized back to JSON. The walk
+   * writes the raw value into a {@code TextNode} and lets Jackson escape it on output, so this is
+   * not applied during substitution — but a caller redacting a message that quotes the serialized
+   * JSON has to match this form as well as the raw one.
+   */
   public static String jsonEscape(String value) {
     return new String(encoder.quoteAsString(value));
   }
@@ -74,21 +191,22 @@ public class SecretUtil {
     return output.toString();
   }
 
-  /** Asks the replacer at most once per name, for providers that meter or charge per lookup. */
-  private static String resolve(
-      String name,
-      SecretContext context,
-      SecretReplacer secretReplacer,
-      Map<String, String> resolutions) {
-    if (!resolutions.containsKey(name)) {
-      resolutions.put(name, secretReplacer.replaceSecrets(name, context));
-    }
-    return resolutions.get(name);
-  }
-
-  private static String name(MatchResult match) {
-    var braced = match.group("braced");
-    return braced != null ? braced : match.group("bare");
+  /** Every secret the given tree declares, each scoped to the field path it occupies. */
+  public static List<Secret> retrieveSecretKeysInInput(ObjectNode input) {
+    List<Secret> result = new ArrayList<>();
+    walkJsonNode(
+        input,
+        (stringValue, fieldPath) -> {
+          REFERENCE
+              .matcher(stringValue)
+              .results()
+              .map(SecretUtil::name)
+              .map(name -> new Secret(name, fieldPath))
+              .forEach(result::add);
+          return stringValue;
+        },
+        new ArrayList<>());
+    return result;
   }
 
   /**

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/SecretUtilTests.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/SecretUtilTests.java
@@ -22,7 +22,10 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.camunda.connector.api.secret.SecretContext;
+import io.camunda.connector.runtime.core.secret.SecretFilter.Secret;
 import io.camunda.connector.runtime.core.secret.SecretReplacer;
 import io.camunda.connector.runtime.core.secret.SecretUtil;
 import java.util.ArrayList;
@@ -35,6 +38,12 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
 public class SecretUtilTests {
+
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+  private static ObjectNode wrap(String value) {
+    return OBJECT_MAPPER.createObjectNode().put("value", value);
+  }
 
   @ParameterizedTest
   @CsvSource({
@@ -60,9 +69,9 @@ public class SecretUtilTests {
   })
   void testSecretPattern(String input, String secret, Boolean shouldDetect) {
     var secretReplacer = mock(SecretReplacer.class);
-    SecretUtil.replaceSecrets(input, null, secretReplacer);
+    SecretUtil.replaceSecrets(wrap(input), null, secretReplacer);
     if (shouldDetect) {
-      verify(secretReplacer).replaceSecrets(eq(secret), any());
+      verify(secretReplacer).replaceSecrets(eq(new Secret(secret, List.of("value"))), any());
     } else {
       verifyNoInteractions(secretReplacer);
     }
@@ -83,10 +92,11 @@ public class SecretUtilTests {
         "{\"field1\": \"{{secrets.KEY1}}\", \"field2\": \"{{secrets.KEY2}}\"}|{\"field1\": \"VALUE1\", \"field2\": \"VALUE2\"}",
       },
       delimiter = '|') // delimiter is needed to escape the comma in the json
-  void testSecretReplacementWithJsonInput(String input, String output) {
-    SecretReplacer secretReplacer = (name, context) -> secrets.get(name);
-    var result = SecretUtil.replaceSecrets(input, null, secretReplacer);
-    assertThat(result).isEqualTo(output);
+  void testSecretReplacementWithJsonInput(String input, String output) throws Exception {
+    SecretReplacer secretReplacer = (secret, context) -> secrets.get(secret.secretName());
+    var result =
+        SecretUtil.replaceSecrets((ObjectNode) OBJECT_MAPPER.readTree(input), null, secretReplacer);
+    assertThat(result).isEqualTo(OBJECT_MAPPER.readTree(output));
   }
 
   @Test
@@ -110,15 +120,52 @@ public class SecretUtilTests {
   }
 
   @Test
+  void shouldReplaceAReferenceNestedInsideArrays() throws Exception {
+    SecretReplacer secretReplacer =
+        (secret, context) -> "TOKEN".equals(secret.secretName()) ? "tok123" : null;
+    var input = (ObjectNode) OBJECT_MAPPER.readTree("{\"values\":[[\"{{secrets.TOKEN}}\"]]}");
+
+    var result = SecretUtil.replaceSecrets(input, null, secretReplacer);
+
+    assertThat(result).isEqualTo(OBJECT_MAPPER.readTree("{\"values\":[[\"tok123\"]]}"));
+  }
+
+  @Test
+  void shouldReplaceAReferenceInAPropertyName() throws Exception {
+    SecretReplacer secretReplacer =
+        (secret, context) -> "KEY".equals(secret.secretName()) ? "resolved-key" : null;
+    var input = (ObjectNode) OBJECT_MAPPER.readTree("{\"{{secrets.KEY}}\":\"value\"}");
+
+    var result = SecretUtil.replaceSecrets(input, null, secretReplacer);
+
+    assertThat(result).isEqualTo(OBJECT_MAPPER.readTree("{\"resolved-key\":\"value\"}"));
+  }
+
+  @Test
+  void shouldKeepTheLaterValueWhenAReplacedPropertyNameCollides() throws Exception {
+    SecretReplacer secretReplacer =
+        (secret, context) -> "KEY".equals(secret.secretName()) ? "resolved-key" : null;
+    var input =
+        (ObjectNode)
+            OBJECT_MAPPER.readTree(
+                "{\"{{secrets.KEY}}\":\"placeholder\",\"resolved-key\":{\"nested\":\"value\"}}");
+
+    var result = SecretUtil.replaceSecrets(input, null, secretReplacer);
+
+    assertThat(result)
+        .isEqualTo(OBJECT_MAPPER.readTree("{\"resolved-key\":{\"nested\":\"value\"}}"));
+  }
+
+  @Test
   void shouldNotResolveABarePrefixInsideAStillDeniedBracketedReference() {
     // FOO is allowed on its own, but "FOO:BAR" is not declared anywhere and so is denied. The
     // parentheses pass correctly leaves the literal "{{secrets.FOO:BAR}}" untouched — but its own
     // text still contains "secrets.FOO", which the bare pass must not separately resolve.
-    SecretReplacer secretReplacer = (name, context) -> "FOO".equals(name) ? "REAL_VALUE" : null;
-
-    String result = SecretUtil.replaceSecrets("{{secrets.FOO:BAR}}", null, secretReplacer);
+    var asked = new ArrayList<String>();
+    String result = replacedValue("{{secrets.FOO:BAR}}", asked, Map.of("FOO", "REAL_VALUE"));
 
     assertThat(result).isEqualTo("{{secrets.FOO:BAR}}");
+    assertThat(asked).containsExactly("FOO:BAR");
   }
 
   @Test
@@ -129,17 +176,15 @@ public class SecretUtilTests {
     // scan removes the reruns, so it removes the chain with them -- A resolves to the literal text
     // "secrets.FOO" and the scan moves past it, never asking for FOO. The denied reference is still
     // denied, now because the scan consumed it whole rather than because it was excluded.
-    SecretReplacer secretReplacer =
-        (name, context) -> {
-          if ("A".equals(name)) return "secrets.FOO";
-          if ("FOO".equals(name)) return "REAL_VALUE";
-          return null;
-        };
-
+    var asked = new ArrayList<String>();
     String result =
-        SecretUtil.replaceSecrets("secrets.A and {{secrets.FOO:BAR}}", null, secretReplacer);
+        replacedValue(
+            "secrets.A and {{secrets.FOO:BAR}}",
+            asked,
+            Map.of("A", "secrets.FOO", "FOO", "REAL_VALUE"));
 
     assertThat(result).isEqualTo("secrets.FOO and {{secrets.FOO:BAR}}");
+    assertThat(asked).containsExactly("A", "FOO:BAR");
   }
 
   @Test
@@ -149,31 +194,34 @@ public class SecretUtilTests {
     // allow-list containing a name resolution never looks up, denying a legitimately declared
     // secret.
     var withWhitespace = "{{ secrets.FOO }}";
-    SecretReplacer secretReplacer = (name, context) -> "FOO".equals(name) ? "resolved" : null;
+    var replaced =
+        SecretUtil.replaceSecrets(
+            wrap(withWhitespace),
+            null,
+            (secret, context) -> "FOO".equals(secret.secretName()) ? "resolved" : null);
 
+    assertThat(replaced.get("value").asText()).isEqualTo("resolved");
     assertThat(SecretUtil.retrieveSecretKeysInInput(withWhitespace)).containsExactly("FOO");
-    assertThat(SecretUtil.replaceSecrets(withWhitespace, null, secretReplacer))
-        .isEqualTo("resolved");
   }
 
   @Test
   void shouldOnlyReplaceAllowListedSecrets() {
     List<String> allowList = List.of("KEY1", "KEY2");
     SecretReplacer secretReplacer =
-        (name, context) -> allowList.contains(name) ? secrets.get(name) : null;
+        (secret, context) ->
+            allowList.contains(secret.secretName()) ? secrets.get(secret.secretName()) : null;
     String content = "Hello {{secrets.KEY1}} and {{secrets.KEY2}} and {{secrets.KEY3}}";
     SecretContext secretContext = new SecretContext("tenantId", "processId");
-    String replacedContent = SecretUtil.replaceSecrets(content, secretContext, secretReplacer);
-    assertThat(replacedContent).isEqualTo("Hello VALUE1 and VALUE2 and {{secrets.KEY3}}");
+    var replacedContent = SecretUtil.replaceSecrets(wrap(content), secretContext, secretReplacer);
+    assertThat(replacedContent.get("value").asText())
+        .isEqualTo("Hello VALUE1 and VALUE2 and {{secrets.KEY3}}");
   }
 
   @Test
   void shouldNotResolveABarePrefixOfADeniedBracketedName() {
     var asked = new ArrayList<String>();
 
-    assertThat(
-            SecretUtil.replaceSecrets(
-                "{{secrets.PROD:API}}", null, recording(asked, Map.of("PROD", "p4ssw0rd"))))
+    assertThat(replacedValue("{{secrets.PROD:API}}", asked, Map.of("PROD", "p4ssw0rd")))
         .isEqualTo("{{secrets.PROD:API}}");
     assertThat(asked).containsExactly("PROD:API");
   }
@@ -183,8 +231,7 @@ public class SecretUtilTests {
     var asked = new ArrayList<String>();
     var secrets = Map.of("A", "{{secrets.PROD:API}}", "PROD", "p4ssw0rd");
 
-    assertThat(SecretUtil.replaceSecrets("{{secrets.A}}", null, recording(asked, secrets)))
-        .isEqualTo("{{secrets.PROD:API}}");
+    assertThat(replacedValue("{{secrets.A}}", asked, secrets)).isEqualTo("{{secrets.PROD:API}}");
     assertThat(asked).containsExactly("A");
   }
 
@@ -193,8 +240,7 @@ public class SecretUtilTests {
     var asked = new ArrayList<String>();
     var secrets = Map.of("NOTE", "see secrets.OTHER", "OTHER", "TOP_SECRET");
 
-    assertThat(SecretUtil.replaceSecrets("{{secrets.NOTE}}", null, recording(asked, secrets)))
-        .isEqualTo("see secrets.OTHER");
+    assertThat(replacedValue("{{secrets.NOTE}}", asked, secrets)).isEqualTo("see secrets.OTHER");
     assertThat(asked).containsExactly("NOTE");
   }
 
@@ -210,9 +256,7 @@ public class SecretUtilTests {
   void shouldAskForEveryNameAtMostOnce() {
     var asked = new ArrayList<String>();
 
-    assertThat(
-            SecretUtil.replaceSecrets(
-                "secrets.K secrets.K {{secrets.K}}", null, recording(asked, Map.of("K", "V"))))
+    assertThat(replacedValue("secrets.K secrets.K {{secrets.K}}", asked, Map.of("K", "V")))
         .isEqualTo("V V V");
     assertThat(asked).containsExactly("K");
   }
@@ -222,7 +266,7 @@ public class SecretUtilTests {
     var asked = new ArrayList<String>();
     var input = "{{secrets.DENIED}} secrets.DENIED {{secrets.DENIED}}";
 
-    assertThat(SecretUtil.replaceSecrets(input, null, recording(asked, Map.of()))).isEqualTo(input);
+    assertThat(replacedValue(input, asked, Map.of())).isEqualTo(input);
     assertThat(asked).containsExactly("DENIED");
   }
 
@@ -234,8 +278,7 @@ public class SecretUtilTests {
             .mapToObj(i -> "{{secrets.DENIED" + i + ":X}}")
             .collect(Collectors.joining(" "));
 
-    assertThat(SecretUtil.replaceSecrets(payload, null, recording(asked, Map.of())))
-        .isEqualTo(payload);
+    assertThat(replacedValue(payload, asked, Map.of())).isEqualTo(payload);
     assertThat(asked).hasSize(5000);
   }
 
@@ -246,14 +289,22 @@ public class SecretUtilTests {
     var asked = new ArrayList<String>();
     var input = "{\"pw\":\"{{secrets.\0}}\"}";
 
-    assertThat(SecretUtil.replaceSecrets(input, null, recording(asked, Map.of()))).isEqualTo(input);
+    assertThat(replacedValue(input, asked, Map.of())).isEqualTo(input);
     assertThat(asked).containsExactly("\0");
   }
 
   private static SecretReplacer recording(List<String> asked, Map<String, String> secrets) {
-    return (name, context) -> {
-      asked.add(name);
-      return secrets.get(name);
+    return (secret, context) -> {
+      asked.add(secret.secretName());
+      return secrets.get(secret.secretName());
     };
+  }
+
+  /** The substituted text of the single {@code value} property {@link #wrap} puts a string in. */
+  private static String replacedValue(
+      String input, List<String> asked, Map<String, String> secrets) {
+    return SecretUtil.replaceSecrets(wrap(input), null, recording(asked, secrets))
+        .get("value")
+        .asText();
   }
 }

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextImplTest.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextImplTest.java
@@ -26,6 +26,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.camunda.connector.api.annotation.FEEL;
 import io.camunda.connector.api.inbound.ActivityLogTag;
 import io.camunda.connector.api.inbound.Health;
@@ -127,8 +128,19 @@ class InboundConnectorContextImplTest {
         true);
   }
 
-  private static String replace(InboundConnectorContextImpl context, String input) {
-    return context.getSecretHandler().replaceSecrets(input, new SecretContext("t", "p"));
+  private static final ObjectMapper PROBE_MAPPER = new ObjectMapper();
+
+  /**
+   * The declared-secret allow-list is scoped by field path, so the probe must sit under the same
+   * property name the secret was declared under for a match to be possible.
+   */
+  private static String replace(InboundConnectorContextImpl context, String field, String text) {
+    ObjectNode probe = PROBE_MAPPER.createObjectNode().put(field, text);
+    return context
+        .getSecretHandler()
+        .replaceSecrets(probe, new SecretContext("t", "p"))
+        .get(field)
+        .asText();
   }
 
   @Test
@@ -139,7 +151,7 @@ class InboundConnectorContextImplTest {
         filteringContext(
             getInboundConnectorDefinition(Map.of("token", "secrets.DECLARED")), secretProvider);
 
-    assertThat(replace(context, "secrets.DECLARED")).isEqualTo("resolved");
+    assertThat(replace(context, "token", "secrets.DECLARED")).isEqualTo("resolved");
   }
 
   @Test
@@ -150,7 +162,7 @@ class InboundConnectorContextImplTest {
         filteringContext(
             getInboundConnectorDefinition(Map.of("token", "{{ secrets.BRACED }}")), secretProvider);
 
-    assertThat(replace(context, "{{ secrets.BRACED }}")).isEqualTo("resolved");
+    assertThat(replace(context, "token", "{{ secrets.BRACED }}")).isEqualTo("resolved");
   }
 
   @Test
@@ -160,7 +172,7 @@ class InboundConnectorContextImplTest {
         filteringContext(
             getInboundConnectorDefinition(Map.of("token", "secrets.DECLARED")), secretProvider);
 
-    assertThat(replace(context, "secrets.INJECTED")).isEqualTo("secrets.INJECTED");
+    assertThat(replace(context, "token", "secrets.INJECTED")).isEqualTo("secrets.INJECTED");
     verify(secretProvider, never()).getSecret(eq("INJECTED"), any());
   }
 
@@ -174,8 +186,28 @@ class InboundConnectorContextImplTest {
             getInboundConnectorDefinition(Map.of("token", "{{secrets.CHAIN_ROOT}}")),
             secretProvider);
 
-    assertThat(replace(context, "{{secrets.CHAIN_ROOT}}")).isEqualTo("secrets.CHAINED");
+    assertThat(replace(context, "token", "{{secrets.CHAIN_ROOT}}")).isEqualTo("secrets.CHAINED");
     verify(secretProvider, never()).getSecret(eq("CHAINED"), any());
+  }
+
+  @Test
+  void secretFilterEnabled_leavesASecretNamedOnlyByASiblingFieldsResolvedValue() {
+    // tokenA resolves to a piece of text that happens to name secrets.SIBLING_ONLY, a secret
+    // declared only under the unrelated tokenB field. Even though the chained text surfaces
+    // during tokenA's own replacement pass, it must not resolve a secret scoped to a different
+    // field path.
+    var secretProvider = mock(SecretProvider.class);
+    when(secretProvider.getSecret(eq("CHAIN_ROOT"), any())).thenReturn("secrets.SIBLING_ONLY");
+    when(secretProvider.getSecret(eq("SIBLING_ONLY"), any())).thenReturn("leaked-value");
+    var context =
+        filteringContext(
+            getInboundConnectorDefinition(
+                Map.of("tokenA", "{{secrets.CHAIN_ROOT}}", "tokenB", "secrets.SIBLING_ONLY")),
+            secretProvider);
+
+    assertThat(replace(context, "tokenA", "{{secrets.CHAIN_ROOT}}"))
+        .isEqualTo("secrets.SIBLING_ONLY");
+    verify(secretProvider, never()).getSecret(eq("SIBLING_ONLY"), any());
   }
 
   @Test
@@ -192,7 +224,7 @@ class InboundConnectorContextImplTest {
             mapper,
             activityLogRegistry);
 
-    assertThat(replace(context, "secrets.INJECTED")).isEqualTo("resolved");
+    assertThat(replace(context, "token", "secrets.INJECTED")).isEqualTo("resolved");
   }
 
   private static ValidInboundConnectorDetails getInboundConnectorDefinition(

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/outbound/AnnotatedOperationTests.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/outbound/AnnotatedOperationTests.java
@@ -20,6 +20,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.client.api.response.ActivatedJob;
 import io.camunda.connector.api.annotation.OutboundConnector;
@@ -153,6 +154,12 @@ public class AnnotatedOperationTests {
     }
     when(activatedJob.getCustomHeaders()).thenReturn(customHeaders);
     when(activatedJob.getVariables()).thenReturn(json);
+    try {
+      when(activatedJob.getVariablesAsType(JsonNode.class))
+          .thenReturn(new ObjectMapper().readTree(json));
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
     return new JobHandlerContext(
         activatedJob,
         new NoOpSecretProvider(),

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/outbound/JobHandlerContextTest.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/outbound/JobHandlerContextTest.java
@@ -29,8 +29,10 @@ import io.camunda.connector.api.error.ConnectorInputException;
 import io.camunda.connector.api.secret.SecretProvider;
 import io.camunda.connector.api.validation.ValidationProvider;
 import io.camunda.connector.runtime.core.secret.SecretFilter;
+import io.camunda.connector.runtime.core.secret.SecretFilter.Secret;
 import io.camunda.connector.runtime.core.testutil.classexample.TestClass;
 import io.camunda.connector.runtime.core.testutil.classexample.TestClassString;
+import java.math.BigDecimal;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -48,6 +50,10 @@ class JobHandlerContextTest {
   private final ObjectMapper objectMapper = new ObjectMapper();
   private JobHandlerContext jobHandlerContext;
 
+  private void stubVariables(String json) {
+    when(activatedJob.getVariables()).thenReturn(json);
+  }
+
   @BeforeEach
   void setUp() {
     jobHandlerContext =
@@ -62,22 +68,67 @@ class JobHandlerContextTest {
 
   @Test
   void getVariables() {
-    when(activatedJob.getVariables()).thenReturn("{}");
+    stubVariables("{}");
     jobHandlerContext.getJobContext().getVariables();
     verify(activatedJob).getVariables();
   }
 
   @Test
+  void bindVariables_preservesFullDecimalPrecision() {
+    stubVariables("{ \"decimal\": 0.1234567890123456789012345 }");
+    BigDecimal bound = jobHandlerContext.bindVariables(TestClass.class).decimal;
+    assertThat(bound).isEqualByComparingTo(new BigDecimal("0.1234567890123456789012345"));
+  }
+
+  @Test
+  void bindVariables_preservesTrailingZeroScale() {
+    // isEqualByComparingTo alone would pass even if the default node factory silently stripped
+    // the trailing zero (1.10 -> 1.1): equals()/isEqualTo is scale-sensitive, compareTo is not.
+    stubVariables("{ \"decimal\": 1.10 }");
+    BigDecimal bound = jobHandlerContext.bindVariables(TestClass.class).decimal;
+    assertThat(bound).isEqualTo(new BigDecimal("1.10"));
+  }
+
+  @Test
+  void bindVariables_preservesLongBeyondDoublePrecision() {
+    stubVariables("{ \"longValue\": 9007199254740993 }");
+    assertThat(jobHandlerContext.bindVariables(TestClass.class).longValue)
+        .isEqualTo(9007199254740993L);
+  }
+
+  @Test
+  void getVariables_preservesDecimalText() {
+    stubVariables(
+        "{ \"a\": 0.00000001, \"b\": 1.10, \"c\": 0.1234567890123456789012345, \"d\":"
+            + " 9007199254740993 }");
+    String variables = jobHandlerContext.getJobContext().getVariables();
+    assertThat(variables)
+        .contains("0.00000001", "1.10", "0.1234567890123456789012345")
+        .contains("9007199254740993");
+  }
+
+  @Test
+  void getVariables_fallsBackToScientificNotationForOutOfRangeDecimalScale() {
+    // Jackson accepts plain output only for a BigDecimal scale within +-9999, and both of these
+    // parse into a DecimalNode outside it. Serializing must fall back to scientific notation, as
+    // the raw job JSON string did, rather than throwing.
+    stubVariables("{ \"tiny\": 1e-10000, \"huge\": 1e+10001 }");
+    assertThat(jobHandlerContext.getJobContext().getVariables())
+        .contains("1E-10000")
+        .contains("1E+10001");
+  }
+
+  @Test
   void bindVariables_success() {
     String json = "{ \"integer\": 3}";
-    when(activatedJob.getVariables()).thenReturn(json);
+    stubVariables(json);
     assertThat(jobHandlerContext.bindVariables(TestClass.class).integer).isEqualTo(3);
   }
 
   @Test
   void bindVariables_failedSecretAreBounded() {
-    String json = "{ \"integer\": \"{{secrets.FOO}}\"";
-    when(activatedJob.getVariables()).thenReturn(json);
+    String json = "{ \"integer\": \"{{secrets.FOO}}\" }";
+    stubVariables(json);
     when(secretProvider.getSecret(eq("FOO"), any())).thenReturn("secret");
     Exception thrown =
         assertThrows(
@@ -88,8 +139,11 @@ class JobHandlerContextTest {
 
   @Test
   void bindVariables_successSecretAreBounded() {
-    String json = "{ \"integer\": {{secrets.FOO}} }";
-    when(activatedJob.getVariables()).thenReturn(json);
+    // Legacy secret substitution now runs after JSON parsing (over the parsed tree), so a
+    // placeholder must sit inside a JSON string like any other value — an unquoted placeholder for
+    // a non-string field is no longer valid JSON and can never reach substitution.
+    String json = "{ \"integer\": \"{{secrets.FOO}}\" }";
+    stubVariables(json);
     when(secretProvider.getSecret(eq("FOO"), any())).thenReturn("1");
     assertThat(jobHandlerContext.bindVariables(TestClass.class).integer).isEqualTo(1);
   }
@@ -97,7 +151,7 @@ class JobHandlerContextTest {
   @Test
   void bindVariables_successJsonSecretAreEscaped() {
     String json = "{ \"value\": \"{{secrets.FOO}}\" }";
-    when(activatedJob.getVariables()).thenReturn(json);
+    stubVariables(json);
     when(secretProvider.getSecret(eq("FOO"), any())).thenReturn("{\"key\": \"secret\"}");
     assertThat(jobHandlerContext.bindVariables(TestClassString.class).value)
         .isEqualTo("{\"key\": \"secret\"}");
@@ -106,7 +160,7 @@ class JobHandlerContextTest {
   @Test
   void bindVariables_successJsonSecretAreEscapedAndCarriageReturnEscaped() {
     String json = "{ \"value\": \"{{secrets.FOO}}\" }";
-    when(activatedJob.getVariables()).thenReturn(json);
+    stubVariables(json);
     when(secretProvider.getSecret(eq("FOO"), any())).thenReturn("{\"key\": \n\"secret\"}");
     assertThat(jobHandlerContext.bindVariables(TestClassString.class).value)
         .isEqualTo("{\"key\": \n\"secret\"}");
@@ -115,7 +169,7 @@ class JobHandlerContextTest {
   @Test
   void bindVariables_successJsonSecretAreEscapedAndNullByteRemoved() {
     String json = "{ \"value\": \"{{secrets.FOO}}\" }";
-    when(activatedJob.getVariables()).thenReturn(json);
+    stubVariables(json);
     when(secretProvider.getSecret(eq("FOO"), any())).thenReturn("{\"key\": \"sec\0ret\"}");
     assertThat(jobHandlerContext.bindVariables(TestClassString.class).value)
         .isEqualTo("{\"key\": \"sec\0ret\"}");
@@ -123,8 +177,8 @@ class JobHandlerContextTest {
 
   @Test
   void bindVariables_secretIsNotAvailable() {
-    String json = "{ \"integer\": {{secrets.FOO2}} }";
-    when(activatedJob.getVariables()).thenReturn(json);
+    String json = "{ \"integer\": \"{{secrets.FOO2}}\" }";
+    stubVariables(json);
     when(secretProvider.getSecret(eq("FOO2"), any())).thenReturn(null);
     assertThrows(
         ConnectorInputException.class, () -> jobHandlerContext.bindVariables(TestClass.class));
@@ -133,7 +187,7 @@ class JobHandlerContextTest {
   @Test
   void bindVariables_successStringSecretAreEscapedAndCarriageReturnEscaped() {
     String json = "{ \"value\": \"{{secrets.FOO}}\" }";
-    when(activatedJob.getVariables()).thenReturn(json);
+    stubVariables(json);
     when(secretProvider.getSecret(eq("FOO"), any())).thenReturn("Hello \n World");
     assertThat(jobHandlerContext.bindVariables(TestClassString.class).value)
         .isEqualTo("Hello \n World");
@@ -142,7 +196,7 @@ class JobHandlerContextTest {
   @Test
   void bindVariables_successStringSecretAreEscapedAndQuoteEscaped() {
     String json = "{ \"value\": \"{{secrets.FOO}}\" }";
-    when(activatedJob.getVariables()).thenReturn(json);
+    stubVariables(json);
     when(secretProvider.getSecret(eq("FOO"), any())).thenReturn("Hello \" World");
     assertThat(jobHandlerContext.bindVariables(TestClassString.class).value)
         .isEqualTo("Hello \" World");
@@ -151,7 +205,7 @@ class JobHandlerContextTest {
   @Test
   void bindVariables_successStringSecretAreEscapedAndNullByteEscaped() {
     String json = "{ \"value\": \"{{secrets.FOO}}\" }";
-    when(activatedJob.getVariables()).thenReturn(json);
+    stubVariables(json);
     when(secretProvider.getSecret(eq("FOO"), any())).thenReturn("Hello \0 World");
     assertThat(jobHandlerContext.bindVariables(TestClassString.class).value)
         .isEqualTo("Hello \0 World");
@@ -160,14 +214,14 @@ class JobHandlerContextTest {
   @Test
   void bindVariables_nullValue() {
     String json = "{ \"integer\": null}";
-    when(activatedJob.getVariables()).thenReturn(json);
+    stubVariables(json);
     assertThat(jobHandlerContext.bindVariables(TestClass.class).integer).isEqualTo(null);
   }
 
   @Test
   void bindVariables_invalidFormat() {
     String json = "{ \"integer\": \"hello\"}";
-    when(activatedJob.getVariables()).thenReturn(json);
+    stubVariables(json);
     Exception thrown =
         assertThrows(
             ConnectorInputException.class, () -> jobHandlerContext.bindVariables(TestClass.class));
@@ -179,7 +233,7 @@ class JobHandlerContextTest {
   @Test
   void bindVariables_invalidFormatNull() {
     String json = "{ \"invalid\": null }";
-    when(activatedJob.getVariables()).thenReturn(json);
+    stubVariables(json);
     Exception thrown =
         assertThrows(
             ConnectorInputException.class, () -> jobHandlerContext.bindVariables(TestClass.class));
@@ -190,7 +244,7 @@ class JobHandlerContextTest {
   @Test
   void bindVariables_invalidParsing() {
     String json = "{ \"integer\" hello\"}";
-    when(activatedJob.getVariables()).thenReturn(json);
+    stubVariables(json);
     Exception thrown =
         assertThrows(
             ConnectorInputException.class, () -> jobHandlerContext.bindVariables(TestClass.class));
@@ -200,8 +254,8 @@ class JobHandlerContextTest {
 
   @Test
   void bindVariables_invalidFormatObject() {
-    String json = "{ \"integer\": \"{ \"hello\" : 3\"}";
-    when(activatedJob.getVariables()).thenReturn(json);
+    String json = "{ \"integer\": \"{ \\\"hello\\\" : 3}\" }";
+    stubVariables(json);
     Exception thrown =
         assertThrows(
             ConnectorInputException.class, () -> jobHandlerContext.bindVariables(TestClass.class));
@@ -213,7 +267,7 @@ class JobHandlerContextTest {
   @Test
   void bindVariables_emptyString() {
     String json = "";
-    when(activatedJob.getVariables()).thenReturn(json);
+    stubVariables(json);
     Exception thrown =
         assertThrows(
             ConnectorInputException.class, () -> jobHandlerContext.bindVariables(TestClass.class));
@@ -223,21 +277,22 @@ class JobHandlerContextTest {
 
   @Test
   void bindVariables_emptyArray() {
+    // Job variables are always a JSON object in Zeebe/Camunda 8, and the tree walk that secret
+    // substitution runs first requires one, so an array is rejected before it ever reaches type
+    // binding.
     String json = "[]";
-    when(activatedJob.getVariables()).thenReturn(json);
+    stubVariables(json);
     Exception thrown =
         assertThrows(
             ConnectorInputException.class, () -> jobHandlerContext.bindVariables(TestClass.class));
 
-    assertThat(thrown.getMessage())
-        .isEqualTo(
-            "Cannot deserialize value of type `io.camunda.connector.runtime.core.testutil.classexample.TestClass` from Array value (token `JsonToken.START_ARRAY`)");
+    assertThat(thrown.getMessage()).isEqualTo("This is not a JSON object");
   }
 
   @Test
   void bindVariables_invalidFormatArray() {
     String json = "{ \"integer\": [\"hello\"] }";
-    when(activatedJob.getVariables()).thenReturn(json);
+    stubVariables(json);
     Exception thrown =
         assertThrows(
             ConnectorInputException.class, () -> jobHandlerContext.bindVariables(TestClass.class));
@@ -259,9 +314,9 @@ class JobHandlerContextTest {
             validationProvider,
             null,
             objectMapper,
-            SecretFilter.allowOnly(List.of("AUTH")));
+            SecretFilter.allowOnly(List.of(new Secret("AUTH", List.of()))));
     String json = "{ \"value\": \"{{secrets.UNDECLARED}}\" }";
-    when(activatedJob.getVariables()).thenReturn(json);
+    stubVariables(json);
 
     var bound = restrictiveContext.bindVariables(TestClassString.class);
 

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/testutil/classexample/TestClass.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/testutil/classexample/TestClass.java
@@ -16,8 +16,12 @@
  */
 package io.camunda.connector.runtime.core.testutil.classexample;
 
+import java.math.BigDecimal;
+
 public class TestClass {
   public Integer integer;
+  public BigDecimal decimal;
+  public Long longValue;
 
   public TestClass(Integer integer) {
     this.integer = integer;

--- a/connector-runtime/connector-runtime-spring/pom.xml
+++ b/connector-runtime/connector-runtime-spring/pom.xml
@@ -126,6 +126,10 @@
       <groupId>io.camunda.connector</groupId>
       <artifactId>connector-feel</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.camunda.feel</groupId>
+      <artifactId>feel-engine</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>io.camunda</groupId>

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/ConfigurableSecretFilterFactory.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/ConfigurableSecretFilterFactory.java
@@ -18,7 +18,6 @@ package io.camunda.connector.runtime.outbound.job;
 
 import io.camunda.connector.runtime.core.secret.SecretFilter;
 import io.camunda.connector.runtime.core.secret.SecretFilterFactory;
-import io.camunda.connector.runtime.core.secret.SecretFilterFactory.SecretFilterContext;
 import io.camunda.connector.runtime.outbound.secret.SecretKeyCache;
 import io.camunda.connector.runtime.outbound.secret.SecretKeyCache.SecretKeyContext;
 import org.slf4j.Logger;

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/LazyLoadingSecretFilter.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/LazyLoadingSecretFilter.java
@@ -18,45 +18,49 @@ package io.camunda.connector.runtime.outbound.job;
 
 import io.camunda.connector.runtime.core.secret.SecretFilter;
 import java.util.List;
-import java.util.Set;
 import java.util.function.Supplier;
 
 /**
  * A {@link SecretFilter} that resolves the allowed secret names on the first {@link
- * #isAllowed(String)} call rather than at construction time. This defers the BPMN process
+ * #isAllowed(Secret)} call rather than at construction time. This defers the BPMN process
  * definition lookup to the point where secrets are actually being replaced, so that any exception
  * thrown by the supplier propagates through the normal connector error-handling path and results in
  * a proper Zeebe {@code failJob} command.
  *
  * <p>The supplier is called exactly once per filter instance regardless of outcome. When the
  * supplier returns {@code null} (LAX mode: lookup failed, fall back to allow-all), all subsequent
- * calls to {@link #isAllowed(String)} return {@code true} without re-invoking the supplier.
+ * calls to {@link #isAllowed(Secret)} return {@code true} without re-invoking the supplier.
  */
 public class LazyLoadingSecretFilter implements SecretFilter {
-  private final Supplier<List<String>> secretNamesSupplier;
+  private final Supplier<List<Secret>> secretsSupplier;
 
   private volatile boolean initialized = false;
-  private Set<String> secretNames;
+  private SecretFilter delegate;
+  private RuntimeException initializationFailure;
 
-  public LazyLoadingSecretFilter(Supplier<List<String>> secretNamesSupplier) {
-    this.secretNamesSupplier = secretNamesSupplier;
+  public LazyLoadingSecretFilter(Supplier<List<Secret>> secretsSupplier) {
+    this.secretsSupplier = secretsSupplier;
   }
 
   @Override
-  public boolean isAllowed(String secretName) {
+  public boolean isAllowed(Secret context) {
     if (!initialized) {
       synchronized (this) {
         if (!initialized) {
-          List<String> names = secretNamesSupplier.get();
-          secretNames = names != null ? Set.copyOf(names) : null;
-          initialized = true;
+          try {
+            List<Secret> names = secretsSupplier.get();
+            delegate = names != null ? SecretFilter.allowOnly(names) : SecretFilter.allowAll();
+          } catch (RuntimeException e) {
+            initializationFailure = e;
+          } finally {
+            initialized = true;
+          }
         }
       }
     }
-    if (secretNames != null) {
-      return secretNames.contains(secretName);
-    } else {
-      return true;
+    if (initializationFailure != null) {
+      throw initializationFailure;
     }
+    return delegate.isAllowed(context);
   }
 }

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/OutboundConnectorExceptionHandler.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/OutboundConnectorExceptionHandler.java
@@ -18,6 +18,7 @@ package io.camunda.connector.runtime.outbound.job;
 
 import static io.camunda.connector.runtime.outbound.job.SpringConnectorJobHandler.MAX_ERROR_MESSAGE_LENGTH;
 
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.camunda.client.api.response.ActivatedJob;
 import io.camunda.connector.api.error.ConnectorException;
 import io.camunda.connector.api.error.ConnectorInputException;
@@ -31,6 +32,7 @@ import io.camunda.connector.runtime.core.error.InvalidBackOffDurationException;
 import io.camunda.connector.runtime.core.error.JobError;
 import io.camunda.connector.runtime.core.outbound.ConnectorResult;
 import io.camunda.connector.runtime.core.secret.SecretFilter;
+import io.camunda.connector.runtime.core.secret.SecretFilter.Secret;
 import io.camunda.connector.runtime.core.secret.SecretNotAvailableException;
 import io.camunda.connector.runtime.core.secret.SecretUtil;
 import java.time.Duration;
@@ -183,26 +185,27 @@ public class OutboundConnectorExceptionHandler {
       ActivatedJob job, SecretFilter secretFilter, Exception jobFailure) {
     try {
       var allowedKeys =
-          SecretUtil.retrieveSecretKeysInInput(job.getVariables()).stream()
-              .filter(secretFilter::isAllowed)
-              .toList();
+          allowedKeys(
+              SecretUtil.retrieveSecretKeysInInput(job.getVariablesAsType(ObjectNode.class)),
+              secretFilter);
+      var allowedNames = allowedKeys.stream().map(Secret::secretName).distinct().toList();
       // A job that declares no secret has nothing to redact, so no provider is asked for anything:
       // a custom fetchAll that refuses every batch must not withhold such a job's error message.
-      if (allowedKeys.isEmpty()) {
+      if (allowedNames.isEmpty()) {
         return new MaskingSecrets(List.of(), null);
       }
       var values =
           this.secretProvider.fetchAll(
-              allowedKeys, new SecretContext(job.getTenantId(), job.getBpmnProcessId()));
+              allowedNames, new SecretContext(job.getTenantId(), job.getBpmnProcessId()));
       // fetchAll drops the names it cannot resolve, so a short read is a silent one: a name the
       // input declares resolved when it was bound, so one missing now means the secret was removed,
       // or access revoked, while the connector ran. Redacting with what did come back would publish
       // the one that did not in the clear.
-      if (values.size() < allowedKeys.size() && !reportsAnUnavailableSecret(jobFailure)) {
+      if (values.size() < allowedNames.size() && !reportsAnUnavailableSecret(jobFailure)) {
         return new MaskingSecrets(
             List.of(),
             new MaskingSecretsIncompleteException(
-                allowedKeys.size() - values.size(), allowedKeys.size()));
+                allowedNames.size() - values.size(), allowedNames.size()));
       }
       return new MaskingSecrets(values, null);
     } catch (Exception ex) {
@@ -213,6 +216,10 @@ public class OutboundConnectorExceptionHandler {
           safeDiagnostic(ex));
       return new MaskingSecrets(List.of(), ex);
     }
+  }
+
+  private static List<Secret> allowedKeys(List<Secret> keys, SecretFilter secretFilter) {
+    return keys.stream().filter(secretFilter::isAllowed).toList();
   }
 
   /**

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/secret/ProcessDefinitionSecretKeyCache.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/secret/ProcessDefinitionSecretKeyCache.java
@@ -17,6 +17,7 @@
 package io.camunda.connector.runtime.outbound.secret;
 
 import io.camunda.client.CamundaClient;
+import io.camunda.connector.runtime.core.secret.SecretFilter.Secret;
 import io.camunda.connector.runtime.core.secret.SecretUtil;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
@@ -33,20 +34,30 @@ import io.camunda.zeebe.model.bpmn.instance.SubProcess;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeInput;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeIoMapping;
 import java.io.ByteArrayInputStream;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
+import java.util.Deque;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.camunda.feel.api.FeelEngineApi;
+import org.camunda.feel.api.FeelEngineBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.cache.Cache;
 
 public class ProcessDefinitionSecretKeyCache implements SecretKeyCache {
   private static final Logger LOG = LoggerFactory.getLogger(ProcessDefinitionSecretKeyCache.class);
+  private static final FeelEngineApi FEEL_ENGINE = FeelEngineBuilder.forJava().build();
   private static final List<Class<? extends BaseElement>> OUTBOUND_ELIGIBLE_TYPES =
       new ArrayList<>();
 
@@ -69,7 +80,7 @@ public class ProcessDefinitionSecretKeyCache implements SecretKeyCache {
   }
 
   @Override
-  public List<String> getSecretKeys(SecretKeyContext secretKeyContext) {
+  public List<Secret> getSecretKeys(SecretKeyContext secretKeyContext) {
     return cache
         .get(
             secretKeyContext.processDefinitionKey(),
@@ -77,7 +88,7 @@ public class ProcessDefinitionSecretKeyCache implements SecretKeyCache {
         .getOrDefault(secretKeyContext.elementId(), Collections.emptyList());
   }
 
-  private Map<String, List<String>> fetchSecretKeysByElementIds(long processDefinitionKey) {
+  private Map<String, List<Secret>> fetchSecretKeysByElementIds(long processDefinitionKey) {
     String bpmnXml =
         camundaClient.newProcessDefinitionGetXmlRequest(processDefinitionKey).execute();
 
@@ -91,7 +102,7 @@ public class ProcessDefinitionSecretKeyCache implements SecretKeyCache {
         .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
   }
 
-  private Map<String, List<String>> inspectBpmnProcess(Process process, long processDefinitionKey) {
+  private Map<String, List<Secret>> inspectBpmnProcess(Process process, long processDefinitionKey) {
     Collection<BaseElement> outboundEligibleElements =
         retrieveOutboundEligibleElementsFromProcess(process);
     if (outboundEligibleElements.isEmpty()) {
@@ -100,7 +111,7 @@ public class ProcessDefinitionSecretKeyCache implements SecretKeyCache {
       return Collections.emptyMap();
     }
 
-    Map<String, List<String>> discoveredOutboundConnectors = new HashMap<>();
+    Map<String, List<Secret>> discoveredOutboundConnectors = new HashMap<>();
     for (BaseElement element : outboundEligibleElements) {
       var inputs = findElementInput(element);
       var definedSecrets = extractSecrets(inputs);
@@ -109,12 +120,186 @@ public class ProcessDefinitionSecretKeyCache implements SecretKeyCache {
     return discoveredOutboundConnectors;
   }
 
-  private List<String> extractSecrets(List<ZeebeInput> inputs) {
-    return inputs.stream()
-        .flatMap(input -> SecretUtil.retrieveSecretKeysInInput(input.getSource()).stream())
-        .map(String::trim)
+  /**
+   * A secret is allowed not only on the input that names it directly, but also on every input whose
+   * own FEEL expression reads the variable that input's target writes — transitively. A template
+   * commonly assembles one input's value (e.g. {@code url}) from others (e.g. {@code baseUrl},
+   * itself holding a secret); the assembled input's runtime value can carry the secret's text just
+   * as directly as the input that named it, so the allow-list has to follow that data flow rather
+   * than stop at the input where the secret's name is written.
+   *
+   * <p>A dependency is resolved by matching a referenced variable's full qualified path against
+   * another input's {@code target} path, one a prefix of the other (a dotted target like {@code
+   * authentication.type} publishes both the top-level variable {@code authentication} and the field
+   * {@code authentication.type}). Requiring a prefix relation on the full path — rather than just
+   * the top-level segment — keeps sibling fields under the same top-level name, like {@code
+   * authentication.type} and {@code authentication.token}, from being treated as dependent on each
+   * other merely for sharing a top-level name.
+   *
+   * <p>Only a preceding, still-effective writer of the referenced path counts as a dependency:
+   * {@code zeebe:input} mappings evaluate in declaration order, each against the output the ones
+   * before it already built, so a later mapping's target is invisible to an earlier one, and a
+   * target written more than once is reachable only through its last writer before this point.
+   */
+  private List<Secret> extractSecrets(List<ZeebeInput> inputs) {
+    Map<ZeebeInput, List<String>> pathByInput = new LinkedHashMap<>();
+    Map<ZeebeInput, List<String>> ownSecretNamesByInput = new LinkedHashMap<>();
+    for (ZeebeInput input : inputs) {
+      pathByInput.put(input, Arrays.asList(input.getTarget().split("\\.")));
+      ownSecretNamesByInput.put(
+          input,
+          SecretUtil.retrieveSecretKeysInInput(input.getSource()).stream()
+              .map(String::trim)
+              .distinct()
+              .toList());
+    }
+
+    // zeebe:input mappings are evaluated in declaration order, each against the output built by
+    // the ones before it -- a later mapping is invisible to an earlier one, and a target written
+    // more than once is only reachable through its last (nearest-preceding), still-effective
+    // writer. effectiveTargets is therefore built up one input at a time, alongside the loop, and
+    // an input's own dependencies are resolved against it before that input registers itself.
+    Map<ZeebeInput, List<ZeebeInput>> directDependencies = new LinkedHashMap<>();
+    Map<List<String>, ZeebeInput> effectiveTargets = new LinkedHashMap<>();
+    for (ZeebeInput input : inputs) {
+      List<List<String>> referencedPaths = referencedVariablePaths(input.getSource());
+      directDependencies.put(
+          input,
+          referencedPaths.stream()
+              .flatMap(referencedPath -> matchingWriters(referencedPath, effectiveTargets))
+              .distinct()
+              .toList());
+      // A write to a parent path replaces the whole subtree beneath it, so every existing writer
+      // of a descendant path is no longer effective from this point on.
+      List<String> ownPath = pathByInput.get(input);
+      effectiveTargets.keySet().removeIf(existingPath -> isProperPrefix(ownPath, existingPath));
+      effectiveTargets.put(ownPath, input);
+    }
+
+    // A later mapping that writes a path *beneath* an earlier one replaces that part of what the
+    // earlier input produced -- and a grant is a path prefix, so it cannot say "everything under
+    // `path` except that subtree". Such a writer therefore grants nothing at its own path and
+    // propagates nothing to the inputs that read it: `authentication = secrets.WHOLE` followed by
+    // `authentication.token = someVariable` would otherwise authorize WHOLE at
+    // authentication.token, because the declared path is a prefix of it -- letting that later,
+    // potentially process-controlled value resolve a secret it never carried -- and equally at any
+    // field that copies the whole object afterwards. Any descendant still in effectiveTargets was
+    // necessarily written *after* this input, since this input's own write evicted the ones before
+    // it. This is the parent-overwrite rule above, applied in the other direction, and fails
+    // closed the same way: a parent whose expression nests a secret under a path a later mapping
+    // does not touch (`authentication = {user: "{{secrets.USER}}"}` alongside
+    // `authentication.token = ...`) loses its grant too, since a prefix cannot express the
+    // difference.
+    Set<ZeebeInput> shadowedWriters =
+        inputs.stream()
+            .filter(
+                candidate ->
+                    effectiveTargets.keySet().stream()
+                        .anyMatch(deeper -> isProperPrefix(pathByInput.get(candidate), deeper)))
+            .collect(Collectors.toSet());
+
+    List<Secret> result = new ArrayList<>();
+    for (ZeebeInput input : inputs) {
+      List<String> path = pathByInput.get(input);
+      // A later mapping can overwrite this input's own target -- directly, or by writing to a
+      // parent path that replaces the whole subtree beneath it -- before the sequence finishes.
+      // effectiveTargets reflects the final state once the loop above has processed every input,
+      // so if it no longer maps `path` back to this exact input, this input's value -- whether its
+      // own secret or one propagated into it through a dependency -- is not reachable at `path`
+      // any more; granting anything there would let whatever the actual final writer put in that
+      // field -- potentially attacker-controlled -- resolve a secret it never carried. This has to
+      // gate the dependency walk below too, not just the own-grant: a dependency chain still
+      // computes what *this* input's expression would have carried, which is moot once something
+      // else, not this input, is what the runtime field actually holds.
+      if (effectiveTargets.get(path) != input || shadowedWriters.contains(input)) {
+        continue;
+      }
+      ownSecretNamesByInput.get(input).forEach(name -> result.add(new Secret(name, path)));
+
+      Set<ZeebeInput> visited = new HashSet<>();
+      Deque<ZeebeInput> pending = new ArrayDeque<>(directDependencies.get(input));
+      while (!pending.isEmpty()) {
+        ZeebeInput dependency = pending.poll();
+        if (!visited.add(dependency)) {
+          continue;
+        }
+        // A shadowed dependency terminates the branch rather than merely contributing no names
+        // of its own: whatever flowed *into* it is just as unreachable through it as its own
+        // secret is, since part of what it produced was replaced by the later writer beneath it.
+        // Walking past it would grant a secret two hops up at this input's path -- which, being
+        // a prefix, covers this input's copy of that same shadowed subtree.
+        if (shadowedWriters.contains(dependency)) {
+          continue;
+        }
+        ownSecretNamesByInput.get(dependency).forEach(name -> result.add(new Secret(name, path)));
+        pending.addAll(directDependencies.getOrDefault(dependency, List.of()));
+      }
+    }
+    return result.stream().distinct().toList();
+  }
+
+  /**
+   * The full qualified path of every variable a FEEL expression references, or an empty list if
+   * {@code source} isn't a FEEL expression (no leading {@code =}) or fails to parse — a static
+   * value or a malformed expression simply has nothing to propagate from.
+   */
+  private static List<List<String>> referencedVariablePaths(String source) {
+    if (source == null) {
+      return List.of();
+    }
+    String trimmed = source.trim();
+    if (!trimmed.startsWith("=")) {
+      return List.of();
+    }
+    var parseResult = FEEL_ENGINE.parseExpression(trimmed.substring(1));
+    if (parseResult.isFailure()) {
+      return List.of();
+    }
+    return parseResult.parsedExpression().getVariableReferences().stream()
+        .map(ref -> ref.getFullQualifiedName())
         .distinct()
         .toList();
+  }
+
+  /**
+   * The writers a reference to {@code referencedPath} depends on, given the writers currently still
+   * effective. Two disjoint cases, since a single symmetric prefix match would let a stale ancestor
+   * writer stand in for a leaf that a later, more specific writer has since replaced:
+   *
+   * <ul>
+   *   <li>The reference targets a specific field or the exact field a writer wrote: at most one
+   *       writer answers it, the <em>nearest</em> (most specific) ancestor-or-self path among the
+   *       effective writers -- a closer writer, even an earlier one, shadows a more distant
+   *       ancestor's stake in that one field.
+   *   <li>The reference targets a whole object a writer's field lives under: every writer whose
+   *       path is a descendant of the reference answers it, since reading the whole object reads
+   *       every field currently set beneath it.
+   * </ul>
+   */
+  private static Stream<ZeebeInput> matchingWriters(
+      List<String> referencedPath, Map<List<String>, ZeebeInput> effectiveTargets) {
+    var nearestAncestorOrSelf =
+        effectiveTargets.entrySet().stream()
+            .filter(entry -> isAncestorOrSelf(entry.getKey(), referencedPath))
+            .max(Comparator.comparingInt(entry -> entry.getKey().size()))
+            .map(Map.Entry::getValue);
+    var descendants =
+        effectiveTargets.entrySet().stream()
+            .filter(entry -> isProperPrefix(referencedPath, entry.getKey()))
+            .map(Map.Entry::getValue);
+    return nearestAncestorOrSelf
+        .map(writer -> Stream.concat(Stream.of(writer), descendants))
+        .orElse(descendants);
+  }
+
+  /** Whether {@code ancestor} is a prefix of {@code path}, including being equal to it. */
+  private static boolean isAncestorOrSelf(List<String> ancestor, List<String> path) {
+    return ancestor.size() <= path.size() && path.subList(0, ancestor.size()).equals(ancestor);
+  }
+
+  /** Whether {@code shorter} is a strict ancestor path of {@code longer} (not equal to it). */
+  private static boolean isProperPrefix(List<String> shorter, List<String> longer) {
+    return shorter.size() < longer.size() && longer.subList(0, shorter.size()).equals(shorter);
   }
 
   private List<ZeebeInput> findElementInput(BaseElement element) {

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/secret/SecretKeyCache.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/secret/SecretKeyCache.java
@@ -16,12 +16,13 @@
  */
 package io.camunda.connector.runtime.outbound.secret;
 
+import io.camunda.connector.runtime.core.secret.SecretFilter.Secret;
 import java.util.List;
 
 public interface SecretKeyCache {
   String SECRET_KEY_CACHE_NAME = SecretKeyCache.class.getName();
 
-  List<String> getSecretKeys(SecretKeyContext secretKeyContext);
+  List<Secret> getSecretKeys(SecretKeyContext secretKeyContext);
 
   record SecretKeyContext(long processDefinitionKey, String elementId) {}
 }

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/JobBuilder.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/JobBuilder.java
@@ -18,17 +18,22 @@ package io.camunda.connector.runtime;
 
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.client.api.command.CompleteJobCommandStep1;
 import io.camunda.client.api.command.FailJobCommandStep1;
+import io.camunda.client.api.command.InternalClientException;
 import io.camunda.client.api.command.ThrowErrorCommandStep1;
 import io.camunda.client.api.response.ActivatedJob;
 import io.camunda.client.api.worker.JobClient;
 import io.camunda.connector.runtime.core.Keywords;
 import io.camunda.connector.runtime.outbound.job.SpringConnectorJobHandler;
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 import org.mockito.ArgumentCaptor;
@@ -76,6 +81,10 @@ public class JobBuilder {
       when(throwCommandStep2.variables(any(Map.class))).thenReturn(throwCommandStep2_2);
       when(job.getKey()).thenReturn(-1L);
       when(job.getType()).thenReturn("some-type");
+      // A real Zeebe job's variables are never absent — worst case "{}" — so default to that
+      // here too, rather than leaving getVariablesAsType() to return null for any test that
+      // doesn't care about variables and never calls withVariables(...).
+      withVariables("{}");
     }
 
     public JobBuilderStep useJobClient(JobClient client) {
@@ -85,7 +94,29 @@ public class JobBuilder {
 
     public JobBuilderStep withVariables(String variables) {
       when(job.getVariables()).thenReturn(variables);
+      // Mirrors the real ActivatedJob: getVariablesAsType(cls) parses `variables` with Jackson and
+      // wraps any failure in an InternalClientException, regardless of which node type the caller
+      // asked for (JsonNode vs ObjectNode) — production code asks for both, depending on the path.
+      lenient()
+          .doAnswer(
+              invocation -> {
+                Class<?> cls = invocation.getArgument(0);
+                JsonNode node = parseLikeClient(variables);
+                return cls.cast(node);
+              })
+          .when(job)
+          .getVariablesAsType(any());
       return this;
+    }
+
+    private static JsonNode parseLikeClient(String json) {
+      try {
+        return new ObjectMapper().readValue(json, JsonNode.class);
+      } catch (IOException e) {
+        throw new InternalClientException(
+            String.format("Failed to deserialize json '%s' to class '%s'", json, JsonNode.class),
+            e);
+      }
     }
 
     public JobBuilderStep withHeaders(Map<String, String> headers) {

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/inbound/InboundConnectorRuntimeConfigurationTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/inbound/InboundConnectorRuntimeConfigurationTest.java
@@ -124,9 +124,12 @@ class InboundConnectorRuntimeConfigurationTest {
   }
 
   private static String resolveUndeclared(InboundConnectorContextImpl context) {
+    var probe = new ObjectMapper().createObjectNode().put("value", "secrets.UNDECLARED");
     return context
         .getSecretHandler()
-        .replaceSecrets("secrets.UNDECLARED", new SecretContext("t", "p"));
+        .replaceSecrets(probe, new SecretContext("t", "p"))
+        .get("value")
+        .asText();
   }
 
   private static SecretProvider alwaysResolvingProvider() {

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/job/ConfigurableSecretFilterFactoryTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/job/ConfigurableSecretFilterFactoryTest.java
@@ -27,6 +27,7 @@ import static org.mockito.Mockito.when;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.fetch.ProcessDefinitionGetXmlRequest;
+import io.camunda.connector.runtime.core.secret.SecretFilter.Secret;
 import io.camunda.connector.runtime.core.secret.SecretFilterFactory.SecretFilterContext;
 import io.camunda.connector.runtime.outbound.job.ConfigurableSecretFilterFactory.SecretFilterMode;
 import io.camunda.connector.runtime.outbound.secret.ProcessDefinitionSecretKeyCache;
@@ -53,27 +54,36 @@ class ConfigurableSecretFilterFactoryTest {
 
   @Mock private SecretKeyCache secretKeyCache;
 
+  private static Secret secret(String name) {
+    return new Secret(name, List.of());
+  }
+
+  private static Secret query(String name) {
+    return new Secret(name, List.of("field"));
+  }
+
   @Test
   void create_disabled_allowsAllSecrets_withoutCacheInteraction() {
     var factory = new ConfigurableSecretFilterFactory(SecretFilterMode.DISABLED, secretKeyCache);
 
     var filter = factory.create(CONTEXT);
 
-    assertThat(filter.isAllowed("ANY_SECRET")).isTrue();
-    assertThat(filter.isAllowed("ANOTHER_SECRET")).isTrue();
+    assertThat(filter.isAllowed(query("ANY_SECRET"))).isTrue();
+    assertThat(filter.isAllowed(query("ANOTHER_SECRET"))).isTrue();
     verifyNoInteractions(secretKeyCache);
   }
 
   @Test
   void create_lax_withSecretKeys_restrictesFilterToList() {
-    when(secretKeyCache.getSecretKeys(SECRET_KEY_CONTEXT)).thenReturn(List.of("API_KEY", "TOKEN"));
+    when(secretKeyCache.getSecretKeys(SECRET_KEY_CONTEXT))
+        .thenReturn(List.of(secret("API_KEY"), secret("TOKEN")));
     var factory = new ConfigurableSecretFilterFactory(SecretFilterMode.LAX, secretKeyCache);
 
     var filter = factory.create(CONTEXT);
 
-    assertThat(filter.isAllowed("API_KEY")).isTrue();
-    assertThat(filter.isAllowed("TOKEN")).isTrue();
-    assertThat(filter.isAllowed("UNLISTED_SECRET")).isFalse();
+    assertThat(filter.isAllowed(query("API_KEY"))).isTrue();
+    assertThat(filter.isAllowed(query("TOKEN"))).isTrue();
+    assertThat(filter.isAllowed(query("UNLISTED_SECRET"))).isFalse();
   }
 
   @Test
@@ -83,18 +93,18 @@ class ConfigurableSecretFilterFactoryTest {
 
     var filter = factory.create(CONTEXT);
 
-    assertThat(filter.isAllowed("ANY_SECRET")).isTrue();
+    assertThat(filter.isAllowed(query("ANY_SECRET"))).isTrue();
   }
 
   @Test
   void create_strict_withSecretKeys_restrictesFilterToList() {
-    when(secretKeyCache.getSecretKeys(SECRET_KEY_CONTEXT)).thenReturn(List.of("API_KEY"));
+    when(secretKeyCache.getSecretKeys(SECRET_KEY_CONTEXT)).thenReturn(List.of(secret("API_KEY")));
     var factory = new ConfigurableSecretFilterFactory(SecretFilterMode.STRICT, secretKeyCache);
 
     var filter = factory.create(CONTEXT);
 
-    assertThat(filter.isAllowed("API_KEY")).isTrue();
-    assertThat(filter.isAllowed("UNLISTED_SECRET")).isFalse();
+    assertThat(filter.isAllowed(query("API_KEY"))).isTrue();
+    assertThat(filter.isAllowed(query("UNLISTED_SECRET"))).isFalse();
   }
 
   @Test
@@ -104,7 +114,7 @@ class ConfigurableSecretFilterFactoryTest {
 
     var filter = factory.create(CONTEXT);
 
-    assertThatThrownBy(() -> filter.isAllowed("ANY_SECRET"))
+    assertThatThrownBy(() -> filter.isAllowed(query("ANY_SECRET")))
         .isInstanceOf(SecretAllowListUnavailableException.class)
         .hasMessageContaining("Error retrieving secret keys");
   }
@@ -120,7 +130,7 @@ class ConfigurableSecretFilterFactoryTest {
 
     var filter = factory.create(CONTEXT);
 
-    assertThatThrownBy(() -> filter.isAllowed("ANY_SECRET"))
+    assertThatThrownBy(() -> filter.isAllowed(query("ANY_SECRET")))
         .hasMessageContaining(ELEMENT_ID)
         .hasMessageContaining(String.valueOf(PROCESS_DEF_KEY))
         .hasMessageContaining(RuntimeException.class.getName())
@@ -143,7 +153,7 @@ class ConfigurableSecretFilterFactoryTest {
 
     var filter = factory.create(CONTEXT);
 
-    assertThatThrownBy(() -> filter.isAllowed("ANY_SECRET"))
+    assertThatThrownBy(() -> filter.isAllowed(query("ANY_SECRET")))
         .hasMessageContaining(java.net.ConnectException.class.getName())
         .hasMessageNotContaining("Connection refused");
   }
@@ -161,7 +171,7 @@ class ConfigurableSecretFilterFactoryTest {
 
     var filter = factory.create(CONTEXT);
 
-    assertThatThrownBy(() -> filter.isAllowed("ANY_SECRET"))
+    assertThatThrownBy(() -> filter.isAllowed(query("ANY_SECRET")))
         .isInstanceOf(SecretAllowListUnavailableException.class);
   }
 
@@ -195,7 +205,7 @@ class ConfigurableSecretFilterFactoryTest {
 
     var filter = factory.create(CONTEXT);
 
-    assertThatThrownBy(() -> filter.isAllowed("ANY_SECRET"))
+    assertThatThrownBy(() -> filter.isAllowed(query("ANY_SECRET")))
         .hasMessageContaining(ELEMENT_ID)
         .hasMessageContaining(String.valueOf(PROCESS_DEF_KEY))
         .hasMessageContaining(RuntimeException.class.getName())

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/job/LazyLoadingSecretFilterTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/job/LazyLoadingSecretFilterTest.java
@@ -17,35 +17,88 @@
 package io.camunda.connector.runtime.outbound.job;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import io.camunda.connector.runtime.core.secret.SecretFilter.Secret;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.Test;
 
 class LazyLoadingSecretFilterTest {
 
+  private static Secret secret(String name) {
+    return new Secret(name, List.of());
+  }
+
+  private static Secret query(String name) {
+    return new Secret(name, List.of("field"));
+  }
+
+  private static Secret at(String name, String... fieldPath) {
+    return new Secret(name, List.of(fieldPath));
+  }
+
   @Test
   void isAllowed_withAllowList_permitsListedSecret() {
-    var filter = new LazyLoadingSecretFilter(() -> List.of("MY_SECRET", "OTHER_SECRET"));
+    var filter =
+        new LazyLoadingSecretFilter(() -> List.of(secret("MY_SECRET"), secret("OTHER_SECRET")));
 
-    assertTrue(filter.isAllowed("MY_SECRET"));
-    assertTrue(filter.isAllowed("OTHER_SECRET"));
+    assertTrue(filter.isAllowed(query("MY_SECRET")));
+    assertTrue(filter.isAllowed(query("OTHER_SECRET")));
   }
 
   @Test
   void isAllowed_withAllowList_deniesUnlistedSecret() {
-    var filter = new LazyLoadingSecretFilter(() -> List.of("MY_SECRET"));
+    var filter = new LazyLoadingSecretFilter(() -> List.of(secret("MY_SECRET")));
 
-    assertFalse(filter.isAllowed("UNLISTED_SECRET"));
+    assertFalse(filter.isAllowed(query("UNLISTED_SECRET")));
+  }
+
+  @Test
+  void isAllowed_permitsRuntimePathNestedDeeperThanDeclaredPath() {
+    // The declared path is derived statically from the zeebe:input target (e.g. "foo"), but a FEEL
+    // context/object expression can put the resolved value under a subpath of that at runtime (e.g.
+    // "foo.bar"). The declared path only has to be a prefix of the runtime path, not an exact
+    // match,
+    // or every input that expands into a nested object would spuriously get its secrets rejected.
+    var filter = new LazyLoadingSecretFilter(() -> List.of(at("TOKEN", "foo")));
+
+    assertTrue(filter.isAllowed(at("TOKEN", "foo", "bar")));
+  }
+
+  @Test
+  void isAllowed_permitsExactRuntimePathMatch() {
+    var filter = new LazyLoadingSecretFilter(() -> List.of(at("TOKEN", "foo", "bar")));
+
+    assertTrue(filter.isAllowed(at("TOKEN", "foo", "bar")));
+  }
+
+  @Test
+  void isAllowed_deniesRuntimePathShallowerThanDeclaredPath() {
+    // The reverse of the nesting case above: a secret statically declared at the deeper path
+    // "foo.bar" must not match a runtime lookup at the shallower "foo" — the declared path can only
+    // be a prefix of the runtime one, never the other way around.
+    var filter = new LazyLoadingSecretFilter(() -> List.of(at("TOKEN", "foo", "bar")));
+
+    assertFalse(filter.isAllowed(at("TOKEN", "foo")));
+  }
+
+  @Test
+  void isAllowed_deniesRuntimePathOnASiblingBranch() {
+    var filter = new LazyLoadingSecretFilter(() -> List.of(at("TOKEN", "foo")));
+
+    assertFalse(filter.isAllowed(at("TOKEN", "baz")));
+    assertFalse(filter.isAllowed(at("TOKEN", "baz", "bar")));
   }
 
   @Test
   void isAllowed_withNullSupplierResult_allowsAll() {
     var filter = new LazyLoadingSecretFilter(() -> null);
 
-    assertTrue(filter.isAllowed("ANY_SECRET"));
-    assertTrue(filter.isAllowed("ANOTHER_SECRET"));
+    assertTrue(filter.isAllowed(query("ANY_SECRET")));
+    assertTrue(filter.isAllowed(query("ANOTHER_SECRET")));
   }
 
   @Test
@@ -55,12 +108,12 @@ class LazyLoadingSecretFilterTest {
         new LazyLoadingSecretFilter(
             () -> {
               callCount.incrementAndGet();
-              return List.of("SECRET");
+              return List.of(secret("SECRET"));
             });
 
-    filter.isAllowed("SECRET");
-    filter.isAllowed("SECRET");
-    filter.isAllowed("OTHER");
+    filter.isAllowed(query("SECRET"));
+    filter.isAllowed(query("SECRET"));
+    filter.isAllowed(query("OTHER"));
 
     assertTrue(callCount.get() == 1, "Supplier must be called exactly once");
   }
@@ -75,9 +128,30 @@ class LazyLoadingSecretFilterTest {
               return null;
             });
 
-    filter.isAllowed("ANY");
-    filter.isAllowed("ANY");
+    filter.isAllowed(query("ANY"));
+    filter.isAllowed(query("ANY"));
 
     assertTrue(callCount.get() == 1, "Supplier must be called exactly once even when null");
+  }
+
+  @Test
+  void isAllowed_supplierFailureCached_supplierNotReinvoked() {
+    var callCount = new AtomicInteger(0);
+    var failure = new IllegalStateException("secret key lookup failed");
+    var filter =
+        new LazyLoadingSecretFilter(
+            () -> {
+              callCount.incrementAndGet();
+              throw failure;
+            });
+
+    var firstThrown =
+        assertThrows(IllegalStateException.class, () -> filter.isAllowed(query("ANY")));
+    var secondThrown =
+        assertThrows(IllegalStateException.class, () -> filter.isAllowed(query("ANY")));
+
+    assertTrue(callCount.get() == 1, "Supplier must be called exactly once even on failure");
+    assertSame(failure, firstThrown);
+    assertSame(failure, secondThrown);
   }
 }

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/job/OutboundConnectorExceptionHandlerTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/job/OutboundConnectorExceptionHandlerTest.java
@@ -25,11 +25,14 @@ import static org.mockito.Mockito.when;
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.read.ListAppender;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.camunda.client.api.response.ActivatedJob;
 import io.camunda.connector.api.error.ConnectorException;
 import io.camunda.connector.api.secret.SecretProvider;
 import io.camunda.connector.runtime.core.outbound.ConnectorResult;
 import io.camunda.connector.runtime.core.secret.SecretFilter;
+import io.camunda.connector.runtime.core.secret.SecretFilter.Secret;
 import io.camunda.connector.runtime.core.secret.SecretNotAvailableException;
 import io.camunda.connector.runtime.secret.FooBarSecretProvider;
 import java.time.Duration;
@@ -46,6 +49,8 @@ import org.slf4j.LoggerFactory;
 
 class OutboundConnectorExceptionHandlerTest {
 
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
   private final OutboundConnectorExceptionHandler handler =
       new OutboundConnectorExceptionHandler(new FooBarSecretProvider());
 
@@ -61,10 +66,19 @@ class OutboundConnectorExceptionHandlerTest {
   private static ActivatedJob jobNaming(String variables) {
     var job = mock(ActivatedJob.class);
     when(job.getVariables()).thenReturn(variables);
+    when(job.getVariablesAsType(ObjectNode.class)).thenReturn(readTree(variables));
     when(job.getKey()).thenReturn(1L);
     when(job.getTenantId()).thenReturn("tenant");
     when(job.getRetries()).thenReturn(3);
     return job;
+  }
+
+  private static ObjectNode readTree(String json) {
+    try {
+      return (ObjectNode) OBJECT_MAPPER.readTree(json);
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
   }
 
   /**
@@ -334,7 +348,7 @@ class OutboundConnectorExceptionHandlerTest {
 
     var result =
         handlerOverStore.manageConnectorJobHandlerException(
-            new SecretNotAvailableException("BAR"),
+            new SecretNotAvailableException(new Secret("BAR", List.of("b"))),
             job,
             Duration.ofSeconds(1),
             SecretFilter.allowAll(),
@@ -359,6 +373,30 @@ class OutboundConnectorExceptionHandlerTest {
             List.of());
 
     assertThat(result.exception().getMessage()).isEqualTo("api rejected *** and ***");
+  }
+
+  @Test
+  void aSecretOccurringAtSeveralPathsIsLookedUpOnlyOnce() {
+    // Secret now carries fieldPath, so TOKEN at three different paths is three distinct Secret
+    // values; the re-read must still collapse them into a single provider lookup by name rather
+    // than fetching the same secret once per path it occurs at.
+    var job =
+        jobNaming(
+            "{\"a\": \"{{secrets.TOKEN}}\", \"b\": \"{{secrets.TOKEN}}\", \"c\":"
+                + " \"{{secrets.TOKEN}}\"}");
+    when(job.getRetries()).thenReturn(3);
+    holdingOnly(Map.of("TOKEN", "token-value"));
+
+    var result =
+        handlerOverStore.manageConnectorJobHandlerException(
+            new RuntimeException("api rejected token-value everywhere"),
+            job,
+            Duration.ofSeconds(1),
+            SecretFilter.allowAll(),
+            List.of());
+
+    assertThat(requestedKeys).containsExactly("TOKEN");
+    assertThat(result.exception().getMessage()).isEqualTo("api rejected *** everywhere");
   }
 
   @Test

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/job/SpringConnectorJobHandlerTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/job/SpringConnectorJobHandlerTest.java
@@ -953,7 +953,7 @@ class SpringConnectorJobHandlerTest {
       // when
       var result =
           JobBuilder.create()
-              .withVariables("{{secrets.FOO}}")
+              .withVariables("{ \"value\": \"{{secrets.FOO}}\" }")
               .executeAndCaptureResult(jobHandler, false);
 
       // then
@@ -974,7 +974,7 @@ class SpringConnectorJobHandlerTest {
       // when
       var result =
           JobBuilder.create()
-              .withVariables("{ \"integer\" : {{secrets.FOO}} }")
+              .withVariables("{ \"integer\" : \"{{secrets.FOO}}\" }")
               .executeAndCaptureResult(jobHandler, false);
 
       // then
@@ -995,7 +995,7 @@ class SpringConnectorJobHandlerTest {
       // when
       var result =
           JobBuilder.create()
-              .withVariables("{ \"integer\" : {{secrets.FOO}} }")
+              .withVariables("{ \"integer\" : \"{{secrets.FOO}}\" }")
               .executeAndCaptureResult(jobHandler, false);
 
       // then

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/secret/ProcessDefinitionSecretKeyCacheTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/secret/ProcessDefinitionSecretKeyCacheTest.java
@@ -23,9 +23,11 @@ import static org.mockito.Mockito.when;
 
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.fetch.ProcessDefinitionGetXmlRequest;
+import io.camunda.connector.runtime.core.secret.SecretFilter.Secret;
 import io.camunda.connector.runtime.outbound.secret.SecretKeyCache.SecretKeyContext;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.List;
 import java.util.concurrent.Callable;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -64,7 +66,223 @@ class ProcessDefinitionSecretKeyCacheTest {
     var keys =
         secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1"));
 
-    assertThat(keys).containsExactlyInAnyOrder("API_KEY", "MY_TOKEN");
+    assertThat(keys)
+        .extracting(Secret::secretName)
+        .containsExactlyInAnyOrder("API_KEY", "MY_TOKEN");
+  }
+
+  @Test
+  void getSecretKeys_dottedTarget_splitsIntoAMultiSegmentFieldPath() throws IOException {
+    // Projecting away fieldPath (as every other assertion in this class does, via
+    // Secret::secretName) would let a regression that assigns every secret an empty or wrong
+    // path pass unnoticed — this asserts the complete Secret, name and path together, against a
+    // target with more than one segment.
+    when(xmlRequest.execute()).thenReturn(loadBpmn("outbound-with-dotted-target.bpmn"));
+
+    var keys =
+        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1"));
+
+    assertThat(keys).containsExactly(new Secret("API_KEY", List.of("auth", "token")));
+  }
+
+  @Test
+  void getSecretKeys_secretPropagatesToAnInputThatReferencesTheDeclaringInputsVariable()
+      throws IOException {
+    // baseUrl declares BASE_URL_SFDC; url is a FEEL expression built from baseUrl and path
+    // ("=baseUrl + \"/services/apexrest/\" + path"). url's runtime value can carry the secret's
+    // resolved text just as directly as baseUrl's can, so the secret must be allowed under url's
+    // own field path too -- not just under baseUrl's.
+    when(xmlRequest.execute()).thenReturn(loadBpmn("outbound-with-referenced-variable.bpmn"));
+
+    var keys =
+        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1"));
+
+    assertThat(keys)
+        .contains(
+            new Secret("BASE_URL_SFDC", List.of("baseUrl")),
+            new Secret("BASE_URL_SFDC", List.of("url")));
+  }
+
+  @Test
+  void getSecretKeys_propagatesTransitivelyThroughAChainOfReferences() throws IOException {
+    // innerBaseUrl declares INNER_SECRET; baseUrl = "=innerBaseUrl + \"/static-context\""
+    // references innerBaseUrl; url = "=baseUrl" references baseUrl, not innerBaseUrl directly.
+    // The secret has to reach url through two hops of the dependency chain, not just one.
+    when(xmlRequest.execute()).thenReturn(loadBpmn("outbound-with-chained-references.bpmn"));
+
+    var keys =
+        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1"));
+
+    assertThat(keys)
+        .containsExactlyInAnyOrder(
+            new Secret("INNER_SECRET", List.of("innerBaseUrl")),
+            new Secret("INNER_SECRET", List.of("baseUrl")),
+            new Secret("INNER_SECRET", List.of("url")));
+  }
+
+  @Test
+  void getSecretKeys_propagationDoesNotReachAnInputThatDoesNotReferenceTheDeclaringVariable()
+      throws IOException {
+    // method ("get") and connectionTimeoutInSeconds ("20") are unrelated static inputs on the same
+    // element -- propagation must not leak the secret onto every sibling input, only onto ones
+    // whose own expression actually reads the variable that carries it.
+    when(xmlRequest.execute()).thenReturn(loadBpmn("outbound-with-referenced-variable.bpmn"));
+
+    var keys =
+        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1"));
+
+    assertThat(keys)
+        .doesNotContain(
+            new Secret("BASE_URL_SFDC", List.of("method")),
+            new Secret("BASE_URL_SFDC", List.of("connectionTimeoutInSeconds")),
+            new Secret("BASE_URL_SFDC", List.of("path")),
+            new Secret("BASE_URL_SFDC", List.of("authentication", "type")));
+  }
+
+  @Test
+  void getSecretKeys_referenceToASiblingFieldDoesNotPropagateASiblingsSecret() throws IOException {
+    // authentication.token and authentication.type are siblings that merely share a top-level
+    // target segment. usesSiblingFieldOnly references authentication.type specifically, not the
+    // whole authentication object, so it must not inherit AUTH_TOKEN from its sibling field.
+    // usesWholeAuth, by reading the whole authentication object, legitimately picks it up.
+    when(xmlRequest.execute()).thenReturn(loadBpmn("outbound-with-sibling-fields.bpmn"));
+
+    var keys =
+        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1"));
+
+    assertThat(keys)
+        .contains(
+            new Secret("AUTH_TOKEN", List.of("authentication", "token")),
+            new Secret("AUTH_TOKEN", List.of("usesWholeAuth")))
+        .doesNotContain(
+            new Secret("AUTH_TOKEN", List.of("usesSiblingFieldOnly")),
+            new Secret("AUTH_TOKEN", List.of("authentication", "type")));
+  }
+
+  @Test
+  void getSecretKeys_referenceToAVariableDefinedLaterDoesNotPropagateItsSecret()
+      throws IOException {
+    // url ("=baseUrl") is declared before baseUrl ("secrets.API_KEY") in the same ioMapping.
+    // zeebe:input mappings evaluate in declaration order, each against the output the ones before
+    // it already built, so url's expression sees the process-scope baseUrl, not this mapping's
+    // own -- API_KEY must not be allowed on url.
+    when(xmlRequest.execute()).thenReturn(loadBpmn("outbound-with-reverse-order-reference.bpmn"));
+
+    var keys =
+        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1"));
+
+    assertThat(keys)
+        .contains(new Secret("API_KEY", List.of("baseUrl")))
+        .doesNotContain(new Secret("API_KEY", List.of("url")));
+  }
+
+  @Test
+  void getSecretKeys_laterParentOverwriteInvalidatesAnEarlierDescendantWriter() throws IOException {
+    // authentication.token = secrets.TOKEN is declared first, then authentication (the whole
+    // parent object) is overwritten wholesale, replacing that field's secret-bearing value. url
+    // references authentication.token afterwards, but by then the token write is shadowed by
+    // the parent overwrite -- TOKEN must not be allowed on url, nor on its own now-overwritten
+    // path: the runtime field at authentication.token holds whatever the parent overwrite put
+    // there, not the secret, so granting TOKEN there would let that overwritten (potentially
+    // attacker-controlled) value resolve a secret it never carried.
+    when(xmlRequest.execute()).thenReturn(loadBpmn("outbound-with-parent-overwrite.bpmn"));
+
+    var keys =
+        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1"));
+
+    // Nothing in this BPMN ever reads authentication.token from a path that's still effective, so
+    // TOKEN isn't just absent from the two paths above -- it's not granted anywhere at all. This
+    // is stricter than doesNotContain(...) on its own: it also catches a regression that grants
+    // TOKEN at some third path this test doesn't otherwise name.
+    assertThat(keys).isEmpty();
+  }
+
+  @Test
+  void getSecretKeys_laterWriteToTheSameExactPathInvalidatesTheEarlierWriter() throws IOException {
+    // Two inputs target the identical path authentication.token: the first carries TOKEN, the
+    // second overwrites it with a plain value. The runtime field holds only the second input's
+    // value, so TOKEN must not be granted at that path -- the earlier grant would otherwise let
+    // the overwriting (potentially attacker-controlled) value resolve a secret it never carried.
+    when(xmlRequest.execute()).thenReturn(loadBpmn("outbound-with-same-path-overwrite.bpmn"));
+
+    var keys =
+        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1"));
+
+    assertThat(keys).isEmpty();
+  }
+
+  @Test
+  void getSecretKeys_laterOverwriteOfAPropagationTargetInvalidatesThePropagatedGrant()
+      throws IOException {
+    // baseUrl = secrets.TOKEN is declared first; url = "=baseUrl" propagates TOKEN to url while
+    // baseUrl is still the effective writer url's expression reads. A third mapping then
+    // overwrites url directly with attacker-controlled data -- url's runtime value comes from that
+    // third mapping, not from the (no longer effective) propagation through the second, so TOKEN
+    // must not be granted at url even though the dependency edge to it was genuinely resolved at
+    // the time it was computed.
+    when(xmlRequest.execute())
+        .thenReturn(loadBpmn("outbound-with-overwritten-propagation-target.bpmn"));
+
+    var keys =
+        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1"));
+
+    assertThat(keys)
+        .containsExactly(new Secret("TOKEN", List.of("baseUrl")))
+        .doesNotContain(new Secret("TOKEN", List.of("url")));
+  }
+
+  @Test
+  void getSecretKeys_laterChildWriteRevokesTheAncestorGrant() throws IOException {
+    // authentication = secrets.WHOLE_SECRET is declared first; authentication.token is then
+    // written by a later mapping. A grant is a path prefix, so a grant at [authentication] also
+    // authorizes a lookup at authentication.token -- the field the later mapping controls. If that
+    // mapping's source were process data rather than the fixture's literal, a placeholder in it
+    // would resolve WHOLE_SECRET, a secret that value never carried. The whole grant therefore
+    // goes, at the parent's own path and at wholeObjectRead, which copies the object afterwards.
+    // Nothing is lost here: the child write replaces the parent's scalar with an object, so the
+    // secret's text is not present at runtime under authentication at all.
+    when(xmlRequest.execute()).thenReturn(loadBpmn("outbound-with-child-overwrite.bpmn"));
+
+    var keys =
+        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1"));
+
+    assertThat(keys).isEmpty();
+  }
+
+  @Test
+  void getSecretKeys_laterChildWriteRevokesAnAncestorGrantThatNestsItsSecretElsewhere()
+      throws IOException {
+    // The fail-closed half of the rule above, pinned deliberately. Here the parent's own FEEL
+    // object nests USER at authentication.user, which the later authentication.token write does
+    // not touch -- so the grant is legitimate for that one field and only over-broad for the
+    // shadowed sibling. A prefix cannot express "under authentication except .token", so the
+    // grant is dropped rather than narrowed, and USER stops resolving on this element. Accepted
+    // over-denial: the alternative is authorizing the secret at a field a later mapping fills
+    // from process data.
+    when(xmlRequest.execute())
+        .thenReturn(loadBpmn("outbound-with-nested-parent-and-child-overwrite.bpmn"));
+
+    var keys =
+        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1"));
+
+    assertThat(keys).isEmpty();
+  }
+
+  @Test
+  void getSecretKeys_shadowedInputDoesNotRelayItsOwnDependenciesSecret() throws IOException {
+    // The shadowed input is itself a dependent here: baseUrl carries T, authentication reads
+    // baseUrl, authentication.token is then written from process data, and copy reads the whole
+    // authentication object. Muting only the shadowed input's *own* names is not enough -- the
+    // walk would keep traversing through it and reach baseUrl, granting T at copy, which
+    // prefix-matches copy.token, the field that carries the shadowed subtree's attacker data.
+    // A shadowed input terminates the branch instead.
+    when(xmlRequest.execute())
+        .thenReturn(loadBpmn("outbound-with-shadowed-input-as-dependency.bpmn"));
+
+    var keys =
+        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1"));
+
+    assertThat(keys).containsExactly(new Secret("T", List.of("baseUrl")));
   }
 
   @Test
@@ -76,8 +294,10 @@ class ProcessDefinitionSecretKeyCacheTest {
         secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "task-alpha"));
     var betaKeys = secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "task-beta"));
 
-    assertThat(alphaKeys).containsExactly("SECRET_ALPHA");
-    assertThat(betaKeys).containsExactlyInAnyOrder("SECRET_BETA", "SECRET_GAMMA");
+    assertThat(alphaKeys).extracting(Secret::secretName).containsExactly("SECRET_ALPHA");
+    assertThat(betaKeys)
+        .extracting(Secret::secretName)
+        .containsExactlyInAnyOrder("SECRET_BETA", "SECRET_GAMMA");
   }
 
   @Test
@@ -98,7 +318,7 @@ class ProcessDefinitionSecretKeyCacheTest {
 
     var keys = secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "plain-task"));
 
-    assertThat(keys).containsExactly("SECRET_X");
+    assertThat(keys).extracting(Secret::secretName).containsExactly("SECRET_X");
   }
 
   @Test
@@ -110,8 +330,8 @@ class ProcessDefinitionSecretKeyCacheTest {
     var childKeys =
         secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "child-task"));
 
-    assertThat(subProcessKeys).containsExactly("ADHOC_SECRET");
-    assertThat(childKeys).containsExactly("CHILD_SECRET");
+    assertThat(subProcessKeys).extracting(Secret::secretName).containsExactly("ADHOC_SECRET");
+    assertThat(childKeys).extracting(Secret::secretName).containsExactly("CHILD_SECRET");
   }
 
   @Test
@@ -128,9 +348,9 @@ class ProcessDefinitionSecretKeyCacheTest {
     var grandchildKeys =
         secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "grandchild-task"));
 
-    assertThat(outerKeys).containsExactly("OUTER_SECRET");
-    assertThat(innerKeys).containsExactly("INNER_SECRET");
-    assertThat(grandchildKeys).containsExactly("GRANDCHILD_SECRET");
+    assertThat(outerKeys).extracting(Secret::secretName).containsExactly("OUTER_SECRET");
+    assertThat(innerKeys).extracting(Secret::secretName).containsExactly("INNER_SECRET");
+    assertThat(grandchildKeys).extracting(Secret::secretName).containsExactly("GRANDCHILD_SECRET");
   }
 
   @Test
@@ -143,8 +363,8 @@ class ProcessDefinitionSecretKeyCacheTest {
     var endEventKeys =
         secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "send-message-end"));
 
-    assertThat(throwEventKeys).containsExactly("THROW_EVENT_SECRET");
-    assertThat(endEventKeys).containsExactly("END_EVENT_SECRET");
+    assertThat(throwEventKeys).extracting(Secret::secretName).containsExactly("THROW_EVENT_SECRET");
+    assertThat(endEventKeys).extracting(Secret::secretName).containsExactly("END_EVENT_SECRET");
   }
 
   @Test

--- a/connector-runtime/connector-runtime-spring/src/test/resources/bpmn/outbound-with-chained-references.bpmn
+++ b/connector-runtime/connector-runtime-spring/src/test/resources/bpmn/outbound-with-chained-references.bpmn
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+                  xmlns:zeebe="http://camunda.org/schema/zeebe/1.0"
+                  id="Definitions_outbound_chained_references"
+                  targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="outbound-with-chained-references" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_1" sourceRef="StartEvent_1" targetRef="service-task-1"/>
+    <bpmn:serviceTask id="service-task-1" name="HTTP Task"
+                      zeebe:modelerTemplate="io.camunda.connectors.HttpJson.v2">
+      <bpmn:extensionElements>
+        <zeebe:ioMapping>
+          <zeebe:input source="secrets.INNER_SECRET" target="innerBaseUrl"/>
+          <zeebe:input source="=innerBaseUrl + &quot;/static-context&quot;" target="baseUrl"/>
+          <zeebe:input source="=baseUrl" target="url"/>
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1</bpmn:incoming>
+      <bpmn:outgoing>Flow_2</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="Flow_2" sourceRef="service-task-1" targetRef="EndEvent_1"/>
+    <bpmn:endEvent id="EndEvent_1">
+      <bpmn:incoming>Flow_2</bpmn:incoming>
+    </bpmn:endEvent>
+  </bpmn:process>
+</bpmn:definitions>

--- a/connector-runtime/connector-runtime-spring/src/test/resources/bpmn/outbound-with-child-overwrite.bpmn
+++ b/connector-runtime/connector-runtime-spring/src/test/resources/bpmn/outbound-with-child-overwrite.bpmn
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+                  xmlns:zeebe="http://camunda.org/schema/zeebe/1.0"
+                  id="Definitions_outbound_child_overwrite"
+                  targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="outbound-with-child-overwrite" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_1" sourceRef="StartEvent_1" targetRef="service-task-1"/>
+    <bpmn:serviceTask id="service-task-1" name="HTTP Task"
+                      zeebe:modelerTemplate="io.camunda.connectors.HttpJson.v2">
+      <bpmn:extensionElements>
+        <zeebe:ioMapping>
+          <zeebe:input source="secrets.WHOLE_SECRET" target="authentication"/>
+          <zeebe:input source="public-value" target="authentication.token"/>
+          <zeebe:input source="=authentication.token" target="url"/>
+          <zeebe:input source="=authentication" target="wholeObjectRead"/>
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1</bpmn:incoming>
+      <bpmn:outgoing>Flow_2</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="Flow_2" sourceRef="service-task-1" targetRef="EndEvent_1"/>
+    <bpmn:endEvent id="EndEvent_1">
+      <bpmn:incoming>Flow_2</bpmn:incoming>
+    </bpmn:endEvent>
+  </bpmn:process>
+</bpmn:definitions>

--- a/connector-runtime/connector-runtime-spring/src/test/resources/bpmn/outbound-with-dotted-target.bpmn
+++ b/connector-runtime/connector-runtime-spring/src/test/resources/bpmn/outbound-with-dotted-target.bpmn
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+                  xmlns:zeebe="http://camunda.org/schema/zeebe/1.0"
+                  id="Definitions_outbound_dotted_target"
+                  targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="outbound-with-dotted-target" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_1" sourceRef="StartEvent_1" targetRef="service-task-1"/>
+    <bpmn:serviceTask id="service-task-1" name="HTTP Task"
+                      zeebe:modelerTemplate="io.camunda.connectors.HttpJson.v2">
+      <bpmn:extensionElements>
+        <zeebe:ioMapping>
+          <zeebe:input source="secrets.API_KEY" target="auth.token"/>
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1</bpmn:incoming>
+      <bpmn:outgoing>Flow_2</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="Flow_2" sourceRef="service-task-1" targetRef="EndEvent_1"/>
+    <bpmn:endEvent id="EndEvent_1">
+      <bpmn:incoming>Flow_2</bpmn:incoming>
+    </bpmn:endEvent>
+  </bpmn:process>
+</bpmn:definitions>

--- a/connector-runtime/connector-runtime-spring/src/test/resources/bpmn/outbound-with-nested-parent-and-child-overwrite.bpmn
+++ b/connector-runtime/connector-runtime-spring/src/test/resources/bpmn/outbound-with-nested-parent-and-child-overwrite.bpmn
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+                  xmlns:zeebe="http://camunda.org/schema/zeebe/1.0"
+                  id="Definitions_outbound_nested_parent_child_overwrite"
+                  targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="outbound-with-nested-parent-and-child-overwrite" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_1" sourceRef="StartEvent_1" targetRef="service-task-1"/>
+    <bpmn:serviceTask id="service-task-1" name="HTTP Task"
+                      zeebe:modelerTemplate="io.camunda.connectors.HttpJson.v2">
+      <bpmn:extensionElements>
+        <zeebe:ioMapping>
+          <zeebe:input source="={ user: &quot;{{secrets.USER}}&quot; }" target="authentication"/>
+          <zeebe:input source="=attackerVar" target="authentication.token"/>
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1</bpmn:incoming>
+      <bpmn:outgoing>Flow_2</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="Flow_2" sourceRef="service-task-1" targetRef="EndEvent_1"/>
+    <bpmn:endEvent id="EndEvent_1">
+      <bpmn:incoming>Flow_2</bpmn:incoming>
+    </bpmn:endEvent>
+  </bpmn:process>
+</bpmn:definitions>

--- a/connector-runtime/connector-runtime-spring/src/test/resources/bpmn/outbound-with-overwritten-propagation-target.bpmn
+++ b/connector-runtime/connector-runtime-spring/src/test/resources/bpmn/outbound-with-overwritten-propagation-target.bpmn
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+                  xmlns:zeebe="http://camunda.org/schema/zeebe/1.0"
+                  id="Definitions_outbound_overwritten_propagation_target"
+                  targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="outbound-with-overwritten-propagation-target" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_1" sourceRef="StartEvent_1" targetRef="service-task-1"/>
+    <bpmn:serviceTask id="service-task-1" name="HTTP Task"
+                      zeebe:modelerTemplate="io.camunda.connectors.HttpJson.v2">
+      <bpmn:extensionElements>
+        <zeebe:ioMapping>
+          <zeebe:input source="secrets.TOKEN" target="baseUrl"/>
+          <zeebe:input source="=baseUrl" target="url"/>
+          <zeebe:input source="attackerVar" target="url"/>
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1</bpmn:incoming>
+      <bpmn:outgoing>Flow_2</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="Flow_2" sourceRef="service-task-1" targetRef="EndEvent_1"/>
+    <bpmn:endEvent id="EndEvent_1">
+      <bpmn:incoming>Flow_2</bpmn:incoming>
+    </bpmn:endEvent>
+  </bpmn:process>
+</bpmn:definitions>

--- a/connector-runtime/connector-runtime-spring/src/test/resources/bpmn/outbound-with-parent-overwrite.bpmn
+++ b/connector-runtime/connector-runtime-spring/src/test/resources/bpmn/outbound-with-parent-overwrite.bpmn
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+                  xmlns:zeebe="http://camunda.org/schema/zeebe/1.0"
+                  id="Definitions_outbound_parent_overwrite"
+                  targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="outbound-with-parent-overwrite" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_1" sourceRef="StartEvent_1" targetRef="service-task-1"/>
+    <bpmn:serviceTask id="service-task-1" name="HTTP Task"
+                      zeebe:modelerTemplate="io.camunda.connectors.HttpJson.v2">
+      <bpmn:extensionElements>
+        <zeebe:ioMapping>
+          <zeebe:input source="secrets.TOKEN" target="authentication.token"/>
+          <zeebe:input source="={token: &quot;public&quot;}" target="authentication"/>
+          <zeebe:input source="=authentication.token" target="url"/>
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1</bpmn:incoming>
+      <bpmn:outgoing>Flow_2</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="Flow_2" sourceRef="service-task-1" targetRef="EndEvent_1"/>
+    <bpmn:endEvent id="EndEvent_1">
+      <bpmn:incoming>Flow_2</bpmn:incoming>
+    </bpmn:endEvent>
+  </bpmn:process>
+</bpmn:definitions>

--- a/connector-runtime/connector-runtime-spring/src/test/resources/bpmn/outbound-with-referenced-variable.bpmn
+++ b/connector-runtime/connector-runtime-spring/src/test/resources/bpmn/outbound-with-referenced-variable.bpmn
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+                  xmlns:zeebe="http://camunda.org/schema/zeebe/1.0"
+                  id="Definitions_outbound_referenced_variable"
+                  targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="outbound-with-referenced-variable" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_1" sourceRef="StartEvent_1" targetRef="service-task-1"/>
+    <bpmn:serviceTask id="service-task-1" name="Salesforce Task"
+                      zeebe:modelerTemplate="io.camunda.connectors.SalesforceApexRest.v1">
+      <bpmn:extensionElements>
+        <zeebe:ioMapping>
+          <zeebe:input source="{{secrets.BASE_URL_SFDC}}" target="baseUrl"/>
+          <zeebe:input target="authentication.type"/>
+          <zeebe:input source="apexRest" target="salesforceInteractionType"/>
+          <zeebe:input source="get" target="method"/>
+          <zeebe:input target="path"/>
+          <zeebe:input source="=baseUrl + &quot;/services/apexrest/&quot; + path" target="url"/>
+          <zeebe:input source="20" target="connectionTimeoutInSeconds"/>
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1</bpmn:incoming>
+      <bpmn:outgoing>Flow_2</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="Flow_2" sourceRef="service-task-1" targetRef="EndEvent_1"/>
+    <bpmn:endEvent id="EndEvent_1">
+      <bpmn:incoming>Flow_2</bpmn:incoming>
+    </bpmn:endEvent>
+  </bpmn:process>
+</bpmn:definitions>

--- a/connector-runtime/connector-runtime-spring/src/test/resources/bpmn/outbound-with-reverse-order-reference.bpmn
+++ b/connector-runtime/connector-runtime-spring/src/test/resources/bpmn/outbound-with-reverse-order-reference.bpmn
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+                  xmlns:zeebe="http://camunda.org/schema/zeebe/1.0"
+                  id="Definitions_outbound_reverse_order_reference"
+                  targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="outbound-with-reverse-order-reference" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_1" sourceRef="StartEvent_1" targetRef="service-task-1"/>
+    <bpmn:serviceTask id="service-task-1" name="HTTP Task"
+                      zeebe:modelerTemplate="io.camunda.connectors.HttpJson.v2">
+      <bpmn:extensionElements>
+        <zeebe:ioMapping>
+          <zeebe:input source="=baseUrl" target="url"/>
+          <zeebe:input source="secrets.API_KEY" target="baseUrl"/>
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1</bpmn:incoming>
+      <bpmn:outgoing>Flow_2</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="Flow_2" sourceRef="service-task-1" targetRef="EndEvent_1"/>
+    <bpmn:endEvent id="EndEvent_1">
+      <bpmn:incoming>Flow_2</bpmn:incoming>
+    </bpmn:endEvent>
+  </bpmn:process>
+</bpmn:definitions>

--- a/connector-runtime/connector-runtime-spring/src/test/resources/bpmn/outbound-with-same-path-overwrite.bpmn
+++ b/connector-runtime/connector-runtime-spring/src/test/resources/bpmn/outbound-with-same-path-overwrite.bpmn
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+                  xmlns:zeebe="http://camunda.org/schema/zeebe/1.0"
+                  id="Definitions_outbound_same_path_overwrite"
+                  targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="outbound-with-same-path-overwrite" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_1" sourceRef="StartEvent_1" targetRef="service-task-1"/>
+    <bpmn:serviceTask id="service-task-1" name="HTTP Task"
+                      zeebe:modelerTemplate="io.camunda.connectors.HttpJson.v2">
+      <bpmn:extensionElements>
+        <zeebe:ioMapping>
+          <zeebe:input source="secrets.TOKEN" target="authentication.token"/>
+          <zeebe:input source="public-value" target="authentication.token"/>
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1</bpmn:incoming>
+      <bpmn:outgoing>Flow_2</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="Flow_2" sourceRef="service-task-1" targetRef="EndEvent_1"/>
+    <bpmn:endEvent id="EndEvent_1">
+      <bpmn:incoming>Flow_2</bpmn:incoming>
+    </bpmn:endEvent>
+  </bpmn:process>
+</bpmn:definitions>

--- a/connector-runtime/connector-runtime-spring/src/test/resources/bpmn/outbound-with-shadowed-input-as-dependency.bpmn
+++ b/connector-runtime/connector-runtime-spring/src/test/resources/bpmn/outbound-with-shadowed-input-as-dependency.bpmn
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+                  xmlns:zeebe="http://camunda.org/schema/zeebe/1.0"
+                  id="Definitions_outbound_shadowed_input_as_dependency"
+                  targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="outbound-with-shadowed-input-as-dependency" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_1" sourceRef="StartEvent_1" targetRef="service-task-1"/>
+    <bpmn:serviceTask id="service-task-1" name="HTTP Task"
+                      zeebe:modelerTemplate="io.camunda.connectors.HttpJson.v2">
+      <bpmn:extensionElements>
+        <zeebe:ioMapping>
+          <zeebe:input source="secrets.T" target="baseUrl"/>
+          <zeebe:input source="=baseUrl" target="authentication"/>
+          <zeebe:input source="=attackerVar" target="authentication.token"/>
+          <zeebe:input source="=authentication" target="copy"/>
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1</bpmn:incoming>
+      <bpmn:outgoing>Flow_2</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="Flow_2" sourceRef="service-task-1" targetRef="EndEvent_1"/>
+    <bpmn:endEvent id="EndEvent_1">
+      <bpmn:incoming>Flow_2</bpmn:incoming>
+    </bpmn:endEvent>
+  </bpmn:process>
+</bpmn:definitions>

--- a/connector-runtime/connector-runtime-spring/src/test/resources/bpmn/outbound-with-sibling-fields.bpmn
+++ b/connector-runtime/connector-runtime-spring/src/test/resources/bpmn/outbound-with-sibling-fields.bpmn
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+                  xmlns:zeebe="http://camunda.org/schema/zeebe/1.0"
+                  id="Definitions_outbound_sibling_fields"
+                  targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="outbound-with-sibling-fields" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_1" sourceRef="StartEvent_1" targetRef="service-task-1"/>
+    <bpmn:serviceTask id="service-task-1" name="HTTP Task"
+                      zeebe:modelerTemplate="io.camunda.connectors.HttpJson.v2">
+      <bpmn:extensionElements>
+        <zeebe:ioMapping>
+          <zeebe:input source="secrets.AUTH_TOKEN" target="authentication.token"/>
+          <zeebe:input source="bearer" target="authentication.type"/>
+          <zeebe:input source="=authentication" target="usesWholeAuth"/>
+          <zeebe:input source="=authentication.type" target="usesSiblingFieldOnly"/>
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1</bpmn:incoming>
+      <bpmn:outgoing>Flow_2</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="Flow_2" sourceRef="service-task-1" targetRef="EndEvent_1"/>
+    <bpmn:endEvent id="EndEvent_1">
+      <bpmn:incoming>Flow_2</bpmn:incoming>
+    </bpmn:endEvent>
+  </bpmn:process>
+</bpmn:definitions>

--- a/connector-runtime/connector-runtime-test/src/main/java/io/camunda/connector/runtime/test/inbound/InboundConnectorContextBuilder.java
+++ b/connector-runtime/connector-runtime-test/src/main/java/io/camunda/connector/runtime/test/inbound/InboundConnectorContextBuilder.java
@@ -18,6 +18,7 @@ package io.camunda.connector.runtime.test.inbound;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.connector.api.document.Document;
 import io.camunda.connector.api.document.DocumentCreationRequest;
@@ -245,7 +246,7 @@ public class InboundConnectorContextBuilder {
       implements InboundConnectorContext, InboundConnectorManagementContext {
 
     private final List<Object> correlatedEvents = new ArrayList<>();
-    private final String propertiesWithSecrets;
+    private final JsonNode propertiesWithSecrets;
     private final CorrelationResult result;
     private final Long activationTimestamp;
     private Health health = Health.unknown();
@@ -257,12 +258,10 @@ public class InboundConnectorContextBuilder {
       super(secretProvider, SecretFilter.allowAll(), validationProvider);
       this.result = result;
       this.activationTimestamp = System.currentTimeMillis();
-      try {
-        propertiesWithSecrets =
-            getSecretHandler().replaceSecrets(objectMapper.writeValueAsString(properties), null);
-      } catch (JsonProcessingException e) {
-        throw new RuntimeException(e);
-      }
+      propertiesWithSecrets =
+          getSecretHandler()
+              .replaceSecrets(
+                  objectMapper.valueToTree(properties != null ? properties : Map.of()), null);
     }
 
     protected void correlate(Object variables) {
@@ -301,7 +300,7 @@ public class InboundConnectorContextBuilder {
     @Override
     public Map<String, Object> getProperties() {
       try {
-        return objectMapper.readValue(propertiesWithSecrets, new TypeReference<>() {});
+        return objectMapper.treeToValue(propertiesWithSecrets, new TypeReference<>() {});
       } catch (JsonProcessingException e) {
         throw new RuntimeException(e);
       }
@@ -310,7 +309,7 @@ public class InboundConnectorContextBuilder {
     @Override
     public <T> T bindProperties(Class<T> cls) {
       try {
-        var mappedObject = objectMapper.readValue(propertiesWithSecrets, cls);
+        var mappedObject = objectMapper.treeToValue(propertiesWithSecrets, cls);
         if (validationProvider != null) {
           getValidationProvider().validate(mappedObject);
         }

--- a/connector-runtime/connector-runtime-test/src/main/java/io/camunda/connector/runtime/test/outbound/OutboundConnectorContextBuilder.java
+++ b/connector-runtime/connector-runtime-test/src/main/java/io/camunda/connector/runtime/test/outbound/OutboundConnectorContextBuilder.java
@@ -16,8 +16,11 @@
  */
 package io.camunda.connector.runtime.test.outbound;
 
+import com.fasterxml.jackson.core.JsonGenerationException;
+import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.connector.api.document.Document;
 import io.camunda.connector.api.document.DocumentCreationRequest;
@@ -217,20 +220,43 @@ public class OutboundConnectorContextBuilder {
   public class TestConnectorContext extends AbstractConnectorContext
       implements OutboundConnectorContext {
 
-    private final String variablesWithSecrets;
+    private final JsonNode variablesWithSecrets;
 
     private final TestJobContext jobContext;
 
     protected TestConnectorContext(
         SecretProvider secretProvider, ValidationProvider validationProvider) {
       super(secretProvider, SecretFilter.allowAll(), validationProvider);
+      var asTree = objectMapper.valueToTree(variables != null ? variables : Map.of());
+      variablesWithSecrets = getSecretHandler().replaceSecrets(asTree, null);
+      this.jobContext =
+          new TestJobContext(() -> headers, () -> writeVariablesAsJson(variablesWithSecrets));
+    }
+
+    /**
+     * Mirrors {@code JobHandlerContext#writeJson}: plain-decimal output, falling back to scientific
+     * notation for a {@code BigDecimal} whose scale falls outside the ±9999 range Jackson accepts
+     * for plain output (e.g. {@code new BigDecimal("1e-10000")}).
+     */
+    private String writeVariablesAsJson(JsonNode node) {
       try {
-        var asString = objectMapper.writeValueAsString(variables);
-        variablesWithSecrets = getSecretHandler().replaceSecrets(asString, null);
+        return objectMapper
+            .writer()
+            .with(JsonGenerator.Feature.WRITE_BIGDECIMAL_AS_PLAIN)
+            .writeValueAsString(node);
+      } catch (JsonGenerationException e) {
+        return writeVariablesWithoutPlainDecimals(node);
       } catch (JsonProcessingException e) {
-        throw new RuntimeException(e);
+        throw new IllegalStateException("Failed to serialize variables: " + node, e);
       }
-      this.jobContext = new TestJobContext(() -> headers, () -> variablesWithSecrets);
+    }
+
+    private String writeVariablesWithoutPlainDecimals(JsonNode node) {
+      try {
+        return objectMapper.writeValueAsString(node);
+      } catch (JsonProcessingException e) {
+        throw new IllegalStateException("Failed to serialize variables: " + node, e);
+      }
     }
 
     @Override
@@ -241,7 +267,7 @@ public class OutboundConnectorContextBuilder {
     @Override
     public <T> T bindVariables(Class<T> cls) {
       try {
-        var mappedObject = objectMapper.readValue(variablesWithSecrets, cls);
+        var mappedObject = objectMapper.treeToValue(variablesWithSecrets, cls);
         if (validationProvider != null) {
           getValidationProvider().validate(mappedObject);
         }

--- a/connector-runtime/connector-runtime-test/src/test/java/io/camunda/connector/runtime/test/inbound/InboundConnectorContextBuilderTest.java
+++ b/connector-runtime/connector-runtime-test/src/test/java/io/camunda/connector/runtime/test/inbound/InboundConnectorContextBuilderTest.java
@@ -20,12 +20,20 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchException;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.camunda.connector.api.error.ConnectorInputException;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
 
 public class InboundConnectorContextBuilderTest {
+
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+  private static ObjectNode wrap(String value) {
+    return OBJECT_MAPPER.createObjectNode().put("value", value);
+  }
 
   @Test
   public void shouldProvidePropertiesAsString() {
@@ -79,15 +87,16 @@ public class InboundConnectorContextBuilderTest {
   public void shouldProvideSecret() {
     var context =
         InboundConnectorContextBuilder.create().properties("{}").secret("foo", "FOO").build();
-    var replaced = context.getSecretHandler().replaceSecrets("secrets.foo", null);
-    assertThat(replaced).isEqualTo("FOO");
+    var replaced = context.getSecretHandler().replaceSecrets(wrap("secrets.foo"), null);
+    assertThat(replaced.get("value").asText()).isEqualTo("FOO");
   }
 
   @Test
   public void shouldThrowOnMissingSecret() {
     var context =
         InboundConnectorContextBuilder.create().properties("{}").secret("x", "FOO").build();
-    Executable replacement = () -> context.getSecretHandler().replaceSecrets("secrets.foo", null);
+    Executable replacement =
+        () -> context.getSecretHandler().replaceSecrets(wrap("secrets.foo"), null);
     assertThrows(
         ConnectorInputException.class, replacement, "Secret with name 'foo' is not available");
   }
@@ -100,16 +109,16 @@ public class InboundConnectorContextBuilderTest {
             .secret("foo", "FOO")
             .secret("bar", "BAR")
             .build();
-    var replaced = context.getSecretHandler().replaceSecrets("secrets.foo secrets.bar", null);
-    assertThat(replaced).isEqualTo("FOO BAR");
+    var replaced = context.getSecretHandler().replaceSecrets(wrap("secrets.foo secrets.bar"), null);
+    assertThat(replaced.get("value").asText()).isEqualTo("FOO BAR");
   }
 
   @Test
   public void shouldProvideSecretWithParentheses() {
     var context =
         InboundConnectorContextBuilder.create().properties("{}").secret("foo", "FOO").build();
-    var replaced = context.getSecretHandler().replaceSecrets("{{secrets.foo}}", null);
-    assertThat(replaced).isEqualTo("FOO");
+    var replaced = context.getSecretHandler().replaceSecrets(wrap("{{secrets.foo}}"), null);
+    assertThat(replaced.get("value").asText()).isEqualTo("FOO");
   }
 
   @Test
@@ -121,8 +130,8 @@ public class InboundConnectorContextBuilderTest {
             .secret("bar", "BAR")
             .build();
     var replaced =
-        context.getSecretHandler().replaceSecrets("{{secrets.foo}} {{secrets.bar}}", null);
-    assertThat(replaced).isEqualTo("FOO BAR");
+        context.getSecretHandler().replaceSecrets(wrap("{{secrets.foo}} {{secrets.bar}}"), null);
+    assertThat(replaced.get("value").asText()).isEqualTo("FOO BAR");
   }
 
   private record TestRecord(String foo) {}

--- a/connector-runtime/connector-runtime-test/src/test/java/io/camunda/connector/runtime/test/outbound/OutboundConnectorContextBuilderTest.java
+++ b/connector-runtime/connector-runtime-test/src/test/java/io/camunda/connector/runtime/test/outbound/OutboundConnectorContextBuilderTest.java
@@ -20,6 +20,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchException;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.camunda.connector.api.error.ConnectorInputException;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
@@ -27,11 +29,36 @@ import org.junit.jupiter.api.function.Executable;
 
 public class OutboundConnectorContextBuilderTest {
 
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+  private static ObjectNode wrap(String value) {
+    return OBJECT_MAPPER.createObjectNode().put("value", value);
+  }
+
   @Test
   public void shouldProvideVariablesAsString() {
     var json = "{ \"foo\" : \"FOO\" }";
     var context = OutboundConnectorContextBuilder.create().variables(json).build();
     assertThat(context.getJobContext().getVariables()).isEqualTo("{\"foo\":\"FOO\"}");
+  }
+
+  @Test
+  public void getVariables_preservesDecimalText() {
+    var context =
+        OutboundConnectorContextBuilder.create()
+            .variables(Map.of("decimal", new java.math.BigDecimal("0.00000001")))
+            .build();
+    assertThat(context.getJobContext().getVariables()).contains("0.00000001");
+  }
+
+  @Test
+  public void getVariables_fallsBackToScientificNotationForOutOfRangeDecimalScale() {
+    // Jackson accepts plain output only for a BigDecimal scale within +-9999.
+    var context =
+        OutboundConnectorContextBuilder.create()
+            .variables(Map.of("decimal", new java.math.BigDecimal("1e-10000")))
+            .build();
+    assertThat(context.getJobContext().getVariables()).contains("1E-10000");
   }
 
   @Test
@@ -79,15 +106,16 @@ public class OutboundConnectorContextBuilderTest {
   public void shouldProvideSecret() {
     var context =
         OutboundConnectorContextBuilder.create().variables("{}").secret("foo", "FOO").build();
-    var replaced = context.getSecretHandler().replaceSecrets("secrets.foo", null);
-    assertThat(replaced).isEqualTo("FOO");
+    var replaced = context.getSecretHandler().replaceSecrets(wrap("secrets.foo"), null);
+    assertThat(replaced.get("value").asText()).isEqualTo("FOO");
   }
 
   @Test
   public void shouldThrowOnMissingSecret() {
     var context =
         OutboundConnectorContextBuilder.create().variables("{}").secret("x", "FOO").build();
-    Executable replacement = () -> context.getSecretHandler().replaceSecrets("secrets.foo", null);
+    Executable replacement =
+        () -> context.getSecretHandler().replaceSecrets(wrap("secrets.foo"), null);
     assertThrows(
         ConnectorInputException.class, replacement, "Secret with name 'foo' is not available");
   }
@@ -100,16 +128,16 @@ public class OutboundConnectorContextBuilderTest {
             .secret("foo", "FOO")
             .secret("bar", "BAR")
             .build();
-    var replaced = context.getSecretHandler().replaceSecrets("secrets.foo secrets.bar", null);
-    assertThat(replaced).isEqualTo("FOO BAR");
+    var replaced = context.getSecretHandler().replaceSecrets(wrap("secrets.foo secrets.bar"), null);
+    assertThat(replaced.get("value").asText()).isEqualTo("FOO BAR");
   }
 
   @Test
   public void shouldProvideSecretWithParentheses() {
     var context =
         OutboundConnectorContextBuilder.create().variables("{}").secret("foo", "FOO").build();
-    var replaced = context.getSecretHandler().replaceSecrets("{{secrets.foo}}", null);
-    assertThat(replaced).isEqualTo("FOO");
+    var replaced = context.getSecretHandler().replaceSecrets(wrap("{{secrets.foo}}"), null);
+    assertThat(replaced.get("value").asText()).isEqualTo("FOO");
   }
 
   @Test
@@ -121,8 +149,8 @@ public class OutboundConnectorContextBuilderTest {
             .secret("bar", "BAR")
             .build();
     var replaced =
-        context.getSecretHandler().replaceSecrets("{{secrets.foo}} {{secrets.bar}}", null);
-    assertThat(replaced).isEqualTo("FOO BAR");
+        context.getSecretHandler().replaceSecrets(wrap("{{secrets.foo}} {{secrets.bar}}"), null);
+    assertThat(replaced.get("value").asText()).isEqualTo("FOO BAR");
   }
 
   private record TestRecord(String foo) {}

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/inbound/InboundSecretFilterDefaultModeWiringTest.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/inbound/InboundSecretFilterDefaultModeWiringTest.java
@@ -18,6 +18,7 @@ package io.camunda.connector.runtime.inbound;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.connector.api.inbound.InboundConnectorContext;
 import io.camunda.connector.api.inbound.InboundConnectorExecutable;
 import io.camunda.connector.api.secret.SecretContext;
@@ -75,11 +76,9 @@ class InboundSecretFilterDefaultModeWiringTest {
     var context =
         (InboundConnectorContextImpl)
             contextFactory.createContext(details, e -> {}, TestExecutable.class, entry -> {});
-    var result =
-        context
-            .getSecretHandler()
-            .replaceSecrets("secrets.UNDECLARED", new SecretContext("t", "p"));
+    var probe = new ObjectMapper().createObjectNode().put("value", "secrets.UNDECLARED");
+    var result = context.getSecretHandler().replaceSecrets(probe, new SecretContext("t", "p"));
 
-    assertThat(result).isEqualTo("secrets.UNDECLARED");
+    assertThat(result.get("value").asText()).isEqualTo("secrets.UNDECLARED");
   }
 }

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/outbound/JobBuilder.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/outbound/JobBuilder.java
@@ -18,17 +18,22 @@ package io.camunda.connector.runtime.outbound;
 
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.client.api.command.CompleteJobCommandStep1;
 import io.camunda.client.api.command.FailJobCommandStep1;
+import io.camunda.client.api.command.InternalClientException;
 import io.camunda.client.api.command.ThrowErrorCommandStep1;
 import io.camunda.client.api.response.ActivatedJob;
 import io.camunda.client.api.worker.JobClient;
 import io.camunda.connector.runtime.core.Keywords;
 import io.camunda.connector.runtime.outbound.job.SpringConnectorJobHandler;
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 import org.mockito.ArgumentCaptor;
@@ -76,6 +81,10 @@ public class JobBuilder {
       when(throwCommandStep2.variables(any(Map.class))).thenReturn(throwCommandStep2_2);
       when(job.getKey()).thenReturn(-1L);
       when(job.getType()).thenReturn("some-type");
+      // A real Zeebe job's variables are never absent — worst case "{}" — so default to that
+      // here too, rather than leaving getVariablesAsType() to return null for any test that
+      // doesn't care about variables and never calls withVariables(...).
+      withVariables("{}");
     }
 
     public JobBuilderStep useJobClient(JobClient client) {
@@ -85,7 +94,29 @@ public class JobBuilder {
 
     public JobBuilderStep withVariables(String variables) {
       when(job.getVariables()).thenReturn(variables);
+      // Mirrors the real ActivatedJob: getVariablesAsType(cls) parses `variables` with Jackson and
+      // wraps any failure in an InternalClientException, regardless of which node type the caller
+      // asked for (JsonNode vs ObjectNode) — production code asks for both, depending on the path.
+      lenient()
+          .doAnswer(
+              invocation -> {
+                Class<?> cls = invocation.getArgument(0);
+                JsonNode node = parseLikeClient(variables);
+                return cls.cast(node);
+              })
+          .when(job)
+          .getVariablesAsType(any());
       return this;
+    }
+
+    private static JsonNode parseLikeClient(String json) {
+      try {
+        return new ObjectMapper().readValue(json, JsonNode.class);
+      } catch (IOException e) {
+        throw new InternalClientException(
+            String.format("Failed to deserialize json '%s' to class '%s'", json, JsonNode.class),
+            e);
+      }
     }
 
     public JobBuilderStep withHeaders(Map<String, String> headers) {

--- a/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/jobworker/AiAgentJobWorkerHandlerTest.java
+++ b/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/jobworker/AiAgentJobWorkerHandlerTest.java
@@ -23,11 +23,13 @@ import static org.awaitility.Awaitility.await;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
 import com.github.tomakehurst.wiremock.junit5.WireMockTest;
 import io.camunda.client.CamundaClient;
@@ -144,6 +146,10 @@ class AiAgentJobWorkerHandlerTest {
     when(job.getKey()).thenReturn(123456L);
     when(job.getType()).thenReturn(AiAgentJobWorker.JOB_WORKER_TYPE);
     when(job.getCustomHeaders()).thenReturn(jobHeaders);
+    lenient().when(job.getVariables()).thenReturn("{}");
+    lenient()
+        .when(job.getVariablesAsType(ObjectNode.class))
+        .thenAnswer(invocation -> OBJECT_MAPPER.readValue(job.getVariables(), ObjectNode.class));
 
     when(executionContextFactory.createExecutionContext(eq(camundaClient), eq(job), anyList()))
         .thenAnswer(


### PR DESCRIPTION
## Description

Backport of #8584 to `stable/8.9`.

This ports field-path-scoped legacy secret filtering and JSON-tree substitution while preserving the stable/8.9 API surface and its existing secret-redaction behavior.

Branch-specific adaptations:
- Retained stable/8.9's two legacy secret syntaxes and two-argument `SecretContext`; this branch does not expose the newer `camunda.secrets.*` or physical-tenant APIs.
- Kept `ADR-0007` absent because that ADR does not exist on stable/8.9.
- Kept the newer-line-only `LegacySecretCharacterizationTest` absent and moved its relevant JSON-tree coverage into stable/8.9's existing `SecretUtilTests`.
- Reconciled the change with the stable/8.9 backports for inbound filtering (#8600), single-scan secret parsing (#8657), and connector error/log redaction (#8664).

Targeted tests passed for `connector-runtime-core`, `connector-runtime-spring`, `connector-runtime-test`, and `spring-boot-starter-camunda-connectors`.

## Related issues

Related to #8584

## Checklist

- [x] Backport labels are added if these code changes should be backported. This PR already targets `stable/8.9`; no additional backport label is required.
- [x] Tests/Integration tests for the changes have been added if applicable.
- [x] If the change requires a documentation update, it has been added to the appropriate section in the documentation. Not applicable: the amended ADR is not present on `stable/8.9`.
