### PR TITLE
[Backport stable/8.6] fix(secrets): field-path-scoped secret filtering over a JSON tree

### DIFF
--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/DefaultProcessElementContext.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/DefaultProcessElementContext.java
@@ -23,7 +23,9 @@ import io.camunda.connector.api.secret.SecretProvider;
 import io.camunda.connector.api.validation.ValidationProvider;
 import io.camunda.connector.runtime.core.AbstractConnectorContext;
 import io.camunda.connector.runtime.core.secret.SecretFilter;
+import io.camunda.connector.runtime.core.secret.SecretFilter.Secret;
 import io.camunda.connector.runtime.core.secret.SecretUtil;
+import java.util.Arrays;
 import java.util.Map;
 
 public class DefaultProcessElementContext extends AbstractConnectorContext
@@ -83,8 +85,11 @@ public class DefaultProcessElementContext extends AbstractConnectorContext
       return SecretFilter.allowAll();
     }
     return SecretFilter.allowOnly(
-        connectorElement.rawProperties().values().stream()
-            .flatMap(value -> SecretUtil.retrieveSecretKeysInInput(value).stream())
+        connectorElement.rawProperties().entrySet().stream()
+            .flatMap(
+                entry ->
+                    SecretUtil.retrieveSecretKeysInInput(entry.getValue()).stream()
+                        .map(name -> new Secret(name, Arrays.asList(entry.getKey().split("\\.")))))
             .distinct()
             .toList());
   }

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextImpl.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextImpl.java
@@ -33,8 +33,10 @@ import io.camunda.connector.runtime.core.inbound.correlation.InboundCorrelationH
 import io.camunda.connector.runtime.core.inbound.details.InboundConnectorDetails;
 import io.camunda.connector.runtime.core.inbound.details.InboundConnectorDetails.ValidInboundConnectorDetails;
 import io.camunda.connector.runtime.core.secret.SecretFilter;
+import io.camunda.connector.runtime.core.secret.SecretFilter.Secret;
 import io.camunda.connector.runtime.core.secret.SecretUtil;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -174,8 +176,11 @@ public class InboundConnectorContextImpl extends AbstractConnectorContext
       return SecretFilter.allowAll();
     }
     return SecretFilter.allowOnly(
-        connectorDetails.rawPropertiesWithoutKeywords().values().stream()
-            .flatMap(value -> SecretUtil.retrieveSecretKeysInInput(value).stream())
+        connectorDetails.rawPropertiesWithoutKeywords().entrySet().stream()
+            .flatMap(
+                entry ->
+                    SecretUtil.retrieveSecretKeysInInput(entry.getValue()).stream()
+                        .map(name -> new Secret(name, Arrays.asList(entry.getKey().split("\\.")))))
             .distinct()
             .toList());
   }

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/InboundPropertyHandler.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/InboundPropertyHandler.java
@@ -108,9 +108,9 @@ public class InboundPropertyHandler {
   public static Map<String, Object> getPropertiesWithSecrets(
       SecretHandler secretHandler, ObjectMapper objectMapper, Map<String, Object> properties) {
     try {
-      var propertiesAsJsonString = objectMapper.writeValueAsString(properties);
-      var propertiesWithSecretsJson = secretHandler.replaceSecrets(propertiesAsJsonString);
-      return objectMapper.readValue(propertiesWithSecretsJson, new TypeReference<>() {});
+      var propertiesAsJson = objectMapper.valueToTree(properties);
+      var propertiesWithSecretsJson = secretHandler.replaceSecrets(propertiesAsJson);
+      return objectMapper.treeToValue(propertiesWithSecretsJson, new TypeReference<>() {});
     } catch (JsonProcessingException e) {
       throw new RuntimeException(e);
     }

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/outbound/JobHandlerContext.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/outbound/JobHandlerContext.java
@@ -16,11 +16,20 @@
  */
 package io.camunda.connector.runtime.core.outbound;
 
+import com.fasterxml.jackson.core.JsonGenerationException;
+import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.exc.*;
+import com.fasterxml.jackson.databind.exc.InvalidFormatException;
+import com.fasterxml.jackson.databind.exc.InvalidNullException;
+import com.fasterxml.jackson.databind.exc.InvalidTypeIdException;
+import com.fasterxml.jackson.databind.exc.MismatchedInputException;
+import com.fasterxml.jackson.databind.exc.PropertyBindingException;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import io.camunda.connector.api.error.ConnectorException;
 import io.camunda.connector.api.outbound.JobContext;
 import io.camunda.connector.api.outbound.OutboundConnectorContext;
@@ -30,8 +39,6 @@ import io.camunda.connector.runtime.core.AbstractConnectorContext;
 import io.camunda.connector.runtime.core.secret.SecretFilter;
 import io.camunda.zeebe.client.api.response.ActivatedJob;
 import java.util.Objects;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Implementation of {@link io.camunda.connector.api.outbound.OutboundConnectorContext} passed on to
@@ -41,12 +48,10 @@ import org.slf4j.LoggerFactory;
 public class JobHandlerContext extends AbstractConnectorContext
     implements OutboundConnectorContext {
 
-  private static final Logger log = LoggerFactory.getLogger(JobHandlerContext.class);
   private final ActivatedJob job;
-
   private final ObjectMapper objectMapper;
   private final JobContext jobContext;
-  private String jsonWithSecrets = null;
+  private JsonNode jsonWithSecrets;
 
   public JobHandlerContext(
       final ActivatedJob job,
@@ -57,7 +62,7 @@ public class JobHandlerContext extends AbstractConnectorContext
     super(secretProvider, secretFilter, validationProvider);
     this.job = job;
     this.objectMapper = objectMapper;
-    this.jobContext = new ActivatedJobContext(job, this::getJsonReplacedWithSecrets);
+    this.jobContext = new ActivatedJobContext(job, () -> writeJson(getJsonReplacedWithSecrets()));
   }
 
   @Override
@@ -67,44 +72,90 @@ public class JobHandlerContext extends AbstractConnectorContext
     return mappedObject;
   }
 
-  private String getJsonReplacedWithSecrets() {
+  private JsonNode getJsonReplacedWithSecrets() {
     if (jsonWithSecrets == null) {
-      jsonWithSecrets = getSecretHandler().replaceSecrets(job.getVariables());
+      jsonWithSecrets = getSecretHandler().replaceSecrets(parseVariables());
     }
     return jsonWithSecrets;
   }
 
-  private <T> T mapJson(Class<T> cls) {
-    var jsonWithSecrets = getJsonReplacedWithSecrets();
+  private JsonNode parseVariables() {
+    JsonNode variables;
     try {
-      return objectMapper.readValue(jsonWithSecrets, cls);
-    } catch (JsonParseException e) {
+      variables =
+          objectMapper
+              .reader()
+              .with(DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS)
+              .with(JsonNodeFactory.withExactBigDecimals(true))
+              .forType(JsonNode.class)
+              .readValue(job.getVariables());
+    } catch (JsonProcessingException e) {
+      throw translateJsonException(e);
+    }
+    if (!variables.isObject()) {
       throw new ConnectorException("JSON_PARSE_ERROR", "This is not a JSON object");
-    } catch (InvalidFormatException
-        | InvalidNullException
-        | InvalidTypeIdException
-        | PropertyBindingException e) {
+    }
+    return variables;
+  }
+
+  private String writeJson(JsonNode node) {
+    try {
+      return objectMapper
+          .writer()
+          .with(JsonGenerator.Feature.WRITE_BIGDECIMAL_AS_PLAIN)
+          .writeValueAsString(node);
+    } catch (JsonGenerationException e) {
+      return writeJsonWithoutPlainDecimals(node);
+    } catch (JsonProcessingException e) {
+      throw translateJsonException(e);
+    }
+  }
+
+  private String writeJsonWithoutPlainDecimals(JsonNode node) {
+    try {
+      return objectMapper.writeValueAsString(node);
+    } catch (JsonProcessingException e) {
+      throw translateJsonException(e);
+    }
+  }
+
+  private <T> T mapJson(Class<T> cls) {
+    try {
+      return objectMapper.treeToValue(getJsonReplacedWithSecrets(), cls);
+    } catch (JsonProcessingException e) {
+      throw translateJsonException(e);
+    }
+  }
+
+  private static ConnectorException translateJsonException(JsonProcessingException e) {
+    if (e instanceof JsonParseException) {
+      return new ConnectorException("JSON_PARSE_ERROR", "This is not a JSON object");
+    }
+    if (e instanceof InvalidFormatException
+        || e instanceof InvalidNullException
+        || e instanceof InvalidTypeIdException
+        || e instanceof PropertyBindingException) {
+      MismatchedInputException mappingException = (MismatchedInputException) e;
       String errorMessage =
-          e.getPath().stream()
+          mappingException.getPath().stream()
               .map(JsonMappingException.Reference::getFieldName)
               .reduce((s, s2) -> s.concat(", ").concat(s2))
               .map("Json object contains an invalid field: "::concat)
               .map(
                   s ->
-                      e.getTargetType() == null
+                      mappingException.getTargetType() == null
                           ? s
                           : s.concat(". It Must be `")
-                              .concat(e.getTargetType().getSimpleName())
+                              .concat(mappingException.getTargetType().getSimpleName())
                               .concat("`"))
               .orElse("Unexpected Error, Further investigation is needed");
-
-      throw new ConnectorException("JSON_FORMAT_ERROR", errorMessage);
-    } catch (MismatchedInputException e) {
-      throw new ConnectorException("JSON_MISMATCH_ERROR", e.getOriginalMessage());
-    } catch (JsonProcessingException e) {
-      throw new ConnectorException(
-          "JSON_PROCESSING_ERROR", "Exception: " + e.getClass().getSimpleName() + "was raised");
+      return new ConnectorException("JSON_FORMAT_ERROR", errorMessage);
     }
+    if (e instanceof MismatchedInputException) {
+      return new ConnectorException("JSON_MISMATCH_ERROR", e.getOriginalMessage());
+    }
+    return new ConnectorException(
+        "JSON_PROCESSING_ERROR", "Exception: " + e.getClass().getSimpleName() + "was raised");
   }
 
   @Override

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/outbound/OutboundConnectorExceptionHandler.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/outbound/OutboundConnectorExceptionHandler.java
@@ -18,6 +18,7 @@ package io.camunda.connector.runtime.core.outbound;
 
 import static io.camunda.connector.runtime.core.outbound.ConnectorJobHandler.MAX_ERROR_MESSAGE_LENGTH;
 
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.camunda.connector.api.error.ConnectorException;
 import io.camunda.connector.api.error.ConnectorInputException;
 import io.camunda.connector.api.error.ConnectorRetryException;
@@ -28,6 +29,7 @@ import io.camunda.connector.runtime.core.error.JobError;
 import io.camunda.connector.runtime.core.secret.SecretAllowListUnavailableException;
 import io.camunda.connector.runtime.core.secret.SecretFailureDiagnostic;
 import io.camunda.connector.runtime.core.secret.SecretFilter;
+import io.camunda.connector.runtime.core.secret.SecretFilter.Secret;
 import io.camunda.connector.runtime.core.secret.SecretNotAvailableException;
 import io.camunda.connector.runtime.core.secret.SecretUtil;
 import io.camunda.zeebe.client.api.response.ActivatedJob;
@@ -220,23 +222,30 @@ public class OutboundConnectorExceptionHandler {
     }
     try {
       var keys =
-          allowedKeys(SecretUtil.retrieveSecretKeysInInput(job.getVariables()), secretFilter);
+          allowedKeys(
+              SecretUtil.retrieveSecretKeysInInput(job.getVariablesAsType(ObjectNode.class)),
+              secretFilter);
+      // Secret now carries fieldPath, so the same name occurring at several paths is several
+      // distinct Secret values -- dedup by name here, rather than relying on the Secret list
+      // itself being duplicate-free, so one provider lookup covers every occurrence of a name
+      // instead of one lookup per occurrence.
+      var names = keys.stream().map(Secret::secretName).distinct().toList();
       // A job that declares no secret has nothing to redact, so no provider is asked for anything:
       // a custom provider that refuses every lookup must not withhold such a job's error message.
-      if (keys.isEmpty()) {
+      if (names.isEmpty()) {
         return new MaskingSecrets(List.of(), null);
       }
-      var values = new ArrayList<String>(keys.size());
-      for (var key : keys) {
-        var value = secretProvider.getSecret(key);
+      var values = new ArrayList<String>(names.size());
+      for (var name : names) {
+        var value = secretProvider.getSecret(name);
         if (value != null) {
           values.add(value);
         }
       }
-      if (values.size() < keys.size() && !reportsAnUnavailableSecret(jobFailure)) {
+      if (values.size() < names.size() && !reportsAnUnavailableSecret(jobFailure)) {
         return new MaskingSecrets(
             List.of(),
-            new MaskingSecretsIncompleteException(keys.size() - values.size(), keys.size()));
+            new MaskingSecretsIncompleteException(names.size() - values.size(), names.size()));
       }
       return new MaskingSecrets(List.copyOf(values), null);
     } catch (Exception ex) {
@@ -259,7 +268,7 @@ public class OutboundConnectorExceptionHandler {
     return union;
   }
 
-  private static List<String> allowedKeys(List<String> keys, SecretFilter secretFilter) {
+  private static List<Secret> allowedKeys(List<Secret> keys, SecretFilter secretFilter) {
     return keys.stream().filter(secretFilter::isAllowed).toList();
   }
 

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretFilter.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretFilter.java
@@ -23,34 +23,57 @@ import java.util.Set;
  * Determines whether a named secret may be resolved within a connector's context.
  *
  * <p>Use {@link #allowAll()} when no restriction applies and {@link #allowOnly(List)} to restrict
- * resolution to a declared set of names. An empty list passed to {@code allowOnly} denies all
+ * resolution to a declared set of secrets. An empty list passed to {@code allowOnly} denies all
  * secrets.
  */
 @FunctionalInterface
 public interface SecretFilter {
 
-  /**
-   * Returns {@code true} if the secret with the given name may be resolved.
-   *
-   * @param secretName the secret name to check
-   * @return {@code true} to allow resolution, {@code false} to leave the reference as-is
-   */
-  boolean isAllowed(String secretName);
-
   /** Returns a filter that permits every secret name. */
   static SecretFilter allowAll() {
-    return name -> true;
+    return context -> true;
   }
 
   /**
    * Returns a filter that permits only the secret names in {@code names}. An empty list denies all
    * secrets.
    *
-   * @param names the permitted secret names
-   * @return a filter restricted to the given names
+   * @param secrets the permitted secret contexts
+   * @return a filter restricted to the given secrets
    */
-  static SecretFilter allowOnly(List<String> names) {
-    var allowed = Set.copyOf(names);
-    return allowed::contains;
+  static SecretFilter allowOnly(List<Secret> secrets) {
+    var allowed = Set.copyOf(secrets);
+    return context ->
+        allowed.stream()
+            .filter(secret -> secret.secretName().equals(context.secretName()))
+            .filter(secret -> context.fieldPath().size() >= secret.fieldPath().size())
+            .anyMatch(
+                secret ->
+                    context
+                        .fieldPath()
+                        .subList(0, secret.fieldPath().size())
+                        .equals(secret.fieldPath()));
+  }
+
+  /**
+   * Returns {@code true} if the secret with the given name may be resolved.
+   *
+   * @param context the secret filter context
+   * @return {@code true} to allow resolution, {@code false} to leave the reference as-is
+   */
+  boolean isAllowed(Secret context);
+
+  record Secret(String secretName, List<String> fieldPath) {
+
+    /**
+     * Defensively copies {@code fieldPath}: callers such as {@code Arrays.asList(...)} return a
+     * fixed-size but still mutable (via {@code set}) list, which would otherwise let anyone holding
+     * a cached {@code Secret} reach in and change which fields it authorizes for later, unrelated
+     * jobs.
+     */
+    public Secret(String secretName, List<String> fieldPath) {
+      this.secretName = secretName;
+      this.fieldPath = List.copyOf(fieldPath);
+    }
   }
 }

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretHandler.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretHandler.java
@@ -16,7 +16,9 @@
  */
 package io.camunda.connector.runtime.core.secret;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import io.camunda.connector.api.secret.SecretProvider;
+import io.camunda.connector.runtime.core.secret.SecretFilter.Secret;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -31,7 +33,7 @@ public class SecretHandler {
 
   protected final SecretProvider secretProvider;
 
-  protected Function<String, String> secretReplacer;
+  protected Function<Secret, String> secretReplacer;
 
   // values this instance substituted, so a caller can redact against a rotated re-read
   private final Set<String> resolvedValues = ConcurrentHashMap.newKeySet();
@@ -39,23 +41,29 @@ public class SecretHandler {
   public SecretHandler(final SecretProvider secretProvider, SecretFilter secretFilter) {
     this.secretProvider = secretProvider;
     secretReplacer =
-        name -> {
-          if (secretFilter.isAllowed(name)) {
+        secret -> {
+          if (secretFilter.isAllowed(secret)) {
             var value =
-                Optional.ofNullable(secretProvider.getSecret(name))
-                    .orElseThrow(() -> new SecretNotAvailableException(name));
+                Optional.ofNullable(secretProvider.getSecret(secret.secretName()))
+                    .orElseThrow(() -> new SecretNotAvailableException(secret));
             resolvedValues.add(value);
-            // a message that re-serializes the input carries this form, not the raw value
+            // the serialized job JSON carries this form, not the raw value, when it differs
             resolvedValues.add(SecretUtil.jsonEscape(value));
             return value;
           }
-          LOG.debug("Secret '{}' not in allow-list — placeholder left unreplaced", name);
+          LOG.debug(
+              "Secret '{}' not in allow-list — placeholder left unreplaced", secret.secretName());
           return null;
         };
   }
 
-  public String replaceSecrets(String input) {
+  public JsonNode replaceSecrets(JsonNode input) {
     return SecretUtil.replaceSecrets(input, secretReplacer);
+  }
+
+  public String replaceSecrets(String input) {
+    return SecretUtil.replaceSecrets(
+        input, name -> secretReplacer.apply(new Secret(name, List.of())));
   }
 
   public List<String> getResolvedValues() {

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretNotAvailableException.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretNotAvailableException.java
@@ -17,6 +17,7 @@
 package io.camunda.connector.runtime.core.secret;
 
 import io.camunda.connector.api.error.ConnectorInputException;
+import io.camunda.connector.runtime.core.secret.SecretFilter.Secret;
 import java.io.Serial;
 
 /**
@@ -31,5 +32,15 @@ public class SecretNotAvailableException extends ConnectorInputException {
 
   public SecretNotAvailableException(String name) {
     super(String.format("Secret with name '%s' is not available", name), null);
+  }
+
+  /**
+   * Omits {@code secret.fieldPath()}: it is derived from JSON property names, and {@link
+   * SecretUtil} supports resolving secrets into property names as well as values, so a path segment
+   * may itself carry a resolved secret's text — echoing it here would leak that text into an error
+   * message error masking cannot always catch.
+   */
+  public SecretNotAvailableException(Secret secret) {
+    this(secret.secretName());
   }
 }

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretUtil.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretUtil.java
@@ -17,10 +17,18 @@
 package io.camunda.connector.runtime.core.secret;
 
 import com.fasterxml.jackson.core.io.JsonStringEncoder;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.node.TextNode;
+import io.camunda.connector.runtime.core.secret.SecretFilter.Secret;
+import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
+import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.regex.MatchResult;
 import java.util.regex.Matcher;
@@ -45,23 +53,134 @@ public class SecretUtil {
         input,
         REFERENCE,
         matcher -> {
-          String value = resolve(name(matcher), secretReplacer, resolutions);
+          String name = name(matcher);
+          if (!resolutions.containsKey(name)) {
+            resolutions.put(name, secretReplacer.apply(name));
+          }
+          String value = resolutions.get(name);
           return value == null ? matcher.group() : jsonEscape(value);
         });
   }
 
-  // The form actually spliced into the substituted JSON, which a raw-value capture would miss.
-  public static String jsonEscape(String value) {
-    return new String(JsonStringEncoder.getInstance().quoteAsString(value));
+  /**
+   * Substitutes every legacy secret reference in the tree, in place, and returns the same node.
+   *
+   * <p>One walk, one scan per string: a second pass over already-substituted text is what let a
+   * narrower form re-read the inside of a reference the first pass had consumed (and, when the walk
+   * renames a property, made the second pass iterate a reordered snapshot of the object).
+   */
+  public static JsonNode replaceSecrets(JsonNode input, Function<Secret, String> secretReplacer) {
+    if (input == null) {
+      throw new IllegalStateException("input cant be null.");
+    }
+    if (!input.isObject()) {
+      throw new IllegalStateException("input must be an ObjectNode.");
+    }
+    Map<Secret, String> resolutions = new HashMap<>();
+    walkJsonNode(
+        input,
+        (stringValue, fieldPath) ->
+            replaceTokens(
+                stringValue,
+                REFERENCE,
+                matcher -> {
+                  var value = resolve(name(matcher), fieldPath, secretReplacer, resolutions);
+                  return value == null ? matcher.group() : value;
+                }),
+        new ArrayList<>());
+    return input;
   }
 
-  /** Asks the replacer at most once per name, for providers that meter or charge per lookup. */
+  /**
+   * Asks the replacer at most once per secret <em>and field path</em>: the same name is a separate
+   * question at a different path, since that is the granularity the allow-list authorizes at.
+   */
   private static String resolve(
-      String name, Function<String, String> secretReplacer, Map<String, String> resolutions) {
-    if (!resolutions.containsKey(name)) {
-      resolutions.put(name, secretReplacer.apply(name));
+      String name,
+      List<String> fieldPath,
+      Function<Secret, String> secretReplacer,
+      Map<Secret, String> resolutions) {
+    var secret = new Secret(name, fieldPath);
+    if (!resolutions.containsKey(secret)) {
+      resolutions.put(secret, secretReplacer.apply(secret));
     }
-    return resolutions.get(name);
+    return resolutions.get(secret);
+  }
+
+  private static void walkJsonNode(
+      JsonNode input, BiFunction<String, List<String>, String> converter, List<String> fieldPath) {
+    switch (input.getNodeType()) {
+      case ARRAY -> walkArray((ArrayNode) input, converter, fieldPath);
+      case OBJECT -> walkObject((ObjectNode) input, converter, fieldPath);
+      default -> {}
+    }
+  }
+
+  /**
+   * Substitutes property names as well as values: the raw-text pass this replaced matched anywhere
+   * in the document, key or value, so a placeholder written as a property name (e.g. {@code
+   * {"{{secrets.KEY}}": "value"}}) resolved just as one written as a value did. Renaming is
+   * deferred until after the entry is otherwise processed, and runs over a snapshot of the original
+   * entries, since renaming a key while iterating the node's live property view would throw.
+   */
+  private static void walkObject(
+      ObjectNode input,
+      BiFunction<String, List<String>, String> converter,
+      List<String> fieldPath) {
+    // Map.entry(...) reads each key/value pair eagerly, decoupling the snapshot from the live
+    // map: input.properties() entries are backed by the same map nodes ObjectNode#set/remove
+    // mutate, so a snapshot that merely copies the entry objects (e.g. List.copyOf(...)) would
+    // still observe later renames through entries for keys processed earlier in this same loop.
+    for (Entry<String, JsonNode> entry :
+        input.properties().stream().map(e -> Map.entry(e.getKey(), e.getValue())).toList()) {
+      String key = entry.getKey();
+      JsonNode value = entry.getValue();
+      List<String> extendedFieldPath = new ArrayList<>(fieldPath);
+      extendedFieldPath.add(key);
+
+      if (value instanceof TextNode stringValue) {
+        input.set(key, new TextNode(converter.apply(stringValue.asText(), extendedFieldPath)));
+      } else {
+        walkJsonNode(value, converter, extendedFieldPath);
+        // Reinserts this entry's own (possibly object/array-mutated-in-place, otherwise
+        // untouched) value at its own original key, in snapshot order. Without this, a key
+        // rename earlier in this same loop that happens to collide with this entry's still
+        // unprocessed key would silently overwrite this entry before its own turn came, and this
+        // entry's non-text value — having no put/set of its own — would never overwrite it back.
+        input.set(key, value);
+      }
+
+      String newKey = converter.apply(key, extendedFieldPath);
+      if (!newKey.equals(key)) {
+        input.set(newKey, input.get(key));
+        input.remove(key);
+      }
+    }
+  }
+
+  /** Recurses into array elements at arbitrary depth, mirroring {@link #walkJsonNode}. */
+  private static void walkArray(
+      ArrayNode arrayNode,
+      BiFunction<String, List<String>, String> converter,
+      List<String> fieldPath) {
+    for (int i = 0; i < arrayNode.size(); i++) {
+      JsonNode item = arrayNode.get(i);
+      if (item instanceof TextNode stringValue) {
+        arrayNode.set(i, new TextNode(converter.apply(stringValue.asText(), fieldPath)));
+      } else {
+        walkJsonNode(item, converter, fieldPath);
+      }
+    }
+  }
+
+  /**
+   * The form a resolved value takes once the substituted tree is serialized back to JSON. The walk
+   * writes the raw value into a {@code TextNode} and lets Jackson escape it on output, so this is
+   * not applied during substitution — but a caller redacting a message that quotes the serialized
+   * JSON has to match this form as well as the raw one.
+   */
+  public static String jsonEscape(String value) {
+    return new String(JsonStringEncoder.getInstance().quoteAsString(value));
   }
 
   private static String name(MatchResult match) {
@@ -79,6 +198,24 @@ public class SecretUtil {
     return input == null
         ? List.of()
         : REFERENCE.matcher(input).results().map(SecretUtil::name).distinct().toList();
+  }
+
+  /** Returns every secret declared in the tree, scoped to the field path it occupies. */
+  public static List<Secret> retrieveSecretKeysInInput(ObjectNode input) {
+    List<Secret> result = new ArrayList<>();
+    walkJsonNode(
+        input,
+        (stringValue, fieldPath) -> {
+          REFERENCE
+              .matcher(stringValue)
+              .results()
+              .map(SecretUtil::name)
+              .map(name -> new Secret(name, fieldPath))
+              .forEach(result::add);
+          return stringValue;
+        },
+        new ArrayList<>());
+    return result.stream().distinct().toList();
   }
 
   public static String replaceTokens(

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/SecretUtilTests.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/SecretUtilTests.java
@@ -17,11 +17,12 @@
 package io.camunda.connector.runtime.core;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoInteractions;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.camunda.connector.api.json.ConnectorsObjectMapperSupplier;
+import io.camunda.connector.runtime.core.secret.SecretFilter.Secret;
 import io.camunda.connector.runtime.core.secret.SecretUtil;
 import java.util.ArrayList;
 import java.util.List;
@@ -34,6 +35,12 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
 public class SecretUtilTests {
+
+  private static final ObjectMapper OBJECT_MAPPER = ConnectorsObjectMapperSupplier.getCopy();
+
+  private static ObjectNode wrap(String value) {
+    return OBJECT_MAPPER.createObjectNode().put("value", value);
+  }
 
   @ParameterizedTest
   @CsvSource({
@@ -57,21 +64,22 @@ public class SecretUtilTests {
     "secrets..,,false",
     "secrets.?,,false"
   })
-  void testSecretPattern(String input, String secret, Boolean shouldDetect) {
-    var secretReplacer = mock(Function.class);
-    SecretUtil.replaceSecrets(input, secretReplacer);
+  void testSecretPattern(String input, String secret, boolean shouldDetect) {
+    var asked = new ArrayList<Secret>();
+
+    SecretUtil.replaceSecrets(
+        wrap(input),
+        candidate -> {
+          asked.add(candidate);
+          return null;
+        });
+
     if (shouldDetect) {
-      verify(secretReplacer).apply(secret);
+      assertThat(asked).containsExactly(new Secret(secret, List.of("value")));
     } else {
-      verifyNoInteractions(secretReplacer);
+      assertThat(asked).isEmpty();
     }
   }
-
-  Map<String, String> secrets =
-      Map.of(
-          "KEY1", "VALUE1",
-          "KEY2", "VALUE2",
-          "KEY3", "VALUE3");
 
   @ParameterizedTest
   @CsvSource(
@@ -81,21 +89,37 @@ public class SecretUtilTests {
         "{\"field1\": \"{{secrets.KEY1}}\"}|{\"field1\": \"VALUE1\"}",
         "{\"field1\": \"{{secrets.KEY1}}\", \"field2\": \"{{secrets.KEY2}}\"}|{\"field1\": \"VALUE1\", \"field2\": \"VALUE2\"}",
       },
-      delimiter = '|') // delimiter is needed to escape the comma in the json
-  void testSecretReplacementWithJsonInput(String input, String output) {
-    Function<String, String> secretReplacer = (name) -> secrets.get(name);
-    var result = SecretUtil.replaceSecrets(input, secretReplacer);
-    assertThat(result).isEqualTo(output);
+      delimiter = '|')
+  void testSecretReplacementWithJsonInput(String input, String output) throws Exception {
+    Map<String, String> secrets =
+        Map.of(
+            "KEY1", "VALUE1",
+            "KEY2", "VALUE2");
+    var tree = (ObjectNode) OBJECT_MAPPER.readTree(input);
+
+    var result = SecretUtil.replaceSecrets(tree, secret -> secrets.get(secret.secretName()));
+
+    assertThat(result).isEqualTo(OBJECT_MAPPER.readTree(output));
   }
 
   @Test
   void shouldOnlyReplaceAllowListedSecrets() {
+    Map<String, String> secrets =
+        Map.of(
+            "KEY1", "VALUE1",
+            "KEY2", "VALUE2",
+            "KEY3", "VALUE3");
     List<String> allowList = List.of("KEY1", "KEY2");
-    Function<String, String> secretReplacer =
-        name -> allowList.contains(name) ? secrets.get(name) : null;
     String content = "Hello {{secrets.KEY1}} and {{secrets.KEY2}} and {{secrets.KEY3}}";
-    String replacedContent = SecretUtil.replaceSecrets(content, secretReplacer);
-    assertThat(replacedContent).isEqualTo("Hello VALUE1 and VALUE2 and {{secrets.KEY3}}");
+
+    var replaced =
+        SecretUtil.replaceSecrets(
+            wrap(content),
+            secret ->
+                allowList.contains(secret.secretName()) ? secrets.get(secret.secretName()) : null);
+
+    assertThat(replaced.get("value").asText())
+        .isEqualTo("Hello VALUE1 and VALUE2 and {{secrets.KEY3}}");
   }
 
   @ParameterizedTest
@@ -117,22 +141,39 @@ public class SecretUtilTests {
   void shouldRetrieveMultipleDistinctSecretKeysInInput() {
     var keys =
         SecretUtil.retrieveSecretKeysInInput("{{secrets.FOO}} and secrets.BAR and {{secrets.FOO}}");
+
     assertThat(keys).containsExactlyInAnyOrder("FOO", "BAR");
   }
 
   @Test
+  void shouldRetrieveSecretKeysWithTheirFieldPaths() throws Exception {
+    var input =
+        (ObjectNode)
+            OBJECT_MAPPER.readTree(
+                """
+                {
+                  "outer": {"inner": "secrets.NESTED"},
+                  "values": [["{{secrets.ARRAY}}"]]
+                }
+                """);
+
+    assertThat(SecretUtil.retrieveSecretKeysInInput(input))
+        .containsExactlyInAnyOrder(
+            new Secret("NESTED", List.of("outer", "inner")),
+            new Secret("ARRAY", List.of("values")));
+  }
+
+  @Test
   void shouldTrimSecretKeyExtractedFromBracketedReference() {
-    var keys = SecretUtil.retrieveSecretKeysInInput("{{ secrets.FOO:BAR }}");
-    assertThat(keys).contains("FOO:BAR");
+    assertThat(SecretUtil.retrieveSecretKeysInInput("{{ secrets.FOO:BAR }}"))
+        .containsExactly("FOO:BAR");
   }
 
   @Test
   void shouldNotResolveABarePrefixOfADeniedBracketedName() {
     var asked = new ArrayList<String>();
 
-    assertThat(
-            SecretUtil.replaceSecrets(
-                "{{secrets.PROD:API}}", recording(asked, Map.of("PROD", "p4ssw0rd"))))
+    assertThat(replacedValue("{{secrets.PROD:API}}", asked, Map.of("PROD", "p4ssw0rd")))
         .isEqualTo("{{secrets.PROD:API}}");
     assertThat(asked).containsExactly("PROD:API");
   }
@@ -142,8 +183,7 @@ public class SecretUtilTests {
     var asked = new ArrayList<String>();
     var secrets = Map.of("A", "{{secrets.PROD:API}}", "PROD", "p4ssw0rd");
 
-    assertThat(SecretUtil.replaceSecrets("{{secrets.A}}", recording(asked, secrets)))
-        .isEqualTo("{{secrets.PROD:API}}");
+    assertThat(replacedValue("{{secrets.A}}", asked, secrets)).isEqualTo("{{secrets.PROD:API}}");
     assertThat(asked).containsExactly("A");
   }
 
@@ -152,8 +192,7 @@ public class SecretUtilTests {
     var asked = new ArrayList<String>();
     var secrets = Map.of("NOTE", "see secrets.OTHER", "OTHER", "TOP_SECRET");
 
-    assertThat(SecretUtil.replaceSecrets("{{secrets.NOTE}}", recording(asked, secrets)))
-        .isEqualTo("see secrets.OTHER");
+    assertThat(replacedValue("{{secrets.NOTE}}", asked, secrets)).isEqualTo("see secrets.OTHER");
     assertThat(asked).containsExactly("NOTE");
   }
 
@@ -166,14 +205,27 @@ public class SecretUtilTests {
   }
 
   @Test
-  void shouldAskForEveryNameAtMostOnce() {
+  void shouldAskForEveryNameAtMostOnceAtOneFieldPath() {
     var asked = new ArrayList<String>();
 
-    assertThat(
-            SecretUtil.replaceSecrets(
-                "secrets.K secrets.K {{secrets.K}}", recording(asked, Map.of("K", "V"))))
+    assertThat(replacedValue("secrets.K secrets.K {{secrets.K}}", asked, Map.of("K", "V")))
         .isEqualTo("V V V");
     assertThat(asked).containsExactly("K");
+  }
+
+  @Test
+  void shouldResolveTheSameNameSeparatelyAtDifferentFieldPaths() throws Exception {
+    var input = (ObjectNode) OBJECT_MAPPER.readTree("{\"a\":\"secrets.K\",\"b\":\"secrets.K\"}");
+    var asked = new ArrayList<Secret>();
+
+    SecretUtil.replaceSecrets(
+        input,
+        secret -> {
+          asked.add(secret);
+          return "V";
+        });
+
+    assertThat(asked).containsExactly(new Secret("K", List.of("a")), new Secret("K", List.of("b")));
   }
 
   @Test
@@ -181,7 +233,7 @@ public class SecretUtilTests {
     var asked = new ArrayList<String>();
     var input = "{{secrets.DENIED}} secrets.DENIED {{secrets.DENIED}}";
 
-    assertThat(SecretUtil.replaceSecrets(input, recording(asked, Map.of()))).isEqualTo(input);
+    assertThat(replacedValue(input, asked, Map.of())).isEqualTo(input);
     assertThat(asked).containsExactly("DENIED");
   }
 
@@ -193,39 +245,87 @@ public class SecretUtilTests {
             .mapToObj(i -> "{{secrets.DENIED" + i + ":X}}")
             .collect(Collectors.joining(" "));
 
-    assertThat(SecretUtil.replaceSecrets(payload, recording(asked, Map.of()))).isEqualTo(payload);
+    assertThat(replacedValue(payload, asked, Map.of())).isEqualTo(payload);
     assertThat(asked).hasSize(5000);
   }
 
   @Test
   void shouldNotWriteTheTextNullWhereANameIsAllWhitespace() {
-    // The NUL is written as an escape rather than as a raw byte: a raw NUL makes git treat the
-    // whole file as binary, which hides every later change to it from review.
     var asked = new ArrayList<String>();
-    var input = "{\"pw\":\"{{secrets.\0}}\"}";
+    var input = "{{secrets.\0}}";
 
-    assertThat(SecretUtil.replaceSecrets(input, recording(asked, Map.of()))).isEqualTo(input);
+    assertThat(replacedValue(input, asked, Map.of())).isEqualTo(input);
     assertThat(asked).containsExactly("\0");
   }
 
   @Test
-  void shouldEscapeTheValueItSplicesIntoJson() throws Exception {
-    // callers substitute into a JSON document and parse the result, so the value has to survive
-    // that round trip: spliced raw, a backslash sequence would bind as whatever JSON reads it as
+  void shouldWriteResolvedTextIntoTheTreeWithoutDoubleEscaping() throws Exception {
     var value = "pa\\nss\"quoted\"";
-    var substituted = SecretUtil.replaceSecrets("{\"token\":\"{{secrets.FOO}}\"}", name -> value);
+    var input = OBJECT_MAPPER.createObjectNode().put("token", "{{secrets.FOO}}");
 
-    assertThat(substituted).isEqualTo("{\"token\":\"pa\\\\nss\\\"quoted\\\"\"}");
-    assertThat(
-            ConnectorsObjectMapperSupplier.getCopy().readTree(substituted).get("token").textValue())
-        .isEqualTo(value);
+    var substituted = SecretUtil.replaceSecrets(input, secret -> value);
+
+    assertThat(substituted.get("token").textValue()).isEqualTo(value);
+    assertThat(OBJECT_MAPPER.writeValueAsString(substituted))
+        .isEqualTo("{\"token\":\"pa\\\\nss\\\"quoted\\\"\"}");
   }
 
-  private static Function<String, String> recording(
+  @Test
+  void shouldReplaceAReferenceNestedInsideArraysOfArbitraryDepth() throws Exception {
+    var input = (ObjectNode) OBJECT_MAPPER.readTree("{\"values\":[[\"{{secrets.TOKEN}}\"]]}");
+
+    var result = SecretUtil.replaceSecrets(input, secret -> "tok123");
+
+    assertThat(result).isEqualTo(OBJECT_MAPPER.readTree("{\"values\":[[\"tok123\"]]}"));
+  }
+
+  @Test
+  void shouldReplaceAReferenceWrittenAsAPropertyName() throws Exception {
+    var input = (ObjectNode) OBJECT_MAPPER.readTree("{\"{{secrets.KEY}}\":\"value\"}");
+
+    var result = SecretUtil.replaceSecrets(input, secret -> "resolved-key");
+
+    assertThat(result).isEqualTo(OBJECT_MAPPER.readTree("{\"resolved-key\":\"value\"}"));
+  }
+
+  @Test
+  void shouldKeepTheLaterPropertyWhenARenamedKeyCollidesWithIt() throws Exception {
+    var input =
+        (ObjectNode)
+            OBJECT_MAPPER.readTree(
+                "{\"{{secrets.KEY}}\":\"placeholder\",\"resolved-key\":{\"nested\":\"value\"}}");
+
+    var result = SecretUtil.replaceSecrets(input, secret -> "resolved-key");
+
+    assertThat(result)
+        .isEqualTo(OBJECT_MAPPER.readTree("{\"resolved-key\":{\"nested\":\"value\"}}"));
+  }
+
+  @Test
+  void shouldRejectANonObjectRoot() throws Exception {
+    assertThatThrownBy(
+            () ->
+                SecretUtil.replaceSecrets(
+                    OBJECT_MAPPER.readTree("[\"secrets.KEY\"]"), ignored -> "V"))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("input must be an ObjectNode.");
+  }
+
+  @Test
+  void legacyStringReplacementRemainsAvailable() {
+    assertThat(SecretUtil.replaceSecrets("{{secrets.KEY}}", name -> "VALUE")).isEqualTo("VALUE");
+  }
+
+  private static Function<Secret, String> recording(
       List<String> asked, Map<String, String> secrets) {
-    return name -> {
-      asked.add(name);
-      return secrets.get(name);
+    return secret -> {
+      asked.add(secret.secretName());
+      return secrets.get(secret.secretName());
     };
+  }
+
+  private static String replacedValue(
+      String input, List<String> asked, Map<String, String> secrets) {
+    return SecretUtil.replaceSecrets(wrap(input), recording(asked, secrets)).get("value").asText();
   }
 }

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextImplTest.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextImplTest.java
@@ -26,6 +26,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.collect.EvictingQueue;
 import io.camunda.connector.api.inbound.Activity;
 import io.camunda.connector.api.inbound.CorrelationResult;
@@ -120,27 +121,15 @@ class InboundConnectorContextImplTest {
         .isInstanceOf(String.class);
   }
 
-  // #7730: inbound secret resolution is restricted to the names the element's own deployed
-  // zeebe:property text declares. The allow-list is a superset of what a correctly-authored model
-  // names, so what it actually stops is a second-order lookup: replaceSecrets runs the brace pass
-  // and then runs the bare pass over that pass's output, letting a resolved value that contains
-  // reference-shaped text reach a secret no model ever declared. Confirmed present on this branch
-  // before backporting: under the previous allow-all filter, a secret whose value is the literal
-  // "secrets.CHAINED" resolved CHAINED.
-  //
-  // Main's suite also covers a hot swap, a sibling element's names, and the new
-  // camunda.secrets.<name> form. None are representable on this branch: connectorDetails and
-  // properties are both final and there is no updateConnectorDetails at all, there is a single
-  // connector-level text rather than a per-element one, and the new form does not exist here.
-
   private InboundConnectorContextImpl filteringContext(
       ValidInboundConnectorDetails details, SecretProvider provider) {
     return new InboundConnectorContextImpl(
         provider, (e) -> {}, details, null, (e) -> {}, mapper, EvictingQueue.create(10), true);
   }
 
-  private static String replace(InboundConnectorContextImpl context, String input) {
-    return context.getSecretHandler().replaceSecrets(input);
+  private static String replace(InboundConnectorContextImpl context, String field, String input) {
+    ObjectNode probe = new ObjectMapper().createObjectNode().put(field, input);
+    return context.getSecretHandler().replaceSecrets(probe).get(field).asText();
   }
 
   @Test
@@ -151,7 +140,7 @@ class InboundConnectorContextImplTest {
         filteringContext(
             getInboundConnectorDefinition(Map.of("token", "secrets.DECLARED")), provider);
 
-    assertThat(replace(context, "secrets.DECLARED")).isEqualTo("resolved");
+    assertThat(replace(context, "token", "secrets.DECLARED")).isEqualTo("resolved");
   }
 
   @Test
@@ -162,7 +151,7 @@ class InboundConnectorContextImplTest {
         filteringContext(
             getInboundConnectorDefinition(Map.of("token", "{{ secrets.BRACED }}")), provider);
 
-    assertThat(replace(context, "{{ secrets.BRACED }}")).isEqualTo("resolved");
+    assertThat(replace(context, "token", "{{ secrets.BRACED }}")).isEqualTo("resolved");
   }
 
   @Test
@@ -172,7 +161,7 @@ class InboundConnectorContextImplTest {
         filteringContext(
             getInboundConnectorDefinition(Map.of("token", "secrets.DECLARED")), provider);
 
-    assertThat(replace(context, "secrets.INJECTED")).isEqualTo("secrets.INJECTED");
+    assertThat(replace(context, "token", "secrets.INJECTED")).isEqualTo("secrets.INJECTED");
     verify(provider, never()).getSecret("INJECTED");
   }
 
@@ -185,8 +174,56 @@ class InboundConnectorContextImplTest {
         filteringContext(
             getInboundConnectorDefinition(Map.of("token", "{{secrets.CHAIN_ROOT}}")), provider);
 
-    assertThat(replace(context, "{{secrets.CHAIN_ROOT}}")).isEqualTo("secrets.CHAINED");
+    assertThat(replace(context, "token", "{{secrets.CHAIN_ROOT}}")).isEqualTo("secrets.CHAINED");
     verify(provider, never()).getSecret("CHAINED");
+  }
+
+  @Test
+  void secretFilterEnabled_leavesASecretDeclaredOnlyOnASiblingField() {
+    var provider = mock(SecretProvider.class);
+    when(provider.getSecret("SIBLING_ONLY")).thenReturn("leaked-value");
+    var context =
+        filteringContext(
+            getInboundConnectorDefinition(
+                Map.of("tokenA", "plain", "tokenB", "secrets.SIBLING_ONLY")),
+            provider);
+
+    assertThat(replace(context, "tokenA", "secrets.SIBLING_ONLY"))
+        .isEqualTo("secrets.SIBLING_ONLY");
+    verify(provider, never()).getSecret("SIBLING_ONLY");
+  }
+
+  @Test
+  void processElementSecretFilterScopesDottedPropertiesToTheirDeclaredPath() {
+    var provider = mock(SecretProvider.class);
+    when(provider.getSecret("AUTH")).thenReturn("resolved");
+    var details = getInboundConnectorDefinition(Map.of("authentication.token", "secrets.AUTH"));
+    var context =
+        new DefaultProcessElementContext(
+            details.connectorElements().getFirst(), (e) -> {}, provider, mapper, true);
+    var matchingProbe =
+        mapper
+            .createObjectNode()
+            .set("authentication", mapper.createObjectNode().put("token", "secrets.AUTH"));
+    var siblingProbe =
+        mapper
+            .createObjectNode()
+            .set("authentication", mapper.createObjectNode().put("type", "secrets.AUTH"));
+
+    assertThat(
+            context
+                .getSecretHandler()
+                .replaceSecrets(matchingProbe)
+                .at("/authentication/token")
+                .asText())
+        .isEqualTo("resolved");
+    assertThat(
+            context
+                .getSecretHandler()
+                .replaceSecrets(siblingProbe)
+                .at("/authentication/type")
+                .asText())
+        .isEqualTo("secrets.AUTH");
   }
 
   @Test
@@ -203,7 +240,7 @@ class InboundConnectorContextImplTest {
             mapper,
             EvictingQueue.create(10));
 
-    assertThat(replace(context, "secrets.INJECTED")).isEqualTo("resolved");
+    assertThat(replace(context, "token", "secrets.INJECTED")).isEqualTo("resolved");
   }
 
   // Secret redaction of operator-visible output (#8643). The values are read back from the

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/outbound/JobBuilder.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/outbound/JobBuilder.java
@@ -18,10 +18,14 @@ package io.camunda.connector.runtime.core.outbound;
 
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.connector.runtime.core.Keywords;
 import io.camunda.zeebe.client.api.command.CompleteJobCommandStep1;
 import io.camunda.zeebe.client.api.command.FailJobCommandStep1;
@@ -74,6 +78,7 @@ class JobBuilder {
       when(throwCommand.errorCode(any())).thenReturn(throwCommandStep2);
       when(throwCommandStep2.variables(any(Map.class))).thenReturn(throwCommandStep2_2);
       when(job.getKey()).thenReturn(-1L);
+      withVariables("{}");
     }
 
     public JobBuilderStep useJobClient(JobClient client) {
@@ -83,7 +88,23 @@ class JobBuilder {
 
     public JobBuilderStep withVariables(String variables) {
       when(job.getVariables()).thenReturn(variables);
+      lenient()
+          .doAnswer(
+              invocation -> {
+                Class<?> cls = invocation.getArgument(0);
+                return cls.cast(parseVariables(variables));
+              })
+          .when(job)
+          .getVariablesAsType(any());
       return this;
+    }
+
+    private static JsonNode parseVariables(String variables) {
+      try {
+        return new ObjectMapper().readTree(variables);
+      } catch (JsonProcessingException e) {
+        throw new IllegalArgumentException("Failed to deserialize job variables", e);
+      }
     }
 
     public JobBuilderStep withHeaders(Map<String, String> headers) {

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/outbound/JobHandlerContextTest.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/outbound/JobHandlerContextTest.java
@@ -27,8 +27,10 @@ import io.camunda.connector.api.error.ConnectorException;
 import io.camunda.connector.api.secret.SecretProvider;
 import io.camunda.connector.api.validation.ValidationProvider;
 import io.camunda.connector.runtime.core.secret.SecretFilter;
+import io.camunda.connector.runtime.core.secret.SecretFilter.Secret;
 import io.camunda.connector.runtime.core.testutil.classexample.TestClass;
 import io.camunda.zeebe.client.api.response.ActivatedJob;
+import java.math.BigDecimal;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -46,6 +48,10 @@ class JobHandlerContextTest {
   private final ObjectMapper objectMapper = new ObjectMapper();
   private JobHandlerContext jobHandlerContext;
 
+  private void stubVariables(String json) {
+    when(activatedJob.getVariables()).thenReturn(json);
+  }
+
   @BeforeEach
   void setUp() {
     jobHandlerContext =
@@ -59,29 +65,64 @@ class JobHandlerContextTest {
 
   @Test
   void getVariables() {
-    when(activatedJob.getVariables()).thenReturn("{}");
+    stubVariables("{}");
     jobHandlerContext.getJobContext().getVariables();
     verify(activatedJob).getVariables();
   }
 
   @Test
+  void bindVariables_preservesFullDecimalPrecision() {
+    stubVariables("{ \"decimal\": 0.1234567890123456789012345 }");
+
+    BigDecimal bound = jobHandlerContext.bindVariables(TestClass.class).decimal;
+
+    assertThat(bound).isEqualByComparingTo(new BigDecimal("0.1234567890123456789012345"));
+  }
+
+  @Test
+  void bindVariables_preservesTrailingZeroScale() {
+    stubVariables("{ \"decimal\": 1.10 }");
+
+    BigDecimal bound = jobHandlerContext.bindVariables(TestClass.class).decimal;
+
+    assertThat(bound).isEqualTo(new BigDecimal("1.10"));
+  }
+
+  @Test
+  void getVariables_preservesDecimalText() {
+    stubVariables("{ \"a\": 0.00000001, \"b\": 1.10, \"c\": 0.1234567890123456789012345 }");
+
+    assertThat(jobHandlerContext.getJobContext().getVariables())
+        .contains("0.00000001", "1.10", "0.1234567890123456789012345");
+  }
+
+  @Test
+  void getVariables_fallsBackToScientificNotationForOutOfRangeDecimalScale() {
+    stubVariables("{ \"tiny\": 1e-10000, \"huge\": 1e+10001 }");
+
+    assertThat(jobHandlerContext.getJobContext().getVariables())
+        .contains("1E-10000")
+        .contains("1E+10001");
+  }
+
+  @Test
   void bindVariables_success() {
     String json = "{ \"integer\": 3}";
-    when(activatedJob.getVariables()).thenReturn(json);
+    stubVariables(json);
     assertThat(jobHandlerContext.bindVariables(TestClass.class).integer).isEqualTo(3);
   }
 
   @Test
   void bindVariables_nullValue() {
     String json = "{ \"integer\": null}";
-    when(activatedJob.getVariables()).thenReturn(json);
+    stubVariables(json);
     assertThat(jobHandlerContext.bindVariables(TestClass.class).integer).isEqualTo(null);
   }
 
   @Test
   void bindVariables_invalidFormat() {
     String json = "{ \"integer\": \"hello\"}";
-    when(activatedJob.getVariables()).thenReturn(json);
+    stubVariables(json);
     Exception thrown =
         assertThrows(
             ConnectorException.class, () -> jobHandlerContext.bindVariables(TestClass.class));
@@ -93,7 +134,7 @@ class JobHandlerContextTest {
   @Test
   void bindVariables_invalidFormatNull() {
     String json = "{ \"invalid\": null }";
-    when(activatedJob.getVariables()).thenReturn(json);
+    stubVariables(json);
     Exception thrown =
         assertThrows(
             ConnectorException.class, () -> jobHandlerContext.bindVariables(TestClass.class));
@@ -114,8 +155,8 @@ class JobHandlerContextTest {
 
   @Test
   void bindVariables_invalidFormatObject() {
-    String json = "{ \"integer\": \"{ \"hello\" : 3\"}";
-    when(activatedJob.getVariables()).thenReturn(json);
+    String json = "{ \"integer\": \"{ \\\"hello\\\" : 3}\" }";
+    stubVariables(json);
     Exception thrown =
         assertThrows(
             ConnectorException.class, () -> jobHandlerContext.bindVariables(TestClass.class));
@@ -127,7 +168,7 @@ class JobHandlerContextTest {
   @Test
   void bindVariables_emptyString() {
     String json = "";
-    when(activatedJob.getVariables()).thenReturn(json);
+    stubVariables(json);
     Exception thrown =
         assertThrows(
             ConnectorException.class, () -> jobHandlerContext.bindVariables(TestClass.class));
@@ -138,20 +179,18 @@ class JobHandlerContextTest {
   @Test
   void bindVariables_emptyArray() {
     String json = "[]";
-    when(activatedJob.getVariables()).thenReturn(json);
+    stubVariables(json);
     Exception thrown =
         assertThrows(
             ConnectorException.class, () -> jobHandlerContext.bindVariables(TestClass.class));
 
-    assertThat(thrown.getMessage())
-        .isEqualTo(
-            "Cannot deserialize value of type `io.camunda.connector.runtime.core.testutil.classexample.TestClass` from Array value (token `JsonToken.START_ARRAY`)");
+    assertThat(thrown.getMessage()).isEqualTo("This is not a JSON object");
   }
 
   @Test
   void bindVariables_invalidFormatArray() {
     String json = "{ \"integer\": [\"hello\"] }";
-    when(activatedJob.getVariables()).thenReturn(json);
+    stubVariables(json);
     Exception thrown =
         assertThrows(
             ConnectorException.class, () -> jobHandlerContext.bindVariables(TestClass.class));
@@ -172,9 +211,9 @@ class JobHandlerContextTest {
             secretProvider,
             validationProvider,
             objectMapper,
-            SecretFilter.allowOnly(List.of("AUTH")));
+            SecretFilter.allowOnly(List.of(new Secret("AUTH", List.of()))));
     String json = "{ \"value\": \"{{secrets.UNDECLARED}}\" }";
-    when(activatedJob.getVariables()).thenReturn(json);
+    stubVariables(json);
 
     var bound = restrictiveContext.bindVariables(SingleStringField.class);
 
@@ -184,5 +223,25 @@ class JobHandlerContextTest {
 
   public static class SingleStringField {
     public String value;
+  }
+
+  @Test
+  void bindVariables_resolvesAQuotedSecretWithoutDoubleEscaping() {
+    stubVariables("{ \"value\": \"{{secrets.FOO}}\" }");
+    when(secretProvider.getSecret("FOO")).thenReturn("Hello \"quoted\" \\\\ value");
+
+    var bound = jobHandlerContext.bindVariables(SingleStringField.class);
+
+    assertThat(bound.value).isEqualTo("Hello \"quoted\" \\\\ value");
+  }
+
+  @Test
+  void bindVariables_rejectsAnUnquotedSecretPlaceholder() {
+    stubVariables("{ \"integer\": {{secrets.FOO}} }");
+
+    assertThatThrownBy(() -> jobHandlerContext.bindVariables(TestClass.class))
+        .isInstanceOf(ConnectorException.class)
+        .hasMessage("This is not a JSON object");
+    verify(secretProvider, never()).getSecret("FOO");
   }
 }

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/outbound/OutboundConnectorExceptionHandlerTest.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/outbound/OutboundConnectorExceptionHandlerTest.java
@@ -21,11 +21,15 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.camunda.connector.api.error.ConnectorInputException;
 import io.camunda.connector.api.secret.SecretProvider;
 import io.camunda.connector.runtime.core.error.BpmnError;
 import io.camunda.connector.runtime.core.error.JobError;
 import io.camunda.connector.runtime.core.secret.SecretFilter;
+import io.camunda.connector.runtime.core.secret.SecretFilter.Secret;
 import io.camunda.connector.runtime.core.secret.SecretNotAvailableException;
 import io.camunda.zeebe.client.api.response.ActivatedJob;
 import java.time.Duration;
@@ -37,6 +41,7 @@ import org.junit.jupiter.api.Test;
 class OutboundConnectorExceptionHandlerTest {
 
   private static final Duration NO_BACKOFF = null;
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
   private final SecretProvider secretProvider = mock(SecretProvider.class);
   private final OutboundConnectorExceptionHandler handler =
@@ -46,6 +51,12 @@ class OutboundConnectorExceptionHandlerTest {
   private ActivatedJob jobNaming(String variables) {
     var job = mock(ActivatedJob.class);
     when(job.getVariables()).thenReturn(variables);
+    try {
+      when(job.getVariablesAsType(ObjectNode.class))
+          .thenReturn((ObjectNode) OBJECT_MAPPER.readTree(variables));
+    } catch (JsonProcessingException e) {
+      throw new IllegalArgumentException("Invalid test variables", e);
+    }
     when(job.getRetries()).thenReturn(3);
     return job;
   }
@@ -127,11 +138,26 @@ class OutboundConnectorExceptionHandlerTest {
             new RuntimeException("api rejected allowed-value and denied-value"),
             job,
             NO_BACKOFF,
-            SecretFilter.allowOnly(List.of("ALLOWED")),
+            SecretFilter.allowOnly(List.of(new Secret("ALLOWED", List.of("a")))),
             List.of());
 
     assertThat(requestedKeys).containsExactly("ALLOWED");
     assertThat(result.exception().getMessage()).isEqualTo("api rejected *** and denied-value");
+  }
+
+  @Test
+  void readsTheSameAllowedSecretNameOnlyOnceAcrossMultipleFieldPaths() {
+    var job = jobNaming("{\"a\": \"secrets.SHARED\", \"b\": \"secrets.SHARED\"}");
+    holdingOnly(Map.of("SHARED", "shared-value"));
+
+    handler.manageConnectorJobHandlerException(
+        new RuntimeException("api rejected shared-value"),
+        job,
+        NO_BACKOFF,
+        SecretFilter.allowAll(),
+        List.of());
+
+    assertThat(requestedKeys).containsExactly("SHARED");
   }
 
   @Test

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/secret/SecretHandlerTest.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/secret/SecretHandlerTest.java
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.camunda.connector.api.secret.SecretProvider;
+import io.camunda.connector.runtime.core.secret.SecretFilter.Secret;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -36,7 +37,9 @@ class SecretHandlerTest {
   @Test
   void replaceSecrets_allowedKey_resolvesFromProvider() {
     when(secretProvider.getSecret("ALLOWED")).thenReturn("VALUE");
-    var handler = new SecretHandler(secretProvider, SecretFilter.allowOnly(List.of("ALLOWED")));
+    var handler =
+        new SecretHandler(
+            secretProvider, SecretFilter.allowOnly(List.of(new Secret("ALLOWED", List.of()))));
 
     var result = handler.replaceSecrets("{{secrets.ALLOWED}}");
 
@@ -45,7 +48,9 @@ class SecretHandlerTest {
 
   @Test
   void replaceSecrets_notAllowedKey_leavesPlaceholderUnreplacedAndNeverCallsProvider() {
-    var handler = new SecretHandler(secretProvider, SecretFilter.allowOnly(List.of("ALLOWED")));
+    var handler =
+        new SecretHandler(
+            secretProvider, SecretFilter.allowOnly(List.of(new Secret("ALLOWED", List.of()))));
 
     var result = handler.replaceSecrets("{{secrets.NOT_ALLOWED}}");
 

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/testutil/classexample/TestClass.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/testutil/classexample/TestClass.java
@@ -16,8 +16,12 @@
  */
 package io.camunda.connector.runtime.core.testutil.classexample;
 
+import java.math.BigDecimal;
+
 public class TestClass {
   public Integer integer;
+  public BigDecimal decimal;
+  public Long longValue;
 
   public TestClass(Integer integer) {
     this.integer = integer;

--- a/connector-runtime/connector-runtime-spring/pom.xml
+++ b/connector-runtime/connector-runtime-spring/pom.xml
@@ -62,6 +62,10 @@
       <groupId>io.camunda.spring</groupId>
       <artifactId>java-client-operate-legacy</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.camunda.feel</groupId>
+      <artifactId>feel-engine</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>io.camunda.connector</groupId>

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/SecretKeyCacheHolder.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/SecretKeyCacheHolder.java
@@ -17,6 +17,7 @@
 package io.camunda.connector.runtime.outbound;
 
 import com.github.benmanes.caffeine.cache.Cache;
+import io.camunda.connector.runtime.core.secret.SecretFilter.Secret;
 import java.util.List;
 import java.util.Map;
 
@@ -36,4 +37,4 @@ import java.util.Map;
  * replace the host's own auto-configured {@code CacheManager} — confirmed via {@code
  * dependency:tree}, not theoretical. Caffeine's {@code Cache} needs neither dependency.
  */
-record SecretKeyCacheHolder(Cache<Long, Map<String, List<String>>> cache) {}
+record SecretKeyCacheHolder(Cache<Long, Map<String, List<Secret>>> cache) {}

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/LazyLoadingSecretFilter.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/LazyLoadingSecretFilter.java
@@ -17,40 +17,33 @@
 package io.camunda.connector.runtime.outbound.job;
 
 import io.camunda.connector.runtime.core.secret.SecretFilter;
+import io.camunda.connector.runtime.core.secret.SecretFilter.Secret;
 import java.util.List;
-import java.util.Set;
 import java.util.function.Supplier;
 
 /**
- * A {@link SecretFilter} that resolves the allowed secret names on the first {@link
- * #isAllowed(String)} call rather than at construction time. This defers the BPMN process
- * definition lookup to the point where secrets are actually being replaced, so that any exception
- * thrown by the supplier propagates through the normal connector error-handling path and results in
- * a proper Zeebe {@code failJob} command.
- *
- * <p>The supplier is called exactly once per filter instance regardless of outcome. When the
- * supplier returns {@code null} (LAX mode: lookup failed, fall back to allow-all), all subsequent
- * calls to {@link #isAllowed(String)} return {@code true} without re-invoking the supplier.
+ * A {@link SecretFilter} that resolves the allowed secrets on the first {@link #isAllowed(Secret)}
+ * call rather than at construction time.
  */
 public class LazyLoadingSecretFilter implements SecretFilter {
-  private final Supplier<List<String>> secretNamesSupplier;
+  private final Supplier<List<Secret>> secretsSupplier;
 
-  private volatile boolean initialized = false;
-  private Set<String> secretNames;
+  private volatile boolean initialized;
+  private SecretFilter delegate;
   private Throwable initializationFailure;
 
-  public LazyLoadingSecretFilter(Supplier<List<String>> secretNamesSupplier) {
-    this.secretNamesSupplier = secretNamesSupplier;
+  public LazyLoadingSecretFilter(Supplier<List<Secret>> secretsSupplier) {
+    this.secretsSupplier = secretsSupplier;
   }
 
   @Override
-  public boolean isAllowed(String secretName) {
+  public boolean isAllowed(Secret secret) {
     if (!initialized) {
       synchronized (this) {
         if (!initialized) {
           try {
-            List<String> names = secretNamesSupplier.get();
-            secretNames = names != null ? Set.copyOf(names) : null;
+            List<Secret> secrets = secretsSupplier.get();
+            delegate = secrets != null ? SecretFilter.allowOnly(secrets) : SecretFilter.allowAll();
           } catch (Throwable e) {
             initializationFailure = e;
             initialized = true;
@@ -60,16 +53,12 @@ public class LazyLoadingSecretFilter implements SecretFilter {
         }
       }
     }
-    if (initializationFailure instanceof RuntimeException re) {
-      throw re;
+    if (initializationFailure instanceof RuntimeException runtimeException) {
+      throw runtimeException;
     }
-    if (initializationFailure instanceof Error err) {
-      throw err;
+    if (initializationFailure instanceof Error error) {
+      throw error;
     }
-    if (secretNames != null) {
-      return secretNames.contains(secretName);
-    } else {
-      return true;
-    }
+    return delegate.isAllowed(secret);
   }
 }

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/secret/ProcessDefinitionSecretKeyCache.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/secret/ProcessDefinitionSecretKeyCache.java
@@ -17,6 +17,7 @@
 package io.camunda.connector.runtime.outbound.secret;
 
 import com.github.benmanes.caffeine.cache.Cache;
+import io.camunda.connector.runtime.core.secret.SecretFilter.Secret;
 import io.camunda.connector.runtime.core.secret.SecretUtil;
 import io.camunda.operate.CamundaOperateClient;
 import io.camunda.operate.exception.OperateException;
@@ -33,19 +34,29 @@ import io.camunda.zeebe.model.bpmn.instance.ServiceTask;
 import io.camunda.zeebe.model.bpmn.instance.SubProcess;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeInput;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeIoMapping;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
+import java.util.Deque;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.camunda.feel.api.FeelEngineApi;
+import org.camunda.feel.api.FeelEngineBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class ProcessDefinitionSecretKeyCache implements SecretKeyCache {
   private static final Logger LOG = LoggerFactory.getLogger(ProcessDefinitionSecretKeyCache.class);
+  private static final FeelEngineApi FEEL_ENGINE = FeelEngineBuilder.forJava().build();
   private static final List<Class<? extends BaseElement>> OUTBOUND_ELIGIBLE_TYPES =
       new ArrayList<>();
 
@@ -60,16 +71,16 @@ public class ProcessDefinitionSecretKeyCache implements SecretKeyCache {
   }
 
   private final CamundaOperateClient camundaOperateClient;
-  private final Cache<Long, Map<String, List<String>>> cache;
+  private final Cache<Long, Map<String, List<Secret>>> cache;
 
   public ProcessDefinitionSecretKeyCache(
-      CamundaOperateClient camundaOperateClient, Cache<Long, Map<String, List<String>>> cache) {
+      CamundaOperateClient camundaOperateClient, Cache<Long, Map<String, List<Secret>>> cache) {
     this.camundaOperateClient = camundaOperateClient;
     this.cache = cache;
   }
 
   @Override
-  public List<String> getSecretKeys(SecretKeyContext secretKeyContext) {
+  public List<Secret> getSecretKeys(SecretKeyContext secretKeyContext) {
     return cache
         .get(secretKeyContext.processDefinitionKey(), this::fetchSecretKeysByElementIdsUnchecked)
         .getOrDefault(secretKeyContext.elementId(), Collections.emptyList());
@@ -82,7 +93,7 @@ public class ProcessDefinitionSecretKeyCache implements SecretKeyCache {
    * unchecked mapping-function failure unwrapped, so every other exception here reaches the caller
    * exactly as thrown.
    */
-  private Map<String, List<String>> fetchSecretKeysByElementIdsUnchecked(
+  private Map<String, List<Secret>> fetchSecretKeysByElementIdsUnchecked(
       long processDefinitionKey) {
     try {
       return fetchSecretKeysByElementIds(processDefinitionKey);
@@ -94,7 +105,7 @@ public class ProcessDefinitionSecretKeyCache implements SecretKeyCache {
     }
   }
 
-  private Map<String, List<String>> fetchSecretKeysByElementIds(long processDefinitionKey)
+  private Map<String, List<Secret>> fetchSecretKeysByElementIds(long processDefinitionKey)
       throws OperateException {
     if (camundaOperateClient == null) {
       throw new SecretFilterUnavailableException(
@@ -116,7 +127,7 @@ public class ProcessDefinitionSecretKeyCache implements SecretKeyCache {
         .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
   }
 
-  private Map<String, List<String>> inspectBpmnProcess(Process process, long processDefinitionKey) {
+  private Map<String, List<Secret>> inspectBpmnProcess(Process process, long processDefinitionKey) {
     Collection<BaseElement> outboundEligibleElements =
         retrieveOutboundEligibleElementsFromProcess(process);
     if (outboundEligibleElements.isEmpty()) {
@@ -125,7 +136,7 @@ public class ProcessDefinitionSecretKeyCache implements SecretKeyCache {
       return Collections.emptyMap();
     }
 
-    Map<String, List<String>> discoveredOutboundConnectors = new HashMap<>();
+    Map<String, List<Secret>> discoveredOutboundConnectors = new HashMap<>();
     for (BaseElement element : outboundEligibleElements) {
       var inputs = findElementInput(element);
       var definedSecrets = extractSecrets(inputs);
@@ -134,12 +145,186 @@ public class ProcessDefinitionSecretKeyCache implements SecretKeyCache {
     return discoveredOutboundConnectors;
   }
 
-  private List<String> extractSecrets(List<ZeebeInput> inputs) {
-    return inputs.stream()
-        .flatMap(input -> SecretUtil.retrieveSecretKeysInInput(input.getSource()).stream())
-        .map(String::trim)
+  /**
+   * A secret is allowed not only on the input that names it directly, but also on every input whose
+   * own FEEL expression reads the variable that input's target writes — transitively. A template
+   * commonly assembles one input's value (e.g. {@code url}) from others (e.g. {@code baseUrl},
+   * itself holding a secret); the assembled input's runtime value can carry the secret's text just
+   * as directly as the input that named it, so the allow-list has to follow that data flow rather
+   * than stop at the input where the secret's name is written.
+   *
+   * <p>A dependency is resolved by matching a referenced variable's full qualified path against
+   * another input's {@code target} path, one a prefix of the other (a dotted target like {@code
+   * authentication.type} publishes both the top-level variable {@code authentication} and the field
+   * {@code authentication.type}). Requiring a prefix relation on the full path — rather than just
+   * the top-level segment — keeps sibling fields under the same top-level name, like {@code
+   * authentication.type} and {@code authentication.token}, from being treated as dependent on each
+   * other merely for sharing a top-level name.
+   *
+   * <p>Only a preceding, still-effective writer of the referenced path counts as a dependency:
+   * {@code zeebe:input} mappings evaluate in declaration order, each against the output the ones
+   * before it already built, so a later mapping's target is invisible to an earlier one, and a
+   * target written more than once is reachable only through its last writer before this point.
+   */
+  private List<Secret> extractSecrets(List<ZeebeInput> inputs) {
+    Map<ZeebeInput, List<String>> pathByInput = new LinkedHashMap<>();
+    Map<ZeebeInput, List<String>> ownSecretNamesByInput = new LinkedHashMap<>();
+    for (ZeebeInput input : inputs) {
+      pathByInput.put(input, Arrays.asList(input.getTarget().split("\\.")));
+      ownSecretNamesByInput.put(
+          input,
+          SecretUtil.retrieveSecretKeysInInput(input.getSource()).stream()
+              .map(String::trim)
+              .distinct()
+              .toList());
+    }
+
+    // zeebe:input mappings are evaluated in declaration order, each against the output built by
+    // the ones before it -- a later mapping is invisible to an earlier one, and a target written
+    // more than once is only reachable through its last (nearest-preceding), still-effective
+    // writer. effectiveTargets is therefore built up one input at a time, alongside the loop, and
+    // an input's own dependencies are resolved against it before that input registers itself.
+    Map<ZeebeInput, List<ZeebeInput>> directDependencies = new LinkedHashMap<>();
+    Map<List<String>, ZeebeInput> effectiveTargets = new LinkedHashMap<>();
+    for (ZeebeInput input : inputs) {
+      List<List<String>> referencedPaths = referencedVariablePaths(input.getSource());
+      directDependencies.put(
+          input,
+          referencedPaths.stream()
+              .flatMap(referencedPath -> matchingWriters(referencedPath, effectiveTargets))
+              .distinct()
+              .toList());
+      // A write to a parent path replaces the whole subtree beneath it, so every existing writer
+      // of a descendant path is no longer effective from this point on.
+      List<String> ownPath = pathByInput.get(input);
+      effectiveTargets.keySet().removeIf(existingPath -> isProperPrefix(ownPath, existingPath));
+      effectiveTargets.put(ownPath, input);
+    }
+
+    // A later mapping that writes a path *beneath* an earlier one replaces that part of what the
+    // earlier input produced -- and a grant is a path prefix, so it cannot say "everything under
+    // `path` except that subtree". Such a writer therefore grants nothing at its own path and
+    // propagates nothing to the inputs that read it: `authentication = secrets.WHOLE` followed by
+    // `authentication.token = someVariable` would otherwise authorize WHOLE at
+    // authentication.token, because the declared path is a prefix of it -- letting that later,
+    // potentially process-controlled value resolve a secret it never carried -- and equally at any
+    // field that copies the whole object afterwards. Any descendant still in effectiveTargets was
+    // necessarily written *after* this input, since this input's own write evicted the ones before
+    // it. This is the parent-overwrite rule above, applied in the other direction, and fails
+    // closed the same way: a parent whose expression nests a secret under a path a later mapping
+    // does not touch (`authentication = {user: "{{secrets.USER}}"}` alongside
+    // `authentication.token = ...`) loses its grant too, since a prefix cannot express the
+    // difference.
+    Set<ZeebeInput> shadowedWriters =
+        inputs.stream()
+            .filter(
+                candidate ->
+                    effectiveTargets.keySet().stream()
+                        .anyMatch(deeper -> isProperPrefix(pathByInput.get(candidate), deeper)))
+            .collect(Collectors.toSet());
+
+    List<Secret> result = new ArrayList<>();
+    for (ZeebeInput input : inputs) {
+      List<String> path = pathByInput.get(input);
+      // A later mapping can overwrite this input's own target -- directly, or by writing to a
+      // parent path that replaces the whole subtree beneath it -- before the sequence finishes.
+      // effectiveTargets reflects the final state once the loop above has processed every input,
+      // so if it no longer maps `path` back to this exact input, this input's value -- whether its
+      // own secret or one propagated into it through a dependency -- is not reachable at `path`
+      // any more; granting anything there would let whatever the actual final writer put in that
+      // field -- potentially attacker-controlled -- resolve a secret it never carried. This has to
+      // gate the dependency walk below too, not just the own-grant: a dependency chain still
+      // computes what *this* input's expression would have carried, which is moot once something
+      // else, not this input, is what the runtime field actually holds.
+      if (effectiveTargets.get(path) != input || shadowedWriters.contains(input)) {
+        continue;
+      }
+      ownSecretNamesByInput.get(input).forEach(name -> result.add(new Secret(name, path)));
+
+      Set<ZeebeInput> visited = new HashSet<>();
+      Deque<ZeebeInput> pending = new ArrayDeque<>(directDependencies.get(input));
+      while (!pending.isEmpty()) {
+        ZeebeInput dependency = pending.poll();
+        if (!visited.add(dependency)) {
+          continue;
+        }
+        // A shadowed dependency terminates the branch rather than merely contributing no names
+        // of its own: whatever flowed *into* it is just as unreachable through it as its own
+        // secret is, since part of what it produced was replaced by the later writer beneath it.
+        // Walking past it would grant a secret two hops up at this input's path -- which, being
+        // a prefix, covers this input's copy of that same shadowed subtree.
+        if (shadowedWriters.contains(dependency)) {
+          continue;
+        }
+        ownSecretNamesByInput.get(dependency).forEach(name -> result.add(new Secret(name, path)));
+        pending.addAll(directDependencies.getOrDefault(dependency, List.of()));
+      }
+    }
+    return result.stream().distinct().toList();
+  }
+
+  /**
+   * The full qualified path of every variable a FEEL expression references, or an empty list if
+   * {@code source} isn't a FEEL expression (no leading {@code =}) or fails to parse — a static
+   * value or a malformed expression simply has nothing to propagate from.
+   */
+  private static List<List<String>> referencedVariablePaths(String source) {
+    if (source == null) {
+      return List.of();
+    }
+    String trimmed = source.trim();
+    if (!trimmed.startsWith("=")) {
+      return List.of();
+    }
+    var parseResult = FEEL_ENGINE.parseExpression(trimmed.substring(1));
+    if (parseResult.isFailure()) {
+      return List.of();
+    }
+    return parseResult.parsedExpression().getVariableReferences().stream()
+        .map(ref -> ref.getFullQualifiedName())
         .distinct()
         .toList();
+  }
+
+  /**
+   * The writers a reference to {@code referencedPath} depends on, given the writers currently still
+   * effective. Two disjoint cases, since a single symmetric prefix match would let a stale ancestor
+   * writer stand in for a leaf that a later, more specific writer has since replaced:
+   *
+   * <ul>
+   *   <li>The reference targets a specific field or the exact field a writer wrote: at most one
+   *       writer answers it, the <em>nearest</em> (most specific) ancestor-or-self path among the
+   *       effective writers -- a closer writer, even an earlier one, shadows a more distant
+   *       ancestor's stake in that one field.
+   *   <li>The reference targets a whole object a writer's field lives under: every writer whose
+   *       path is a descendant of the reference answers it, since reading the whole object reads
+   *       every field currently set beneath it.
+   * </ul>
+   */
+  private static Stream<ZeebeInput> matchingWriters(
+      List<String> referencedPath, Map<List<String>, ZeebeInput> effectiveTargets) {
+    var nearestAncestorOrSelf =
+        effectiveTargets.entrySet().stream()
+            .filter(entry -> isAncestorOrSelf(entry.getKey(), referencedPath))
+            .max(Comparator.comparingInt(entry -> entry.getKey().size()))
+            .map(Map.Entry::getValue);
+    var descendants =
+        effectiveTargets.entrySet().stream()
+            .filter(entry -> isProperPrefix(referencedPath, entry.getKey()))
+            .map(Map.Entry::getValue);
+    return nearestAncestorOrSelf
+        .map(writer -> Stream.concat(Stream.of(writer), descendants))
+        .orElse(descendants);
+  }
+
+  /** Whether {@code ancestor} is a prefix of {@code path}, including being equal to it. */
+  private static boolean isAncestorOrSelf(List<String> ancestor, List<String> path) {
+    return ancestor.size() <= path.size() && path.subList(0, ancestor.size()).equals(ancestor);
+  }
+
+  /** Whether {@code shorter} is a strict ancestor path of {@code longer} (not equal to it). */
+  private static boolean isProperPrefix(List<String> shorter, List<String> longer) {
+    return shorter.size() < longer.size() && longer.subList(0, shorter.size()).equals(shorter);
   }
 
   private List<ZeebeInput> findElementInput(BaseElement element) {

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/secret/SecretKeyCache.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/secret/SecretKeyCache.java
@@ -16,10 +16,11 @@
  */
 package io.camunda.connector.runtime.outbound.secret;
 
+import io.camunda.connector.runtime.core.secret.SecretFilter.Secret;
 import java.util.List;
 
 public interface SecretKeyCache {
-  List<String> getSecretKeys(SecretKeyContext secretKeyContext);
+  List<Secret> getSecretKeys(SecretKeyContext secretKeyContext);
 
   record SecretKeyContext(long processDefinitionKey, String elementId) {}
 }

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/inbound/InboundConnectorRuntimeConfigurationTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/inbound/InboundConnectorRuntimeConfigurationTest.java
@@ -104,7 +104,8 @@ class InboundConnectorRuntimeConfigurationTest {
                 e -> {},
                 TestExecutable.class,
                 EvictingQueue.create(10));
-    return context.getSecretHandler().replaceSecrets("secrets.UNDECLARED");
+    var probe = new ObjectMapper().createObjectNode().put("token", "secrets.UNDECLARED");
+    return context.getSecretHandler().replaceSecrets(probe).get("token").asText();
   }
 
   private String resolveChainedViaElementContext(SecretFilterMode mode) {

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/job/ConfigurableSecretFilterFactoryTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/job/ConfigurableSecretFilterFactoryTest.java
@@ -26,6 +26,7 @@ import static org.mockito.Mockito.when;
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import io.camunda.connector.runtime.core.secret.SecretAllowListUnavailableException;
+import io.camunda.connector.runtime.core.secret.SecretFilter.Secret;
 import io.camunda.connector.runtime.core.secret.SecretFilterFactory.SecretFilterContext;
 import io.camunda.connector.runtime.outbound.job.ConfigurableSecretFilterFactory.SecretFilterMode;
 import io.camunda.connector.runtime.outbound.secret.ProcessDefinitionSecretKeyCache;
@@ -58,21 +59,22 @@ class ConfigurableSecretFilterFactoryTest {
 
     var filter = factory.create(CONTEXT);
 
-    assertThat(filter.isAllowed("ANY_SECRET")).isTrue();
-    assertThat(filter.isAllowed("ANOTHER_SECRET")).isTrue();
+    assertThat(filter.isAllowed(secret("ANY_SECRET"))).isTrue();
+    assertThat(filter.isAllowed(secret("ANOTHER_SECRET"))).isTrue();
     verifyNoInteractions(secretKeyCache);
   }
 
   @Test
   void create_lax_withSecretKeys_restrictsFilterToList() {
-    when(secretKeyCache.getSecretKeys(SECRET_KEY_CONTEXT)).thenReturn(List.of("API_KEY", "TOKEN"));
+    when(secretKeyCache.getSecretKeys(SECRET_KEY_CONTEXT))
+        .thenReturn(List.of(secret("API_KEY"), secret("TOKEN")));
     var factory = new ConfigurableSecretFilterFactory(SecretFilterMode.LAX, secretKeyCache);
 
     var filter = factory.create(CONTEXT);
 
-    assertThat(filter.isAllowed("API_KEY")).isTrue();
-    assertThat(filter.isAllowed("TOKEN")).isTrue();
-    assertThat(filter.isAllowed("UNLISTED_SECRET")).isFalse();
+    assertThat(filter.isAllowed(secret("API_KEY"))).isTrue();
+    assertThat(filter.isAllowed(secret("TOKEN"))).isTrue();
+    assertThat(filter.isAllowed(secret("UNLISTED_SECRET"))).isFalse();
   }
 
   @Test
@@ -82,18 +84,18 @@ class ConfigurableSecretFilterFactoryTest {
 
     var filter = factory.create(CONTEXT);
 
-    assertThat(filter.isAllowed("ANY_SECRET")).isTrue();
+    assertThat(filter.isAllowed(secret("ANY_SECRET"))).isTrue();
   }
 
   @Test
   void create_strict_withSecretKeys_restrictsFilterToList() {
-    when(secretKeyCache.getSecretKeys(SECRET_KEY_CONTEXT)).thenReturn(List.of("API_KEY"));
+    when(secretKeyCache.getSecretKeys(SECRET_KEY_CONTEXT)).thenReturn(List.of(secret("API_KEY")));
     var factory = new ConfigurableSecretFilterFactory(SecretFilterMode.STRICT, secretKeyCache);
 
     var filter = factory.create(CONTEXT);
 
-    assertThat(filter.isAllowed("API_KEY")).isTrue();
-    assertThat(filter.isAllowed("UNLISTED_SECRET")).isFalse();
+    assertThat(filter.isAllowed(secret("API_KEY"))).isTrue();
+    assertThat(filter.isAllowed(secret("UNLISTED_SECRET"))).isFalse();
   }
 
   @Test
@@ -103,7 +105,7 @@ class ConfigurableSecretFilterFactoryTest {
 
     var filter = factory.create(CONTEXT);
 
-    assertThatThrownBy(() -> filter.isAllowed("ANY_SECRET"))
+    assertThatThrownBy(() -> filter.isAllowed(secret("ANY_SECRET")))
         .isInstanceOf(SecretAllowListUnavailableException.class)
         .hasMessageContaining("Error retrieving secret keys");
   }
@@ -119,7 +121,7 @@ class ConfigurableSecretFilterFactoryTest {
 
     var filter = factory.create(CONTEXT);
 
-    assertThatThrownBy(() -> filter.isAllowed("ANY_SECRET"))
+    assertThatThrownBy(() -> filter.isAllowed(secret("ANY_SECRET")))
         .hasMessageContaining(ELEMENT_ID)
         .hasMessageContaining(String.valueOf(PROCESS_DEF_KEY))
         .hasMessageContaining(RuntimeException.class.getName())
@@ -158,7 +160,7 @@ class ConfigurableSecretFilterFactoryTest {
 
     var filter = factory.create(CONTEXT);
 
-    assertThatThrownBy(() -> filter.isAllowed("ANY_SECRET"))
+    assertThatThrownBy(() -> filter.isAllowed(secret("ANY_SECRET")))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("No CamundaOperateClient available");
   }
@@ -178,7 +180,7 @@ class ConfigurableSecretFilterFactoryTest {
 
     var filter = factory.create(CONTEXT);
 
-    assertThatThrownBy(() -> filter.isAllowed("ANY_SECRET"))
+    assertThatThrownBy(() -> filter.isAllowed(secret("ANY_SECRET")))
         .hasMessageContaining(java.net.ConnectException.class.getName())
         .hasMessageNotContaining("Connection refused");
   }
@@ -196,12 +198,12 @@ class ConfigurableSecretFilterFactoryTest {
 
     var filter = factory.create(CONTEXT);
 
-    assertThatThrownBy(() -> filter.isAllowed("ANY_SECRET"))
+    assertThatThrownBy(() -> filter.isAllowed(secret("ANY_SECRET")))
         .isInstanceOf(SecretAllowListUnavailableException.class);
   }
 
   private void assertMessageIdentifiesTheFailureWithoutLeakingTheCauseText(
-      Cache<Long, Map<String, List<String>>> cache) throws Exception {
+      Cache<Long, Map<String, List<Secret>>> cache) throws Exception {
     var operateClient = mock(CamundaOperateClient.class);
     when(operateClient.getProcessDefinitionModel(PROCESS_DEF_KEY))
         .thenThrow(new OperateException("Operate returned 404 for process definition 42"));
@@ -210,11 +212,15 @@ class ConfigurableSecretFilterFactoryTest {
 
     var filter = factory.create(CONTEXT);
 
-    assertThatThrownBy(() -> filter.isAllowed("ANY_SECRET"))
+    assertThatThrownBy(() -> filter.isAllowed(secret("ANY_SECRET")))
         .hasMessageContaining(ELEMENT_ID)
         .hasMessageContaining(String.valueOf(PROCESS_DEF_KEY))
         .hasMessageContaining(OperateException.class.getName())
         .hasMessageNotContaining("could not be loaded using")
         .hasMessageNotContaining("Operate returned 404 for process definition 42");
+  }
+
+  private static Secret secret(String name) {
+    return new Secret(name, List.of());
   }
 }

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/job/LazyLoadingSecretFilterTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/job/LazyLoadingSecretFilterTest.java
@@ -20,6 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import io.camunda.connector.runtime.core.secret.SecretFilter.Secret;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.Test;
@@ -28,25 +29,30 @@ class LazyLoadingSecretFilterTest {
 
   @Test
   void isAllowed_withAllowList_permitsListedSecret() {
-    var filter = new LazyLoadingSecretFilter(() -> List.of("MY_SECRET", "OTHER_SECRET"));
+    var filter =
+        new LazyLoadingSecretFilter(
+            () -> List.of(secret("MY_SECRET", "foo"), secret("OTHER_SECRET", "bar")));
 
-    assertTrue(filter.isAllowed("MY_SECRET"));
-    assertTrue(filter.isAllowed("OTHER_SECRET"));
+    assertTrue(filter.isAllowed(secret("MY_SECRET", "foo")));
+    assertTrue(filter.isAllowed(secret("MY_SECRET", "foo", "nested")));
+    assertTrue(filter.isAllowed(secret("OTHER_SECRET", "bar")));
   }
 
   @Test
   void isAllowed_withAllowList_deniesUnlistedSecret() {
-    var filter = new LazyLoadingSecretFilter(() -> List.of("MY_SECRET"));
+    var filter = new LazyLoadingSecretFilter(() -> List.of(secret("MY_SECRET", "foo", "bar")));
 
-    assertFalse(filter.isAllowed("UNLISTED_SECRET"));
+    assertFalse(filter.isAllowed(secret("UNLISTED_SECRET", "foo", "bar")));
+    assertFalse(filter.isAllowed(secret("MY_SECRET", "foo")));
+    assertFalse(filter.isAllowed(secret("MY_SECRET", "baz")));
   }
 
   @Test
   void isAllowed_withNullSupplierResult_allowsAll() {
     var filter = new LazyLoadingSecretFilter(() -> null);
 
-    assertTrue(filter.isAllowed("ANY_SECRET"));
-    assertTrue(filter.isAllowed("ANOTHER_SECRET"));
+    assertTrue(filter.isAllowed(secret("ANY_SECRET")));
+    assertTrue(filter.isAllowed(secret("ANOTHER_SECRET")));
   }
 
   @Test
@@ -56,12 +62,12 @@ class LazyLoadingSecretFilterTest {
         new LazyLoadingSecretFilter(
             () -> {
               callCount.incrementAndGet();
-              return List.of("SECRET");
+              return List.of(secret("SECRET"));
             });
 
-    filter.isAllowed("SECRET");
-    filter.isAllowed("SECRET");
-    filter.isAllowed("OTHER");
+    filter.isAllowed(secret("SECRET"));
+    filter.isAllowed(secret("SECRET"));
+    filter.isAllowed(secret("OTHER"));
 
     assertTrue(callCount.get() == 1, "Supplier must be called exactly once");
   }
@@ -76,8 +82,8 @@ class LazyLoadingSecretFilterTest {
               return null;
             });
 
-    filter.isAllowed("ANY");
-    filter.isAllowed("ANY");
+    filter.isAllowed(secret("ANY"));
+    filter.isAllowed(secret("ANY"));
 
     assertTrue(callCount.get() == 1, "Supplier must be called exactly once even when null");
   }
@@ -92,8 +98,8 @@ class LazyLoadingSecretFilterTest {
               throw new IllegalArgumentException("lookup failed");
             });
 
-    assertThrows(IllegalArgumentException.class, () -> filter.isAllowed("ANY"));
-    assertThrows(IllegalArgumentException.class, () -> filter.isAllowed("ANY"));
+    assertThrows(IllegalArgumentException.class, () -> filter.isAllowed(secret("ANY")));
+    assertThrows(IllegalArgumentException.class, () -> filter.isAllowed(secret("ANY")));
 
     assertTrue(callCount.get() == 1, "Supplier must not be re-invoked after a cached failure");
   }
@@ -108,9 +114,14 @@ class LazyLoadingSecretFilterTest {
               throw new NoClassDefFoundError("some.missing.Class");
             });
 
-    assertThrows(NoClassDefFoundError.class, () -> filter.isAllowed("UNDECLARED_SECRET"));
-    assertThrows(NoClassDefFoundError.class, () -> filter.isAllowed("ANOTHER_UNDECLARED_SECRET"));
+    assertThrows(NoClassDefFoundError.class, () -> filter.isAllowed(secret("UNDECLARED_SECRET")));
+    assertThrows(
+        NoClassDefFoundError.class, () -> filter.isAllowed(secret("ANOTHER_UNDECLARED_SECRET")));
 
     assertTrue(callCount.get() == 1, "Supplier must not be re-invoked after a cached failure");
+  }
+
+  private static Secret secret(String name, String... fieldPath) {
+    return new Secret(name, List.of(fieldPath));
   }
 }

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/secret/ProcessDefinitionSecretKeyCacheTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/secret/ProcessDefinitionSecretKeyCacheTest.java
@@ -21,11 +21,12 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.when;
 
 import com.github.benmanes.caffeine.cache.Caffeine;
+import io.camunda.connector.runtime.core.secret.SecretFilter.Secret;
 import io.camunda.connector.runtime.outbound.secret.SecretKeyCache.SecretKeyContext;
 import io.camunda.operate.CamundaOperateClient;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
-import java.io.IOException;
+import java.util.List;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -61,7 +62,231 @@ class ProcessDefinitionSecretKeyCacheTest {
     var keys =
         secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1"));
 
-    assertThat(keys).containsExactlyInAnyOrder("API_KEY", "MY_TOKEN");
+    assertThat(keys)
+        .extracting(Secret::secretName)
+        .containsExactlyInAnyOrder("API_KEY", "MY_TOKEN");
+  }
+
+  @Test
+  void getSecretKeys_dottedTarget_splitsIntoAMultiSegmentFieldPath() throws Exception {
+    // Projecting away fieldPath (as every other assertion in this class does, via
+    // Secret::secretName) would let a regression that assigns every secret an empty or wrong
+    // path pass unnoticed — this asserts the complete Secret, name and path together, against a
+    // target with more than one segment.
+    when(camundaOperateClient.getProcessDefinitionModel(PROCESS_DEF_KEY))
+        .thenReturn(loadBpmn("outbound-with-dotted-target.bpmn"));
+
+    var keys =
+        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1"));
+
+    assertThat(keys).containsExactly(new Secret("API_KEY", List.of("auth", "token")));
+  }
+
+  @Test
+  void getSecretKeys_secretPropagatesToAnInputThatReferencesTheDeclaringInputsVariable()
+      throws Exception {
+    // baseUrl declares BASE_URL_SFDC; url is a FEEL expression built from baseUrl and path
+    // ("=baseUrl + \"/services/apexrest/\" + path"). url's runtime value can carry the secret's
+    // resolved text just as directly as baseUrl's can, so the secret must be allowed under url's
+    // own field path too -- not just under baseUrl's.
+    when(camundaOperateClient.getProcessDefinitionModel(PROCESS_DEF_KEY))
+        .thenReturn(loadBpmn("outbound-with-referenced-variable.bpmn"));
+
+    var keys =
+        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1"));
+
+    assertThat(keys)
+        .contains(
+            new Secret("BASE_URL_SFDC", List.of("baseUrl")),
+            new Secret("BASE_URL_SFDC", List.of("url")));
+  }
+
+  @Test
+  void getSecretKeys_propagatesTransitivelyThroughAChainOfReferences() throws Exception {
+    // innerBaseUrl declares INNER_SECRET; baseUrl = "=innerBaseUrl + \"/static-context\""
+    // references innerBaseUrl; url = "=baseUrl" references baseUrl, not innerBaseUrl directly.
+    // The secret has to reach url through two hops of the dependency chain, not just one.
+    when(camundaOperateClient.getProcessDefinitionModel(PROCESS_DEF_KEY))
+        .thenReturn(loadBpmn("outbound-with-chained-references.bpmn"));
+
+    var keys =
+        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1"));
+
+    assertThat(keys)
+        .containsExactlyInAnyOrder(
+            new Secret("INNER_SECRET", List.of("innerBaseUrl")),
+            new Secret("INNER_SECRET", List.of("baseUrl")),
+            new Secret("INNER_SECRET", List.of("url")));
+  }
+
+  @Test
+  void getSecretKeys_propagationDoesNotReachAnInputThatDoesNotReferenceTheDeclaringVariable()
+      throws Exception {
+    // method ("get") and connectionTimeoutInSeconds ("20") are unrelated static inputs on the same
+    // element -- propagation must not leak the secret onto every sibling input, only onto ones
+    // whose own expression actually reads the variable that carries it.
+    when(camundaOperateClient.getProcessDefinitionModel(PROCESS_DEF_KEY))
+        .thenReturn(loadBpmn("outbound-with-referenced-variable.bpmn"));
+
+    var keys =
+        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1"));
+
+    assertThat(keys)
+        .doesNotContain(
+            new Secret("BASE_URL_SFDC", List.of("method")),
+            new Secret("BASE_URL_SFDC", List.of("connectionTimeoutInSeconds")),
+            new Secret("BASE_URL_SFDC", List.of("path")),
+            new Secret("BASE_URL_SFDC", List.of("authentication", "type")));
+  }
+
+  @Test
+  void getSecretKeys_referenceToASiblingFieldDoesNotPropagateASiblingsSecret() throws Exception {
+    // authentication.token and authentication.type are siblings that merely share a top-level
+    // target segment. usesSiblingFieldOnly references authentication.type specifically, not the
+    // whole authentication object, so it must not inherit AUTH_TOKEN from its sibling field.
+    // usesWholeAuth, by reading the whole authentication object, legitimately picks it up.
+    when(camundaOperateClient.getProcessDefinitionModel(PROCESS_DEF_KEY))
+        .thenReturn(loadBpmn("outbound-with-sibling-fields.bpmn"));
+
+    var keys =
+        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1"));
+
+    assertThat(keys)
+        .contains(
+            new Secret("AUTH_TOKEN", List.of("authentication", "token")),
+            new Secret("AUTH_TOKEN", List.of("usesWholeAuth")))
+        .doesNotContain(
+            new Secret("AUTH_TOKEN", List.of("usesSiblingFieldOnly")),
+            new Secret("AUTH_TOKEN", List.of("authentication", "type")));
+  }
+
+  @Test
+  void getSecretKeys_referenceToAVariableDefinedLaterDoesNotPropagateItsSecret() throws Exception {
+    // url ("=baseUrl") is declared before baseUrl ("secrets.API_KEY") in the same ioMapping.
+    // zeebe:input mappings evaluate in declaration order, each against the output the ones before
+    // it already built, so url's expression sees the process-scope baseUrl, not this mapping's
+    // own -- API_KEY must not be allowed on url.
+    when(camundaOperateClient.getProcessDefinitionModel(PROCESS_DEF_KEY))
+        .thenReturn(loadBpmn("outbound-with-reverse-order-reference.bpmn"));
+
+    var keys =
+        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1"));
+
+    assertThat(keys)
+        .contains(new Secret("API_KEY", List.of("baseUrl")))
+        .doesNotContain(new Secret("API_KEY", List.of("url")));
+  }
+
+  @Test
+  void getSecretKeys_laterParentOverwriteInvalidatesAnEarlierDescendantWriter() throws Exception {
+    // authentication.token = secrets.TOKEN is declared first, then authentication (the whole
+    // parent object) is overwritten wholesale, replacing that field's secret-bearing value. url
+    // references authentication.token afterwards, but by then the token write is shadowed by
+    // the parent overwrite -- TOKEN must not be allowed on url, nor on its own now-overwritten
+    // path: the runtime field at authentication.token holds whatever the parent overwrite put
+    // there, not the secret, so granting TOKEN there would let that overwritten (potentially
+    // attacker-controlled) value resolve a secret it never carried.
+    when(camundaOperateClient.getProcessDefinitionModel(PROCESS_DEF_KEY))
+        .thenReturn(loadBpmn("outbound-with-parent-overwrite.bpmn"));
+
+    var keys =
+        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1"));
+
+    // Nothing in this BPMN ever reads authentication.token from a path that's still effective, so
+    // TOKEN isn't just absent from the two paths above -- it's not granted anywhere at all. This
+    // is stricter than doesNotContain(...) on its own: it also catches a regression that grants
+    // TOKEN at some third path this test doesn't otherwise name.
+    assertThat(keys).isEmpty();
+  }
+
+  @Test
+  void getSecretKeys_laterWriteToTheSameExactPathInvalidatesTheEarlierWriter() throws Exception {
+    // Two inputs target the identical path authentication.token: the first carries TOKEN, the
+    // second overwrites it with a plain value. The runtime field holds only the second input's
+    // value, so TOKEN must not be granted at that path -- the earlier grant would otherwise let
+    // the overwriting (potentially attacker-controlled) value resolve a secret it never carried.
+    when(camundaOperateClient.getProcessDefinitionModel(PROCESS_DEF_KEY))
+        .thenReturn(loadBpmn("outbound-with-same-path-overwrite.bpmn"));
+
+    var keys =
+        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1"));
+
+    assertThat(keys).isEmpty();
+  }
+
+  @Test
+  void getSecretKeys_laterOverwriteOfAPropagationTargetInvalidatesThePropagatedGrant()
+      throws Exception {
+    // baseUrl = secrets.TOKEN is declared first; url = "=baseUrl" propagates TOKEN to url while
+    // baseUrl is still the effective writer url's expression reads. A third mapping then
+    // overwrites url directly with attacker-controlled data -- url's runtime value comes from that
+    // third mapping, not from the (no longer effective) propagation through the second, so TOKEN
+    // must not be granted at url even though the dependency edge to it was genuinely resolved at
+    // the time it was computed.
+    when(camundaOperateClient.getProcessDefinitionModel(PROCESS_DEF_KEY))
+        .thenReturn(loadBpmn("outbound-with-overwritten-propagation-target.bpmn"));
+
+    var keys =
+        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1"));
+
+    assertThat(keys)
+        .containsExactly(new Secret("TOKEN", List.of("baseUrl")))
+        .doesNotContain(new Secret("TOKEN", List.of("url")));
+  }
+
+  @Test
+  void getSecretKeys_laterChildWriteRevokesTheAncestorGrant() throws Exception {
+    // authentication = secrets.WHOLE_SECRET is declared first; authentication.token is then
+    // written by a later mapping. A grant is a path prefix, so a grant at [authentication] also
+    // authorizes a lookup at authentication.token -- the field the later mapping controls. If that
+    // mapping's source were process data rather than the fixture's literal, a placeholder in it
+    // would resolve WHOLE_SECRET, a secret that value never carried. The whole grant therefore
+    // goes, at the parent's own path and at wholeObjectRead, which copies the object afterwards.
+    // Nothing is lost here: the child write replaces the parent's scalar with an object, so the
+    // secret's text is not present at runtime under authentication at all.
+    when(camundaOperateClient.getProcessDefinitionModel(PROCESS_DEF_KEY))
+        .thenReturn(loadBpmn("outbound-with-child-overwrite.bpmn"));
+
+    var keys =
+        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1"));
+
+    assertThat(keys).isEmpty();
+  }
+
+  @Test
+  void getSecretKeys_laterChildWriteRevokesAnAncestorGrantThatNestsItsSecretElsewhere()
+      throws Exception {
+    // The fail-closed half of the rule above, pinned deliberately. Here the parent's own FEEL
+    // object nests USER at authentication.user, which the later authentication.token write does
+    // not touch -- so the grant is legitimate for that one field and only over-broad for the
+    // shadowed sibling. A prefix cannot express "under authentication except .token", so the
+    // grant is dropped rather than narrowed, and USER stops resolving on this element. Accepted
+    // over-denial: the alternative is authorizing the secret at a field a later mapping fills
+    // from process data.
+    when(camundaOperateClient.getProcessDefinitionModel(PROCESS_DEF_KEY))
+        .thenReturn(loadBpmn("outbound-with-nested-parent-and-child-overwrite.bpmn"));
+
+    var keys =
+        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1"));
+
+    assertThat(keys).isEmpty();
+  }
+
+  @Test
+  void getSecretKeys_shadowedInputDoesNotRelayItsOwnDependenciesSecret() throws Exception {
+    // The shadowed input is itself a dependent here: baseUrl carries T, authentication reads
+    // baseUrl, authentication.token is then written from process data, and copy reads the whole
+    // authentication object. Muting only the shadowed input's *own* names is not enough -- the
+    // walk would keep traversing through it and reach baseUrl, granting T at copy, which
+    // prefix-matches copy.token, the field that carries the shadowed subtree's attacker data.
+    // A shadowed input terminates the branch instead.
+    when(camundaOperateClient.getProcessDefinitionModel(PROCESS_DEF_KEY))
+        .thenReturn(loadBpmn("outbound-with-shadowed-input-as-dependency.bpmn"));
+
+    var keys =
+        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1"));
+
+    assertThat(keys).containsExactly(new Secret("T", List.of("baseUrl")));
   }
 
   @Test
@@ -74,8 +299,10 @@ class ProcessDefinitionSecretKeyCacheTest {
         secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "task-alpha"));
     var betaKeys = secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "task-beta"));
 
-    assertThat(alphaKeys).containsExactly("SECRET_ALPHA");
-    assertThat(betaKeys).containsExactlyInAnyOrder("SECRET_BETA", "SECRET_GAMMA");
+    assertThat(alphaKeys).extracting(Secret::secretName).containsExactly("SECRET_ALPHA");
+    assertThat(betaKeys)
+        .extracting(Secret::secretName)
+        .containsExactlyInAnyOrder("SECRET_BETA", "SECRET_GAMMA");
   }
 
   @Test
@@ -99,7 +326,7 @@ class ProcessDefinitionSecretKeyCacheTest {
 
     var keys = secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "plain-task"));
 
-    assertThat(keys).containsExactly("SECRET_X");
+    assertThat(keys).extracting(Secret::secretName).containsExactly("SECRET_X");
   }
 
   @Test
@@ -122,7 +349,7 @@ class ProcessDefinitionSecretKeyCacheTest {
 
     var keys = secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, elementId));
 
-    assertThat(keys).containsExactly(secretKey);
+    assertThat(keys).extracting(Secret::secretName).containsExactly(secretKey);
   }
 
   private static Stream<Arguments> otherEligibleTaskTypes() {
@@ -147,9 +374,9 @@ class ProcessDefinitionSecretKeyCacheTest {
     var grandchildKeys =
         secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "grandchild-task"));
 
-    assertThat(outerKeys).containsExactly("OUTER_SECRET");
-    assertThat(innerKeys).containsExactly("INNER_SECRET");
-    assertThat(grandchildKeys).containsExactly("GRANDCHILD_SECRET");
+    assertThat(outerKeys).extracting(Secret::secretName).containsExactly("OUTER_SECRET");
+    assertThat(innerKeys).extracting(Secret::secretName).containsExactly("INNER_SECRET");
+    assertThat(grandchildKeys).extracting(Secret::secretName).containsExactly("GRANDCHILD_SECRET");
   }
 
   @Test
@@ -163,8 +390,8 @@ class ProcessDefinitionSecretKeyCacheTest {
     var endEventKeys =
         secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "send-message-end"));
 
-    assertThat(throwEventKeys).containsExactly("THROW_EVENT_SECRET");
-    assertThat(endEventKeys).containsExactly("END_EVENT_SECRET");
+    assertThat(throwEventKeys).extracting(Secret::secretName).containsExactly("THROW_EVENT_SECRET");
+    assertThat(endEventKeys).extracting(Secret::secretName).containsExactly("END_EVENT_SECRET");
   }
 
   @Test
@@ -193,7 +420,7 @@ class ProcessDefinitionSecretKeyCacheTest {
         .hasCauseInstanceOf(io.camunda.operate.exception.OperateException.class);
   }
 
-  private BpmnModelInstance loadBpmn(String fileName) throws IOException {
+  private BpmnModelInstance loadBpmn(String fileName) throws Exception {
     try (var stream = getClass().getClassLoader().getResourceAsStream("bpmn/" + fileName)) {
       if (stream == null) {
         throw new IllegalArgumentException("BPMN resource not found: bpmn/" + fileName);

--- a/connector-runtime/connector-runtime-spring/src/test/resources/bpmn/outbound-with-chained-references.bpmn
+++ b/connector-runtime/connector-runtime-spring/src/test/resources/bpmn/outbound-with-chained-references.bpmn
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+                  xmlns:zeebe="http://camunda.org/schema/zeebe/1.0"
+                  id="Definitions_outbound_chained_references"
+                  targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="outbound-with-chained-references" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_1" sourceRef="StartEvent_1" targetRef="service-task-1"/>
+    <bpmn:serviceTask id="service-task-1" name="HTTP Task"
+                      zeebe:modelerTemplate="io.camunda.connectors.HttpJson.v2">
+      <bpmn:extensionElements>
+        <zeebe:ioMapping>
+          <zeebe:input source="secrets.INNER_SECRET" target="innerBaseUrl"/>
+          <zeebe:input source="=innerBaseUrl + &quot;/static-context&quot;" target="baseUrl"/>
+          <zeebe:input source="=baseUrl" target="url"/>
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1</bpmn:incoming>
+      <bpmn:outgoing>Flow_2</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="Flow_2" sourceRef="service-task-1" targetRef="EndEvent_1"/>
+    <bpmn:endEvent id="EndEvent_1">
+      <bpmn:incoming>Flow_2</bpmn:incoming>
+    </bpmn:endEvent>
+  </bpmn:process>
+</bpmn:definitions>

--- a/connector-runtime/connector-runtime-spring/src/test/resources/bpmn/outbound-with-child-overwrite.bpmn
+++ b/connector-runtime/connector-runtime-spring/src/test/resources/bpmn/outbound-with-child-overwrite.bpmn
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+                  xmlns:zeebe="http://camunda.org/schema/zeebe/1.0"
+                  id="Definitions_outbound_child_overwrite"
+                  targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="outbound-with-child-overwrite" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_1" sourceRef="StartEvent_1" targetRef="service-task-1"/>
+    <bpmn:serviceTask id="service-task-1" name="HTTP Task"
+                      zeebe:modelerTemplate="io.camunda.connectors.HttpJson.v2">
+      <bpmn:extensionElements>
+        <zeebe:ioMapping>
+          <zeebe:input source="secrets.WHOLE_SECRET" target="authentication"/>
+          <zeebe:input source="public-value" target="authentication.token"/>
+          <zeebe:input source="=authentication.token" target="url"/>
+          <zeebe:input source="=authentication" target="wholeObjectRead"/>
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1</bpmn:incoming>
+      <bpmn:outgoing>Flow_2</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="Flow_2" sourceRef="service-task-1" targetRef="EndEvent_1"/>
+    <bpmn:endEvent id="EndEvent_1">
+      <bpmn:incoming>Flow_2</bpmn:incoming>
+    </bpmn:endEvent>
+  </bpmn:process>
+</bpmn:definitions>

--- a/connector-runtime/connector-runtime-spring/src/test/resources/bpmn/outbound-with-dotted-target.bpmn
+++ b/connector-runtime/connector-runtime-spring/src/test/resources/bpmn/outbound-with-dotted-target.bpmn
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+                  xmlns:zeebe="http://camunda.org/schema/zeebe/1.0"
+                  id="Definitions_outbound_dotted_target"
+                  targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="outbound-with-dotted-target" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_1" sourceRef="StartEvent_1" targetRef="service-task-1"/>
+    <bpmn:serviceTask id="service-task-1" name="HTTP Task"
+                      zeebe:modelerTemplate="io.camunda.connectors.HttpJson.v2">
+      <bpmn:extensionElements>
+        <zeebe:ioMapping>
+          <zeebe:input source="secrets.API_KEY" target="auth.token"/>
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1</bpmn:incoming>
+      <bpmn:outgoing>Flow_2</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="Flow_2" sourceRef="service-task-1" targetRef="EndEvent_1"/>
+    <bpmn:endEvent id="EndEvent_1">
+      <bpmn:incoming>Flow_2</bpmn:incoming>
+    </bpmn:endEvent>
+  </bpmn:process>
+</bpmn:definitions>

--- a/connector-runtime/connector-runtime-spring/src/test/resources/bpmn/outbound-with-nested-parent-and-child-overwrite.bpmn
+++ b/connector-runtime/connector-runtime-spring/src/test/resources/bpmn/outbound-with-nested-parent-and-child-overwrite.bpmn
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+                  xmlns:zeebe="http://camunda.org/schema/zeebe/1.0"
+                  id="Definitions_outbound_nested_parent_child_overwrite"
+                  targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="outbound-with-nested-parent-and-child-overwrite" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_1" sourceRef="StartEvent_1" targetRef="service-task-1"/>
+    <bpmn:serviceTask id="service-task-1" name="HTTP Task"
+                      zeebe:modelerTemplate="io.camunda.connectors.HttpJson.v2">
+      <bpmn:extensionElements>
+        <zeebe:ioMapping>
+          <zeebe:input source="={ user: &quot;{{secrets.USER}}&quot; }" target="authentication"/>
+          <zeebe:input source="=attackerVar" target="authentication.token"/>
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1</bpmn:incoming>
+      <bpmn:outgoing>Flow_2</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="Flow_2" sourceRef="service-task-1" targetRef="EndEvent_1"/>
+    <bpmn:endEvent id="EndEvent_1">
+      <bpmn:incoming>Flow_2</bpmn:incoming>
+    </bpmn:endEvent>
+  </bpmn:process>
+</bpmn:definitions>

--- a/connector-runtime/connector-runtime-spring/src/test/resources/bpmn/outbound-with-overwritten-propagation-target.bpmn
+++ b/connector-runtime/connector-runtime-spring/src/test/resources/bpmn/outbound-with-overwritten-propagation-target.bpmn
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+                  xmlns:zeebe="http://camunda.org/schema/zeebe/1.0"
+                  id="Definitions_outbound_overwritten_propagation_target"
+                  targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="outbound-with-overwritten-propagation-target" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_1" sourceRef="StartEvent_1" targetRef="service-task-1"/>
+    <bpmn:serviceTask id="service-task-1" name="HTTP Task"
+                      zeebe:modelerTemplate="io.camunda.connectors.HttpJson.v2">
+      <bpmn:extensionElements>
+        <zeebe:ioMapping>
+          <zeebe:input source="secrets.TOKEN" target="baseUrl"/>
+          <zeebe:input source="=baseUrl" target="url"/>
+          <zeebe:input source="attackerVar" target="url"/>
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1</bpmn:incoming>
+      <bpmn:outgoing>Flow_2</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="Flow_2" sourceRef="service-task-1" targetRef="EndEvent_1"/>
+    <bpmn:endEvent id="EndEvent_1">
+      <bpmn:incoming>Flow_2</bpmn:incoming>
+    </bpmn:endEvent>
+  </bpmn:process>
+</bpmn:definitions>

--- a/connector-runtime/connector-runtime-spring/src/test/resources/bpmn/outbound-with-parent-overwrite.bpmn
+++ b/connector-runtime/connector-runtime-spring/src/test/resources/bpmn/outbound-with-parent-overwrite.bpmn
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+                  xmlns:zeebe="http://camunda.org/schema/zeebe/1.0"
+                  id="Definitions_outbound_parent_overwrite"
+                  targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="outbound-with-parent-overwrite" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_1" sourceRef="StartEvent_1" targetRef="service-task-1"/>
+    <bpmn:serviceTask id="service-task-1" name="HTTP Task"
+                      zeebe:modelerTemplate="io.camunda.connectors.HttpJson.v2">
+      <bpmn:extensionElements>
+        <zeebe:ioMapping>
+          <zeebe:input source="secrets.TOKEN" target="authentication.token"/>
+          <zeebe:input source="={token: &quot;public&quot;}" target="authentication"/>
+          <zeebe:input source="=authentication.token" target="url"/>
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1</bpmn:incoming>
+      <bpmn:outgoing>Flow_2</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="Flow_2" sourceRef="service-task-1" targetRef="EndEvent_1"/>
+    <bpmn:endEvent id="EndEvent_1">
+      <bpmn:incoming>Flow_2</bpmn:incoming>
+    </bpmn:endEvent>
+  </bpmn:process>
+</bpmn:definitions>

--- a/connector-runtime/connector-runtime-spring/src/test/resources/bpmn/outbound-with-referenced-variable.bpmn
+++ b/connector-runtime/connector-runtime-spring/src/test/resources/bpmn/outbound-with-referenced-variable.bpmn
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+                  xmlns:zeebe="http://camunda.org/schema/zeebe/1.0"
+                  id="Definitions_outbound_referenced_variable"
+                  targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="outbound-with-referenced-variable" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_1" sourceRef="StartEvent_1" targetRef="service-task-1"/>
+    <bpmn:serviceTask id="service-task-1" name="Salesforce Task"
+                      zeebe:modelerTemplate="io.camunda.connectors.SalesforceApexRest.v1">
+      <bpmn:extensionElements>
+        <zeebe:ioMapping>
+          <zeebe:input source="{{secrets.BASE_URL_SFDC}}" target="baseUrl"/>
+          <zeebe:input target="authentication.type"/>
+          <zeebe:input source="apexRest" target="salesforceInteractionType"/>
+          <zeebe:input source="get" target="method"/>
+          <zeebe:input target="path"/>
+          <zeebe:input source="=baseUrl + &quot;/services/apexrest/&quot; + path" target="url"/>
+          <zeebe:input source="20" target="connectionTimeoutInSeconds"/>
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1</bpmn:incoming>
+      <bpmn:outgoing>Flow_2</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="Flow_2" sourceRef="service-task-1" targetRef="EndEvent_1"/>
+    <bpmn:endEvent id="EndEvent_1">
+      <bpmn:incoming>Flow_2</bpmn:incoming>
+    </bpmn:endEvent>
+  </bpmn:process>
+</bpmn:definitions>

--- a/connector-runtime/connector-runtime-spring/src/test/resources/bpmn/outbound-with-reverse-order-reference.bpmn
+++ b/connector-runtime/connector-runtime-spring/src/test/resources/bpmn/outbound-with-reverse-order-reference.bpmn
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+                  xmlns:zeebe="http://camunda.org/schema/zeebe/1.0"
+                  id="Definitions_outbound_reverse_order_reference"
+                  targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="outbound-with-reverse-order-reference" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_1" sourceRef="StartEvent_1" targetRef="service-task-1"/>
+    <bpmn:serviceTask id="service-task-1" name="HTTP Task"
+                      zeebe:modelerTemplate="io.camunda.connectors.HttpJson.v2">
+      <bpmn:extensionElements>
+        <zeebe:ioMapping>
+          <zeebe:input source="=baseUrl" target="url"/>
+          <zeebe:input source="secrets.API_KEY" target="baseUrl"/>
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1</bpmn:incoming>
+      <bpmn:outgoing>Flow_2</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="Flow_2" sourceRef="service-task-1" targetRef="EndEvent_1"/>
+    <bpmn:endEvent id="EndEvent_1">
+      <bpmn:incoming>Flow_2</bpmn:incoming>
+    </bpmn:endEvent>
+  </bpmn:process>
+</bpmn:definitions>

--- a/connector-runtime/connector-runtime-spring/src/test/resources/bpmn/outbound-with-same-path-overwrite.bpmn
+++ b/connector-runtime/connector-runtime-spring/src/test/resources/bpmn/outbound-with-same-path-overwrite.bpmn
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+                  xmlns:zeebe="http://camunda.org/schema/zeebe/1.0"
+                  id="Definitions_outbound_same_path_overwrite"
+                  targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="outbound-with-same-path-overwrite" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_1" sourceRef="StartEvent_1" targetRef="service-task-1"/>
+    <bpmn:serviceTask id="service-task-1" name="HTTP Task"
+                      zeebe:modelerTemplate="io.camunda.connectors.HttpJson.v2">
+      <bpmn:extensionElements>
+        <zeebe:ioMapping>
+          <zeebe:input source="secrets.TOKEN" target="authentication.token"/>
+          <zeebe:input source="public-value" target="authentication.token"/>
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1</bpmn:incoming>
+      <bpmn:outgoing>Flow_2</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="Flow_2" sourceRef="service-task-1" targetRef="EndEvent_1"/>
+    <bpmn:endEvent id="EndEvent_1">
+      <bpmn:incoming>Flow_2</bpmn:incoming>
+    </bpmn:endEvent>
+  </bpmn:process>
+</bpmn:definitions>

--- a/connector-runtime/connector-runtime-spring/src/test/resources/bpmn/outbound-with-shadowed-input-as-dependency.bpmn
+++ b/connector-runtime/connector-runtime-spring/src/test/resources/bpmn/outbound-with-shadowed-input-as-dependency.bpmn
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+                  xmlns:zeebe="http://camunda.org/schema/zeebe/1.0"
+                  id="Definitions_outbound_shadowed_input_as_dependency"
+                  targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="outbound-with-shadowed-input-as-dependency" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_1" sourceRef="StartEvent_1" targetRef="service-task-1"/>
+    <bpmn:serviceTask id="service-task-1" name="HTTP Task"
+                      zeebe:modelerTemplate="io.camunda.connectors.HttpJson.v2">
+      <bpmn:extensionElements>
+        <zeebe:ioMapping>
+          <zeebe:input source="secrets.T" target="baseUrl"/>
+          <zeebe:input source="=baseUrl" target="authentication"/>
+          <zeebe:input source="=attackerVar" target="authentication.token"/>
+          <zeebe:input source="=authentication" target="copy"/>
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1</bpmn:incoming>
+      <bpmn:outgoing>Flow_2</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="Flow_2" sourceRef="service-task-1" targetRef="EndEvent_1"/>
+    <bpmn:endEvent id="EndEvent_1">
+      <bpmn:incoming>Flow_2</bpmn:incoming>
+    </bpmn:endEvent>
+  </bpmn:process>
+</bpmn:definitions>

--- a/connector-runtime/connector-runtime-spring/src/test/resources/bpmn/outbound-with-sibling-fields.bpmn
+++ b/connector-runtime/connector-runtime-spring/src/test/resources/bpmn/outbound-with-sibling-fields.bpmn
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+                  xmlns:zeebe="http://camunda.org/schema/zeebe/1.0"
+                  id="Definitions_outbound_sibling_fields"
+                  targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="outbound-with-sibling-fields" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_1" sourceRef="StartEvent_1" targetRef="service-task-1"/>
+    <bpmn:serviceTask id="service-task-1" name="HTTP Task"
+                      zeebe:modelerTemplate="io.camunda.connectors.HttpJson.v2">
+      <bpmn:extensionElements>
+        <zeebe:ioMapping>
+          <zeebe:input source="secrets.AUTH_TOKEN" target="authentication.token"/>
+          <zeebe:input source="bearer" target="authentication.type"/>
+          <zeebe:input source="=authentication" target="usesWholeAuth"/>
+          <zeebe:input source="=authentication.type" target="usesSiblingFieldOnly"/>
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1</bpmn:incoming>
+      <bpmn:outgoing>Flow_2</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="Flow_2" sourceRef="service-task-1" targetRef="EndEvent_1"/>
+    <bpmn:endEvent id="EndEvent_1">
+      <bpmn:incoming>Flow_2</bpmn:incoming>
+    </bpmn:endEvent>
+  </bpmn:process>
+</bpmn:definitions>

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/inbound/InboundSecretFilterDefaultModeWiringTest.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/inbound/InboundSecretFilterDefaultModeWiringTest.java
@@ -18,6 +18,7 @@ package io.camunda.connector.runtime.inbound;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.EvictingQueue;
 import io.camunda.connector.api.inbound.InboundConnectorContext;
 import io.camunda.connector.api.inbound.InboundConnectorExecutable;
@@ -77,7 +78,9 @@ class InboundSecretFilterDefaultModeWiringTest {
             contextFactory.createContext(
                 details, e -> {}, TestExecutable.class, EvictingQueue.create(10));
 
-    assertThat(context.getSecretHandler().replaceSecrets("secrets.UNDECLARED"))
-        .isEqualTo("secrets.UNDECLARED");
+    var probe = new ObjectMapper().createObjectNode().put("value", "secrets.UNDECLARED");
+    var result = context.getSecretHandler().replaceSecrets(probe);
+
+    assertThat(result.get("value").asText()).isEqualTo("secrets.UNDECLARED");
   }
 }

--- a/connector-sdk/test/src/main/java/io/camunda/connector/test/inbound/InboundConnectorContextBuilder.java
+++ b/connector-sdk/test/src/main/java/io/camunda/connector/test/inbound/InboundConnectorContextBuilder.java
@@ -18,6 +18,7 @@ package io.camunda.connector.test.inbound;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.connector.api.inbound.Activity;
 import io.camunda.connector.api.inbound.CorrelationResult;
@@ -197,12 +198,9 @@ public class InboundConnectorContextBuilder {
       implements InboundConnectorContext, InboundConnectorReportingContext {
 
     private final List<Object> correlatedEvents = new ArrayList<>();
-
-    private Health health = Health.unknown();
-
-    private final String propertiesWithSecrets;
-
+    private final JsonNode propertiesWithSecrets;
     private final CorrelationResult result;
+    private Health health = Health.unknown();
 
     protected TestInboundConnectorContext(
         SecretProvider secretProvider,
@@ -210,12 +208,9 @@ public class InboundConnectorContextBuilder {
         CorrelationResult result) {
       super(secretProvider, SecretFilter.allowAll(), validationProvider);
       this.result = result;
-      try {
-        propertiesWithSecrets =
-            getSecretHandler().replaceSecrets(objectMapper.writeValueAsString(properties));
-      } catch (JsonProcessingException e) {
-        throw new RuntimeException(e);
-      }
+      propertiesWithSecrets =
+          getSecretHandler()
+              .replaceSecrets(objectMapper.valueToTree(properties != null ? properties : Map.of()));
     }
 
     protected void correlate(Object variables) {
@@ -257,7 +252,7 @@ public class InboundConnectorContextBuilder {
     @Override
     public Map<String, Object> getProperties() {
       try {
-        return objectMapper.readValue(propertiesWithSecrets, new TypeReference<>() {});
+        return objectMapper.treeToValue(propertiesWithSecrets, new TypeReference<>() {});
       } catch (JsonProcessingException e) {
         throw new RuntimeException(e);
       }
@@ -266,7 +261,7 @@ public class InboundConnectorContextBuilder {
     @Override
     public <T> T bindProperties(Class<T> cls) {
       try {
-        var mappedObject = objectMapper.readValue(propertiesWithSecrets, cls);
+        var mappedObject = objectMapper.treeToValue(propertiesWithSecrets, cls);
         if (validationProvider != null) {
           getValidationProvider().validate(mappedObject);
         }

--- a/connector-sdk/test/src/main/java/io/camunda/connector/test/outbound/OutboundConnectorContextBuilder.java
+++ b/connector-sdk/test/src/main/java/io/camunda/connector/test/outbound/OutboundConnectorContextBuilder.java
@@ -16,8 +16,11 @@
  */
 package io.camunda.connector.test.outbound;
 
+import com.fasterxml.jackson.core.JsonGenerationException;
+import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.connector.api.json.ConnectorsObjectMapperSupplier;
 import io.camunda.connector.api.outbound.JobContext;
@@ -176,20 +179,43 @@ public class OutboundConnectorContextBuilder {
   public class TestConnectorContext extends AbstractConnectorContext
       implements OutboundConnectorContext {
 
-    private final String variablesWithSecrets;
+    private final JsonNode variablesWithSecrets;
 
     private final TestJobContext jobContext;
 
     protected TestConnectorContext(
         SecretProvider secretProvider, ValidationProvider validationProvider) {
       super(secretProvider, SecretFilter.allowAll(), validationProvider);
+      var asTree = objectMapper.valueToTree(variables != null ? variables : Map.of());
+      variablesWithSecrets = getSecretHandler().replaceSecrets(asTree);
+      this.jobContext =
+          new TestJobContext(() -> headers, () -> writeVariablesAsJson(variablesWithSecrets));
+    }
+
+    /**
+     * Mirrors {@code JobHandlerContext#writeJson}: plain-decimal output, falling back to scientific
+     * notation for a {@code BigDecimal} whose scale falls outside the ±9999 range Jackson accepts
+     * for plain output (e.g. {@code new BigDecimal("1e-10000")}).
+     */
+    private String writeVariablesAsJson(JsonNode node) {
       try {
-        var asString = objectMapper.writeValueAsString(variables);
-        variablesWithSecrets = getSecretHandler().replaceSecrets(asString);
+        return objectMapper
+            .writer()
+            .with(JsonGenerator.Feature.WRITE_BIGDECIMAL_AS_PLAIN)
+            .writeValueAsString(node);
+      } catch (JsonGenerationException e) {
+        return writeVariablesWithoutPlainDecimals(node);
       } catch (JsonProcessingException e) {
-        throw new RuntimeException(e);
+        throw new IllegalStateException("Failed to serialize variables: " + node, e);
       }
-      this.jobContext = new TestJobContext(() -> headers, () -> variablesWithSecrets);
+    }
+
+    private String writeVariablesWithoutPlainDecimals(JsonNode node) {
+      try {
+        return objectMapper.writeValueAsString(node);
+      } catch (JsonProcessingException e) {
+        throw new IllegalStateException("Failed to serialize variables: " + node, e);
+      }
     }
 
     @Override
@@ -200,7 +226,7 @@ public class OutboundConnectorContextBuilder {
     @Override
     public <T> T bindVariables(Class<T> cls) {
       try {
-        var mappedObject = objectMapper.readValue(variablesWithSecrets, cls);
+        var mappedObject = objectMapper.treeToValue(variablesWithSecrets, cls);
         if (validationProvider != null) {
           getValidationProvider().validate(mappedObject);
         }

--- a/connector-sdk/test/src/test/java/io/camunda/connector/test/inbound/InboundConnectorContextBuilderTest.java
+++ b/connector-sdk/test/src/test/java/io/camunda/connector/test/inbound/InboundConnectorContextBuilderTest.java
@@ -20,12 +20,20 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchException;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.camunda.connector.api.error.ConnectorInputException;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
 
 public class InboundConnectorContextBuilderTest {
+
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+  private static ObjectNode wrap(String value) {
+    return OBJECT_MAPPER.createObjectNode().put("value", value);
+  }
 
   @Test
   public void shouldProvidePropertiesAsString() {
@@ -79,15 +87,15 @@ public class InboundConnectorContextBuilderTest {
   public void shouldProvideSecret() {
     var context =
         InboundConnectorContextBuilder.create().properties("{}").secret("foo", "FOO").build();
-    var replaced = context.getSecretHandler().replaceSecrets("secrets.foo");
-    assertThat(replaced).isEqualTo("FOO");
+    var replaced = context.getSecretHandler().replaceSecrets(wrap("secrets.foo"));
+    assertThat(replaced.get("value").asText()).isEqualTo("FOO");
   }
 
   @Test
   public void shouldThrowOnMissingSecret() {
     var context =
         InboundConnectorContextBuilder.create().properties("{}").secret("x", "FOO").build();
-    Executable replacement = () -> context.getSecretHandler().replaceSecrets("secrets.foo");
+    Executable replacement = () -> context.getSecretHandler().replaceSecrets(wrap("secrets.foo"));
     assertThrows(
         ConnectorInputException.class, replacement, "Secret with name 'foo' is not available");
   }
@@ -100,16 +108,16 @@ public class InboundConnectorContextBuilderTest {
             .secret("foo", "FOO")
             .secret("bar", "BAR")
             .build();
-    var replaced = context.getSecretHandler().replaceSecrets("secrets.foo secrets.bar");
-    assertThat(replaced).isEqualTo("FOO BAR");
+    var replaced = context.getSecretHandler().replaceSecrets(wrap("secrets.foo secrets.bar"));
+    assertThat(replaced.get("value").asText()).isEqualTo("FOO BAR");
   }
 
   @Test
   public void shouldProvideSecretWithParentheses() {
     var context =
         InboundConnectorContextBuilder.create().properties("{}").secret("foo", "FOO").build();
-    var replaced = context.getSecretHandler().replaceSecrets("{{secrets.foo}}");
-    assertThat(replaced).isEqualTo("FOO");
+    var replaced = context.getSecretHandler().replaceSecrets(wrap("{{secrets.foo}}"));
+    assertThat(replaced.get("value").asText()).isEqualTo("FOO");
   }
 
   @Test
@@ -120,8 +128,14 @@ public class InboundConnectorContextBuilderTest {
             .secret("foo", "FOO")
             .secret("bar", "BAR")
             .build();
-    var replaced = context.getSecretHandler().replaceSecrets("{{secrets.foo}} {{secrets.bar}}");
-    assertThat(replaced).isEqualTo("FOO BAR");
+    var replaced =
+        context.getSecretHandler().replaceSecrets(wrap("{{secrets.foo}} {{secrets.bar}}"));
+    assertThat(replaced.get("value").asText()).isEqualTo("FOO BAR");
+  }
+
+  @Test
+  public void shouldDefaultPropertiesToAnEmptyObject() {
+    assertThat(InboundConnectorContextBuilder.create().build().getProperties()).isEmpty();
   }
 
   private record TestRecord(String foo) {}

--- a/connector-sdk/test/src/test/java/io/camunda/connector/test/outbound/OutboundConnectorContextBuilderTest.java
+++ b/connector-sdk/test/src/test/java/io/camunda/connector/test/outbound/OutboundConnectorContextBuilderTest.java
@@ -20,6 +20,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchException;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.camunda.connector.api.error.ConnectorInputException;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
@@ -27,11 +29,37 @@ import org.junit.jupiter.api.function.Executable;
 
 public class OutboundConnectorContextBuilderTest {
 
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+  private static ObjectNode wrap(String value) {
+    return OBJECT_MAPPER.createObjectNode().put("value", value);
+  }
+
   @Test
   public void shouldProvideVariablesAsString() {
     var json = "{ \"foo\" : \"FOO\" }";
     var context = OutboundConnectorContextBuilder.create().variables(json).build();
     assertThat(context.getJobContext().getVariables()).isEqualTo("{\"foo\":\"FOO\"}");
+  }
+
+  @Test
+  public void getVariables_preservesDecimalText() {
+    var context =
+        OutboundConnectorContextBuilder.create()
+            .variables(Map.of("decimal", new java.math.BigDecimal("0.00000001")))
+            .build();
+
+    assertThat(context.getJobContext().getVariables()).contains("0.00000001");
+  }
+
+  @Test
+  public void getVariables_fallsBackToScientificNotationForOutOfRangeDecimalScale() {
+    var context =
+        OutboundConnectorContextBuilder.create()
+            .variables(Map.of("decimal", new java.math.BigDecimal("1e-10000")))
+            .build();
+
+    assertThat(context.getJobContext().getVariables()).contains("1E-10000");
   }
 
   @Test
@@ -79,15 +107,15 @@ public class OutboundConnectorContextBuilderTest {
   public void shouldProvideSecret() {
     var context =
         OutboundConnectorContextBuilder.create().variables("{}").secret("foo", "FOO").build();
-    var replaced = context.getSecretHandler().replaceSecrets("secrets.foo");
-    assertThat(replaced).isEqualTo("FOO");
+    var replaced = context.getSecretHandler().replaceSecrets(wrap("secrets.foo"));
+    assertThat(replaced.get("value").asText()).isEqualTo("FOO");
   }
 
   @Test
   public void shouldThrowOnMissingSecret() {
     var context =
         OutboundConnectorContextBuilder.create().variables("{}").secret("x", "FOO").build();
-    Executable replacement = () -> context.getSecretHandler().replaceSecrets("secrets.foo");
+    Executable replacement = () -> context.getSecretHandler().replaceSecrets(wrap("secrets.foo"));
     assertThrows(
         ConnectorInputException.class, replacement, "Secret with name 'foo' is not available");
   }
@@ -100,16 +128,16 @@ public class OutboundConnectorContextBuilderTest {
             .secret("foo", "FOO")
             .secret("bar", "BAR")
             .build();
-    var replaced = context.getSecretHandler().replaceSecrets("secrets.foo secrets.bar");
-    assertThat(replaced).isEqualTo("FOO BAR");
+    var replaced = context.getSecretHandler().replaceSecrets(wrap("secrets.foo secrets.bar"));
+    assertThat(replaced.get("value").asText()).isEqualTo("FOO BAR");
   }
 
   @Test
   public void shouldProvideSecretWithParentheses() {
     var context =
         OutboundConnectorContextBuilder.create().variables("{}").secret("foo", "FOO").build();
-    var replaced = context.getSecretHandler().replaceSecrets("{{secrets.foo}}");
-    assertThat(replaced).isEqualTo("FOO");
+    var replaced = context.getSecretHandler().replaceSecrets(wrap("{{secrets.foo}}"));
+    assertThat(replaced.get("value").asText()).isEqualTo("FOO");
   }
 
   @Test
@@ -120,8 +148,15 @@ public class OutboundConnectorContextBuilderTest {
             .secret("foo", "FOO")
             .secret("bar", "BAR")
             .build();
-    var replaced = context.getSecretHandler().replaceSecrets("{{secrets.foo}} {{secrets.bar}}");
-    assertThat(replaced).isEqualTo("FOO BAR");
+    var replaced =
+        context.getSecretHandler().replaceSecrets(wrap("{{secrets.foo}} {{secrets.bar}}"));
+    assertThat(replaced.get("value").asText()).isEqualTo("FOO BAR");
+  }
+
+  @Test
+  public void shouldDefaultVariablesToAnEmptyObject() {
+    assertThat(OutboundConnectorContextBuilder.create().build().getJobContext().getVariables())
+        .isEqualTo("{}");
   }
 
   private record TestRecord(String foo) {}


### PR DESCRIPTION
## Description

Backport of #8584 to `stable/8.6`.

This scopes legacy secret resolution to the JSON field paths declared by the connector model, preserves tree-based replacement semantics, and follows ordered FEEL input dependencies without granting secrets through overwritten or shadowed mappings.

Branch-specific adaptations preserve the stable/8.6 Zeebe, Operate, and one-argument secret-provider APIs. Changes from newer runtime-test and outbound-handler locations were mapped to the existing SDK test and runtime-core modules, the stable-only inbound process-element path receives the same field scoping, and deleted ADR/test paths were not resurrected.

Targeted tests passed across runtime core, runtime spring, SDK test utilities, and the Spring Boot starter.

## Related issues

Related to #8584

## Checklist

- [x] This PR targets the requested stable branch directly.
- [x] Tests/Integration tests for the changes have been added if applicable.
- [x] No documentation update is required on this stable branch; its ADR tree no longer contains the amended source ADR.
