### PR TITLE
[Backport stable/8.7] fix(secrets): field-path-scoped secret filtering over a JSON tree

### DIFF
--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/DefaultProcessElementContext.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/DefaultProcessElementContext.java
@@ -24,7 +24,9 @@ import io.camunda.connector.api.secret.SecretProvider;
 import io.camunda.connector.api.validation.ValidationProvider;
 import io.camunda.connector.runtime.core.AbstractConnectorContext;
 import io.camunda.connector.runtime.core.secret.SecretFilter;
+import io.camunda.connector.runtime.core.secret.SecretFilter.Secret;
 import io.camunda.connector.runtime.core.secret.SecretUtil;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
@@ -84,8 +86,11 @@ public class DefaultProcessElementContext extends AbstractConnectorContext
       return SecretFilter.allowAll();
     }
     return SecretFilter.allowOnly(
-        connectorElement.rawProperties().values().stream()
-            .flatMap(value -> SecretUtil.retrieveSecretKeysInInput(value).stream())
+        connectorElement.rawProperties().entrySet().stream()
+            .flatMap(
+                entry ->
+                    SecretUtil.retrieveSecretKeysInInput(entry.getValue()).stream()
+                        .map(name -> new Secret(name, Arrays.asList(entry.getKey().split("\\.")))))
             .distinct()
             .toList());
   }

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextImpl.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextImpl.java
@@ -29,6 +29,7 @@ import io.camunda.connector.runtime.core.AbstractConnectorContext;
 import io.camunda.connector.runtime.core.inbound.correlation.InboundCorrelationHandler;
 import io.camunda.connector.runtime.core.inbound.details.InboundConnectorDetails.ValidInboundConnectorDetails;
 import io.camunda.connector.runtime.core.secret.SecretFilter;
+import io.camunda.connector.runtime.core.secret.SecretFilter.Secret;
 import io.camunda.connector.runtime.core.secret.SecretUtil;
 import io.camunda.document.Document;
 import io.camunda.document.factory.DocumentFactory;
@@ -37,6 +38,7 @@ import io.camunda.document.reference.DocumentReference;
 import io.camunda.document.store.DocumentCreationRequest;
 import io.camunda.document.store.InMemoryDocumentStore;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -334,8 +336,11 @@ public class InboundConnectorContextImpl extends AbstractConnectorContext
       return SecretFilter.allowAll();
     }
     return SecretFilter.allowOnly(
-        connectorDetails.rawPropertiesWithoutKeywords().values().stream()
-            .flatMap(value -> SecretUtil.retrieveSecretKeysInInput(value).stream())
+        connectorDetails.rawPropertiesWithoutKeywords().entrySet().stream()
+            .flatMap(
+                entry ->
+                    SecretUtil.retrieveSecretKeysInInput(entry.getValue()).stream()
+                        .map(name -> new Secret(name, Arrays.asList(entry.getKey().split("\\.")))))
             .distinct()
             .toList());
   }

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/InboundPropertyHandler.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/InboundPropertyHandler.java
@@ -112,10 +112,10 @@ public class InboundPropertyHandler {
       Map<String, Object> properties,
       SecretContext secretContext) {
     try {
-      var propertiesAsJsonString = objectMapper.writeValueAsString(properties);
+      var propertiesAsJsonString = objectMapper.valueToTree(properties);
       var propertiesWithSecretsJson =
           secretHandler.replaceSecrets(propertiesAsJsonString, secretContext);
-      return objectMapper.readValue(propertiesWithSecretsJson, new TypeReference<>() {});
+      return objectMapper.treeToValue(propertiesWithSecretsJson, new TypeReference<>() {});
     } catch (JsonProcessingException e) {
       throw new RuntimeException(e);
     }

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/outbound/JobHandlerContext.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/outbound/JobHandlerContext.java
@@ -16,11 +16,16 @@
  */
 package io.camunda.connector.runtime.core.outbound;
 
+import com.fasterxml.jackson.core.JsonGenerationException;
+import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.exc.*;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import io.camunda.connector.api.error.ConnectorInputException;
 import io.camunda.connector.api.outbound.JobContext;
 import io.camunda.connector.api.outbound.OutboundConnectorContext;
@@ -40,8 +45,8 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Implementation of {@link io.camunda.connector.api.outbound.OutboundConnectorContext} passed on to
- * a {@link io.camunda.connector.api.outbound.OutboundConnectorFunction} when called from the {@link
- * ConnectorJobHandler}.
+ * a {@link io.camunda.connector.api.outbound.OutboundConnectorFunction} when called from the
+ * JobHandler, e.g. SpringConnectorJobHandler.
  */
 public class JobHandlerContext extends AbstractConnectorContext
     implements OutboundConnectorContext {
@@ -52,7 +57,7 @@ public class JobHandlerContext extends AbstractConnectorContext
   private final ObjectMapper objectMapper;
   private final JobContext jobContext;
   private final DocumentFactory documentFactory;
-  private String jsonWithSecrets = null;
+  private JsonNode jsonWithSecrets = null;
 
   public JobHandlerContext(
       final ActivatedJob job,
@@ -65,7 +70,7 @@ public class JobHandlerContext extends AbstractConnectorContext
     this.documentFactory = documentFactory;
     this.job = job;
     this.objectMapper = objectMapper;
-    this.jobContext = new ActivatedJobContext(job, this::getJsonReplacedWithSecrets);
+    this.jobContext = new ActivatedJobContext(job, () -> writeJson(getJsonReplacedWithSecrets()));
   }
 
   @Override
@@ -75,43 +80,112 @@ public class JobHandlerContext extends AbstractConnectorContext
     return mappedObject;
   }
 
-  private String getJsonReplacedWithSecrets() {
+  private JsonNode getJsonReplacedWithSecrets() {
     if (jsonWithSecrets == null) {
       jsonWithSecrets =
-          getSecretHandler()
-              .replaceSecrets(job.getVariables(), new SecretContext(job.getTenantId()));
+          getSecretHandler().replaceSecrets(parseVariables(), new SecretContext(job.getTenantId()));
     }
     return jsonWithSecrets;
+  }
+
+  /**
+   * Parses via this context's own {@code objectMapper}, with {@code USE_BIG_DECIMAL_FOR_FLOATS}
+   * enabled, rather than {@code job.getVariablesAsType(JsonNode.class)} — the client's own {@code
+   * JsonMapper} parses untyped JSON numbers to {@code double} by default, which loses precision
+   * (e.g. {@code 0.1234567890123456789012345} -> {@code 0.12345678901234568}) before the value ever
+   * reaches a {@code BigDecimal}-typed connector field. Reading through an {@code ObjectReader}
+   * rather than reconfiguring the shared mapper keeps that feature scoped to this one parse. The
+   * node factory is additionally configured with {@code withExactBigDecimals(true)}: its default
+   * strips trailing zeros off the parsed {@code BigDecimal} itself at node construction (e.g.
+   * {@code 1.10} becomes scale-1 {@code 1.1}), a value change a {@code BigDecimal}-typed connector
+   * field would observe via {@code equals}, not merely a difference in how it prints.
+   */
+  private JsonNode parseVariables() {
+    JsonNode variables;
+    try {
+      variables =
+          objectMapper
+              .reader()
+              .with(DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS)
+              .with(JsonNodeFactory.withExactBigDecimals(true))
+              .forType(JsonNode.class)
+              .readValue(job.getVariables());
+    } catch (JsonProcessingException e) {
+      throw translateJsonException(e);
+    }
+    if (!variables.isObject()) {
+      throw new ConnectorInputException("This is not a JSON object");
+    }
+    return variables;
+  }
+
+  /**
+   * {@code JsonNode.toString()} serializes through Jackson's shared internal mapper, which writes a
+   * {@code DecimalNode} via plain {@code BigDecimal.toString()} — reintroducing scientific notation
+   * for small-magnitude values (e.g. {@code 0.00000001} -> {@code 1E-8}) even though the digits
+   * themselves survived parsing. {@code WRITE_BIGDECIMAL_AS_PLAIN} keeps the plain-decimal form the
+   * raw job JSON used.
+   *
+   * <p>Jackson refuses plain output for a {@code BigDecimal} whose scale falls outside ±9999 (e.g.
+   * {@code 1e-10000}, which parses fine into a {@code DecimalNode}). Such a document is written
+   * without the feature instead, i.e. in scientific notation — the same text the previous
+   * raw-string path returned — rather than failing the job.
+   */
+  private String writeJson(JsonNode node) {
+    try {
+      return objectMapper
+          .writer()
+          .with(JsonGenerator.Feature.WRITE_BIGDECIMAL_AS_PLAIN)
+          .writeValueAsString(node);
+    } catch (JsonGenerationException e) {
+      return writeJsonWithoutPlainDecimals(node);
+    } catch (JsonProcessingException e) {
+      throw translateJsonException(e);
+    }
+  }
+
+  private String writeJsonWithoutPlainDecimals(JsonNode node) {
+    try {
+      return objectMapper.writeValueAsString(node);
+    } catch (JsonProcessingException e) {
+      throw translateJsonException(e);
+    }
   }
 
   private <T> T mapJson(Class<T> cls) {
     var jsonWithSecrets = getJsonReplacedWithSecrets();
     try {
-      return objectMapper.readValue(jsonWithSecrets, cls);
-    } catch (JsonParseException e) {
-      throw new ConnectorInputException("This is not a JSON object", e);
-    } catch (InvalidFormatException
-        | InvalidNullException
-        | InvalidTypeIdException
-        | PropertyBindingException e) {
+      return objectMapper.treeToValue(jsonWithSecrets, cls);
+    } catch (JsonProcessingException e) {
+      throw translateJsonException(e);
+    }
+  }
+
+  private static ConnectorInputException translateJsonException(JsonProcessingException e) {
+    if (e instanceof JsonParseException) {
+      return new ConnectorInputException("This is not a JSON object", e);
+    }
+    if (e instanceof InvalidFormatException
+        || e instanceof InvalidNullException
+        || e instanceof InvalidTypeIdException
+        || e instanceof PropertyBindingException) {
+      MismatchedInputException mappingException = (MismatchedInputException) e;
       String errorMessage =
-          e.getPath().stream()
+          mappingException.getPath().stream()
               .map(JsonMappingException.Reference::getFieldName)
               .reduce((s, s2) -> s.concat(", ").concat(s2))
               .map("Json object contains an invalid field: "::concat)
               .map(
                   s ->
-                      e.getTargetType() == null
+                      mappingException.getTargetType() == null
                           ? s
                           : s.concat(". It Must be `")
-                              .concat(e.getTargetType().getSimpleName())
+                              .concat(mappingException.getTargetType().getSimpleName())
                               .concat("`"))
               .orElse("Unexpected Error, Further investigation is needed");
-
-      throw new ConnectorInputException(errorMessage, e);
-    } catch (JsonProcessingException e) {
-      throw new ConnectorInputException(e.getOriginalMessage(), e);
+      return new ConnectorInputException(errorMessage, e);
     }
+    return new ConnectorInputException(e.getOriginalMessage(), e);
   }
 
   @Override

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/outbound/OutboundConnectorExceptionHandler.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/outbound/OutboundConnectorExceptionHandler.java
@@ -18,6 +18,7 @@ package io.camunda.connector.runtime.core.outbound;
 
 import static io.camunda.connector.runtime.core.outbound.ConnectorJobHandler.MAX_ERROR_MESSAGE_LENGTH;
 
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.camunda.connector.api.error.ConnectorException;
 import io.camunda.connector.api.error.ConnectorInputException;
 import io.camunda.connector.api.error.ConnectorRetryException;
@@ -30,6 +31,7 @@ import io.camunda.connector.runtime.core.error.JobError;
 import io.camunda.connector.runtime.core.secret.SecretAllowListUnavailableException;
 import io.camunda.connector.runtime.core.secret.SecretFailureDiagnostic;
 import io.camunda.connector.runtime.core.secret.SecretFilter;
+import io.camunda.connector.runtime.core.secret.SecretFilter.Secret;
 import io.camunda.connector.runtime.core.secret.SecretNotAvailableException;
 import io.camunda.connector.runtime.core.secret.SecretUtil;
 import io.camunda.zeebe.client.api.response.ActivatedJob;
@@ -272,22 +274,23 @@ public class OutboundConnectorExceptionHandler {
       ActivatedJob job, SecretFilter secretFilter, Exception jobFailure) {
     try {
       var allowedKeys =
-          SecretUtil.retrieveSecretKeysInInput(job.getVariables()).stream()
-              .filter(secretFilter::isAllowed)
-              .toList();
-      if (allowedKeys.isEmpty()) {
+          allowedKeys(
+              SecretUtil.retrieveSecretKeysInInput(job.getVariablesAsType(ObjectNode.class)),
+              secretFilter);
+      var allowedNames = allowedKeys.stream().map(Secret::secretName).distinct().toList();
+      if (allowedNames.isEmpty()) {
         return new MaskingSecrets(List.of(), null);
       }
-      var values = this.secretProvider.fetchAll(allowedKeys, new SecretContext(job.getTenantId()));
+      var values = this.secretProvider.fetchAll(allowedNames, new SecretContext(job.getTenantId()));
       // fetchAll drops the names it cannot resolve, so a short read is a silent one: a name the
       // input declares resolved when it was bound, so one missing now means the secret was removed,
       // or access revoked, while the connector ran. Redacting with what did come back would publish
       // the one that did not in the clear.
-      if (values.size() < allowedKeys.size() && !reportsAnUnavailableSecret(jobFailure)) {
+      if (values.size() < allowedNames.size() && !reportsAnUnavailableSecret(jobFailure)) {
         return new MaskingSecrets(
             List.of(),
             new MaskingSecretsIncompleteException(
-                allowedKeys.size() - values.size(), allowedKeys.size()));
+                allowedNames.size() - values.size(), allowedNames.size()));
       }
       return new MaskingSecrets(values, null);
     } catch (Exception ex) {
@@ -298,6 +301,10 @@ public class OutboundConnectorExceptionHandler {
           safeDiagnostic(ex));
       return new MaskingSecrets(List.of(), ex);
     }
+  }
+
+  private static List<Secret> allowedKeys(List<Secret> keys, SecretFilter secretFilter) {
+    return keys.stream().filter(secretFilter::isAllowed).toList();
   }
 
   /**

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretFilter.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretFilter.java
@@ -23,34 +23,57 @@ import java.util.Set;
  * Determines whether a named secret may be resolved within a connector's context.
  *
  * <p>Use {@link #allowAll()} when no restriction applies and {@link #allowOnly(List)} to restrict
- * resolution to a declared set of names. An empty list passed to {@code allowOnly} denies all
+ * resolution to a declared set of secrets. An empty list passed to {@code allowOnly} denies all
  * secrets.
  */
 @FunctionalInterface
 public interface SecretFilter {
 
-  /**
-   * Returns {@code true} if the secret with the given name may be resolved.
-   *
-   * @param secretName the secret name to check
-   * @return {@code true} to allow resolution, {@code false} to leave the reference as-is
-   */
-  boolean isAllowed(String secretName);
-
   /** Returns a filter that permits every secret name. */
   static SecretFilter allowAll() {
-    return name -> true;
+    return context -> true;
   }
 
   /**
    * Returns a filter that permits only the secret names in {@code names}. An empty list denies all
    * secrets.
    *
-   * @param names the permitted secret names
-   * @return a filter restricted to the given names
+   * @param secrets the permitted secret contexts
+   * @return a filter restricted to the given secrets
    */
-  static SecretFilter allowOnly(List<String> names) {
-    var allowed = Set.copyOf(names);
-    return allowed::contains;
+  static SecretFilter allowOnly(List<Secret> secrets) {
+    var allowed = Set.copyOf(secrets);
+    return context ->
+        allowed.stream()
+            .filter(secret -> secret.secretName().equals(context.secretName()))
+            .filter(secret -> context.fieldPath().size() >= secret.fieldPath().size())
+            .anyMatch(
+                secret ->
+                    context
+                        .fieldPath()
+                        .subList(0, secret.fieldPath().size())
+                        .equals(secret.fieldPath()));
+  }
+
+  /**
+   * Returns {@code true} if the secret with the given name may be resolved.
+   *
+   * @param context the secret filter context
+   * @return {@code true} to allow resolution, {@code false} to leave the reference as-is
+   */
+  boolean isAllowed(Secret context);
+
+  record Secret(String secretName, List<String> fieldPath) {
+
+    /**
+     * Defensively copies {@code fieldPath}: callers such as {@code Arrays.asList(...)} return a
+     * fixed-size but still mutable (via {@code set}) list, which would otherwise let anyone holding
+     * a cached {@code Secret} reach in and change which fields it authorizes for later, unrelated
+     * jobs.
+     */
+    public Secret(String secretName, List<String> fieldPath) {
+      this.secretName = secretName;
+      this.fieldPath = List.copyOf(fieldPath);
+    }
   }
 }

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretFilter.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretFilter.java
@@ -20,11 +20,11 @@ import java.util.List;
 import java.util.Set;
 
 /**
- * Determines whether a named secret may be resolved within a connector's context.
+ * Determines whether a named secret may be resolved at a field path within a connector's context.
  *
  * <p>Use {@link #allowAll()} when no restriction applies and {@link #allowOnly(List)} to restrict
- * resolution to a declared set of secrets. An empty list passed to {@code allowOnly} denies all
- * secrets.
+ * resolution by both secret name and declared field path. An empty list passed to {@code allowOnly}
+ * denies all secrets.
  */
 @FunctionalInterface
 public interface SecretFilter {
@@ -35,10 +35,12 @@ public interface SecretFilter {
   }
 
   /**
-   * Returns a filter that permits only the secret names in {@code names}. An empty list denies all
-   * secrets.
+   * Returns a filter that permits a runtime secret context when its name matches and an allowed
+   * secret's declared field path is a prefix of its runtime field path. Exact paths match, and a
+   * declaration at a parent path authorizes nested fields but not sibling paths. An empty list
+   * denies all secrets.
    *
-   * @param secrets the permitted secret contexts
+   * @param secrets the permitted secret names and their declared field paths
    * @return a filter restricted to the given secrets
    */
   static SecretFilter allowOnly(List<Secret> secrets) {
@@ -56,7 +58,7 @@ public interface SecretFilter {
   }
 
   /**
-   * Returns {@code true} if the secret with the given name may be resolved.
+   * Returns {@code true} if the secret may be resolved at its runtime field path.
    *
    * @param context the secret filter context
    * @return {@code true} to allow resolution, {@code false} to leave the reference as-is

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretHandler.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretHandler.java
@@ -16,6 +16,7 @@
  */
 package io.camunda.connector.runtime.core.secret;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import io.camunda.connector.api.secret.SecretContext;
 import io.camunda.connector.api.secret.SecretProvider;
 import java.util.List;
@@ -39,20 +40,25 @@ public class SecretHandler {
   public SecretHandler(final SecretProvider secretProvider, SecretFilter secretFilter) {
     this.secretProvider = secretProvider;
     secretReplacer =
-        (name, context) -> {
-          if (secretFilter.isAllowed(name)) {
+        (secretFilterContext, context) -> {
+          if (secretFilter.isAllowed(secretFilterContext)) {
             var value =
-                Optional.ofNullable(secretProvider.getSecret(name, context))
-                    .orElseThrow(() -> new SecretNotAvailableException(name));
+                Optional.ofNullable(
+                        secretProvider.getSecret(secretFilterContext.secretName(), context))
+                    .orElseThrow(() -> new SecretNotAvailableException(secretFilterContext));
             resolvedValues.add(value);
+            // the serialized job JSON carries this form, not the raw value, when it differs
+            resolvedValues.add(SecretUtil.jsonEscape(value));
             return value;
           }
-          LOG.debug("Secret '{}' not in allow-list — placeholder left unreplaced", name);
+          LOG.debug(
+              "Secret '{}' not in allow-list — placeholder left unreplaced",
+              secretFilterContext.secretName());
           return null;
         };
   }
 
-  public String replaceSecrets(String input, SecretContext context) {
+  public JsonNode replaceSecrets(JsonNode input, SecretContext context) {
     return SecretUtil.replaceSecrets(input, context, secretReplacer);
   }
 

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretNotAvailableException.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretNotAvailableException.java
@@ -17,6 +17,7 @@
 package io.camunda.connector.runtime.core.secret;
 
 import io.camunda.connector.api.error.ConnectorInputException;
+import io.camunda.connector.runtime.core.secret.SecretFilter.Secret;
 
 /**
  * A secret reference the filter allowed, for which no configured provider held a value. The
@@ -32,5 +33,15 @@ public class SecretNotAvailableException extends ConnectorInputException {
 
   public SecretNotAvailableException(String secretName) {
     super(String.format("Secret with name '%s' is not available", secretName), null);
+  }
+
+  /**
+   * Omits {@code secret.fieldPath()}: it is derived from JSON property names, and {@link
+   * SecretUtil} supports resolving secrets into property names as well as values, so a path segment
+   * may itself carry a resolved secret's text — echoing it here would leak that text into an error
+   * message error masking cannot always catch.
+   */
+  public SecretNotAvailableException(Secret secret) {
+    this(secret.secretName());
   }
 }

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretReplacer.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretReplacer.java
@@ -17,7 +17,8 @@
 package io.camunda.connector.runtime.core.secret;
 
 import io.camunda.connector.api.secret.SecretContext;
+import io.camunda.connector.runtime.core.secret.SecretFilter.Secret;
 
 public interface SecretReplacer {
-  String replaceSecrets(String name, SecretContext secretContext);
+  String replaceSecrets(Secret secret, SecretContext secretContext);
 }

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretUtil.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretUtil.java
@@ -16,11 +16,20 @@
  */
 package io.camunda.connector.runtime.core.secret;
 
+import com.fasterxml.jackson.core.io.JsonStringEncoder;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.node.TextNode;
 import io.camunda.connector.api.secret.SecretContext;
+import io.camunda.connector.runtime.core.secret.SecretFilter.Secret;
+import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
+import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.regex.MatchResult;
 import java.util.regex.Matcher;
@@ -29,6 +38,8 @@ import java.util.regex.Pattern;
 /** Utility class to replace secrets in strings. */
 public class SecretUtil {
 
+  private static final JsonStringEncoder encoder = JsonStringEncoder.getInstance();
+
   // One pattern, so that one scan consumes each reference whole: scanning per form or per caller
   // lets a narrower alternative re-read the inside of a wider match, as a name never declared.
   private static final Pattern REFERENCE =
@@ -36,19 +47,134 @@ public class SecretUtil {
           "\\{\\{\\s*secrets\\.(?<braced>\\S+?)\\s*}}"
               + "|secrets\\.(?<bare>([a-zA-Z0-9]+[\\/._-])*[a-zA-Z0-9]+)");
 
-  public static String replaceSecrets(
-      String input, SecretContext context, SecretReplacer secretReplacer) {
+  /**
+   * Substitutes every legacy secret reference in the tree, in place, and returns the same node.
+   *
+   * <p>One walk, one scan per string: a second pass over already-substituted text is what let a
+   * narrower form re-read the inside of a reference the first pass had consumed (and, when the walk
+   * renames a property, made the second pass iterate a reordered snapshot of the object).
+   */
+  public static JsonNode replaceSecrets(
+      JsonNode input, SecretContext context, SecretReplacer secretReplacer) {
     if (input == null) {
       throw new IllegalStateException("input cant be null.");
     }
-    Map<String, String> resolutions = new HashMap<>();
-    return replaceTokens(
+    if (!input.isObject()) {
+      throw new IllegalStateException("input must be an ObjectNode.");
+    }
+    Map<Secret, String> resolutions = new HashMap<>();
+    walkJsonNode(
         input,
-        REFERENCE,
-        matcher -> {
-          String value = resolve(name(matcher), context, secretReplacer, resolutions);
-          return value == null ? matcher.group() : value;
-        });
+        (stringValue, fieldPath) ->
+            replaceTokens(
+                stringValue,
+                REFERENCE,
+                matcher -> {
+                  var value =
+                      resolve(name(matcher), fieldPath, context, secretReplacer, resolutions);
+                  return value == null ? matcher.group() : value;
+                }),
+        new ArrayList<>());
+    return input;
+  }
+
+  /**
+   * Asks the replacer at most once per secret <em>and field path</em>: the same name is a separate
+   * question at a different path, since that is the granularity the allow-list authorizes at.
+   */
+  private static String resolve(
+      String name,
+      List<String> fieldPath,
+      SecretContext context,
+      SecretReplacer secretReplacer,
+      Map<Secret, String> resolutions) {
+    var secret = new Secret(name, fieldPath);
+    if (!resolutions.containsKey(secret)) {
+      resolutions.put(secret, secretReplacer.replaceSecrets(secret, context));
+    }
+    return resolutions.get(secret);
+  }
+
+  /** The name a legacy provider is asked for. */
+  private static String name(MatchResult match) {
+    var braced = match.group("braced");
+    return braced != null ? braced : match.group("bare");
+  }
+
+  private static void walkJsonNode(
+      JsonNode input, BiFunction<String, List<String>, String> converter, List<String> fieldPath) {
+    switch (input.getNodeType()) {
+      case ARRAY -> walkArray((ArrayNode) input, converter, fieldPath);
+      case OBJECT -> walkObject((ObjectNode) input, converter, fieldPath);
+      default -> {}
+    }
+  }
+
+  /**
+   * Substitutes property names as well as values: the raw-text pass this replaced matched anywhere
+   * in the document, key or value, so a placeholder written as a property name (e.g. {@code
+   * {"{{secrets.KEY}}": "value"}}) resolved just as one written as a value did. Renaming is
+   * deferred until after the entry is otherwise processed, and runs over a snapshot of the original
+   * entries, since renaming a key while iterating the node's live property view would throw.
+   */
+  private static void walkObject(
+      ObjectNode input,
+      BiFunction<String, List<String>, String> converter,
+      List<String> fieldPath) {
+    // Map.entry(...) reads each key/value pair eagerly, decoupling the snapshot from the live
+    // map: input.properties() entries are backed by the same map nodes ObjectNode#set/remove
+    // mutate, so a snapshot that merely copies the entry objects (e.g. List.copyOf(...)) would
+    // still observe later renames through entries for keys processed earlier in this same loop.
+    for (Entry<String, JsonNode> entry :
+        input.properties().stream().map(e -> Map.entry(e.getKey(), e.getValue())).toList()) {
+      String key = entry.getKey();
+      JsonNode value = entry.getValue();
+      List<String> extendedFieldPath = new ArrayList<>(fieldPath);
+      extendedFieldPath.add(key);
+
+      if (value instanceof TextNode stringValue) {
+        input.set(key, new TextNode(converter.apply(stringValue.asText(), extendedFieldPath)));
+      } else {
+        walkJsonNode(value, converter, extendedFieldPath);
+        // Reinserts this entry's own (possibly object/array-mutated-in-place, otherwise
+        // untouched) value at its own original key, in snapshot order. Without this, a key
+        // rename earlier in this same loop that happens to collide with this entry's still
+        // unprocessed key would silently overwrite this entry before its own turn came, and this
+        // entry's non-text value — having no put/set of its own — would never overwrite it back.
+        input.set(key, value);
+      }
+
+      String newKey = converter.apply(key, extendedFieldPath);
+      if (!newKey.equals(key)) {
+        input.set(newKey, input.get(key));
+        input.remove(key);
+      }
+    }
+  }
+
+  /** Recurses into array elements at arbitrary depth, mirroring {@link #walkJsonNode}. */
+  private static void walkArray(
+      ArrayNode arrayNode,
+      BiFunction<String, List<String>, String> converter,
+      List<String> fieldPath) {
+    for (int i = 0; i < arrayNode.size(); i++) {
+      JsonNode item = arrayNode.get(i);
+      if (item instanceof TextNode stringValue) {
+        arrayNode.set(i, new TextNode(converter.apply(stringValue.asText(), fieldPath)));
+      } else {
+        walkJsonNode(item, converter, fieldPath);
+      }
+    }
+  }
+
+  /**
+   * The form a resolved value takes once the substituted tree is serialized back to JSON. The walk
+   * writes the raw value into a {@code TextNode} and lets Jackson escape it on output, so this is
+   * not applied during substitution — but a caller redacting a message that quotes the serialized
+   * JSON has to match this form as well as the raw one.
+   */
+  public static String jsonEscape(String value) {
+    return new String(encoder.quoteAsString(value));
   }
 
   public static String replaceTokens(
@@ -66,28 +192,29 @@ public class SecretUtil {
     return output.toString();
   }
 
-  /** Asks the replacer at most once per name, for providers that meter or charge per lookup. */
-  private static String resolve(
-      String name,
-      SecretContext context,
-      SecretReplacer secretReplacer,
-      Map<String, String> resolutions) {
-    if (!resolutions.containsKey(name)) {
-      resolutions.put(name, secretReplacer.replaceSecrets(name, context));
-    }
-    return resolutions.get(name);
-  }
-
-  private static String name(MatchResult match) {
-    var braced = match.group("braced");
-    return braced != null ? braced : match.group("bare");
+  /** Every secret the given tree declares, each scoped to the field path it occupies. */
+  public static List<Secret> retrieveSecretKeysInInput(ObjectNode input) {
+    List<Secret> result = new ArrayList<>();
+    walkJsonNode(
+        input,
+        (stringValue, fieldPath) -> {
+          REFERENCE
+              .matcher(stringValue)
+              .results()
+              .map(SecretUtil::name)
+              .distinct()
+              .map(name -> new Secret(name, fieldPath))
+              .forEach(result::add);
+          return stringValue;
+        },
+        new ArrayList<>());
+    return result;
   }
 
   /**
    * Every secret name the given text declares, in either form, read by the same scan {@link
    * #replaceSecrets} uses: a name that method asks a provider for appears here spelled exactly as
-   * it asks for it, and no name appears that the scan never read. Feeding both from one scan is
-   * what keeps the outbound allow-list and exception redaction agreeing with resolution.
+   * it asks for it, and no name appears that the scan never read.
    */
   public static List<String> retrieveSecretKeysInInput(String input) {
     return input == null
@@ -102,7 +229,6 @@ public class SecretUtil {
       return "";
     }
     return secrets.stream()
-        // a provider may answer with an empty value, and replacing that matches everywhere
         .filter(secret -> !secret.isEmpty())
         .sorted(Comparator.comparingInt(String::length).reversed())
         .reduce(message, (newMessage, nextSecret) -> newMessage.replace(nextSecret, "***"));

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/SecretUtilTests.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/SecretUtilTests.java
@@ -22,6 +22,10 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.camunda.connector.api.secret.SecretContext;
+import io.camunda.connector.runtime.core.secret.SecretFilter.Secret;
 import io.camunda.connector.runtime.core.secret.SecretReplacer;
 import io.camunda.connector.runtime.core.secret.SecretUtil;
 import java.util.ArrayList;
@@ -34,6 +38,12 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
 public class SecretUtilTests {
+
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+  private static ObjectNode wrap(String value) {
+    return OBJECT_MAPPER.createObjectNode().put("value", value);
+  }
 
   @ParameterizedTest
   @CsvSource({
@@ -59,9 +69,9 @@ public class SecretUtilTests {
   })
   void testSecretPattern(String input, String secret, Boolean shouldDetect) {
     var secretReplacer = mock(SecretReplacer.class);
-    SecretUtil.replaceSecrets(input, null, secretReplacer);
+    SecretUtil.replaceSecrets(wrap(input), null, secretReplacer);
     if (shouldDetect) {
-      verify(secretReplacer).replaceSecrets(eq(secret), any());
+      verify(secretReplacer).replaceSecrets(eq(new Secret(secret, List.of("value"))), any());
     } else {
       verifyNoInteractions(secretReplacer);
     }
@@ -82,25 +92,143 @@ public class SecretUtilTests {
         "{\"field1\": \"{{secrets.KEY1}}\", \"field2\": \"{{secrets.KEY2}}\"}|{\"field1\": \"VALUE1\", \"field2\": \"VALUE2\"}",
       },
       delimiter = '|') // delimiter is needed to escape the comma in the json
-  void testSecretReplacementWithJsonInput(String input, String output) {
-    SecretReplacer secretReplacer = (name, context) -> secrets.get(name);
-    var result = SecretUtil.replaceSecrets(input, null, secretReplacer);
-    assertThat(result).isEqualTo(output);
+  void testSecretReplacementWithJsonInput(String input, String output) throws Exception {
+    SecretReplacer secretReplacer = (secret, context) -> secrets.get(secret.secretName());
+    var result =
+        SecretUtil.replaceSecrets((ObjectNode) OBJECT_MAPPER.readTree(input), null, secretReplacer);
+    assertThat(result).isEqualTo(OBJECT_MAPPER.readTree(output));
   }
 
   @Test
-  void shouldTrimSecretKeyExtractedFromBracketedReference() {
-    var keys = SecretUtil.retrieveSecretKeysInInput("{{ secrets.FOO:BAR }}");
-    assertThat(keys).contains("FOO:BAR");
+  void aReferenceNestedInsideAnArrayOfArraysIsReplaced() throws Exception {
+    var input = (ObjectNode) OBJECT_MAPPER.readTree("{\"values\":[[\"{{secrets.KEY1}}\"]]}");
+
+    var result =
+        SecretUtil.replaceSecrets(
+            input, null, (secret, context) -> secrets.get(secret.secretName()));
+
+    assertThat(result).isEqualTo(OBJECT_MAPPER.readTree("{\"values\":[[\"VALUE1\"]]}"));
+  }
+
+  @Test
+  void aReferenceWrittenAsAPropertyNameIsReplaced() throws Exception {
+    var input = (ObjectNode) OBJECT_MAPPER.readTree("{\"{{secrets.KEY1}}\":\"value\"}");
+
+    var result =
+        SecretUtil.replaceSecrets(
+            input, null, (secret, context) -> secrets.get(secret.secretName()));
+
+    assertThat(result).isEqualTo(OBJECT_MAPPER.readTree("{\"VALUE1\":\"value\"}"));
+  }
+
+  @Test
+  void aRenamedKeyCollidingWithALaterNonTextPropertyLosesToIt() throws Exception {
+    var input =
+        (ObjectNode)
+            OBJECT_MAPPER.readTree(
+                "{\"{{secrets.KEY1}}\":\"placeholder\",\"VALUE1\":{\"nested\":\"value\"}}");
+
+    var result =
+        SecretUtil.replaceSecrets(
+            input, null, (secret, context) -> secrets.get(secret.secretName()));
+
+    assertThat(result).isEqualTo(OBJECT_MAPPER.readTree("{\"VALUE1\":{\"nested\":\"value\"}}"));
+  }
+
+  @Test
+  void shouldNotAdmitABarePrefixOfABracketedNameWithSpecialCharacters() {
+    // {{secrets.DECLARED_A:SUB}} is one declaration. The bare pattern's narrower character class
+    // (no ':') would also match "secrets.DECLARED_A" inside that same literal text, spuriously
+    // admitting the shorter "DECLARED_A" into the allow-list this feeds — letting a runtime value
+    // that merely spells {{secrets.DECLARED_A}} resolve a secret the model never declared.
+    assertThat(SecretUtil.retrieveSecretKeysInInput("{{secrets.DECLARED_A:SUB}}"))
+        .containsExactly("DECLARED_A:SUB");
+  }
+
+  @Test
+  void shouldStillReportABareReferenceOutsideAnyBracketedOccurrence() {
+    // The exclusion only applies to a bare match nested inside a bracketed one; a genuinely
+    // separate bare occurrence elsewhere in the text must still be reported.
+    assertThat(
+            SecretUtil.retrieveSecretKeysInInput(
+                "{{secrets.DECLARED_A:SUB}} and also secrets.OTHER_BARE"))
+        .containsExactlyInAnyOrder("DECLARED_A:SUB", "OTHER_BARE");
+  }
+
+  @Test
+  void shouldNotResolveABarePrefixInsideAStillDeniedBracketedReference() {
+    // FOO is allowed on its own, but "FOO:BAR" is not declared anywhere and so is denied. The
+    // parentheses pass correctly leaves the literal "{{secrets.FOO:BAR}}" untouched — but its own
+    // text still contains "secrets.FOO", which the bare pass must not separately resolve.
+    SecretReplacer secretReplacer =
+        (secret, context) -> "FOO".equals(secret.secretName()) ? "REAL_VALUE" : null;
+
+    String result =
+        SecretUtil.replaceSecrets(wrap("{{secrets.FOO:BAR}}"), null, secretReplacer)
+            .get("value")
+            .asText();
+
+    assertThat(result).isEqualTo("{{secrets.FOO:BAR}}");
+  }
+
+  @Test
+  void shouldNotChainAResolvedValueIntoAFurtherReplacement() {
+    // This pinned the opposite: the bare pass used to rerun once per match in the original text, so
+    // a resolved value that itself looked like a reference chained into a further replacement, and
+    // the point was that a denied bracketed reference stayed denied across every rerun. The single
+    // scan removes the reruns, so it removes the chain with them -- A resolves to the literal text
+    // "secrets.FOO" and the scan moves past it, never asking for FOO. The denied reference is still
+    // denied, now because the scan consumed it whole rather than because it was excluded.
+    SecretReplacer secretReplacer =
+        (secret, context) -> {
+          if ("A".equals(secret.secretName())) return "secrets.FOO";
+          if ("FOO".equals(secret.secretName())) return "REAL_VALUE";
+          return null;
+        };
+
+    String result =
+        SecretUtil.replaceSecrets(wrap("secrets.A and {{secrets.FOO:BAR}}"), null, secretReplacer)
+            .get("value")
+            .asText();
+
+    assertThat(result).isEqualTo("secrets.FOO and {{secrets.FOO:BAR}}");
+  }
+
+  @Test
+  void shouldTrimTheExtractedNameSoItMatchesWhatReplacementLooksUp() {
+    // The parentheses pattern's capture reaches past the name to the closing braces, so
+    // "{{ secrets.FOO }}" declares FOO, not "FOO ". Returning the untrimmed form left the
+    // allow-list containing a name resolution never looks up, denying a legitimately declared
+    // secret.
+    var withWhitespace = "{{ secrets.FOO }}";
+    var replaced =
+        SecretUtil.replaceSecrets(
+            wrap(withWhitespace),
+            null,
+            (secret, context) -> "FOO".equals(secret.secretName()) ? "resolved" : null);
+
+    assertThat(replaced.get("value").asText()).isEqualTo("resolved");
+    assertThat(SecretUtil.retrieveSecretKeysInInput(withWhitespace)).containsExactly("FOO");
+  }
+
+  @Test
+  void shouldOnlyReplaceAllowListedSecrets() {
+    List<String> allowList = List.of("KEY1", "KEY2");
+    SecretReplacer secretReplacer =
+        (secret, context) ->
+            allowList.contains(secret.secretName()) ? secrets.get(secret.secretName()) : null;
+    String content = "Hello {{secrets.KEY1}} and {{secrets.KEY2}} and {{secrets.KEY3}}";
+    SecretContext secretContext = new SecretContext("tenantId");
+    var replacedContent = SecretUtil.replaceSecrets(wrap(content), secretContext, secretReplacer);
+    assertThat(replacedContent.get("value").asText())
+        .isEqualTo("Hello VALUE1 and VALUE2 and {{secrets.KEY3}}");
   }
 
   @Test
   void shouldNotResolveABarePrefixOfADeniedBracketedName() {
     var asked = new ArrayList<String>();
 
-    assertThat(
-            SecretUtil.replaceSecrets(
-                "{{secrets.PROD:API}}", null, recording(asked, Map.of("PROD", "p4ssw0rd"))))
+    assertThat(replacedValue("{{secrets.PROD:API}}", asked, Map.of("PROD", "p4ssw0rd")))
         .isEqualTo("{{secrets.PROD:API}}");
     assertThat(asked).containsExactly("PROD:API");
   }
@@ -110,8 +238,7 @@ public class SecretUtilTests {
     var asked = new ArrayList<String>();
     var secrets = Map.of("A", "{{secrets.PROD:API}}", "PROD", "p4ssw0rd");
 
-    assertThat(SecretUtil.replaceSecrets("{{secrets.A}}", null, recording(asked, secrets)))
-        .isEqualTo("{{secrets.PROD:API}}");
+    assertThat(replacedValue("{{secrets.A}}", asked, secrets)).isEqualTo("{{secrets.PROD:API}}");
     assertThat(asked).containsExactly("A");
   }
 
@@ -120,8 +247,7 @@ public class SecretUtilTests {
     var asked = new ArrayList<String>();
     var secrets = Map.of("NOTE", "see secrets.OTHER", "OTHER", "TOP_SECRET");
 
-    assertThat(SecretUtil.replaceSecrets("{{secrets.NOTE}}", null, recording(asked, secrets)))
-        .isEqualTo("see secrets.OTHER");
+    assertThat(replacedValue("{{secrets.NOTE}}", asked, secrets)).isEqualTo("see secrets.OTHER");
     assertThat(asked).containsExactly("NOTE");
   }
 
@@ -137,9 +263,7 @@ public class SecretUtilTests {
   void shouldAskForEveryNameAtMostOnce() {
     var asked = new ArrayList<String>();
 
-    assertThat(
-            SecretUtil.replaceSecrets(
-                "secrets.K secrets.K {{secrets.K}}", null, recording(asked, Map.of("K", "V"))))
+    assertThat(replacedValue("secrets.K secrets.K {{secrets.K}}", asked, Map.of("K", "V")))
         .isEqualTo("V V V");
     assertThat(asked).containsExactly("K");
   }
@@ -149,7 +273,7 @@ public class SecretUtilTests {
     var asked = new ArrayList<String>();
     var input = "{{secrets.DENIED}} secrets.DENIED {{secrets.DENIED}}";
 
-    assertThat(SecretUtil.replaceSecrets(input, null, recording(asked, Map.of()))).isEqualTo(input);
+    assertThat(replacedValue(input, asked, Map.of())).isEqualTo(input);
     assertThat(asked).containsExactly("DENIED");
   }
 
@@ -161,8 +285,7 @@ public class SecretUtilTests {
             .mapToObj(i -> "{{secrets.DENIED" + i + ":X}}")
             .collect(Collectors.joining(" "));
 
-    assertThat(SecretUtil.replaceSecrets(payload, null, recording(asked, Map.of())))
-        .isEqualTo(payload);
+    assertThat(replacedValue(payload, asked, Map.of())).isEqualTo(payload);
     assertThat(asked).hasSize(5000);
   }
 
@@ -173,14 +296,22 @@ public class SecretUtilTests {
     var asked = new ArrayList<String>();
     var input = "{\"pw\":\"{{secrets.\0}}\"}";
 
-    assertThat(SecretUtil.replaceSecrets(input, null, recording(asked, Map.of()))).isEqualTo(input);
+    assertThat(replacedValue(input, asked, Map.of())).isEqualTo(input);
     assertThat(asked).containsExactly("\0");
   }
 
   private static SecretReplacer recording(List<String> asked, Map<String, String> secrets) {
-    return (name, context) -> {
-      asked.add(name);
-      return secrets.get(name);
+    return (secret, context) -> {
+      asked.add(secret.secretName());
+      return secrets.get(secret.secretName());
     };
+  }
+
+  /** The substituted text of the single {@code value} property {@link #wrap} puts a string in. */
+  private static String replacedValue(
+      String input, List<String> asked, Map<String, String> secrets) {
+    return SecretUtil.replaceSecrets(wrap(input), null, recording(asked, secrets))
+        .get("value")
+        .asText();
   }
 }

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextImplTest.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextImplTest.java
@@ -26,6 +26,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.collect.EvictingQueue;
 import io.camunda.connector.api.error.ConnectorRetryException;
 import io.camunda.connector.api.inbound.ActivationCheckResult;
@@ -124,19 +125,6 @@ class InboundConnectorContextImplTest {
         .isInstanceOf(String.class);
   }
 
-  // #7730: inbound secret resolution is restricted to the names the element's own deployed
-  // zeebe:property text declares. The allow-list is a superset of what a correctly-authored model
-  // names, so what it actually stops is a second-order lookup: replaceSecrets runs the brace pass
-  // and then runs the bare pass over that pass's output, letting a resolved value that contains
-  // reference-shaped text reach a secret no model ever declared. Confirmed present on this branch
-  // before backporting: under the previous allow-all filter, a secret whose value is the literal
-  // "secrets.CHAINED" resolved CHAINED.
-  //
-  // Main's suite also covers a hot swap, a sibling element's names, and the new
-  // camunda.secrets.<name> form. None are representable on this branch: connectorDetails and
-  // properties are both final and there is no updateConnectorDetails at all, there is a single
-  // connector-level text rather than a per-element one, and the new form does not exist here.
-
   private InboundConnectorContextImpl filteringContext(
       ValidInboundConnectorDetails details, SecretProvider provider) {
     return new InboundConnectorContextImpl(
@@ -151,8 +139,13 @@ class InboundConnectorContextImplTest {
         true);
   }
 
-  private static String replace(InboundConnectorContextImpl context, String input) {
-    return context.getSecretHandler().replaceSecrets(input, new SecretContext("t"));
+  private static String replace(InboundConnectorContextImpl context, String field, String input) {
+    ObjectNode probe = new ObjectMapper().createObjectNode().put(field, input);
+    return context
+        .getSecretHandler()
+        .replaceSecrets(probe, new SecretContext("t"))
+        .get(field)
+        .asText();
   }
 
   @Test
@@ -163,7 +156,7 @@ class InboundConnectorContextImplTest {
         filteringContext(
             getInboundConnectorDefinition(Map.of("token", "secrets.DECLARED")), provider);
 
-    assertThat(replace(context, "secrets.DECLARED")).isEqualTo("resolved");
+    assertThat(replace(context, "token", "secrets.DECLARED")).isEqualTo("resolved");
   }
 
   @Test
@@ -174,7 +167,7 @@ class InboundConnectorContextImplTest {
         filteringContext(
             getInboundConnectorDefinition(Map.of("token", "{{ secrets.BRACED }}")), provider);
 
-    assertThat(replace(context, "{{ secrets.BRACED }}")).isEqualTo("resolved");
+    assertThat(replace(context, "token", "{{ secrets.BRACED }}")).isEqualTo("resolved");
   }
 
   @Test
@@ -184,7 +177,7 @@ class InboundConnectorContextImplTest {
         filteringContext(
             getInboundConnectorDefinition(Map.of("token", "secrets.DECLARED")), provider);
 
-    assertThat(replace(context, "secrets.INJECTED")).isEqualTo("secrets.INJECTED");
+    assertThat(replace(context, "token", "secrets.INJECTED")).isEqualTo("secrets.INJECTED");
     verify(provider, never()).getSecret(eq("INJECTED"), any());
   }
 
@@ -197,8 +190,56 @@ class InboundConnectorContextImplTest {
         filteringContext(
             getInboundConnectorDefinition(Map.of("token", "{{secrets.CHAIN_ROOT}}")), provider);
 
-    assertThat(replace(context, "{{secrets.CHAIN_ROOT}}")).isEqualTo("secrets.CHAINED");
+    assertThat(replace(context, "token", "{{secrets.CHAIN_ROOT}}")).isEqualTo("secrets.CHAINED");
     verify(provider, never()).getSecret(eq("CHAINED"), any());
+  }
+
+  @Test
+  void secretFilterEnabled_leavesASecretDeclaredOnlyOnASiblingField() {
+    var provider = mock(SecretProvider.class);
+    when(provider.getSecret(eq("SIBLING_ONLY"), any())).thenReturn("leaked-value");
+    var context =
+        filteringContext(
+            getInboundConnectorDefinition(
+                Map.of("tokenA", "plain", "tokenB", "secrets.SIBLING_ONLY")),
+            provider);
+
+    assertThat(replace(context, "tokenA", "secrets.SIBLING_ONLY"))
+        .isEqualTo("secrets.SIBLING_ONLY");
+    verify(provider, never()).getSecret(eq("SIBLING_ONLY"), any());
+  }
+
+  @Test
+  void processElementSecretFilterScopesDottedPropertiesToTheirDeclaredPath() {
+    var provider = mock(SecretProvider.class);
+    when(provider.getSecret(eq("AUTH"), any())).thenReturn("resolved");
+    var details = getInboundConnectorDefinition(Map.of("authentication.token", "secrets.AUTH"));
+    var context =
+        new DefaultProcessElementContext(
+            details.connectorElements().getFirst(), (e) -> {}, provider, mapper, true);
+    var matchingProbe =
+        mapper
+            .createObjectNode()
+            .set("authentication", mapper.createObjectNode().put("token", "secrets.AUTH"));
+    var siblingProbe =
+        mapper
+            .createObjectNode()
+            .set("authentication", mapper.createObjectNode().put("type", "secrets.AUTH"));
+
+    assertThat(
+            context
+                .getSecretHandler()
+                .replaceSecrets(matchingProbe, new SecretContext("t"))
+                .at("/authentication/token")
+                .asText())
+        .isEqualTo("resolved");
+    assertThat(
+            context
+                .getSecretHandler()
+                .replaceSecrets(siblingProbe, new SecretContext("t"))
+                .at("/authentication/type")
+                .asText())
+        .isEqualTo("secrets.AUTH");
   }
 
   @Test
@@ -215,7 +256,7 @@ class InboundConnectorContextImplTest {
             mapper,
             EvictingQueue.create(10));
 
-    assertThat(replace(context, "secrets.INJECTED")).isEqualTo("resolved");
+    assertThat(replace(context, "token", "secrets.INJECTED")).isEqualTo("resolved");
   }
 
   private static ValidInboundConnectorDetails getInboundConnectorDefinition(

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/outbound/ConnectorJobHandlerTest.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/outbound/ConnectorJobHandlerTest.java
@@ -917,7 +917,7 @@ class ConnectorJobHandlerTest {
       // when
       var result =
           JobBuilder.create()
-              .withVariables("{{secrets.FOO}}")
+              .withVariables("{ \"value\" : \"{{secrets.FOO}}\" }")
               .executeAndCaptureResult(jobHandler, false);
 
       // then
@@ -938,7 +938,7 @@ class ConnectorJobHandlerTest {
       // when
       var result =
           JobBuilder.create()
-              .withVariables("{ \"integer\" : {{secrets.FOO}} }")
+              .withVariables("{ \"integer\" : \"{{secrets.FOO}}\" }")
               .executeAndCaptureResult(jobHandler, false);
 
       // then
@@ -959,7 +959,7 @@ class ConnectorJobHandlerTest {
       // when
       var result =
           JobBuilder.create()
-              .withVariables("{ \"integer\" : {{secrets.FOO}} }")
+              .withVariables("{ \"integer\" : \"{{secrets.FOO}}\" }")
               .executeAndCaptureResult(jobHandler, false);
 
       // then

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/outbound/JobBuilder.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/outbound/JobBuilder.java
@@ -18,10 +18,14 @@ package io.camunda.connector.runtime.core.outbound;
 
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.connector.runtime.core.Keywords;
 import io.camunda.zeebe.client.api.command.CompleteJobCommandStep1;
 import io.camunda.zeebe.client.api.command.FailJobCommandStep1;
@@ -74,6 +78,7 @@ class JobBuilder {
       when(throwCommand.errorCode(any())).thenReturn(throwCommandStep2);
       when(throwCommandStep2.variables(any(Map.class))).thenReturn(throwCommandStep2_2);
       when(job.getKey()).thenReturn(-1L);
+      withVariables("{}");
     }
 
     public JobBuilderStep useJobClient(JobClient client) {
@@ -83,7 +88,23 @@ class JobBuilder {
 
     public JobBuilderStep withVariables(String variables) {
       when(job.getVariables()).thenReturn(variables);
+      lenient()
+          .doAnswer(
+              invocation -> {
+                Class<?> cls = invocation.getArgument(0);
+                return cls.cast(parseVariables(variables));
+              })
+          .when(job)
+          .getVariablesAsType(any());
       return this;
+    }
+
+    private static JsonNode parseVariables(String variables) {
+      try {
+        return new ObjectMapper().readTree(variables);
+      } catch (JsonProcessingException e) {
+        throw new IllegalArgumentException("Failed to deserialize job variables", e);
+      }
     }
 
     public JobBuilderStep withHeaders(Map<String, String> headers) {

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/outbound/JobHandlerContextTest.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/outbound/JobHandlerContextTest.java
@@ -28,8 +28,10 @@ import io.camunda.connector.api.error.ConnectorInputException;
 import io.camunda.connector.api.secret.SecretProvider;
 import io.camunda.connector.api.validation.ValidationProvider;
 import io.camunda.connector.runtime.core.secret.SecretFilter;
+import io.camunda.connector.runtime.core.secret.SecretFilter.Secret;
 import io.camunda.connector.runtime.core.testutil.classexample.TestClass;
 import io.camunda.zeebe.client.api.response.ActivatedJob;
+import java.math.BigDecimal;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -47,6 +49,10 @@ class JobHandlerContextTest {
   private final ObjectMapper objectMapper = new ObjectMapper();
   private JobHandlerContext jobHandlerContext;
 
+  private void stubVariables(String json) {
+    when(activatedJob.getVariables()).thenReturn(json);
+  }
+
   @BeforeEach
   void setUp() {
     jobHandlerContext =
@@ -61,21 +67,56 @@ class JobHandlerContextTest {
 
   @Test
   void getVariables() {
-    when(activatedJob.getVariables()).thenReturn("{}");
+    stubVariables("{}");
     jobHandlerContext.getJobContext().getVariables();
     verify(activatedJob).getVariables();
   }
 
   @Test
+  void bindVariables_preservesFullDecimalPrecision() {
+    stubVariables("{ \"decimal\": 0.1234567890123456789012345 }");
+
+    BigDecimal bound = jobHandlerContext.bindVariables(TestClass.class).decimal;
+
+    assertThat(bound).isEqualByComparingTo(new BigDecimal("0.1234567890123456789012345"));
+  }
+
+  @Test
+  void bindVariables_preservesTrailingZeroScale() {
+    stubVariables("{ \"decimal\": 1.10 }");
+
+    BigDecimal bound = jobHandlerContext.bindVariables(TestClass.class).decimal;
+
+    assertThat(bound).isEqualTo(new BigDecimal("1.10"));
+  }
+
+  @Test
+  void getVariables_preservesDecimalText() {
+    stubVariables("{ \"a\": 0.00000001, \"b\": 1.10, \"c\": 0.1234567890123456789012345 }");
+
+    assertThat(jobHandlerContext.getJobContext().getVariables())
+        .contains("0.00000001", "1.10", "0.1234567890123456789012345");
+  }
+
+  @Test
+  void getVariables_fallsBackToScientificNotationForOutOfRangeDecimalScale() {
+    stubVariables("{ \"tiny\": 1e-10000, \"huge\": 1e+10001 }");
+
+    assertThat(jobHandlerContext.getJobContext().getVariables())
+        .contains("1E-10000")
+        .contains("1E+10001");
+  }
+
+  @Test
   void bindVariables_success() {
     String json = "{ \"integer\": 3}";
-    when(activatedJob.getVariables()).thenReturn(json);
+    stubVariables(json);
     assertThat(jobHandlerContext.bindVariables(TestClass.class).integer).isEqualTo(3);
   }
 
   @Test
   void bindVariables_failedSecretAreBounded() {
-    String json = "{ \"integer\": \"{{secrets.FOO}}\"";
+    String json = "{ \"integer\": \"{{secrets.FOO}}\" }";
     when(activatedJob.getVariables()).thenReturn(json);
     when(secretProvider.getSecret(eq("FOO"), any())).thenReturn("secret");
     Exception thrown =
@@ -87,7 +128,7 @@ class JobHandlerContextTest {
 
   @Test
   void bindVariables_successSecretAreBounded() {
-    String json = "{ \"integer\": {{secrets.FOO}} }";
+    String json = "{ \"integer\": \"{{secrets.FOO}}\" }";
     when(activatedJob.getVariables()).thenReturn(json);
     when(secretProvider.getSecret(eq("FOO"), any())).thenReturn("1");
     assertThat(jobHandlerContext.bindVariables(TestClass.class).integer).isEqualTo(1);
@@ -95,7 +136,7 @@ class JobHandlerContextTest {
 
   @Test
   void bindVariables_secretIsNotAvailable() {
-    String json = "{ \"integer\": {{secrets.FOO2}} }";
+    String json = "{ \"integer\": \"{{secrets.FOO2}}\" }";
     when(activatedJob.getVariables()).thenReturn(json);
     when(secretProvider.getSecret(eq("FOO2"), any())).thenReturn(null);
     assertThrows(
@@ -105,14 +146,14 @@ class JobHandlerContextTest {
   @Test
   void bindVariables_nullValue() {
     String json = "{ \"integer\": null}";
-    when(activatedJob.getVariables()).thenReturn(json);
+    stubVariables(json);
     assertThat(jobHandlerContext.bindVariables(TestClass.class).integer).isEqualTo(null);
   }
 
   @Test
   void bindVariables_invalidFormat() {
     String json = "{ \"integer\": \"hello\"}";
-    when(activatedJob.getVariables()).thenReturn(json);
+    stubVariables(json);
     Exception thrown =
         assertThrows(
             ConnectorInputException.class, () -> jobHandlerContext.bindVariables(TestClass.class));
@@ -124,7 +165,7 @@ class JobHandlerContextTest {
   @Test
   void bindVariables_invalidFormatNull() {
     String json = "{ \"invalid\": null }";
-    when(activatedJob.getVariables()).thenReturn(json);
+    stubVariables(json);
     Exception thrown =
         assertThrows(
             ConnectorInputException.class, () -> jobHandlerContext.bindVariables(TestClass.class));
@@ -145,8 +186,8 @@ class JobHandlerContextTest {
 
   @Test
   void bindVariables_invalidFormatObject() {
-    String json = "{ \"integer\": \"{ \"hello\" : 3\"}";
-    when(activatedJob.getVariables()).thenReturn(json);
+    String json = "{ \"integer\": \"{ \\\"hello\\\" : 3}\" }";
+    stubVariables(json);
     Exception thrown =
         assertThrows(
             ConnectorInputException.class, () -> jobHandlerContext.bindVariables(TestClass.class));
@@ -158,7 +199,7 @@ class JobHandlerContextTest {
   @Test
   void bindVariables_emptyString() {
     String json = "";
-    when(activatedJob.getVariables()).thenReturn(json);
+    stubVariables(json);
     Exception thrown =
         assertThrows(
             ConnectorInputException.class, () -> jobHandlerContext.bindVariables(TestClass.class));
@@ -169,20 +210,18 @@ class JobHandlerContextTest {
   @Test
   void bindVariables_emptyArray() {
     String json = "[]";
-    when(activatedJob.getVariables()).thenReturn(json);
+    stubVariables(json);
     Exception thrown =
         assertThrows(
             ConnectorInputException.class, () -> jobHandlerContext.bindVariables(TestClass.class));
 
-    assertThat(thrown.getMessage())
-        .isEqualTo(
-            "Cannot deserialize value of type `io.camunda.connector.runtime.core.testutil.classexample.TestClass` from Array value (token `JsonToken.START_ARRAY`)");
+    assertThat(thrown.getMessage()).isEqualTo("This is not a JSON object");
   }
 
   @Test
   void bindVariables_invalidFormatArray() {
     String json = "{ \"integer\": [\"hello\"] }";
-    when(activatedJob.getVariables()).thenReturn(json);
+    stubVariables(json);
     Exception thrown =
         assertThrows(
             ConnectorInputException.class, () -> jobHandlerContext.bindVariables(TestClass.class));
@@ -204,9 +243,9 @@ class JobHandlerContextTest {
             validationProvider,
             null,
             objectMapper,
-            SecretFilter.allowOnly(List.of("AUTH")));
+            SecretFilter.allowOnly(List.of(new Secret("AUTH", List.of()))));
     String json = "{ \"value\": \"{{secrets.UNDECLARED}}\" }";
-    when(activatedJob.getVariables()).thenReturn(json);
+    stubVariables(json);
 
     var bound = restrictiveContext.bindVariables(SingleStringField.class);
 
@@ -216,5 +255,25 @@ class JobHandlerContextTest {
 
   public static class SingleStringField {
     public String value;
+  }
+
+  @Test
+  void bindVariables_resolvesAQuotedSecretWithoutDoubleEscaping() {
+    stubVariables("{ \"value\": \"{{secrets.FOO}}\" }");
+    when(secretProvider.getSecret(eq("FOO"), any())).thenReturn("Hello \"quoted\" \\\\ value");
+
+    var bound = jobHandlerContext.bindVariables(SingleStringField.class);
+
+    assertThat(bound.value).isEqualTo("Hello \"quoted\" \\\\ value");
+  }
+
+  @Test
+  void bindVariables_rejectsAnUnquotedSecretPlaceholder() {
+    stubVariables("{ \"integer\": {{secrets.FOO}} }");
+
+    assertThatThrownBy(() -> jobHandlerContext.bindVariables(TestClass.class))
+        .isInstanceOf(ConnectorInputException.class)
+        .hasMessage("This is not a JSON object");
+    verify(secretProvider, never()).getSecret(eq("FOO"), any());
   }
 }

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/outbound/OutboundConnectorExceptionHandlerTest.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/outbound/OutboundConnectorExceptionHandlerTest.java
@@ -20,6 +20,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.camunda.connector.api.error.ConnectorExceptionBuilder;
 import io.camunda.connector.api.error.ConnectorInputException;
 import io.camunda.connector.api.error.ConnectorRetryExceptionBuilder;
@@ -28,9 +30,11 @@ import io.camunda.connector.api.secret.SecretProvider;
 import io.camunda.connector.runtime.core.FooBarSecretProvider;
 import io.camunda.connector.runtime.core.secret.SecretAllowListUnavailableException;
 import io.camunda.connector.runtime.core.secret.SecretFilter;
+import io.camunda.connector.runtime.core.secret.SecretFilter.Secret;
 import io.camunda.connector.runtime.core.secret.SecretNotAvailableException;
 import io.camunda.zeebe.client.api.response.ActivatedJob;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -40,6 +44,8 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
 class OutboundConnectorExceptionHandlerTest {
+
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
   private final OutboundConnectorExceptionHandler handler =
       new OutboundConnectorExceptionHandler(new FooBarSecretProvider());
@@ -51,16 +57,36 @@ class OutboundConnectorExceptionHandlerTest {
   private static ActivatedJob jobNaming(String variables) {
     var job = mock(ActivatedJob.class);
     when(job.getVariables()).thenReturn(variables);
+    when(job.getVariablesAsType(ObjectNode.class)).thenReturn(readTree(variables));
     when(job.getKey()).thenReturn(1L);
     when(job.getTenantId()).thenReturn("tenant");
     when(job.getRetries()).thenReturn(3);
     return job;
   }
 
+  private static ObjectNode readTree(String json) {
+    try {
+      return (ObjectNode) OBJECT_MAPPER.readTree(json);
+    } catch (Exception e) {
+      throw new IllegalArgumentException("Invalid test variables", e);
+    }
+  }
+
   private static SecretProvider holdingOnly(Map<String, String> secrets) {
     return new SecretProvider() {
       @Override
       public String getSecret(String name, SecretContext context) {
+        return secrets.get(name);
+      }
+    };
+  }
+
+  private static SecretProvider recordingProvider(
+      Map<String, String> secrets, List<String> requestedNames) {
+    return new SecretProvider() {
+      @Override
+      public String getSecret(String name, SecretContext context) {
+        requestedNames.add(name);
         return secrets.get(name);
       }
     };
@@ -700,5 +726,49 @@ class OutboundConnectorExceptionHandlerTest {
 
     assertThat(result.exception().getMessage()).isEqualTo("api rejected the request");
     assertThat(result.retries()).isEqualTo(2);
+  }
+
+  @Test
+  void onlySecretsAllowedAtTheirFieldPathAreReadBack() {
+    var job = jobNaming("{\"a\":\"{{secrets.ALLOWED}}\",\"b\":\"{{secrets.DENIED}}\"}");
+    var requestedNames = new ArrayList<String>();
+    var pathScopedHandler =
+        new OutboundConnectorExceptionHandler(
+            recordingProvider(
+                Map.of("ALLOWED", "allowed-value", "DENIED", "denied-value"), requestedNames));
+
+    var result =
+        pathScopedHandler.manageConnectorJobHandlerException(
+            new RuntimeException("api rejected allowed-value and denied-value"),
+            job,
+            Duration.ofSeconds(1),
+            SecretFilter.allowOnly(List.of(new Secret("ALLOWED", List.of("a")))),
+            List.of());
+
+    assertThat(requestedNames).containsExactly("ALLOWED");
+    assertThat(result.exception().getMessage()).isEqualTo("api rejected *** and denied-value");
+  }
+
+  @Test
+  void aSecretOccurringAtSeveralPathsIsLookedUpOnlyOnce() {
+    var job =
+        jobNaming(
+            "{\"a\":\"{{secrets.TOKEN}}\",\"b\":\"{{secrets.TOKEN}}\","
+                + "\"c\":\"{{secrets.TOKEN}}\"}");
+    var requestedNames = new ArrayList<String>();
+    var recordingHandler =
+        new OutboundConnectorExceptionHandler(
+            recordingProvider(Map.of("TOKEN", "token-value"), requestedNames));
+
+    var result =
+        recordingHandler.manageConnectorJobHandlerException(
+            new RuntimeException("api rejected token-value everywhere"),
+            job,
+            Duration.ofSeconds(1),
+            SecretFilter.allowAll(),
+            List.of());
+
+    assertThat(requestedNames).containsExactly("TOKEN");
+    assertThat(result.exception().getMessage()).isEqualTo("api rejected *** everywhere");
   }
 }

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/testutil/classexample/TestClass.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/testutil/classexample/TestClass.java
@@ -16,8 +16,12 @@
  */
 package io.camunda.connector.runtime.core.testutil.classexample;
 
+import java.math.BigDecimal;
+
 public class TestClass {
   public Integer integer;
+  public BigDecimal decimal;
+  public Long longValue;
 
   public TestClass(Integer integer) {
     this.integer = integer;

--- a/connector-runtime/connector-runtime-spring/pom.xml
+++ b/connector-runtime/connector-runtime-spring/pom.xml
@@ -52,6 +52,10 @@
       <groupId>io.camunda.spring</groupId>
       <artifactId>java-client-operate</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.camunda.feel</groupId>
+      <artifactId>feel-engine</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>io.camunda.connector</groupId>

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/SecretKeyCacheHolder.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/SecretKeyCacheHolder.java
@@ -17,6 +17,7 @@
 package io.camunda.connector.runtime.outbound;
 
 import com.github.benmanes.caffeine.cache.Cache;
+import io.camunda.connector.runtime.core.secret.SecretFilter.Secret;
 import java.util.List;
 import java.util.Map;
 
@@ -36,4 +37,4 @@ import java.util.Map;
  * replace the host's own auto-configured {@code CacheManager} — confirmed via {@code
  * dependency:tree}, not theoretical. Caffeine's {@code Cache} needs neither dependency.
  */
-record SecretKeyCacheHolder(Cache<Long, Map<String, List<String>>> cache) {}
+record SecretKeyCacheHolder(Cache<Long, Map<String, List<Secret>>> cache) {}

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/LazyLoadingSecretFilter.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/LazyLoadingSecretFilter.java
@@ -18,39 +18,38 @@ package io.camunda.connector.runtime.outbound.job;
 
 import io.camunda.connector.runtime.core.secret.SecretFilter;
 import java.util.List;
-import java.util.Set;
 import java.util.function.Supplier;
 
 /**
  * A {@link SecretFilter} that resolves the allowed secret names on the first {@link
- * #isAllowed(String)} call rather than at construction time. This defers the BPMN process
+ * #isAllowed(Secret)} call rather than at construction time. This defers the BPMN process
  * definition lookup to the point where secrets are actually being replaced, so that any exception
  * thrown by the supplier propagates through the normal connector error-handling path and results in
  * a proper Zeebe {@code failJob} command.
  *
  * <p>The supplier is called exactly once per filter instance regardless of outcome. When the
  * supplier returns {@code null} (LAX mode: lookup failed, fall back to allow-all), all subsequent
- * calls to {@link #isAllowed(String)} return {@code true} without re-invoking the supplier.
+ * calls to {@link #isAllowed(Secret)} return {@code true} without re-invoking the supplier.
  */
 public class LazyLoadingSecretFilter implements SecretFilter {
-  private final Supplier<List<String>> secretNamesSupplier;
+  private final Supplier<List<Secret>> secretsSupplier;
 
   private volatile boolean initialized = false;
-  private Set<String> secretNames;
+  private SecretFilter delegate;
   private RuntimeException initializationFailure;
 
-  public LazyLoadingSecretFilter(Supplier<List<String>> secretNamesSupplier) {
-    this.secretNamesSupplier = secretNamesSupplier;
+  public LazyLoadingSecretFilter(Supplier<List<Secret>> secretsSupplier) {
+    this.secretsSupplier = secretsSupplier;
   }
 
   @Override
-  public boolean isAllowed(String secretName) {
+  public boolean isAllowed(Secret context) {
     if (!initialized) {
       synchronized (this) {
         if (!initialized) {
           try {
-            List<String> names = secretNamesSupplier.get();
-            secretNames = names != null ? Set.copyOf(names) : null;
+            List<Secret> names = secretsSupplier.get();
+            delegate = names != null ? SecretFilter.allowOnly(names) : SecretFilter.allowAll();
           } catch (RuntimeException e) {
             initializationFailure = e;
           } finally {
@@ -62,10 +61,6 @@ public class LazyLoadingSecretFilter implements SecretFilter {
     if (initializationFailure != null) {
       throw initializationFailure;
     }
-    if (secretNames != null) {
-      return secretNames.contains(secretName);
-    } else {
-      return true;
-    }
+    return delegate.isAllowed(context);
   }
 }

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/secret/ProcessDefinitionSecretKeyCache.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/secret/ProcessDefinitionSecretKeyCache.java
@@ -17,6 +17,7 @@
 package io.camunda.connector.runtime.outbound.secret;
 
 import com.github.benmanes.caffeine.cache.Cache;
+import io.camunda.connector.runtime.core.secret.SecretFilter.Secret;
 import io.camunda.connector.runtime.core.secret.SecretUtil;
 import io.camunda.operate.CamundaOperateClient;
 import io.camunda.operate.exception.OperateException;
@@ -33,19 +34,29 @@ import io.camunda.zeebe.model.bpmn.instance.ServiceTask;
 import io.camunda.zeebe.model.bpmn.instance.SubProcess;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeInput;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeIoMapping;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
+import java.util.Deque;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.camunda.feel.api.FeelEngineApi;
+import org.camunda.feel.api.FeelEngineBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class ProcessDefinitionSecretKeyCache implements SecretKeyCache {
   private static final Logger LOG = LoggerFactory.getLogger(ProcessDefinitionSecretKeyCache.class);
+  private static final FeelEngineApi FEEL_ENGINE = FeelEngineBuilder.forJava().build();
   private static final List<Class<? extends BaseElement>> OUTBOUND_ELIGIBLE_TYPES =
       new ArrayList<>();
 
@@ -60,16 +71,16 @@ public class ProcessDefinitionSecretKeyCache implements SecretKeyCache {
   }
 
   private final CamundaOperateClient camundaOperateClient;
-  private final Cache<Long, Map<String, List<String>>> cache;
+  private final Cache<Long, Map<String, List<Secret>>> cache;
 
   public ProcessDefinitionSecretKeyCache(
-      CamundaOperateClient camundaOperateClient, Cache<Long, Map<String, List<String>>> cache) {
+      CamundaOperateClient camundaOperateClient, Cache<Long, Map<String, List<Secret>>> cache) {
     this.camundaOperateClient = camundaOperateClient;
     this.cache = cache;
   }
 
   @Override
-  public List<String> getSecretKeys(SecretKeyContext secretKeyContext) {
+  public List<Secret> getSecretKeys(SecretKeyContext secretKeyContext) {
     return cache
         .get(secretKeyContext.processDefinitionKey(), this::fetchSecretKeysByElementIdsUnchecked)
         .getOrDefault(secretKeyContext.elementId(), Collections.emptyList());
@@ -82,7 +93,7 @@ public class ProcessDefinitionSecretKeyCache implements SecretKeyCache {
    * unchecked mapping-function failure unwrapped, so every other exception here reaches the caller
    * exactly as thrown.
    */
-  private Map<String, List<String>> fetchSecretKeysByElementIdsUnchecked(
+  private Map<String, List<Secret>> fetchSecretKeysByElementIdsUnchecked(
       long processDefinitionKey) {
     try {
       return fetchSecretKeysByElementIds(processDefinitionKey);
@@ -94,7 +105,7 @@ public class ProcessDefinitionSecretKeyCache implements SecretKeyCache {
     }
   }
 
-  private Map<String, List<String>> fetchSecretKeysByElementIds(long processDefinitionKey)
+  private Map<String, List<Secret>> fetchSecretKeysByElementIds(long processDefinitionKey)
       throws OperateException {
     if (camundaOperateClient == null) {
       throw new SecretFilterUnavailableException(
@@ -116,7 +127,7 @@ public class ProcessDefinitionSecretKeyCache implements SecretKeyCache {
         .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
   }
 
-  private Map<String, List<String>> inspectBpmnProcess(Process process, long processDefinitionKey) {
+  private Map<String, List<Secret>> inspectBpmnProcess(Process process, long processDefinitionKey) {
     Collection<BaseElement> outboundEligibleElements =
         retrieveOutboundEligibleElementsFromProcess(process);
     if (outboundEligibleElements.isEmpty()) {
@@ -125,7 +136,7 @@ public class ProcessDefinitionSecretKeyCache implements SecretKeyCache {
       return Collections.emptyMap();
     }
 
-    Map<String, List<String>> discoveredOutboundConnectors = new HashMap<>();
+    Map<String, List<Secret>> discoveredOutboundConnectors = new HashMap<>();
     for (BaseElement element : outboundEligibleElements) {
       var inputs = findElementInput(element);
       var definedSecrets = extractSecrets(inputs);
@@ -134,12 +145,186 @@ public class ProcessDefinitionSecretKeyCache implements SecretKeyCache {
     return discoveredOutboundConnectors;
   }
 
-  private List<String> extractSecrets(List<ZeebeInput> inputs) {
-    return inputs.stream()
-        .flatMap(input -> SecretUtil.retrieveSecretKeysInInput(input.getSource()).stream())
-        .map(String::trim)
+  /**
+   * A secret is allowed not only on the input that names it directly, but also on every input whose
+   * own FEEL expression reads the variable that input's target writes — transitively. A template
+   * commonly assembles one input's value (e.g. {@code url}) from others (e.g. {@code baseUrl},
+   * itself holding a secret); the assembled input's runtime value can carry the secret's text just
+   * as directly as the input that named it, so the allow-list has to follow that data flow rather
+   * than stop at the input where the secret's name is written.
+   *
+   * <p>A dependency is resolved by matching a referenced variable's full qualified path against
+   * another input's {@code target} path, one a prefix of the other (a dotted target like {@code
+   * authentication.type} publishes both the top-level variable {@code authentication} and the field
+   * {@code authentication.type}). Requiring a prefix relation on the full path — rather than just
+   * the top-level segment — keeps sibling fields under the same top-level name, like {@code
+   * authentication.type} and {@code authentication.token}, from being treated as dependent on each
+   * other merely for sharing a top-level name.
+   *
+   * <p>Only a preceding, still-effective writer of the referenced path counts as a dependency:
+   * {@code zeebe:input} mappings evaluate in declaration order, each against the output the ones
+   * before it already built, so a later mapping's target is invisible to an earlier one, and a
+   * target written more than once is reachable only through its last writer before this point.
+   */
+  private List<Secret> extractSecrets(List<ZeebeInput> inputs) {
+    Map<ZeebeInput, List<String>> pathByInput = new LinkedHashMap<>();
+    Map<ZeebeInput, List<String>> ownSecretNamesByInput = new LinkedHashMap<>();
+    for (ZeebeInput input : inputs) {
+      pathByInput.put(input, Arrays.asList(input.getTarget().split("\\.")));
+      ownSecretNamesByInput.put(
+          input,
+          SecretUtil.retrieveSecretKeysInInput(input.getSource()).stream()
+              .map(String::trim)
+              .distinct()
+              .toList());
+    }
+
+    // zeebe:input mappings are evaluated in declaration order, each against the output built by
+    // the ones before it -- a later mapping is invisible to an earlier one, and a target written
+    // more than once is only reachable through its last (nearest-preceding), still-effective
+    // writer. effectiveTargets is therefore built up one input at a time, alongside the loop, and
+    // an input's own dependencies are resolved against it before that input registers itself.
+    Map<ZeebeInput, List<ZeebeInput>> directDependencies = new LinkedHashMap<>();
+    Map<List<String>, ZeebeInput> effectiveTargets = new LinkedHashMap<>();
+    for (ZeebeInput input : inputs) {
+      List<List<String>> referencedPaths = referencedVariablePaths(input.getSource());
+      directDependencies.put(
+          input,
+          referencedPaths.stream()
+              .flatMap(referencedPath -> matchingWriters(referencedPath, effectiveTargets))
+              .distinct()
+              .toList());
+      // A write to a parent path replaces the whole subtree beneath it, so every existing writer
+      // of a descendant path is no longer effective from this point on.
+      List<String> ownPath = pathByInput.get(input);
+      effectiveTargets.keySet().removeIf(existingPath -> isProperPrefix(ownPath, existingPath));
+      effectiveTargets.put(ownPath, input);
+    }
+
+    // A later mapping that writes a path *beneath* an earlier one replaces that part of what the
+    // earlier input produced -- and a grant is a path prefix, so it cannot say "everything under
+    // `path` except that subtree". Such a writer therefore grants nothing at its own path and
+    // propagates nothing to the inputs that read it: `authentication = secrets.WHOLE` followed by
+    // `authentication.token = someVariable` would otherwise authorize WHOLE at
+    // authentication.token, because the declared path is a prefix of it -- letting that later,
+    // potentially process-controlled value resolve a secret it never carried -- and equally at any
+    // field that copies the whole object afterwards. Any descendant still in effectiveTargets was
+    // necessarily written *after* this input, since this input's own write evicted the ones before
+    // it. This is the parent-overwrite rule above, applied in the other direction, and fails
+    // closed the same way: a parent whose expression nests a secret under a path a later mapping
+    // does not touch (`authentication = {user: "{{secrets.USER}}"}` alongside
+    // `authentication.token = ...`) loses its grant too, since a prefix cannot express the
+    // difference.
+    Set<ZeebeInput> shadowedWriters =
+        inputs.stream()
+            .filter(
+                candidate ->
+                    effectiveTargets.keySet().stream()
+                        .anyMatch(deeper -> isProperPrefix(pathByInput.get(candidate), deeper)))
+            .collect(Collectors.toSet());
+
+    List<Secret> result = new ArrayList<>();
+    for (ZeebeInput input : inputs) {
+      List<String> path = pathByInput.get(input);
+      // A later mapping can overwrite this input's own target -- directly, or by writing to a
+      // parent path that replaces the whole subtree beneath it -- before the sequence finishes.
+      // effectiveTargets reflects the final state once the loop above has processed every input,
+      // so if it no longer maps `path` back to this exact input, this input's value -- whether its
+      // own secret or one propagated into it through a dependency -- is not reachable at `path`
+      // any more; granting anything there would let whatever the actual final writer put in that
+      // field -- potentially attacker-controlled -- resolve a secret it never carried. This has to
+      // gate the dependency walk below too, not just the own-grant: a dependency chain still
+      // computes what *this* input's expression would have carried, which is moot once something
+      // else, not this input, is what the runtime field actually holds.
+      if (effectiveTargets.get(path) != input || shadowedWriters.contains(input)) {
+        continue;
+      }
+      ownSecretNamesByInput.get(input).forEach(name -> result.add(new Secret(name, path)));
+
+      Set<ZeebeInput> visited = new HashSet<>();
+      Deque<ZeebeInput> pending = new ArrayDeque<>(directDependencies.get(input));
+      while (!pending.isEmpty()) {
+        ZeebeInput dependency = pending.poll();
+        if (!visited.add(dependency)) {
+          continue;
+        }
+        // A shadowed dependency terminates the branch rather than merely contributing no names
+        // of its own: whatever flowed *into* it is just as unreachable through it as its own
+        // secret is, since part of what it produced was replaced by the later writer beneath it.
+        // Walking past it would grant a secret two hops up at this input's path -- which, being
+        // a prefix, covers this input's copy of that same shadowed subtree.
+        if (shadowedWriters.contains(dependency)) {
+          continue;
+        }
+        ownSecretNamesByInput.get(dependency).forEach(name -> result.add(new Secret(name, path)));
+        pending.addAll(directDependencies.getOrDefault(dependency, List.of()));
+      }
+    }
+    return result.stream().distinct().toList();
+  }
+
+  /**
+   * The full qualified path of every variable a FEEL expression references, or an empty list if
+   * {@code source} isn't a FEEL expression (no leading {@code =}) or fails to parse — a static
+   * value or a malformed expression simply has nothing to propagate from.
+   */
+  private static List<List<String>> referencedVariablePaths(String source) {
+    if (source == null) {
+      return List.of();
+    }
+    String trimmed = source.trim();
+    if (!trimmed.startsWith("=")) {
+      return List.of();
+    }
+    var parseResult = FEEL_ENGINE.parseExpression(trimmed.substring(1));
+    if (parseResult.isFailure()) {
+      return List.of();
+    }
+    return parseResult.parsedExpression().getVariableReferences().stream()
+        .map(ref -> ref.getFullQualifiedName())
         .distinct()
         .toList();
+  }
+
+  /**
+   * The writers a reference to {@code referencedPath} depends on, given the writers currently still
+   * effective. Two disjoint cases, since a single symmetric prefix match would let a stale ancestor
+   * writer stand in for a leaf that a later, more specific writer has since replaced:
+   *
+   * <ul>
+   *   <li>The reference targets a specific field or the exact field a writer wrote: at most one
+   *       writer answers it, the <em>nearest</em> (most specific) ancestor-or-self path among the
+   *       effective writers -- a closer writer, even an earlier one, shadows a more distant
+   *       ancestor's stake in that one field.
+   *   <li>The reference targets a whole object a writer's field lives under: every writer whose
+   *       path is a descendant of the reference answers it, since reading the whole object reads
+   *       every field currently set beneath it.
+   * </ul>
+   */
+  private static Stream<ZeebeInput> matchingWriters(
+      List<String> referencedPath, Map<List<String>, ZeebeInput> effectiveTargets) {
+    var nearestAncestorOrSelf =
+        effectiveTargets.entrySet().stream()
+            .filter(entry -> isAncestorOrSelf(entry.getKey(), referencedPath))
+            .max(Comparator.comparingInt(entry -> entry.getKey().size()))
+            .map(Map.Entry::getValue);
+    var descendants =
+        effectiveTargets.entrySet().stream()
+            .filter(entry -> isProperPrefix(referencedPath, entry.getKey()))
+            .map(Map.Entry::getValue);
+    return nearestAncestorOrSelf
+        .map(writer -> Stream.concat(Stream.of(writer), descendants))
+        .orElse(descendants);
+  }
+
+  /** Whether {@code ancestor} is a prefix of {@code path}, including being equal to it. */
+  private static boolean isAncestorOrSelf(List<String> ancestor, List<String> path) {
+    return ancestor.size() <= path.size() && path.subList(0, ancestor.size()).equals(ancestor);
+  }
+
+  /** Whether {@code shorter} is a strict ancestor path of {@code longer} (not equal to it). */
+  private static boolean isProperPrefix(List<String> shorter, List<String> longer) {
+    return shorter.size() < longer.size() && longer.subList(0, shorter.size()).equals(shorter);
   }
 
   private List<ZeebeInput> findElementInput(BaseElement element) {

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/secret/SecretKeyCache.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/secret/SecretKeyCache.java
@@ -16,10 +16,11 @@
  */
 package io.camunda.connector.runtime.outbound.secret;
 
+import io.camunda.connector.runtime.core.secret.SecretFilter.Secret;
 import java.util.List;
 
 public interface SecretKeyCache {
-  List<String> getSecretKeys(SecretKeyContext secretKeyContext);
+  List<Secret> getSecretKeys(SecretKeyContext secretKeyContext);
 
   record SecretKeyContext(long processDefinitionKey, String elementId) {}
 }

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/inbound/InboundConnectorRuntimeConfigurationTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/inbound/InboundConnectorRuntimeConfigurationTest.java
@@ -94,7 +94,12 @@ class InboundConnectorRuntimeConfigurationTest {
   }
 
   private static String resolveUndeclared(InboundConnectorContextImpl context) {
-    return context.getSecretHandler().replaceSecrets("secrets.UNDECLARED", new SecretContext("t"));
+    var probe = new ObjectMapper().createObjectNode().put("value", "secrets.UNDECLARED");
+    return context
+        .getSecretHandler()
+        .replaceSecrets(probe, new SecretContext("t"))
+        .get("value")
+        .asText();
   }
 
   private static SecretProvider alwaysResolvingProvider() {

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/job/ConfigurableSecretFilterFactoryTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/job/ConfigurableSecretFilterFactoryTest.java
@@ -26,6 +26,7 @@ import static org.mockito.Mockito.when;
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import io.camunda.connector.runtime.core.secret.SecretAllowListUnavailableException;
+import io.camunda.connector.runtime.core.secret.SecretFilter.Secret;
 import io.camunda.connector.runtime.core.secret.SecretFilterFactory.SecretFilterContext;
 import io.camunda.connector.runtime.outbound.job.ConfigurableSecretFilterFactory.SecretFilterMode;
 import io.camunda.connector.runtime.outbound.secret.ProcessDefinitionSecretKeyCache;
@@ -58,21 +59,22 @@ class ConfigurableSecretFilterFactoryTest {
 
     var filter = factory.create(CONTEXT);
 
-    assertThat(filter.isAllowed("ANY_SECRET")).isTrue();
-    assertThat(filter.isAllowed("ANOTHER_SECRET")).isTrue();
+    assertThat(filter.isAllowed(secret("ANY_SECRET"))).isTrue();
+    assertThat(filter.isAllowed(secret("ANOTHER_SECRET"))).isTrue();
     verifyNoInteractions(secretKeyCache);
   }
 
   @Test
   void create_lax_withSecretKeys_restrictsFilterToList() {
-    when(secretKeyCache.getSecretKeys(SECRET_KEY_CONTEXT)).thenReturn(List.of("API_KEY", "TOKEN"));
+    when(secretKeyCache.getSecretKeys(SECRET_KEY_CONTEXT))
+        .thenReturn(List.of(secret("API_KEY"), secret("TOKEN")));
     var factory = new ConfigurableSecretFilterFactory(SecretFilterMode.LAX, secretKeyCache);
 
     var filter = factory.create(CONTEXT);
 
-    assertThat(filter.isAllowed("API_KEY")).isTrue();
-    assertThat(filter.isAllowed("TOKEN")).isTrue();
-    assertThat(filter.isAllowed("UNLISTED_SECRET")).isFalse();
+    assertThat(filter.isAllowed(secret("API_KEY"))).isTrue();
+    assertThat(filter.isAllowed(secret("TOKEN"))).isTrue();
+    assertThat(filter.isAllowed(secret("UNLISTED_SECRET"))).isFalse();
   }
 
   @Test
@@ -82,18 +84,18 @@ class ConfigurableSecretFilterFactoryTest {
 
     var filter = factory.create(CONTEXT);
 
-    assertThat(filter.isAllowed("ANY_SECRET")).isTrue();
+    assertThat(filter.isAllowed(secret("ANY_SECRET"))).isTrue();
   }
 
   @Test
   void create_strict_withSecretKeys_restrictsFilterToList() {
-    when(secretKeyCache.getSecretKeys(SECRET_KEY_CONTEXT)).thenReturn(List.of("API_KEY"));
+    when(secretKeyCache.getSecretKeys(SECRET_KEY_CONTEXT)).thenReturn(List.of(secret("API_KEY")));
     var factory = new ConfigurableSecretFilterFactory(SecretFilterMode.STRICT, secretKeyCache);
 
     var filter = factory.create(CONTEXT);
 
-    assertThat(filter.isAllowed("API_KEY")).isTrue();
-    assertThat(filter.isAllowed("UNLISTED_SECRET")).isFalse();
+    assertThat(filter.isAllowed(secret("API_KEY"))).isTrue();
+    assertThat(filter.isAllowed(secret("UNLISTED_SECRET"))).isFalse();
   }
 
   @Test
@@ -103,7 +105,7 @@ class ConfigurableSecretFilterFactoryTest {
 
     var filter = factory.create(CONTEXT);
 
-    assertThatThrownBy(() -> filter.isAllowed("ANY_SECRET"))
+    assertThatThrownBy(() -> filter.isAllowed(secret("ANY_SECRET")))
         .isInstanceOf(SecretAllowListUnavailableException.class)
         .hasMessageContaining("Error retrieving secret keys");
   }
@@ -119,7 +121,7 @@ class ConfigurableSecretFilterFactoryTest {
 
     var filter = factory.create(CONTEXT);
 
-    assertThatThrownBy(() -> filter.isAllowed("ANY_SECRET"))
+    assertThatThrownBy(() -> filter.isAllowed(secret("ANY_SECRET")))
         .hasMessageContaining(ELEMENT_ID)
         .hasMessageContaining(String.valueOf(PROCESS_DEF_KEY))
         .hasMessageContaining(RuntimeException.class.getName())
@@ -158,7 +160,7 @@ class ConfigurableSecretFilterFactoryTest {
 
     var filter = factory.create(CONTEXT);
 
-    assertThatThrownBy(() -> filter.isAllowed("ANY_SECRET"))
+    assertThatThrownBy(() -> filter.isAllowed(secret("ANY_SECRET")))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("No CamundaOperateClient available");
   }
@@ -178,7 +180,7 @@ class ConfigurableSecretFilterFactoryTest {
 
     var filter = factory.create(CONTEXT);
 
-    assertThatThrownBy(() -> filter.isAllowed("ANY_SECRET"))
+    assertThatThrownBy(() -> filter.isAllowed(secret("ANY_SECRET")))
         .hasMessageContaining(java.net.ConnectException.class.getName())
         .hasMessageNotContaining("Connection refused");
   }
@@ -196,12 +198,12 @@ class ConfigurableSecretFilterFactoryTest {
 
     var filter = factory.create(CONTEXT);
 
-    assertThatThrownBy(() -> filter.isAllowed("ANY_SECRET"))
+    assertThatThrownBy(() -> filter.isAllowed(secret("ANY_SECRET")))
         .isInstanceOf(SecretAllowListUnavailableException.class);
   }
 
   private void assertMessageIdentifiesTheFailureWithoutLeakingTheCauseText(
-      Cache<Long, Map<String, List<String>>> cache) throws Exception {
+      Cache<Long, Map<String, List<Secret>>> cache) throws Exception {
     var operateClient = mock(CamundaOperateClient.class);
     when(operateClient.getProcessDefinitionModel(PROCESS_DEF_KEY))
         .thenThrow(new OperateException("Operate returned 404 for process definition 42"));
@@ -210,11 +212,15 @@ class ConfigurableSecretFilterFactoryTest {
 
     var filter = factory.create(CONTEXT);
 
-    assertThatThrownBy(() -> filter.isAllowed("ANY_SECRET"))
+    assertThatThrownBy(() -> filter.isAllowed(secret("ANY_SECRET")))
         .hasMessageContaining(ELEMENT_ID)
         .hasMessageContaining(String.valueOf(PROCESS_DEF_KEY))
         .hasMessageContaining(OperateException.class.getName())
         .hasMessageNotContaining("could not be loaded using")
         .hasMessageNotContaining("Operate returned 404 for process definition 42");
+  }
+
+  private static Secret secret(String name) {
+    return new Secret(name, List.of());
   }
 }

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/job/LazyLoadingSecretFilterTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/job/LazyLoadingSecretFilterTest.java
@@ -17,36 +17,88 @@
 package io.camunda.connector.runtime.outbound.job;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import io.camunda.connector.runtime.core.secret.SecretFilter.Secret;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.Test;
 
 class LazyLoadingSecretFilterTest {
 
+  private static Secret secret(String name) {
+    return new Secret(name, List.of());
+  }
+
+  private static Secret query(String name) {
+    return new Secret(name, List.of("field"));
+  }
+
+  private static Secret at(String name, String... fieldPath) {
+    return new Secret(name, List.of(fieldPath));
+  }
+
   @Test
   void isAllowed_withAllowList_permitsListedSecret() {
-    var filter = new LazyLoadingSecretFilter(() -> List.of("MY_SECRET", "OTHER_SECRET"));
+    var filter =
+        new LazyLoadingSecretFilter(() -> List.of(secret("MY_SECRET"), secret("OTHER_SECRET")));
 
-    assertTrue(filter.isAllowed("MY_SECRET"));
-    assertTrue(filter.isAllowed("OTHER_SECRET"));
+    assertTrue(filter.isAllowed(query("MY_SECRET")));
+    assertTrue(filter.isAllowed(query("OTHER_SECRET")));
   }
 
   @Test
   void isAllowed_withAllowList_deniesUnlistedSecret() {
-    var filter = new LazyLoadingSecretFilter(() -> List.of("MY_SECRET"));
+    var filter = new LazyLoadingSecretFilter(() -> List.of(secret("MY_SECRET")));
 
-    assertFalse(filter.isAllowed("UNLISTED_SECRET"));
+    assertFalse(filter.isAllowed(query("UNLISTED_SECRET")));
+  }
+
+  @Test
+  void isAllowed_permitsRuntimePathNestedDeeperThanDeclaredPath() {
+    // The declared path is derived statically from the zeebe:input target (e.g. "foo"), but a FEEL
+    // context/object expression can put the resolved value under a subpath of that at runtime (e.g.
+    // "foo.bar"). The declared path only has to be a prefix of the runtime path, not an exact
+    // match,
+    // or every input that expands into a nested object would spuriously get its secrets rejected.
+    var filter = new LazyLoadingSecretFilter(() -> List.of(at("TOKEN", "foo")));
+
+    assertTrue(filter.isAllowed(at("TOKEN", "foo", "bar")));
+  }
+
+  @Test
+  void isAllowed_permitsExactRuntimePathMatch() {
+    var filter = new LazyLoadingSecretFilter(() -> List.of(at("TOKEN", "foo", "bar")));
+
+    assertTrue(filter.isAllowed(at("TOKEN", "foo", "bar")));
+  }
+
+  @Test
+  void isAllowed_deniesRuntimePathShallowerThanDeclaredPath() {
+    // The reverse of the nesting case above: a secret statically declared at the deeper path
+    // "foo.bar" must not match a runtime lookup at the shallower "foo" — the declared path can only
+    // be a prefix of the runtime one, never the other way around.
+    var filter = new LazyLoadingSecretFilter(() -> List.of(at("TOKEN", "foo", "bar")));
+
+    assertFalse(filter.isAllowed(at("TOKEN", "foo")));
+  }
+
+  @Test
+  void isAllowed_deniesRuntimePathOnASiblingBranch() {
+    var filter = new LazyLoadingSecretFilter(() -> List.of(at("TOKEN", "foo")));
+
+    assertFalse(filter.isAllowed(at("TOKEN", "baz")));
+    assertFalse(filter.isAllowed(at("TOKEN", "baz", "bar")));
   }
 
   @Test
   void isAllowed_withNullSupplierResult_allowsAll() {
     var filter = new LazyLoadingSecretFilter(() -> null);
 
-    assertTrue(filter.isAllowed("ANY_SECRET"));
-    assertTrue(filter.isAllowed("ANOTHER_SECRET"));
+    assertTrue(filter.isAllowed(query("ANY_SECRET")));
+    assertTrue(filter.isAllowed(query("ANOTHER_SECRET")));
   }
 
   @Test
@@ -56,12 +108,12 @@ class LazyLoadingSecretFilterTest {
         new LazyLoadingSecretFilter(
             () -> {
               callCount.incrementAndGet();
-              return List.of("SECRET");
+              return List.of(secret("SECRET"));
             });
 
-    filter.isAllowed("SECRET");
-    filter.isAllowed("SECRET");
-    filter.isAllowed("OTHER");
+    filter.isAllowed(query("SECRET"));
+    filter.isAllowed(query("SECRET"));
+    filter.isAllowed(query("OTHER"));
 
     assertTrue(callCount.get() == 1, "Supplier must be called exactly once");
   }
@@ -76,25 +128,30 @@ class LazyLoadingSecretFilterTest {
               return null;
             });
 
-    filter.isAllowed("ANY");
-    filter.isAllowed("ANY");
+    filter.isAllowed(query("ANY"));
+    filter.isAllowed(query("ANY"));
 
     assertTrue(callCount.get() == 1, "Supplier must be called exactly once even when null");
   }
 
   @Test
-  void isAllowed_supplierThrows_failureCachedAndSupplierNotReinvoked() {
+  void isAllowed_supplierFailureCached_supplierNotReinvoked() {
     var callCount = new AtomicInteger(0);
+    var failure = new IllegalStateException("secret key lookup failed");
     var filter =
         new LazyLoadingSecretFilter(
             () -> {
               callCount.incrementAndGet();
-              throw new IllegalArgumentException("lookup failed");
+              throw failure;
             });
 
-    assertThrows(IllegalArgumentException.class, () -> filter.isAllowed("ANY"));
-    assertThrows(IllegalArgumentException.class, () -> filter.isAllowed("ANY"));
+    var firstThrown =
+        assertThrows(IllegalStateException.class, () -> filter.isAllowed(query("ANY")));
+    var secondThrown =
+        assertThrows(IllegalStateException.class, () -> filter.isAllowed(query("ANY")));
 
-    assertTrue(callCount.get() == 1, "Supplier must not be re-invoked after a cached failure");
+    assertTrue(callCount.get() == 1, "Supplier must be called exactly once even on failure");
+    assertSame(failure, firstThrown);
+    assertSame(failure, secondThrown);
   }
 }

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/secret/ProcessDefinitionSecretKeyCacheTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/secret/ProcessDefinitionSecretKeyCacheTest.java
@@ -21,11 +21,12 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.when;
 
 import com.github.benmanes.caffeine.cache.Caffeine;
+import io.camunda.connector.runtime.core.secret.SecretFilter.Secret;
 import io.camunda.connector.runtime.outbound.secret.SecretKeyCache.SecretKeyContext;
 import io.camunda.operate.CamundaOperateClient;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
-import java.io.IOException;
+import java.util.List;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -61,7 +62,231 @@ class ProcessDefinitionSecretKeyCacheTest {
     var keys =
         secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1"));
 
-    assertThat(keys).containsExactlyInAnyOrder("API_KEY", "MY_TOKEN");
+    assertThat(keys)
+        .extracting(Secret::secretName)
+        .containsExactlyInAnyOrder("API_KEY", "MY_TOKEN");
+  }
+
+  @Test
+  void getSecretKeys_dottedTarget_splitsIntoAMultiSegmentFieldPath() throws Exception {
+    // Projecting away fieldPath (as every other assertion in this class does, via
+    // Secret::secretName) would let a regression that assigns every secret an empty or wrong
+    // path pass unnoticed — this asserts the complete Secret, name and path together, against a
+    // target with more than one segment.
+    when(camundaOperateClient.getProcessDefinitionModel(PROCESS_DEF_KEY))
+        .thenReturn(loadBpmn("outbound-with-dotted-target.bpmn"));
+
+    var keys =
+        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1"));
+
+    assertThat(keys).containsExactly(new Secret("API_KEY", List.of("auth", "token")));
+  }
+
+  @Test
+  void getSecretKeys_secretPropagatesToAnInputThatReferencesTheDeclaringInputsVariable()
+      throws Exception {
+    // baseUrl declares BASE_URL_SFDC; url is a FEEL expression built from baseUrl and path
+    // ("=baseUrl + \"/services/apexrest/\" + path"). url's runtime value can carry the secret's
+    // resolved text just as directly as baseUrl's can, so the secret must be allowed under url's
+    // own field path too -- not just under baseUrl's.
+    when(camundaOperateClient.getProcessDefinitionModel(PROCESS_DEF_KEY))
+        .thenReturn(loadBpmn("outbound-with-referenced-variable.bpmn"));
+
+    var keys =
+        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1"));
+
+    assertThat(keys)
+        .contains(
+            new Secret("BASE_URL_SFDC", List.of("baseUrl")),
+            new Secret("BASE_URL_SFDC", List.of("url")));
+  }
+
+  @Test
+  void getSecretKeys_propagatesTransitivelyThroughAChainOfReferences() throws Exception {
+    // innerBaseUrl declares INNER_SECRET; baseUrl = "=innerBaseUrl + \"/static-context\""
+    // references innerBaseUrl; url = "=baseUrl" references baseUrl, not innerBaseUrl directly.
+    // The secret has to reach url through two hops of the dependency chain, not just one.
+    when(camundaOperateClient.getProcessDefinitionModel(PROCESS_DEF_KEY))
+        .thenReturn(loadBpmn("outbound-with-chained-references.bpmn"));
+
+    var keys =
+        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1"));
+
+    assertThat(keys)
+        .containsExactlyInAnyOrder(
+            new Secret("INNER_SECRET", List.of("innerBaseUrl")),
+            new Secret("INNER_SECRET", List.of("baseUrl")),
+            new Secret("INNER_SECRET", List.of("url")));
+  }
+
+  @Test
+  void getSecretKeys_propagationDoesNotReachAnInputThatDoesNotReferenceTheDeclaringVariable()
+      throws Exception {
+    // method ("get") and connectionTimeoutInSeconds ("20") are unrelated static inputs on the same
+    // element -- propagation must not leak the secret onto every sibling input, only onto ones
+    // whose own expression actually reads the variable that carries it.
+    when(camundaOperateClient.getProcessDefinitionModel(PROCESS_DEF_KEY))
+        .thenReturn(loadBpmn("outbound-with-referenced-variable.bpmn"));
+
+    var keys =
+        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1"));
+
+    assertThat(keys)
+        .doesNotContain(
+            new Secret("BASE_URL_SFDC", List.of("method")),
+            new Secret("BASE_URL_SFDC", List.of("connectionTimeoutInSeconds")),
+            new Secret("BASE_URL_SFDC", List.of("path")),
+            new Secret("BASE_URL_SFDC", List.of("authentication", "type")));
+  }
+
+  @Test
+  void getSecretKeys_referenceToASiblingFieldDoesNotPropagateASiblingsSecret() throws Exception {
+    // authentication.token and authentication.type are siblings that merely share a top-level
+    // target segment. usesSiblingFieldOnly references authentication.type specifically, not the
+    // whole authentication object, so it must not inherit AUTH_TOKEN from its sibling field.
+    // usesWholeAuth, by reading the whole authentication object, legitimately picks it up.
+    when(camundaOperateClient.getProcessDefinitionModel(PROCESS_DEF_KEY))
+        .thenReturn(loadBpmn("outbound-with-sibling-fields.bpmn"));
+
+    var keys =
+        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1"));
+
+    assertThat(keys)
+        .contains(
+            new Secret("AUTH_TOKEN", List.of("authentication", "token")),
+            new Secret("AUTH_TOKEN", List.of("usesWholeAuth")))
+        .doesNotContain(
+            new Secret("AUTH_TOKEN", List.of("usesSiblingFieldOnly")),
+            new Secret("AUTH_TOKEN", List.of("authentication", "type")));
+  }
+
+  @Test
+  void getSecretKeys_referenceToAVariableDefinedLaterDoesNotPropagateItsSecret() throws Exception {
+    // url ("=baseUrl") is declared before baseUrl ("secrets.API_KEY") in the same ioMapping.
+    // zeebe:input mappings evaluate in declaration order, each against the output the ones before
+    // it already built, so url's expression sees the process-scope baseUrl, not this mapping's
+    // own -- API_KEY must not be allowed on url.
+    when(camundaOperateClient.getProcessDefinitionModel(PROCESS_DEF_KEY))
+        .thenReturn(loadBpmn("outbound-with-reverse-order-reference.bpmn"));
+
+    var keys =
+        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1"));
+
+    assertThat(keys)
+        .contains(new Secret("API_KEY", List.of("baseUrl")))
+        .doesNotContain(new Secret("API_KEY", List.of("url")));
+  }
+
+  @Test
+  void getSecretKeys_laterParentOverwriteInvalidatesAnEarlierDescendantWriter() throws Exception {
+    // authentication.token = secrets.TOKEN is declared first, then authentication (the whole
+    // parent object) is overwritten wholesale, replacing that field's secret-bearing value. url
+    // references authentication.token afterwards, but by then the token write is shadowed by
+    // the parent overwrite -- TOKEN must not be allowed on url, nor on its own now-overwritten
+    // path: the runtime field at authentication.token holds whatever the parent overwrite put
+    // there, not the secret, so granting TOKEN there would let that overwritten (potentially
+    // attacker-controlled) value resolve a secret it never carried.
+    when(camundaOperateClient.getProcessDefinitionModel(PROCESS_DEF_KEY))
+        .thenReturn(loadBpmn("outbound-with-parent-overwrite.bpmn"));
+
+    var keys =
+        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1"));
+
+    // Nothing in this BPMN ever reads authentication.token from a path that's still effective, so
+    // TOKEN isn't just absent from the two paths above -- it's not granted anywhere at all. This
+    // is stricter than doesNotContain(...) on its own: it also catches a regression that grants
+    // TOKEN at some third path this test doesn't otherwise name.
+    assertThat(keys).isEmpty();
+  }
+
+  @Test
+  void getSecretKeys_laterWriteToTheSameExactPathInvalidatesTheEarlierWriter() throws Exception {
+    // Two inputs target the identical path authentication.token: the first carries TOKEN, the
+    // second overwrites it with a plain value. The runtime field holds only the second input's
+    // value, so TOKEN must not be granted at that path -- the earlier grant would otherwise let
+    // the overwriting (potentially attacker-controlled) value resolve a secret it never carried.
+    when(camundaOperateClient.getProcessDefinitionModel(PROCESS_DEF_KEY))
+        .thenReturn(loadBpmn("outbound-with-same-path-overwrite.bpmn"));
+
+    var keys =
+        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1"));
+
+    assertThat(keys).isEmpty();
+  }
+
+  @Test
+  void getSecretKeys_laterOverwriteOfAPropagationTargetInvalidatesThePropagatedGrant()
+      throws Exception {
+    // baseUrl = secrets.TOKEN is declared first; url = "=baseUrl" propagates TOKEN to url while
+    // baseUrl is still the effective writer url's expression reads. A third mapping then
+    // overwrites url directly with attacker-controlled data -- url's runtime value comes from that
+    // third mapping, not from the (no longer effective) propagation through the second, so TOKEN
+    // must not be granted at url even though the dependency edge to it was genuinely resolved at
+    // the time it was computed.
+    when(camundaOperateClient.getProcessDefinitionModel(PROCESS_DEF_KEY))
+        .thenReturn(loadBpmn("outbound-with-overwritten-propagation-target.bpmn"));
+
+    var keys =
+        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1"));
+
+    assertThat(keys)
+        .containsExactly(new Secret("TOKEN", List.of("baseUrl")))
+        .doesNotContain(new Secret("TOKEN", List.of("url")));
+  }
+
+  @Test
+  void getSecretKeys_laterChildWriteRevokesTheAncestorGrant() throws Exception {
+    // authentication = secrets.WHOLE_SECRET is declared first; authentication.token is then
+    // written by a later mapping. A grant is a path prefix, so a grant at [authentication] also
+    // authorizes a lookup at authentication.token -- the field the later mapping controls. If that
+    // mapping's source were process data rather than the fixture's literal, a placeholder in it
+    // would resolve WHOLE_SECRET, a secret that value never carried. The whole grant therefore
+    // goes, at the parent's own path and at wholeObjectRead, which copies the object afterwards.
+    // Nothing is lost here: the child write replaces the parent's scalar with an object, so the
+    // secret's text is not present at runtime under authentication at all.
+    when(camundaOperateClient.getProcessDefinitionModel(PROCESS_DEF_KEY))
+        .thenReturn(loadBpmn("outbound-with-child-overwrite.bpmn"));
+
+    var keys =
+        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1"));
+
+    assertThat(keys).isEmpty();
+  }
+
+  @Test
+  void getSecretKeys_laterChildWriteRevokesAnAncestorGrantThatNestsItsSecretElsewhere()
+      throws Exception {
+    // The fail-closed half of the rule above, pinned deliberately. Here the parent's own FEEL
+    // object nests USER at authentication.user, which the later authentication.token write does
+    // not touch -- so the grant is legitimate for that one field and only over-broad for the
+    // shadowed sibling. A prefix cannot express "under authentication except .token", so the
+    // grant is dropped rather than narrowed, and USER stops resolving on this element. Accepted
+    // over-denial: the alternative is authorizing the secret at a field a later mapping fills
+    // from process data.
+    when(camundaOperateClient.getProcessDefinitionModel(PROCESS_DEF_KEY))
+        .thenReturn(loadBpmn("outbound-with-nested-parent-and-child-overwrite.bpmn"));
+
+    var keys =
+        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1"));
+
+    assertThat(keys).isEmpty();
+  }
+
+  @Test
+  void getSecretKeys_shadowedInputDoesNotRelayItsOwnDependenciesSecret() throws Exception {
+    // The shadowed input is itself a dependent here: baseUrl carries T, authentication reads
+    // baseUrl, authentication.token is then written from process data, and copy reads the whole
+    // authentication object. Muting only the shadowed input's *own* names is not enough -- the
+    // walk would keep traversing through it and reach baseUrl, granting T at copy, which
+    // prefix-matches copy.token, the field that carries the shadowed subtree's attacker data.
+    // A shadowed input terminates the branch instead.
+    when(camundaOperateClient.getProcessDefinitionModel(PROCESS_DEF_KEY))
+        .thenReturn(loadBpmn("outbound-with-shadowed-input-as-dependency.bpmn"));
+
+    var keys =
+        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1"));
+
+    assertThat(keys).containsExactly(new Secret("T", List.of("baseUrl")));
   }
 
   @Test
@@ -74,8 +299,10 @@ class ProcessDefinitionSecretKeyCacheTest {
         secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "task-alpha"));
     var betaKeys = secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "task-beta"));
 
-    assertThat(alphaKeys).containsExactly("SECRET_ALPHA");
-    assertThat(betaKeys).containsExactlyInAnyOrder("SECRET_BETA", "SECRET_GAMMA");
+    assertThat(alphaKeys).extracting(Secret::secretName).containsExactly("SECRET_ALPHA");
+    assertThat(betaKeys)
+        .extracting(Secret::secretName)
+        .containsExactlyInAnyOrder("SECRET_BETA", "SECRET_GAMMA");
   }
 
   @Test
@@ -99,7 +326,7 @@ class ProcessDefinitionSecretKeyCacheTest {
 
     var keys = secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "plain-task"));
 
-    assertThat(keys).containsExactly("SECRET_X");
+    assertThat(keys).extracting(Secret::secretName).containsExactly("SECRET_X");
   }
 
   @Test
@@ -122,7 +349,7 @@ class ProcessDefinitionSecretKeyCacheTest {
 
     var keys = secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, elementId));
 
-    assertThat(keys).containsExactly(secretKey);
+    assertThat(keys).extracting(Secret::secretName).containsExactly(secretKey);
   }
 
   private static Stream<Arguments> otherEligibleTaskTypes() {
@@ -143,8 +370,8 @@ class ProcessDefinitionSecretKeyCacheTest {
     var endEventKeys =
         secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "send-message-end"));
 
-    assertThat(throwEventKeys).containsExactly("THROW_EVENT_SECRET");
-    assertThat(endEventKeys).containsExactly("END_EVENT_SECRET");
+    assertThat(throwEventKeys).extracting(Secret::secretName).containsExactly("THROW_EVENT_SECRET");
+    assertThat(endEventKeys).extracting(Secret::secretName).containsExactly("END_EVENT_SECRET");
   }
 
   @Test
@@ -162,9 +389,9 @@ class ProcessDefinitionSecretKeyCacheTest {
     var grandchildKeys =
         secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "grandchild-task"));
 
-    assertThat(outerKeys).containsExactly("OUTER_SECRET");
-    assertThat(innerKeys).containsExactly("INNER_SECRET");
-    assertThat(grandchildKeys).containsExactly("GRANDCHILD_SECRET");
+    assertThat(outerKeys).extracting(Secret::secretName).containsExactly("OUTER_SECRET");
+    assertThat(innerKeys).extracting(Secret::secretName).containsExactly("INNER_SECRET");
+    assertThat(grandchildKeys).extracting(Secret::secretName).containsExactly("GRANDCHILD_SECRET");
   }
 
   @Test
@@ -193,7 +420,7 @@ class ProcessDefinitionSecretKeyCacheTest {
         .hasCauseInstanceOf(io.camunda.operate.exception.OperateException.class);
   }
 
-  private BpmnModelInstance loadBpmn(String fileName) throws IOException {
+  private BpmnModelInstance loadBpmn(String fileName) throws Exception {
     try (var stream = getClass().getClassLoader().getResourceAsStream("bpmn/" + fileName)) {
       if (stream == null) {
         throw new IllegalArgumentException("BPMN resource not found: bpmn/" + fileName);

--- a/connector-runtime/connector-runtime-spring/src/test/resources/bpmn/outbound-with-chained-references.bpmn
+++ b/connector-runtime/connector-runtime-spring/src/test/resources/bpmn/outbound-with-chained-references.bpmn
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+                  xmlns:zeebe="http://camunda.org/schema/zeebe/1.0"
+                  id="Definitions_outbound_chained_references"
+                  targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="outbound-with-chained-references" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_1" sourceRef="StartEvent_1" targetRef="service-task-1"/>
+    <bpmn:serviceTask id="service-task-1" name="HTTP Task"
+                      zeebe:modelerTemplate="io.camunda.connectors.HttpJson.v2">
+      <bpmn:extensionElements>
+        <zeebe:ioMapping>
+          <zeebe:input source="secrets.INNER_SECRET" target="innerBaseUrl"/>
+          <zeebe:input source="=innerBaseUrl + &quot;/static-context&quot;" target="baseUrl"/>
+          <zeebe:input source="=baseUrl" target="url"/>
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1</bpmn:incoming>
+      <bpmn:outgoing>Flow_2</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="Flow_2" sourceRef="service-task-1" targetRef="EndEvent_1"/>
+    <bpmn:endEvent id="EndEvent_1">
+      <bpmn:incoming>Flow_2</bpmn:incoming>
+    </bpmn:endEvent>
+  </bpmn:process>
+</bpmn:definitions>

--- a/connector-runtime/connector-runtime-spring/src/test/resources/bpmn/outbound-with-child-overwrite.bpmn
+++ b/connector-runtime/connector-runtime-spring/src/test/resources/bpmn/outbound-with-child-overwrite.bpmn
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+                  xmlns:zeebe="http://camunda.org/schema/zeebe/1.0"
+                  id="Definitions_outbound_child_overwrite"
+                  targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="outbound-with-child-overwrite" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_1" sourceRef="StartEvent_1" targetRef="service-task-1"/>
+    <bpmn:serviceTask id="service-task-1" name="HTTP Task"
+                      zeebe:modelerTemplate="io.camunda.connectors.HttpJson.v2">
+      <bpmn:extensionElements>
+        <zeebe:ioMapping>
+          <zeebe:input source="secrets.WHOLE_SECRET" target="authentication"/>
+          <zeebe:input source="public-value" target="authentication.token"/>
+          <zeebe:input source="=authentication.token" target="url"/>
+          <zeebe:input source="=authentication" target="wholeObjectRead"/>
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1</bpmn:incoming>
+      <bpmn:outgoing>Flow_2</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="Flow_2" sourceRef="service-task-1" targetRef="EndEvent_1"/>
+    <bpmn:endEvent id="EndEvent_1">
+      <bpmn:incoming>Flow_2</bpmn:incoming>
+    </bpmn:endEvent>
+  </bpmn:process>
+</bpmn:definitions>

--- a/connector-runtime/connector-runtime-spring/src/test/resources/bpmn/outbound-with-dotted-target.bpmn
+++ b/connector-runtime/connector-runtime-spring/src/test/resources/bpmn/outbound-with-dotted-target.bpmn
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+                  xmlns:zeebe="http://camunda.org/schema/zeebe/1.0"
+                  id="Definitions_outbound_dotted_target"
+                  targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="outbound-with-dotted-target" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_1" sourceRef="StartEvent_1" targetRef="service-task-1"/>
+    <bpmn:serviceTask id="service-task-1" name="HTTP Task"
+                      zeebe:modelerTemplate="io.camunda.connectors.HttpJson.v2">
+      <bpmn:extensionElements>
+        <zeebe:ioMapping>
+          <zeebe:input source="secrets.API_KEY" target="auth.token"/>
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1</bpmn:incoming>
+      <bpmn:outgoing>Flow_2</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="Flow_2" sourceRef="service-task-1" targetRef="EndEvent_1"/>
+    <bpmn:endEvent id="EndEvent_1">
+      <bpmn:incoming>Flow_2</bpmn:incoming>
+    </bpmn:endEvent>
+  </bpmn:process>
+</bpmn:definitions>

--- a/connector-runtime/connector-runtime-spring/src/test/resources/bpmn/outbound-with-nested-parent-and-child-overwrite.bpmn
+++ b/connector-runtime/connector-runtime-spring/src/test/resources/bpmn/outbound-with-nested-parent-and-child-overwrite.bpmn
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+                  xmlns:zeebe="http://camunda.org/schema/zeebe/1.0"
+                  id="Definitions_outbound_nested_parent_child_overwrite"
+                  targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="outbound-with-nested-parent-and-child-overwrite" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_1" sourceRef="StartEvent_1" targetRef="service-task-1"/>
+    <bpmn:serviceTask id="service-task-1" name="HTTP Task"
+                      zeebe:modelerTemplate="io.camunda.connectors.HttpJson.v2">
+      <bpmn:extensionElements>
+        <zeebe:ioMapping>
+          <zeebe:input source="={ user: &quot;{{secrets.USER}}&quot; }" target="authentication"/>
+          <zeebe:input source="=attackerVar" target="authentication.token"/>
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1</bpmn:incoming>
+      <bpmn:outgoing>Flow_2</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="Flow_2" sourceRef="service-task-1" targetRef="EndEvent_1"/>
+    <bpmn:endEvent id="EndEvent_1">
+      <bpmn:incoming>Flow_2</bpmn:incoming>
+    </bpmn:endEvent>
+  </bpmn:process>
+</bpmn:definitions>

--- a/connector-runtime/connector-runtime-spring/src/test/resources/bpmn/outbound-with-overwritten-propagation-target.bpmn
+++ b/connector-runtime/connector-runtime-spring/src/test/resources/bpmn/outbound-with-overwritten-propagation-target.bpmn
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+                  xmlns:zeebe="http://camunda.org/schema/zeebe/1.0"
+                  id="Definitions_outbound_overwritten_propagation_target"
+                  targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="outbound-with-overwritten-propagation-target" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_1" sourceRef="StartEvent_1" targetRef="service-task-1"/>
+    <bpmn:serviceTask id="service-task-1" name="HTTP Task"
+                      zeebe:modelerTemplate="io.camunda.connectors.HttpJson.v2">
+      <bpmn:extensionElements>
+        <zeebe:ioMapping>
+          <zeebe:input source="secrets.TOKEN" target="baseUrl"/>
+          <zeebe:input source="=baseUrl" target="url"/>
+          <zeebe:input source="attackerVar" target="url"/>
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1</bpmn:incoming>
+      <bpmn:outgoing>Flow_2</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="Flow_2" sourceRef="service-task-1" targetRef="EndEvent_1"/>
+    <bpmn:endEvent id="EndEvent_1">
+      <bpmn:incoming>Flow_2</bpmn:incoming>
+    </bpmn:endEvent>
+  </bpmn:process>
+</bpmn:definitions>

--- a/connector-runtime/connector-runtime-spring/src/test/resources/bpmn/outbound-with-parent-overwrite.bpmn
+++ b/connector-runtime/connector-runtime-spring/src/test/resources/bpmn/outbound-with-parent-overwrite.bpmn
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+                  xmlns:zeebe="http://camunda.org/schema/zeebe/1.0"
+                  id="Definitions_outbound_parent_overwrite"
+                  targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="outbound-with-parent-overwrite" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_1" sourceRef="StartEvent_1" targetRef="service-task-1"/>
+    <bpmn:serviceTask id="service-task-1" name="HTTP Task"
+                      zeebe:modelerTemplate="io.camunda.connectors.HttpJson.v2">
+      <bpmn:extensionElements>
+        <zeebe:ioMapping>
+          <zeebe:input source="secrets.TOKEN" target="authentication.token"/>
+          <zeebe:input source="={token: &quot;public&quot;}" target="authentication"/>
+          <zeebe:input source="=authentication.token" target="url"/>
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1</bpmn:incoming>
+      <bpmn:outgoing>Flow_2</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="Flow_2" sourceRef="service-task-1" targetRef="EndEvent_1"/>
+    <bpmn:endEvent id="EndEvent_1">
+      <bpmn:incoming>Flow_2</bpmn:incoming>
+    </bpmn:endEvent>
+  </bpmn:process>
+</bpmn:definitions>

--- a/connector-runtime/connector-runtime-spring/src/test/resources/bpmn/outbound-with-referenced-variable.bpmn
+++ b/connector-runtime/connector-runtime-spring/src/test/resources/bpmn/outbound-with-referenced-variable.bpmn
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+                  xmlns:zeebe="http://camunda.org/schema/zeebe/1.0"
+                  id="Definitions_outbound_referenced_variable"
+                  targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="outbound-with-referenced-variable" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_1" sourceRef="StartEvent_1" targetRef="service-task-1"/>
+    <bpmn:serviceTask id="service-task-1" name="Salesforce Task"
+                      zeebe:modelerTemplate="io.camunda.connectors.SalesforceApexRest.v1">
+      <bpmn:extensionElements>
+        <zeebe:ioMapping>
+          <zeebe:input source="{{secrets.BASE_URL_SFDC}}" target="baseUrl"/>
+          <zeebe:input target="authentication.type"/>
+          <zeebe:input source="apexRest" target="salesforceInteractionType"/>
+          <zeebe:input source="get" target="method"/>
+          <zeebe:input target="path"/>
+          <zeebe:input source="=baseUrl + &quot;/services/apexrest/&quot; + path" target="url"/>
+          <zeebe:input source="20" target="connectionTimeoutInSeconds"/>
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1</bpmn:incoming>
+      <bpmn:outgoing>Flow_2</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="Flow_2" sourceRef="service-task-1" targetRef="EndEvent_1"/>
+    <bpmn:endEvent id="EndEvent_1">
+      <bpmn:incoming>Flow_2</bpmn:incoming>
+    </bpmn:endEvent>
+  </bpmn:process>
+</bpmn:definitions>

--- a/connector-runtime/connector-runtime-spring/src/test/resources/bpmn/outbound-with-reverse-order-reference.bpmn
+++ b/connector-runtime/connector-runtime-spring/src/test/resources/bpmn/outbound-with-reverse-order-reference.bpmn
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+                  xmlns:zeebe="http://camunda.org/schema/zeebe/1.0"
+                  id="Definitions_outbound_reverse_order_reference"
+                  targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="outbound-with-reverse-order-reference" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_1" sourceRef="StartEvent_1" targetRef="service-task-1"/>
+    <bpmn:serviceTask id="service-task-1" name="HTTP Task"
+                      zeebe:modelerTemplate="io.camunda.connectors.HttpJson.v2">
+      <bpmn:extensionElements>
+        <zeebe:ioMapping>
+          <zeebe:input source="=baseUrl" target="url"/>
+          <zeebe:input source="secrets.API_KEY" target="baseUrl"/>
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1</bpmn:incoming>
+      <bpmn:outgoing>Flow_2</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="Flow_2" sourceRef="service-task-1" targetRef="EndEvent_1"/>
+    <bpmn:endEvent id="EndEvent_1">
+      <bpmn:incoming>Flow_2</bpmn:incoming>
+    </bpmn:endEvent>
+  </bpmn:process>
+</bpmn:definitions>

--- a/connector-runtime/connector-runtime-spring/src/test/resources/bpmn/outbound-with-same-path-overwrite.bpmn
+++ b/connector-runtime/connector-runtime-spring/src/test/resources/bpmn/outbound-with-same-path-overwrite.bpmn
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+                  xmlns:zeebe="http://camunda.org/schema/zeebe/1.0"
+                  id="Definitions_outbound_same_path_overwrite"
+                  targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="outbound-with-same-path-overwrite" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_1" sourceRef="StartEvent_1" targetRef="service-task-1"/>
+    <bpmn:serviceTask id="service-task-1" name="HTTP Task"
+                      zeebe:modelerTemplate="io.camunda.connectors.HttpJson.v2">
+      <bpmn:extensionElements>
+        <zeebe:ioMapping>
+          <zeebe:input source="secrets.TOKEN" target="authentication.token"/>
+          <zeebe:input source="public-value" target="authentication.token"/>
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1</bpmn:incoming>
+      <bpmn:outgoing>Flow_2</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="Flow_2" sourceRef="service-task-1" targetRef="EndEvent_1"/>
+    <bpmn:endEvent id="EndEvent_1">
+      <bpmn:incoming>Flow_2</bpmn:incoming>
+    </bpmn:endEvent>
+  </bpmn:process>
+</bpmn:definitions>

--- a/connector-runtime/connector-runtime-spring/src/test/resources/bpmn/outbound-with-shadowed-input-as-dependency.bpmn
+++ b/connector-runtime/connector-runtime-spring/src/test/resources/bpmn/outbound-with-shadowed-input-as-dependency.bpmn
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+                  xmlns:zeebe="http://camunda.org/schema/zeebe/1.0"
+                  id="Definitions_outbound_shadowed_input_as_dependency"
+                  targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="outbound-with-shadowed-input-as-dependency" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_1" sourceRef="StartEvent_1" targetRef="service-task-1"/>
+    <bpmn:serviceTask id="service-task-1" name="HTTP Task"
+                      zeebe:modelerTemplate="io.camunda.connectors.HttpJson.v2">
+      <bpmn:extensionElements>
+        <zeebe:ioMapping>
+          <zeebe:input source="secrets.T" target="baseUrl"/>
+          <zeebe:input source="=baseUrl" target="authentication"/>
+          <zeebe:input source="=attackerVar" target="authentication.token"/>
+          <zeebe:input source="=authentication" target="copy"/>
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1</bpmn:incoming>
+      <bpmn:outgoing>Flow_2</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="Flow_2" sourceRef="service-task-1" targetRef="EndEvent_1"/>
+    <bpmn:endEvent id="EndEvent_1">
+      <bpmn:incoming>Flow_2</bpmn:incoming>
+    </bpmn:endEvent>
+  </bpmn:process>
+</bpmn:definitions>

--- a/connector-runtime/connector-runtime-spring/src/test/resources/bpmn/outbound-with-sibling-fields.bpmn
+++ b/connector-runtime/connector-runtime-spring/src/test/resources/bpmn/outbound-with-sibling-fields.bpmn
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+                  xmlns:zeebe="http://camunda.org/schema/zeebe/1.0"
+                  id="Definitions_outbound_sibling_fields"
+                  targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="outbound-with-sibling-fields" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_1" sourceRef="StartEvent_1" targetRef="service-task-1"/>
+    <bpmn:serviceTask id="service-task-1" name="HTTP Task"
+                      zeebe:modelerTemplate="io.camunda.connectors.HttpJson.v2">
+      <bpmn:extensionElements>
+        <zeebe:ioMapping>
+          <zeebe:input source="secrets.AUTH_TOKEN" target="authentication.token"/>
+          <zeebe:input source="bearer" target="authentication.type"/>
+          <zeebe:input source="=authentication" target="usesWholeAuth"/>
+          <zeebe:input source="=authentication.type" target="usesSiblingFieldOnly"/>
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1</bpmn:incoming>
+      <bpmn:outgoing>Flow_2</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="Flow_2" sourceRef="service-task-1" targetRef="EndEvent_1"/>
+    <bpmn:endEvent id="EndEvent_1">
+      <bpmn:incoming>Flow_2</bpmn:incoming>
+    </bpmn:endEvent>
+  </bpmn:process>
+</bpmn:definitions>

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/inbound/InboundSecretFilterDefaultModeWiringTest.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/inbound/InboundSecretFilterDefaultModeWiringTest.java
@@ -18,6 +18,7 @@ package io.camunda.connector.runtime.inbound;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.EvictingQueue;
 import io.camunda.connector.api.inbound.InboundConnectorContext;
 import io.camunda.connector.api.inbound.InboundConnectorExecutable;
@@ -77,9 +78,9 @@ class InboundSecretFilterDefaultModeWiringTest {
         (InboundConnectorContextImpl)
             contextFactory.createContext(
                 details, e -> {}, TestExecutable.class, EvictingQueue.create(10));
-    var result =
-        context.getSecretHandler().replaceSecrets("secrets.UNDECLARED", new SecretContext("t"));
+    var probe = new ObjectMapper().createObjectNode().put("value", "secrets.UNDECLARED");
+    var result = context.getSecretHandler().replaceSecrets(probe, new SecretContext("t"));
 
-    assertThat(result).isEqualTo("secrets.UNDECLARED");
+    assertThat(result.get("value").asText()).isEqualTo("secrets.UNDECLARED");
   }
 }

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/outbound/JobBuilder.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/outbound/JobBuilder.java
@@ -18,10 +18,14 @@ package io.camunda.connector.runtime.outbound;
 
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.connector.runtime.core.Keywords;
 import io.camunda.connector.runtime.core.outbound.ConnectorJobHandler;
 import io.camunda.zeebe.client.api.command.CompleteJobCommandStep1;
@@ -75,6 +79,7 @@ class JobBuilder {
       when(throwCommand.errorCode(any())).thenReturn(throwCommandStep2);
       when(throwCommandStep2.variables(any(Map.class))).thenReturn(throwCommandStep2_2);
       when(job.getKey()).thenReturn(-1L);
+      withVariables("{}");
     }
 
     public JobBuilderStep useJobClient(JobClient client) {
@@ -84,7 +89,23 @@ class JobBuilder {
 
     public JobBuilderStep withVariables(String variables) {
       when(job.getVariables()).thenReturn(variables);
+      lenient()
+          .doAnswer(
+              invocation -> {
+                Class<?> cls = invocation.getArgument(0);
+                return cls.cast(parseVariables(variables));
+              })
+          .when(job)
+          .getVariablesAsType(any());
       return this;
+    }
+
+    private static JsonNode parseVariables(String variables) {
+      try {
+        return new ObjectMapper().readTree(variables);
+      } catch (JsonProcessingException e) {
+        throw new IllegalArgumentException("Failed to deserialize job variables", e);
+      }
     }
 
     public JobBuilderStep withHeaders(Map<String, String> headers) {

--- a/connector-sdk/test/src/main/java/io/camunda/connector/test/inbound/InboundConnectorContextBuilder.java
+++ b/connector-sdk/test/src/main/java/io/camunda/connector/test/inbound/InboundConnectorContextBuilder.java
@@ -18,6 +18,7 @@ package io.camunda.connector.test.inbound;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.connector.api.inbound.*;
 import io.camunda.connector.api.inbound.CorrelationResult.Success;
@@ -215,7 +216,7 @@ public class InboundConnectorContextBuilder {
       implements InboundConnectorContext, InboundConnectorReportingContext {
 
     private final List<Object> correlatedEvents = new ArrayList<>();
-    private final String propertiesWithSecrets;
+    private final JsonNode propertiesWithSecrets;
     private final CorrelationResult result;
     private final Long activationTimestamp;
     private Health health = Health.unknown();
@@ -227,12 +228,10 @@ public class InboundConnectorContextBuilder {
       super(secretProvider, SecretFilter.allowAll(), validationProvider);
       this.result = result;
       this.activationTimestamp = System.currentTimeMillis();
-      try {
-        propertiesWithSecrets =
-            getSecretHandler().replaceSecrets(objectMapper.writeValueAsString(properties), null);
-      } catch (JsonProcessingException e) {
-        throw new RuntimeException(e);
-      }
+      propertiesWithSecrets =
+          getSecretHandler()
+              .replaceSecrets(
+                  objectMapper.valueToTree(properties != null ? properties : Map.of()), null);
     }
 
     protected void correlate(Object variables) {
@@ -306,7 +305,7 @@ public class InboundConnectorContextBuilder {
     @Override
     public Map<String, Object> getProperties() {
       try {
-        return objectMapper.readValue(propertiesWithSecrets, new TypeReference<>() {});
+        return objectMapper.treeToValue(propertiesWithSecrets, new TypeReference<>() {});
       } catch (JsonProcessingException e) {
         throw new RuntimeException(e);
       }
@@ -315,7 +314,7 @@ public class InboundConnectorContextBuilder {
     @Override
     public <T> T bindProperties(Class<T> cls) {
       try {
-        var mappedObject = objectMapper.readValue(propertiesWithSecrets, cls);
+        var mappedObject = objectMapper.treeToValue(propertiesWithSecrets, cls);
         if (validationProvider != null) {
           getValidationProvider().validate(mappedObject);
         }

--- a/connector-sdk/test/src/main/java/io/camunda/connector/test/outbound/OutboundConnectorContextBuilder.java
+++ b/connector-sdk/test/src/main/java/io/camunda/connector/test/outbound/OutboundConnectorContextBuilder.java
@@ -16,8 +16,11 @@
  */
 package io.camunda.connector.test.outbound;
 
+import com.fasterxml.jackson.core.JsonGenerationException;
+import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.connector.api.json.ConnectorsObjectMapperSupplier;
 import io.camunda.connector.api.outbound.JobContext;
@@ -191,20 +194,43 @@ public class OutboundConnectorContextBuilder {
   public class TestConnectorContext extends AbstractConnectorContext
       implements OutboundConnectorContext {
 
-    private final String variablesWithSecrets;
+    private final JsonNode variablesWithSecrets;
 
     private final TestJobContext jobContext;
 
     protected TestConnectorContext(
         SecretProvider secretProvider, ValidationProvider validationProvider) {
       super(secretProvider, SecretFilter.allowAll(), validationProvider);
+      var asTree = objectMapper.valueToTree(variables != null ? variables : Map.of());
+      variablesWithSecrets = getSecretHandler().replaceSecrets(asTree, null);
+      this.jobContext =
+          new TestJobContext(() -> headers, () -> writeVariablesAsJson(variablesWithSecrets));
+    }
+
+    /**
+     * Mirrors {@code JobHandlerContext#writeJson}: plain-decimal output, falling back to scientific
+     * notation for a {@code BigDecimal} whose scale falls outside the ±9999 range Jackson accepts
+     * for plain output (e.g. {@code new BigDecimal("1e-10000")}).
+     */
+    private String writeVariablesAsJson(JsonNode node) {
       try {
-        var asString = objectMapper.writeValueAsString(variables);
-        variablesWithSecrets = getSecretHandler().replaceSecrets(asString, null);
+        return objectMapper
+            .writer()
+            .with(JsonGenerator.Feature.WRITE_BIGDECIMAL_AS_PLAIN)
+            .writeValueAsString(node);
+      } catch (JsonGenerationException e) {
+        return writeVariablesWithoutPlainDecimals(node);
       } catch (JsonProcessingException e) {
-        throw new RuntimeException(e);
+        throw new IllegalStateException("Failed to serialize variables: " + node, e);
       }
-      this.jobContext = new TestJobContext(() -> headers, () -> variablesWithSecrets);
+    }
+
+    private String writeVariablesWithoutPlainDecimals(JsonNode node) {
+      try {
+        return objectMapper.writeValueAsString(node);
+      } catch (JsonProcessingException e) {
+        throw new IllegalStateException("Failed to serialize variables: " + node, e);
+      }
     }
 
     @Override
@@ -215,7 +241,7 @@ public class OutboundConnectorContextBuilder {
     @Override
     public <T> T bindVariables(Class<T> cls) {
       try {
-        var mappedObject = objectMapper.readValue(variablesWithSecrets, cls);
+        var mappedObject = objectMapper.treeToValue(variablesWithSecrets, cls);
         if (validationProvider != null) {
           getValidationProvider().validate(mappedObject);
         }

--- a/connector-sdk/test/src/test/java/io/camunda/connector/test/inbound/InboundConnectorContextBuilderTest.java
+++ b/connector-sdk/test/src/test/java/io/camunda/connector/test/inbound/InboundConnectorContextBuilderTest.java
@@ -20,12 +20,20 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchException;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.camunda.connector.api.error.ConnectorInputException;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
 
 public class InboundConnectorContextBuilderTest {
+
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+  private static ObjectNode wrap(String value) {
+    return OBJECT_MAPPER.createObjectNode().put("value", value);
+  }
 
   @Test
   public void shouldProvidePropertiesAsString() {
@@ -79,15 +87,16 @@ public class InboundConnectorContextBuilderTest {
   public void shouldProvideSecret() {
     var context =
         InboundConnectorContextBuilder.create().properties("{}").secret("foo", "FOO").build();
-    var replaced = context.getSecretHandler().replaceSecrets("secrets.foo", null);
-    assertThat(replaced).isEqualTo("FOO");
+    var replaced = context.getSecretHandler().replaceSecrets(wrap("secrets.foo"), null);
+    assertThat(replaced.get("value").asText()).isEqualTo("FOO");
   }
 
   @Test
   public void shouldThrowOnMissingSecret() {
     var context =
         InboundConnectorContextBuilder.create().properties("{}").secret("x", "FOO").build();
-    Executable replacement = () -> context.getSecretHandler().replaceSecrets("secrets.foo", null);
+    Executable replacement =
+        () -> context.getSecretHandler().replaceSecrets(wrap("secrets.foo"), null);
     assertThrows(
         ConnectorInputException.class, replacement, "Secret with name 'foo' is not available");
   }
@@ -100,16 +109,16 @@ public class InboundConnectorContextBuilderTest {
             .secret("foo", "FOO")
             .secret("bar", "BAR")
             .build();
-    var replaced = context.getSecretHandler().replaceSecrets("secrets.foo secrets.bar", null);
-    assertThat(replaced).isEqualTo("FOO BAR");
+    var replaced = context.getSecretHandler().replaceSecrets(wrap("secrets.foo secrets.bar"), null);
+    assertThat(replaced.get("value").asText()).isEqualTo("FOO BAR");
   }
 
   @Test
   public void shouldProvideSecretWithParentheses() {
     var context =
         InboundConnectorContextBuilder.create().properties("{}").secret("foo", "FOO").build();
-    var replaced = context.getSecretHandler().replaceSecrets("{{secrets.foo}}", null);
-    assertThat(replaced).isEqualTo("FOO");
+    var replaced = context.getSecretHandler().replaceSecrets(wrap("{{secrets.foo}}"), null);
+    assertThat(replaced.get("value").asText()).isEqualTo("FOO");
   }
 
   @Test
@@ -121,8 +130,13 @@ public class InboundConnectorContextBuilderTest {
             .secret("bar", "BAR")
             .build();
     var replaced =
-        context.getSecretHandler().replaceSecrets("{{secrets.foo}} {{secrets.bar}}", null);
-    assertThat(replaced).isEqualTo("FOO BAR");
+        context.getSecretHandler().replaceSecrets(wrap("{{secrets.foo}} {{secrets.bar}}"), null);
+    assertThat(replaced.get("value").asText()).isEqualTo("FOO BAR");
+  }
+
+  @Test
+  public void shouldDefaultPropertiesToAnEmptyObject() {
+    assertThat(InboundConnectorContextBuilder.create().build().getProperties()).isEmpty();
   }
 
   private record TestRecord(String foo) {}

--- a/connector-sdk/test/src/test/java/io/camunda/connector/test/outbound/OutboundConnectorContextBuilderTest.java
+++ b/connector-sdk/test/src/test/java/io/camunda/connector/test/outbound/OutboundConnectorContextBuilderTest.java
@@ -20,6 +20,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchException;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.camunda.connector.api.error.ConnectorInputException;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
@@ -27,11 +29,37 @@ import org.junit.jupiter.api.function.Executable;
 
 public class OutboundConnectorContextBuilderTest {
 
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+  private static ObjectNode wrap(String value) {
+    return OBJECT_MAPPER.createObjectNode().put("value", value);
+  }
+
   @Test
   public void shouldProvideVariablesAsString() {
     var json = "{ \"foo\" : \"FOO\" }";
     var context = OutboundConnectorContextBuilder.create().variables(json).build();
     assertThat(context.getJobContext().getVariables()).isEqualTo("{\"foo\":\"FOO\"}");
+  }
+
+  @Test
+  public void getVariables_preservesDecimalText() {
+    var context =
+        OutboundConnectorContextBuilder.create()
+            .variables(Map.of("decimal", new java.math.BigDecimal("0.00000001")))
+            .build();
+
+    assertThat(context.getJobContext().getVariables()).contains("0.00000001");
+  }
+
+  @Test
+  public void getVariables_fallsBackToScientificNotationForOutOfRangeDecimalScale() {
+    var context =
+        OutboundConnectorContextBuilder.create()
+            .variables(Map.of("decimal", new java.math.BigDecimal("1e-10000")))
+            .build();
+
+    assertThat(context.getJobContext().getVariables()).contains("1E-10000");
   }
 
   @Test
@@ -79,15 +107,16 @@ public class OutboundConnectorContextBuilderTest {
   public void shouldProvideSecret() {
     var context =
         OutboundConnectorContextBuilder.create().variables("{}").secret("foo", "FOO").build();
-    var replaced = context.getSecretHandler().replaceSecrets("secrets.foo", null);
-    assertThat(replaced).isEqualTo("FOO");
+    var replaced = context.getSecretHandler().replaceSecrets(wrap("secrets.foo"), null);
+    assertThat(replaced.get("value").asText()).isEqualTo("FOO");
   }
 
   @Test
   public void shouldThrowOnMissingSecret() {
     var context =
         OutboundConnectorContextBuilder.create().variables("{}").secret("x", "FOO").build();
-    Executable replacement = () -> context.getSecretHandler().replaceSecrets("secrets.foo", null);
+    Executable replacement =
+        () -> context.getSecretHandler().replaceSecrets(wrap("secrets.foo"), null);
     assertThrows(
         ConnectorInputException.class, replacement, "Secret with name 'foo' is not available");
   }
@@ -100,16 +129,16 @@ public class OutboundConnectorContextBuilderTest {
             .secret("foo", "FOO")
             .secret("bar", "BAR")
             .build();
-    var replaced = context.getSecretHandler().replaceSecrets("secrets.foo secrets.bar", null);
-    assertThat(replaced).isEqualTo("FOO BAR");
+    var replaced = context.getSecretHandler().replaceSecrets(wrap("secrets.foo secrets.bar"), null);
+    assertThat(replaced.get("value").asText()).isEqualTo("FOO BAR");
   }
 
   @Test
   public void shouldProvideSecretWithParentheses() {
     var context =
         OutboundConnectorContextBuilder.create().variables("{}").secret("foo", "FOO").build();
-    var replaced = context.getSecretHandler().replaceSecrets("{{secrets.foo}}", null);
-    assertThat(replaced).isEqualTo("FOO");
+    var replaced = context.getSecretHandler().replaceSecrets(wrap("{{secrets.foo}}"), null);
+    assertThat(replaced.get("value").asText()).isEqualTo("FOO");
   }
 
   @Test
@@ -121,8 +150,14 @@ public class OutboundConnectorContextBuilderTest {
             .secret("bar", "BAR")
             .build();
     var replaced =
-        context.getSecretHandler().replaceSecrets("{{secrets.foo}} {{secrets.bar}}", null);
-    assertThat(replaced).isEqualTo("FOO BAR");
+        context.getSecretHandler().replaceSecrets(wrap("{{secrets.foo}} {{secrets.bar}}"), null);
+    assertThat(replaced.get("value").asText()).isEqualTo("FOO BAR");
+  }
+
+  @Test
+  public void shouldDefaultVariablesToAnEmptyObject() {
+    assertThat(OutboundConnectorContextBuilder.create().build().getJobContext().getVariables())
+        .isEqualTo("{}");
   }
 
   private record TestRecord(String foo) {}


### PR DESCRIPTION
## Description

Backports #8584 to `stable/8.7` so legacy secret resolution is scoped by both secret name and JSON field path, including secrets propagated through dependent FEEL input mappings. Secret substitution now walks the parsed JSON tree while preserving nested arrays, property-name substitution, numeric precision, and the branch’s existing error translation and redaction behavior.

Branch-specific conflict resolutions preserve stable/8.7’s tenant-aware secret-provider API, Zeebe/Operate clients, Caffeine-backed process-definition cache, document API packages, and module layout. Runtime-test changes were mapped to `connector-sdk/test`, outbound exception-handler coverage remains in runtime core, deleted ADR and newer-layout tests were not restored, and `connectors/agentic-ai` is absent on this branch so no ActivatedJob fixture adaptation was needed.

Focused Maven coverage passed across runtime core, runtime Spring, the Spring Boot starter, and SDK test utilities: 189 tests with no failures, errors, or skips.

Known inherited risk is tracked in #8675. Its FEEL lexical-scope, parent/child shadow-ordering, cascading property-key, and whole-tree decimal-fallback defects are intentionally deferred and unchanged in this backport.

## Related issues

Backport of #8584.

Deferred follow-up defects: #8675.

## Checklist

- [ ] PR has a **milestone** or the `no milestone` label.
