### PR TITLE
ci: ignore AI Agent E2E Tests (CPT) in AlwaysGreen triage

### DIFF
--- a/.github/scripts/alwaysgreen/classify.py
+++ b/.github/scripts/alwaysgreen/classify.py
@@ -115,9 +115,6 @@ SURFACE_HELM_INSTALL = "helm-install"
 SURFACE_HELM_CLEANUP = "helm-cleanup"
 SURFACE_BUILD = "build"
 SURFACE_CI_INFRA = "ci-infra"
-#: connectors only: a Maven integration test driving a real LLM. Classified so it
-#: is reported and routed, never dispatched — see DISPATCHABLE_SURFACES.
-SURFACE_CONNECTORS_AI = "connectors-ai-e2e"
 
 #: Surfaces handed to the fix agent. Everything else is recorded and reported only.
 #:
@@ -139,8 +136,15 @@ SURFACE_CONNECTORS_AI = "connectors-ai-e2e"
 DISPATCHABLE_SURFACES = frozenset({SURFACE_SM_E2E, SURFACE_SAAS_E2E})
 
 #: A pure propagator: it fails whenever the reusable helm workflow failed and
-#: carries no independent signal.
-IGNORED_JOB_PREFIXES = ("Observe Helm chart Integration Tests status",)
+#: carries no independent signal. "AI Agent E2E Tests" is a connectors-only Maven
+#: integration test driving a real LLM — its own flakiness, not a signal AlwaysGreen
+#: can act on (it is `continue-on-error` on merge_group already, and no fix agent
+#: would ever be dispatched for it), so it is dropped before classification instead
+#: of being reported as a suppressed non-dispatchable surface.
+IGNORED_JOB_PREFIXES = (
+    "Observe Helm chart Integration Tests status",
+    "AI Agent E2E Tests",
+)
 
 #: Literal prefixes, deliberately stopping before the first `${{`, matched
 #: against the trailing segment of a (possibly nested) job name. An entry may
@@ -158,7 +162,6 @@ _SURFACE_PREFIXES: tuple[tuple[str | re.Pattern[str], str], ...] = (
     ("Generate test matrix", SURFACE_CI_INFRA),
     ("Trigger SaaS E2E tests", SURFACE_SAAS_E2E),
     ("Build and Publish Connectors Docker Image", SURFACE_BUILD),
-    ("AI Agent E2E Tests", SURFACE_CONNECTORS_AI),
     ("Prepare inputs", SURFACE_CI_INFRA),
 )
 

--- a/.github/scripts/alwaysgreen/test_classify.py
+++ b/.github/scripts/alwaysgreen/test_classify.py
@@ -551,10 +551,8 @@ def test_connectors_image_build_is_classified_as_build():
     )
 
 
-def test_ai_agent_cpt_is_classified_but_not_dispatchable():
-    surface = classify.surface_for_job("AI Agent E2E Tests (CPT)")
-    assert surface == classify.SURFACE_CONNECTORS_AI
-    assert surface not in classify.DISPATCHABLE_SURFACES
+def test_ai_agent_cpt_is_ignored():
+    assert classify.surface_for_job("AI Agent E2E Tests (CPT)") is None
 
 
 def test_connectors_saas_trigger_reuses_the_existing_prefix():

--- a/.github/workflows/connectors-streak-detector.yml
+++ b/.github/workflows/connectors-streak-detector.yml
@@ -497,11 +497,20 @@ jobs:
           # AlwaysGreen's own jobs are excluded: a Slack or Vault hiccup in the feedback
           # job is not a pipeline failure, and treating it as one would have triage
           # re-triaging its own noise.
+          #
+          # "AI Agent E2E Tests" is excluded here too, mirroring classify.py's
+          # IGNORED_JOB_PREFIXES. This gate reads raw job conclusions and knows nothing
+          # about that list, so without this a run whose only failure is that job still
+          # sets any_failed=true, still gets handed to triage, and triage's "Post Slack
+          # summary" step is unconditional -- it would post an empty-plan "nothing to
+          # dispatch" message for a job nobody wants triage to look at in the first
+          # place.
           failed=$(jq -r --argjson countable "$countable" '
             .jobs[]
             | select(.conclusion as $c | $countable | index($c))
             | .name
             | select(startswith("AlwaysGreen ") | not)
+            | select(startswith("AI Agent E2E Tests") | not)
           ' <<<"$jobs_json")
 
           any_failed=false


### PR DESCRIPTION
## Description

`AI Agent E2E Tests (CPT)` (a connectors-only Maven integration test driving a real LLM) was already classified as `SURFACE_CONNECTORS_AI`, which sits outside `DISPATCHABLE_SURFACES` — so no fix agent was ever dispatched for it. But it still went through classification and came out as a `suppressed` (`not-dispatchable`) entry, which shows up in the triage job summary and posts to Slack — noise for a job that is already `continue-on-error` on `merge_group` (see [MERGE_QUEUE_HELM_TEST.yaml:608-614](https://github.com/camunda/connectors/blob/main/.github/workflows/MERGE_QUEUE_HELM_TEST.yaml#L608-L614)).

This drops it into `IGNORED_JOB_PREFIXES` instead, alongside the existing pure-propagator entry, so `surface_for_job()` returns `None` and it's skipped before classification entirely — no candidate, no suppressed entry, no Slack mention.

Reference run: https://github.com/camunda/connectors/actions/runs/34098351527

## Related issues

closes #

## Checklist

- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest
  release, as this branch will be rebased onto main before the next release. Example backport labels:
    - `backport stable/8.8`: for changes that should be included in the next 8.8.x release.
    - **or** `backport release-8.8.7`: for changes that should be included in the specific release 8.8.7, and this
      *release has already been created*. The release branch will be merged back into stable/8.8 later, so the change
      will be included in future 8.8.x releases as well.
- [x] Tests/Integration tests for the changes have been added if applicable.
- [ ] If the change requires a documentation update, it has been added to the appropriate section in the documentation.