### PR TITLE
ci: speed up release preparation and E2E tests

### DIFF
--- a/.github/workflows/E2E_BRANCH_RUN.yml
+++ b/.github/workflows/E2E_BRANCH_RUN.yml
@@ -6,19 +6,38 @@ on:
       branch:
         type: string
         required: true
+      run-unit-tests:
+        description: 'Run unit and integration tests before the E2E matrix'
+        type: boolean
+        required: false
+        default: true
+      maven-cache-key:
+        description: 'Maven cache key supplied by a calling workflow'
+        type: string
+        required: false
+        default: ''
+      build-runner:
+        description: 'Runner used to build the artifacts consumed by the E2E matrix'
+        type: string
+        required: false
+        default: 'ubuntu-latest'
+      runner-overrides:
+        description: 'JSON map from E2E module names to runner labels'
+        type: string
+        required: false
+        default: '{"connectors-e2e-test-agentic-ai":"gcp-core-8-default"}'
 
 jobs:
 
   build:
     name: Build
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.build-runner }}
     outputs:
       modules: ${{ steps.set-modules.outputs.modules }}
     env:
       # Runner overrides: JSON map from e2e module name → runner label.
-      # Modules absent from the map use ubuntu-latest.
-      # To redirect a new module to a different runner, add one key-value pair here.
-      E2E_RUNNER_OVERRIDES: '{"connectors-e2e-test-agentic-ai":"gcp-core-8-default"}'
+      # Modules absent from the map use ubuntu-latest; callers can provide their own map.
+      E2E_RUNNER_OVERRIDES: ${{ inputs.runner-overrides }}
     steps:
       - uses: actions/checkout@v7
         with:
@@ -62,11 +81,18 @@ jobs:
             secret/data/products/connectors/ci/nexus USER | CI_NEXUS_USR;
             secret/data/products/connectors/ci/nexus PASSWORD | CI_NEXUS_PSW;
 
+      - name: Resolve Maven cache key
+        id: maven-cache-key
+        env:
+          PROVIDED_KEY: ${{ inputs.maven-cache-key }}
+          DEFAULT_KEY: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+        run: echo "value=${PROVIDED_KEY:-$DEFAULT_KEY}" >> "$GITHUB_OUTPUT"
+
       - name: Restore cache
         uses: actions/cache@v6
         with:
           path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          key: ${{ steps.maven-cache-key.outputs.value }}
           restore-keys: |
             ${{ runner.os }}-maven-
 
@@ -99,7 +125,7 @@ jobs:
       # aggregator (-pl '!connectors-e2e-test') would NOT exclude its nested children, so they would
       # otherwise run their e2e tests here instead of isolated in the matrix.
       - name: Run unit/integration tests (non-PR)
-        if: github.event_name != 'pull_request'
+        if: inputs.run-unit-tests && github.event_name != 'pull_request'
         run: |
           E2E_EXCLUDES=$(find connectors-e2e-test -name pom.xml -not -path '*/target/*' -printf '!%h\n' | paste -sd, -)
           $MVN_CMD --batch-mode verify -pl "$E2E_EXCLUDES"
@@ -144,7 +170,7 @@ jobs:
           overwrite: true
 
   # Test phase (matrix: entry): each e2e-test module runs in its own job, in isolation.
-  # Runner is baked into each entry by the build job (sourced from e2e-runner-overrides.json).
+  # Runner is baked into each entry by the build job from the runner-overrides input.
   test:
     name: ${{ matrix.entry.module }}
     needs: build
@@ -242,7 +268,7 @@ jobs:
       # Run only this module's tests. No -am: base/connector SNAPSHOTs come from the downloaded
       # artifact, so nothing upstream is rebuilt.
       - name: Test e2e module
-        run: $MVN_CMD --batch-mode test -pl "${{ matrix.entry.module }}" -f connectors-e2e-test/pom.xml
+        run: $MVN_CMD --batch-mode verify -pl "${{ matrix.entry.module }}" -f connectors-e2e-test/pom.xml
 
       - name: Publish Test Report
         if: always()

--- a/.github/workflows/E2E_BRANCH_RUN.yml
+++ b/.github/workflows/E2E_BRANCH_RUN.yml
@@ -143,6 +143,7 @@ jobs:
             pkg=$(grep -m1 -oP '(?<=<packaging>)[^<]+' "$p" || echo jar)
             [ "$pkg" = "pom" ] && continue
             case "$base" in *-base) continue;; esac
+            [ -d "$d/src/test" ] || continue
             module="${d#connectors-e2e-test/}"
             runner=$(printf '%s' "$E2E_RUNNER_OVERRIDES" | jq -r --arg m "$module" '.[$m] // "ubuntu-latest"')
             printf '{"module":"%s","runner":"%s"}\n' "$module" "$runner"

--- a/.github/workflows/RELEASE.yaml
+++ b/.github/workflows/RELEASE.yaml
@@ -64,7 +64,7 @@ jobs:
   setup:
     needs: create-release
     name: Prepare the repository
-    runs-on: gcp-core-2-release
+    runs-on: gcp-core-8-release
     permissions:
       contents: write
       checks: write
@@ -72,6 +72,7 @@ jobs:
       tagType: ${{ steps.prev_version.outputs.release_type }}
       releaseBranch: ${{ steps.determine_release_branch.outputs.releaseBranch }}
       previousTag: ${{ steps.prev_version.outputs.previous_version }}
+      mavenCacheKey: ${{ steps.maven-cache-key.outputs.value }}
     steps:
       - uses: actions/checkout@v7
         with:
@@ -102,11 +103,17 @@ jobs:
           distribution: 'temurin'
           java-version: '21.0.9'
 
+      - name: Determine Maven cache key
+        id: maven-cache-key
+        env:
+          CACHE_KEY: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+        run: echo "value=$CACHE_KEY" >> "$GITHUB_OUTPUT"
+
       - name: Restore cache
         uses: actions/cache@v6
         with:
           path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          key: ${{ steps.maven-cache-key.outputs.value }}
           restore-keys: |
             ${{ runner.os }}-maven-
 
@@ -171,7 +178,7 @@ jobs:
           RELEASE_VERSION: ${{ inputs.version }}
 
       - name: Compile and Test
-        run: ./mvnw -B -U package generate-sources source:jar javadoc:jar -Pe2eExcluded
+        run: ./mvnw -B -U package source:jar javadoc:jar -Pe2eExcluded
 
       - name: Publish Test Report
         if: always()
@@ -237,93 +244,17 @@ jobs:
     needs: setup
     name: Run E2E tests
     if: ${{ !inputs.skip-e2e-tests }}
-    runs-on: ubuntu-latest
     permissions:
       contents: read
       checks: write
-    steps:
-      - name: Download repository
-        uses: actions/download-artifact@v8
-        with:
-          name: repository
-
-      - name: Ensure Maven wrapper is executable
-        run: chmod +x ./mvnw
-
-      - name: Prepare Java and Maven settings
-        uses: actions/setup-java@v6
-        with:
-          distribution: 'temurin'
-          java-version: '21.0.9'
-
-      - name: Restore cache
-        uses: actions/cache@v6
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
-
-      - name: Import Secrets
-        id: secrets
-        uses: hashicorp/vault-action@v4.0.0
-        with:
-          url: ${{ secrets.VAULT_ADDR }}
-          method: approle
-          roleId: ${{ secrets.VAULT_ROLE_ID }}
-          secretId: ${{ secrets.VAULT_SECRET_ID }}
-          exportEnv: false
-          secrets: |
-            secret/data/products/connectors/ci/nexus USER | CI_NEXUS_USR;
-            secret/data/products/connectors/ci/nexus PASSWORD | CI_NEXUS_PSW;
-
-      - name: 'Create settings.xml'
-        uses: s4u/maven-settings-action@v4.0.0
-        with:
-          githubServer: false
-          # Mirror uses id=nexus-mirror (distinct from deploy id=camunda-nexus) so each gets the right credentials:
-          # - nexus-mirror: CI Nexus creds for the pull-through cache at repository.nexus.camunda.cloud
-          # - camunda-nexus: Nexus creds for resolving artifacts
-          servers: |
-            [{
-              "id": "nexus-mirror",
-              "username": "${{ steps.secrets.outputs.CI_NEXUS_USR }}",
-              "password": "${{ steps.secrets.outputs.CI_NEXUS_PSW }}"
-             },
-             {
-               "id": "camunda-nexus",
-               "username": "${{ steps.secrets.outputs.CI_NEXUS_USR }}",
-               "password": "${{ steps.secrets.outputs.CI_NEXUS_PSW }}"
-             }]
-          mirrors: '[{"url": "https://repository.nexus.camunda.cloud/content/groups/internal/", "id": "nexus-mirror", "mirrorOf": "*,!confluent,!shibboleth", "name": "camunda Nexus"}]'
-
-      - name: Install artifacts
-        run: ./mvnw -B install -DskipTests -DskipChecks -Pe2eExcluded
-
-      - name: Install Node.js
-        uses: actions/setup-node@v7.0.0
-        with:
-          node-version: '24'
-
-      - name: Install element templates CLI
-        run: npm install --global element-templates-cli@$(jq -r '.devDependencies["element-templates-cli"]' .github/workflows/package.json)
-
-      - name: Run E2E tests
-        run: ./mvnw -B verify -f connectors-e2e-test/pom.xml
-
-      - name: Publish Test Report
-        if: always()
-        uses: ScalableCapital/action-surefire-report@v2
-        with:
-          report_paths: 'connectors-e2e-test/**/target/surefire-reports/*.xml'
-          report_mode: check-run
-
-      - name: Upload detailed surefire reports
-        if: always()
-        uses: actions/upload-artifact@v7
-        with:
-          name: e2e-surefire-reports
-          path: 'connectors-e2e-test/**/target/surefire-reports/*.xml'
+    uses: ./.github/workflows/E2E_BRANCH_RUN.yml
+    with:
+      branch: ${{ inputs.version }}
+      run-unit-tests: false
+      maven-cache-key: ${{ needs.setup.outputs.mavenCacheKey }}
+      build-runner: gcp-core-8-release
+      runner-overrides: '{"connectors-e2e-test-agentic-ai":"gcp-core-8-release","connectors-e2e-test-inbound-runtime":"gcp-core-8-release"}'
+    secrets: inherit
 
 
   version-bump-docs-links:
@@ -477,7 +408,7 @@ jobs:
         uses: actions/cache@v6
         with:
           path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          key: ${{ needs.setup.outputs.mavenCacheKey }}
           restore-keys: |
             ${{ runner.os }}-maven-
 


### PR DESCRIPTION
## Description

Reduce the release critical path by reusing the existing per-module E2E matrix instead of running all E2E suites serially. Release builds use release-scoped 8-core runners for preparation, E2E setup, and the two longest suites, while nightly E2E behavior remains unchanged.

The release now reuses one Maven cache key across stages, avoids a duplicate unit/integration-test pass during E2E setup, and removes a redundant Maven lifecycle phase. Maven publication remains serial and unchanged because parallel reactor execution made container-based tests unreliable.

## Remaining work

This PR is the first optimization slice. Follow-up work tracked by #8699 includes:

- Measure the next releases against the existing baseline, including wall time, runner cost, exact/fallback/cold cache behavior, and E2E flakiness.
- Build release artifacts once and publish those exact outputs instead of rebuilding the reactor during E2E setup and Maven deployment.
- Reduce the 1.30 GB repository artifact and roughly 2 GB Maven cache transferred between jobs.
- Profile the Maven deployment separately: reactor packaging/signing, Artifactory staging, and Maven Central validation currently have different CPU and network bottlenecks.
- Evaluate a release-scoped, network-co-located runner for Maven deployment without parallelizing the container-based test reactor.
- Apply the E2E exclusion correction and applicable workflow optimizations to maintained stable branches.
- Investigate reducing the dependency on completion of the monorepo release before the Connectors release can start.

## Related issues

Related to #8699

## Checklist

- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest release, as this branch will be rebased onto main before the next release.
- [x] Tests/Integration tests for the changes have been added if applicable.
- [x] If the change requires a documentation update, it has been added to the appropriate section in the documentation.
