### PR TITLE
fix(runtime): propagate unexpected job handler failures

### DIFF
--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/SpringConnectorJobHandler.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/SpringConnectorJobHandler.java
@@ -178,13 +178,15 @@ public class SpringConnectorJobHandler implements JobHandler {
   }
 
   private void executeJob(
-      JobClient client, ActivatedJob job, CounterMetricsContext counterMetricsContext) {
+      JobClient client, ActivatedJob job, CounterMetricsContext counterMetricsContext)
+      throws Exception {
     try {
       internalHandle(client, job, counterMetricsContext);
     } catch (Exception e) {
       connectorsOutboundMetrics.increaseFailed(counterMetricsContext);
       connectorsOutboundMetrics.recordFailed(job.getType());
       LOGGER.warn("Failed to handle job: {} of type: {}", job.getKey(), job.getType());
+      throw e;
     }
   }
 

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/job/SpringConnectorJobHandlerTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/job/SpringConnectorJobHandlerTest.java
@@ -21,6 +21,7 @@ import static io.camunda.connector.runtime.core.Keywords.ERROR_EXPRESSION_KEYWOR
 import static io.camunda.connector.runtime.core.Keywords.RESULT_EXPRESSION_KEYWORD;
 import static io.camunda.connector.runtime.core.Keywords.RESULT_VARIABLE_KEYWORD;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -75,6 +76,7 @@ import io.camunda.connector.runtime.core.Keywords;
 import io.camunda.connector.runtime.core.document.DocumentFactoryImpl;
 import io.camunda.connector.runtime.core.document.store.InMemoryDocumentStore;
 import io.camunda.connector.runtime.core.secret.SecretFilter;
+import io.camunda.connector.runtime.core.secret.SecretFilterFactory;
 import io.camunda.connector.runtime.core.secret.SecretProviderAggregator;
 import io.camunda.connector.runtime.secret.FooBarSecretProvider;
 import io.camunda.connector.validation.impl.DefaultValidationProvider;
@@ -750,6 +752,28 @@ class SpringConnectorJobHandlerTest {
 
       // then
       assertThat(result.getErrorMessage()).startsWith("expected");
+    }
+
+    @Test
+    void shouldPropagateExceptionOutsideConnectorErrorHandling() {
+      var failure = new IllegalStateException("expected");
+      var secretFilterFactory = mock(SecretFilterFactory.class);
+      when(secretFilterFactory.create(any())).thenThrow(failure);
+      var metricsRecorder = new MicrometerMetricsRecorder(new SimpleMeterRegistry());
+      var jobHandler =
+          new SpringConnectorJobHandler(
+              metricsRecorder,
+              new JobCallbackCommandWrapperFactory(
+                  BackoffSupplier.newBackoffBuilder().build(), commandScheduler, metricsRecorder),
+              new SecretProviderAggregator(List.of(new FooBarSecretProvider())),
+              new DefaultValidationProvider(),
+              mock(DocumentFactory.class),
+              TestObjectMapperSupplier.INSTANCE,
+              context -> null,
+              secretFilterFactory,
+              mock(CamundaClient.class, RETURNS_DEEP_STUBS));
+
+      assertThatThrownBy(() -> JobBuilder.create().execute(jobHandler)).isSameAs(failure);
     }
 
     @Test


### PR DESCRIPTION
> *This was generated by AI during triage.*

## Description

Unexpected failures outside the connector result-handling path were logged and treated as successfully handled. This could leave an activated job without a completion or failure command until its activation timeout expired.

Propagate these failures after recording the existing metrics so the job worker can apply its standard failure handling. A regression test covers failures occurring before connector execution.

The alternative of issuing another failure command at this boundary was rejected because command failures can also reach it; propagation preserves the job worker's existing fallback behavior without duplicating that logic.

## Related issues

closes #8548

## Checklist

- [x] Backport labels are added if these code changes should be backported. No backport label is added to the latest release, as this branch will be rebased onto main before the next release.
- [x] Tests/Integration tests for the changes have been added if applicable.
- [x] If the change requires a documentation update, it has been added to the appropriate section in the documentation. (Not applicable.)
