### PR TITLE
[Backport stable/8.8] fix(http): align SSL error code and root-cause handling with main (#8515)

### DIFF
--- a/connector-commons/http-client/src/main/java/io/camunda/connector/http/client/client/apache/CustomApacheHttpClient.java
+++ b/connector-commons/http-client/src/main/java/io/camunda/connector/http/client/client/apache/CustomApacheHttpClient.java
@@ -80,11 +80,12 @@ public class CustomApacheHttpClient implements HttpClient {
           e);
     } catch (SSLException e) {
       throw new ConnectorException(
-          "SSL_HANDSHAKE_FAILED",
-          "TLS handshake failed: "
+          "SSL_ERROR",
+          "A TLS/SSL error occurred: "
               + rootMessage(e)
-              + ". Verify that the server's certificate is trusted by this runtime, and that no "
-              + "proxy or firewall is interfering with the TLS handshake.",
+              + ". If this happened during the handshake, verify that the server's certificate is "
+              + "trusted by this runtime, and that no proxy or firewall is interfering with the "
+              + "TLS handshake.",
           e);
     } catch (IOException e) {
       throw new ConnectorException(
@@ -101,7 +102,8 @@ public class CustomApacheHttpClient implements HttpClient {
     while (cause.getCause() != null && cause.getCause() != cause) {
       cause = cause.getCause();
     }
-    return cause.getMessage();
+    var message = cause.getMessage();
+    return message == null || message.isBlank() ? cause.getClass().getSimpleName() : message;
   }
 
   public static String getHeaderIgnoreCase(Map<String, Object> headers, String headerName) {

--- a/connector-commons/http-client/src/test/java/io/camunda/connector/http/client/client/apache/CustomApacheHttpClientTest.java
+++ b/connector-commons/http-client/src/test/java/io/camunda/connector/http/client/client/apache/CustomApacheHttpClientTest.java
@@ -26,6 +26,7 @@ import static uk.org.webcompere.systemstubs.SystemStubs.withEnvironmentVariables
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.http.Fault;
 import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
 import com.github.tomakehurst.wiremock.junit5.WireMockTest;
 import com.github.tomakehurst.wiremock.matching.MultipartValuePatternBuilder;
@@ -41,10 +42,12 @@ import io.camunda.connector.http.client.model.auth.BasicAuthentication;
 import io.camunda.connector.http.client.model.auth.BearerAuthentication;
 import io.camunda.connector.http.client.model.auth.OAuthAuthentication;
 import io.camunda.connector.test.utils.DockerImages;
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
+import javax.net.ssl.SSLException;
 import org.apache.commons.text.StringEscapeUtils;
 import org.apache.hc.core5.http.ContentType;
 import org.apache.hc.core5.http.HttpHeaders;
@@ -616,6 +619,24 @@ public class CustomApacheHttpClientTest {
           .contains(
               "The request timed out. Please try increasing the read and connection timeouts.");
     }
+
+    @Test
+    public void shouldReturn408WithRootCause_whenConnectionIsResetByPeer(
+        WireMockRuntimeInfo wmRuntimeInfo) {
+      stubFor(get("/path").willReturn(aResponse().withFault(Fault.CONNECTION_RESET_BY_PEER)));
+
+      HttpClientRequest request = new HttpClientRequest();
+      request.setMethod(HttpMethod.GET);
+      request.setUrl(wmRuntimeInfo.getHttpBaseUrl() + "/path");
+      ConnectorException e =
+          assertThrows(ConnectorException.class, () -> customApacheHttpClient.execute(request));
+      assertThat(e.getErrorCode()).isEqualTo(String.valueOf(HttpStatus.SC_REQUEST_TIMEOUT));
+      assertThat(e.getMessage())
+          .isEqualTo(
+              "An error occurred while executing the request, or the connection was aborted: "
+                  + "Connection reset");
+      assertThat(e.getCause()).isInstanceOf(IOException.class);
+    }
   }
 
   @Nested
@@ -1160,6 +1181,37 @@ public class CustomApacheHttpClientTest {
         request.withBasicAuth("clientId", "clientSecret");
       }
       stubFor(request.willReturn(unauthorized().withBody("Unauthorized")));
+    }
+  }
+
+  @Nested
+  class SslTests {
+    private static final WireMockServer httpsServer =
+        new WireMockServer(options().dynamicPort().dynamicHttpsPort());
+
+    @BeforeAll
+    static void startHttpsServer() {
+      httpsServer.start();
+      httpsServer.stubFor(get("/path").willReturn(ok().withBody("secure")));
+    }
+
+    @AfterAll
+    static void stopHttpsServer() {
+      httpsServer.stop();
+    }
+
+    @Test
+    public void shouldReturnSslError_whenServerCertificateIsNotTrusted() {
+      HttpClientRequest request = new HttpClientRequest();
+      request.setMethod(HttpMethod.GET);
+      request.setUrl("https://localhost:" + httpsServer.httpsPort() + "/path");
+
+      ConnectorException e =
+          assertThrows(ConnectorException.class, () -> customApacheHttpClient.execute(request));
+      assertThat(e.getErrorCode()).isEqualTo("SSL_ERROR");
+      assertThat(e.getMessage()).contains("A TLS/SSL error occurred");
+      assertThat(e.getMessage()).contains("certification path");
+      assertThat(e.getCause()).isInstanceOf(SSLException.class);
     }
   }
 }

--- a/connector-commons/http-client/src/test/java/io/camunda/connector/http/client/client/apache/CustomApacheHttpClientTest.java
+++ b/connector-commons/http-client/src/test/java/io/camunda/connector/http/client/client/apache/CustomApacheHttpClientTest.java
@@ -637,6 +637,16 @@ public class CustomApacheHttpClientTest {
                   + "Connection reset");
       assertThat(e.getCause()).isInstanceOf(IOException.class);
     }
+
+    @Test
+    public void shouldFallBackToClassName_whenRootCauseMessageIsNullOrBlank() throws Exception {
+      var method = CustomApacheHttpClient.class.getDeclaredMethod("rootMessage", Throwable.class);
+      method.setAccessible(true);
+
+      assertThat(method.invoke(null, new IOException((String) null))).isEqualTo("IOException");
+      assertThat(method.invoke(null, new IOException("  ", new IOException("   "))))
+          .isEqualTo("IOException");
+    }
   }
 
   @Nested


### PR DESCRIPTION
## Summary

Follow-up backport of #8515 