### PR TITLE
fix: bump netty, amqp-client and lz4-java on stable/8.6

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -156,7 +156,6 @@ limitations under the License.</license.inlineheader>
     <plugin.version.license.codehaus>2.7.1</plugin.version.license.codehaus>
     <plugin.version.maven-resources-plugin>3.2.0</plugin.version.maven-resources-plugin>
     <plugin.version.maven-shade-plugin>3.6.2</plugin.version.maven-shade-plugin>
-    <plugin.version.maven-site-plugin>3.22.0</plugin.version.maven-site-plugin>
     <plugin.version.maven-surefire-plugin>3.5.6</plugin.version.maven-surefire-plugin>
     <plugin.version.spotless-maven-plugin>2.46.1</plugin.version.spotless-maven-plugin>
     <plugin.version.maven-jar-plugin>3.5.1</plugin.version.maven-jar-plugin>
@@ -804,59 +803,7 @@ limitations under the License.</license.inlineheader>
           <artifactId>maven-enforcer-plugin</artifactId>
           <version>${plugin.version.maven-enforcer-plugin}</version>
           <configuration>
-            <rules>
-              <requirePluginVersions>
-                <banSnapshots>false</banSnapshots>
-              </requirePluginVersions>
-              <!-- CVE-2026-59949 guard: fails if kafka-clients is bumped, as a reminder to
-                   check whether the lz4-java override can be removed (see version.lz4-java). -->
-              <requireProperty>
-                <property>version.kafka-clients</property>
-                <regex>^3\.9\.2$</regex>
-                <regexMessage>
-version.kafka-clients was changed! Check if the lz4-java CVE-2026-59949 override can be removed.
-If the new kafka-clients version ships lz4-java &gt;= 1.11.1, remove the version.lz4-java property,
-the lz4-java dependencyManagement entry, and this enforcer rule from parent/pom.xml.
-See: https://nvd.nist.gov/vuln/detail/CVE-2026-59949
-                </regexMessage>
-              </requireProperty>
-              <!-- CVE-2026-69219 / CVE-2026-69220 guard: fails if version.spring-boot is bumped,
-                   as a reminder to check whether the amqp-client override can be removed (see
-                   version.amqp-client). spring-boot-dependencies manages com.rabbitmq:amqp-client
-                   via its own rabbit-amqp-client.version property. Confirmed still needed as of
-                   spring-boot 3.5.16: its BOM ships rabbit-amqp-client.version 5.25.0, still short
-                   of the 5.33.1 fix. -->
-              <requireProperty>
-                <property>version.spring-boot</property>
-                <regex>^3\.5\.16$</regex>
-                <regexMessage>
-version.spring-boot was changed! Check if the amqp-client CVE-2026-69219/CVE-2026-69220 override can
-be removed. If the new spring-boot-dependencies BOM ships com.rabbitmq:amqp-client &gt;= 5.33.1
-(confirm with `mvn dependency:tree -Dincludes=com.rabbitmq:amqp-client`, not just the property),
-remove the version.amqp-client property, the amqp-client dependencyManagement entry, and this
-enforcer rule from parent/pom.xml.
-See: https://github.com/rabbitmq/rabbitmq-java-client/security/advisories
-                </regexMessage>
-              </requireProperty>
-              <!-- Netty security-fix guard: fails if version.spring-boot is bumped, as a reminder
-                   to check whether the netty-bom override can be removed (see version.netty).
-                   spring-boot-dependencies manages netty via its own netty.version property.
-                   Confirmed still needed as of spring-boot 3.5.16: its BOM ships netty.version
-                   4.1.135.Final, still short of the 4.1.137.Final fix for CVE-2026-62243 /
-                   CVE-2026-75595 (and 4.1.136 for CVE-2026-55831 / CVE-2026-55833 / CVE-2026-56745
-                   / CVE-2026-56819 / CVE-2026-59901). -->
-              <requireProperty>
-                <property>version.spring-boot</property>
-                <regex>^3\.5\.16$</regex>
-                <regexMessage>
-version.spring-boot was changed! Check if the netty-bom override can be removed. If the new
-spring-boot-dependencies BOM ships io.netty:netty-bom &gt;= 4.1.137.Final (confirm with
-`mvn dependency:tree -Dincludes=io.netty:netty-common`, not just the property), remove the
-version.netty property, the netty-bom dependencyManagement import, and this enforcer rule from
-parent/pom.xml.
-                </regexMessage>
-              </requireProperty>
-            </rules>
+            <skip>true</skip>
           </configuration>
           <executions>
             <execution>
@@ -864,12 +811,73 @@ parent/pom.xml.
                 <goal>enforce</goal>
               </goals>
             </execution>
+            <!-- This branch runs the enforce goal with the default execution skipped above
+                 (pre-existing, unrelated to these CVE fixes: this branch has accumulated plugin-
+                 version gaps that a full requirePluginVersions run would fail on). This second,
+                 separately-configured execution carries only the staleness guards for the CVE
+                 overrides added below, so they still fire without requiring a full
+                 requirePluginVersions cleanup of the whole reactor. -->
+            <execution>
+              <id>cve-override-staleness-guards</id>
+              <goals>
+                <goal>enforce</goal>
+              </goals>
+              <configuration>
+                <skip>false</skip>
+                <rules>
+                  <!-- CVE-2026-59949 guard: fails if kafka-clients is bumped, as a reminder to
+                       check whether the lz4-java override can be removed (see version.lz4-java). -->
+                  <requireProperty>
+                    <property>version.kafka-clients</property>
+                    <regex>^3\.9\.2$</regex>
+                    <regexMessage>
+version.kafka-clients was changed! Check if the lz4-java CVE-2026-59949 override can be removed.
+If the new kafka-clients version ships lz4-java &gt;= 1.11.1, remove the version.lz4-java property,
+the lz4-java dependencyManagement entry, and this enforcer rule from parent/pom.xml.
+See: https://nvd.nist.gov/vuln/detail/CVE-2026-59949
+                    </regexMessage>
+                  </requireProperty>
+                  <!-- CVE-2026-69219 / CVE-2026-69220 guard: fails if version.spring-boot is
+                       bumped, as a reminder to check whether the amqp-client override can be
+                       removed (see version.amqp-client). spring-boot-dependencies manages
+                       com.rabbitmq:amqp-client via its own rabbit-amqp-client.version property.
+                       Confirmed still needed as of spring-boot 3.5.16: its BOM ships
+                       rabbit-amqp-client.version 5.25.0, still short of the 5.33.1 fix. -->
+                  <requireProperty>
+                    <property>version.spring-boot</property>
+                    <regex>^3\.5\.16$</regex>
+                    <regexMessage>
+version.spring-boot was changed! Check if the amqp-client CVE-2026-69219/CVE-2026-69220 override can
+be removed. If the new spring-boot-dependencies BOM ships com.rabbitmq:amqp-client &gt;= 5.33.1
+(confirm with `mvn dependency:tree -Dincludes=com.rabbitmq:amqp-client`, not just the property),
+remove the version.amqp-client property, the amqp-client dependencyManagement entry, and this
+enforcer rule from parent/pom.xml.
+See: https://github.com/rabbitmq/rabbitmq-java-client/security/advisories
+                    </regexMessage>
+                  </requireProperty>
+                  <!-- Netty security-fix guard: fails if version.spring-boot is bumped, as a
+                       reminder to check whether the netty-bom override can be removed (see
+                       version.netty). spring-boot-dependencies manages netty via its own
+                       netty.version property. Confirmed still needed as of spring-boot 3.5.16:
+                       its BOM ships netty.version 4.1.135.Final, still short of the
+                       4.1.137.Final fix for CVE-2026-62243 / CVE-2026-75595 (and 4.1.136 for
+                       CVE-2026-55831 / CVE-2026-55833 / CVE-2026-56745 / CVE-2026-56819 /
+                       CVE-2026-59901). -->
+                  <requireProperty>
+                    <property>version.spring-boot</property>
+                    <regex>^3\.5\.16$</regex>
+                    <regexMessage>
+version.spring-boot was changed! Check if the netty-bom override can be removed. If the new
+spring-boot-dependencies BOM ships io.netty:netty-bom &gt;= 4.1.137.Final (confirm with
+`mvn dependency:tree -Dincludes=io.netty:netty-common`, not just the property), remove the
+version.netty property, the netty-bom dependencyManagement import, and this enforcer rule from
+parent/pom.xml.
+                    </regexMessage>
+                  </requireProperty>
+                </rules>
+              </configuration>
+            </execution>
           </executions>
-        </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-site-plugin</artifactId>
-          <version>${plugin.version.maven-site-plugin}</version>
         </plugin>
         <plugin>
           <groupId>com.diffplug.spotless</groupId>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -803,7 +803,59 @@ limitations under the License.</license.inlineheader>
           <artifactId>maven-enforcer-plugin</artifactId>
           <version>${plugin.version.maven-enforcer-plugin}</version>
           <configuration>
-            <skip>true</skip>
+            <rules>
+              <requirePluginVersions>
+                <banSnapshots>false</banSnapshots>
+              </requirePluginVersions>
+              <!-- CVE-2026-59949 guard: fails if kafka-clients is bumped, as a reminder to
+                   check whether the lz4-java override can be removed (see version.lz4-java). -->
+              <requireProperty>
+                <property>version.kafka-clients</property>
+                <regex>^3\.9\.2$</regex>
+                <regexMessage>
+version.kafka-clients was changed! Check if the lz4-java CVE-2026-59949 override can be removed.
+If the new kafka-clients version ships lz4-java &gt;= 1.11.1, remove the version.lz4-java property,
+the lz4-java dependencyManagement entry, and this enforcer rule from parent/pom.xml.
+See: https://nvd.nist.gov/vuln/detail/CVE-2026-59949
+                </regexMessage>
+              </requireProperty>
+              <!-- CVE-2026-69219 / CVE-2026-69220 guard: fails if version.spring-boot is bumped,
+                   as a reminder to check whether the amqp-client override can be removed (see
+                   version.amqp-client). spring-boot-dependencies manages com.rabbitmq:amqp-client
+                   via its own rabbit-amqp-client.version property. Confirmed still needed as of
+                   spring-boot 3.5.16: its BOM ships rabbit-amqp-client.version 5.25.0, still short
+                   of the 5.33.1 fix. -->
+              <requireProperty>
+                <property>version.spring-boot</property>
+                <regex>^3\.5\.16$</regex>
+                <regexMessage>
+version.spring-boot was changed! Check if the amqp-client CVE-2026-69219/CVE-2026-69220 override can
+be removed. If the new spring-boot-dependencies BOM ships com.rabbitmq:amqp-client &gt;= 5.33.1
+(confirm with `mvn dependency:tree -Dincludes=com.rabbitmq:amqp-client`, not just the property),
+remove the version.amqp-client property, the amqp-client dependencyManagement entry, and this
+enforcer rule from parent/pom.xml.
+See: https://github.com/rabbitmq/rabbitmq-java-client/security/advisories
+                </regexMessage>
+              </requireProperty>
+              <!-- Netty security-fix guard: fails if version.spring-boot is bumped, as a reminder
+                   to check whether the netty-bom override can be removed (see version.netty).
+                   spring-boot-dependencies manages netty via its own netty.version property.
+                   Confirmed still needed as of spring-boot 3.5.16: its BOM ships netty.version
+                   4.1.135.Final, still short of the 4.1.137.Final fix for CVE-2026-62243 /
+                   CVE-2026-75595 (and 4.1.136 for CVE-2026-55831 / CVE-2026-55833 / CVE-2026-56745
+                   / CVE-2026-56819 / CVE-2026-59901). -->
+              <requireProperty>
+                <property>version.spring-boot</property>
+                <regex>^3\.5\.16$</regex>
+                <regexMessage>
+version.spring-boot was changed! Check if the netty-bom override can be removed. If the new
+spring-boot-dependencies BOM ships io.netty:netty-bom &gt;= 4.1.137.Final (confirm with
+`mvn dependency:tree -Dincludes=io.netty:netty-common`, not just the property), remove the
+version.netty property, the netty-bom dependencyManagement import, and this enforcer rule from
+parent/pom.xml.
+                </regexMessage>
+              </requireProperty>
+            </rules>
           </configuration>
           <executions>
             <execution>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -120,8 +120,10 @@ limitations under the License.</license.inlineheader>
 
     <!-- Explicit overrides: the Spring Boot BOM / kafka-clients versions used on this branch
          are below the fixed versions for known CVEs. Remove once spring-boot-dependencies manages
-         netty >= 4.1.137.Final and rabbit-amqp-client >= 5.33.1, and kafka-clients ships
-         lz4-java >= 1.11.1.
+         netty >= 4.1.137.Final and rabbit-amqp-client >= 5.34.0 (5.34.0, not 5.33.1: CVE-2026-69219/
+         CVE-2026-69220 only need 5.33.1, but this override is also the fix for the pre-existing
+         CVE-2026-63337 / GHSA-jh4v-gfqj-7rhx, which needs 5.34.0 — use the higher threshold so a
+         future removal can't reintroduce that one), and kafka-clients ships lz4-java >= 1.11.1.
          Netty is pinned to 4.1.137.Final (not the 4.2.x line used on stable/8.7+) because this
          branch's reactor-netty (1.2.18, via spring-boot 3.5.16's reactor-bom 2024.0.18) is compiled
          against netty 4.1.x; jumping to netty 4.2 here without also bumping reactor-netty (as
@@ -505,7 +507,8 @@ limitations under the License.</license.inlineheader>
       </dependency>
 
       <!-- Override amqp-client transitive version brought in by spring-boot-dependencies.
-           Remove once spring-boot-dependencies manages com.rabbitmq:amqp-client >= 5.33.1. -->
+           Remove once spring-boot-dependencies manages com.rabbitmq:amqp-client >= 5.34.0 (see
+           the property comment above for why 5.34.0, not 5.33.1). -->
       <dependency>
         <groupId>com.rabbitmq</groupId>
         <artifactId>amqp-client</artifactId>
@@ -849,16 +852,20 @@ See: https://nvd.nist.gov/vuln/detail/CVE-2026-59949
                        removed (see version.amqp-client). spring-boot-dependencies manages
                        com.rabbitmq:amqp-client via its own rabbit-amqp-client.version property.
                        Confirmed still needed as of spring-boot 3.5.16: its BOM ships
-                       rabbit-amqp-client.version 5.25.0, still short of the 5.33.1 fix. -->
+                       rabbit-amqp-client.version 5.25.0, still short of the 5.34.0 fix. The
+                       threshold is 5.34.0, not the 5.33.1 that CVE-2026-69219/CVE-2026-69220 alone
+                       would need, because this same override also covers the pre-existing
+                       CVE-2026-63337 / GHSA-jh4v-gfqj-7rhx, which is only fixed at >= 5.34.0. -->
                   <requireProperty>
                     <property>version.spring-boot</property>
                     <regex>^3\.5\.16$</regex>
                     <regexMessage>
-version.spring-boot was changed! Check if the amqp-client CVE-2026-69219/CVE-2026-69220 override can
-be removed. If the new spring-boot-dependencies BOM ships com.rabbitmq:amqp-client &gt;= 5.33.1
-(confirm with `mvn dependency:tree -Dincludes=com.rabbitmq:amqp-client`, not just the property),
-remove the version.amqp-client property, the amqp-client dependencyManagement entry, and this
-enforcer rule from parent/pom.xml.
+version.spring-boot was changed! Check if the amqp-client CVE-2026-69219/CVE-2026-69220 (and
+CVE-2026-63337) override can be removed. If the new spring-boot-dependencies BOM ships
+com.rabbitmq:amqp-client &gt;= 5.34.0 (confirm with
+`mvn dependency:tree -Dincludes=com.rabbitmq:amqp-client`, not just the property), remove the
+version.amqp-client property, the amqp-client dependencyManagement entry, and this enforcer rule
+from parent/pom.xml.
 See: https://github.com/rabbitmq/rabbitmq-java-client/security/advisories
                     </regexMessage>
                   </requireProperty>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -156,6 +156,7 @@ limitations under the License.</license.inlineheader>
     <plugin.version.license.codehaus>2.7.1</plugin.version.license.codehaus>
     <plugin.version.maven-resources-plugin>3.2.0</plugin.version.maven-resources-plugin>
     <plugin.version.maven-shade-plugin>3.6.2</plugin.version.maven-shade-plugin>
+    <plugin.version.maven-site-plugin>3.22.0</plugin.version.maven-site-plugin>
     <plugin.version.maven-surefire-plugin>3.5.6</plugin.version.maven-surefire-plugin>
     <plugin.version.spotless-maven-plugin>2.46.1</plugin.version.spotless-maven-plugin>
     <plugin.version.maven-jar-plugin>3.5.1</plugin.version.maven-jar-plugin>
@@ -864,6 +865,11 @@ parent/pom.xml.
               </goals>
             </execution>
           </executions>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-site-plugin</artifactId>
+          <version>${plugin.version.maven-site-plugin}</version>
         </plugin>
         <plugin>
           <groupId>com.diffplug.spotless</groupId>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -118,6 +118,14 @@ limitations under the License.</license.inlineheader>
 
     <version.kafka-clients>3.9.2</version.kafka-clients>
 
+    <!-- Explicit overrides: the Spring Boot BOM / kafka-clients versions used on this branch
+         are below the fixed versions for known CVEs. Remove once spring-boot-dependencies manages
+         netty >= 4.2.17.Final and rabbit-amqp-client >= 5.33.1, and kafka-clients ships
+         lz4-java >= 1.11.1. -->
+    <version.netty>4.2.17.Final</version.netty>
+    <version.amqp-client>5.35.0</version.amqp-client>
+    <version.lz4-java>1.11.2</version.lz4-java>
+
     <version.microsoft-graph>6.69.0</version.microsoft-graph>
     <version.azure-identity>1.18.6</version.azure-identity>
 
@@ -167,6 +175,15 @@ limitations under the License.</license.inlineheader>
         <groupId>com.fasterxml.jackson.datatype</groupId>
         <artifactId>jackson-datatype-jsr310</artifactId>
         <version>${version.jackson-datatype-jsr310}</version>
+      </dependency>
+
+      <!-- Netty BOM imported before Spring Boot so its version takes precedence -->
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-bom</artifactId>
+        <version>${version.netty}</version>
+        <scope>import</scope>
+        <type>pom</type>
       </dependency>
 
       <!-- Spring Boot BOM -->
@@ -470,6 +487,22 @@ limitations under the License.</license.inlineheader>
         <groupId>org.apache.kafka</groupId>
         <artifactId>kafka-clients</artifactId>
         <version>${version.kafka-clients}</version>
+      </dependency>
+
+      <!-- Override lz4-java transitive version brought in by kafka-clients.
+           Remove once kafka-clients ships lz4-java >= 1.11.1. -->
+      <dependency>
+        <groupId>at.yawk.lz4</groupId>
+        <artifactId>lz4-java</artifactId>
+        <version>${version.lz4-java}</version>
+      </dependency>
+
+      <!-- Override amqp-client transitive version brought in by spring-boot-dependencies.
+           Remove once spring-boot-dependencies manages com.rabbitmq:amqp-client >= 5.33.1. -->
+      <dependency>
+        <groupId>com.rabbitmq</groupId>
+        <artifactId>amqp-client</artifactId>
+        <version>${version.amqp-client}</version>
       </dependency>
 
       <dependency>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -120,9 +120,16 @@ limitations under the License.</license.inlineheader>
 
     <!-- Explicit overrides: the Spring Boot BOM / kafka-clients versions used on this branch
          are below the fixed versions for known CVEs. Remove once spring-boot-dependencies manages
-         netty >= 4.2.17.Final and rabbit-amqp-client >= 5.33.1, and kafka-clients ships
-         lz4-java >= 1.11.1. -->
-    <version.netty>4.2.17.Final</version.netty>
+         netty >= 4.1.137.Final and rabbit-amqp-client >= 5.33.1, and kafka-clients ships
+         lz4-java >= 1.11.1.
+         Netty is pinned to 4.1.137.Final (not the 4.2.x line used on stable/8.7+) because this
+         branch's reactor-netty (1.2.18, via spring-boot 3.5.16's reactor-bom 2024.0.18) is compiled
+         against netty 4.1.x; jumping to netty 4.2 here without also bumping reactor-netty (as
+         stable/8.7 did to 1.3.7) would pair a 4.1-compiled reactor-netty with a 4.2 netty-bom,
+         which is not guaranteed binary compatible. 4.1.137.Final stays on the already-resolved
+         4.1.x line and covers all 7 netty CVEs (4.1.136 fixes CVE-2026-55831/55833/56745/56819/
+         59901; 4.1.137.Final additionally fixes CVE-2026-62243/75595). -->
+    <version.netty>4.1.137.Final</version.netty>
     <version.amqp-client>5.35.0</version.amqp-client>
     <version.lz4-java>1.11.2</version.lz4-java>
 


### PR DESCRIPTION
## Summary

Bumps `io.netty:netty-bom` to `4.1.137.Final`, `com.rabbitmq:amqp-client` to `5.35.0`, and `at.yawk.lz4:lz4-java` to `1.11.2`, matching the versions already used on `stable/8.7`+.

Security fix. Details in the internal tracking issue: camunda/team-connectors#1277