### PR TITLE
fix(databricks): point the connector at its Camunda documentation

### DIFF
--- a/connectors/databricks/element-templates/databricks-connector.json
+++ b/connectors/databricks/element-templates/databricks-connector.json
@@ -18,7 +18,7 @@
     "oauth m2m",
     "service principal"
   ],
-  "documentationRef" : "https://docs.databricks.com/api/workspace/introduction",
+  "documentationRef" : "https://docs.camunda.io/docs/8.10/components/connectors/out-of-the-box-connectors/databricks/",
   "category" : {
     "id" : "connectors",
     "name" : "Connectors"
@@ -652,7 +652,7 @@
           }
         ]
       },
-      "tooltip" : "Full request body for a custom model endpoint, using exactly one of dataframe_split, dataframe_records, inputs, or instances. Prefer dataframe_split, because dataframe_records does not guarantee column ordering. See <a href=\"https://docs.databricks.com/api/workspace/servingendpoints/query\">Model Serving query API</a>.",
+      "tooltip" : "Full request body for a custom model endpoint, using exactly one of dataframe_split, dataframe_records, inputs, or instances. Prefer dataframe_split, because dataframe_records does not guarantee column ordering. See <a href=\"https://docs.databricks.com/api/model-serving-query/v1/query\">Model Serving query API</a>.",
       "type" : "Text"
     },
     {


### PR DESCRIPTION
Follow-up to #8736, which repaired stale and broken documentation links across the connectors but left Databricks out of scope.

## Connector documentation link

The template's `documentationRef` pointed at the Databricks REST API reference:

```
https://docs.databricks.com/api/workspace/introduction
```

So the documentation link on the element in the Modeler opened Databricks' API docs rather than guidance on using the Camunda connector. That URL has also rotted — it now drops to the generic `/api/workspace/` index, with no introduction page.

A Camunda page for this connector exists, so it is linked instead:

```
https://docs.camunda.io/docs/8.10/components/connectors/out-of-the-box-connectors/databricks/
```

Pinned to 8.10 because the page has so far only been published to the unreleased documentation — the same situation as the AgentCore Runtime connector in #8736. The numbered form resolves today, keeps the literal `/next/` out of the template as the CI check requires, and becomes stable when 8.10 ships. The unversioned and 8.9 forms both 404.

## Relocated Databricks link

The model serving query tooltip pointed at `/api/workspace/servingendpoints/query`, which Databricks has moved to `/api/model-serving-query/v1/query`. Updated to the new location.

The OAuth M2M link is left as-is — it still resolves, and a vendor API reference is the right target for that tooltip.

## Verification

- All four remaining links checked with curl: 200, no redirect away from the intended page.
- `element-template-validator`: `Scanned 716 template(s). No findings.`
- Forbidden-`/next/` check passes.
- Template parses as valid JSON.
- This template is hand-maintained — `connectors/databricks/` declares no generator plugin — so there is no Java source to update and nothing to regenerate.
- No template `version` bump: the change does not affect how the template applies, and `CurrentVersionBumpRule` passes.

## Not included

The two generic `use-connectors` links in this template are unversioned, as they are in most templates. That is the repo-wide cleanup tracked in #8752, deliberately not started here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
