### PR TITLE
ci: skip SaaS E2E dispatch cleanly when the downstream workflow is disabled

### DIFF
--- a/.github/workflows/MERGE_QUEUE_HELM_TEST.yaml
+++ b/.github/workflows/MERGE_QUEUE_HELM_TEST.yaml
@@ -342,7 +342,26 @@ jobs:
           owner: camunda
           repositories: connectors,c8-cross-component-e2e-tests
 
+      - name: Check downstream SaaS workflow is enabled
+        id: check-downstream
+        env:
+          GH_TOKEN: ${{ steps.github-token.outputs.token }}
+        run: |
+          STATE="$(gh api repos/camunda/c8-cross-component-e2e-tests/actions/workflows/playwright_saas_pr_trigger_connectors.yml --jq .state)"
+          echo "Downstream workflow state: $STATE"
+          if [[ "$STATE" != "active" ]]; then
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            {
+              echo "### SaaS E2E tests skipped"
+              echo ""
+              echo "The downstream workflow (\`playwright_saas_pr_trigger_connectors.yml\` in camunda/c8-cross-component-e2e-tests) is currently **${STATE}**, not active -- skipping dispatch instead of waiting for a run that will never start."
+            } >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Trigger repository_dispatch for SaaS Connectors
+        if: steps.check-downstream.outputs.enabled != 'false'
         env:
           GITHUB_TOKEN: ${{ steps.github-token.outputs.token }}
           CORRELATION_ID: ${{ github.repository }}:${{ github.run_id }}:${{ github.run_attempt }}:${{ github.sha }}
@@ -385,6 +404,7 @@ jobs:
 
       - name: Wait for downstream workflow to finish
         id: wait-downstream
+        if: steps.check-downstream.outputs.enabled != 'false'
         env:
           GH_TOKEN: ${{ steps.github-token.outputs.token }}
           CORRELATION_ID: ${{ github.repository }}:${{ github.run_id }}:${{ github.run_attempt }}:${{ github.sha }}

--- a/.github/workflows/MERGE_QUEUE_HELM_TEST.yaml
+++ b/.github/workflows/MERGE_QUEUE_HELM_TEST.yaml
@@ -347,9 +347,27 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.github-token.outputs.token }}
         run: |
-          STATE="$(gh api repos/camunda/c8-cross-component-e2e-tests/actions/workflows/playwright_saas_pr_trigger_connectors.yml --jq .state)"
-          echo "Downstream workflow state: $STATE"
-          if [[ "$STATE" != "active" ]]; then
+          # Fail CLOSED on the gate (see the two dispatch/wait steps below,
+          # which require enabled == 'true' explicitly) but fail OPEN on
+          # inability to determine state: a transient API blip here must not
+          # silently skip real SaaS coverage on an otherwise-normal PR, so a
+          # retry-exhausted check falls back to the pre-this-PR behavior
+          # (dispatch as usual) rather than skipping.
+          STATE=""
+          for attempt in 1 2 3; do
+            if STATE="$(gh api repos/camunda/c8-cross-component-e2e-tests/actions/workflows/playwright_saas_pr_trigger_connectors.yml --jq .state 2>&1)"; then
+              break
+            fi
+            echo "::warning::Attempt ${attempt}/3 to read downstream workflow state failed: $STATE" >&2
+            STATE=""
+            [[ $attempt -lt 3 ]] && sleep $((attempt * 5))
+          done
+
+          if [[ -z "$STATE" ]]; then
+            echo "::warning::Could not determine downstream workflow state after 3 attempts -- defaulting to enabled so a transient API issue doesn't silently skip real SaaS coverage."
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          elif [[ "$STATE" != "active" ]]; then
+            echo "Downstream workflow state: $STATE"
             echo "enabled=false" >> "$GITHUB_OUTPUT"
             {
               echo "### SaaS E2E tests skipped"
@@ -357,11 +375,12 @@ jobs:
               echo "The downstream workflow (\`playwright_saas_pr_trigger_connectors.yml\` in camunda/c8-cross-component-e2e-tests) is currently **${STATE}**, not active -- skipping dispatch instead of waiting for a run that will never start."
             } >> "$GITHUB_STEP_SUMMARY"
           else
+            echo "Downstream workflow state: $STATE"
             echo "enabled=true" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Trigger repository_dispatch for SaaS Connectors
-        if: steps.check-downstream.outputs.enabled != 'false'
+        if: steps.check-downstream.outputs.enabled == 'true'
         env:
           GITHUB_TOKEN: ${{ steps.github-token.outputs.token }}
           CORRELATION_ID: ${{ github.repository }}:${{ github.run_id }}:${{ github.run_attempt }}:${{ github.sha }}
@@ -404,7 +423,7 @@ jobs:
 
       - name: Wait for downstream workflow to finish
         id: wait-downstream
-        if: steps.check-downstream.outputs.enabled != 'false'
+        if: steps.check-downstream.outputs.enabled == 'true'
         env:
           GH_TOKEN: ${{ steps.github-token.outputs.token }}
           CORRELATION_ID: ${{ github.repository }}:${{ github.run_id }}:${{ github.run_attempt }}:${{ github.sha }}


### PR DESCRIPTION
## Summary
Same fix as camunda/camunda#62546.

- The downstream workflow (`camunda/c8-cross-component-e2e-tests`'s `playwright_saas_pr_trigger_connectors.yml`) is being temporarily disabled while an org-creation reliability issue is worked out there.
- Without this change, disabling it there causes `Trigger repository_dispatch for SaaS Connectors` + `Wait for downstream workflow to finish` to dispatch into a void: `repository_dispatch` never creates a run for a disabled workflow, so the `wait-downstream` step's poll never finds one and burns its timeout before exiting non-zero on every single PR/merge-queue run.

## Fix
Add a cheap state check (`GET .../actions/workflows/{file}` -> `.state`) right after the dispatch token is minted, and gate both the dispatch step and `wait-downstream` on it.

All later steps already guard themselves on `wait-downstream`'s outputs/outcome (`downstream_run_url != ''`, `outcome == 'failure'`), so skipping those two steps propagates cleanly through the rest of the job with no further changes needed -- confirmed by reading each downstream step's own condition.

Re-enabling the downstream workflow requires no follow-up here: the next run just sees `state=active` and proceeds exactly as before.

## Test plan
- [x] YAML parses cleanly.
- [ ] Confirm on a real PR run once the downstream workflow is actually disabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)