### PR TITLE
fix: validate static auth credentials against endpoint

### DIFF
--- a/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/model/auth/RestAuthenticationValidator.java
+++ b/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/model/auth/RestAuthenticationValidator.java
@@ -13,26 +13,29 @@ import io.camunda.connector.api.validation.ConfigurationValidator;
 import io.camunda.connector.http.client.authentication.OAuthConstants;
 import io.camunda.connector.http.client.authentication.OAuthService;
 import io.camunda.connector.http.client.client.apache.CustomApacheHttpClient;
+import io.camunda.connector.http.client.mapper.ResponseMapper;
+import io.camunda.connector.http.client.model.HttpClientRequest;
+import io.camunda.connector.http.client.model.HttpMethod;
 import java.util.Map;
 import java.util.Set;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Only the OAuth client-credentials variant can be checked out-of-band: it carries its own token
- * endpoint, so a token is actually requested. Basic, bearer and API key hold a secret with nothing
- * to present it to, and checking the refresh-token grant would consume a token the provider may
- * rotate — both return {@link ConfigurationValidationResult#unsupported() unsupported} rather than
- * an unverified success.
+ * Presents the credential to an endpoint and reports whether it was refused. A static secret
+ * (basic, bearer, API key) goes to {@link RestAuthenticationConfiguration#url()}, which the
+ * configuration makes mandatory for exactly those types; an OAuth client-credentials grant asks its
+ * own token endpoint for a token. Only the refresh-token grant is left unchecked, since a check
+ * would consume a token the provider may rotate (RFC 6749 §6).
  */
 public class RestAuthenticationValidator
     implements ConfigurationValidator<RestAuthenticationConfiguration> {
 
   private static final Logger LOG = LoggerFactory.getLogger(RestAuthenticationValidator.class);
 
-  static final String MISSING_AUTH_MESSAGE = "Authentication is required.";
-  static final String UNAUTHORIZED_MESSAGE =
-      "The token endpoint rejected the credential (unauthorized).";
+  static final String MISSING_AUTH_MESSAGE =
+      "A credential must specify an authentication mechanism other than 'None'.";
+  static final String UNAUTHORIZED_MESSAGE = "The endpoint rejected the credential (unauthorized).";
   static final String GENERIC_MESSAGE =
       "The REST authentication credential could not be validated.";
 
@@ -44,32 +47,47 @@ public class RestAuthenticationValidator
 
   @Override
   public ConfigurationValidationResult validate(RestAuthenticationConfiguration configuration) {
-    if (configuration.authentication() == null) {
-      return ConfigurationValidationResult.failure(ErrorCode.INVALID_INPUT, MISSING_AUTH_MESSAGE);
-    }
+    // Fully enumerated rather than defaulted: the exhaustiveness check then turns a newly added
+    // authentication variant into a build error instead of a silently unvalidated credential.
     return switch (configuration.authentication()) {
-      case NoAuthentication ignored -> ConfigurationValidationResult.success();
-      case BasicAuthentication ignored -> ConfigurationValidationResult.unsupported();
-      case BearerAuthentication ignored -> ConfigurationValidationResult.unsupported();
-      case ApiKeyAuthentication ignored -> ConfigurationValidationResult.unsupported();
+      case null ->
+          ConfigurationValidationResult.failure(ErrorCode.INVALID_INPUT, MISSING_AUTH_MESSAGE);
+      case NoAuthentication ignored ->
+          ConfigurationValidationResult.failure(ErrorCode.INVALID_INPUT, MISSING_AUTH_MESSAGE);
+      case BasicAuthentication ignored -> callEndpoint(configuration);
+      case BearerAuthentication ignored -> callEndpoint(configuration);
+      case ApiKeyAuthentication ignored -> callEndpoint(configuration);
       case OAuthAuthentication oauth -> requestToken(oauth);
       case OAuthRefreshTokenAuthentication ignored -> ConfigurationValidationResult.unsupported();
     };
   }
 
+  private static ConfigurationValidationResult callEndpoint(
+      RestAuthenticationConfiguration configuration) {
+    var request = new HttpClientRequest();
+    request.setMethod(HttpMethod.GET);
+    request.setUrl(configuration.url());
+    request.setAuthentication(AuthenticationMapper.map(configuration.authentication()));
+    return attempt(request, response -> null);
+  }
+
   private static ConfigurationValidationResult requestToken(OAuthAuthentication authentication) {
+    var oAuthService = new OAuthService();
+    var mapped =
+        (io.camunda.connector.http.client.model.auth.OAuthAuthentication)
+            AuthenticationMapper.map(authentication);
+    return attempt(
+        oAuthService.createOAuthRequestFrom(mapped), oAuthService::extractTokenFromResponse);
+  }
+
+  private static <T> ConfigurationValidationResult attempt(
+      HttpClientRequest request, ResponseMapper<T> responseMapper) {
     try {
-      var oAuthService = new OAuthService();
-      var mapped =
-          (io.camunda.connector.http.client.model.auth.OAuthAuthentication)
-              AuthenticationMapper.map(authentication);
-      new CustomApacheHttpClient()
-          .execute(
-              oAuthService.createOAuthRequestFrom(mapped), oAuthService::extractTokenFromResponse);
+      new CustomApacheHttpClient().execute(request, responseMapper);
       return ConfigurationValidationResult.success();
     } catch (Exception e) {
       LOG.debug(
-          "Token request failed for a REST authentication credential (type {}, code {})",
+          "Validation request failed for a REST authentication credential (type {}, code {})",
           e.getClass().getName(),
           e instanceof ConnectorException connectorException
               ? connectorException.getErrorCode()

--- a/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/model/auth/RestAuthenticationValidator.java
+++ b/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/model/auth/RestAuthenticationValidator.java
@@ -83,7 +83,14 @@ public class RestAuthenticationValidator
   private static <T> ConfigurationValidationResult attempt(
       HttpClientRequest request, ResponseMapper<T> responseMapper) {
     try {
-      new CustomApacheHttpClient().execute(request, responseMapper);
+      var response = new CustomApacheHttpClient().execute(request, responseMapper);
+      // Only 4xx and above are thrown, and redirects are not followed, so a 3xx lands here: an
+      // endpoint that answers an unaccepted credential by redirecting to a login page has not
+      // accepted it.
+      if (response.status() >= 300) {
+        LOG.debug("A REST authentication credential was answered with {}", response.status());
+        return ConfigurationValidationResult.failure(ErrorCode.ERROR, GENERIC_MESSAGE);
+      }
       return ConfigurationValidationResult.success();
     } catch (Exception e) {
       LOG.debug(

--- a/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/model/auth/RestAuthenticationValidator.java
+++ b/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/model/auth/RestAuthenticationValidator.java
@@ -13,7 +13,6 @@ import io.camunda.connector.api.validation.ConfigurationValidator;
 import io.camunda.connector.http.client.authentication.OAuthConstants;
 import io.camunda.connector.http.client.authentication.OAuthService;
 import io.camunda.connector.http.client.client.apache.CustomApacheHttpClient;
-import io.camunda.connector.http.client.mapper.ResponseMapper;
 import io.camunda.connector.http.client.model.HttpClientRequest;
 import io.camunda.connector.http.client.model.HttpMethod;
 import java.util.Map;
@@ -27,6 +26,13 @@ import org.slf4j.LoggerFactory;
  * configuration makes mandatory for exactly those types; an OAuth client-credentials grant asks its
  * own token endpoint for a token. Only the refresh-token grant is left unchecked, since a check
  * would consume a token the provider may rotate (RFC 6749 §6).
+ *
+ * <p>What counts as a refusal differs between the two, because the evidence does: a token endpoint
+ * refuses under a defined contract, while an arbitrary resource URL is answering a request derived
+ * from the credential rather than one a task makes — see {@code callEndpoint} below. Anything short
+ * of a stated refusal is {@link ConfigurationValidationResult#unsupported() unsupported} rather
+ * than a failure, so a credential that works is never condemned by a check that could not reach a
+ * verdict.
  */
 public class RestAuthenticationValidator
     implements ConfigurationValidator<RestAuthenticationConfiguration> {
@@ -62,45 +68,69 @@ public class RestAuthenticationValidator
     };
   }
 
+  /**
+   * A bare {@code GET} on the bound URL, which is the only request that can be derived from the
+   * credential: the configuration carries no method, and the URL is a default a task may override
+   * ({@code HttpCommonRequest#url}). So the endpoint is answering a request no task necessarily
+   * makes, and only a 401 — the status RFC 9110 reserves for a missing or invalid credential — is
+   * it stating that this credential was refused. Every other answer is reported as no verdict — a
+   * 403 (a token scoped elsewhere, or a WAF), a 404 or 405 (the bare GET, not the secret), a
+   * redirect, an unreachable host: reporting any of them as a failure would condemn a credential
+   * that works.
+   */
   private static ConfigurationValidationResult callEndpoint(
       RestAuthenticationConfiguration configuration) {
     var request = new HttpClientRequest();
     request.setMethod(HttpMethod.GET);
     request.setUrl(configuration.url());
     request.setAuthentication(AuthenticationMapper.map(configuration.authentication()));
-    return attempt(request, response -> null);
+    try {
+      // Only 4xx and above are thrown, and redirects are not followed, so a 3xx lands here.
+      var response = new CustomApacheHttpClient().execute(request, ignored -> null);
+      return response.status() < 300
+          ? ConfigurationValidationResult.success()
+          : ConfigurationValidationResult.unsupported();
+    } catch (Exception e) {
+      logFailure(e);
+      return e instanceof ConnectorException connectorException
+              && "401".equals(connectorException.getErrorCode())
+          ? ConfigurationValidationResult.failure(ErrorCode.UNAUTHORIZED, UNAUTHORIZED_MESSAGE)
+          : ConfigurationValidationResult.unsupported();
+    }
   }
 
+  /**
+   * Unlike an arbitrary resource URL, a token endpoint has a contract (RFC 6749 §5.2) under which
+   * its refusals do speak about the credential, so {@link #classifyFailure(Exception)} keeps its
+   * verdict on all of them.
+   */
   private static ConfigurationValidationResult requestToken(OAuthAuthentication authentication) {
     var oAuthService = new OAuthService();
     var mapped =
         (io.camunda.connector.http.client.model.auth.OAuthAuthentication)
             AuthenticationMapper.map(authentication);
-    return attempt(
-        oAuthService.createOAuthRequestFrom(mapped), oAuthService::extractTokenFromResponse);
-  }
-
-  private static <T> ConfigurationValidationResult attempt(
-      HttpClientRequest request, ResponseMapper<T> responseMapper) {
     try {
-      var response = new CustomApacheHttpClient().execute(request, responseMapper);
-      // Only 4xx and above are thrown, and redirects are not followed, so a 3xx lands here: an
-      // endpoint that answers an unaccepted credential by redirecting to a login page has not
-      // accepted it.
-      if (response.status() >= 300) {
-        LOG.debug("A REST authentication credential was answered with {}", response.status());
-        return ConfigurationValidationResult.failure(ErrorCode.ERROR, GENERIC_MESSAGE);
-      }
-      return ConfigurationValidationResult.success();
+      var response =
+          new CustomApacheHttpClient()
+              .execute(
+                  oAuthService.createOAuthRequestFrom(mapped),
+                  oAuthService::extractTokenFromResponse);
+      return response.status() < 300
+          ? ConfigurationValidationResult.success()
+          : ConfigurationValidationResult.failure(ErrorCode.ERROR, GENERIC_MESSAGE);
     } catch (Exception e) {
-      LOG.debug(
-          "Validation request failed for a REST authentication credential (type {}, code {})",
-          e.getClass().getName(),
-          e instanceof ConnectorException connectorException
-              ? connectorException.getErrorCode()
-              : "n/a");
+      logFailure(e);
       return classifyFailure(e);
     }
+  }
+
+  private static void logFailure(Exception e) {
+    LOG.debug(
+        "Validation request failed for a REST authentication credential (type {}, code {})",
+        e.getClass().getName(),
+        e instanceof ConnectorException connectorException
+            ? connectorException.getErrorCode()
+            : "n/a");
   }
 
   static ConfigurationValidationResult classifyFailure(Exception e) {

--- a/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/model/auth/RestAuthenticationValidator.java
+++ b/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/model/auth/RestAuthenticationValidator.java
@@ -26,13 +26,6 @@ import org.slf4j.LoggerFactory;
  * configuration makes mandatory for exactly those types; an OAuth client-credentials grant asks its
  * own token endpoint for a token. Only the refresh-token grant is left unchecked, since a check
  * would consume a token the provider may rotate (RFC 6749 §6).
- *
- * <p>What counts as a refusal differs between the two, because the evidence does: a token endpoint
- * refuses under a defined contract, while an arbitrary resource URL is answering a request derived
- * from the credential rather than one a task makes — see {@code callEndpoint} below. Anything short
- * of a stated refusal is {@link ConfigurationValidationResult#unsupported() unsupported} rather
- * than a failure, so a credential that works is never condemned by a check that could not reach a
- * verdict.
  */
 public class RestAuthenticationValidator
     implements ConfigurationValidator<RestAuthenticationConfiguration> {
@@ -53,8 +46,6 @@ public class RestAuthenticationValidator
 
   @Override
   public ConfigurationValidationResult validate(RestAuthenticationConfiguration configuration) {
-    // Fully enumerated rather than defaulted: the exhaustiveness check then turns a newly added
-    // authentication variant into a build error instead of a silently unvalidated credential.
     return switch (configuration.authentication()) {
       case null ->
           ConfigurationValidationResult.failure(ErrorCode.INVALID_INPUT, MISSING_AUTH_MESSAGE);
@@ -68,16 +59,7 @@ public class RestAuthenticationValidator
     };
   }
 
-  /**
-   * A bare {@code GET} on the bound URL, which is the only request that can be derived from the
-   * credential: the configuration carries no method, and the URL is a default a task may override
-   * ({@code HttpCommonRequest#url}). So the endpoint is answering a request no task necessarily
-   * makes, and only a 401 — the status RFC 9110 reserves for a missing or invalid credential — is
-   * it stating that this credential was refused. Every other answer is reported as no verdict — a
-   * 403 (a token scoped elsewhere, or a WAF), a 404 or 405 (the bare GET, not the secret), a
-   * redirect, an unreachable host: reporting any of them as a failure would condemn a credential
-   * that works.
-   */
+  /** Only a 401 says the credential was refused; every other answer is about the bare GET. */
   private static ConfigurationValidationResult callEndpoint(
       RestAuthenticationConfiguration configuration) {
     var request = new HttpClientRequest();
@@ -85,7 +67,6 @@ public class RestAuthenticationValidator
     request.setUrl(configuration.url());
     request.setAuthentication(AuthenticationMapper.map(configuration.authentication()));
     try {
-      // Only 4xx and above are thrown, and redirects are not followed, so a 3xx lands here.
       var response = new CustomApacheHttpClient().execute(request, ignored -> null);
       return response.status() < 300
           ? ConfigurationValidationResult.success()
@@ -99,11 +80,6 @@ public class RestAuthenticationValidator
     }
   }
 
-  /**
-   * Unlike an arbitrary resource URL, a token endpoint has a contract (RFC 6749 §5.2) under which
-   * its refusals do speak about the credential, so {@link #classifyFailure(Exception)} keeps its
-   * verdict on all of them.
-   */
   private static ConfigurationValidationResult requestToken(OAuthAuthentication authentication) {
     var oAuthService = new OAuthService();
     var mapped =

--- a/connectors/http/http-base/src/test/java/io/camunda/connector/http/base/model/auth/RestAuthenticationValidatorTest.java
+++ b/connectors/http/http-base/src/test/java/io/camunda/connector/http/base/model/auth/RestAuthenticationValidatorTest.java
@@ -280,7 +280,6 @@ class RestAuthenticationValidatorTest {
           authentication, "http://localhost:" + wireMock.getHttpPort() + "/api");
     }
 
-    /** The stub only answers when the credential arrived, so a success proves it was presented. */
     @Test
     void basicSucceedsWhenTheEndpointAcceptsIt(WireMockRuntimeInfo wireMock) {
       WireMock.stubFor(
@@ -321,7 +320,6 @@ class RestAuthenticationValidatorTest {
       assertThat(result.message()).doesNotContain(SENSITIVE);
     }
 
-    /** A token scoped to another path, or a WAF in front of the endpoint — not a bad secret. */
     @Test
     void noVerdictWhenTheEndpointForbidsTheRequest(WireMockRuntimeInfo wireMock) {
       WireMock.stubFor(
@@ -332,7 +330,6 @@ class RestAuthenticationValidatorTest {
       assertThat(result.status()).isEqualTo(Status.UNSUPPORTED);
     }
 
-    /** The configuration carries no method, so the bare GET is the validator's own choice. */
     @Test
     void noVerdictWhenTheEndpointDoesNotAllowGet(WireMockRuntimeInfo wireMock) {
       WireMock.stubFor(WireMock.get("/api").willReturn(WireMock.aResponse().withStatus(405)));

--- a/connectors/http/http-base/src/test/java/io/camunda/connector/http/base/model/auth/RestAuthenticationValidatorTest.java
+++ b/connectors/http/http-base/src/test/java/io/camunda/connector/http/base/model/auth/RestAuthenticationValidatorTest.java
@@ -321,27 +321,46 @@ class RestAuthenticationValidatorTest {
       assertThat(result.message()).doesNotContain(SENSITIVE);
     }
 
+    /** A token scoped to another path, or a WAF in front of the endpoint — not a bad secret. */
     @Test
-    void errorWhenTheEndpointRedirectsToALoginPage(WireMockRuntimeInfo wireMock) {
+    void noVerdictWhenTheEndpointForbidsTheRequest(WireMockRuntimeInfo wireMock) {
+      WireMock.stubFor(
+          WireMock.get("/api").willReturn(WireMock.forbidden().withBody("denied " + SENSITIVE)));
+
+      var result = validator.validate(boundTo(new BearerAuthentication("token"), wireMock));
+
+      assertThat(result.status()).isEqualTo(Status.UNSUPPORTED);
+    }
+
+    /** The configuration carries no method, so the bare GET is the validator's own choice. */
+    @Test
+    void noVerdictWhenTheEndpointDoesNotAllowGet(WireMockRuntimeInfo wireMock) {
+      WireMock.stubFor(WireMock.get("/api").willReturn(WireMock.aResponse().withStatus(405)));
+
+      var result = validator.validate(boundTo(new BearerAuthentication("token"), wireMock));
+
+      assertThat(result.status()).isEqualTo(Status.UNSUPPORTED);
+    }
+
+    @Test
+    void noVerdictWhenTheEndpointRedirects(WireMockRuntimeInfo wireMock) {
       WireMock.stubFor(
           WireMock.get("/api")
               .willReturn(WireMock.aResponse().withStatus(302).withHeader("Location", "/login")));
 
       var result = validator.validate(boundTo(new BearerAuthentication("token"), wireMock));
 
-      assertThat(result.status()).isEqualTo(Status.FAILURE);
-      assertThat(result.code()).isEqualTo("ERROR");
+      assertThat(result.status()).isEqualTo(Status.UNSUPPORTED);
     }
 
     @Test
-    void errorWhenTheEndpointIsUnreachable() {
+    void noVerdictWhenTheEndpointIsUnreachable() {
       var result =
           validator.validate(
               new RestAuthenticationConfiguration(
                   new BearerAuthentication("token"), "http://localhost:1/api"));
 
-      assertThat(result.status()).isEqualTo(Status.FAILURE);
-      assertThat(result.code()).isEqualTo("ERROR");
+      assertThat(result.status()).isEqualTo(Status.UNSUPPORTED);
     }
   }
 }

--- a/connectors/http/http-base/src/test/java/io/camunda/connector/http/base/model/auth/RestAuthenticationValidatorTest.java
+++ b/connectors/http/http-base/src/test/java/io/camunda/connector/http/base/model/auth/RestAuthenticationValidatorTest.java
@@ -322,6 +322,18 @@ class RestAuthenticationValidatorTest {
     }
 
     @Test
+    void errorWhenTheEndpointRedirectsToALoginPage(WireMockRuntimeInfo wireMock) {
+      WireMock.stubFor(
+          WireMock.get("/api")
+              .willReturn(WireMock.aResponse().withStatus(302).withHeader("Location", "/login")));
+
+      var result = validator.validate(boundTo(new BearerAuthentication("token"), wireMock));
+
+      assertThat(result.status()).isEqualTo(Status.FAILURE);
+      assertThat(result.code()).isEqualTo("ERROR");
+    }
+
+    @Test
     void errorWhenTheEndpointIsUnreachable() {
       var result =
           validator.validate(

--- a/connectors/http/http-base/src/test/java/io/camunda/connector/http/base/model/auth/RestAuthenticationValidatorTest.java
+++ b/connectors/http/http-base/src/test/java/io/camunda/connector/http/base/model/auth/RestAuthenticationValidatorTest.java
@@ -26,11 +26,7 @@ class RestAuthenticationValidatorTest {
   private static final String SENSITIVE = "SENSITIVE-DETAIL";
 
   private static RestAuthenticationConfiguration configuration(Authentication authentication) {
-    String url =
-        authentication != null && RestAuthenticationConfiguration.requiresUrl(authentication)
-            ? "https://example.com/api"
-            : null;
-    return new RestAuthenticationConfiguration(authentication, url);
+    return new RestAuthenticationConfiguration(authentication, null);
   }
 
   private static OAuthAuthentication clientCredentials(String tokenEndpoint) {
@@ -58,34 +54,11 @@ class RestAuthenticationValidatorTest {
     private final RestAuthenticationValidator validator = new RestAuthenticationValidator();
 
     @Test
-    void noAuthenticationIsUsable() {
+    void noAuthenticationIsRejected() {
       var result = validator.validate(configuration(new NoAuthentication()));
 
-      assertThat(result.status()).isEqualTo(Status.SUCCESS);
-    }
-
-    @Test
-    void basicIsNotValidatable() {
-      var result = validator.validate(configuration(new BasicAuthentication("user", "password")));
-
-      assertThat(result.status()).isEqualTo(Status.UNSUPPORTED);
-    }
-
-    @Test
-    void bearerIsNotValidatable() {
-      var result = validator.validate(configuration(new BearerAuthentication("token")));
-
-      assertThat(result.status()).isEqualTo(Status.UNSUPPORTED);
-    }
-
-    @Test
-    void apiKeyIsNotValidatable() {
-      var result =
-          validator.validate(
-              configuration(
-                  new ApiKeyAuthentication(ApiKeyLocation.HEADERS, "X-Api-Key", "secret")));
-
-      assertThat(result.status()).isEqualTo(Status.UNSUPPORTED);
+      assertThat(result.status()).isEqualTo(Status.FAILURE);
+      assertThat(result.code()).isEqualTo("INVALID_INPUT");
     }
 
     @Test
@@ -289,6 +262,71 @@ class RestAuthenticationValidatorTest {
     @Test
     void errorWhenTheTokenEndpointIsUnreachable() {
       var result = validator.validate(configuration(clientCredentials("http://localhost:1/token")));
+
+      assertThat(result.status()).isEqualTo(Status.FAILURE);
+      assertThat(result.code()).isEqualTo("ERROR");
+    }
+  }
+
+  @Nested
+  @WireMockTest
+  class AgainstARealEndpoint {
+
+    private final RestAuthenticationValidator validator = new RestAuthenticationValidator();
+
+    private RestAuthenticationConfiguration boundTo(
+        Authentication authentication, WireMockRuntimeInfo wireMock) {
+      return new RestAuthenticationConfiguration(
+          authentication, "http://localhost:" + wireMock.getHttpPort() + "/api");
+    }
+
+    /** The stub only answers when the credential arrived, so a success proves it was presented. */
+    @Test
+    void basicSucceedsWhenTheEndpointAcceptsIt(WireMockRuntimeInfo wireMock) {
+      WireMock.stubFor(
+          WireMock.get("/api").withBasicAuth("user", "password").willReturn(WireMock.ok()));
+
+      var result =
+          validator.validate(boundTo(new BasicAuthentication("user", "password"), wireMock));
+
+      assertThat(result.status()).isEqualTo(Status.SUCCESS);
+    }
+
+    @Test
+    void apiKeySucceedsWhenTheEndpointAcceptsIt(WireMockRuntimeInfo wireMock) {
+      WireMock.stubFor(
+          WireMock.get("/api")
+              .withHeader("X-Api-Key", WireMock.equalTo("secret"))
+              .willReturn(WireMock.ok()));
+
+      var result =
+          validator.validate(
+              boundTo(
+                  new ApiKeyAuthentication(ApiKeyLocation.HEADERS, "X-Api-Key", "secret"),
+                  wireMock));
+
+      assertThat(result.status()).isEqualTo(Status.SUCCESS);
+    }
+
+    @Test
+    void bearerIsUnauthorizedWhenTheEndpointRejectsIt(WireMockRuntimeInfo wireMock) {
+      WireMock.stubFor(
+          WireMock.get("/api")
+              .willReturn(WireMock.unauthorized().withBody("denied because " + SENSITIVE)));
+
+      var result = validator.validate(boundTo(new BearerAuthentication("token"), wireMock));
+
+      assertThat(result.status()).isEqualTo(Status.FAILURE);
+      assertThat(result.code()).isEqualTo("UNAUTHORIZED");
+      assertThat(result.message()).doesNotContain(SENSITIVE);
+    }
+
+    @Test
+    void errorWhenTheEndpointIsUnreachable() {
+      var result =
+          validator.validate(
+              new RestAuthenticationConfiguration(
+                  new BearerAuthentication("token"), "http://localhost:1/api"));
 
       assertThat(result.status()).isEqualTo(Status.FAILURE);
       assertThat(result.code()).isEqualTo("ERROR");


### PR DESCRIPTION
This pull request updates the authentication validation logic for REST connectors, making the validation more robust by actively testing credentials against real endpoints. The main changes include switching from static validation for basic, bearer, and API key authentication to actually making HTTP requests to the configured endpoint, refining error handling, and updating tests to reflect the new behavior.

**Authentication validation logic changes:**

* Basic, bearer, and API key authentication are now validated by making a real HTTP request to the configured endpoint, rather than being marked as "unsupported" by default. Only "No Authentication" is rejected outright.
* The validator now distinguishes between different failure types: a 401 Unauthorized response is treated as a credential failure, while other error codes result in an "unsupported" verdict.
* Error messages and logging have been improved for clarity and sensitivity, ensuring that sensitive details are not leaked in validation messages. [[1]](diffhunk://#diff-372b4a78c04588abbcdc7ff6cf76faac01b3ed0a62bbd63678850389014b3824R16-R37) [[2]](diffhunk://#diff-372b4a78c04588abbcdc7ff6cf76faac01b3ed0a62bbd63678850389014b3824L47-L78)

**Test updates and improvements:**

* Unit tests have been updated to expect the new validation outcomes, including the rejection of "No Authentication" and the real validation of basic, bearer, and API key credentials.
* New integration tests using WireMock validate the behavior of the validator against real endpoints, covering successful authentication, unauthorized responses, forbidden responses, unsupported methods, redirects, and unreachable endpoints.

**Code and documentation cleanup:**

* The documentation and comments in `RestAuthenticationValidator` have been updated to reflect the new validation strategy, clarifying the behavior for each authentication type.
* Test helper methods were simplified to always require an explicit URL, matching the new validation approach.