### PR TITLE
fix(runtime): unquote secret references in the configuration validation

### DIFF
--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/configuration/ConfigurationValidationService.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/configuration/ConfigurationValidationService.java
@@ -41,17 +41,15 @@ import org.slf4j.LoggerFactory;
  * does); then call the validator. A missing registration yields {@code UNSUPPORTED}; anything else
  * that goes wrong yields {@code FAILURE}.
  *
- * <p><b>Secrets.</b> Configurations support {@code camunda.secrets.<name>} only. A reference
- * arrives quoted, since the caller writes the configuration as JSON, and is unquoted before
- * evaluation so the cluster parses it as a reference rather than a string literal (see {@link
- * #unquoteSecretReferences}). It then survives evaluation as placeholder text and is substituted by
- * the evaluator's result processor, restricted to the references the cluster reports for that
- * evaluation. The legacy {@code {{secrets.X}}} and bare {@code secrets.X} forms are not resolved
- * here at all: they would have to be replaced over the evaluation <em>result</em>, where nothing
- * distinguishes a name a configuration declared from one that arrived as data, and out-of-band
- * validation has no process or element scope to derive an allow-list from. A configuration still
- * carrying that syntax is rejected rather than passed through, so the problem is reported here
- * rather than as an unexplained failure at the target.
+ * <p><b>Secrets.</b> Configurations support {@code camunda.secrets.<name>} only. Such a reference
+ * survives evaluation as placeholder text and is substituted by the evaluator's result processor,
+ * restricted to the references the cluster reports for that evaluation. The legacy {@code
+ * {{secrets.X}}} and bare {@code secrets.X} forms are not resolved here at all: they would have to
+ * be replaced over the evaluation <em>result</em>, where nothing distinguishes a name a
+ * configuration declared from one that arrived as data, and out-of-band validation has no process
+ * or element scope to derive an allow-list from. A configuration still carrying that syntax is
+ * rejected rather than passed through, so the problem is reported here rather than as an
+ * unexplained failure at the target.
  *
  * <p><b>Multi-engine.</b> A stored configuration lives on one orchestration cluster, so the
  * reference must be evaluated against the engine that holds it — each engine has its own {@code
@@ -82,11 +80,7 @@ public class ConfigurationValidationService {
       "The configuration uses an unsupported secret syntax. Reference secrets as"
           + " camunda.secrets.<name>.";
 
-  /**
-   * A {@code camunda.secrets.<name>} reference sitting in a JSON value position, quoted as a
-   * string. The lookahead keeps a key of that name — {@code "camunda.secrets.X":} — quoted, since
-   * unquoting it would produce invalid FEEL rather than a reference.
-   */
+  // A camunda.secrets.<name> reference in a JSON value position; the lookahead skips keys.
   private static final Pattern QUOTED_SECRET_REFERENCE =
       Pattern.compile("\"(camunda\\.secrets\\.[\\p{Alnum}_-]+)\"(?!\\s*:)");
 
@@ -228,14 +222,8 @@ public class ConfigurationValidationService {
   }
 
   /**
-   * Strips the quotes around every {@code camunda.secrets.<name>} value in the reference, turning
-   * each one from a FEEL string literal into a path expression.
-   *
-   * <p>Callers hand over the configuration as JSON, where a secret reference can only be written as
-   * a quoted string. Evaluated as-is the cluster sees a literal, reports no referenced secret for
-   * it, and the value comes back as the reference text itself — so validation runs against a
-   * placeholder instead of the credential. Unquoted, the cluster parses it as a reference, reports
-   * it, and the result processor substitutes the value under that same allow-list.
+   * Unquotes every {@code camunda.secrets.<name>} value, so the cluster parses it as a reference
+   * instead of a string literal and reports it as a referenced secret.
    */
   static String unquoteSecretReferences(String credentialRef) {
     return credentialRef == null

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/configuration/ConfigurationValidationService.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/configuration/ConfigurationValidationService.java
@@ -82,7 +82,7 @@ public class ConfigurationValidationService {
 
   // A camunda.secrets.<name> reference in a JSON value position; the lookahead skips keys.
   private static final Pattern QUOTED_SECRET_REFERENCE =
-      Pattern.compile("\"(camunda\\.secrets\\.[\\p{Alnum}_-]+)\"(?!\\s*:)");
+      Pattern.compile("\"(camunda\\.secrets\\.`?[\\p{Alnum}_-]+`?)\"(?!\\s*:)");
 
   private final ConfigurationValidationRegistry registry;
   private final Map<String, FeelExpressionEvaluator> feelExpressionEvaluatorsByPhysicalTenantId;

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/configuration/ConfigurationValidationService.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/configuration/ConfigurationValidationService.java
@@ -26,6 +26,7 @@ import io.camunda.connector.feel.FeelExpressionEvaluator;
 import io.camunda.connector.runtime.core.configuration.ConfigurationValidationRegistry.RegisteredValidator;
 import io.camunda.connector.runtime.core.secret.LegacySecretSyntaxRejectingProcessor.LegacySecretSyntaxException;
 import java.util.Map;
+import java.util.regex.Pattern;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -40,15 +41,17 @@ import org.slf4j.LoggerFactory;
  * does); then call the validator. A missing registration yields {@code UNSUPPORTED}; anything else
  * that goes wrong yields {@code FAILURE}.
  *
- * <p><b>Secrets.</b> Configurations support {@code camunda.secrets.<name>} only. Such a reference
- * survives evaluation as placeholder text and is substituted by the evaluator's result processor,
- * restricted to the references the cluster reports for that evaluation. The legacy {@code
- * {{secrets.X}}} and bare {@code secrets.X} forms are not resolved here at all: they would have to
- * be replaced over the evaluation <em>result</em>, where nothing distinguishes a name a
- * configuration declared from one that arrived as data, and out-of-band validation has no process
- * or element scope to derive an allow-list from. A configuration still carrying that syntax is
- * rejected rather than passed through, so the problem is reported here rather than as an
- * unexplained failure at the target.
+ * <p><b>Secrets.</b> Configurations support {@code camunda.secrets.<name>} only. A reference
+ * arrives quoted, since the caller writes the configuration as JSON, and is unquoted before
+ * evaluation so the cluster parses it as a reference rather than a string literal (see {@link
+ * #unquoteSecretReferences}). It then survives evaluation as placeholder text and is substituted by
+ * the evaluator's result processor, restricted to the references the cluster reports for that
+ * evaluation. The legacy {@code {{secrets.X}}} and bare {@code secrets.X} forms are not resolved
+ * here at all: they would have to be replaced over the evaluation <em>result</em>, where nothing
+ * distinguishes a name a configuration declared from one that arrived as data, and out-of-band
+ * validation has no process or element scope to derive an allow-list from. A configuration still
+ * carrying that syntax is rejected rather than passed through, so the problem is reported here
+ * rather than as an unexplained failure at the target.
  *
  * <p><b>Multi-engine.</b> A stored configuration lives on one orchestration cluster, so the
  * reference must be evaluated against the engine that holds it — each engine has its own {@code
@@ -78,6 +81,14 @@ public class ConfigurationValidationService {
   private static final String LEGACY_SECRET_SYNTAX_MESSAGE =
       "The configuration uses an unsupported secret syntax. Reference secrets as"
           + " camunda.secrets.<name>.";
+
+  /**
+   * A {@code camunda.secrets.<name>} reference sitting in a JSON value position, quoted as a
+   * string. The lookahead keeps a key of that name — {@code "camunda.secrets.X":} — quoted, since
+   * unquoting it would produce invalid FEEL rather than a reference.
+   */
+  private static final Pattern QUOTED_SECRET_REFERENCE =
+      Pattern.compile("\"(camunda\\.secrets\\.[\\p{Alnum}_-]+)\"(?!\\s*:)");
 
   private final ConfigurationValidationRegistry registry;
   private final Map<String, FeelExpressionEvaluator> feelExpressionEvaluatorsByPhysicalTenantId;
@@ -211,7 +222,24 @@ public class ConfigurationValidationService {
       throws Exception {
     // The legacy-syntax check runs inside the evaluator's result processor, before any secret
     // value is substituted, so it never inspects resolved secret material.
-    String resolvedJson = feelExpressionEvaluator.evaluateToJson(request.credentialRef());
+    String resolvedJson =
+        feelExpressionEvaluator.evaluateToJson(unquoteSecretReferences(request.credentialRef()));
     return objectMapper.readValue(resolvedJson, configurationClass);
+  }
+
+  /**
+   * Strips the quotes around every {@code camunda.secrets.<name>} value in the reference, turning
+   * each one from a FEEL string literal into a path expression.
+   *
+   * <p>Callers hand over the configuration as JSON, where a secret reference can only be written as
+   * a quoted string. Evaluated as-is the cluster sees a literal, reports no referenced secret for
+   * it, and the value comes back as the reference text itself — so validation runs against a
+   * placeholder instead of the credential. Unquoted, the cluster parses it as a reference, reports
+   * it, and the result processor substitutes the value under that same allow-list.
+   */
+  static String unquoteSecretReferences(String credentialRef) {
+    return credentialRef == null
+        ? null
+        : QUOTED_SECRET_REFERENCE.matcher(credentialRef).replaceAll("$1");
   }
 }

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/configuration/ConfigurationValidationServiceTest.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/configuration/ConfigurationValidationServiceTest.java
@@ -154,6 +154,33 @@ class ConfigurationValidationServiceTest {
     };
   }
 
+  /** Captures the expression the service actually handed to the evaluator. */
+  private FeelExpressionEvaluator feelCapturing(String json, List<String> expressions) {
+    var delegate = feelReturning(json);
+    return new FeelExpressionEvaluator() {
+      @Override
+      public <T> T evaluate(String expression, Object... variables) {
+        throw new UnsupportedOperationException();
+      }
+
+      @Override
+      public <T> T evaluate(String expression, Class<T> targetType, Object... variables) {
+        throw new UnsupportedOperationException();
+      }
+
+      @Override
+      public <T> T evaluate(String expression, JavaType targetType, Object... variables) {
+        throw new UnsupportedOperationException();
+      }
+
+      @Override
+      public String evaluateToJson(String expression, Object... variables) {
+        expressions.add(expression);
+        return delegate.evaluateToJson(expression, variables);
+      }
+    };
+  }
+
   private ConfigurationValidationService serviceWith(String resolvedJson) {
     return serviceWith(Map.of("engine-a", feelReturning(resolvedJson)));
   }
@@ -401,5 +428,49 @@ class ConfigurationValidationServiceTest {
     assertThat(result.status()).isEqualTo(Status.FAILURE);
     assertThat(result.code()).isEqualTo("INVALID_INPUT");
     assertThat(result.message()).doesNotContain("supersecretvalue");
+  }
+
+  @Test
+  void unquotesSecretReferencesSoTheClusterParsesThemAsReferences() {
+    // Callers send the configuration as JSON, where a reference can only be written as a quoted
+    // string. Left quoted it is a FEEL string literal: the cluster reports no referenced secret
+    // for it, and validation runs against the reference text instead of the credential.
+    var expressions = new ArrayList<String>();
+    var service = serviceWith(Map.of("engine-a", feelCapturing("{\"value\":\"x\"}", expressions)));
+
+    service.validate(
+        new ConfigurationValidationRequest(
+            "ok",
+            "={\"token\":\"camunda.secrets.MY-TOKEN_1\",\"user\":\"alice\"}",
+            "tenant",
+            "engine-a"));
+
+    assertThat(expressions)
+        .containsExactly("={\"token\":camunda.secrets.MY-TOKEN_1,\"user\":\"alice\"}");
+  }
+
+  @Test
+  void leavesAReferenceShapedJsonKeyQuoted() {
+    // Unquoting a key would produce invalid FEEL rather than a reference.
+    var expressions = new ArrayList<String>();
+    var service = serviceWith(Map.of("engine-a", feelCapturing("{\"value\":\"x\"}", expressions)));
+
+    service.validate(
+        new ConfigurationValidationRequest(
+            "ok", "={\"camunda.secrets.TOKEN\" : \"literal\"}", "tenant", "engine-a"));
+
+    assertThat(expressions).containsExactly("={\"camunda.secrets.TOKEN\" : \"literal\"}");
+  }
+
+  @Test
+  void leavesAPlainReferenceExpressionUntouched() {
+    var expressions = new ArrayList<String>();
+    var service = serviceWith(Map.of("engine-a", feelCapturing("{\"value\":\"x\"}", expressions)));
+
+    service.validate(
+        new ConfigurationValidationRequest(
+            "ok", "=camunda.vars.env.awsProd", "tenant", "engine-a"));
+
+    assertThat(expressions).containsExactly("=camunda.vars.env.awsProd");
   }
 }

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/configuration/ConfigurationValidationServiceTest.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/configuration/ConfigurationValidationServiceTest.java
@@ -154,7 +154,7 @@ class ConfigurationValidationServiceTest {
     };
   }
 
-  /** Captures the expression the service actually handed to the evaluator. */
+  /** Records the expression the service handed to the evaluator. */
   private FeelExpressionEvaluator feelCapturing(String json, List<String> expressions) {
     var delegate = feelReturning(json);
     return new FeelExpressionEvaluator() {
@@ -432,9 +432,6 @@ class ConfigurationValidationServiceTest {
 
   @Test
   void unquotesSecretReferencesSoTheClusterParsesThemAsReferences() {
-    // Callers send the configuration as JSON, where a reference can only be written as a quoted
-    // string. Left quoted it is a FEEL string literal: the cluster reports no referenced secret
-    // for it, and validation runs against the reference text instead of the credential.
     var expressions = new ArrayList<String>();
     var service = serviceWith(Map.of("engine-a", feelCapturing("{\"value\":\"x\"}", expressions)));
 
@@ -451,7 +448,6 @@ class ConfigurationValidationServiceTest {
 
   @Test
   void leavesAReferenceShapedJsonKeyQuoted() {
-    // Unquoting a key would produce invalid FEEL rather than a reference.
     var expressions = new ArrayList<String>();
     var service = serviceWith(Map.of("engine-a", feelCapturing("{\"value\":\"x\"}", expressions)));
 


### PR DESCRIPTION
This pull request enhances how secret references are handled during configuration validation, ensuring that references to secrets are properly unquoted so the cluster interprets them as references rather than string literals. This change improves both the correctness and security of secret handling, and introduces new tests to verify the behavior.

**Secret reference handling improvements:**

* Added a new method `unquoteSecretReferences` to strip quotes around `camunda.secrets.<name>` values in JSON configurations, ensuring these are parsed as references and not as string literals.
* Introduced a regular expression pattern `QUOTED_SECRET_REFERENCE` to accurately identify and unquote secret references in JSON, while leaving keys intact to avoid invalid FEEL expressions.
* Updated the documentation in `ConfigurationValidationService` to clarify the handling of quoted secret references and the rationale for unquoting.

**Testing improvements:**

* Added new unit tests to verify that secret references are correctly unquoted, that reference-shaped JSON keys remain quoted, and that plain reference expressions are left untouched.
* Introduced a helper method `feelCapturing` in the test suite to capture and assert the actual expressions passed to the evaluator, improving test coverage and reliability.