### PR TITLE
[Backport stable/8.10] feat(element-templates): support reusable credential overrides

### DIFF
--- a/connectors-e2e-test/connectors-e2e-test-aws/connectors-e2e-test-aws-base/src/test/java/io/camunda/connector/e2e/SqsInboundPropertiesTest.java
+++ b/connectors-e2e-test/connectors-e2e-test-aws/connectors-e2e-test-aws-base/src/test/java/io/camunda/connector/e2e/SqsInboundPropertiesTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.e2e;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.camunda.connector.aws.ObjectMapperSupplier;
+import io.camunda.connector.aws.model.impl.AwsAuthentication.AwsStaticCredentialsAuthentication;
+import io.camunda.connector.feel.FeelExpressionEvaluator;
+import io.camunda.connector.feel.jackson.FeelContextAwareObjectReader;
+import io.camunda.connector.feel.jackson.JacksonModuleFeelFunction;
+import io.camunda.connector.inbound.model.SqsInboundProperties;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class SqsInboundPropertiesTest {
+
+  @Test
+  void bindsCredentialExpressionThroughFeelReader() throws Exception {
+    String expression = "=camunda.vars.env.sqsCredential";
+    var credential =
+        Map.of(
+            "authentication",
+            Map.of("type", "credentials", "accessKey", "cred-ak", "secretKey", "cred-sk"),
+            "region",
+            "eu-west-1");
+    var evaluator = mock(FeelExpressionEvaluator.class);
+    when(evaluator.evaluate(eq(expression), any(Object[].class))).thenReturn(credential);
+    var objectMapper =
+        ObjectMapperSupplier.getMapperInstance()
+            .copy()
+            .registerModule(new JacksonModuleFeelFunction());
+    JsonNode propertiesJson = objectMapper.valueToTree(Map.of("awsCredential", expression));
+
+    var properties =
+        FeelContextAwareObjectReader.of(objectMapper)
+            .withEvaluator(evaluator)
+            .readValue(propertiesJson, SqsInboundProperties.class);
+
+    assertThat(properties.getAuthentication())
+        .isInstanceOf(AwsStaticCredentialsAuthentication.class);
+    assertThat(((AwsStaticCredentialsAuthentication) properties.getAuthentication()).accessKey())
+        .isEqualTo("cred-ak");
+    assertThat(properties.getConfiguration().region()).isEqualTo("eu-west-1");
+  }
+}

--- a/connectors/aws/aws-base/src/main/java/io/camunda/connector/aws/AwsClientSupport.java
+++ b/connectors/aws/aws-base/src/main/java/io/camunda/connector/aws/AwsClientSupport.java
@@ -15,6 +15,7 @@ public class AwsClientSupport {
 
   public static <B extends AwsClientBuilder<B, C>, C extends AutoCloseable> C createClient(
       B builder, AwsBaseRequest request) {
+    AwsUtils.extractRegionOrDefault(request.getConfiguration(), null);
     return configureClient(builder, request).build();
   }
 
@@ -22,7 +23,7 @@ public class AwsClientSupport {
       B builder, AwsBaseRequest request) {
     builder.credentialsProvider(CredentialsProviderSupportV2.credentialsProvider(request));
     var config = request.getConfiguration();
-    if (config != null && config.region() != null) {
+    if (config != null && config.region() != null && !config.region().isBlank()) {
       builder.region(Region.of(config.region()));
     }
     if (config != null && config.endpoint() != null && !config.endpoint().isBlank()) {

--- a/connectors/aws/aws-base/src/main/java/io/camunda/connector/aws/AwsUtils.java
+++ b/connectors/aws/aws-base/src/main/java/io/camunda/connector/aws/AwsUtils.java
@@ -17,6 +17,7 @@ public class AwsUtils {
       final AwsConfiguration configuration, final String region) {
     return Optional.ofNullable(configuration)
         .map(AwsConfiguration::region)
+        .filter(str -> !str.isBlank())
         .or(() -> Optional.ofNullable(region))
         .filter(str -> !str.isBlank())
         .orElseThrow(

--- a/connectors/aws/aws-base/src/main/java/io/camunda/connector/aws/model/impl/AwsBaseRequest.java
+++ b/connectors/aws/aws-base/src/main/java/io/camunda/connector/aws/model/impl/AwsBaseRequest.java
@@ -7,6 +7,8 @@
 package io.camunda.connector.aws.model.impl;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import io.camunda.connector.api.annotation.FEEL;
+import io.camunda.connector.generator.java.annotation.FeelMode;
 import io.camunda.connector.generator.java.annotation.NestedProperties;
 import io.camunda.connector.generator.java.annotation.TemplateProperty;
 import io.camunda.connector.generator.java.annotation.TemplateProperty.NullableBoolean;
@@ -29,8 +31,9 @@ public class AwsBaseRequest {
       optional = true,
       binding = @TemplateProperty.PropertyBinding(name = "awsCredential"),
       description =
-          "Choose a reusable AWS credential, or configure one-time authentication parameters"
-              + " below.")
+          "Select a saved AWS credential with an optional default region, or enter authentication"
+              + " details and a region below.")
+  @FEEL
   @Valid
   private AwsCredentialConfiguration awsCredential;
 
@@ -50,9 +53,8 @@ public class AwsBaseRequest {
               isEmpty = NullableBoolean.TRUE))
   private AwsAuthentication authentication;
 
-  // Hidden and un-required (via the isEmpty condition) once a credential is chosen above: the
-  // bound credential's own region always wins (see getConfiguration()), so leaving `region`
-  // visible and required here would force a value that's silently discarded.
+  // Hidden and un-required (via the isEmpty condition) once a credential is chosen. In that case,
+  // the template-only regionOverride below renders in its place.
   @NestedProperties(
       condition =
           @TemplateProperty.PropertyCondition(
@@ -60,6 +62,26 @@ public class AwsBaseRequest {
               isEmpty = NullableBoolean.TRUE))
   @TemplateProperty(group = "configuration")
   private AwsBaseConfiguration configuration;
+
+  // Template-only twin of `configuration.region`, shown when a credential is selected. The engine
+  // still writes the existing `configuration.region` input, which Jackson binds into
+  // AwsBaseConfiguration; this field is never populated.
+  @JsonIgnore
+  @TemplateProperty(
+      id = "regionOverride",
+      group = "configuration",
+      label = "Region",
+      feel = FeelMode.optional,
+      optional = true,
+      binding = @TemplateProperty.PropertyBinding(name = "configuration.region"),
+      condition =
+          @TemplateProperty.PropertyCondition(
+              property = "awsCredential",
+              isEmpty = NullableBoolean.FALSE),
+      description =
+          "Overrides the default region in the selected credential. Required when the credential"
+              + " has no default region.")
+  private String regionOverride;
 
   public AwsCredentialConfiguration getAwsCredential() {
     return awsCredential;
@@ -107,16 +129,19 @@ public class AwsBaseRequest {
     return awsCredential != null ? null : authentication;
   }
 
-  /**
-   * When a credential is bound, its region drives the configuration; the inline endpoint (if any)
-   * is preserved.
-   */
+  /** A nonblank inline region overrides the credential's default region. */
   public AwsBaseConfiguration getConfiguration() {
     if (awsCredential == null) {
       return configuration;
     }
+    String inlineRegion = configuration != null ? configuration.region() : null;
+    String credentialRegion = awsCredential.region();
+    String region =
+        inlineRegion != null && !inlineRegion.isBlank()
+            ? inlineRegion
+            : credentialRegion != null && !credentialRegion.isBlank() ? credentialRegion : null;
     String endpoint = configuration != null ? configuration.endpoint() : null;
-    return new AwsBaseConfiguration(awsCredential.region(), endpoint);
+    return new AwsBaseConfiguration(region, endpoint);
   }
 
   public void setConfiguration(final AwsBaseConfiguration configuration) {

--- a/connectors/aws/aws-base/src/main/java/io/camunda/connector/aws/model/impl/AwsCredentialConfiguration.java
+++ b/connectors/aws/aws-base/src/main/java/io/camunda/connector/aws/model/impl/AwsCredentialConfiguration.java
@@ -9,20 +9,19 @@ package io.camunda.connector.aws.model.impl;
 import io.camunda.connector.api.annotation.Configuration;
 import io.camunda.connector.generator.java.annotation.TemplateProperty;
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotBlank;
 
 /**
  * Configuration (credential) template for reusable AWS credentials, shared by AWS connectors.
  * Reuses the existing sealed {@link AwsAuthentication} (a discriminated union of static credentials
- * vs. the default credentials chain) plus the region, demonstrating that a discriminated auth model
- * maps onto the configuration-template format (a discriminator dropdown with conditional fields).
+ * vs. the default credentials chain) plus an optional default region, demonstrating that a
+ * discriminated auth model maps onto the configuration-template format (a discriminator dropdown
+ * with conditional fields).
  */
-@Configuration(id = "io.camunda:aws-credential:1", version = 1, name = "AWS Credential")
+@Configuration(id = "io.camunda:aws-credential:1", version = 2, name = "AWS Credential")
 public record AwsCredentialConfiguration(
     @Valid @TemplateProperty(group = "authentication") AwsAuthentication authentication,
-    @NotBlank
-        @TemplateProperty(
+    @TemplateProperty(
             group = "configuration",
-            label = "Region",
-            constraints = @TemplateProperty.PropertyConstraints(notEmpty = true))
+            label = "Default region",
+            description = "Used when a connector does not specify a region override.")
         String region) {}

--- a/connectors/aws/aws-base/src/main/java/io/camunda/connector/aws/model/impl/AwsCredentialValidator.java
+++ b/connectors/aws/aws-base/src/main/java/io/camunda/connector/aws/model/impl/AwsCredentialValidator.java
@@ -105,9 +105,15 @@ public class AwsCredentialValidator implements ConfigurationValidator<AwsCredent
         StsClient.builder()
             .credentialsProvider(
                 CredentialsProviderSupportV2.credentialsProvider(configuration.authentication()))
-            .region(Region.of(configuration.region()))
+            .region(resolveValidationRegion(configuration.region()))
             .build()) {
       sts.getCallerIdentity();
     }
+  }
+
+  static Region resolveValidationRegion(String region) {
+    // Credential validation runs before any connector-specific override is available. AWS's global
+    // STS endpoint can validate the identity without assigning a default service region.
+    return region == null || region.isBlank() ? Region.AWS_GLOBAL : Region.of(region);
   }
 }

--- a/connectors/aws/aws-base/src/test/java/io/camunda/connector/aws/AwsBaseRequestTest.java
+++ b/connectors/aws/aws-base/src/test/java/io/camunda/connector/aws/AwsBaseRequestTest.java
@@ -63,13 +63,8 @@ class AwsBaseRequestTest {
     assertFalse(request.isDefaultCredentialsChainUsedInSaaS());
   }
 
-  /**
-   * When both an inline authentication/region and a bound credential are set, the credential must
-   * win for authentication and region, while the inline endpoint (which the credential has no
-   * equivalent for) is preserved.
-   */
   @Test
-  void credentialTakesPrecedenceOverInlineWhilePreservingInlineEndpoint() {
+  void inlineRegionOverridesCredentialDefaultWhileCredentialAuthenticationWins() {
     AwsBaseRequest request = new AwsBaseRequest();
     request.setAuthentication(
         new AwsAuthentication.AwsStaticCredentialsAuthentication("inline-key", "inline-secret"));
@@ -84,8 +79,34 @@ class AwsBaseRequestTest {
         new AwsAuthentication.AwsStaticCredentialsAuthentication(
             "credential-key", "credential-secret"),
         request.getAuthentication());
+    assertEquals("eu-central-1", request.getConfiguration().region());
+    assertEquals("https://inline-endpoint", request.getConfiguration().endpoint());
+  }
+
+  @Test
+  void credentialDefaultRegionIsUsedWhenInlineRegionIsBlank() {
+    AwsBaseRequest request = new AwsBaseRequest();
+    request.setConfiguration(new AwsBaseConfiguration(" ", "https://inline-endpoint"));
+    request.setAwsCredential(
+        new AwsCredentialConfiguration(
+            new AwsAuthentication.AwsStaticCredentialsAuthentication(
+                "credential-key", "credential-secret"),
+            "us-east-1"));
+
     assertEquals("us-east-1", request.getConfiguration().region());
     assertEquals("https://inline-endpoint", request.getConfiguration().endpoint());
+  }
+
+  @Test
+  void blankCredentialDefaultRegionIsNormalizedWhenNoOverrideExists() {
+    AwsBaseRequest request = new AwsBaseRequest();
+    request.setAwsCredential(
+        new AwsCredentialConfiguration(
+            new AwsAuthentication.AwsStaticCredentialsAuthentication(
+                "credential-key", "credential-secret"),
+            " "));
+
+    assertNull(request.getConfiguration().region());
   }
 
   /**
@@ -104,6 +125,19 @@ class AwsBaseRequestTest {
                 "credential-key", "credential-secret"),
             "us-east-1"));
     request.setAuthentication(new AwsAuthentication.AwsStaticCredentialsAuthentication(null, null));
+
+    assertThatCode(() -> new DefaultValidationProvider().validate(request))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  void validationSucceedsWhenCredentialRegionIsMissing() {
+    AwsBaseRequest request = new AwsBaseRequest();
+    request.setAwsCredential(
+        new AwsCredentialConfiguration(
+            new AwsAuthentication.AwsStaticCredentialsAuthentication(
+                "credential-key", "credential-secret"),
+            null));
 
     assertThatCode(() -> new DefaultValidationProvider().validate(request))
         .doesNotThrowAnyException();

--- a/connectors/aws/aws-base/src/test/java/io/camunda/connector/aws/AwsClientSupportTest.java
+++ b/connectors/aws/aws-base/src/test/java/io/camunda/connector/aws/AwsClientSupportTest.java
@@ -7,6 +7,7 @@
 package io.camunda.connector.aws;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -15,6 +16,7 @@ import static org.mockito.Mockito.verify;
 import io.camunda.connector.aws.model.impl.AwsAuthentication.AwsStaticCredentialsAuthentication;
 import io.camunda.connector.aws.model.impl.AwsBaseConfiguration;
 import io.camunda.connector.aws.model.impl.AwsBaseRequest;
+import jakarta.validation.ValidationException;
 import java.net.URI;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -75,6 +77,24 @@ class AwsClientSupportTest {
     AwsClientSupport.configureClient(builder, requestWith(null, null));
 
     verify(builder, never()).region(any());
+  }
+
+  @Test
+  void configureClientOmitsRegionWhenBlank() {
+    TestBuilder builder = mock(TestBuilder.class);
+
+    AwsClientSupport.configureClient(builder, requestWith(" ", null));
+
+    verify(builder, never()).region(any());
+  }
+
+  @Test
+  void createClientRejectsMissingEffectiveRegion() {
+    TestBuilder builder = mock(TestBuilder.class);
+
+    assertThatThrownBy(() -> AwsClientSupport.createClient(builder, requestWith(null, null)))
+        .isInstanceOf(ValidationException.class)
+        .hasMessageContaining("configuration.region");
   }
 
   @Test

--- a/connectors/aws/aws-base/src/test/java/io/camunda/connector/aws/AwsUtilsTest.java
+++ b/connectors/aws/aws-base/src/test/java/io/camunda/connector/aws/AwsUtilsTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.aws;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.connector.aws.model.impl.AwsBaseConfiguration;
+import jakarta.validation.ValidationException;
+import org.junit.jupiter.api.Test;
+
+class AwsUtilsTest {
+
+  @Test
+  void blankConfigurationRegionFallsBackToLegacyRegion() {
+    assertThat(AwsUtils.extractRegionOrDefault(new AwsBaseConfiguration(" ", null), "eu-central-1"))
+        .isEqualTo("eu-central-1");
+  }
+
+  @Test
+  void missingConfigurationAndFallbackRegionsAreRejected() {
+    assertThatThrownBy(() -> AwsUtils.extractRegionOrDefault(null, null))
+        .isInstanceOf(ValidationException.class)
+        .hasMessageContaining("configuration.region");
+  }
+}

--- a/connectors/aws/aws-base/src/test/java/io/camunda/connector/aws/model/impl/AwsCredentialValidatorTest.java
+++ b/connectors/aws/aws-base/src/test/java/io/camunda/connector/aws/model/impl/AwsCredentialValidatorTest.java
@@ -11,6 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.camunda.connector.api.validation.ConfigurationValidationResult.Status;
 import io.camunda.connector.aws.model.impl.AwsAuthentication.AwsStaticCredentialsAuthentication;
 import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.sts.model.StsException;
 
 class AwsCredentialValidatorTest {
@@ -26,6 +27,28 @@ class AwsCredentialValidatorTest {
     var result = validator.validate(VALID);
 
     assertThat(result.status()).isEqualTo(Status.SUCCESS);
+  }
+
+  @Test
+  void successWhenIdentityCheckPassesWithoutDefaultRegion() {
+    var validator = new AwsCredentialValidator(configuration -> {});
+    var configuration =
+        new AwsCredentialConfiguration(
+            new AwsStaticCredentialsAuthentication("access-key", "secret-key"), null);
+
+    assertThat(validator.validate(configuration).status()).isEqualTo(Status.SUCCESS);
+  }
+
+  @Test
+  void usesGlobalStsRegionWhenDefaultRegionIsMissing() {
+    assertThat(AwsCredentialValidator.resolveValidationRegion(null)).isEqualTo(Region.AWS_GLOBAL);
+    assertThat(AwsCredentialValidator.resolveValidationRegion(" ")).isEqualTo(Region.AWS_GLOBAL);
+  }
+
+  @Test
+  void usesCredentialDefaultRegionForStsWhenPresent() {
+    assertThat(AwsCredentialValidator.resolveValidationRegion("eu-central-1"))
+        .isEqualTo(Region.EU_CENTRAL_1);
   }
 
   @Test

--- a/connectors/aws/aws-bedrock-agentcore-long-term-memory/element-templates/aws-bedrock-agentcore-long-term-memory-outbound-connector.json
+++ b/connectors/aws/aws-bedrock-agentcore-long-term-memory/element-templates/aws-bedrock-agentcore-long-term-memory-outbound-connector.json
@@ -70,7 +70,7 @@
   }, {
     "id" : "awsCredential",
     "label" : "AWS credential",
-    "description" : "Choose a reusable AWS credential, or configure one-time authentication parameters below.",
+    "description" : "Select a saved AWS credential with an optional default region, or enter authentication details and a region below.",
     "optional" : true,
     "group" : "authentication",
     "binding" : {
@@ -221,6 +221,23 @@
       "type" : "simple"
     },
     "type" : "Hidden"
+  }, {
+    "id" : "regionOverride",
+    "label" : "Region",
+    "description" : "Overrides the default region in the selected credential. Required when the credential has no default region.",
+    "optional" : true,
+    "feel" : "optional",
+    "group" : "configuration",
+    "binding" : {
+      "name" : "configuration.region",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "awsCredential",
+      "isEmpty" : false,
+      "type" : "simple"
+    },
+    "type" : "String"
   }, {
     "id" : "operation.query",
     "label" : "Search query",
@@ -459,7 +476,7 @@
   "configurationTemplates" : [ {
     "id" : "io.camunda:aws-credential:1",
     "kind" : "CREDENTIAL",
-    "version" : 1,
+    "version" : 2,
     "name" : "AWS Credential",
     "properties" : [ {
       "id" : "authentication.type",
@@ -519,10 +536,8 @@
       "secret" : true
     }, {
       "id" : "region",
-      "label" : "Region",
-      "constraints" : {
-        "notEmpty" : true
-      },
+      "label" : "Default region",
+      "description" : "Used when a connector does not specify a region override.",
       "group" : "configuration",
       "binding" : {
         "name" : "region",

--- a/connectors/aws/aws-bedrock-agentcore-long-term-memory/element-templates/hybrid/aws-bedrock-agentcore-long-term-memory-outbound-connector-hybrid.json
+++ b/connectors/aws/aws-bedrock-agentcore-long-term-memory/element-templates/hybrid/aws-bedrock-agentcore-long-term-memory-outbound-connector-hybrid.json
@@ -75,7 +75,7 @@
   }, {
     "id" : "awsCredential",
     "label" : "AWS credential",
-    "description" : "Choose a reusable AWS credential, or configure one-time authentication parameters below.",
+    "description" : "Select a saved AWS credential with an optional default region, or enter authentication details and a region below.",
     "optional" : true,
     "group" : "authentication",
     "binding" : {
@@ -226,6 +226,23 @@
       "type" : "simple"
     },
     "type" : "Hidden"
+  }, {
+    "id" : "regionOverride",
+    "label" : "Region",
+    "description" : "Overrides the default region in the selected credential. Required when the credential has no default region.",
+    "optional" : true,
+    "feel" : "optional",
+    "group" : "configuration",
+    "binding" : {
+      "name" : "configuration.region",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "awsCredential",
+      "isEmpty" : false,
+      "type" : "simple"
+    },
+    "type" : "String"
   }, {
     "id" : "operation.query",
     "label" : "Search query",
@@ -464,7 +481,7 @@
   "configurationTemplates" : [ {
     "id" : "io.camunda:aws-credential:1",
     "kind" : "CREDENTIAL",
-    "version" : 1,
+    "version" : 2,
     "name" : "AWS Credential",
     "properties" : [ {
       "id" : "authentication.type",
@@ -524,10 +541,8 @@
       "secret" : true
     }, {
       "id" : "region",
-      "label" : "Region",
-      "constraints" : {
-        "notEmpty" : true
-      },
+      "label" : "Default region",
+      "description" : "Used when a connector does not specify a region override.",
       "group" : "configuration",
       "binding" : {
         "name" : "region",

--- a/connectors/aws/aws-bedrock-agentcore-runtime/element-templates/aws-bedrock-agentcore-runtime-outbound-connector.json
+++ b/connectors/aws/aws-bedrock-agentcore-runtime/element-templates/aws-bedrock-agentcore-runtime-outbound-connector.json
@@ -48,7 +48,7 @@
   }, {
     "id" : "awsCredential",
     "label" : "AWS credential",
-    "description" : "Choose a reusable AWS credential, or configure one-time authentication parameters below.",
+    "description" : "Select a saved AWS credential with an optional default region, or enter authentication details and a region below.",
     "optional" : true,
     "group" : "authentication",
     "binding" : {
@@ -169,6 +169,23 @@
       "type" : "simple"
     },
     "type" : "Hidden"
+  }, {
+    "id" : "regionOverride",
+    "label" : "Region",
+    "description" : "Overrides the default region in the selected credential. Required when the credential has no default region.",
+    "optional" : true,
+    "feel" : "optional",
+    "group" : "configuration",
+    "binding" : {
+      "name" : "configuration.region",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "awsCredential",
+      "isEmpty" : false,
+      "type" : "simple"
+    },
+    "type" : "String"
   }, {
     "id" : "input.agentRuntimeArn",
     "label" : "Agent Runtime ARN",
@@ -303,7 +320,7 @@
   "configurationTemplates" : [ {
     "id" : "io.camunda:aws-credential:1",
     "kind" : "CREDENTIAL",
-    "version" : 1,
+    "version" : 2,
     "name" : "AWS Credential",
     "properties" : [ {
       "id" : "authentication.type",
@@ -363,10 +380,8 @@
       "secret" : true
     }, {
       "id" : "region",
-      "label" : "Region",
-      "constraints" : {
-        "notEmpty" : true
-      },
+      "label" : "Default region",
+      "description" : "Used when a connector does not specify a region override.",
       "group" : "configuration",
       "binding" : {
         "name" : "region",

--- a/connectors/aws/aws-bedrock-agentcore-runtime/element-templates/hybrid/aws-bedrock-agentcore-runtime-outbound-connector-hybrid.json
+++ b/connectors/aws/aws-bedrock-agentcore-runtime/element-templates/hybrid/aws-bedrock-agentcore-runtime-outbound-connector-hybrid.json
@@ -53,7 +53,7 @@
   }, {
     "id" : "awsCredential",
     "label" : "AWS credential",
-    "description" : "Choose a reusable AWS credential, or configure one-time authentication parameters below.",
+    "description" : "Select a saved AWS credential with an optional default region, or enter authentication details and a region below.",
     "optional" : true,
     "group" : "authentication",
     "binding" : {
@@ -174,6 +174,23 @@
       "type" : "simple"
     },
     "type" : "Hidden"
+  }, {
+    "id" : "regionOverride",
+    "label" : "Region",
+    "description" : "Overrides the default region in the selected credential. Required when the credential has no default region.",
+    "optional" : true,
+    "feel" : "optional",
+    "group" : "configuration",
+    "binding" : {
+      "name" : "configuration.region",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "awsCredential",
+      "isEmpty" : false,
+      "type" : "simple"
+    },
+    "type" : "String"
   }, {
     "id" : "input.agentRuntimeArn",
     "label" : "Agent Runtime ARN",
@@ -308,7 +325,7 @@
   "configurationTemplates" : [ {
     "id" : "io.camunda:aws-credential:1",
     "kind" : "CREDENTIAL",
-    "version" : 1,
+    "version" : 2,
     "name" : "AWS Credential",
     "properties" : [ {
       "id" : "authentication.type",
@@ -368,10 +385,8 @@
       "secret" : true
     }, {
       "id" : "region",
-      "label" : "Region",
-      "constraints" : {
-        "notEmpty" : true
-      },
+      "label" : "Default region",
+      "description" : "Used when a connector does not specify a region override.",
       "group" : "configuration",
       "binding" : {
         "name" : "region",

--- a/connectors/aws/aws-bedrock-codeinterpreter/element-templates/aws-bedrock-codeinterpreter-outbound-connector.json
+++ b/connectors/aws/aws-bedrock-codeinterpreter/element-templates/aws-bedrock-codeinterpreter-outbound-connector.json
@@ -50,7 +50,7 @@
   }, {
     "id" : "awsCredential",
     "label" : "AWS credential",
-    "description" : "Choose a reusable AWS credential, or configure one-time authentication parameters below.",
+    "description" : "Select a saved AWS credential with an optional default region, or enter authentication details and a region below.",
     "optional" : true,
     "group" : "authentication",
     "binding" : {
@@ -171,6 +171,23 @@
       "type" : "simple"
     },
     "type" : "Hidden"
+  }, {
+    "id" : "regionOverride",
+    "label" : "Region",
+    "description" : "Overrides the default region in the selected credential. Required when the credential has no default region.",
+    "optional" : true,
+    "feel" : "optional",
+    "group" : "configuration",
+    "binding" : {
+      "name" : "configuration.region",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "awsCredential",
+      "isEmpty" : false,
+      "type" : "simple"
+    },
+    "type" : "String"
   }, {
     "id" : "input.language",
     "label" : "Language",
@@ -351,7 +368,7 @@
   "configurationTemplates" : [ {
     "id" : "io.camunda:aws-credential:1",
     "kind" : "CREDENTIAL",
-    "version" : 1,
+    "version" : 2,
     "name" : "AWS Credential",
     "properties" : [ {
       "id" : "authentication.type",
@@ -411,10 +428,8 @@
       "secret" : true
     }, {
       "id" : "region",
-      "label" : "Region",
-      "constraints" : {
-        "notEmpty" : true
-      },
+      "label" : "Default region",
+      "description" : "Used when a connector does not specify a region override.",
       "group" : "configuration",
       "binding" : {
         "name" : "region",

--- a/connectors/aws/aws-bedrock-codeinterpreter/element-templates/hybrid/aws-bedrock-codeinterpreter-outbound-connector-hybrid.json
+++ b/connectors/aws/aws-bedrock-codeinterpreter/element-templates/hybrid/aws-bedrock-codeinterpreter-outbound-connector-hybrid.json
@@ -55,7 +55,7 @@
   }, {
     "id" : "awsCredential",
     "label" : "AWS credential",
-    "description" : "Choose a reusable AWS credential, or configure one-time authentication parameters below.",
+    "description" : "Select a saved AWS credential with an optional default region, or enter authentication details and a region below.",
     "optional" : true,
     "group" : "authentication",
     "binding" : {
@@ -176,6 +176,23 @@
       "type" : "simple"
     },
     "type" : "Hidden"
+  }, {
+    "id" : "regionOverride",
+    "label" : "Region",
+    "description" : "Overrides the default region in the selected credential. Required when the credential has no default region.",
+    "optional" : true,
+    "feel" : "optional",
+    "group" : "configuration",
+    "binding" : {
+      "name" : "configuration.region",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "awsCredential",
+      "isEmpty" : false,
+      "type" : "simple"
+    },
+    "type" : "String"
   }, {
     "id" : "input.language",
     "label" : "Language",
@@ -356,7 +373,7 @@
   "configurationTemplates" : [ {
     "id" : "io.camunda:aws-credential:1",
     "kind" : "CREDENTIAL",
-    "version" : 1,
+    "version" : 2,
     "name" : "AWS Credential",
     "properties" : [ {
       "id" : "authentication.type",
@@ -416,10 +433,8 @@
       "secret" : true
     }, {
       "id" : "region",
-      "label" : "Region",
-      "constraints" : {
-        "notEmpty" : true
-      },
+      "label" : "Default region",
+      "description" : "Used when a connector does not specify a region override.",
       "group" : "configuration",
       "binding" : {
         "name" : "region",

--- a/connectors/aws/aws-bedrock-knowledgebase/element-templates/aws-bedrock-knowledgebase-outbound-connector.json
+++ b/connectors/aws/aws-bedrock-knowledgebase/element-templates/aws-bedrock-knowledgebase-outbound-connector.json
@@ -50,7 +50,7 @@
   }, {
     "id" : "awsCredential",
     "label" : "AWS credential",
-    "description" : "Choose a reusable AWS credential, or configure one-time authentication parameters below.",
+    "description" : "Select a saved AWS credential with an optional default region, or enter authentication details and a region below.",
     "optional" : true,
     "group" : "authentication",
     "binding" : {
@@ -186,6 +186,23 @@
       "type" : "simple"
     },
     "type" : "Hidden"
+  }, {
+    "id" : "regionOverride",
+    "label" : "Region",
+    "description" : "Overrides the default region in the selected credential. Required when the credential has no default region.",
+    "optional" : true,
+    "feel" : "optional",
+    "group" : "configuration",
+    "binding" : {
+      "name" : "configuration.region",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "awsCredential",
+      "isEmpty" : false,
+      "type" : "simple"
+    },
+    "type" : "String"
   }, {
     "id" : "operation.operationDiscriminator",
     "label" : "Operation",
@@ -330,7 +347,7 @@
   "configurationTemplates" : [ {
     "id" : "io.camunda:aws-credential:1",
     "kind" : "CREDENTIAL",
-    "version" : 1,
+    "version" : 2,
     "name" : "AWS Credential",
     "properties" : [ {
       "id" : "authentication.type",
@@ -390,10 +407,8 @@
       "secret" : true
     }, {
       "id" : "region",
-      "label" : "Region",
-      "constraints" : {
-        "notEmpty" : true
-      },
+      "label" : "Default region",
+      "description" : "Used when a connector does not specify a region override.",
       "group" : "configuration",
       "binding" : {
         "name" : "region",

--- a/connectors/aws/aws-bedrock-knowledgebase/element-templates/hybrid/aws-bedrock-knowledgebase-outbound-connector-hybrid.json
+++ b/connectors/aws/aws-bedrock-knowledgebase/element-templates/hybrid/aws-bedrock-knowledgebase-outbound-connector-hybrid.json
@@ -55,7 +55,7 @@
   }, {
     "id" : "awsCredential",
     "label" : "AWS credential",
-    "description" : "Choose a reusable AWS credential, or configure one-time authentication parameters below.",
+    "description" : "Select a saved AWS credential with an optional default region, or enter authentication details and a region below.",
     "optional" : true,
     "group" : "authentication",
     "binding" : {
@@ -191,6 +191,23 @@
       "type" : "simple"
     },
     "type" : "Hidden"
+  }, {
+    "id" : "regionOverride",
+    "label" : "Region",
+    "description" : "Overrides the default region in the selected credential. Required when the credential has no default region.",
+    "optional" : true,
+    "feel" : "optional",
+    "group" : "configuration",
+    "binding" : {
+      "name" : "configuration.region",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "awsCredential",
+      "isEmpty" : false,
+      "type" : "simple"
+    },
+    "type" : "String"
   }, {
     "id" : "operation.operationDiscriminator",
     "label" : "Operation",
@@ -335,7 +352,7 @@
   "configurationTemplates" : [ {
     "id" : "io.camunda:aws-credential:1",
     "kind" : "CREDENTIAL",
-    "version" : 1,
+    "version" : 2,
     "name" : "AWS Credential",
     "properties" : [ {
       "id" : "authentication.type",
@@ -395,10 +412,8 @@
       "secret" : true
     }, {
       "id" : "region",
-      "label" : "Region",
-      "constraints" : {
-        "notEmpty" : true
-      },
+      "label" : "Default region",
+      "description" : "Used when a connector does not specify a region override.",
       "group" : "configuration",
       "binding" : {
         "name" : "region",

--- a/connectors/aws/aws-bedrock/element-templates/aws-bedrock-outbound-connector.json
+++ b/connectors/aws/aws-bedrock/element-templates/aws-bedrock-outbound-connector.json
@@ -72,7 +72,7 @@
   }, {
     "id" : "awsCredential",
     "label" : "AWS credential",
-    "description" : "Choose a reusable AWS credential, or configure one-time authentication parameters below.",
+    "description" : "Select a saved AWS credential with an optional default region, or enter authentication details and a region below.",
     "optional" : true,
     "group" : "authentication",
     "binding" : {
@@ -193,6 +193,23 @@
       "type" : "simple"
     },
     "type" : "Hidden"
+  }, {
+    "id" : "regionOverride",
+    "label" : "Region",
+    "description" : "Overrides the default region in the selected credential. Required when the credential has no default region.",
+    "optional" : true,
+    "feel" : "optional",
+    "group" : "configuration",
+    "binding" : {
+      "name" : "configuration.region",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "awsCredential",
+      "isEmpty" : false,
+      "type" : "simple"
+    },
+    "type" : "String"
   }, {
     "id" : "data.modelId0",
     "label" : "Model ID",
@@ -706,7 +723,7 @@
   "configurationTemplates" : [ {
     "id" : "io.camunda:aws-credential:1",
     "kind" : "CREDENTIAL",
-    "version" : 1,
+    "version" : 2,
     "name" : "AWS Credential",
     "properties" : [ {
       "id" : "authentication.type",
@@ -766,10 +783,8 @@
       "secret" : true
     }, {
       "id" : "region",
-      "label" : "Region",
-      "constraints" : {
-        "notEmpty" : true
-      },
+      "label" : "Default region",
+      "description" : "Used when a connector does not specify a region override.",
       "group" : "configuration",
       "binding" : {
         "name" : "region",

--- a/connectors/aws/aws-bedrock/element-templates/hybrid/aws-bedrock-outbound-connector-hybrid.json
+++ b/connectors/aws/aws-bedrock/element-templates/hybrid/aws-bedrock-outbound-connector-hybrid.json
@@ -77,7 +77,7 @@
   }, {
     "id" : "awsCredential",
     "label" : "AWS credential",
-    "description" : "Choose a reusable AWS credential, or configure one-time authentication parameters below.",
+    "description" : "Select a saved AWS credential with an optional default region, or enter authentication details and a region below.",
     "optional" : true,
     "group" : "authentication",
     "binding" : {
@@ -198,6 +198,23 @@
       "type" : "simple"
     },
     "type" : "Hidden"
+  }, {
+    "id" : "regionOverride",
+    "label" : "Region",
+    "description" : "Overrides the default region in the selected credential. Required when the credential has no default region.",
+    "optional" : true,
+    "feel" : "optional",
+    "group" : "configuration",
+    "binding" : {
+      "name" : "configuration.region",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "awsCredential",
+      "isEmpty" : false,
+      "type" : "simple"
+    },
+    "type" : "String"
   }, {
     "id" : "data.modelId0",
     "label" : "Model ID",
@@ -711,7 +728,7 @@
   "configurationTemplates" : [ {
     "id" : "io.camunda:aws-credential:1",
     "kind" : "CREDENTIAL",
-    "version" : 1,
+    "version" : 2,
     "name" : "AWS Credential",
     "properties" : [ {
       "id" : "authentication.type",
@@ -771,10 +788,8 @@
       "secret" : true
     }, {
       "id" : "region",
-      "label" : "Region",
-      "constraints" : {
-        "notEmpty" : true
-      },
+      "label" : "Default region",
+      "description" : "Used when a connector does not specify a region override.",
       "group" : "configuration",
       "binding" : {
         "name" : "region",

--- a/connectors/aws/aws-comprehend/element-templates/aws-comprehend-outbound-connector.json
+++ b/connectors/aws/aws-comprehend/element-templates/aws-comprehend-outbound-connector.json
@@ -68,7 +68,7 @@
   }, {
     "id" : "awsCredential",
     "label" : "AWS credential",
-    "description" : "Choose a reusable AWS credential, or configure one-time authentication parameters below.",
+    "description" : "Select a saved AWS credential with an optional default region, or enter authentication details and a region below.",
     "optional" : true,
     "group" : "authentication",
     "binding" : {
@@ -189,6 +189,23 @@
       "type" : "simple"
     },
     "type" : "Hidden"
+  }, {
+    "id" : "regionOverride",
+    "label" : "Region",
+    "description" : "Overrides the default region in the selected credential. Required when the credential has no default region.",
+    "optional" : true,
+    "feel" : "optional",
+    "group" : "configuration",
+    "binding" : {
+      "name" : "configuration.region",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "awsCredential",
+      "isEmpty" : false,
+      "type" : "simple"
+    },
+    "type" : "String"
   }, {
     "id" : "input.text",
     "label" : "Text",
@@ -691,7 +708,7 @@
   "configurationTemplates" : [ {
     "id" : "io.camunda:aws-credential:1",
     "kind" : "CREDENTIAL",
-    "version" : 1,
+    "version" : 2,
     "name" : "AWS Credential",
     "properties" : [ {
       "id" : "authentication.type",
@@ -751,10 +768,8 @@
       "secret" : true
     }, {
       "id" : "region",
-      "label" : "Region",
-      "constraints" : {
-        "notEmpty" : true
-      },
+      "label" : "Default region",
+      "description" : "Used when a connector does not specify a region override.",
       "group" : "configuration",
       "binding" : {
         "name" : "region",

--- a/connectors/aws/aws-comprehend/element-templates/hybrid/aws-comprehend-outbound-connector-hybrid.json
+++ b/connectors/aws/aws-comprehend/element-templates/hybrid/aws-comprehend-outbound-connector-hybrid.json
@@ -73,7 +73,7 @@
   }, {
     "id" : "awsCredential",
     "label" : "AWS credential",
-    "description" : "Choose a reusable AWS credential, or configure one-time authentication parameters below.",
+    "description" : "Select a saved AWS credential with an optional default region, or enter authentication details and a region below.",
     "optional" : true,
     "group" : "authentication",
     "binding" : {
@@ -194,6 +194,23 @@
       "type" : "simple"
     },
     "type" : "Hidden"
+  }, {
+    "id" : "regionOverride",
+    "label" : "Region",
+    "description" : "Overrides the default region in the selected credential. Required when the credential has no default region.",
+    "optional" : true,
+    "feel" : "optional",
+    "group" : "configuration",
+    "binding" : {
+      "name" : "configuration.region",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "awsCredential",
+      "isEmpty" : false,
+      "type" : "simple"
+    },
+    "type" : "String"
   }, {
     "id" : "input.text",
     "label" : "Text",
@@ -696,7 +713,7 @@
   "configurationTemplates" : [ {
     "id" : "io.camunda:aws-credential:1",
     "kind" : "CREDENTIAL",
-    "version" : 1,
+    "version" : 2,
     "name" : "AWS Credential",
     "properties" : [ {
       "id" : "authentication.type",
@@ -756,10 +773,8 @@
       "secret" : true
     }, {
       "id" : "region",
-      "label" : "Region",
-      "constraints" : {
-        "notEmpty" : true
-      },
+      "label" : "Default region",
+      "description" : "Used when a connector does not specify a region override.",
       "group" : "configuration",
       "binding" : {
         "name" : "region",

--- a/connectors/aws/aws-dynamodb/element-templates/aws-dynamodb-outbound-connector.json
+++ b/connectors/aws/aws-dynamodb/element-templates/aws-dynamodb-outbound-connector.json
@@ -122,7 +122,7 @@
   }, {
     "id" : "awsCredential",
     "label" : "AWS credential",
-    "description" : "Choose a reusable AWS credential, or configure one-time authentication parameters below.",
+    "description" : "Select a saved AWS credential with an optional default region, or enter authentication details and a region below.",
     "optional" : true,
     "group" : "authentication",
     "binding" : {
@@ -243,6 +243,23 @@
       "type" : "simple"
     },
     "type" : "Hidden"
+  }, {
+    "id" : "regionOverride",
+    "label" : "Region",
+    "description" : "Overrides the default region in the selected credential. Required when the credential has no default region.",
+    "optional" : true,
+    "feel" : "optional",
+    "group" : "configuration",
+    "binding" : {
+      "name" : "configuration.region",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "awsCredential",
+      "isEmpty" : false,
+      "type" : "simple"
+    },
+    "type" : "String"
   }, {
     "id" : "input.createTable.tableName",
     "label" : "Table name",
@@ -1182,7 +1199,7 @@
   "configurationTemplates" : [ {
     "id" : "io.camunda:aws-credential:1",
     "kind" : "CREDENTIAL",
-    "version" : 1,
+    "version" : 2,
     "name" : "AWS Credential",
     "properties" : [ {
       "id" : "authentication.type",
@@ -1242,10 +1259,8 @@
       "secret" : true
     }, {
       "id" : "region",
-      "label" : "Region",
-      "constraints" : {
-        "notEmpty" : true
-      },
+      "label" : "Default region",
+      "description" : "Used when a connector does not specify a region override.",
       "group" : "configuration",
       "binding" : {
         "name" : "region",

--- a/connectors/aws/aws-dynamodb/element-templates/hybrid/aws-dynamodb-outbound-connector-hybrid.json
+++ b/connectors/aws/aws-dynamodb/element-templates/hybrid/aws-dynamodb-outbound-connector-hybrid.json
@@ -127,7 +127,7 @@
   }, {
     "id" : "awsCredential",
     "label" : "AWS credential",
-    "description" : "Choose a reusable AWS credential, or configure one-time authentication parameters below.",
+    "description" : "Select a saved AWS credential with an optional default region, or enter authentication details and a region below.",
     "optional" : true,
     "group" : "authentication",
     "binding" : {
@@ -248,6 +248,23 @@
       "type" : "simple"
     },
     "type" : "Hidden"
+  }, {
+    "id" : "regionOverride",
+    "label" : "Region",
+    "description" : "Overrides the default region in the selected credential. Required when the credential has no default region.",
+    "optional" : true,
+    "feel" : "optional",
+    "group" : "configuration",
+    "binding" : {
+      "name" : "configuration.region",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "awsCredential",
+      "isEmpty" : false,
+      "type" : "simple"
+    },
+    "type" : "String"
   }, {
     "id" : "input.createTable.tableName",
     "label" : "Table name",
@@ -1187,7 +1204,7 @@
   "configurationTemplates" : [ {
     "id" : "io.camunda:aws-credential:1",
     "kind" : "CREDENTIAL",
-    "version" : 1,
+    "version" : 2,
     "name" : "AWS Credential",
     "properties" : [ {
       "id" : "authentication.type",
@@ -1247,10 +1264,8 @@
       "secret" : true
     }, {
       "id" : "region",
-      "label" : "Region",
-      "constraints" : {
-        "notEmpty" : true
-      },
+      "label" : "Default region",
+      "description" : "Used when a connector does not specify a region override.",
       "group" : "configuration",
       "binding" : {
         "name" : "region",

--- a/connectors/aws/aws-eventbridge/element-templates/aws-eventbridge-outbound-connector.json
+++ b/connectors/aws/aws-eventbridge/element-templates/aws-eventbridge-outbound-connector.json
@@ -52,7 +52,7 @@
   }, {
     "id" : "awsCredential",
     "label" : "AWS credential",
-    "description" : "Choose a reusable AWS credential, or configure one-time authentication parameters below.",
+    "description" : "Select a saved AWS credential with an optional default region, or enter authentication details and a region below.",
     "optional" : true,
     "group" : "authentication",
     "binding" : {
@@ -173,6 +173,23 @@
       "type" : "simple"
     },
     "type" : "Hidden"
+  }, {
+    "id" : "regionOverride",
+    "label" : "Region",
+    "description" : "Overrides the default region in the selected credential. Required when the credential has no default region.",
+    "optional" : true,
+    "feel" : "optional",
+    "group" : "configuration",
+    "binding" : {
+      "name" : "configuration.region",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "awsCredential",
+      "isEmpty" : false,
+      "type" : "simple"
+    },
+    "type" : "String"
   }, {
     "id" : "input.source",
     "label" : "Source",
@@ -326,7 +343,7 @@
   "configurationTemplates" : [ {
     "id" : "io.camunda:aws-credential:1",
     "kind" : "CREDENTIAL",
-    "version" : 1,
+    "version" : 2,
     "name" : "AWS Credential",
     "properties" : [ {
       "id" : "authentication.type",
@@ -386,10 +403,8 @@
       "secret" : true
     }, {
       "id" : "region",
-      "label" : "Region",
-      "constraints" : {
-        "notEmpty" : true
-      },
+      "label" : "Default region",
+      "description" : "Used when a connector does not specify a region override.",
       "group" : "configuration",
       "binding" : {
         "name" : "region",

--- a/connectors/aws/aws-eventbridge/element-templates/hybrid/aws-eventbridge-outbound-connector-hybrid.json
+++ b/connectors/aws/aws-eventbridge/element-templates/hybrid/aws-eventbridge-outbound-connector-hybrid.json
@@ -57,7 +57,7 @@
   }, {
     "id" : "awsCredential",
     "label" : "AWS credential",
-    "description" : "Choose a reusable AWS credential, or configure one-time authentication parameters below.",
+    "description" : "Select a saved AWS credential with an optional default region, or enter authentication details and a region below.",
     "optional" : true,
     "group" : "authentication",
     "binding" : {
@@ -178,6 +178,23 @@
       "type" : "simple"
     },
     "type" : "Hidden"
+  }, {
+    "id" : "regionOverride",
+    "label" : "Region",
+    "description" : "Overrides the default region in the selected credential. Required when the credential has no default region.",
+    "optional" : true,
+    "feel" : "optional",
+    "group" : "configuration",
+    "binding" : {
+      "name" : "configuration.region",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "awsCredential",
+      "isEmpty" : false,
+      "type" : "simple"
+    },
+    "type" : "String"
   }, {
     "id" : "input.source",
     "label" : "Source",
@@ -331,7 +348,7 @@
   "configurationTemplates" : [ {
     "id" : "io.camunda:aws-credential:1",
     "kind" : "CREDENTIAL",
-    "version" : 1,
+    "version" : 2,
     "name" : "AWS Credential",
     "properties" : [ {
       "id" : "authentication.type",
@@ -391,10 +408,8 @@
       "secret" : true
     }, {
       "id" : "region",
-      "label" : "Region",
-      "constraints" : {
-        "notEmpty" : true
-      },
+      "label" : "Default region",
+      "description" : "Used when a connector does not specify a region override.",
       "group" : "configuration",
       "binding" : {
         "name" : "region",

--- a/connectors/aws/aws-lambda/element-templates/aws-lambda-outbound-connector.json
+++ b/connectors/aws/aws-lambda/element-templates/aws-lambda-outbound-connector.json
@@ -52,7 +52,7 @@
   }, {
     "id" : "awsCredential",
     "label" : "AWS credential",
-    "description" : "Choose a reusable AWS credential, or configure one-time authentication parameters below.",
+    "description" : "Select a saved AWS credential with an optional default region, or enter authentication details and a region below.",
     "optional" : true,
     "group" : "authentication",
     "binding" : {
@@ -173,6 +173,23 @@
       "type" : "simple"
     },
     "type" : "Hidden"
+  }, {
+    "id" : "regionOverride",
+    "label" : "Region",
+    "description" : "Overrides the default region in the selected credential. Required when the credential has no default region.",
+    "optional" : true,
+    "feel" : "optional",
+    "group" : "configuration",
+    "binding" : {
+      "name" : "configuration.region",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "awsCredential",
+      "isEmpty" : false,
+      "type" : "simple"
+    },
+    "type" : "String"
   }, {
     "id" : "awsFunction.operationType",
     "label" : "Operation type",
@@ -311,7 +328,7 @@
   "configurationTemplates" : [ {
     "id" : "io.camunda:aws-credential:1",
     "kind" : "CREDENTIAL",
-    "version" : 1,
+    "version" : 2,
     "name" : "AWS Credential",
     "properties" : [ {
       "id" : "authentication.type",
@@ -371,10 +388,8 @@
       "secret" : true
     }, {
       "id" : "region",
-      "label" : "Region",
-      "constraints" : {
-        "notEmpty" : true
-      },
+      "label" : "Default region",
+      "description" : "Used when a connector does not specify a region override.",
       "group" : "configuration",
       "binding" : {
         "name" : "region",

--- a/connectors/aws/aws-lambda/element-templates/hybrid/aws-lambda-outbound-connector-hybrid.json
+++ b/connectors/aws/aws-lambda/element-templates/hybrid/aws-lambda-outbound-connector-hybrid.json
@@ -57,7 +57,7 @@
   }, {
     "id" : "awsCredential",
     "label" : "AWS credential",
-    "description" : "Choose a reusable AWS credential, or configure one-time authentication parameters below.",
+    "description" : "Select a saved AWS credential with an optional default region, or enter authentication details and a region below.",
     "optional" : true,
     "group" : "authentication",
     "binding" : {
@@ -178,6 +178,23 @@
       "type" : "simple"
     },
     "type" : "Hidden"
+  }, {
+    "id" : "regionOverride",
+    "label" : "Region",
+    "description" : "Overrides the default region in the selected credential. Required when the credential has no default region.",
+    "optional" : true,
+    "feel" : "optional",
+    "group" : "configuration",
+    "binding" : {
+      "name" : "configuration.region",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "awsCredential",
+      "isEmpty" : false,
+      "type" : "simple"
+    },
+    "type" : "String"
   }, {
     "id" : "awsFunction.operationType",
     "label" : "Operation type",
@@ -316,7 +333,7 @@
   "configurationTemplates" : [ {
     "id" : "io.camunda:aws-credential:1",
     "kind" : "CREDENTIAL",
-    "version" : 1,
+    "version" : 2,
     "name" : "AWS Credential",
     "properties" : [ {
       "id" : "authentication.type",
@@ -376,10 +393,8 @@
       "secret" : true
     }, {
       "id" : "region",
-      "label" : "Region",
-      "constraints" : {
-        "notEmpty" : true
-      },
+      "label" : "Default region",
+      "description" : "Used when a connector does not specify a region override.",
       "group" : "configuration",
       "binding" : {
         "name" : "region",

--- a/connectors/aws/aws-s3/element-templates/aws-s3-outbound-connector.json
+++ b/connectors/aws/aws-s3/element-templates/aws-s3-outbound-connector.json
@@ -78,7 +78,7 @@
   }, {
     "id" : "awsCredential",
     "label" : "AWS credential",
-    "description" : "Choose a reusable AWS credential, or configure one-time authentication parameters below.",
+    "description" : "Select a saved AWS credential with an optional default region, or enter authentication details and a region below.",
     "optional" : true,
     "group" : "authentication",
     "binding" : {
@@ -199,6 +199,23 @@
       "type" : "simple"
     },
     "type" : "Hidden"
+  }, {
+    "id" : "regionOverride",
+    "label" : "Region",
+    "description" : "Overrides the default region in the selected credential. Required when the credential has no default region.",
+    "optional" : true,
+    "feel" : "optional",
+    "group" : "configuration",
+    "binding" : {
+      "name" : "configuration.region",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "awsCredential",
+      "isEmpty" : false,
+      "type" : "simple"
+    },
+    "type" : "String"
   }, {
     "id" : "deleteActionBucket",
     "label" : "AWS bucket",
@@ -664,7 +681,7 @@
   "configurationTemplates" : [ {
     "id" : "io.camunda:aws-credential:1",
     "kind" : "CREDENTIAL",
-    "version" : 1,
+    "version" : 2,
     "name" : "AWS Credential",
     "properties" : [ {
       "id" : "authentication.type",
@@ -724,10 +741,8 @@
       "secret" : true
     }, {
       "id" : "region",
-      "label" : "Region",
-      "constraints" : {
-        "notEmpty" : true
-      },
+      "label" : "Default region",
+      "description" : "Used when a connector does not specify a region override.",
       "group" : "configuration",
       "binding" : {
         "name" : "region",

--- a/connectors/aws/aws-s3/element-templates/hybrid/aws-s3-outbound-connector-hybrid.json
+++ b/connectors/aws/aws-s3/element-templates/hybrid/aws-s3-outbound-connector-hybrid.json
@@ -83,7 +83,7 @@
   }, {
     "id" : "awsCredential",
     "label" : "AWS credential",
-    "description" : "Choose a reusable AWS credential, or configure one-time authentication parameters below.",
+    "description" : "Select a saved AWS credential with an optional default region, or enter authentication details and a region below.",
     "optional" : true,
     "group" : "authentication",
     "binding" : {
@@ -204,6 +204,23 @@
       "type" : "simple"
     },
     "type" : "Hidden"
+  }, {
+    "id" : "regionOverride",
+    "label" : "Region",
+    "description" : "Overrides the default region in the selected credential. Required when the credential has no default region.",
+    "optional" : true,
+    "feel" : "optional",
+    "group" : "configuration",
+    "binding" : {
+      "name" : "configuration.region",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "awsCredential",
+      "isEmpty" : false,
+      "type" : "simple"
+    },
+    "type" : "String"
   }, {
     "id" : "deleteActionBucket",
     "label" : "AWS bucket",
@@ -669,7 +686,7 @@
   "configurationTemplates" : [ {
     "id" : "io.camunda:aws-credential:1",
     "kind" : "CREDENTIAL",
-    "version" : 1,
+    "version" : 2,
     "name" : "AWS Credential",
     "properties" : [ {
       "id" : "authentication.type",
@@ -729,10 +746,8 @@
       "secret" : true
     }, {
       "id" : "region",
-      "label" : "Region",
-      "constraints" : {
-        "notEmpty" : true
-      },
+      "label" : "Default region",
+      "description" : "Used when a connector does not specify a region override.",
       "group" : "configuration",
       "binding" : {
         "name" : "region",

--- a/connectors/aws/aws-sagemaker/element-templates/aws-sagemaker-outbound-connector.json
+++ b/connectors/aws/aws-sagemaker/element-templates/aws-sagemaker-outbound-connector.json
@@ -49,7 +49,7 @@
   }, {
     "id" : "awsCredential",
     "label" : "AWS credential",
-    "description" : "Choose a reusable AWS credential, or configure one-time authentication parameters below.",
+    "description" : "Select a saved AWS credential with an optional default region, or enter authentication details and a region below.",
     "optional" : true,
     "group" : "authentication",
     "binding" : {
@@ -170,6 +170,23 @@
       "type" : "simple"
     },
     "type" : "Hidden"
+  }, {
+    "id" : "regionOverride",
+    "label" : "Region",
+    "description" : "Overrides the default region in the selected credential. Required when the credential has no default region.",
+    "optional" : true,
+    "feel" : "optional",
+    "group" : "configuration",
+    "binding" : {
+      "name" : "configuration.region",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "awsCredential",
+      "isEmpty" : false,
+      "type" : "simple"
+    },
+    "type" : "String"
   }, {
     "id" : "input.invocationType",
     "label" : "Inference type",
@@ -523,7 +540,7 @@
   "configurationTemplates" : [ {
     "id" : "io.camunda:aws-credential:1",
     "kind" : "CREDENTIAL",
-    "version" : 1,
+    "version" : 2,
     "name" : "AWS Credential",
     "properties" : [ {
       "id" : "authentication.type",
@@ -583,10 +600,8 @@
       "secret" : true
     }, {
       "id" : "region",
-      "label" : "Region",
-      "constraints" : {
-        "notEmpty" : true
-      },
+      "label" : "Default region",
+      "description" : "Used when a connector does not specify a region override.",
       "group" : "configuration",
       "binding" : {
         "name" : "region",

--- a/connectors/aws/aws-sagemaker/element-templates/hybrid/aws-sagemaker-outbound-connector-hybrid.json
+++ b/connectors/aws/aws-sagemaker/element-templates/hybrid/aws-sagemaker-outbound-connector-hybrid.json
@@ -54,7 +54,7 @@
   }, {
     "id" : "awsCredential",
     "label" : "AWS credential",
-    "description" : "Choose a reusable AWS credential, or configure one-time authentication parameters below.",
+    "description" : "Select a saved AWS credential with an optional default region, or enter authentication details and a region below.",
     "optional" : true,
     "group" : "authentication",
     "binding" : {
@@ -175,6 +175,23 @@
       "type" : "simple"
     },
     "type" : "Hidden"
+  }, {
+    "id" : "regionOverride",
+    "label" : "Region",
+    "description" : "Overrides the default region in the selected credential. Required when the credential has no default region.",
+    "optional" : true,
+    "feel" : "optional",
+    "group" : "configuration",
+    "binding" : {
+      "name" : "configuration.region",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "awsCredential",
+      "isEmpty" : false,
+      "type" : "simple"
+    },
+    "type" : "String"
   }, {
     "id" : "input.invocationType",
     "label" : "Inference type",
@@ -528,7 +545,7 @@
   "configurationTemplates" : [ {
     "id" : "io.camunda:aws-credential:1",
     "kind" : "CREDENTIAL",
-    "version" : 1,
+    "version" : 2,
     "name" : "AWS Credential",
     "properties" : [ {
       "id" : "authentication.type",
@@ -588,10 +605,8 @@
       "secret" : true
     }, {
       "id" : "region",
-      "label" : "Region",
-      "constraints" : {
-        "notEmpty" : true
-      },
+      "label" : "Default region",
+      "description" : "Used when a connector does not specify a region override.",
       "group" : "configuration",
       "binding" : {
         "name" : "region",

--- a/connectors/aws/aws-sagemaker/src/main/java/io/camunda/connector/sagemaker/suppliers/SageMakeClientSupplier.java
+++ b/connectors/aws/aws-sagemaker/src/main/java/io/camunda/connector/sagemaker/suppliers/SageMakeClientSupplier.java
@@ -13,8 +13,8 @@ import software.amazon.awssdk.services.sagemakerruntime.SageMakerRuntimeClient;
 
 public class SageMakeClientSupplier {
 
-  // Delegates to AwsClientSupport (issue #7083); endpoint override is now honored, and a missing
-  // region falls through to the SDK's default chain instead of throwing NullPointerException.
+  // Delegates to AwsClientSupport (issue #7083); endpoint override is honored and an effective
+  // region is required.
   public SageMakerRuntimeClient getSyncClient(final SageMakerRequest request) {
     return AwsClientSupport.createClient(SageMakerRuntimeClient.builder(), request);
   }

--- a/connectors/aws/aws-sns/element-templates/aws-sns-outbound-connector.json
+++ b/connectors/aws/aws-sns/element-templates/aws-sns-outbound-connector.json
@@ -49,7 +49,7 @@
   }, {
     "id" : "awsCredential",
     "label" : "AWS credential",
-    "description" : "Choose a reusable AWS credential, or configure one-time authentication parameters below.",
+    "description" : "Select a saved AWS credential with an optional default region, or enter authentication details and a region below.",
     "optional" : true,
     "group" : "authentication",
     "binding" : {
@@ -207,6 +207,23 @@
       "type" : "simple"
     },
     "type" : "Hidden"
+  }, {
+    "id" : "regionOverride",
+    "label" : "Region",
+    "description" : "Overrides the default region in the selected credential. Required when the credential has no default region.",
+    "optional" : true,
+    "feel" : "optional",
+    "group" : "configuration",
+    "binding" : {
+      "name" : "configuration.region",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "awsCredential",
+      "isEmpty" : false,
+      "type" : "simple"
+    },
+    "type" : "String"
   }, {
     "id" : "topic.messageGroupId",
     "label" : "Message group ID",
@@ -369,7 +386,7 @@
   "configurationTemplates" : [ {
     "id" : "io.camunda:aws-credential:1",
     "kind" : "CREDENTIAL",
-    "version" : 1,
+    "version" : 2,
     "name" : "AWS Credential",
     "properties" : [ {
       "id" : "authentication.type",
@@ -429,10 +446,8 @@
       "secret" : true
     }, {
       "id" : "region",
-      "label" : "Region",
-      "constraints" : {
-        "notEmpty" : true
-      },
+      "label" : "Default region",
+      "description" : "Used when a connector does not specify a region override.",
       "group" : "configuration",
       "binding" : {
         "name" : "region",

--- a/connectors/aws/aws-sns/element-templates/hybrid/aws-sns-outbound-connector-hybrid.json
+++ b/connectors/aws/aws-sns/element-templates/hybrid/aws-sns-outbound-connector-hybrid.json
@@ -54,7 +54,7 @@
   }, {
     "id" : "awsCredential",
     "label" : "AWS credential",
-    "description" : "Choose a reusable AWS credential, or configure one-time authentication parameters below.",
+    "description" : "Select a saved AWS credential with an optional default region, or enter authentication details and a region below.",
     "optional" : true,
     "group" : "authentication",
     "binding" : {
@@ -212,6 +212,23 @@
       "type" : "simple"
     },
     "type" : "Hidden"
+  }, {
+    "id" : "regionOverride",
+    "label" : "Region",
+    "description" : "Overrides the default region in the selected credential. Required when the credential has no default region.",
+    "optional" : true,
+    "feel" : "optional",
+    "group" : "configuration",
+    "binding" : {
+      "name" : "configuration.region",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "awsCredential",
+      "isEmpty" : false,
+      "type" : "simple"
+    },
+    "type" : "String"
   }, {
     "id" : "topic.messageGroupId",
     "label" : "Message group ID",
@@ -374,7 +391,7 @@
   "configurationTemplates" : [ {
     "id" : "io.camunda:aws-credential:1",
     "kind" : "CREDENTIAL",
-    "version" : 1,
+    "version" : 2,
     "name" : "AWS Credential",
     "properties" : [ {
       "id" : "authentication.type",
@@ -434,10 +451,8 @@
       "secret" : true
     }, {
       "id" : "region",
-      "label" : "Region",
-      "constraints" : {
-        "notEmpty" : true
-      },
+      "label" : "Default region",
+      "description" : "Used when a connector does not specify a region override.",
       "group" : "configuration",
       "binding" : {
         "name" : "region",

--- a/connectors/aws/aws-sqs/element-templates/aws-sqs-boundary-connector.json
+++ b/connectors/aws/aws-sqs/element-templates/aws-sqs-boundary-connector.json
@@ -58,7 +58,7 @@
   }, {
     "id" : "awsCredential",
     "label" : "AWS credential",
-    "description" : "Choose a reusable AWS credential, or configure one-time authentication parameters below.",
+    "description" : "Select a saved AWS credential with an optional default region, or enter authentication details and a region below.",
     "optional" : true,
     "group" : "authentication",
     "binding" : {
@@ -176,6 +176,23 @@
       "type" : "simple"
     },
     "type" : "Hidden"
+  }, {
+    "id" : "regionOverride",
+    "label" : "Region",
+    "description" : "Overrides the default region in the selected credential. Required when the credential has no default region.",
+    "optional" : true,
+    "feel" : "optional",
+    "group" : "configuration",
+    "binding" : {
+      "name" : "configuration.region",
+      "type" : "zeebe:property"
+    },
+    "condition" : {
+      "property" : "awsCredential",
+      "isEmpty" : false,
+      "type" : "simple"
+    },
+    "type" : "String"
   }, {
     "id" : "queue.queue.url",
     "label" : "Queue URL",
@@ -413,7 +430,7 @@
   "configurationTemplates" : [ {
     "id" : "io.camunda:aws-credential:1",
     "kind" : "CREDENTIAL",
-    "version" : 1,
+    "version" : 2,
     "name" : "AWS Credential",
     "properties" : [ {
       "id" : "authentication.type",
@@ -473,10 +490,8 @@
       "secret" : true
     }, {
       "id" : "region",
-      "label" : "Region",
-      "constraints" : {
-        "notEmpty" : true
-      },
+      "label" : "Default region",
+      "description" : "Used when a connector does not specify a region override.",
       "group" : "configuration",
       "binding" : {
         "name" : "region",

--- a/connectors/aws/aws-sqs/element-templates/aws-sqs-inbound-intermediate-connector.json
+++ b/connectors/aws/aws-sqs/element-templates/aws-sqs-inbound-intermediate-connector.json
@@ -58,7 +58,7 @@
   }, {
     "id" : "awsCredential",
     "label" : "AWS credential",
-    "description" : "Choose a reusable AWS credential, or configure one-time authentication parameters below.",
+    "description" : "Select a saved AWS credential with an optional default region, or enter authentication details and a region below.",
     "optional" : true,
     "group" : "authentication",
     "binding" : {
@@ -176,6 +176,23 @@
       "type" : "simple"
     },
     "type" : "Hidden"
+  }, {
+    "id" : "regionOverride",
+    "label" : "Region",
+    "description" : "Overrides the default region in the selected credential. Required when the credential has no default region.",
+    "optional" : true,
+    "feel" : "optional",
+    "group" : "configuration",
+    "binding" : {
+      "name" : "configuration.region",
+      "type" : "zeebe:property"
+    },
+    "condition" : {
+      "property" : "awsCredential",
+      "isEmpty" : false,
+      "type" : "simple"
+    },
+    "type" : "String"
   }, {
     "id" : "queue.queue.url",
     "label" : "Queue URL",
@@ -413,7 +430,7 @@
   "configurationTemplates" : [ {
     "id" : "io.camunda:aws-credential:1",
     "kind" : "CREDENTIAL",
-    "version" : 1,
+    "version" : 2,
     "name" : "AWS Credential",
     "properties" : [ {
       "id" : "authentication.type",
@@ -473,10 +490,8 @@
       "secret" : true
     }, {
       "id" : "region",
-      "label" : "Region",
-      "constraints" : {
-        "notEmpty" : true
-      },
+      "label" : "Default region",
+      "description" : "Used when a connector does not specify a region override.",
       "group" : "configuration",
       "binding" : {
         "name" : "region",

--- a/connectors/aws/aws-sqs/element-templates/aws-sqs-outbound-connector.json
+++ b/connectors/aws/aws-sqs/element-templates/aws-sqs-outbound-connector.json
@@ -49,7 +49,7 @@
   }, {
     "id" : "awsCredential",
     "label" : "AWS credential",
-    "description" : "Choose a reusable AWS credential, or configure one-time authentication parameters below.",
+    "description" : "Select a saved AWS credential with an optional default region, or enter authentication details and a region below.",
     "optional" : true,
     "group" : "authentication",
     "binding" : {
@@ -208,6 +208,23 @@
     },
     "type" : "Hidden"
   }, {
+    "id" : "regionOverride",
+    "label" : "Region",
+    "description" : "Overrides the default region in the selected credential. Required when the credential has no default region.",
+    "optional" : true,
+    "feel" : "optional",
+    "group" : "configuration",
+    "binding" : {
+      "name" : "configuration.region",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "awsCredential",
+      "isEmpty" : false,
+      "type" : "simple"
+    },
+    "type" : "String"
+  }, {
     "id" : "queue.messageBody",
     "label" : "Message body",
     "optional" : false,
@@ -360,7 +377,7 @@
   "configurationTemplates" : [ {
     "id" : "io.camunda:aws-credential:1",
     "kind" : "CREDENTIAL",
-    "version" : 1,
+    "version" : 2,
     "name" : "AWS Credential",
     "properties" : [ {
       "id" : "authentication.type",
@@ -420,10 +437,8 @@
       "secret" : true
     }, {
       "id" : "region",
-      "label" : "Region",
-      "constraints" : {
-        "notEmpty" : true
-      },
+      "label" : "Default region",
+      "description" : "Used when a connector does not specify a region override.",
       "group" : "configuration",
       "binding" : {
         "name" : "region",

--- a/connectors/aws/aws-sqs/element-templates/aws-sqs-receive-connector.json
+++ b/connectors/aws/aws-sqs/element-templates/aws-sqs-receive-connector.json
@@ -57,7 +57,7 @@
   }, {
     "id" : "awsCredential",
     "label" : "AWS credential",
-    "description" : "Choose a reusable AWS credential, or configure one-time authentication parameters below.",
+    "description" : "Select a saved AWS credential with an optional default region, or enter authentication details and a region below.",
     "optional" : true,
     "group" : "authentication",
     "binding" : {
@@ -175,6 +175,23 @@
       "type" : "simple"
     },
     "type" : "Hidden"
+  }, {
+    "id" : "regionOverride",
+    "label" : "Region",
+    "description" : "Overrides the default region in the selected credential. Required when the credential has no default region.",
+    "optional" : true,
+    "feel" : "optional",
+    "group" : "configuration",
+    "binding" : {
+      "name" : "configuration.region",
+      "type" : "zeebe:property"
+    },
+    "condition" : {
+      "property" : "awsCredential",
+      "isEmpty" : false,
+      "type" : "simple"
+    },
+    "type" : "String"
   }, {
     "id" : "queue.queue.url",
     "label" : "Queue URL",
@@ -412,7 +429,7 @@
   "configurationTemplates" : [ {
     "id" : "io.camunda:aws-credential:1",
     "kind" : "CREDENTIAL",
-    "version" : 1,
+    "version" : 2,
     "name" : "AWS Credential",
     "properties" : [ {
       "id" : "authentication.type",
@@ -472,10 +489,8 @@
       "secret" : true
     }, {
       "id" : "region",
-      "label" : "Region",
-      "constraints" : {
-        "notEmpty" : true
-      },
+      "label" : "Default region",
+      "description" : "Used when a connector does not specify a region override.",
       "group" : "configuration",
       "binding" : {
         "name" : "region",

--- a/connectors/aws/aws-sqs/element-templates/aws-sqs-start-message.json
+++ b/connectors/aws/aws-sqs/element-templates/aws-sqs-start-message.json
@@ -58,7 +58,7 @@
   }, {
     "id" : "awsCredential",
     "label" : "AWS credential",
-    "description" : "Choose a reusable AWS credential, or configure one-time authentication parameters below.",
+    "description" : "Select a saved AWS credential with an optional default region, or enter authentication details and a region below.",
     "optional" : true,
     "group" : "authentication",
     "binding" : {
@@ -176,6 +176,23 @@
       "type" : "simple"
     },
     "type" : "Hidden"
+  }, {
+    "id" : "regionOverride",
+    "label" : "Region",
+    "description" : "Overrides the default region in the selected credential. Required when the credential has no default region.",
+    "optional" : true,
+    "feel" : "optional",
+    "group" : "configuration",
+    "binding" : {
+      "name" : "configuration.region",
+      "type" : "zeebe:property"
+    },
+    "condition" : {
+      "property" : "awsCredential",
+      "isEmpty" : false,
+      "type" : "simple"
+    },
+    "type" : "String"
   }, {
     "id" : "queue.queue.url",
     "label" : "Queue URL",
@@ -441,7 +458,7 @@
   "configurationTemplates" : [ {
     "id" : "io.camunda:aws-credential:1",
     "kind" : "CREDENTIAL",
-    "version" : 1,
+    "version" : 2,
     "name" : "AWS Credential",
     "properties" : [ {
       "id" : "authentication.type",
@@ -501,10 +518,8 @@
       "secret" : true
     }, {
       "id" : "region",
-      "label" : "Region",
-      "constraints" : {
-        "notEmpty" : true
-      },
+      "label" : "Default region",
+      "description" : "Used when a connector does not specify a region override.",
       "group" : "configuration",
       "binding" : {
         "name" : "region",

--- a/connectors/aws/aws-sqs/element-templates/hybrid/aws-sqs-boundary-connector-hybrid.json
+++ b/connectors/aws/aws-sqs/element-templates/hybrid/aws-sqs-boundary-connector-hybrid.json
@@ -63,7 +63,7 @@
   }, {
     "id" : "awsCredential",
     "label" : "AWS credential",
-    "description" : "Choose a reusable AWS credential, or configure one-time authentication parameters below.",
+    "description" : "Select a saved AWS credential with an optional default region, or enter authentication details and a region below.",
     "optional" : true,
     "group" : "authentication",
     "binding" : {
@@ -181,6 +181,23 @@
       "type" : "simple"
     },
     "type" : "Hidden"
+  }, {
+    "id" : "regionOverride",
+    "label" : "Region",
+    "description" : "Overrides the default region in the selected credential. Required when the credential has no default region.",
+    "optional" : true,
+    "feel" : "optional",
+    "group" : "configuration",
+    "binding" : {
+      "name" : "configuration.region",
+      "type" : "zeebe:property"
+    },
+    "condition" : {
+      "property" : "awsCredential",
+      "isEmpty" : false,
+      "type" : "simple"
+    },
+    "type" : "String"
   }, {
     "id" : "queue.queue.url",
     "label" : "Queue URL",
@@ -418,7 +435,7 @@
   "configurationTemplates" : [ {
     "id" : "io.camunda:aws-credential:1",
     "kind" : "CREDENTIAL",
-    "version" : 1,
+    "version" : 2,
     "name" : "AWS Credential",
     "properties" : [ {
       "id" : "authentication.type",
@@ -478,10 +495,8 @@
       "secret" : true
     }, {
       "id" : "region",
-      "label" : "Region",
-      "constraints" : {
-        "notEmpty" : true
-      },
+      "label" : "Default region",
+      "description" : "Used when a connector does not specify a region override.",
       "group" : "configuration",
       "binding" : {
         "name" : "region",

--- a/connectors/aws/aws-sqs/element-templates/hybrid/aws-sqs-inbound-intermediate-connector-hybrid.json
+++ b/connectors/aws/aws-sqs/element-templates/hybrid/aws-sqs-inbound-intermediate-connector-hybrid.json
@@ -63,7 +63,7 @@
   }, {
     "id" : "awsCredential",
     "label" : "AWS credential",
-    "description" : "Choose a reusable AWS credential, or configure one-time authentication parameters below.",
+    "description" : "Select a saved AWS credential with an optional default region, or enter authentication details and a region below.",
     "optional" : true,
     "group" : "authentication",
     "binding" : {
@@ -181,6 +181,23 @@
       "type" : "simple"
     },
     "type" : "Hidden"
+  }, {
+    "id" : "regionOverride",
+    "label" : "Region",
+    "description" : "Overrides the default region in the selected credential. Required when the credential has no default region.",
+    "optional" : true,
+    "feel" : "optional",
+    "group" : "configuration",
+    "binding" : {
+      "name" : "configuration.region",
+      "type" : "zeebe:property"
+    },
+    "condition" : {
+      "property" : "awsCredential",
+      "isEmpty" : false,
+      "type" : "simple"
+    },
+    "type" : "String"
   }, {
     "id" : "queue.queue.url",
     "label" : "Queue URL",
@@ -418,7 +435,7 @@
   "configurationTemplates" : [ {
     "id" : "io.camunda:aws-credential:1",
     "kind" : "CREDENTIAL",
-    "version" : 1,
+    "version" : 2,
     "name" : "AWS Credential",
     "properties" : [ {
       "id" : "authentication.type",
@@ -478,10 +495,8 @@
       "secret" : true
     }, {
       "id" : "region",
-      "label" : "Region",
-      "constraints" : {
-        "notEmpty" : true
-      },
+      "label" : "Default region",
+      "description" : "Used when a connector does not specify a region override.",
       "group" : "configuration",
       "binding" : {
         "name" : "region",

--- a/connectors/aws/aws-sqs/element-templates/hybrid/aws-sqs-outbound-connector-hybrid.json
+++ b/connectors/aws/aws-sqs/element-templates/hybrid/aws-sqs-outbound-connector-hybrid.json
@@ -54,7 +54,7 @@
   }, {
     "id" : "awsCredential",
     "label" : "AWS credential",
-    "description" : "Choose a reusable AWS credential, or configure one-time authentication parameters below.",
+    "description" : "Select a saved AWS credential with an optional default region, or enter authentication details and a region below.",
     "optional" : true,
     "group" : "authentication",
     "binding" : {
@@ -213,6 +213,23 @@
     },
     "type" : "Hidden"
   }, {
+    "id" : "regionOverride",
+    "label" : "Region",
+    "description" : "Overrides the default region in the selected credential. Required when the credential has no default region.",
+    "optional" : true,
+    "feel" : "optional",
+    "group" : "configuration",
+    "binding" : {
+      "name" : "configuration.region",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "awsCredential",
+      "isEmpty" : false,
+      "type" : "simple"
+    },
+    "type" : "String"
+  }, {
     "id" : "queue.messageBody",
     "label" : "Message body",
     "optional" : false,
@@ -365,7 +382,7 @@
   "configurationTemplates" : [ {
     "id" : "io.camunda:aws-credential:1",
     "kind" : "CREDENTIAL",
-    "version" : 1,
+    "version" : 2,
     "name" : "AWS Credential",
     "properties" : [ {
       "id" : "authentication.type",
@@ -425,10 +442,8 @@
       "secret" : true
     }, {
       "id" : "region",
-      "label" : "Region",
-      "constraints" : {
-        "notEmpty" : true
-      },
+      "label" : "Default region",
+      "description" : "Used when a connector does not specify a region override.",
       "group" : "configuration",
       "binding" : {
         "name" : "region",

--- a/connectors/aws/aws-sqs/element-templates/hybrid/aws-sqs-receive-connector-hybrid.json
+++ b/connectors/aws/aws-sqs/element-templates/hybrid/aws-sqs-receive-connector-hybrid.json
@@ -62,7 +62,7 @@
   }, {
     "id" : "awsCredential",
     "label" : "AWS credential",
-    "description" : "Choose a reusable AWS credential, or configure one-time authentication parameters below.",
+    "description" : "Select a saved AWS credential with an optional default region, or enter authentication details and a region below.",
     "optional" : true,
     "group" : "authentication",
     "binding" : {
@@ -180,6 +180,23 @@
       "type" : "simple"
     },
     "type" : "Hidden"
+  }, {
+    "id" : "regionOverride",
+    "label" : "Region",
+    "description" : "Overrides the default region in the selected credential. Required when the credential has no default region.",
+    "optional" : true,
+    "feel" : "optional",
+    "group" : "configuration",
+    "binding" : {
+      "name" : "configuration.region",
+      "type" : "zeebe:property"
+    },
+    "condition" : {
+      "property" : "awsCredential",
+      "isEmpty" : false,
+      "type" : "simple"
+    },
+    "type" : "String"
   }, {
     "id" : "queue.queue.url",
     "label" : "Queue URL",
@@ -417,7 +434,7 @@
   "configurationTemplates" : [ {
     "id" : "io.camunda:aws-credential:1",
     "kind" : "CREDENTIAL",
-    "version" : 1,
+    "version" : 2,
     "name" : "AWS Credential",
     "properties" : [ {
       "id" : "authentication.type",
@@ -477,10 +494,8 @@
       "secret" : true
     }, {
       "id" : "region",
-      "label" : "Region",
-      "constraints" : {
-        "notEmpty" : true
-      },
+      "label" : "Default region",
+      "description" : "Used when a connector does not specify a region override.",
       "group" : "configuration",
       "binding" : {
         "name" : "region",

--- a/connectors/aws/aws-sqs/element-templates/hybrid/aws-sqs-start-message-hybrid.json
+++ b/connectors/aws/aws-sqs/element-templates/hybrid/aws-sqs-start-message-hybrid.json
@@ -63,7 +63,7 @@
   }, {
     "id" : "awsCredential",
     "label" : "AWS credential",
-    "description" : "Choose a reusable AWS credential, or configure one-time authentication parameters below.",
+    "description" : "Select a saved AWS credential with an optional default region, or enter authentication details and a region below.",
     "optional" : true,
     "group" : "authentication",
     "binding" : {
@@ -181,6 +181,23 @@
       "type" : "simple"
     },
     "type" : "Hidden"
+  }, {
+    "id" : "regionOverride",
+    "label" : "Region",
+    "description" : "Overrides the default region in the selected credential. Required when the credential has no default region.",
+    "optional" : true,
+    "feel" : "optional",
+    "group" : "configuration",
+    "binding" : {
+      "name" : "configuration.region",
+      "type" : "zeebe:property"
+    },
+    "condition" : {
+      "property" : "awsCredential",
+      "isEmpty" : false,
+      "type" : "simple"
+    },
+    "type" : "String"
   }, {
     "id" : "queue.queue.url",
     "label" : "Queue URL",
@@ -446,7 +463,7 @@
   "configurationTemplates" : [ {
     "id" : "io.camunda:aws-credential:1",
     "kind" : "CREDENTIAL",
-    "version" : 1,
+    "version" : 2,
     "name" : "AWS Credential",
     "properties" : [ {
       "id" : "authentication.type",
@@ -506,10 +523,8 @@
       "secret" : true
     }, {
       "id" : "region",
-      "label" : "Region",
-      "constraints" : {
-        "notEmpty" : true
-      },
+      "label" : "Default region",
+      "description" : "Used when a connector does not specify a region override.",
       "group" : "configuration",
       "binding" : {
         "name" : "region",

--- a/connectors/aws/aws-textract/element-templates/aws-textract-outbound-connector.json
+++ b/connectors/aws/aws-textract/element-templates/aws-textract-outbound-connector.json
@@ -55,7 +55,7 @@
   }, {
     "id" : "awsCredential",
     "label" : "AWS credential",
-    "description" : "Choose a reusable AWS credential, or configure one-time authentication parameters below.",
+    "description" : "Select a saved AWS credential with an optional default region, or enter authentication details and a region below.",
     "optional" : true,
     "group" : "authentication",
     "binding" : {
@@ -176,6 +176,23 @@
       "type" : "simple"
     },
     "type" : "Hidden"
+  }, {
+    "id" : "regionOverride",
+    "label" : "Region",
+    "description" : "Overrides the default region in the selected credential. Required when the credential has no default region.",
+    "optional" : true,
+    "feel" : "optional",
+    "group" : "configuration",
+    "binding" : {
+      "name" : "configuration.region",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "awsCredential",
+      "isEmpty" : false,
+      "type" : "simple"
+    },
+    "type" : "String"
   }, {
     "id" : "input.documentLocationType",
     "label" : "Document location",
@@ -726,7 +743,7 @@
   "configurationTemplates" : [ {
     "id" : "io.camunda:aws-credential:1",
     "kind" : "CREDENTIAL",
-    "version" : 1,
+    "version" : 2,
     "name" : "AWS Credential",
     "properties" : [ {
       "id" : "authentication.type",
@@ -786,10 +803,8 @@
       "secret" : true
     }, {
       "id" : "region",
-      "label" : "Region",
-      "constraints" : {
-        "notEmpty" : true
-      },
+      "label" : "Default region",
+      "description" : "Used when a connector does not specify a region override.",
       "group" : "configuration",
       "binding" : {
         "name" : "region",

--- a/connectors/aws/aws-textract/element-templates/hybrid/aws-textract-outbound-connector-hybrid.json
+++ b/connectors/aws/aws-textract/element-templates/hybrid/aws-textract-outbound-connector-hybrid.json
@@ -60,7 +60,7 @@
   }, {
     "id" : "awsCredential",
     "label" : "AWS credential",
-    "description" : "Choose a reusable AWS credential, or configure one-time authentication parameters below.",
+    "description" : "Select a saved AWS credential with an optional default region, or enter authentication details and a region below.",
     "optional" : true,
     "group" : "authentication",
     "binding" : {
@@ -181,6 +181,23 @@
       "type" : "simple"
     },
     "type" : "Hidden"
+  }, {
+    "id" : "regionOverride",
+    "label" : "Region",
+    "description" : "Overrides the default region in the selected credential. Required when the credential has no default region.",
+    "optional" : true,
+    "feel" : "optional",
+    "group" : "configuration",
+    "binding" : {
+      "name" : "configuration.region",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "awsCredential",
+      "isEmpty" : false,
+      "type" : "simple"
+    },
+    "type" : "String"
   }, {
     "id" : "input.documentLocationType",
     "label" : "Document location",
@@ -731,7 +748,7 @@
   "configurationTemplates" : [ {
     "id" : "io.camunda:aws-credential:1",
     "kind" : "CREDENTIAL",
-    "version" : 1,
+    "version" : 2,
     "name" : "AWS Credential",
     "properties" : [ {
       "id" : "authentication.type",
@@ -791,10 +808,8 @@
       "secret" : true
     }, {
       "id" : "region",
-      "label" : "Region",
-      "constraints" : {
-        "notEmpty" : true
-      },
+      "label" : "Default region",
+      "description" : "Used when a connector does not specify a region override.",
       "group" : "configuration",
       "binding" : {
         "name" : "region",

--- a/connectors/http/graphql/element-templates/graphql-outbound-connector.json
+++ b/connectors/http/graphql/element-templates/graphql-outbound-connector.json
@@ -608,13 +608,6 @@
     "label" : "URL",
     "description" : "Overrides the URL carried by the selected credential. Required when the credential carries none, as an OAuth credential need not.",
     "optional" : true,
-    "constraints" : {
-      "notEmpty" : false,
-      "pattern" : {
-        "value" : "^($|=|(http://|https://|secrets|\\{\\{).*$)",
-        "message" : "Must be a http(s) URL"
-      }
-    },
     "feel" : "optional",
     "group" : "endpoint",
     "binding" : {
@@ -809,7 +802,7 @@
   "configurationTemplates" : [ {
     "id" : "io.camunda.connectors:rest-authentication:1",
     "kind" : "CREDENTIAL",
-    "version" : 1,
+    "version" : 2,
     "name" : "REST Authentication",
     "properties" : [ {
       "id" : "authentication.type",
@@ -1077,7 +1070,7 @@
       },
       "group" : "authentication",
       "binding" : {
-        "name" : "authentication.oauthRefreshToken.oauthTokenEndpoint",
+        "name" : "authentication.oauthTokenEndpoint",
         "type" : "property"
       },
       "condition" : {
@@ -1094,7 +1087,7 @@
       },
       "group" : "authentication",
       "binding" : {
-        "name" : "authentication.oauthRefreshToken.clientId",
+        "name" : "authentication.clientId",
         "type" : "property"
       },
       "condition" : {
@@ -1109,7 +1102,7 @@
       "label" : "Client secret",
       "group" : "authentication",
       "binding" : {
-        "name" : "authentication.oauthRefreshToken.clientSecret",
+        "name" : "authentication.clientSecret",
         "type" : "property"
       },
       "condition" : {
@@ -1128,7 +1121,7 @@
       },
       "group" : "authentication",
       "binding" : {
-        "name" : "authentication.oauthRefreshToken.refreshToken",
+        "name" : "authentication.refreshToken",
         "type" : "property"
       },
       "condition" : {
@@ -1144,7 +1137,7 @@
       "label" : "Scopes",
       "group" : "authentication",
       "binding" : {
-        "name" : "authentication.oauthRefreshToken.scopes",
+        "name" : "authentication.scopes",
         "type" : "property"
       },
       "condition" : {
@@ -1157,9 +1150,9 @@
     }, {
       "id" : "url",
       "label" : "URL",
-      "description" : "The endpoint this credential is bound to. Required for basic, bearer and API key authentication; optional for OAuth, which carries its own token endpoint.",
+      "description" : "The endpoint this credential is bound to. Required for basic, bearer and API key authentication; not shown for OAuth, which carries its own token endpoint.",
       "constraints" : {
-        "notEmpty" : false,
+        "notEmpty" : true,
         "pattern" : {
           "value" : "^((http://|https://|secrets|\\{\\{).*$)",
           "message" : "Must be a http(s) URL"
@@ -1169,6 +1162,11 @@
       "binding" : {
         "name" : "url",
         "type" : "property"
+      },
+      "condition" : {
+        "property" : "authentication.type",
+        "oneOf" : [ "apiKey", "basic", "bearer" ],
+        "type" : "simple"
       },
       "type" : "String"
     } ]

--- a/connectors/http/graphql/element-templates/hybrid/graphql-outbound-connector-hybrid.json
+++ b/connectors/http/graphql/element-templates/hybrid/graphql-outbound-connector-hybrid.json
@@ -613,13 +613,6 @@
     "label" : "URL",
     "description" : "Overrides the URL carried by the selected credential. Required when the credential carries none, as an OAuth credential need not.",
     "optional" : true,
-    "constraints" : {
-      "notEmpty" : false,
-      "pattern" : {
-        "value" : "^($|=|(http://|https://|secrets|\\{\\{).*$)",
-        "message" : "Must be a http(s) URL"
-      }
-    },
     "feel" : "optional",
     "group" : "endpoint",
     "binding" : {
@@ -814,7 +807,7 @@
   "configurationTemplates" : [ {
     "id" : "io.camunda.connectors:rest-authentication:1",
     "kind" : "CREDENTIAL",
-    "version" : 1,
+    "version" : 2,
     "name" : "REST Authentication",
     "properties" : [ {
       "id" : "authentication.type",
@@ -1082,7 +1075,7 @@
       },
       "group" : "authentication",
       "binding" : {
-        "name" : "authentication.oauthRefreshToken.oauthTokenEndpoint",
+        "name" : "authentication.oauthTokenEndpoint",
         "type" : "property"
       },
       "condition" : {
@@ -1099,7 +1092,7 @@
       },
       "group" : "authentication",
       "binding" : {
-        "name" : "authentication.oauthRefreshToken.clientId",
+        "name" : "authentication.clientId",
         "type" : "property"
       },
       "condition" : {
@@ -1114,7 +1107,7 @@
       "label" : "Client secret",
       "group" : "authentication",
       "binding" : {
-        "name" : "authentication.oauthRefreshToken.clientSecret",
+        "name" : "authentication.clientSecret",
         "type" : "property"
       },
       "condition" : {
@@ -1133,7 +1126,7 @@
       },
       "group" : "authentication",
       "binding" : {
-        "name" : "authentication.oauthRefreshToken.refreshToken",
+        "name" : "authentication.refreshToken",
         "type" : "property"
       },
       "condition" : {
@@ -1149,7 +1142,7 @@
       "label" : "Scopes",
       "group" : "authentication",
       "binding" : {
-        "name" : "authentication.oauthRefreshToken.scopes",
+        "name" : "authentication.scopes",
         "type" : "property"
       },
       "condition" : {
@@ -1162,9 +1155,9 @@
     }, {
       "id" : "url",
       "label" : "URL",
-      "description" : "The endpoint this credential is bound to. Required for basic, bearer and API key authentication; optional for OAuth, which carries its own token endpoint.",
+      "description" : "The endpoint this credential is bound to. Required for basic, bearer and API key authentication; not shown for OAuth, which carries its own token endpoint.",
       "constraints" : {
-        "notEmpty" : false,
+        "notEmpty" : true,
         "pattern" : {
           "value" : "^((http://|https://|secrets|\\{\\{).*$)",
           "message" : "Must be a http(s) URL"
@@ -1174,6 +1167,11 @@
       "binding" : {
         "name" : "url",
         "type" : "property"
+      },
+      "condition" : {
+        "property" : "authentication.type",
+        "oneOf" : [ "apiKey", "basic", "bearer" ],
+        "type" : "simple"
       },
       "type" : "String"
     } ]

--- a/connectors/http/graphql/src/main/java/io/camunda/connector/http/graphql/model/GraphQLRequest.java
+++ b/connectors/http/graphql/src/main/java/io/camunda/connector/http/graphql/model/GraphQLRequest.java
@@ -74,7 +74,9 @@ public record GraphQLRequest(
     // optional override rather than a required field. Declared on the outer record (rather than
     // inside GraphQL) so the nested record's canonical constructor stays untouched; the explicit
     // binding is what places it on `graphql.url`. Never populated - the engine writes a single
-    // `graphql.url` input, which Jackson binds to GraphQL#url above.
+    // `graphql.url` input, which Jackson binds to GraphQL#url above. Keep this component
+    // constraint-free: Modeler's field validator applies patterns to an undefined optional value,
+    // while runtime validation still applies the URL pattern to GraphQL#url.
     @TemplateProperty(
             id = "urlOverride",
             group = "endpoint",
@@ -86,12 +88,6 @@ public record GraphQLRequest(
                 @PropertyCondition(
                     property = "authenticationConfiguration",
                     isEmpty = NullableBoolean.FALSE),
-            constraints =
-                @TemplateProperty.PropertyConstraints(
-                    pattern =
-                        @TemplateProperty.Pattern(
-                            value = HttpCommonRequest.URL_PATTERN,
-                            message = HttpCommonRequest.URL_PATTERN_MESSAGE)),
             description =
                 "Overrides the URL carried by the selected credential. Required when the credential"
                     + " carries none, as an OAuth credential need not.")

--- a/connectors/http/graphql/src/test/java/io/camunda/connector/http/graphql/GraphQLFunctionTest.java
+++ b/connectors/http/graphql/src/test/java/io/camunda/connector/http/graphql/GraphQLFunctionTest.java
@@ -170,6 +170,33 @@ public class GraphQLFunctionTest extends BaseTest {
         .isEqualTo("http://localhost:8087/other-path");
   }
 
+  @Test
+  void malformedInlineUrlIsRejectedWhenCredentialIsBound() {
+    String variables =
+        """
+        {
+          "graphql": {
+            "query": "query { field }",
+            "method": "get",
+            "url": "not-a-url"
+          },
+          "authenticationConfiguration": {
+            "authentication": { "type": "bearer", "token": "valid-token" },
+            "url": "http://localhost:8087/graphql"
+          }
+        }
+        """;
+    var context =
+        OutboundConnectorContextBuilder.create()
+            .variables(variables)
+            .includeAllValidators()
+            .build();
+
+    assertThatThrownBy(() -> context.bindVariables(GraphQLRequest.class))
+        .isInstanceOf(ConnectorInputException.class)
+        .hasMessageContaining("Must be a http(s) URL");
+  }
+
   /**
    * The URL may come from the credential instead of the model, so it is asserted on the effective
    * value ({@code isUrlPresent()}) rather than by a {@code @NotBlank} on the component - a model

--- a/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/model/HttpCommonRequest.java
+++ b/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/model/HttpCommonRequest.java
@@ -36,10 +36,9 @@ import java.util.Optional;
 public class HttpCommonRequest {
 
   /**
-   * Shared by every URL property built on this model, inline or credential-override. Matches the
-   * empty string too: the override field is optional, and without that alternative Modeler's
-   * client-side pattern check rejects a blank value even though {@code notEmpty} correctly allows
-   * it - requiredness and shape are two different constraints.
+   * Shared by runtime validation and required inline URL properties. Matches the empty string so
+   * Modeler reports requiredness through {@code notEmpty} instead of also reporting a pattern
+   * violation.
    */
   @TemplateProperty(ignore = true)
   public static final String URL_PATTERN = "^($|=|(http://|https://|secrets|\\{\\{).*$)";
@@ -84,7 +83,9 @@ public class HttpCommonRequest {
   // Template-only twin of `url`, bound to the same `url` input and shown in its place once a
   // credential is chosen: there the URL may come from the credential, so the inline value is an
   // optional override rather than a required field. Never populated - the engine writes a single
-  // `url` input, which Jackson binds to the field above.
+  // `url` input, which Jackson binds to the field above. Keep this twin constraint-free: Modeler's
+  // field validator applies patterns to an undefined optional value, while runtime validation still
+  // applies the URL pattern to the actual `url` field.
   @JsonIgnore
   @TemplateProperty(
       id = "urlOverride",
@@ -97,10 +98,6 @@ public class HttpCommonRequest {
           @PropertyCondition(
               property = "authenticationConfiguration",
               isEmpty = NullableBoolean.FALSE),
-      constraints =
-          @TemplateProperty.PropertyConstraints(
-              pattern =
-                  @TemplateProperty.Pattern(value = URL_PATTERN, message = URL_PATTERN_MESSAGE)),
       description =
           "Overrides the URL carried by the selected credential. Required when the credential"
               + " carries none, as an OAuth credential need not.")

--- a/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/model/auth/RestAuthenticationConfiguration.java
+++ b/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/model/auth/RestAuthenticationConfiguration.java
@@ -9,6 +9,8 @@ package io.camunda.connector.http.base.model.auth;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.connector.api.annotation.Configuration;
 import io.camunda.connector.generator.java.annotation.TemplateProperty;
+import io.camunda.connector.generator.java.annotation.TemplateProperty.PropertyCondition;
+import io.camunda.connector.generator.java.annotation.TemplateProperty.PropertyConstraints;
 import io.camunda.connector.hostvalidator.VerifiedHost;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.AssertTrue;
@@ -31,16 +33,16 @@ import jakarta.validation.constraints.Pattern;
  * @param authentication the reusable authentication. Never {@link NoAuthentication}.
  * @param url the endpoint this credential is bound to. Mandatory for the authentication types that
  *     are meaningless without one — a static secret: basic, bearer or API key (see {@link
- *     #requiresUrl(Authentication)}). The OAuth variants already carry their own token endpoint and
- *     are routinely reused across resource URLs, so for them it is optional. Whichever type is
- *     chosen, the consuming connector's inline URL — when the process author sets one — wins over
- *     this value: binding a credential and pointing a task at a URL are both decisions of the same
- *     process author, so an override is a modelling choice rather than an escalation, and there is
- *     no attempt to constrain it here.
+ *     #requiresUrl(Authentication)}) — and, to keep the field's required-ness honest in Modeler,
+ *     hidden entirely for the OAuth variants, which already carry their own token endpoint and are
+ *     routinely reused across resource URLs. Whichever type is chosen, the consuming connector's
+ *     inline URL — when the process author sets one — wins over this value: binding a credential
+ *     and pointing a task at a URL are both decisions of the same process author, so an override is
+ *     a modelling choice rather than an escalation, and there is no attempt to constrain it here.
  */
 @Configuration(
     id = "io.camunda.connectors:rest-authentication:1",
-    version = 1,
+    version = 2,
     name = "REST Authentication")
 public record RestAuthenticationConfiguration(
     @Valid
@@ -58,10 +60,19 @@ public record RestAuthenticationConfiguration(
         @TemplateProperty(
             group = "endpoint",
             label = "URL",
-            optional = true,
             description =
                 "The endpoint this credential is bound to. Required for basic, bearer and API key"
-                    + " authentication; optional for OAuth, which carries its own token endpoint.")
+                    + " authentication; not shown for OAuth, which carries its own token"
+                    + " endpoint.",
+            condition =
+                @PropertyCondition(
+                    property = "authentication.type",
+                    oneOf = {
+                      ApiKeyAuthentication.TYPE,
+                      BasicAuthentication.TYPE,
+                      BearerAuthentication.TYPE
+                    }),
+            constraints = @PropertyConstraints(notEmpty = true))
         String url) {
 
   /**
@@ -97,10 +108,11 @@ public record RestAuthenticationConfiguration(
   }
 
   /**
-   * The URL is mandatory exactly when the chosen authentication type requires one. Enforced on the
-   * record (not as a {@code @NotBlank} on the component) because the requirement is conditional —
-   * an OAuth credential legitimately has no URL — and the element template cannot express a
-   * per-authentication-type constraint on a single field.
+   * The URL is mandatory exactly when the chosen authentication type requires one. The element
+   * template above enforces this in Modeler: the field is shown, and required, only for the
+   * authentication types {@link #requiresUrl(Authentication)} names. This method remains the
+   * backstop for paths that bypass Modeler entirely — a hand-edited BPMN file or a credential
+   * constructed directly against the API.
    */
   @AssertTrue(message = "URL is required for this authentication type")
   @JsonIgnore

--- a/connectors/http/http-base/src/test/java/io/camunda/connector/http/base/model/auth/RestAuthenticationConfigurationTest.java
+++ b/connectors/http/http-base/src/test/java/io/camunda/connector/http/base/model/auth/RestAuthenticationConfigurationTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.http.base.model.auth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.connector.jackson.ConnectorsObjectMapperSupplier;
+import io.camunda.connector.runtime.core.validation.ValidationUtil;
+import org.junit.jupiter.api.Test;
+
+class RestAuthenticationConfigurationTest {
+
+  @Test
+  void refreshTokenCredentialPayloadUsesFlatRuntimeFields() throws Exception {
+    var configuration =
+        ConnectorsObjectMapperSupplier.getCopy()
+            .readValue(
+                """
+                {
+                  "authentication": {
+                    "type": "oauth-refresh-token",
+                    "oauthTokenEndpoint": "https://example.com/oauth/token",
+                    "clientId": "client-id",
+                    "clientSecret": "client-secret",
+                    "refreshToken": "refresh-token",
+                    "scopes": "openid offline_access"
+                  }
+                }
+                """,
+                RestAuthenticationConfiguration.class);
+
+    ValidationUtil.discoverDefaultValidationProviderImplementation().validate(configuration);
+
+    assertThat(configuration.authentication())
+        .isEqualTo(
+            new OAuthRefreshTokenAuthentication(
+                "https://example.com/oauth/token",
+                "client-id",
+                "client-secret",
+                "refresh-token",
+                "openid offline_access"));
+    assertThat(configuration.url()).isNull();
+  }
+}

--- a/connectors/http/polling/element-templates/http-polling-boundary-catch-event-connector.json
+++ b/connectors/http/polling/element-templates/http-polling-boundary-catch-event-connector.json
@@ -592,13 +592,6 @@
     "label" : "URL",
     "description" : "Overrides the URL carried by the selected credential. Required when the credential carries none, as an OAuth credential need not.",
     "optional" : true,
-    "constraints" : {
-      "notEmpty" : false,
-      "pattern" : {
-        "value" : "^($|=|(http://|https://|secrets|\\{\\{).*$)",
-        "message" : "Must be a http(s) URL"
-      }
-    },
     "feel" : "optional",
     "group" : "endpoint",
     "binding" : {
@@ -850,7 +843,7 @@
   "configurationTemplates" : [ {
     "id" : "io.camunda.connectors:rest-authentication:1",
     "kind" : "CREDENTIAL",
-    "version" : 1,
+    "version" : 2,
     "name" : "REST Authentication",
     "properties" : [ {
       "id" : "authentication.type",
@@ -1118,7 +1111,7 @@
       },
       "group" : "authentication",
       "binding" : {
-        "name" : "authentication.oauthRefreshToken.oauthTokenEndpoint",
+        "name" : "authentication.oauthTokenEndpoint",
         "type" : "property"
       },
       "condition" : {
@@ -1135,7 +1128,7 @@
       },
       "group" : "authentication",
       "binding" : {
-        "name" : "authentication.oauthRefreshToken.clientId",
+        "name" : "authentication.clientId",
         "type" : "property"
       },
       "condition" : {
@@ -1150,7 +1143,7 @@
       "label" : "Client secret",
       "group" : "authentication",
       "binding" : {
-        "name" : "authentication.oauthRefreshToken.clientSecret",
+        "name" : "authentication.clientSecret",
         "type" : "property"
       },
       "condition" : {
@@ -1169,7 +1162,7 @@
       },
       "group" : "authentication",
       "binding" : {
-        "name" : "authentication.oauthRefreshToken.refreshToken",
+        "name" : "authentication.refreshToken",
         "type" : "property"
       },
       "condition" : {
@@ -1185,7 +1178,7 @@
       "label" : "Scopes",
       "group" : "authentication",
       "binding" : {
-        "name" : "authentication.oauthRefreshToken.scopes",
+        "name" : "authentication.scopes",
         "type" : "property"
       },
       "condition" : {
@@ -1198,9 +1191,9 @@
     }, {
       "id" : "url",
       "label" : "URL",
-      "description" : "The endpoint this credential is bound to. Required for basic, bearer and API key authentication; optional for OAuth, which carries its own token endpoint.",
+      "description" : "The endpoint this credential is bound to. Required for basic, bearer and API key authentication; not shown for OAuth, which carries its own token endpoint.",
       "constraints" : {
-        "notEmpty" : false,
+        "notEmpty" : true,
         "pattern" : {
           "value" : "^((http://|https://|secrets|\\{\\{).*$)",
           "message" : "Must be a http(s) URL"
@@ -1210,6 +1203,11 @@
       "binding" : {
         "name" : "url",
         "type" : "property"
+      },
+      "condition" : {
+        "property" : "authentication.type",
+        "oneOf" : [ "apiKey", "basic", "bearer" ],
+        "type" : "simple"
       },
       "type" : "String"
     } ]

--- a/connectors/http/polling/element-templates/http-polling-connector.json
+++ b/connectors/http/polling/element-templates/http-polling-connector.json
@@ -592,13 +592,6 @@
     "label" : "URL",
     "description" : "Overrides the URL carried by the selected credential. Required when the credential carries none, as an OAuth credential need not.",
     "optional" : true,
-    "constraints" : {
-      "notEmpty" : false,
-      "pattern" : {
-        "value" : "^($|=|(http://|https://|secrets|\\{\\{).*$)",
-        "message" : "Must be a http(s) URL"
-      }
-    },
     "feel" : "optional",
     "group" : "endpoint",
     "binding" : {
@@ -850,7 +843,7 @@
   "configurationTemplates" : [ {
     "id" : "io.camunda.connectors:rest-authentication:1",
     "kind" : "CREDENTIAL",
-    "version" : 1,
+    "version" : 2,
     "name" : "REST Authentication",
     "properties" : [ {
       "id" : "authentication.type",
@@ -1118,7 +1111,7 @@
       },
       "group" : "authentication",
       "binding" : {
-        "name" : "authentication.oauthRefreshToken.oauthTokenEndpoint",
+        "name" : "authentication.oauthTokenEndpoint",
         "type" : "property"
       },
       "condition" : {
@@ -1135,7 +1128,7 @@
       },
       "group" : "authentication",
       "binding" : {
-        "name" : "authentication.oauthRefreshToken.clientId",
+        "name" : "authentication.clientId",
         "type" : "property"
       },
       "condition" : {
@@ -1150,7 +1143,7 @@
       "label" : "Client secret",
       "group" : "authentication",
       "binding" : {
-        "name" : "authentication.oauthRefreshToken.clientSecret",
+        "name" : "authentication.clientSecret",
         "type" : "property"
       },
       "condition" : {
@@ -1169,7 +1162,7 @@
       },
       "group" : "authentication",
       "binding" : {
-        "name" : "authentication.oauthRefreshToken.refreshToken",
+        "name" : "authentication.refreshToken",
         "type" : "property"
       },
       "condition" : {
@@ -1185,7 +1178,7 @@
       "label" : "Scopes",
       "group" : "authentication",
       "binding" : {
-        "name" : "authentication.oauthRefreshToken.scopes",
+        "name" : "authentication.scopes",
         "type" : "property"
       },
       "condition" : {
@@ -1198,9 +1191,9 @@
     }, {
       "id" : "url",
       "label" : "URL",
-      "description" : "The endpoint this credential is bound to. Required for basic, bearer and API key authentication; optional for OAuth, which carries its own token endpoint.",
+      "description" : "The endpoint this credential is bound to. Required for basic, bearer and API key authentication; not shown for OAuth, which carries its own token endpoint.",
       "constraints" : {
-        "notEmpty" : false,
+        "notEmpty" : true,
         "pattern" : {
           "value" : "^((http://|https://|secrets|\\{\\{).*$)",
           "message" : "Must be a http(s) URL"
@@ -1210,6 +1203,11 @@
       "binding" : {
         "name" : "url",
         "type" : "property"
+      },
+      "condition" : {
+        "property" : "authentication.type",
+        "oneOf" : [ "apiKey", "basic", "bearer" ],
+        "type" : "simple"
       },
       "type" : "String"
     } ]

--- a/connectors/http/polling/src/main/java/io/camunda/connector/http/polling/model/PollingRuntimeProperties.java
+++ b/connectors/http/polling/src/main/java/io/camunda/connector/http/polling/model/PollingRuntimeProperties.java
@@ -35,6 +35,7 @@ public class PollingRuntimeProperties {
       description =
           "Choose a reusable authentication credential, or configure one-time authentication"
               + " parameters below.")
+  @FEEL
   @Valid
   private RestAuthenticationConfiguration authenticationConfiguration;
 
@@ -78,7 +79,9 @@ public class PollingRuntimeProperties {
   // Template-only twin of `url`, bound to the same `url` input and shown in its place once a
   // credential is chosen: there the URL may come from the credential, so the inline value is an
   // optional override rather than a required field. Never populated - the engine writes a single
-  // `url` input, which Jackson binds to the field above.
+  // `url` input, which Jackson binds to the field above. Keep this twin constraint-free: Modeler's
+  // field validator applies patterns to an undefined optional value, while runtime validation still
+  // applies the URL pattern to getUrl().
   @JsonIgnore
   @TemplateProperty(
       id = "urlOverride",
@@ -91,12 +94,6 @@ public class PollingRuntimeProperties {
           @PropertyCondition(
               property = "authenticationConfiguration",
               isEmpty = NullableBoolean.FALSE),
-      constraints =
-          @TemplateProperty.PropertyConstraints(
-              pattern =
-                  @TemplateProperty.Pattern(
-                      value = HttpCommonRequest.URL_PATTERN,
-                      message = HttpCommonRequest.URL_PATTERN_MESSAGE)),
       description =
           "Overrides the URL carried by the selected credential. Required when the credential"
               + " carries none, as an OAuth credential need not.")

--- a/connectors/http/polling/src/test/java/io/camunda/connector/http/polling/model/PollingRuntimePropertiesCredentialValidationTest.java
+++ b/connectors/http/polling/src/test/java/io/camunda/connector/http/polling/model/PollingRuntimePropertiesCredentialValidationTest.java
@@ -221,6 +221,29 @@ class PollingRuntimePropertiesCredentialValidationTest {
         .isEqualTo("http://localhost:8085/other-path");
   }
 
+  @Test
+  void malformedInlineUrlIsRejectedWhenCredentialIsBound() {
+    String properties =
+        """
+        {
+          "url": "not-a-url",
+          "method": "GET",
+          "authenticationConfiguration": {
+            "authentication": { "type": "bearer", "token": "valid-token" },
+            "url": "http://localhost:8085/http-endpoint"
+          }
+        }
+        """;
+    var context =
+        InboundConnectorContextBuilder.create()
+            .properties(properties)
+            .validation(new TestValidationProvider())
+            .build();
+
+    assertThatThrownBy(() -> context.bindProperties(PollingRuntimeProperties.class))
+        .hasMessageContaining("Must be a http(s) URL");
+  }
+
   /**
    * An OAuth credential need not carry a URL (see {@code
    * RestAuthenticationConfiguration#requiresUrl}), so binding one with neither an inline URL nor an

--- a/connectors/http/polling/src/test/java/io/camunda/connector/http/polling/model/PollingRuntimePropertiesTest.java
+++ b/connectors/http/polling/src/test/java/io/camunda/connector/http/polling/model/PollingRuntimePropertiesTest.java
@@ -7,9 +7,23 @@
 package io.camunda.connector.http.polling.model;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.command.EvaluateExpressionCommandStep1.EvaluateExpressionCommandStep2;
+import io.camunda.client.api.response.EvaluateExpressionResponse;
+import io.camunda.connector.api.secret.SecretProvider;
 import io.camunda.connector.http.base.model.auth.BearerAuthentication;
 import io.camunda.connector.http.base.model.auth.RestAuthenticationConfiguration;
+import io.camunda.connector.runtime.core.inbound.InboundConnectorContextImpl;
+import io.camunda.connector.runtime.core.inbound.activitylog.ActivityLogRegistry;
+import io.camunda.connector.runtime.core.inbound.details.InboundConnectorDetails.ValidInboundConnectorDetails;
+import io.camunda.connector.runtime.test.inbound.InboundConnectorContextBuilder;
+import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 
 /** Verifies the per-connector consumption of a bound authentication credential (configuration). */
@@ -56,5 +70,49 @@ class PollingRuntimePropertiesTest {
             new BearerAuthentication("credential-token"), "https://credential.example.com"));
 
     assertThat(properties.getUrl()).isEqualTo("https://override.example.com");
+  }
+
+  @Test
+  void bindsCredentialExpressionThroughInboundContext() {
+    String expression = "=camunda.vars.env.httpCredential";
+    var client = mock(CamundaClient.class, RETURNS_DEEP_STUBS);
+    var command = mock(EvaluateExpressionCommandStep2.class, RETURNS_DEEP_STUBS);
+    var response = mock(EvaluateExpressionResponse.class);
+    when(client.newEvaluateExpressionCommand().expression(expression)).thenReturn(command);
+    when(command.send().join()).thenReturn(response);
+    when(response.getResult())
+        .thenReturn(
+            Map.of(
+                "authentication",
+                Map.of("type", "bearer", "token", "credential-token"),
+                "url",
+                "https://credential.example.com"));
+    var details = mock(ValidInboundConnectorDetails.class);
+    when(details.rawPropertiesWithoutKeywords())
+        .thenReturn(Map.of("authenticationConfiguration", expression, "method", "GET"));
+    when(details.connectorElements()).thenReturn(List.of());
+    var context =
+        new InboundConnectorContextImpl(
+            mock(SecretProvider.class),
+            ignored -> {},
+            details,
+            null,
+            ignored -> {},
+            new ObjectMapperBuilder().configuredObjectMapper(),
+            new ActivityLogRegistry(),
+            client);
+
+    var properties = context.bindProperties(PollingRuntimeProperties.class);
+
+    assertThat(properties.getAuthentication()).isInstanceOf(BearerAuthentication.class);
+    assertThat(((BearerAuthentication) properties.getAuthentication()).token())
+        .isEqualTo("credential-token");
+    assertThat(properties.getUrl()).isEqualTo("https://credential.example.com");
+  }
+
+  private static class ObjectMapperBuilder extends InboundConnectorContextBuilder {
+    private ObjectMapper configuredObjectMapper() {
+      return objectMapper;
+    }
   }
 }

--- a/connectors/http/rest/element-templates/http-json-connector.json
+++ b/connectors/http/rest/element-templates/http-json-connector.json
@@ -656,13 +656,6 @@
     "label" : "URL",
     "description" : "Overrides the URL carried by the selected credential. Required when the credential carries none, as an OAuth credential need not.",
     "optional" : true,
-    "constraints" : {
-      "notEmpty" : false,
-      "pattern" : {
-        "value" : "^($|=|(http://|https://|secrets|\\{\\{).*$)",
-        "message" : "Must be a http(s) URL"
-      }
-    },
     "feel" : "optional",
     "group" : "endpoint",
     "binding" : {
@@ -929,7 +922,7 @@
   "configurationTemplates" : [ {
     "id" : "io.camunda.connectors:rest-authentication:1",
     "kind" : "CREDENTIAL",
-    "version" : 1,
+    "version" : 2,
     "name" : "REST Authentication",
     "properties" : [ {
       "id" : "authentication.type",
@@ -1197,7 +1190,7 @@
       },
       "group" : "authentication",
       "binding" : {
-        "name" : "authentication.oauthRefreshToken.oauthTokenEndpoint",
+        "name" : "authentication.oauthTokenEndpoint",
         "type" : "property"
       },
       "condition" : {
@@ -1214,7 +1207,7 @@
       },
       "group" : "authentication",
       "binding" : {
-        "name" : "authentication.oauthRefreshToken.clientId",
+        "name" : "authentication.clientId",
         "type" : "property"
       },
       "condition" : {
@@ -1229,7 +1222,7 @@
       "label" : "Client secret",
       "group" : "authentication",
       "binding" : {
-        "name" : "authentication.oauthRefreshToken.clientSecret",
+        "name" : "authentication.clientSecret",
         "type" : "property"
       },
       "condition" : {
@@ -1248,7 +1241,7 @@
       },
       "group" : "authentication",
       "binding" : {
-        "name" : "authentication.oauthRefreshToken.refreshToken",
+        "name" : "authentication.refreshToken",
         "type" : "property"
       },
       "condition" : {
@@ -1264,7 +1257,7 @@
       "label" : "Scopes",
       "group" : "authentication",
       "binding" : {
-        "name" : "authentication.oauthRefreshToken.scopes",
+        "name" : "authentication.scopes",
         "type" : "property"
       },
       "condition" : {
@@ -1277,9 +1270,9 @@
     }, {
       "id" : "url",
       "label" : "URL",
-      "description" : "The endpoint this credential is bound to. Required for basic, bearer and API key authentication; optional for OAuth, which carries its own token endpoint.",
+      "description" : "The endpoint this credential is bound to. Required for basic, bearer and API key authentication; not shown for OAuth, which carries its own token endpoint.",
       "constraints" : {
-        "notEmpty" : false,
+        "notEmpty" : true,
         "pattern" : {
           "value" : "^((http://|https://|secrets|\\{\\{).*$)",
           "message" : "Must be a http(s) URL"
@@ -1289,6 +1282,11 @@
       "binding" : {
         "name" : "url",
         "type" : "property"
+      },
+      "condition" : {
+        "property" : "authentication.type",
+        "oneOf" : [ "apiKey", "basic", "bearer" ],
+        "type" : "simple"
       },
       "type" : "String"
     } ]

--- a/connectors/http/rest/element-templates/hybrid/http-json-connector-hybrid.json
+++ b/connectors/http/rest/element-templates/hybrid/http-json-connector-hybrid.json
@@ -661,13 +661,6 @@
     "label" : "URL",
     "description" : "Overrides the URL carried by the selected credential. Required when the credential carries none, as an OAuth credential need not.",
     "optional" : true,
-    "constraints" : {
-      "notEmpty" : false,
-      "pattern" : {
-        "value" : "^($|=|(http://|https://|secrets|\\{\\{).*$)",
-        "message" : "Must be a http(s) URL"
-      }
-    },
     "feel" : "optional",
     "group" : "endpoint",
     "binding" : {
@@ -934,7 +927,7 @@
   "configurationTemplates" : [ {
     "id" : "io.camunda.connectors:rest-authentication:1",
     "kind" : "CREDENTIAL",
-    "version" : 1,
+    "version" : 2,
     "name" : "REST Authentication",
     "properties" : [ {
       "id" : "authentication.type",
@@ -1202,7 +1195,7 @@
       },
       "group" : "authentication",
       "binding" : {
-        "name" : "authentication.oauthRefreshToken.oauthTokenEndpoint",
+        "name" : "authentication.oauthTokenEndpoint",
         "type" : "property"
       },
       "condition" : {
@@ -1219,7 +1212,7 @@
       },
       "group" : "authentication",
       "binding" : {
-        "name" : "authentication.oauthRefreshToken.clientId",
+        "name" : "authentication.clientId",
         "type" : "property"
       },
       "condition" : {
@@ -1234,7 +1227,7 @@
       "label" : "Client secret",
       "group" : "authentication",
       "binding" : {
-        "name" : "authentication.oauthRefreshToken.clientSecret",
+        "name" : "authentication.clientSecret",
         "type" : "property"
       },
       "condition" : {
@@ -1253,7 +1246,7 @@
       },
       "group" : "authentication",
       "binding" : {
-        "name" : "authentication.oauthRefreshToken.refreshToken",
+        "name" : "authentication.refreshToken",
         "type" : "property"
       },
       "condition" : {
@@ -1269,7 +1262,7 @@
       "label" : "Scopes",
       "group" : "authentication",
       "binding" : {
-        "name" : "authentication.oauthRefreshToken.scopes",
+        "name" : "authentication.scopes",
         "type" : "property"
       },
       "condition" : {
@@ -1282,9 +1275,9 @@
     }, {
       "id" : "url",
       "label" : "URL",
-      "description" : "The endpoint this credential is bound to. Required for basic, bearer and API key authentication; optional for OAuth, which carries its own token endpoint.",
+      "description" : "The endpoint this credential is bound to. Required for basic, bearer and API key authentication; not shown for OAuth, which carries its own token endpoint.",
       "constraints" : {
-        "notEmpty" : false,
+        "notEmpty" : true,
         "pattern" : {
           "value" : "^((http://|https://|secrets|\\{\\{).*$)",
           "message" : "Must be a http(s) URL"
@@ -1294,6 +1287,11 @@
       "binding" : {
         "name" : "url",
         "type" : "property"
+      },
+      "condition" : {
+        "property" : "authentication.type",
+        "oneOf" : [ "apiKey", "basic", "bearer" ],
+        "type" : "simple"
       },
       "type" : "String"
     } ]

--- a/connectors/http/rest/src/test/java/io/camunda/connector/http/rest/HttpJsonFunctionTest.java
+++ b/connectors/http/rest/src/test/java/io/camunda/connector/http/rest/HttpJsonFunctionTest.java
@@ -251,6 +251,30 @@ public class HttpJsonFunctionTest extends BaseTest {
         .isEqualTo("http://localhost:8086/other-path");
   }
 
+  @Test
+  void malformedInlineUrlIsRejectedWhenCredentialIsBound() {
+    String variables =
+        """
+        {
+          "method": "get",
+          "url": "not-a-url",
+          "authenticationConfiguration": {
+            "authentication": { "type": "bearer", "token": "valid-token" },
+            "url": "http://localhost:8086/http-endpoint"
+          }
+        }
+        """;
+    var context =
+        OutboundConnectorContextBuilder.create()
+            .includeAllValidators()
+            .variables(variables)
+            .build();
+
+    assertThatThrownBy(() -> context.bindVariables(HttpJsonRequest.class))
+        .isInstanceOf(ConnectorInputException.class)
+        .hasMessageContaining("Must be a http(s) URL");
+  }
+
   /**
    * The URL may come from the credential instead of the model, so it is asserted on the effective
    * value ({@code isUrlPresent()}) rather than by a {@code @NotBlank} on the field - a model that

--- a/connectors/idp-extraction/element-templates/hybrid/hybrid-idp-extraction-outbound-connector-hybrid.json
+++ b/connectors/idp-extraction/element-templates/hybrid/hybrid-idp-extraction-outbound-connector-hybrid.json
@@ -168,7 +168,7 @@
   }, {
     "id" : "baseRequest.awsCredential",
     "label" : "AWS credential",
-    "description" : "Choose a reusable AWS credential, or configure one-time authentication parameters below.",
+    "description" : "Select a saved AWS credential with an optional default region, or enter authentication details and a region below.",
     "optional" : true,
     "group" : "authentication",
     "binding" : {
@@ -521,6 +521,29 @@
       } ]
     },
     "type" : "Hidden"
+  }, {
+    "id" : "baseRequest.regionOverride",
+    "label" : "Region",
+    "description" : "Overrides the default region in the selected credential. Required when the credential has no default region.",
+    "optional" : true,
+    "feel" : "optional",
+    "group" : "configuration",
+    "binding" : {
+      "name" : "baseRequest.configuration.region",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "allMatch" : [ {
+        "property" : "baseRequest.awsCredential",
+        "isEmpty" : false,
+        "type" : "simple"
+      }, {
+        "property" : "baseRequest.type",
+        "equals" : "aws",
+        "type" : "simple"
+      } ]
+    },
+    "type" : "String"
   }, {
     "id" : "baseRequest.documentIntelligenceConfiguration.endpoint",
     "label" : "Azure Document Intelligence Endpoint",
@@ -906,7 +929,7 @@
   "configurationTemplates" : [ {
     "id" : "io.camunda:aws-credential:1",
     "kind" : "CREDENTIAL",
-    "version" : 1,
+    "version" : 2,
     "name" : "AWS Credential",
     "properties" : [ {
       "id" : "authentication.type",
@@ -966,10 +989,8 @@
       "secret" : true
     }, {
       "id" : "region",
-      "label" : "Region",
-      "constraints" : {
-        "notEmpty" : true
-      },
+      "label" : "Default region",
+      "description" : "Used when a connector does not specify a region override.",
       "group" : "configuration",
       "binding" : {
         "name" : "region",

--- a/connectors/idp-extraction/element-templates/idp-extraction-outbound-connector.json
+++ b/connectors/idp-extraction/element-templates/idp-extraction-outbound-connector.json
@@ -163,7 +163,7 @@
   }, {
     "id" : "baseRequest.awsCredential",
     "label" : "AWS credential",
-    "description" : "Choose a reusable AWS credential, or configure one-time authentication parameters below.",
+    "description" : "Select a saved AWS credential with an optional default region, or enter authentication details and a region below.",
     "optional" : true,
     "group" : "authentication",
     "binding" : {
@@ -516,6 +516,29 @@
       } ]
     },
     "type" : "Hidden"
+  }, {
+    "id" : "baseRequest.regionOverride",
+    "label" : "Region",
+    "description" : "Overrides the default region in the selected credential. Required when the credential has no default region.",
+    "optional" : true,
+    "feel" : "optional",
+    "group" : "configuration",
+    "binding" : {
+      "name" : "baseRequest.configuration.region",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "allMatch" : [ {
+        "property" : "baseRequest.awsCredential",
+        "isEmpty" : false,
+        "type" : "simple"
+      }, {
+        "property" : "baseRequest.type",
+        "equals" : "aws",
+        "type" : "simple"
+      } ]
+    },
+    "type" : "String"
   }, {
     "id" : "baseRequest.documentIntelligenceConfiguration.endpoint",
     "label" : "Azure Document Intelligence Endpoint",
@@ -901,7 +924,7 @@
   "configurationTemplates" : [ {
     "id" : "io.camunda:aws-credential:1",
     "kind" : "CREDENTIAL",
-    "version" : 1,
+    "version" : 2,
     "name" : "AWS Credential",
     "properties" : [ {
       "id" : "authentication.type",
@@ -961,10 +984,8 @@
       "secret" : true
     }, {
       "id" : "region",
-      "label" : "Region",
-      "constraints" : {
-        "notEmpty" : true
-      },
+      "label" : "Default region",
+      "description" : "Used when a connector does not specify a region override.",
       "group" : "configuration",
       "binding" : {
         "name" : "region",

--- a/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/utils/ProviderUtil.java
+++ b/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/utils/ProviderUtil.java
@@ -6,6 +6,8 @@
  */
 package io.camunda.connector.idp.extraction.utils;
 
+import static io.camunda.connector.aws.AwsUtils.extractRegionOrDefault;
+
 import com.google.auth.oauth2.GoogleCredentials;
 import io.camunda.connector.idp.extraction.client.ai.AzureAiFoundryClient;
 import io.camunda.connector.idp.extraction.client.ai.AzureOpenAiClient;
@@ -57,7 +59,9 @@ public class ProviderUtil {
         AwsCredentialsProvider credentialsProvider =
             AwsUtil.credentialsProvider(aws.getAuthentication());
         yield new AwsTextrtactExtractionClient(
-            credentialsProvider, aws.getConfiguration().region(), aws.getS3BucketName());
+            credentialsProvider,
+            extractRegionOrDefault(aws.getConfiguration(), null),
+            aws.getS3BucketName());
       }
       case AzureProvider azure ->
           new AzureDocumentIntelligenceExtractionClient(
@@ -114,7 +118,9 @@ public class ProviderUtil {
         AwsCredentialsProvider credentialsProvider =
             AwsUtil.credentialsProvider(aws.getAuthentication());
         yield new AwsTextrtactExtractionClient(
-            credentialsProvider, aws.getConfiguration().region(), aws.getS3BucketName());
+            credentialsProvider,
+            extractRegionOrDefault(aws.getConfiguration(), null),
+            aws.getS3BucketName());
       }
       case GcpProvider gcp -> {
         DocumentAiRequestConfiguration config =
@@ -196,7 +202,9 @@ public class ProviderUtil {
         AwsCredentialsProvider credentialsProvider =
             AwsUtil.credentialsProvider(aws.getAuthentication());
         yield new BedrockAiClient(
-            credentialsProvider, aws.getConfiguration().region(), input.converseData());
+            credentialsProvider,
+            extractRegionOrDefault(aws.getConfiguration(), null),
+            input.converseData());
       }
       case OpenAiProvider openAi ->
           new OpenAiClient(

--- a/connectors/idp-extraction/src/test/java/io/camunda/connector/idp/extraction/utils/ProviderUtilTest.java
+++ b/connectors/idp-extraction/src/test/java/io/camunda/connector/idp/extraction/utils/ProviderUtilTest.java
@@ -11,6 +11,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import io.camunda.connector.aws.model.impl.AwsAuthentication.AwsStaticCredentialsAuthentication;
+import io.camunda.connector.aws.model.impl.AwsBaseConfiguration;
 import io.camunda.connector.idp.extraction.client.ai.AzureAiFoundryClient;
 import io.camunda.connector.idp.extraction.client.ai.AzureOpenAiClient;
 import io.camunda.connector.idp.extraction.client.ai.BedrockAiClient;
@@ -24,6 +26,8 @@ import io.camunda.connector.idp.extraction.client.extraction.PdfBoxExtractionCli
 import io.camunda.connector.idp.extraction.client.extraction.base.MlExtractor;
 import io.camunda.connector.idp.extraction.client.extraction.base.TextExtractor;
 import io.camunda.connector.idp.extraction.model.ConverseData;
+import io.camunda.connector.idp.extraction.model.providers.AwsProvider;
+import io.camunda.connector.idp.extraction.model.providers.ProviderConfig;
 import io.camunda.connector.idp.extraction.model.providers.gcp.GcpAuthenticationType;
 import io.camunda.connector.idp.extraction.request.common.ai.AzureAiRequest;
 import io.camunda.connector.idp.extraction.request.common.ai.BedrockAiRequest;
@@ -33,6 +37,7 @@ import io.camunda.connector.idp.extraction.request.common.extraction.DocumentAiE
 import io.camunda.connector.idp.extraction.request.common.extraction.DocumentIntelligenceExtractorRequest;
 import io.camunda.connector.idp.extraction.request.common.extraction.ExtractionProvider;
 import io.camunda.connector.idp.extraction.request.common.extraction.TextractExtractorRequest;
+import jakarta.validation.ValidationException;
 import java.util.Map;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -41,6 +46,20 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class ProviderUtilTest {
+
+  @SuppressWarnings("deprecation")
+  @Test
+  void legacyAwsProviderRejectsMissingEffectiveRegion() {
+    AwsProvider aws = mock(AwsProvider.class);
+    when(aws.getAuthentication())
+        .thenReturn(new AwsStaticCredentialsAuthentication("accessKey", "secretKey"));
+    when(aws.getConfiguration()).thenReturn(new AwsBaseConfiguration(null, null));
+    ProviderConfig provider = aws;
+
+    assertThatThrownBy(() -> ProviderUtil.getTextExtractor(provider))
+        .isInstanceOf(ValidationException.class)
+        .hasMessageContaining("configuration.region");
+  }
 
   @Nested
   class GetMlExtractorFromExtractionProviderTests {

--- a/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/util/TemplatePropertiesUtil.java
+++ b/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/util/TemplatePropertiesUtil.java
@@ -581,16 +581,16 @@ public class TemplatePropertiesUtil {
   /**
    * Extracts properties from a {@code @Configuration}-annotated class in configuration-template
    * extraction mode: each property's binding is replaced with a {@link
-   * PropertyBinding.ConfigurationTemplateProperty} (name = property id), {@code feel} is disabled,
-   * and any {@code secret} hint from {@link
+   * PropertyBinding.ConfigurationTemplateProperty} using its runtime binding name, {@code feel} is
+   * disabled, and any {@code secret} hint from {@link
    * io.camunda.connector.generator.java.annotation.TemplateProperty#secret()} is preserved.
    */
   public static List<PropertyBuilder> extractConfigurationTemplatePropertiesFromType(
       Class<?> type, TemplateGenerationContext context) {
     var builders = extractTemplatePropertiesFromType(type, context);
     for (var builder : builders) {
-      // Override binding: configuration-template properties use {"type":"property","name":<id>}
-      builder.binding(new PropertyBinding.ConfigurationTemplateProperty(builder.getId()));
+      // Preserve the runtime path while switching to the configuration-template binding type.
+      builder.binding(toConfigurationTemplateProperty(builder.getBinding()));
       // No feel on configuration-template properties (values are atomic literals / secret refs)
       builder.feel(FeelMode.disabled);
       // The configuration-template schema forbids `optional`; optionality is expressed via
@@ -598,6 +598,21 @@ public class TemplatePropertiesUtil {
       builder.optional(null);
     }
     return builders;
+  }
+
+  private static PropertyBinding.ConfigurationTemplateProperty toConfigurationTemplateProperty(
+      PropertyBinding binding) {
+    return switch (binding) {
+      case ZeebeInput input -> new PropertyBinding.ConfigurationTemplateProperty(input.name());
+      case ZeebeProperty property ->
+          new PropertyBinding.ConfigurationTemplateProperty(property.name());
+      default -> throw unsupportedConfigurationBinding(binding);
+    };
+  }
+
+  private static IllegalStateException unsupportedConfigurationBinding(PropertyBinding binding) {
+    return new IllegalStateException(
+        "Unsupported configuration-template property binding: " + binding.type());
   }
 
   private static Set<Class<?>> excludedSubTypes(TemplateProperty annotation) {

--- a/element-template-generator/core/src/test/java/io/camunda/connector/generator/java/util/TemplatePropertiesUtilTest.java
+++ b/element-template-generator/core/src/test/java/io/camunda/connector/generator/java/util/TemplatePropertiesUtilTest.java
@@ -18,10 +18,24 @@ package io.camunda.connector.generator.java.util;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.camunda.connector.generator.dsl.PropertyBinding.ConfigurationTemplateProperty;
+import io.camunda.connector.generator.java.annotation.TemplateProperty;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
 public class TemplatePropertiesUtilTest {
+
+  @io.camunda.connector.api.annotation.Configuration(
+      id = "io.camunda:test-credential:1",
+      version = 1,
+      name = "Test Credential")
+  record TestCredential(
+      @TemplateProperty(
+              id = "nested.clientId",
+              binding = @TemplateProperty.PropertyBinding(name = "clientId"))
+          String clientId) {}
 
   @ParameterizedTest
   @CsvSource({
@@ -36,5 +50,37 @@ public class TemplatePropertiesUtilTest {
 
     // then
     assertThat(actual).isEqualTo(expected);
+  }
+
+  @Test
+  void configurationPropertyKeepsUiIdAndUsesOutboundRuntimeBinding() {
+    var properties =
+        TemplatePropertiesUtil.extractConfigurationTemplatePropertiesFromType(
+            TestCredential.class, new TemplateGenerationContext.Outbound("test", Set.of()));
+
+    assertThat(properties)
+        .singleElement()
+        .satisfies(
+            property -> {
+              assertThat(property.getId()).isEqualTo("nested.clientId");
+              assertThat(property.getBinding())
+                  .isEqualTo(new ConfigurationTemplateProperty("clientId"));
+            });
+  }
+
+  @Test
+  void configurationPropertyKeepsUiIdAndUsesInboundRuntimeBinding() {
+    var properties =
+        TemplatePropertiesUtil.extractConfigurationTemplatePropertiesFromType(
+            TestCredential.class, new TemplateGenerationContext.Inbound("test", Set.of()));
+
+    assertThat(properties)
+        .singleElement()
+        .satisfies(
+            property -> {
+              assertThat(property.getId()).isEqualTo("nested.clientId");
+              assertThat(property.getBinding())
+                  .isEqualTo(new ConfigurationTemplateProperty("clientId"));
+            });
   }
 }


### PR DESCRIPTION
## Description

Manual backport of #8706 to `stable/8.10`.

The original squash commit was cherry-picked with provenance. Conflict resolution omitted the main-only reusable-credential contributor guide, which does not exist on `stable/8.10`. The OAuth credential-binding regression from the main-only REST validator suite was adapted into a stable-compatible test so all relevant production changes and regression coverage are retained.

## Related issues

Backports #8706

## Checklist

- [x] This PR targets `stable/8.10`.
- [x] Tests/Integration tests for the changes have been added if applicable.
- [x] No stable documentation update is required because the affected contributor guide is not present on this branch.
