### PR TITLE
[Backport stable/8.10] fix(secrets): retry outbound secret allow-list XML fetch on transient failure

### DIFF
--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretFilterFactory.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretFilterFactory.java
@@ -16,6 +16,8 @@
  */
 package io.camunda.connector.runtime.core.secret;
 
+import java.time.Instant;
+
 public interface SecretFilterFactory {
   SecretFilter create(SecretFilterContext context);
 
@@ -23,5 +25,5 @@ public interface SecretFilterFactory {
     return context -> SecretFilter.allowAll();
   }
 
-  record SecretFilterContext(long processDefinitionKey, String elementId) {}
+  record SecretFilterContext(long processDefinitionKey, String elementId, Instant deadline) {}
 }

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/ConfigurableSecretFilterFactory.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/ConfigurableSecretFilterFactory.java
@@ -51,7 +51,8 @@ public class ConfigurableSecretFilterFactory implements SecretFilterFactory {
         () -> {
           try {
             return secretKeyCache.getSecretKeys(
-                new SecretKeyContext(context.processDefinitionKey(), context.elementId()));
+                new SecretKeyContext(
+                    context.processDefinitionKey(), context.elementId(), context.deadline()));
           } catch (RuntimeException e) {
             // realCause walks to the root of the chain, not just one level: the client can wrap
             // the actual failure in its own generic exception type before it ever reaches here,

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/SpringConnectorJobHandler.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/SpringConnectorJobHandler.java
@@ -74,6 +74,7 @@ import io.camunda.connector.runtime.metrics.ConnectorMetrics;
 import io.camunda.connector.runtime.metrics.ConnectorOutboundMetrics;
 import io.grpc.StatusRuntimeException;
 import java.time.Duration;
+import java.time.Instant;
 import java.time.format.DateTimeParseException;
 import java.util.List;
 import java.util.Map;
@@ -197,9 +198,34 @@ public class SpringConnectorJobHandler implements JobHandler {
         job.getKey(),
         job.getType(),
         job.getTenantId());
+
+    Duration retryBackoff = null;
+    long deadline = job.getDeadline();
+    Exception deadlineResolutionFailure = null;
+    try {
+      retryBackoff = getBackoffDuration(job);
+      Long updatedDeadline = updateJobTimeoutIfPresent(job);
+      if (updatedDeadline != null) {
+        deadline = updatedDeadline;
+        if (deadline <= System.currentTimeMillis()) {
+          // A short but valid jobTimeout can already have elapsed by the time the synchronous
+          // update command returns (network latency). The broker may already consider this
+          // worker's lease gone, so the connector must not run — doing so risks duplicating side
+          // effects if the job gets reassigned. Propagate rather than continue, mirroring the
+          // definitive-rejection case above.
+          throw new IllegalStateException(
+              "Job timeout deadline already elapsed by the time the update was applied for job: "
+                  + job.getKey());
+        }
+      }
+    } catch (Exception e) {
+      deadlineResolutionFailure = e;
+    }
+
     var secretFilter =
         secretFilterFactory.create(
-            new SecretFilterContext(job.getProcessDefinitionKey(), job.getElementId()));
+            new SecretFilterContext(
+                job.getProcessDefinitionKey(), job.getElementId(), Instant.ofEpochMilli(deadline)));
     var context =
         new JobHandlerContext(
             job,
@@ -208,7 +234,18 @@ public class SpringConnectorJobHandler implements JobHandler {
             documentFactory,
             objectMapper,
             secretFilter);
-    ResultWithDeadline resultWithDeadline = getConnectorResult(job, context, secretFilter);
+
+    ResultWithDeadline resultWithDeadline =
+        deadlineResolutionFailure != null
+            ? new ResultWithDeadline(
+                outboundConnectorExceptionHandler.manageConnectorJobHandlerException(
+                    deadlineResolutionFailure,
+                    job,
+                    retryBackoff,
+                    secretFilter,
+                    context.getSecretHandler().getResolvedValues()),
+                deadline)
+            : getConnectorResult(job, context, secretFilter, deadline, retryBackoff);
     processFinalResult(
         client,
         job,
@@ -228,26 +265,12 @@ public class SpringConnectorJobHandler implements JobHandler {
   private record ResultWithDeadline(ConnectorResult result, long deadline) {}
 
   private ResultWithDeadline getConnectorResult(
-      ActivatedJob job, JobHandlerContext context, SecretFilter secretFilter) {
-    Duration retryBackoff = null;
-    long deadline = job.getDeadline();
+      ActivatedJob job,
+      JobHandlerContext context,
+      SecretFilter secretFilter,
+      long deadline,
+      Duration retryBackoff) {
     try {
-      retryBackoff = getBackoffDuration(job);
-      Long updatedDeadline = updateJobTimeoutIfPresent(job);
-      if (updatedDeadline != null) {
-        deadline = updatedDeadline;
-        if (deadline <= System.currentTimeMillis()) {
-          // A short but valid jobTimeout can already have elapsed by the time the synchronous
-          // update command returns (network latency). The broker may already consider this
-          // worker's lease gone, so the connector must not run — doing so risks duplicating side
-          // effects if the job gets reassigned. Propagate rather than continue, mirroring the
-          // definitive-rejection case above.
-          throw new IllegalStateException(
-              "Job timeout deadline already elapsed by the time the update was applied for job: "
-                  + job.getKey());
-        }
-      }
-
       var connectorResponse = getConnectorResponse(context);
 
       if (connectorResponse instanceof AdHocSubProcessConnectorResponse ahsp) {

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/secret/ProcessDefinitionSecretKeyCache.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/secret/ProcessDefinitionSecretKeyCache.java
@@ -16,6 +16,9 @@
  */
 package io.camunda.connector.runtime.outbound.secret;
 
+import dev.failsafe.Failsafe;
+import dev.failsafe.RetryPolicy;
+import dev.failsafe.Timeout;
 import io.camunda.client.CamundaClient;
 import io.camunda.connector.runtime.core.secret.SecretFilter.Secret;
 import io.camunda.connector.runtime.core.secret.SecretUtil;
@@ -34,6 +37,8 @@ import io.camunda.zeebe.model.bpmn.instance.SubProcess;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeInput;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeIoMapping;
 import java.io.ByteArrayInputStream;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -61,6 +66,18 @@ public class ProcessDefinitionSecretKeyCache implements SecretKeyCache {
   private static final List<Class<? extends BaseElement>> OUTBOUND_ELIGIBLE_TYPES =
       new ArrayList<>();
 
+  private static final int XML_FETCH_MAX_RETRIES = 3;
+
+  private static final Duration XML_FETCH_INITIAL_RETRY_DELAY = Duration.ofSeconds(1);
+
+  /**
+   * Retries stop this far ahead of the activated job's deadline, leaving room for the connector
+   * function itself to run before the job's lease expires -- a fetch that only succeeds after the
+   * lease is gone risks the job being reassigned while this worker keeps executing, per the
+   * duplicate-side-effect concern in {@code SpringConnectorJobHandler}.
+   */
+  private static final Duration XML_FETCH_DEADLINE_SAFETY_MARGIN = Duration.ofSeconds(5);
+
   static {
     OUTBOUND_ELIGIBLE_TYPES.add(ServiceTask.class);
     OUTBOUND_ELIGIBLE_TYPES.add(SendTask.class);
@@ -74,6 +91,7 @@ public class ProcessDefinitionSecretKeyCache implements SecretKeyCache {
   private final String physicalTenantId;
   private final CamundaClient camundaClient;
   private final Cache cache;
+  private final Duration xmlFetchInitialRetryDelay;
 
   /**
    * Source/binary-compatibility overload for existing callers compiled against the original
@@ -92,9 +110,19 @@ public class ProcessDefinitionSecretKeyCache implements SecretKeyCache {
    */
   public ProcessDefinitionSecretKeyCache(
       String physicalTenantId, CamundaClient camundaClient, Cache cache) {
+    this(physicalTenantId, camundaClient, cache, XML_FETCH_INITIAL_RETRY_DELAY);
+  }
+
+  /** Test-only seam: lets retry tests use a near-zero delay instead of the real one. */
+  public ProcessDefinitionSecretKeyCache(
+      String physicalTenantId,
+      CamundaClient camundaClient,
+      Cache cache,
+      Duration xmlFetchInitialRetryDelay) {
     this.physicalTenantId = physicalTenantId;
     this.camundaClient = camundaClient;
     this.cache = cache;
+    this.xmlFetchInitialRetryDelay = xmlFetchInitialRetryDelay;
   }
 
   private record CachedProcessDefinitionKey(String physicalTenantId, long processDefinitionKey) {}
@@ -104,13 +132,17 @@ public class ProcessDefinitionSecretKeyCache implements SecretKeyCache {
     var cacheKey =
         new CachedProcessDefinitionKey(physicalTenantId, secretKeyContext.processDefinitionKey());
     return cache
-        .get(cacheKey, () -> fetchSecretKeysByElementIds(secretKeyContext.processDefinitionKey()))
+        .get(
+            cacheKey,
+            () ->
+                fetchSecretKeysByElementIds(
+                    secretKeyContext.processDefinitionKey(), secretKeyContext.deadline()))
         .getOrDefault(secretKeyContext.elementId(), Collections.emptyList());
   }
 
-  private Map<String, List<Secret>> fetchSecretKeysByElementIds(long processDefinitionKey) {
-    String bpmnXml =
-        camundaClient.newProcessDefinitionGetXmlRequest(processDefinitionKey).execute();
+  private Map<String, List<Secret>> fetchSecretKeysByElementIds(
+      long processDefinitionKey, Instant deadline) {
+    String bpmnXml = fetchBpmnXmlWithRetry(processDefinitionKey, deadline);
 
     BpmnModelInstance modelInstance =
         Bpmn.readModelFromStream(new ByteArrayInputStream(bpmnXml.getBytes()));
@@ -120,6 +152,40 @@ public class ProcessDefinitionSecretKeyCache implements SecretKeyCache {
     return processes.stream()
         .flatMap(process -> inspectBpmnProcess(process, processDefinitionKey).entrySet().stream())
         .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+  }
+
+  private String fetchBpmnXmlWithRetry(long processDefinitionKey, Instant deadline) {
+    Duration remaining =
+        Duration.between(Instant.now(), deadline).minus(XML_FETCH_DEADLINE_SAFETY_MARGIN);
+    if (remaining.isNegative() || remaining.isZero()) {
+      throw new IllegalStateException(
+          "BPMN XML fetch deadline already elapsed for process definition key "
+              + processDefinitionKey);
+    }
+    Timeout<String> xmlFetchTimeout = Timeout.<String>builder(remaining).withInterrupt().build();
+    if (remaining.compareTo(xmlFetchInitialRetryDelay) <= 0) {
+      return Failsafe.with(xmlFetchTimeout)
+          .get(
+              () ->
+                  camundaClient.newProcessDefinitionGetXmlRequest(processDefinitionKey).execute());
+    }
+    RetryPolicy<String> xmlFetchRetryPolicy =
+        RetryPolicy.<String>builder()
+            .withBackoff(
+                xmlFetchInitialRetryDelay,
+                xmlFetchInitialRetryDelay.multipliedBy(1L << (XML_FETCH_MAX_RETRIES - 1)))
+            .withMaxRetries(XML_FETCH_MAX_RETRIES)
+            .withMaxDuration(remaining)
+            .onFailedAttempt(
+                event ->
+                    LOG.warn(
+                        "Attempt {}/{} to fetch BPMN XML failed: {}",
+                        event.getAttemptCount(),
+                        XML_FETCH_MAX_RETRIES + 1,
+                        event.getLastException().getClass().getName()))
+            .build();
+    return Failsafe.with(xmlFetchTimeout, xmlFetchRetryPolicy)
+        .get(() -> camundaClient.newProcessDefinitionGetXmlRequest(processDefinitionKey).execute());
   }
 
   private Map<String, List<Secret>> inspectBpmnProcess(Process process, long processDefinitionKey) {

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/secret/SecretKeyCache.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/secret/SecretKeyCache.java
@@ -17,6 +17,7 @@
 package io.camunda.connector.runtime.outbound.secret;
 
 import io.camunda.connector.runtime.core.secret.SecretFilter.Secret;
+import java.time.Instant;
 import java.util.List;
 
 public interface SecretKeyCache {
@@ -24,5 +25,5 @@ public interface SecretKeyCache {
 
   List<Secret> getSecretKeys(SecretKeyContext secretKeyContext);
 
-  record SecretKeyContext(long processDefinitionKey, String elementId) {}
+  record SecretKeyContext(long processDefinitionKey, String elementId, Instant deadline) {}
 }

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/job/ConfigurableSecretFilterFactoryTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/job/ConfigurableSecretFilterFactoryTest.java
@@ -32,6 +32,8 @@ import io.camunda.connector.runtime.outbound.job.ConfigurableSecretFilterFactory
 import io.camunda.connector.runtime.outbound.secret.ProcessDefinitionSecretKeyCache;
 import io.camunda.connector.runtime.outbound.secret.SecretKeyCache;
 import io.camunda.connector.runtime.outbound.secret.SecretKeyCache.SecretKeyContext;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -46,10 +48,11 @@ class ConfigurableSecretFilterFactoryTest {
 
   private static final long PROCESS_DEF_KEY = 42L;
   private static final String ELEMENT_ID = "service-task-1";
+  private static final Instant DEADLINE = Instant.now().plusSeconds(3600);
   private static final SecretFilterContext CONTEXT =
-      new SecretFilterContext(PROCESS_DEF_KEY, ELEMENT_ID);
+      new SecretFilterContext(PROCESS_DEF_KEY, ELEMENT_ID, DEADLINE);
   private static final SecretKeyContext SECRET_KEY_CONTEXT =
-      new SecretKeyContext(PROCESS_DEF_KEY, ELEMENT_ID);
+      new SecretKeyContext(PROCESS_DEF_KEY, ELEMENT_ID, DEADLINE);
 
   @Mock private SecretKeyCache secretKeyCache;
 
@@ -194,7 +197,8 @@ class ConfigurableSecretFilterFactoryTest {
     var camundaClient = mock(CamundaClient.class, RETURNS_DEEP_STUBS);
     when(camundaClient.newProcessDefinitionGetXmlRequest(PROCESS_DEF_KEY).execute())
         .thenThrow(new RuntimeException("Operate returned 404 for process definition 42"));
-    SecretKeyCache realSecretKeyCache = new ProcessDefinitionSecretKeyCache(camundaClient, cache);
+    SecretKeyCache realSecretKeyCache =
+        new ProcessDefinitionSecretKeyCache("default", camundaClient, cache, Duration.ofMillis(1));
     var factory = new ConfigurableSecretFilterFactory(SecretFilterMode.STRICT, realSecretKeyCache);
 
     var filter = factory.create(CONTEXT);

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/job/SpringConnectorJobHandlerTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/job/SpringConnectorJobHandlerTest.java
@@ -75,6 +75,8 @@ import io.camunda.connector.runtime.core.Keywords;
 import io.camunda.connector.runtime.core.document.DocumentFactoryImpl;
 import io.camunda.connector.runtime.core.document.store.InMemoryDocumentStore;
 import io.camunda.connector.runtime.core.secret.SecretFilter;
+import io.camunda.connector.runtime.core.secret.SecretFilterFactory;
+import io.camunda.connector.runtime.core.secret.SecretFilterFactory.SecretFilterContext;
 import io.camunda.connector.runtime.core.secret.SecretProviderAggregator;
 import io.camunda.connector.runtime.secret.FooBarSecretProvider;
 import io.camunda.connector.validation.impl.DefaultValidationProvider;
@@ -83,6 +85,7 @@ import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
+import java.time.Instant;
 import java.util.Base64;
 import java.util.HashMap;
 import java.util.List;
@@ -211,6 +214,25 @@ class SpringConnectorJobHandlerTest {
         TestObjectMapperSupplier.INSTANCE,
         call,
         job -> SecretFilter.allowAll(),
+        camundaClient);
+  }
+
+  private SpringConnectorJobHandler newConnectorJobHandler(
+      OutboundConnectorFunction call,
+      CamundaClient camundaClient,
+      SecretFilterFactory secretFilterFactory) {
+    return new SpringConnectorJobHandler(
+        new MicrometerMetricsRecorder(new SimpleMeterRegistry()),
+        new JobCallbackCommandWrapperFactory(
+            BackoffSupplier.newBackoffBuilder().build(),
+            commandScheduler,
+            new MicrometerMetricsRecorder(new SimpleMeterRegistry())),
+        new SecretProviderAggregator(List.of(new FooBarSecretProvider())),
+        new DefaultValidationProvider(),
+        mock(DocumentFactory.class),
+        TestObjectMapperSupplier.INSTANCE,
+        call,
+        secretFilterFactory,
         camundaClient);
   }
 
@@ -1195,6 +1217,57 @@ class SpringConnectorJobHandlerTest {
 
       assertThat(capturedDeadline).isLessThan(staleDeadline);
       assertThat(Math.abs(capturedDeadline - expectedDeadline)).isLessThan(5000L);
+    }
+
+    @Test
+    void shouldUseUpdatedDeadline_ForSecretFilter_WhenHeaderPresent() throws Exception {
+      long staleDeadline = System.currentTimeMillis() + Duration.ofMinutes(25).toMillis();
+      var secretFilterFactory = mock(SecretFilterFactory.class);
+      when(secretFilterFactory.create(any())).thenReturn(SecretFilter.allowAll());
+      var jobHandler = newConnectorJobHandler(context -> "ok", camundaClient, secretFilterFactory);
+      var jobBuilder =
+          JobBuilder.create()
+              .withDeadline(staleDeadline)
+              .withHeaders(Map.of(Keywords.JOB_TIMEOUT_KEYWORD, "PT10M"));
+
+      jobBuilder.executeAndCaptureResult(jobHandler);
+
+      ArgumentCaptor<SecretFilterContext> contextCaptor =
+          ArgumentCaptor.forClass(SecretFilterContext.class);
+      verify(secretFilterFactory).create(contextCaptor.capture());
+      Instant capturedDeadline = contextCaptor.getValue().deadline();
+      Instant expectedDeadline = Instant.now().plus(Duration.ofMinutes(10));
+
+      assertThat(capturedDeadline).isNotEqualTo(Instant.ofEpochMilli(staleDeadline));
+      assertThat(Duration.between(capturedDeadline, expectedDeadline).abs())
+          .isLessThan(Duration.ofSeconds(5));
+    }
+
+    @Test
+    void shouldUseEarlierDeadline_ForSecretFilter_WhenUpdateCommandFailsAmbiguously()
+        throws Exception {
+      long staleDeadline = System.currentTimeMillis() + Duration.ofMinutes(25).toMillis();
+      when(updateTimeoutStep2.execute())
+          .thenThrow(new ClientStatusException(Status.UNAVAILABLE, new RuntimeException("boom")));
+      var secretFilterFactory = mock(SecretFilterFactory.class);
+      when(secretFilterFactory.create(any())).thenReturn(SecretFilter.allowAll());
+      var jobHandler = newConnectorJobHandler(context -> "ok", camundaClient, secretFilterFactory);
+      var jobBuilder =
+          JobBuilder.create()
+              .withDeadline(staleDeadline)
+              .withHeaders(Map.of(Keywords.JOB_TIMEOUT_KEYWORD, "PT1M"));
+
+      jobBuilder.executeAndCaptureResult(jobHandler);
+
+      ArgumentCaptor<SecretFilterContext> contextCaptor =
+          ArgumentCaptor.forClass(SecretFilterContext.class);
+      verify(secretFilterFactory).create(contextCaptor.capture());
+      Instant capturedDeadline = contextCaptor.getValue().deadline();
+      Instant expectedDeadline = Instant.now().plus(Duration.ofMinutes(1));
+
+      assertThat(capturedDeadline).isBefore(Instant.ofEpochMilli(staleDeadline));
+      assertThat(Duration.between(capturedDeadline, expectedDeadline).abs())
+          .isLessThan(Duration.ofSeconds(5));
     }
   }
 

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/secret/ProcessDefinitionSecretKeyCacheTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/secret/ProcessDefinitionSecretKeyCacheTest.java
@@ -17,19 +17,25 @@
 package io.camunda.connector.runtime.outbound.secret;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import dev.failsafe.TimeoutExceededException;
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.fetch.ProcessDefinitionGetXmlRequest;
 import io.camunda.connector.runtime.core.secret.SecretFilter.Secret;
 import io.camunda.connector.runtime.outbound.secret.SecretKeyCache.SecretKeyContext;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.List;
 import java.util.concurrent.Callable;
 import org.junit.jupiter.api.BeforeEach;
@@ -44,6 +50,7 @@ import org.springframework.cache.concurrent.ConcurrentMapCache;
 class ProcessDefinitionSecretKeyCacheTest {
 
   private static final long PROCESS_DEF_KEY = 1L;
+  private static final Instant DEADLINE = Instant.now().plusSeconds(3600);
 
   @Mock private CamundaClient camundaClient;
   @Mock private ProcessDefinitionGetXmlRequest xmlRequest;
@@ -73,7 +80,8 @@ class ProcessDefinitionSecretKeyCacheTest {
     when(xmlRequest.execute()).thenReturn(loadBpmn("outbound-with-secrets.bpmn"));
 
     var keys =
-        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1"));
+        secretKeyCache.getSecretKeys(
+            new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1", DEADLINE));
 
     assertThat(keys)
         .extracting(Secret::secretName)
@@ -89,7 +97,8 @@ class ProcessDefinitionSecretKeyCacheTest {
     when(xmlRequest.execute()).thenReturn(loadBpmn("outbound-with-dotted-target.bpmn"));
 
     var keys =
-        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1"));
+        secretKeyCache.getSecretKeys(
+            new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1", DEADLINE));
 
     assertThat(keys).containsExactly(new Secret("API_KEY", List.of("auth", "token")));
   }
@@ -104,7 +113,8 @@ class ProcessDefinitionSecretKeyCacheTest {
     when(xmlRequest.execute()).thenReturn(loadBpmn("outbound-with-referenced-variable.bpmn"));
 
     var keys =
-        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1"));
+        secretKeyCache.getSecretKeys(
+            new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1", DEADLINE));
 
     assertThat(keys)
         .contains(
@@ -120,7 +130,8 @@ class ProcessDefinitionSecretKeyCacheTest {
     when(xmlRequest.execute()).thenReturn(loadBpmn("outbound-with-chained-references.bpmn"));
 
     var keys =
-        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1"));
+        secretKeyCache.getSecretKeys(
+            new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1", DEADLINE));
 
     assertThat(keys)
         .containsExactlyInAnyOrder(
@@ -138,7 +149,8 @@ class ProcessDefinitionSecretKeyCacheTest {
     when(xmlRequest.execute()).thenReturn(loadBpmn("outbound-with-referenced-variable.bpmn"));
 
     var keys =
-        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1"));
+        secretKeyCache.getSecretKeys(
+            new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1", DEADLINE));
 
     assertThat(keys)
         .doesNotContain(
@@ -157,7 +169,8 @@ class ProcessDefinitionSecretKeyCacheTest {
     when(xmlRequest.execute()).thenReturn(loadBpmn("outbound-with-sibling-fields.bpmn"));
 
     var keys =
-        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1"));
+        secretKeyCache.getSecretKeys(
+            new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1", DEADLINE));
 
     assertThat(keys)
         .contains(
@@ -178,7 +191,8 @@ class ProcessDefinitionSecretKeyCacheTest {
     when(xmlRequest.execute()).thenReturn(loadBpmn("outbound-with-reverse-order-reference.bpmn"));
 
     var keys =
-        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1"));
+        secretKeyCache.getSecretKeys(
+            new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1", DEADLINE));
 
     assertThat(keys)
         .contains(new Secret("API_KEY", List.of("baseUrl")))
@@ -197,7 +211,8 @@ class ProcessDefinitionSecretKeyCacheTest {
     when(xmlRequest.execute()).thenReturn(loadBpmn("outbound-with-parent-overwrite.bpmn"));
 
     var keys =
-        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1"));
+        secretKeyCache.getSecretKeys(
+            new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1", DEADLINE));
 
     // Nothing in this BPMN ever reads authentication.token from a path that's still effective, so
     // TOKEN isn't just absent from the two paths above -- it's not granted anywhere at all. This
@@ -215,7 +230,8 @@ class ProcessDefinitionSecretKeyCacheTest {
     when(xmlRequest.execute()).thenReturn(loadBpmn("outbound-with-same-path-overwrite.bpmn"));
 
     var keys =
-        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1"));
+        secretKeyCache.getSecretKeys(
+            new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1", DEADLINE));
 
     assertThat(keys).isEmpty();
   }
@@ -233,7 +249,8 @@ class ProcessDefinitionSecretKeyCacheTest {
         .thenReturn(loadBpmn("outbound-with-overwritten-propagation-target.bpmn"));
 
     var keys =
-        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1"));
+        secretKeyCache.getSecretKeys(
+            new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1", DEADLINE));
 
     assertThat(keys)
         .containsExactly(new Secret("TOKEN", List.of("baseUrl")))
@@ -253,7 +270,8 @@ class ProcessDefinitionSecretKeyCacheTest {
     when(xmlRequest.execute()).thenReturn(loadBpmn("outbound-with-child-overwrite.bpmn"));
 
     var keys =
-        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1"));
+        secretKeyCache.getSecretKeys(
+            new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1", DEADLINE));
 
     assertThat(keys).isEmpty();
   }
@@ -272,7 +290,8 @@ class ProcessDefinitionSecretKeyCacheTest {
         .thenReturn(loadBpmn("outbound-with-nested-parent-and-child-overwrite.bpmn"));
 
     var keys =
-        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1"));
+        secretKeyCache.getSecretKeys(
+            new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1", DEADLINE));
 
     assertThat(keys).isEmpty();
   }
@@ -289,7 +308,8 @@ class ProcessDefinitionSecretKeyCacheTest {
         .thenReturn(loadBpmn("outbound-with-shadowed-input-as-dependency.bpmn"));
 
     var keys =
-        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1"));
+        secretKeyCache.getSecretKeys(
+            new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1", DEADLINE));
 
     assertThat(keys).containsExactly(new Secret("T", List.of("baseUrl")));
   }
@@ -300,8 +320,9 @@ class ProcessDefinitionSecretKeyCacheTest {
     when(xmlRequest.execute()).thenReturn(loadBpmn("outbound-multiple-tasks-with-secrets.bpmn"));
 
     var alphaKeys =
-        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "task-alpha"));
-    var betaKeys = secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "task-beta"));
+        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "task-alpha", DEADLINE));
+    var betaKeys =
+        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "task-beta", DEADLINE));
 
     assertThat(alphaKeys).extracting(Secret::secretName).containsExactly("SECRET_ALPHA");
     assertThat(betaKeys)
@@ -314,7 +335,8 @@ class ProcessDefinitionSecretKeyCacheTest {
     when(xmlRequest.execute()).thenReturn(loadBpmn("outbound-no-secrets.bpmn"));
 
     var keys =
-        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "no-secrets-task"));
+        secretKeyCache.getSecretKeys(
+            new SecretKeyContext(PROCESS_DEF_KEY, "no-secrets-task", DEADLINE));
 
     assertThat(keys).isEmpty();
   }
@@ -326,7 +348,8 @@ class ProcessDefinitionSecretKeyCacheTest {
     // built by applying an element template in Modeler.
     when(xmlRequest.execute()).thenReturn(loadBpmn("outbound-no-template.bpmn"));
 
-    var keys = secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "plain-task"));
+    var keys =
+        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "plain-task", DEADLINE));
 
     assertThat(keys).extracting(Secret::secretName).containsExactly("SECRET_X");
   }
@@ -336,9 +359,10 @@ class ProcessDefinitionSecretKeyCacheTest {
     when(xmlRequest.execute()).thenReturn(loadBpmn("outbound-adhoc-subprocess.bpmn"));
 
     var subProcessKeys =
-        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "agent-subprocess"));
+        secretKeyCache.getSecretKeys(
+            new SecretKeyContext(PROCESS_DEF_KEY, "agent-subprocess", DEADLINE));
     var childKeys =
-        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "child-task"));
+        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "child-task", DEADLINE));
 
     assertThat(subProcessKeys).extracting(Secret::secretName).containsExactly("ADHOC_SECRET");
     assertThat(childKeys).extracting(Secret::secretName).containsExactly("CHILD_SECRET");
@@ -352,11 +376,14 @@ class ProcessDefinitionSecretKeyCacheTest {
     when(xmlRequest.execute()).thenReturn(loadBpmn("outbound-nested-embedded-subprocess.bpmn"));
 
     var outerKeys =
-        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "outer-subprocess"));
+        secretKeyCache.getSecretKeys(
+            new SecretKeyContext(PROCESS_DEF_KEY, "outer-subprocess", DEADLINE));
     var innerKeys =
-        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "inner-subprocess"));
+        secretKeyCache.getSecretKeys(
+            new SecretKeyContext(PROCESS_DEF_KEY, "inner-subprocess", DEADLINE));
     var grandchildKeys =
-        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "grandchild-task"));
+        secretKeyCache.getSecretKeys(
+            new SecretKeyContext(PROCESS_DEF_KEY, "grandchild-task", DEADLINE));
 
     assertThat(outerKeys).extracting(Secret::secretName).containsExactly("OUTER_SECRET");
     assertThat(innerKeys).extracting(Secret::secretName).containsExactly("INNER_SECRET");
@@ -369,9 +396,11 @@ class ProcessDefinitionSecretKeyCacheTest {
     when(xmlRequest.execute()).thenReturn(loadBpmn("outbound-message-events.bpmn"));
 
     var throwEventKeys =
-        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "send-message-throw"));
+        secretKeyCache.getSecretKeys(
+            new SecretKeyContext(PROCESS_DEF_KEY, "send-message-throw", DEADLINE));
     var endEventKeys =
-        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "send-message-end"));
+        secretKeyCache.getSecretKeys(
+            new SecretKeyContext(PROCESS_DEF_KEY, "send-message-end", DEADLINE));
 
     assertThat(throwEventKeys).extracting(Secret::secretName).containsExactly("THROW_EVENT_SECRET");
     assertThat(endEventKeys).extracting(Secret::secretName).containsExactly("END_EVENT_SECRET");
@@ -382,7 +411,8 @@ class ProcessDefinitionSecretKeyCacheTest {
     when(xmlRequest.execute()).thenReturn(loadBpmn("outbound-with-secrets.bpmn"));
 
     var keys =
-        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "nonexistent-task"));
+        secretKeyCache.getSecretKeys(
+            new SecretKeyContext(PROCESS_DEF_KEY, "nonexistent-task", DEADLINE));
 
     assertThat(keys).isEmpty();
   }
@@ -406,9 +436,11 @@ class ProcessDefinitionSecretKeyCacheTest {
     var cacheForTenantB = new ProcessDefinitionSecretKeyCache("tenant-b", clientB, sharedCache);
 
     var keysA =
-        cacheForTenantA.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1"));
+        cacheForTenantA.getSecretKeys(
+            new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1", DEADLINE));
     var keysB =
-        cacheForTenantB.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "no-secrets-task"));
+        cacheForTenantB.getSecretKeys(
+            new SecretKeyContext(PROCESS_DEF_KEY, "no-secrets-task", DEADLINE));
 
     assertThat(keysA)
         .extracting(Secret::secretName)
@@ -418,6 +450,102 @@ class ProcessDefinitionSecretKeyCacheTest {
     // entry despite the identical processDefinitionKey
     verify(clientA).newProcessDefinitionGetXmlRequest(PROCESS_DEF_KEY);
     verify(clientB).newProcessDefinitionGetXmlRequest(PROCESS_DEF_KEY);
+  }
+
+  @Test
+  void getSecretKeys_xmlFetchTransientlyFails_retriesAndSucceeds() throws IOException {
+    // simulates the get-XML endpoint's eventual-consistency window right after deployment: the
+    // first two attempts 404 before the definition becomes visible, the third succeeds
+    var retryingCache =
+        new ProcessDefinitionSecretKeyCache("tenant", camundaClient, cache, Duration.ofMillis(1));
+    when(xmlRequest.execute())
+        .thenThrow(new RuntimeException("not found (yet)"))
+        .thenThrow(new RuntimeException("not found (yet)"))
+        .thenReturn(loadBpmn("outbound-with-secrets.bpmn"));
+
+    var keys =
+        retryingCache.getSecretKeys(
+            new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1", DEADLINE));
+
+    assertThat(keys)
+        .extracting(Secret::secretName)
+        .containsExactlyInAnyOrder("API_KEY", "MY_TOKEN");
+    verify(xmlRequest, times(3)).execute();
+  }
+
+  @Test
+  void getSecretKeys_xmlFetchFailsPastMaxRetries_throwsLastFailure() {
+    var retryingCache =
+        new ProcessDefinitionSecretKeyCache("tenant", camundaClient, cache, Duration.ofMillis(1));
+    when(xmlRequest.execute()).thenThrow(new RuntimeException("still not found"));
+
+    assertThatThrownBy(
+            () ->
+                retryingCache.getSecretKeys(
+                    new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1", DEADLINE)))
+        .isInstanceOf(RuntimeException.class)
+        .hasMessage("still not found");
+    // 1 initial attempt + 3 retries
+    verify(xmlRequest, times(4)).execute();
+  }
+
+  @Test
+  void getSecretKeys_deadlineWithinSafetyMargin_failsWithoutAttemptingFetch() {
+    assertThatThrownBy(
+            () ->
+                secretKeyCache.getSecretKeys(
+                    new SecretKeyContext(
+                        PROCESS_DEF_KEY, "service-task-1", Instant.now().plusSeconds(2))))
+        .isInstanceOf(IllegalStateException.class);
+    verify(xmlRequest, times(0)).execute();
+  }
+
+  @Test
+  void getSecretKeys_deadlineLeavesOnlyAPartialRetryWindow_stopsRetryingBeforeMaxRetries() {
+    var retryingCache =
+        new ProcessDefinitionSecretKeyCache("tenant", camundaClient, cache, Duration.ofMillis(200));
+    when(xmlRequest.execute()).thenThrow(new RuntimeException("still not found"));
+    Instant deadline = Instant.now().plusSeconds(5).plusMillis(300);
+
+    long start = System.nanoTime();
+    assertThatThrownBy(
+            () ->
+                retryingCache.getSecretKeys(
+                    new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1", deadline)))
+        .satisfiesAnyOf(
+            e -> assertThat(e).isInstanceOf(TimeoutExceededException.class),
+            e -> assertThat(e).hasMessage("still not found"));
+    long elapsedMillis = (System.nanoTime() - start) / 1_000_000;
+
+    assertThat(elapsedMillis).isLessThan(700);
+    verify(xmlRequest, atLeast(2)).execute();
+  }
+
+  @Test
+  void getSecretKeys_xmlFetchIgnoresInterruptAndSucceedsPastDeadline_stillFails()
+      throws IOException {
+    var retryingCache =
+        new ProcessDefinitionSecretKeyCache("tenant", camundaClient, cache, Duration.ofMillis(200));
+    String bpmnXml = loadBpmn("outbound-with-secrets.bpmn");
+    when(xmlRequest.execute())
+        .thenAnswer(
+            invocation -> {
+              long until = System.nanoTime() + Duration.ofMillis(250).toNanos();
+              while (System.nanoTime() < until) {
+                try {
+                  Thread.sleep(10);
+                } catch (InterruptedException ignored) {
+                }
+              }
+              return bpmnXml;
+            });
+    Instant deadline = Instant.now().plusSeconds(5).plusMillis(150);
+
+    assertThatThrownBy(
+            () ->
+                retryingCache.getSecretKeys(
+                    new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1", deadline)))
+        .isInstanceOf(TimeoutExceededException.class);
   }
 
   private String loadBpmn(String fileName) throws IOException {


### PR DESCRIPTION
# Description
Backport of #8756 to `stable/8.10`.

Manual cherry-pick — the automated backport failed due to a merge conflict in `SpringConnectorJobHandlerTest.java` (an import-ordering conflict, since the two new imports weren't duplicated elsewhere in the file). Resolved by hand; all affected tests (`connector-runtime-core`, `connector-runtime-spring`) pass.