### PR TITLE
[Backport stable/8.9] fix(secrets): retry outbound secret allow-list XML fetch on transient failure

### DIFF
--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretFilterFactory.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretFilterFactory.java
@@ -16,6 +16,8 @@
  */
 package io.camunda.connector.runtime.core.secret;
 
+import java.time.Instant;
+
 public interface SecretFilterFactory {
   SecretFilter create(SecretFilterContext context);
 
@@ -23,5 +25,5 @@ public interface SecretFilterFactory {
     return context -> SecretFilter.allowAll();
   }
 
-  record SecretFilterContext(long processDefinitionKey, String elementId) {}
+  record SecretFilterContext(long processDefinitionKey, String elementId, Instant deadline) {}
 }

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/ConfigurableSecretFilterFactory.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/ConfigurableSecretFilterFactory.java
@@ -48,7 +48,8 @@ public class ConfigurableSecretFilterFactory implements SecretFilterFactory {
         () -> {
           try {
             return secretKeyCache.getSecretKeys(
-                new SecretKeyContext(context.processDefinitionKey(), context.elementId()));
+                new SecretKeyContext(
+                    context.processDefinitionKey(), context.elementId(), context.deadline()));
           } catch (RuntimeException e) {
             // realCause walks to the root of the chain, not just one level: e is usually a
             // Cache.ValueRetrievalException (Spring's Cache#get(key, loader) wraps whatever the

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/SpringConnectorJobHandler.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/SpringConnectorJobHandler.java
@@ -46,6 +46,7 @@ import io.camunda.connector.runtime.core.secret.SecretProviderAggregator;
 import io.camunda.connector.runtime.core.secret.SecretProviderDiscovery;
 import io.camunda.connector.runtime.metrics.ConnectorMetrics;
 import java.time.Duration;
+import java.time.Instant;
 import java.time.format.DateTimeParseException;
 import java.util.Map;
 import java.util.Optional;
@@ -173,7 +174,10 @@ public class SpringConnectorJobHandler implements JobHandler {
     try {
       SecretFilter secretFilter =
           secretFilterFactory.create(
-              new SecretFilterContext(job.getProcessDefinitionKey(), job.getElementId()));
+              new SecretFilterContext(
+                  job.getProcessDefinitionKey(),
+                  job.getElementId(),
+                  Instant.ofEpochMilli(job.getDeadline())));
       internalHandle(client, job, counterMetricsContext, secretFilter);
     } catch (Exception e) {
       connectorsOutboundMetrics.increaseFailed(counterMetricsContext);

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/secret/ProcessDefinitionSecretKeyCache.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/secret/ProcessDefinitionSecretKeyCache.java
@@ -16,6 +16,9 @@
  */
 package io.camunda.connector.runtime.outbound.secret;
 
+import dev.failsafe.Failsafe;
+import dev.failsafe.RetryPolicy;
+import dev.failsafe.Timeout;
 import io.camunda.client.CamundaClient;
 import io.camunda.connector.runtime.core.secret.SecretFilter.Secret;
 import io.camunda.connector.runtime.core.secret.SecretUtil;
@@ -34,6 +37,8 @@ import io.camunda.zeebe.model.bpmn.instance.SubProcess;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeInput;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeIoMapping;
 import java.io.ByteArrayInputStream;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -61,6 +66,18 @@ public class ProcessDefinitionSecretKeyCache implements SecretKeyCache {
   private static final List<Class<? extends BaseElement>> OUTBOUND_ELIGIBLE_TYPES =
       new ArrayList<>();
 
+  private static final int XML_FETCH_MAX_RETRIES = 3;
+
+  private static final Duration XML_FETCH_INITIAL_RETRY_DELAY = Duration.ofSeconds(1);
+
+  /**
+   * Retries stop this far ahead of the activated job's deadline, leaving room for the connector
+   * function itself to run before the job's lease expires -- a fetch that only succeeds after the
+   * lease is gone risks the job being reassigned while this worker keeps executing, per the
+   * duplicate-side-effect concern in {@code SpringConnectorJobHandler}.
+   */
+  private static final Duration XML_FETCH_DEADLINE_SAFETY_MARGIN = Duration.ofSeconds(5);
+
   static {
     OUTBOUND_ELIGIBLE_TYPES.add(ServiceTask.class);
     OUTBOUND_ELIGIBLE_TYPES.add(SendTask.class);
@@ -73,10 +90,18 @@ public class ProcessDefinitionSecretKeyCache implements SecretKeyCache {
 
   private final CamundaClient camundaClient;
   private final Cache cache;
+  private final Duration xmlFetchInitialRetryDelay;
 
   public ProcessDefinitionSecretKeyCache(CamundaClient camundaClient, Cache cache) {
+    this(camundaClient, cache, XML_FETCH_INITIAL_RETRY_DELAY);
+  }
+
+  /** Test-only seam: lets retry tests use a near-zero delay instead of the real one. */
+  public ProcessDefinitionSecretKeyCache(
+      CamundaClient camundaClient, Cache cache, Duration xmlFetchInitialRetryDelay) {
     this.camundaClient = camundaClient;
     this.cache = cache;
+    this.xmlFetchInitialRetryDelay = xmlFetchInitialRetryDelay;
   }
 
   @Override
@@ -84,13 +109,15 @@ public class ProcessDefinitionSecretKeyCache implements SecretKeyCache {
     return cache
         .get(
             secretKeyContext.processDefinitionKey(),
-            () -> fetchSecretKeysByElementIds(secretKeyContext.processDefinitionKey()))
+            () ->
+                fetchSecretKeysByElementIds(
+                    secretKeyContext.processDefinitionKey(), secretKeyContext.deadline()))
         .getOrDefault(secretKeyContext.elementId(), Collections.emptyList());
   }
 
-  private Map<String, List<Secret>> fetchSecretKeysByElementIds(long processDefinitionKey) {
-    String bpmnXml =
-        camundaClient.newProcessDefinitionGetXmlRequest(processDefinitionKey).execute();
+  private Map<String, List<Secret>> fetchSecretKeysByElementIds(
+      long processDefinitionKey, Instant deadline) {
+    String bpmnXml = fetchBpmnXmlWithRetry(processDefinitionKey, deadline);
 
     BpmnModelInstance modelInstance =
         Bpmn.readModelFromStream(new ByteArrayInputStream(bpmnXml.getBytes()));
@@ -100,6 +127,40 @@ public class ProcessDefinitionSecretKeyCache implements SecretKeyCache {
     return processes.stream()
         .flatMap(process -> inspectBpmnProcess(process, processDefinitionKey).entrySet().stream())
         .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+  }
+
+  private String fetchBpmnXmlWithRetry(long processDefinitionKey, Instant deadline) {
+    Duration remaining =
+        Duration.between(Instant.now(), deadline).minus(XML_FETCH_DEADLINE_SAFETY_MARGIN);
+    if (remaining.isNegative() || remaining.isZero()) {
+      throw new IllegalStateException(
+          "BPMN XML fetch deadline already elapsed for process definition key "
+              + processDefinitionKey);
+    }
+    Timeout<String> xmlFetchTimeout = Timeout.<String>builder(remaining).withInterrupt().build();
+    if (remaining.compareTo(xmlFetchInitialRetryDelay) <= 0) {
+      return Failsafe.with(xmlFetchTimeout)
+          .get(
+              () ->
+                  camundaClient.newProcessDefinitionGetXmlRequest(processDefinitionKey).execute());
+    }
+    RetryPolicy<String> xmlFetchRetryPolicy =
+        RetryPolicy.<String>builder()
+            .withBackoff(
+                xmlFetchInitialRetryDelay,
+                xmlFetchInitialRetryDelay.multipliedBy(1L << (XML_FETCH_MAX_RETRIES - 1)))
+            .withMaxRetries(XML_FETCH_MAX_RETRIES)
+            .withMaxDuration(remaining)
+            .onFailedAttempt(
+                event ->
+                    LOG.warn(
+                        "Attempt {}/{} to fetch BPMN XML failed: {}",
+                        event.getAttemptCount(),
+                        XML_FETCH_MAX_RETRIES + 1,
+                        event.getLastException().getClass().getName()))
+            .build();
+    return Failsafe.with(xmlFetchTimeout, xmlFetchRetryPolicy)
+        .get(() -> camundaClient.newProcessDefinitionGetXmlRequest(processDefinitionKey).execute());
   }
 
   private Map<String, List<Secret>> inspectBpmnProcess(Process process, long processDefinitionKey) {

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/secret/SecretKeyCache.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/secret/SecretKeyCache.java
@@ -17,6 +17,7 @@
 package io.camunda.connector.runtime.outbound.secret;
 
 import io.camunda.connector.runtime.core.secret.SecretFilter.Secret;
+import java.time.Instant;
 import java.util.List;
 
 public interface SecretKeyCache {
@@ -24,5 +25,5 @@ public interface SecretKeyCache {
 
   List<Secret> getSecretKeys(SecretKeyContext secretKeyContext);
 
-  record SecretKeyContext(long processDefinitionKey, String elementId) {}
+  record SecretKeyContext(long processDefinitionKey, String elementId, Instant deadline) {}
 }

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/job/ConfigurableSecretFilterFactoryTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/job/ConfigurableSecretFilterFactoryTest.java
@@ -33,6 +33,8 @@ import io.camunda.connector.runtime.outbound.job.ConfigurableSecretFilterFactory
 import io.camunda.connector.runtime.outbound.secret.ProcessDefinitionSecretKeyCache;
 import io.camunda.connector.runtime.outbound.secret.SecretKeyCache;
 import io.camunda.connector.runtime.outbound.secret.SecretKeyCache.SecretKeyContext;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -47,10 +49,11 @@ class ConfigurableSecretFilterFactoryTest {
 
   private static final long PROCESS_DEF_KEY = 42L;
   private static final String ELEMENT_ID = "service-task-1";
+  private static final Instant DEADLINE = Instant.now().plusSeconds(3600);
   private static final SecretFilterContext CONTEXT =
-      new SecretFilterContext(PROCESS_DEF_KEY, ELEMENT_ID);
+      new SecretFilterContext(PROCESS_DEF_KEY, ELEMENT_ID, DEADLINE);
   private static final SecretKeyContext SECRET_KEY_CONTEXT =
-      new SecretKeyContext(PROCESS_DEF_KEY, ELEMENT_ID);
+      new SecretKeyContext(PROCESS_DEF_KEY, ELEMENT_ID, DEADLINE);
 
   @Mock private SecretKeyCache secretKeyCache;
 
@@ -200,7 +203,8 @@ class ConfigurableSecretFilterFactoryTest {
     when(camundaClient.newProcessDefinitionGetXmlRequest(anyLong())).thenReturn(xmlRequest);
     when(xmlRequest.execute())
         .thenThrow(new RuntimeException("Operate returned 404 for process definition 42"));
-    SecretKeyCache realSecretKeyCache = new ProcessDefinitionSecretKeyCache(camundaClient, cache);
+    SecretKeyCache realSecretKeyCache =
+        new ProcessDefinitionSecretKeyCache(camundaClient, cache, Duration.ofMillis(1));
     var factory = new ConfigurableSecretFilterFactory(SecretFilterMode.STRICT, realSecretKeyCache);
 
     var filter = factory.create(CONTEXT);

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/secret/ProcessDefinitionSecretKeyCacheTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/secret/ProcessDefinitionSecretKeyCacheTest.java
@@ -17,16 +17,24 @@
 package io.camunda.connector.runtime.outbound.secret;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import dev.failsafe.TimeoutExceededException;
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.fetch.ProcessDefinitionGetXmlRequest;
 import io.camunda.connector.runtime.core.secret.SecretFilter.Secret;
 import io.camunda.connector.runtime.outbound.secret.SecretKeyCache.SecretKeyContext;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.List;
 import java.util.concurrent.Callable;
 import org.junit.jupiter.api.BeforeEach;
@@ -40,6 +48,7 @@ import org.springframework.cache.Cache;
 class ProcessDefinitionSecretKeyCacheTest {
 
   private static final long PROCESS_DEF_KEY = 1L;
+  private static final Instant DEADLINE = Instant.now().plusSeconds(3600);
 
   @Mock private CamundaClient camundaClient;
   @Mock private ProcessDefinitionGetXmlRequest xmlRequest;
@@ -50,7 +59,11 @@ class ProcessDefinitionSecretKeyCacheTest {
   @BeforeEach
   void setUp() throws Exception {
     secretKeyCache = new ProcessDefinitionSecretKeyCache(camundaClient, cache);
-    when(camundaClient.newProcessDefinitionGetXmlRequest(anyLong())).thenReturn(xmlRequest);
+    // lenient: getSecretKeys_deadlineWithinSafetyMargin_failsWithoutAttemptingFetch below never
+    // reaches the XML fetch, so this stub would otherwise be flagged as unnecessary there
+    lenient()
+        .when(camundaClient.newProcessDefinitionGetXmlRequest(anyLong()))
+        .thenReturn(xmlRequest);
     when(cache.get(anyLong(), any(Callable.class)))
         .thenAnswer(
             invocation -> {
@@ -64,7 +77,8 @@ class ProcessDefinitionSecretKeyCacheTest {
     when(xmlRequest.execute()).thenReturn(loadBpmn("outbound-with-secrets.bpmn"));
 
     var keys =
-        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1"));
+        secretKeyCache.getSecretKeys(
+            new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1", DEADLINE));
 
     assertThat(keys)
         .extracting(Secret::secretName)
@@ -80,7 +94,8 @@ class ProcessDefinitionSecretKeyCacheTest {
     when(xmlRequest.execute()).thenReturn(loadBpmn("outbound-with-dotted-target.bpmn"));
 
     var keys =
-        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1"));
+        secretKeyCache.getSecretKeys(
+            new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1", DEADLINE));
 
     assertThat(keys).containsExactly(new Secret("API_KEY", List.of("auth", "token")));
   }
@@ -95,7 +110,8 @@ class ProcessDefinitionSecretKeyCacheTest {
     when(xmlRequest.execute()).thenReturn(loadBpmn("outbound-with-referenced-variable.bpmn"));
 
     var keys =
-        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1"));
+        secretKeyCache.getSecretKeys(
+            new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1", DEADLINE));
 
     assertThat(keys)
         .contains(
@@ -111,7 +127,8 @@ class ProcessDefinitionSecretKeyCacheTest {
     when(xmlRequest.execute()).thenReturn(loadBpmn("outbound-with-chained-references.bpmn"));
 
     var keys =
-        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1"));
+        secretKeyCache.getSecretKeys(
+            new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1", DEADLINE));
 
     assertThat(keys)
         .containsExactlyInAnyOrder(
@@ -129,7 +146,8 @@ class ProcessDefinitionSecretKeyCacheTest {
     when(xmlRequest.execute()).thenReturn(loadBpmn("outbound-with-referenced-variable.bpmn"));
 
     var keys =
-        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1"));
+        secretKeyCache.getSecretKeys(
+            new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1", DEADLINE));
 
     assertThat(keys)
         .doesNotContain(
@@ -148,7 +166,8 @@ class ProcessDefinitionSecretKeyCacheTest {
     when(xmlRequest.execute()).thenReturn(loadBpmn("outbound-with-sibling-fields.bpmn"));
 
     var keys =
-        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1"));
+        secretKeyCache.getSecretKeys(
+            new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1", DEADLINE));
 
     assertThat(keys)
         .contains(
@@ -169,7 +188,8 @@ class ProcessDefinitionSecretKeyCacheTest {
     when(xmlRequest.execute()).thenReturn(loadBpmn("outbound-with-reverse-order-reference.bpmn"));
 
     var keys =
-        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1"));
+        secretKeyCache.getSecretKeys(
+            new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1", DEADLINE));
 
     assertThat(keys)
         .contains(new Secret("API_KEY", List.of("baseUrl")))
@@ -188,7 +208,8 @@ class ProcessDefinitionSecretKeyCacheTest {
     when(xmlRequest.execute()).thenReturn(loadBpmn("outbound-with-parent-overwrite.bpmn"));
 
     var keys =
-        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1"));
+        secretKeyCache.getSecretKeys(
+            new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1", DEADLINE));
 
     // Nothing in this BPMN ever reads authentication.token from a path that's still effective, so
     // TOKEN isn't just absent from the two paths above -- it's not granted anywhere at all. This
@@ -206,7 +227,8 @@ class ProcessDefinitionSecretKeyCacheTest {
     when(xmlRequest.execute()).thenReturn(loadBpmn("outbound-with-same-path-overwrite.bpmn"));
 
     var keys =
-        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1"));
+        secretKeyCache.getSecretKeys(
+            new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1", DEADLINE));
 
     assertThat(keys).isEmpty();
   }
@@ -224,7 +246,8 @@ class ProcessDefinitionSecretKeyCacheTest {
         .thenReturn(loadBpmn("outbound-with-overwritten-propagation-target.bpmn"));
 
     var keys =
-        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1"));
+        secretKeyCache.getSecretKeys(
+            new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1", DEADLINE));
 
     assertThat(keys)
         .containsExactly(new Secret("TOKEN", List.of("baseUrl")))
@@ -244,7 +267,8 @@ class ProcessDefinitionSecretKeyCacheTest {
     when(xmlRequest.execute()).thenReturn(loadBpmn("outbound-with-child-overwrite.bpmn"));
 
     var keys =
-        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1"));
+        secretKeyCache.getSecretKeys(
+            new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1", DEADLINE));
 
     assertThat(keys).isEmpty();
   }
@@ -263,7 +287,8 @@ class ProcessDefinitionSecretKeyCacheTest {
         .thenReturn(loadBpmn("outbound-with-nested-parent-and-child-overwrite.bpmn"));
 
     var keys =
-        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1"));
+        secretKeyCache.getSecretKeys(
+            new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1", DEADLINE));
 
     assertThat(keys).isEmpty();
   }
@@ -280,7 +305,8 @@ class ProcessDefinitionSecretKeyCacheTest {
         .thenReturn(loadBpmn("outbound-with-shadowed-input-as-dependency.bpmn"));
 
     var keys =
-        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1"));
+        secretKeyCache.getSecretKeys(
+            new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1", DEADLINE));
 
     assertThat(keys).containsExactly(new Secret("T", List.of("baseUrl")));
   }
@@ -291,8 +317,9 @@ class ProcessDefinitionSecretKeyCacheTest {
     when(xmlRequest.execute()).thenReturn(loadBpmn("outbound-multiple-tasks-with-secrets.bpmn"));
 
     var alphaKeys =
-        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "task-alpha"));
-    var betaKeys = secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "task-beta"));
+        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "task-alpha", DEADLINE));
+    var betaKeys =
+        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "task-beta", DEADLINE));
 
     assertThat(alphaKeys).extracting(Secret::secretName).containsExactly("SECRET_ALPHA");
     assertThat(betaKeys)
@@ -305,7 +332,8 @@ class ProcessDefinitionSecretKeyCacheTest {
     when(xmlRequest.execute()).thenReturn(loadBpmn("outbound-no-secrets.bpmn"));
 
     var keys =
-        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "no-secrets-task"));
+        secretKeyCache.getSecretKeys(
+            new SecretKeyContext(PROCESS_DEF_KEY, "no-secrets-task", DEADLINE));
 
     assertThat(keys).isEmpty();
   }
@@ -316,7 +344,8 @@ class ProcessDefinitionSecretKeyCacheTest {
     // without one is still eligible and its own declared secrets are still returned.
     when(xmlRequest.execute()).thenReturn(loadBpmn("outbound-no-template.bpmn"));
 
-    var keys = secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "plain-task"));
+    var keys =
+        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "plain-task", DEADLINE));
 
     assertThat(keys).extracting(Secret::secretName).containsExactly("SECRET_X");
   }
@@ -326,9 +355,10 @@ class ProcessDefinitionSecretKeyCacheTest {
     when(xmlRequest.execute()).thenReturn(loadBpmn("outbound-adhoc-subprocess.bpmn"));
 
     var subProcessKeys =
-        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "agent-subprocess"));
+        secretKeyCache.getSecretKeys(
+            new SecretKeyContext(PROCESS_DEF_KEY, "agent-subprocess", DEADLINE));
     var childKeys =
-        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "child-task"));
+        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "child-task", DEADLINE));
 
     assertThat(subProcessKeys).extracting(Secret::secretName).containsExactly("ADHOC_SECRET");
     assertThat(childKeys).extracting(Secret::secretName).containsExactly("CHILD_SECRET");
@@ -342,11 +372,14 @@ class ProcessDefinitionSecretKeyCacheTest {
     when(xmlRequest.execute()).thenReturn(loadBpmn("outbound-nested-embedded-subprocess.bpmn"));
 
     var outerKeys =
-        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "outer-subprocess"));
+        secretKeyCache.getSecretKeys(
+            new SecretKeyContext(PROCESS_DEF_KEY, "outer-subprocess", DEADLINE));
     var innerKeys =
-        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "inner-subprocess"));
+        secretKeyCache.getSecretKeys(
+            new SecretKeyContext(PROCESS_DEF_KEY, "inner-subprocess", DEADLINE));
     var grandchildKeys =
-        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "grandchild-task"));
+        secretKeyCache.getSecretKeys(
+            new SecretKeyContext(PROCESS_DEF_KEY, "grandchild-task", DEADLINE));
 
     assertThat(outerKeys).extracting(Secret::secretName).containsExactly("OUTER_SECRET");
     assertThat(innerKeys).extracting(Secret::secretName).containsExactly("INNER_SECRET");
@@ -359,9 +392,11 @@ class ProcessDefinitionSecretKeyCacheTest {
     when(xmlRequest.execute()).thenReturn(loadBpmn("outbound-message-events.bpmn"));
 
     var throwEventKeys =
-        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "send-message-throw"));
+        secretKeyCache.getSecretKeys(
+            new SecretKeyContext(PROCESS_DEF_KEY, "send-message-throw", DEADLINE));
     var endEventKeys =
-        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "send-message-end"));
+        secretKeyCache.getSecretKeys(
+            new SecretKeyContext(PROCESS_DEF_KEY, "send-message-end", DEADLINE));
 
     assertThat(throwEventKeys).extracting(Secret::secretName).containsExactly("THROW_EVENT_SECRET");
     assertThat(endEventKeys).extracting(Secret::secretName).containsExactly("END_EVENT_SECRET");
@@ -372,9 +407,106 @@ class ProcessDefinitionSecretKeyCacheTest {
     when(xmlRequest.execute()).thenReturn(loadBpmn("outbound-with-secrets.bpmn"));
 
     var keys =
-        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "nonexistent-task"));
+        secretKeyCache.getSecretKeys(
+            new SecretKeyContext(PROCESS_DEF_KEY, "nonexistent-task", DEADLINE));
 
     assertThat(keys).isEmpty();
+  }
+
+  @Test
+  void getSecretKeys_xmlFetchTransientlyFails_retriesAndSucceeds() throws IOException {
+    // simulates the get-XML endpoint's eventual-consistency window right after deployment: the
+    // first two attempts 404 before the definition becomes visible, the third succeeds
+    var retryingCache =
+        new ProcessDefinitionSecretKeyCache(camundaClient, cache, Duration.ofMillis(1));
+    when(xmlRequest.execute())
+        .thenThrow(new RuntimeException("not found (yet)"))
+        .thenThrow(new RuntimeException("not found (yet)"))
+        .thenReturn(loadBpmn("outbound-with-secrets.bpmn"));
+
+    var keys =
+        retryingCache.getSecretKeys(
+            new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1", DEADLINE));
+
+    assertThat(keys)
+        .extracting(Secret::secretName)
+        .containsExactlyInAnyOrder("API_KEY", "MY_TOKEN");
+    verify(xmlRequest, times(3)).execute();
+  }
+
+  @Test
+  void getSecretKeys_xmlFetchFailsPastMaxRetries_throwsLastFailure() {
+    var retryingCache =
+        new ProcessDefinitionSecretKeyCache(camundaClient, cache, Duration.ofMillis(1));
+    when(xmlRequest.execute()).thenThrow(new RuntimeException("still not found"));
+
+    assertThatThrownBy(
+            () ->
+                retryingCache.getSecretKeys(
+                    new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1", DEADLINE)))
+        .isInstanceOf(RuntimeException.class)
+        .hasMessage("still not found");
+    // 1 initial attempt + 3 retries
+    verify(xmlRequest, times(4)).execute();
+  }
+
+  @Test
+  void getSecretKeys_deadlineWithinSafetyMargin_failsWithoutAttemptingFetch() {
+    assertThatThrownBy(
+            () ->
+                secretKeyCache.getSecretKeys(
+                    new SecretKeyContext(
+                        PROCESS_DEF_KEY, "service-task-1", Instant.now().plusSeconds(2))))
+        .isInstanceOf(IllegalStateException.class);
+    verify(xmlRequest, times(0)).execute();
+  }
+
+  @Test
+  void getSecretKeys_deadlineLeavesOnlyAPartialRetryWindow_stopsRetryingBeforeMaxRetries() {
+    var retryingCache =
+        new ProcessDefinitionSecretKeyCache(camundaClient, cache, Duration.ofMillis(200));
+    when(xmlRequest.execute()).thenThrow(new RuntimeException("still not found"));
+    Instant deadline = Instant.now().plusSeconds(5).plusMillis(300);
+
+    long start = System.nanoTime();
+    assertThatThrownBy(
+            () ->
+                retryingCache.getSecretKeys(
+                    new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1", deadline)))
+        .satisfiesAnyOf(
+            e -> assertThat(e).isInstanceOf(TimeoutExceededException.class),
+            e -> assertThat(e).hasMessage("still not found"));
+    long elapsedMillis = (System.nanoTime() - start) / 1_000_000;
+
+    assertThat(elapsedMillis).isLessThan(700);
+    verify(xmlRequest, atLeast(2)).execute();
+  }
+
+  @Test
+  void getSecretKeys_xmlFetchIgnoresInterruptAndSucceedsPastDeadline_stillFails()
+      throws IOException {
+    var retryingCache =
+        new ProcessDefinitionSecretKeyCache(camundaClient, cache, Duration.ofMillis(200));
+    String bpmnXml = loadBpmn("outbound-with-secrets.bpmn");
+    when(xmlRequest.execute())
+        .thenAnswer(
+            invocation -> {
+              long until = System.nanoTime() + Duration.ofMillis(250).toNanos();
+              while (System.nanoTime() < until) {
+                try {
+                  Thread.sleep(10);
+                } catch (InterruptedException ignored) {
+                }
+              }
+              return bpmnXml;
+            });
+    Instant deadline = Instant.now().plusSeconds(5).plusMillis(150);
+
+    assertThatThrownBy(
+            () ->
+                retryingCache.getSecretKeys(
+                    new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1", deadline)))
+        .isInstanceOf(TimeoutExceededException.class);
   }
 
   private String loadBpmn(String fileName) throws IOException {

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/jobworker/AiAgentJobWorkerHandlerImpl.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/jobworker/AiAgentJobWorkerHandlerImpl.java
@@ -35,6 +35,7 @@ import io.camunda.connector.runtime.core.secret.SecretFilterFactory.SecretFilter
 import io.camunda.connector.runtime.metrics.ConnectorMetrics;
 import io.camunda.connector.runtime.outbound.job.OutboundConnectorExceptionHandler;
 import java.time.Duration;
+import java.time.Instant;
 import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
 import java.util.List;
@@ -92,7 +93,10 @@ public class AiAgentJobWorkerHandlerImpl implements AiAgentJobWorkerHandler {
       final CounterMetricsContext counterMetricsContext) {
     final SecretFilter secretFilter =
         secretFilterFactory.create(
-            new SecretFilterContext(job.getProcessDefinitionKey(), job.getElementId()));
+            new SecretFilterContext(
+                job.getProcessDefinitionKey(),
+                job.getElementId(),
+                Instant.ofEpochMilli(job.getDeadline())));
     // the values this job's input binding substituted, so an error raised after one of them rotates
     // is still redacted with what the agent was handed
     final List<String> capturedSecrets = new ArrayList<>();

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/jobworker/JobWorkerAgentExecutionContextFactoryImpl.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/jobworker/JobWorkerAgentExecutionContextFactoryImpl.java
@@ -18,6 +18,7 @@ import io.camunda.connector.runtime.core.outbound.JobHandlerContext;
 import io.camunda.connector.runtime.core.secret.SecretFilter;
 import io.camunda.connector.runtime.core.secret.SecretFilterFactory;
 import io.camunda.connector.runtime.core.secret.SecretFilterFactory.SecretFilterContext;
+import java.time.Instant;
 import java.util.List;
 
 public class JobWorkerAgentExecutionContextFactoryImpl
@@ -46,7 +47,10 @@ public class JobWorkerAgentExecutionContextFactoryImpl
       final JobClient jobClient, final ActivatedJob job, final List<String> capturedSecretValues) {
     final SecretFilter secretFilter =
         secretFilterFactory.create(
-            new SecretFilterContext(job.getProcessDefinitionKey(), job.getElementId()));
+            new SecretFilterContext(
+                job.getProcessDefinitionKey(),
+                job.getElementId(),
+                Instant.ofEpochMilli(job.getDeadline())));
     final JobHandlerContext context =
         new JobHandlerContext(
             job, secretProvider, validationProvider, documentFactory, objectMapper, secretFilter);


### PR DESCRIPTION
## Description

Backports #8756 to `stable/8.9`.

`ProcessDefinitionSecretKeyCache.fetchSecretKeysByElementIds` reads the deployed process definition's BPMN XML to build the per-element secret allow-list. That read hits an eventually consistent secondary store, so it can fail right after deployment before the definition becomes visible there. #8633 previously addressed this by surfacing the failure as a job error and relying on Zeebe's own job retry/backoff — but that turns an internal, self-healing race into user-visible, incorrect error-handling behavior for any process with its own error-boundary expressions. This backport instead retries the XML fetch itself, bounded by the activated job's deadline (via Failsafe's `RetryPolicy` + an interruptible `Timeout`), so the transient failure stays invisible to the process and only surfaces once retries are truly exhausted or the deadline is reached.

### Manual resolution notes

The automated cherry-pick failed with conflicts because `stable/8.9` lacks two things that already existed on `main` when #8756 was authored:

- The multi-tenant `physicalTenantId` plumbing in `ProcessDefinitionSecretKeyCache` (cache keyed only by `processDefinitionKey` on this branch, not `(physicalTenantId, processDefinitionKey)`).
- The job-timeout-header / effective-deadline resolution in `SpringConnectorJobHandler` (`updateJobTimeoutIfPresent`, async `JobCallbackCommandWrapper` completions).

Both are unrelated, separately-merged features not part of #8756's own diff. The conflicts were resolved by applying only #8756's actual changes on top of `stable/8.9`'s existing (simpler) code:

- `ProcessDefinitionSecretKeyCache`: added the deadline-bounded retry/timeout logic without introducing `physicalTenantId` (kept the existing single-tenant constructor, added a `Duration xmlFetchInitialRetryDelay` test seam).
- `SpringConnectorJobHandler`: since this branch has no job-timeout-header override, the effective deadline used for `SecretFilterContext` is simply `job.getDeadline()` (no `updateJobTimeoutIfPresent` involved).
- Test files were adapted the same way: all `SecretKeyContext`/`SecretFilterContext` call sites gained the required `deadline` argument, and the new retry/deadline tests from #8756 were ported (dropping the tenant-id argument that doesn't exist here). The two new tests in #8756's `SpringConnectorJobHandlerTest` that specifically covered the job-timeout-header interaction were not ported, since that feature doesn't exist on this branch.
- One additional fix beyond a straight port: `ConfigurableSecretFilterFactoryTest`'s auto-merged real-cache test called the (nonexistent on this branch) 4-arg tenant-aware constructor; adjusted to the 3-arg one.
- A pre-existing test (`getSecretKeys_deadlineWithinSafetyMargin_failsWithoutAttemptingFetch`) needed `lenient()` on the shared `camundaClient.newProcessDefinitionGetXmlRequest` stub, since that particular case never reaches the XML fetch.

## Related issues

Related to #8633.

Source PR: #8756.

## Checklist

- [x] Cherry-pick conflicts resolved by hand, preserving #8756's intent without pulling in unrelated multi-tenant/job-timeout-header features absent from this branch.
- [x] `./mvnw -pl connector-runtime/connector-runtime-core,connector-runtime/connector-runtime-spring -am test` passes (328 tests, 0 failures).
- [x] No documentation update is required for this backport.