### PR TITLE
[Backport stable/8.7] fix: retry outbound secret allow-list XML fetch on transient failure

### DIFF
--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/outbound/ConnectorJobHandler.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/outbound/ConnectorJobHandler.java
@@ -47,6 +47,7 @@ import io.camunda.zeebe.client.api.response.FailJobResponse;
 import io.camunda.zeebe.client.api.worker.JobClient;
 import io.camunda.zeebe.client.api.worker.JobHandler;
 import java.time.Duration;
+import java.time.Instant;
 import java.time.format.DateTimeParseException;
 import java.util.Map;
 import java.util.Optional;
@@ -129,7 +130,10 @@ public class ConnectorJobHandler implements JobHandler {
     LOGGER.info("Received job: {} for tenant: {}", job.getKey(), job.getTenantId());
     SecretFilter secretFilter =
         secretFilterFactory.create(
-            new SecretFilterContext(job.getProcessDefinitionKey(), job.getElementId()));
+            new SecretFilterContext(
+                job.getProcessDefinitionKey(),
+                job.getElementId(),
+                Instant.ofEpochMilli(job.getDeadline())));
     // built here rather than inside the call, so the values it substituted are still available to
     // redact with afterwards: a secret rotated in the store since then no longer re-reads to what
     // this job actually sent, and the error it provoked would publish the value it did send

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretFilterFactory.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretFilterFactory.java
@@ -16,6 +16,8 @@
  */
 package io.camunda.connector.runtime.core.secret;
 
+import java.time.Instant;
+
 public interface SecretFilterFactory {
   SecretFilter create(SecretFilterContext context);
 
@@ -23,5 +25,5 @@ public interface SecretFilterFactory {
     return context -> SecretFilter.allowAll();
   }
 
-  record SecretFilterContext(long processDefinitionKey, String elementId) {}
+  record SecretFilterContext(long processDefinitionKey, String elementId, Instant deadline) {}
 }

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/outbound/ConnectorJobHandlerTest.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/outbound/ConnectorJobHandlerTest.java
@@ -45,11 +45,14 @@ import io.camunda.connector.api.secret.SecretProvider;
 import io.camunda.connector.runtime.core.ConnectorHelper;
 import io.camunda.connector.runtime.core.FooBarSecretProvider;
 import io.camunda.connector.runtime.core.Keywords;
+import io.camunda.connector.runtime.core.secret.SecretFilter;
 import io.camunda.connector.runtime.core.secret.SecretFilterFactory;
+import io.camunda.connector.runtime.core.secret.SecretFilterFactory.SecretFilterContext;
 import io.camunda.zeebe.client.api.command.FailJobCommandStep1;
 import io.camunda.zeebe.client.api.command.FailJobCommandStep1.FailJobCommandStep2;
 import io.camunda.zeebe.client.api.worker.JobClient;
 import java.time.Duration;
+import java.time.Instant;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -1469,6 +1472,36 @@ class ConnectorJobHandlerTest {
       // then
       assertThat(result.getErrorCode()).isEqualTo("AUTH_FAILED");
       assertThat(result.getErrorMessage()).isNull();
+    }
+  }
+
+  @Nested
+  class SecretFilterContextTests {
+
+    @Test
+    void shouldPassJobDeadlineToSecretFilterFactory() {
+      // given
+      long deadlineEpochMilli = 1_700_000_000_000L;
+      SecretFilterFactory secretFilterFactory = mock(SecretFilterFactory.class);
+      when(secretFilterFactory.create(any())).thenReturn(SecretFilter.allowAll());
+      var jobHandler =
+          new ConnectorJobHandler(
+              context -> Map.of("hello", "world"),
+              new FooBarSecretProvider(),
+              e -> {},
+              null,
+              null,
+              secretFilterFactory);
+
+      // when
+      JobBuilder.create().withDeadline(deadlineEpochMilli).executeAndCaptureResult(jobHandler);
+
+      // then
+      ArgumentCaptor<SecretFilterContext> contextCaptor =
+          ArgumentCaptor.forClass(SecretFilterContext.class);
+      verify(secretFilterFactory).create(contextCaptor.capture());
+      assertThat(contextCaptor.getValue().deadline())
+          .isEqualTo(Instant.ofEpochMilli(deadlineEpochMilli));
     }
   }
 

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/outbound/JobBuilder.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/outbound/JobBuilder.java
@@ -117,6 +117,11 @@ class JobBuilder {
       return this;
     }
 
+    public JobBuilderStep withDeadline(long deadlineEpochMilli) {
+      when(job.getDeadline()).thenReturn(deadlineEpochMilli);
+      return this;
+    }
+
     public JobBuilderStep withResultVariableHeader(final String value) {
       return withHeader(Keywords.RESULT_VARIABLE_KEYWORD, value);
     }

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/ConfigurableSecretFilterFactory.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/ConfigurableSecretFilterFactory.java
@@ -54,7 +54,8 @@ public class ConfigurableSecretFilterFactory implements SecretFilterFactory {
         () -> {
           try {
             return secretKeyCache.getSecretKeys(
-                new SecretKeyContext(context.processDefinitionKey(), context.elementId()));
+                new SecretKeyContext(
+                    context.processDefinitionKey(), context.elementId(), context.deadline()));
           } catch (SecretFilterUnavailableException e) {
             // Self-authored operator guidance, never derived from a client or parser response --
             // unlike every other failure below, its message is safe to surface as-is.

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/secret/ProcessDefinitionSecretKeyCache.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/secret/ProcessDefinitionSecretKeyCache.java
@@ -74,7 +74,7 @@ public class ProcessDefinitionSecretKeyCache implements SecretKeyCache {
    * Retries stop this far ahead of the activated job's deadline, leaving room for the connector
    * function itself to run before the job's lease expires -- a fetch that only succeeds after the
    * lease is gone risks the job being reassigned while this worker keeps executing, per the
-   * duplicate-side-effect concern in {@code SpringConnectorJobHandler}.
+   * duplicate-side-effect concern in {@code ConnectorJobHandler}.
    */
   private static final Duration XML_FETCH_DEADLINE_SAFETY_MARGIN = Duration.ofSeconds(5);
 

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/secret/ProcessDefinitionSecretKeyCache.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/secret/ProcessDefinitionSecretKeyCache.java
@@ -17,6 +17,10 @@
 package io.camunda.connector.runtime.outbound.secret;
 
 import com.github.benmanes.caffeine.cache.Cache;
+import dev.failsafe.Failsafe;
+import dev.failsafe.FailsafeException;
+import dev.failsafe.RetryPolicy;
+import dev.failsafe.Timeout;
 import io.camunda.connector.runtime.core.secret.SecretFilter.Secret;
 import io.camunda.connector.runtime.core.secret.SecretUtil;
 import io.camunda.operate.CamundaOperateClient;
@@ -34,6 +38,8 @@ import io.camunda.zeebe.model.bpmn.instance.ServiceTask;
 import io.camunda.zeebe.model.bpmn.instance.SubProcess;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeInput;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeIoMapping;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -60,6 +66,18 @@ public class ProcessDefinitionSecretKeyCache implements SecretKeyCache {
   private static final List<Class<? extends BaseElement>> OUTBOUND_ELIGIBLE_TYPES =
       new ArrayList<>();
 
+  private static final int XML_FETCH_MAX_RETRIES = 3;
+
+  private static final Duration XML_FETCH_INITIAL_RETRY_DELAY = Duration.ofSeconds(1);
+
+  /**
+   * Retries stop this far ahead of the activated job's deadline, leaving room for the connector
+   * function itself to run before the job's lease expires -- a fetch that only succeeds after the
+   * lease is gone risks the job being reassigned while this worker keeps executing, per the
+   * duplicate-side-effect concern in {@code SpringConnectorJobHandler}.
+   */
+  private static final Duration XML_FETCH_DEADLINE_SAFETY_MARGIN = Duration.ofSeconds(5);
+
   static {
     OUTBOUND_ELIGIBLE_TYPES.add(ServiceTask.class);
     OUTBOUND_ELIGIBLE_TYPES.add(SendTask.class);
@@ -72,17 +90,29 @@ public class ProcessDefinitionSecretKeyCache implements SecretKeyCache {
 
   private final CamundaOperateClient camundaOperateClient;
   private final Cache<Long, Map<String, List<Secret>>> cache;
+  private final Duration xmlFetchInitialRetryDelay;
 
   public ProcessDefinitionSecretKeyCache(
       CamundaOperateClient camundaOperateClient, Cache<Long, Map<String, List<Secret>>> cache) {
+    this(camundaOperateClient, cache, XML_FETCH_INITIAL_RETRY_DELAY);
+  }
+
+  /** Test-only seam: lets retry tests use a near-zero delay instead of the real one. */
+  public ProcessDefinitionSecretKeyCache(
+      CamundaOperateClient camundaOperateClient,
+      Cache<Long, Map<String, List<Secret>>> cache,
+      Duration xmlFetchInitialRetryDelay) {
     this.camundaOperateClient = camundaOperateClient;
     this.cache = cache;
+    this.xmlFetchInitialRetryDelay = xmlFetchInitialRetryDelay;
   }
 
   @Override
   public List<Secret> getSecretKeys(SecretKeyContext secretKeyContext) {
     return cache
-        .get(secretKeyContext.processDefinitionKey(), this::fetchSecretKeysByElementIdsUnchecked)
+        .get(
+            secretKeyContext.processDefinitionKey(),
+            key -> fetchSecretKeysByElementIdsUnchecked(key, secretKeyContext.deadline()))
         .getOrDefault(secretKeyContext.elementId(), Collections.emptyList());
   }
 
@@ -94,9 +124,9 @@ public class ProcessDefinitionSecretKeyCache implements SecretKeyCache {
    * exactly as thrown.
    */
   private Map<String, List<Secret>> fetchSecretKeysByElementIdsUnchecked(
-      long processDefinitionKey) {
+      long processDefinitionKey, Instant deadline) {
     try {
-      return fetchSecretKeysByElementIds(processDefinitionKey);
+      return fetchSecretKeysByElementIds(processDefinitionKey, deadline);
     } catch (OperateException e) {
       throw new SecretKeyLookupException(
           "Failed to look up declared secret keys for process definition key "
@@ -105,8 +135,8 @@ public class ProcessDefinitionSecretKeyCache implements SecretKeyCache {
     }
   }
 
-  private Map<String, List<Secret>> fetchSecretKeysByElementIds(long processDefinitionKey)
-      throws OperateException {
+  private Map<String, List<Secret>> fetchSecretKeysByElementIds(
+      long processDefinitionKey, Instant deadline) throws OperateException {
     if (camundaOperateClient == null) {
       throw new SecretFilterUnavailableException(
           "No CamundaOperateClient available to look up declared secret keys for process"
@@ -117,14 +147,59 @@ public class ProcessDefinitionSecretKeyCache implements SecretKeyCache {
               + "=DISABLED, or provide a CamundaOperateClient bean, to use the outbound secret"
               + " filter in an outbound-only deployment.");
     }
-    BpmnModelInstance modelInstance =
-        camundaOperateClient.getProcessDefinitionModel(processDefinitionKey);
+    BpmnModelInstance modelInstance = fetchBpmnModelWithRetry(processDefinitionKey, deadline);
     var processes =
         modelInstance.getDefinitions().getChildElementsByType(Process.class).stream().toList();
 
     return processes.stream()
         .flatMap(process -> inspectBpmnProcess(process, processDefinitionKey).entrySet().stream())
         .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+  }
+
+  private BpmnModelInstance fetchBpmnModelWithRetry(long processDefinitionKey, Instant deadline)
+      throws OperateException {
+    Duration remaining =
+        Duration.between(Instant.now(), deadline).minus(XML_FETCH_DEADLINE_SAFETY_MARGIN);
+    if (remaining.isNegative() || remaining.isZero()) {
+      throw new IllegalStateException(
+          "BPMN XML fetch deadline already elapsed for process definition key "
+              + processDefinitionKey);
+    }
+    Timeout<BpmnModelInstance> xmlFetchTimeout =
+        Timeout.<BpmnModelInstance>builder(remaining).withInterrupt().build();
+    try {
+      if (remaining.compareTo(xmlFetchInitialRetryDelay) <= 0) {
+        return Failsafe.with(xmlFetchTimeout)
+            .get(() -> camundaOperateClient.getProcessDefinitionModel(processDefinitionKey));
+      }
+      RetryPolicy<BpmnModelInstance> xmlFetchRetryPolicy =
+          RetryPolicy.<BpmnModelInstance>builder()
+              .withBackoff(
+                  xmlFetchInitialRetryDelay,
+                  xmlFetchInitialRetryDelay.multipliedBy(1L << (XML_FETCH_MAX_RETRIES - 1)))
+              .withMaxRetries(XML_FETCH_MAX_RETRIES)
+              .withMaxDuration(remaining)
+              .onFailedAttempt(
+                  event ->
+                      LOG.warn(
+                          "Attempt {}/{} to fetch BPMN XML failed: {}",
+                          event.getAttemptCount(),
+                          XML_FETCH_MAX_RETRIES + 1,
+                          event.getLastException().getClass().getName()))
+              .build();
+      return Failsafe.with(xmlFetchTimeout, xmlFetchRetryPolicy)
+          .get(() -> camundaOperateClient.getProcessDefinitionModel(processDefinitionKey));
+    } catch (FailsafeException e) {
+      // A checked OperateException from the retried call arrives here wrapped, per Failsafe's
+      // get(CheckedSupplier) contract; unwrap it so this method's own throws clause -- and every
+      // caller's existing OperateException handling -- still applies. A FailsafeException with no
+      // cause (notably TimeoutExceededException, thrown directly by the Timeout policy rather than
+      // wrapping a checked exception) is rethrown as-is.
+      if (e.getCause() instanceof OperateException operateException) {
+        throw operateException;
+      }
+      throw e;
+    }
   }
 
   private Map<String, List<Secret>> inspectBpmnProcess(Process process, long processDefinitionKey) {

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/secret/SecretKeyCache.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/secret/SecretKeyCache.java
@@ -17,10 +17,11 @@
 package io.camunda.connector.runtime.outbound.secret;
 
 import io.camunda.connector.runtime.core.secret.SecretFilter.Secret;
+import java.time.Instant;
 import java.util.List;
 
 public interface SecretKeyCache {
   List<Secret> getSecretKeys(SecretKeyContext secretKeyContext);
 
-  record SecretKeyContext(long processDefinitionKey, String elementId) {}
+  record SecretKeyContext(long processDefinitionKey, String elementId, Instant deadline) {}
 }

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/job/ConfigurableSecretFilterFactoryTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/job/ConfigurableSecretFilterFactoryTest.java
@@ -34,6 +34,8 @@ import io.camunda.connector.runtime.outbound.secret.SecretKeyCache;
 import io.camunda.connector.runtime.outbound.secret.SecretKeyCache.SecretKeyContext;
 import io.camunda.operate.CamundaOperateClient;
 import io.camunda.operate.exception.OperateException;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
@@ -46,10 +48,11 @@ class ConfigurableSecretFilterFactoryTest {
 
   private static final long PROCESS_DEF_KEY = 42L;
   private static final String ELEMENT_ID = "service-task-1";
+  private static final Instant DEADLINE = Instant.now().plusSeconds(3600);
   private static final SecretFilterContext CONTEXT =
-      new SecretFilterContext(PROCESS_DEF_KEY, ELEMENT_ID);
+      new SecretFilterContext(PROCESS_DEF_KEY, ELEMENT_ID, DEADLINE);
   private static final SecretKeyContext SECRET_KEY_CONTEXT =
-      new SecretKeyContext(PROCESS_DEF_KEY, ELEMENT_ID);
+      new SecretKeyContext(PROCESS_DEF_KEY, ELEMENT_ID, DEADLINE);
 
   @Mock private SecretKeyCache secretKeyCache;
 
@@ -207,7 +210,10 @@ class ConfigurableSecretFilterFactoryTest {
     var operateClient = mock(CamundaOperateClient.class);
     when(operateClient.getProcessDefinitionModel(PROCESS_DEF_KEY))
         .thenThrow(new OperateException("Operate returned 404 for process definition 42"));
-    SecretKeyCache realSecretKeyCache = new ProcessDefinitionSecretKeyCache(operateClient, cache);
+    // Near-zero retry delay: this is a permanent failure exercised through every retry attempt,
+    // and the default delay would otherwise make this test sleep through Failsafe's real backoff.
+    SecretKeyCache realSecretKeyCache =
+        new ProcessDefinitionSecretKeyCache(operateClient, cache, Duration.ofMillis(1));
     var factory = new ConfigurableSecretFilterFactory(SecretFilterMode.STRICT, realSecretKeyCache);
 
     var filter = factory.create(CONTEXT);

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/secret/ProcessDefinitionSecretKeyCacheTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/secret/ProcessDefinitionSecretKeyCacheTest.java
@@ -18,14 +18,21 @@ package io.camunda.connector.runtime.outbound.secret;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.github.benmanes.caffeine.cache.Caffeine;
+import dev.failsafe.TimeoutExceededException;
 import io.camunda.connector.runtime.core.secret.SecretFilter.Secret;
 import io.camunda.connector.runtime.outbound.secret.SecretKeyCache.SecretKeyContext;
 import io.camunda.operate.CamundaOperateClient;
+import io.camunda.operate.exception.OperateException;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.List;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
@@ -41,6 +48,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 class ProcessDefinitionSecretKeyCacheTest {
 
   private static final long PROCESS_DEF_KEY = 1L;
+  private static final Instant DEADLINE = Instant.now().plusSeconds(3600);
 
   @Mock private CamundaOperateClient camundaOperateClient;
 
@@ -60,7 +68,8 @@ class ProcessDefinitionSecretKeyCacheTest {
         .thenReturn(loadBpmn("outbound-with-secrets.bpmn"));
 
     var keys =
-        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1"));
+        secretKeyCache.getSecretKeys(
+            new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1", DEADLINE));
 
     assertThat(keys)
         .extracting(Secret::secretName)
@@ -77,7 +86,8 @@ class ProcessDefinitionSecretKeyCacheTest {
         .thenReturn(loadBpmn("outbound-with-dotted-target.bpmn"));
 
     var keys =
-        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1"));
+        secretKeyCache.getSecretKeys(
+            new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1", DEADLINE));
 
     assertThat(keys).containsExactly(new Secret("API_KEY", List.of("auth", "token")));
   }
@@ -93,7 +103,8 @@ class ProcessDefinitionSecretKeyCacheTest {
         .thenReturn(loadBpmn("outbound-with-referenced-variable.bpmn"));
 
     var keys =
-        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1"));
+        secretKeyCache.getSecretKeys(
+            new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1", DEADLINE));
 
     assertThat(keys)
         .contains(
@@ -110,7 +121,8 @@ class ProcessDefinitionSecretKeyCacheTest {
         .thenReturn(loadBpmn("outbound-with-chained-references.bpmn"));
 
     var keys =
-        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1"));
+        secretKeyCache.getSecretKeys(
+            new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1", DEADLINE));
 
     assertThat(keys)
         .containsExactlyInAnyOrder(
@@ -129,7 +141,8 @@ class ProcessDefinitionSecretKeyCacheTest {
         .thenReturn(loadBpmn("outbound-with-referenced-variable.bpmn"));
 
     var keys =
-        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1"));
+        secretKeyCache.getSecretKeys(
+            new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1", DEADLINE));
 
     assertThat(keys)
         .doesNotContain(
@@ -149,7 +162,8 @@ class ProcessDefinitionSecretKeyCacheTest {
         .thenReturn(loadBpmn("outbound-with-sibling-fields.bpmn"));
 
     var keys =
-        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1"));
+        secretKeyCache.getSecretKeys(
+            new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1", DEADLINE));
 
     assertThat(keys)
         .contains(
@@ -170,7 +184,8 @@ class ProcessDefinitionSecretKeyCacheTest {
         .thenReturn(loadBpmn("outbound-with-reverse-order-reference.bpmn"));
 
     var keys =
-        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1"));
+        secretKeyCache.getSecretKeys(
+            new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1", DEADLINE));
 
     assertThat(keys)
         .contains(new Secret("API_KEY", List.of("baseUrl")))
@@ -190,7 +205,8 @@ class ProcessDefinitionSecretKeyCacheTest {
         .thenReturn(loadBpmn("outbound-with-parent-overwrite.bpmn"));
 
     var keys =
-        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1"));
+        secretKeyCache.getSecretKeys(
+            new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1", DEADLINE));
 
     // Nothing in this BPMN ever reads authentication.token from a path that's still effective, so
     // TOKEN isn't just absent from the two paths above -- it's not granted anywhere at all. This
@@ -209,7 +225,8 @@ class ProcessDefinitionSecretKeyCacheTest {
         .thenReturn(loadBpmn("outbound-with-same-path-overwrite.bpmn"));
 
     var keys =
-        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1"));
+        secretKeyCache.getSecretKeys(
+            new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1", DEADLINE));
 
     assertThat(keys).isEmpty();
   }
@@ -227,7 +244,8 @@ class ProcessDefinitionSecretKeyCacheTest {
         .thenReturn(loadBpmn("outbound-with-overwritten-propagation-target.bpmn"));
 
     var keys =
-        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1"));
+        secretKeyCache.getSecretKeys(
+            new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1", DEADLINE));
 
     assertThat(keys)
         .containsExactly(new Secret("TOKEN", List.of("baseUrl")))
@@ -248,7 +266,8 @@ class ProcessDefinitionSecretKeyCacheTest {
         .thenReturn(loadBpmn("outbound-with-child-overwrite.bpmn"));
 
     var keys =
-        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1"));
+        secretKeyCache.getSecretKeys(
+            new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1", DEADLINE));
 
     assertThat(keys).isEmpty();
   }
@@ -267,7 +286,8 @@ class ProcessDefinitionSecretKeyCacheTest {
         .thenReturn(loadBpmn("outbound-with-nested-parent-and-child-overwrite.bpmn"));
 
     var keys =
-        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1"));
+        secretKeyCache.getSecretKeys(
+            new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1", DEADLINE));
 
     assertThat(keys).isEmpty();
   }
@@ -284,7 +304,8 @@ class ProcessDefinitionSecretKeyCacheTest {
         .thenReturn(loadBpmn("outbound-with-shadowed-input-as-dependency.bpmn"));
 
     var keys =
-        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1"));
+        secretKeyCache.getSecretKeys(
+            new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1", DEADLINE));
 
     assertThat(keys).containsExactly(new Secret("T", List.of("baseUrl")));
   }
@@ -296,8 +317,9 @@ class ProcessDefinitionSecretKeyCacheTest {
         .thenReturn(loadBpmn("outbound-multiple-tasks-with-secrets.bpmn"));
 
     var alphaKeys =
-        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "task-alpha"));
-    var betaKeys = secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "task-beta"));
+        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "task-alpha", DEADLINE));
+    var betaKeys =
+        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "task-beta", DEADLINE));
 
     assertThat(alphaKeys).extracting(Secret::secretName).containsExactly("SECRET_ALPHA");
     assertThat(betaKeys)
@@ -311,7 +333,8 @@ class ProcessDefinitionSecretKeyCacheTest {
         .thenReturn(loadBpmn("outbound-no-secrets.bpmn"));
 
     var keys =
-        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "no-secrets-task"));
+        secretKeyCache.getSecretKeys(
+            new SecretKeyContext(PROCESS_DEF_KEY, "no-secrets-task", DEADLINE));
 
     assertThat(keys).isEmpty();
   }
@@ -324,7 +347,8 @@ class ProcessDefinitionSecretKeyCacheTest {
     when(camundaOperateClient.getProcessDefinitionModel(PROCESS_DEF_KEY))
         .thenReturn(loadBpmn("outbound-no-template.bpmn"));
 
-    var keys = secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "plain-task"));
+    var keys =
+        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "plain-task", DEADLINE));
 
     assertThat(keys).extracting(Secret::secretName).containsExactly("SECRET_X");
   }
@@ -335,7 +359,8 @@ class ProcessDefinitionSecretKeyCacheTest {
         .thenReturn(loadBpmn("outbound-with-secrets.bpmn"));
 
     var keys =
-        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "nonexistent-task"));
+        secretKeyCache.getSecretKeys(
+            new SecretKeyContext(PROCESS_DEF_KEY, "nonexistent-task", DEADLINE));
 
     assertThat(keys).isEmpty();
   }
@@ -347,7 +372,8 @@ class ProcessDefinitionSecretKeyCacheTest {
     when(camundaOperateClient.getProcessDefinitionModel(PROCESS_DEF_KEY))
         .thenReturn(loadBpmn("outbound-task-types.bpmn"));
 
-    var keys = secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, elementId));
+    var keys =
+        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, elementId, DEADLINE));
 
     assertThat(keys).extracting(Secret::secretName).containsExactly(secretKey);
   }
@@ -366,9 +392,11 @@ class ProcessDefinitionSecretKeyCacheTest {
         .thenReturn(loadBpmn("outbound-message-events.bpmn"));
 
     var throwEventKeys =
-        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "send-message-throw"));
+        secretKeyCache.getSecretKeys(
+            new SecretKeyContext(PROCESS_DEF_KEY, "send-message-throw", DEADLINE));
     var endEventKeys =
-        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "send-message-end"));
+        secretKeyCache.getSecretKeys(
+            new SecretKeyContext(PROCESS_DEF_KEY, "send-message-end", DEADLINE));
 
     assertThat(throwEventKeys).extracting(Secret::secretName).containsExactly("THROW_EVENT_SECRET");
     assertThat(endEventKeys).extracting(Secret::secretName).containsExactly("END_EVENT_SECRET");
@@ -383,11 +411,14 @@ class ProcessDefinitionSecretKeyCacheTest {
         .thenReturn(loadBpmn("outbound-nested-embedded-subprocess.bpmn"));
 
     var outerKeys =
-        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "outer-subprocess"));
+        secretKeyCache.getSecretKeys(
+            new SecretKeyContext(PROCESS_DEF_KEY, "outer-subprocess", DEADLINE));
     var innerKeys =
-        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "inner-subprocess"));
+        secretKeyCache.getSecretKeys(
+            new SecretKeyContext(PROCESS_DEF_KEY, "inner-subprocess", DEADLINE));
     var grandchildKeys =
-        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "grandchild-task"));
+        secretKeyCache.getSecretKeys(
+            new SecretKeyContext(PROCESS_DEF_KEY, "grandchild-task", DEADLINE));
 
     assertThat(outerKeys).extracting(Secret::secretName).containsExactly("OUTER_SECRET");
     assertThat(innerKeys).extracting(Secret::secretName).containsExactly("INNER_SECRET");
@@ -400,7 +431,9 @@ class ProcessDefinitionSecretKeyCacheTest {
         new ProcessDefinitionSecretKeyCache(null, Caffeine.newBuilder().build());
 
     assertThatThrownBy(
-            () -> cacheWithoutClient.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "task")))
+            () ->
+                cacheWithoutClient.getSecretKeys(
+                    new SecretKeyContext(PROCESS_DEF_KEY, "task", DEADLINE)))
         .isInstanceOf(SecretFilterUnavailableException.class)
         .hasMessageContaining("No CamundaOperateClient available");
   }
@@ -412,12 +445,122 @@ class ProcessDefinitionSecretKeyCacheTest {
     // SecretKeyLookupException is the only wrapper this path ever introduces, needed solely to
     // cross the Function boundary with the checked OperateException.
     when(camundaOperateClient.getProcessDefinitionModel(PROCESS_DEF_KEY))
-        .thenThrow(new io.camunda.operate.exception.OperateException("404"));
+        .thenThrow(new OperateException("404"));
 
     assertThatThrownBy(
-            () -> secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "task")))
+            () ->
+                secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "task", DEADLINE)))
         .isInstanceOf(SecretKeyLookupException.class)
-        .hasCauseInstanceOf(io.camunda.operate.exception.OperateException.class);
+        .hasCauseInstanceOf(OperateException.class);
+  }
+
+  @Test
+  void getSecretKeys_xmlFetchTransientlyFails_retriesAndSucceeds() throws Exception {
+    // simulates the get-XML endpoint's eventual-consistency window right after deployment: the
+    // first two attempts 404 before the definition becomes visible, the third succeeds
+    var retryingCache =
+        new ProcessDefinitionSecretKeyCache(
+            camundaOperateClient, Caffeine.newBuilder().build(), Duration.ofMillis(1));
+    when(camundaOperateClient.getProcessDefinitionModel(PROCESS_DEF_KEY))
+        .thenThrow(new OperateException("not found (yet)"))
+        .thenThrow(new OperateException("not found (yet)"))
+        .thenReturn(loadBpmn("outbound-with-secrets.bpmn"));
+
+    var keys =
+        retryingCache.getSecretKeys(
+            new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1", DEADLINE));
+
+    assertThat(keys)
+        .extracting(Secret::secretName)
+        .containsExactlyInAnyOrder("API_KEY", "MY_TOKEN");
+    verify(camundaOperateClient, times(3)).getProcessDefinitionModel(PROCESS_DEF_KEY);
+  }
+
+  @Test
+  void getSecretKeys_xmlFetchFailsPastMaxRetries_throwsLastFailure() throws Exception {
+    var retryingCache =
+        new ProcessDefinitionSecretKeyCache(
+            camundaOperateClient, Caffeine.newBuilder().build(), Duration.ofMillis(1));
+    when(camundaOperateClient.getProcessDefinitionModel(PROCESS_DEF_KEY))
+        .thenThrow(new OperateException("still not found"));
+
+    assertThatThrownBy(
+            () ->
+                retryingCache.getSecretKeys(
+                    new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1", DEADLINE)))
+        .isInstanceOf(SecretKeyLookupException.class)
+        .hasCauseInstanceOf(OperateException.class)
+        .cause()
+        .hasMessage("still not found");
+    // 1 initial attempt + 3 retries
+    verify(camundaOperateClient, times(4)).getProcessDefinitionModel(PROCESS_DEF_KEY);
+  }
+
+  @Test
+  void getSecretKeys_deadlineWithinSafetyMargin_failsWithoutAttemptingFetch() throws Exception {
+    assertThatThrownBy(
+            () ->
+                secretKeyCache.getSecretKeys(
+                    new SecretKeyContext(
+                        PROCESS_DEF_KEY, "service-task-1", Instant.now().plusSeconds(2))))
+        .isInstanceOf(IllegalStateException.class);
+    verify(camundaOperateClient, times(0)).getProcessDefinitionModel(PROCESS_DEF_KEY);
+  }
+
+  @Test
+  void getSecretKeys_deadlineLeavesOnlyAPartialRetryWindow_stopsRetryingBeforeMaxRetries()
+      throws Exception {
+    var retryingCache =
+        new ProcessDefinitionSecretKeyCache(
+            camundaOperateClient, Caffeine.newBuilder().build(), Duration.ofMillis(200));
+    when(camundaOperateClient.getProcessDefinitionModel(PROCESS_DEF_KEY))
+        .thenThrow(new OperateException("still not found"));
+    Instant deadline = Instant.now().plusSeconds(5).plusMillis(300);
+
+    long start = System.nanoTime();
+    assertThatThrownBy(
+            () ->
+                retryingCache.getSecretKeys(
+                    new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1", deadline)))
+        .satisfiesAnyOf(
+            e -> assertThat(e).isInstanceOf(TimeoutExceededException.class),
+            e ->
+                assertThat(e)
+                    .isInstanceOf(SecretKeyLookupException.class)
+                    .cause()
+                    .hasMessage("still not found"));
+    long elapsedMillis = (System.nanoTime() - start) / 1_000_000;
+
+    assertThat(elapsedMillis).isLessThan(700);
+    verify(camundaOperateClient, atLeast(2)).getProcessDefinitionModel(PROCESS_DEF_KEY);
+  }
+
+  @Test
+  void getSecretKeys_xmlFetchIgnoresInterruptAndSucceedsPastDeadline_stillFails()
+      throws Exception {
+    var retryingCache =
+        new ProcessDefinitionSecretKeyCache(
+            camundaOperateClient, Caffeine.newBuilder().build(), Duration.ofMillis(200));
+    BpmnModelInstance bpmnModel = loadBpmn("outbound-with-secrets.bpmn");
+    when(camundaOperateClient.getProcessDefinitionModel(PROCESS_DEF_KEY))
+        .thenAnswer(
+            invocation -> {
+              long until = System.nanoTime() + Duration.ofMillis(250).toNanos();
+              while (System.nanoTime() < until) {
+                try {
+                  Thread.sleep(10);
+                } catch (InterruptedException ignored) {
+                }
+              }
+              return bpmnModel;
+            });
+    Instant deadline = Instant.now().plusSeconds(5).plusMillis(150);
+
+    assertThatThrownBy(
+            () ->
+                retryingCache.getSecretKeys(
+                    new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1", deadline)))
+        .isInstanceOf(TimeoutExceededException.class);
   }
 
   private BpmnModelInstance loadBpmn(String fileName) throws Exception {

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/secret/ProcessDefinitionSecretKeyCacheTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/secret/ProcessDefinitionSecretKeyCacheTest.java
@@ -449,7 +449,8 @@ class ProcessDefinitionSecretKeyCacheTest {
 
     assertThatThrownBy(
             () ->
-                secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "task", DEADLINE)))
+                secretKeyCache.getSecretKeys(
+                    new SecretKeyContext(PROCESS_DEF_KEY, "task", DEADLINE)))
         .isInstanceOf(SecretKeyLookupException.class)
         .hasCauseInstanceOf(OperateException.class);
   }
@@ -536,8 +537,7 @@ class ProcessDefinitionSecretKeyCacheTest {
   }
 
   @Test
-  void getSecretKeys_xmlFetchIgnoresInterruptAndSucceedsPastDeadline_stillFails()
-      throws Exception {
+  void getSecretKeys_xmlFetchIgnoresInterruptAndSucceedsPastDeadline_stillFails() throws Exception {
     var retryingCache =
         new ProcessDefinitionSecretKeyCache(
             camundaOperateClient, Caffeine.newBuilder().build(), Duration.ofMillis(200));


### PR DESCRIPTION
# Description

Backport of #8756 to `stable/8.7`. The automated backport bot's cherry-pick failed with conflicts — this branch's outbound job-handling and secret-lookup code has a different shape than `main`'s, so the conflicts were resolved by hand rather than by blindly taking one side.

The underlying fix: `ProcessDefinitionSecretKeyCache`'s BPMN-XML read (used to build the per-element secret allow-list) hits an eventually-consistent secondary store, so it can transiently fail right after deployment. Previously this surfaced as a job error (relying on Zeebe's own retry/backoff), which a process's own error-boundary expressions could observe — turning an internal, self-healing race into user-visible, incorrect error-handling behavior. This backport retries the XML fetch itself, inside the lookup (via Failsafe's `RetryPolicy` + `Timeout`, bounded by the activated job's own deadline with a 5s safety margin), keeping the transient failure invisible to the process.

## What is ported, and what is not

- **The retry-with-deadline-bound fix itself — ported in full**, including: bounding to 3 retries (4 attempts total: 1 initial + 3 retries), logging only the exception class (not its message, since client/parser failures can echo response content), an interruptible `Timeout` composed *outside* the retry policy so the whole retry sequence — not each individual attempt — is bounded by the remaining budget, and the near-zero-delay test seam.
- **The `SecretFilterContext`/`SecretKeyContext` deadline plumbing — ported, simplified.** `main` resolves an *effective* deadline before building the secret filter, because a `jobTimeout` custom header can shorten or extend `job.getDeadline()` after the job is activated. `stable/8.7` has no `jobTimeout`-header feature at all (`ConnectorJobHandler` never adjusts the deadline), so the effective deadline is simply `job.getDeadline()` — no resolution step needed. The deadline is threaded straight through in `ConnectorJobHandler.handle()`.
- **The multi-tenant cache-key test — not ported.** `main`'s `ProcessDefinitionSecretKeyCache` takes a `physicalTenantId` (added by a later, unrelated refactor) and mixes it into the cache key; `stable/8.7` has no multi-tenancy here, so `getSecretKeys_collidingProcessDefinitionKeyAcrossPhysicalTenants...` doesn't apply and was dropped.

## Branch-specific notes

- `stable/8.7` still has `SpringConnectorJobHandler` (spring module, package `outbound.jobhandling`) as a thin metrics/retry wrapper *extending* `ConnectorJobHandler` (connector-runtime-core) — the two were only merged into one class later, on `main` (#5414-era refactor is already done there, not here). The cherry-pick's `SpringConnectorJobHandler.java` changes were therefore re-targeted at `connector-runtime-core`'s `ConnectorJobHandler.handle()`, the actual place `SecretFilterContext` is built here. The stray `outbound/job/SpringConnectorJobHandler.java`(+Test) files git left behind from the conflicted cherry-pick (a modify/delete conflict — that path doesn't exist on this branch) were removed.
- `stable/8.7`'s `ProcessDefinitionSecretKeyCache` reads the process definition via `CamundaOperateClient.getProcessDefinitionModel` (returns a parsed `BpmnModelInstance` directly, throws checked `OperateException`), not `main`'s `CamundaClient.newProcessDefinitionGetXmlRequest().execute()` (returns raw XML, unchecked exceptions). The retry/timeout wrapping is written against the checked-exception path: Failsafe wraps a checked exception's final failure in `FailsafeException`, which is unwrapped back to `OperateException` so the class's existing `SecretKeyLookupException` boundary is unaffected.
- `stable/8.7`'s `ConfigurableSecretFilterFactory` still has a `SecretFilterUnavailableException` catch (from an older, still-present "no `CamundaOperateClient` bean configured" guidance path) that doesn't exist on `main`. It's unrelated to this fix and was left untouched, just updated to pass the new `deadline` through.

## Verification

`./mvnw -pl connector-runtime/connector-runtime-core,connector-runtime/connector-runtime-spring -am test` passes: 306/306 tests, 0 failures. (Local verification required temporarily swapping the branch's internal-only Spring Boot BOM pin, `spring-boot-dependencies:3.5.16-spring-boot-3.5.19`, for its public-Maven-Central base version `3.5.16` with the enforcer plugin skipped — that swap was reverted before committing; the pushed code targets the same internal BOM version as the rest of `stable/8.7`.) CI (`run-tests`, `check-format`) is green on this PR.

## Related issues

Source PR: #8756.

## Checklist

- [x] No further backport labels are added.
- [x] Tests for the changes are included (adapted to this branch's `CamundaOperateClient`-based architecture) and verified locally and in CI.
- [x] No documentation update is required for this backport.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
