### PR TITLE
[Backport stable/8.6] fix(secrets): retry outbound secret allow-list XML fetch on transient failure

### DIFF
--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/outbound/ConnectorJobHandler.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/outbound/ConnectorJobHandler.java
@@ -42,6 +42,7 @@ import io.camunda.zeebe.client.api.response.FailJobResponse;
 import io.camunda.zeebe.client.api.worker.JobClient;
 import io.camunda.zeebe.client.api.worker.JobHandler;
 import java.time.Duration;
+import java.time.Instant;
 import java.time.format.DateTimeParseException;
 import java.util.HashMap;
 import java.util.List;
@@ -169,7 +170,10 @@ public class ConnectorJobHandler implements JobHandler {
 
     SecretFilter secretFilter =
         secretFilterFactory.create(
-            new SecretFilterContext(job.getProcessDefinitionKey(), job.getElementId()));
+            new SecretFilterContext(
+                job.getProcessDefinitionKey(),
+                job.getElementId(),
+                Instant.ofEpochMilli(job.getDeadline())));
 
     ConnectorResult result;
 

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretFilterFactory.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretFilterFactory.java
@@ -16,6 +16,8 @@
  */
 package io.camunda.connector.runtime.core.secret;
 
+import java.time.Instant;
+
 public interface SecretFilterFactory {
   SecretFilter create(SecretFilterContext context);
 
@@ -23,5 +25,5 @@ public interface SecretFilterFactory {
     return context -> SecretFilter.allowAll();
   }
 
-  record SecretFilterContext(long processDefinitionKey, String elementId) {}
+  record SecretFilterContext(long processDefinitionKey, String elementId, Instant deadline) {}
 }

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/outbound/ConnectorJobHandlerTest.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/outbound/ConnectorJobHandlerTest.java
@@ -43,11 +43,14 @@ import io.camunda.connector.runtime.core.ConnectorHelper;
 import io.camunda.connector.runtime.core.FooBarSecretProvider;
 import io.camunda.connector.runtime.core.Keywords;
 import io.camunda.connector.runtime.core.secret.SecretAllowListUnavailableException;
+import io.camunda.connector.runtime.core.secret.SecretFilter;
 import io.camunda.connector.runtime.core.secret.SecretFilterFactory;
+import io.camunda.connector.runtime.core.secret.SecretFilterFactory.SecretFilterContext;
 import io.camunda.zeebe.client.api.command.FailJobCommandStep1;
 import io.camunda.zeebe.client.api.command.FailJobCommandStep1.FailJobCommandStep2;
 import io.camunda.zeebe.client.api.worker.JobClient;
 import java.time.Duration;
+import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
@@ -1468,6 +1471,33 @@ class ConnectorJobHandlerTest {
       // discovery runs before anything is bound, so the failure carries no secret and is reported
       // as it is; letting it escape would leave the job for its activation timeout instead
       assertThat(result.getErrorMessage()).isEqualTo("no secret provider could be discovered");
+    }
+  }
+
+  // the deadline handed to the secret filter factory bounds the allow-list XML fetch retry: a
+  // wrong unit or value here would silently defeat that retry's safety margin
+  @Nested
+  class SecretFilterContextDeadlineTests {
+
+    @Test
+    void theActivatedJobsDeadlineIsPassedThroughAsAnInstant() {
+      var contextCaptor = ArgumentCaptor.forClass(SecretFilterContext.class);
+      SecretFilterFactory secretFilterFactory = mock(SecretFilterFactory.class);
+      when(secretFilterFactory.create(contextCaptor.capture())).thenReturn(SecretFilter.allowAll());
+      var jobHandler =
+          new ConnectorJobHandler(context -> "ok", null, e -> {}, null, secretFilterFactory);
+      long deadlineEpochMilli = 1_726_000_000_000L;
+
+      JobBuilder.create()
+          .withProcessDefinitionKey(42L)
+          .withElementId("Activity_1")
+          .withDeadline(deadlineEpochMilli)
+          .executeAndCaptureResult(jobHandler);
+
+      assertThat(contextCaptor.getValue().processDefinitionKey()).isEqualTo(42L);
+      assertThat(contextCaptor.getValue().elementId()).isEqualTo("Activity_1");
+      assertThat(contextCaptor.getValue().deadline())
+          .isEqualTo(Instant.ofEpochMilli(deadlineEpochMilli));
     }
   }
 }

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/outbound/JobBuilder.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/outbound/JobBuilder.java
@@ -117,6 +117,21 @@ class JobBuilder {
       return this;
     }
 
+    public JobBuilderStep withDeadline(long deadline) {
+      when(job.getDeadline()).thenReturn(deadline);
+      return this;
+    }
+
+    public JobBuilderStep withProcessDefinitionKey(long processDefinitionKey) {
+      when(job.getProcessDefinitionKey()).thenReturn(processDefinitionKey);
+      return this;
+    }
+
+    public JobBuilderStep withElementId(String elementId) {
+      when(job.getElementId()).thenReturn(elementId);
+      return this;
+    }
+
     public JobBuilderStep withResultVariableHeader(final String value) {
       return withHeader(Keywords.RESULT_VARIABLE_KEYWORD, value);
     }

--- a/connector-runtime/connector-runtime-spring/pom.xml
+++ b/connector-runtime/connector-runtime-spring/pom.xml
@@ -66,6 +66,10 @@
       <groupId>org.camunda.feel</groupId>
       <artifactId>feel-engine</artifactId>
     </dependency>
+    <dependency>
+      <groupId>dev.failsafe</groupId>
+      <artifactId>failsafe</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>io.camunda.connector</groupId>

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/ConfigurableSecretFilterFactory.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/ConfigurableSecretFilterFactory.java
@@ -54,7 +54,8 @@ public class ConfigurableSecretFilterFactory implements SecretFilterFactory {
         () -> {
           try {
             return secretKeyCache.getSecretKeys(
-                new SecretKeyContext(context.processDefinitionKey(), context.elementId()));
+                new SecretKeyContext(
+                    context.processDefinitionKey(), context.elementId(), context.deadline()));
           } catch (SecretFilterUnavailableException e) {
             // Self-authored operator guidance, never derived from a client or parser response --
             // unlike every other failure below, its message is safe to surface as-is.

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/secret/ProcessDefinitionSecretKeyCache.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/secret/ProcessDefinitionSecretKeyCache.java
@@ -17,6 +17,10 @@
 package io.camunda.connector.runtime.outbound.secret;
 
 import com.github.benmanes.caffeine.cache.Cache;
+import dev.failsafe.Failsafe;
+import dev.failsafe.FailsafeException;
+import dev.failsafe.RetryPolicy;
+import dev.failsafe.Timeout;
 import io.camunda.connector.runtime.core.secret.SecretFilter.Secret;
 import io.camunda.connector.runtime.core.secret.SecretUtil;
 import io.camunda.operate.CamundaOperateClient;
@@ -34,6 +38,8 @@ import io.camunda.zeebe.model.bpmn.instance.ServiceTask;
 import io.camunda.zeebe.model.bpmn.instance.SubProcess;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeInput;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeIoMapping;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -60,6 +66,18 @@ public class ProcessDefinitionSecretKeyCache implements SecretKeyCache {
   private static final List<Class<? extends BaseElement>> OUTBOUND_ELIGIBLE_TYPES =
       new ArrayList<>();
 
+  private static final int XML_FETCH_MAX_RETRIES = 3;
+
+  private static final Duration XML_FETCH_INITIAL_RETRY_DELAY = Duration.ofSeconds(1);
+
+  /**
+   * Retries stop this far ahead of the activated job's deadline, leaving room for the connector
+   * function itself to run before the job's lease expires -- a fetch that only succeeds after the
+   * lease is gone risks the job being reassigned while this worker keeps executing, per the
+   * duplicate-side-effect concern in {@code SpringConnectorJobHandler}.
+   */
+  private static final Duration XML_FETCH_DEADLINE_SAFETY_MARGIN = Duration.ofSeconds(5);
+
   static {
     OUTBOUND_ELIGIBLE_TYPES.add(ServiceTask.class);
     OUTBOUND_ELIGIBLE_TYPES.add(SendTask.class);
@@ -72,17 +90,29 @@ public class ProcessDefinitionSecretKeyCache implements SecretKeyCache {
 
   private final CamundaOperateClient camundaOperateClient;
   private final Cache<Long, Map<String, List<Secret>>> cache;
+  private final Duration xmlFetchInitialRetryDelay;
 
   public ProcessDefinitionSecretKeyCache(
       CamundaOperateClient camundaOperateClient, Cache<Long, Map<String, List<Secret>>> cache) {
+    this(camundaOperateClient, cache, XML_FETCH_INITIAL_RETRY_DELAY);
+  }
+
+  /** Test-only seam: lets retry tests use a near-zero delay instead of the real one. */
+  public ProcessDefinitionSecretKeyCache(
+      CamundaOperateClient camundaOperateClient,
+      Cache<Long, Map<String, List<Secret>>> cache,
+      Duration xmlFetchInitialRetryDelay) {
     this.camundaOperateClient = camundaOperateClient;
     this.cache = cache;
+    this.xmlFetchInitialRetryDelay = xmlFetchInitialRetryDelay;
   }
 
   @Override
   public List<Secret> getSecretKeys(SecretKeyContext secretKeyContext) {
     return cache
-        .get(secretKeyContext.processDefinitionKey(), this::fetchSecretKeysByElementIdsUnchecked)
+        .get(
+            secretKeyContext.processDefinitionKey(),
+            key -> fetchSecretKeysByElementIdsUnchecked(key, secretKeyContext.deadline()))
         .getOrDefault(secretKeyContext.elementId(), Collections.emptyList());
   }
 
@@ -94,9 +124,9 @@ public class ProcessDefinitionSecretKeyCache implements SecretKeyCache {
    * exactly as thrown.
    */
   private Map<String, List<Secret>> fetchSecretKeysByElementIdsUnchecked(
-      long processDefinitionKey) {
+      long processDefinitionKey, Instant deadline) {
     try {
-      return fetchSecretKeysByElementIds(processDefinitionKey);
+      return fetchSecretKeysByElementIds(processDefinitionKey, deadline);
     } catch (OperateException e) {
       throw new SecretKeyLookupException(
           "Failed to look up declared secret keys for process definition key "
@@ -105,8 +135,8 @@ public class ProcessDefinitionSecretKeyCache implements SecretKeyCache {
     }
   }
 
-  private Map<String, List<Secret>> fetchSecretKeysByElementIds(long processDefinitionKey)
-      throws OperateException {
+  private Map<String, List<Secret>> fetchSecretKeysByElementIds(
+      long processDefinitionKey, Instant deadline) throws OperateException {
     if (camundaOperateClient == null) {
       throw new SecretFilterUnavailableException(
           "No CamundaOperateClient available to look up declared secret keys for process"
@@ -118,13 +148,61 @@ public class ProcessDefinitionSecretKeyCache implements SecretKeyCache {
               + " filter in an outbound-only deployment.");
     }
     BpmnModelInstance modelInstance =
-        camundaOperateClient.getProcessDefinitionModel(processDefinitionKey);
+        fetchProcessDefinitionModelWithRetry(processDefinitionKey, deadline);
     var processes =
         modelInstance.getDefinitions().getChildElementsByType(Process.class).stream().toList();
 
     return processes.stream()
         .flatMap(process -> inspectBpmnProcess(process, processDefinitionKey).entrySet().stream())
         .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+  }
+
+  /**
+   * {@code CamundaOperateClient} declares the checked {@link OperateException} on this call, so a
+   * final, retries-exhausted failure comes back out of Failsafe wrapped in the unchecked {@link
+   * FailsafeException} (per Failsafe's contract for a {@code CheckedSupplier}); unwrap it back to
+   * the original {@link OperateException} so callers see the same exception type as before this
+   * method retried anything.
+   */
+  private BpmnModelInstance fetchProcessDefinitionModelWithRetry(
+      long processDefinitionKey, Instant deadline) throws OperateException {
+    Duration remaining =
+        Duration.between(Instant.now(), deadline).minus(XML_FETCH_DEADLINE_SAFETY_MARGIN);
+    if (remaining.isNegative() || remaining.isZero()) {
+      throw new IllegalStateException(
+          "BPMN XML fetch deadline already elapsed for process definition key "
+              + processDefinitionKey);
+    }
+    Timeout<BpmnModelInstance> xmlFetchTimeout =
+        Timeout.<BpmnModelInstance>builder(remaining).withInterrupt().build();
+    try {
+      if (remaining.compareTo(xmlFetchInitialRetryDelay) <= 0) {
+        return Failsafe.with(xmlFetchTimeout)
+            .get(() -> camundaOperateClient.getProcessDefinitionModel(processDefinitionKey));
+      }
+      RetryPolicy<BpmnModelInstance> xmlFetchRetryPolicy =
+          RetryPolicy.<BpmnModelInstance>builder()
+              .withBackoff(
+                  xmlFetchInitialRetryDelay,
+                  xmlFetchInitialRetryDelay.multipliedBy(1L << (XML_FETCH_MAX_RETRIES - 1)))
+              .withMaxRetries(XML_FETCH_MAX_RETRIES)
+              .withMaxDuration(remaining)
+              .onFailedAttempt(
+                  event ->
+                      LOG.warn(
+                          "Attempt {}/{} to fetch BPMN XML failed: {}",
+                          event.getAttemptCount(),
+                          XML_FETCH_MAX_RETRIES + 1,
+                          event.getLastException().getClass().getName()))
+              .build();
+      return Failsafe.with(xmlFetchTimeout, xmlFetchRetryPolicy)
+          .get(() -> camundaOperateClient.getProcessDefinitionModel(processDefinitionKey));
+    } catch (FailsafeException e) {
+      if (e.getCause() instanceof OperateException operateException) {
+        throw operateException;
+      }
+      throw e;
+    }
   }
 
   private Map<String, List<Secret>> inspectBpmnProcess(Process process, long processDefinitionKey) {

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/secret/SecretKeyCache.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/secret/SecretKeyCache.java
@@ -17,10 +17,11 @@
 package io.camunda.connector.runtime.outbound.secret;
 
 import io.camunda.connector.runtime.core.secret.SecretFilter.Secret;
+import java.time.Instant;
 import java.util.List;
 
 public interface SecretKeyCache {
   List<Secret> getSecretKeys(SecretKeyContext secretKeyContext);
 
-  record SecretKeyContext(long processDefinitionKey, String elementId) {}
+  record SecretKeyContext(long processDefinitionKey, String elementId, Instant deadline) {}
 }

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/job/ConfigurableSecretFilterFactoryTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/job/ConfigurableSecretFilterFactoryTest.java
@@ -34,6 +34,8 @@ import io.camunda.connector.runtime.outbound.secret.SecretKeyCache;
 import io.camunda.connector.runtime.outbound.secret.SecretKeyCache.SecretKeyContext;
 import io.camunda.operate.CamundaOperateClient;
 import io.camunda.operate.exception.OperateException;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
@@ -46,10 +48,11 @@ class ConfigurableSecretFilterFactoryTest {
 
   private static final long PROCESS_DEF_KEY = 42L;
   private static final String ELEMENT_ID = "service-task-1";
+  private static final Instant DEADLINE = Instant.now().plusSeconds(3600);
   private static final SecretFilterContext CONTEXT =
-      new SecretFilterContext(PROCESS_DEF_KEY, ELEMENT_ID);
+      new SecretFilterContext(PROCESS_DEF_KEY, ELEMENT_ID, DEADLINE);
   private static final SecretKeyContext SECRET_KEY_CONTEXT =
-      new SecretKeyContext(PROCESS_DEF_KEY, ELEMENT_ID);
+      new SecretKeyContext(PROCESS_DEF_KEY, ELEMENT_ID, DEADLINE);
 
   @Mock private SecretKeyCache secretKeyCache;
 
@@ -207,7 +210,8 @@ class ConfigurableSecretFilterFactoryTest {
     var operateClient = mock(CamundaOperateClient.class);
     when(operateClient.getProcessDefinitionModel(PROCESS_DEF_KEY))
         .thenThrow(new OperateException("Operate returned 404 for process definition 42"));
-    SecretKeyCache realSecretKeyCache = new ProcessDefinitionSecretKeyCache(operateClient, cache);
+    SecretKeyCache realSecretKeyCache =
+        new ProcessDefinitionSecretKeyCache(operateClient, cache, Duration.ofMillis(1));
     var factory = new ConfigurableSecretFilterFactory(SecretFilterMode.STRICT, realSecretKeyCache);
 
     var filter = factory.create(CONTEXT);

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/secret/ProcessDefinitionSecretKeyCacheTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/secret/ProcessDefinitionSecretKeyCacheTest.java
@@ -18,14 +18,20 @@ package io.camunda.connector.runtime.outbound.secret;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.github.benmanes.caffeine.cache.Caffeine;
+import dev.failsafe.TimeoutExceededException;
 import io.camunda.connector.runtime.core.secret.SecretFilter.Secret;
 import io.camunda.connector.runtime.outbound.secret.SecretKeyCache.SecretKeyContext;
 import io.camunda.operate.CamundaOperateClient;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.List;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
@@ -41,6 +47,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 class ProcessDefinitionSecretKeyCacheTest {
 
   private static final long PROCESS_DEF_KEY = 1L;
+  private static final Instant DEADLINE = Instant.now().plusSeconds(3600);
 
   @Mock private CamundaOperateClient camundaOperateClient;
 
@@ -60,7 +67,8 @@ class ProcessDefinitionSecretKeyCacheTest {
         .thenReturn(loadBpmn("outbound-with-secrets.bpmn"));
 
     var keys =
-        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1"));
+        secretKeyCache.getSecretKeys(
+            new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1", DEADLINE));
 
     assertThat(keys)
         .extracting(Secret::secretName)
@@ -77,7 +85,8 @@ class ProcessDefinitionSecretKeyCacheTest {
         .thenReturn(loadBpmn("outbound-with-dotted-target.bpmn"));
 
     var keys =
-        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1"));
+        secretKeyCache.getSecretKeys(
+            new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1", DEADLINE));
 
     assertThat(keys).containsExactly(new Secret("API_KEY", List.of("auth", "token")));
   }
@@ -93,7 +102,8 @@ class ProcessDefinitionSecretKeyCacheTest {
         .thenReturn(loadBpmn("outbound-with-referenced-variable.bpmn"));
 
     var keys =
-        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1"));
+        secretKeyCache.getSecretKeys(
+            new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1", DEADLINE));
 
     assertThat(keys)
         .contains(
@@ -110,7 +120,8 @@ class ProcessDefinitionSecretKeyCacheTest {
         .thenReturn(loadBpmn("outbound-with-chained-references.bpmn"));
 
     var keys =
-        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1"));
+        secretKeyCache.getSecretKeys(
+            new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1", DEADLINE));
 
     assertThat(keys)
         .containsExactlyInAnyOrder(
@@ -129,7 +140,8 @@ class ProcessDefinitionSecretKeyCacheTest {
         .thenReturn(loadBpmn("outbound-with-referenced-variable.bpmn"));
 
     var keys =
-        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1"));
+        secretKeyCache.getSecretKeys(
+            new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1", DEADLINE));
 
     assertThat(keys)
         .doesNotContain(
@@ -149,7 +161,8 @@ class ProcessDefinitionSecretKeyCacheTest {
         .thenReturn(loadBpmn("outbound-with-sibling-fields.bpmn"));
 
     var keys =
-        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1"));
+        secretKeyCache.getSecretKeys(
+            new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1", DEADLINE));
 
     assertThat(keys)
         .contains(
@@ -170,7 +183,8 @@ class ProcessDefinitionSecretKeyCacheTest {
         .thenReturn(loadBpmn("outbound-with-reverse-order-reference.bpmn"));
 
     var keys =
-        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1"));
+        secretKeyCache.getSecretKeys(
+            new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1", DEADLINE));
 
     assertThat(keys)
         .contains(new Secret("API_KEY", List.of("baseUrl")))
@@ -190,7 +204,8 @@ class ProcessDefinitionSecretKeyCacheTest {
         .thenReturn(loadBpmn("outbound-with-parent-overwrite.bpmn"));
 
     var keys =
-        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1"));
+        secretKeyCache.getSecretKeys(
+            new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1", DEADLINE));
 
     // Nothing in this BPMN ever reads authentication.token from a path that's still effective, so
     // TOKEN isn't just absent from the two paths above -- it's not granted anywhere at all. This
@@ -209,7 +224,8 @@ class ProcessDefinitionSecretKeyCacheTest {
         .thenReturn(loadBpmn("outbound-with-same-path-overwrite.bpmn"));
 
     var keys =
-        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1"));
+        secretKeyCache.getSecretKeys(
+            new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1", DEADLINE));
 
     assertThat(keys).isEmpty();
   }
@@ -227,7 +243,8 @@ class ProcessDefinitionSecretKeyCacheTest {
         .thenReturn(loadBpmn("outbound-with-overwritten-propagation-target.bpmn"));
 
     var keys =
-        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1"));
+        secretKeyCache.getSecretKeys(
+            new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1", DEADLINE));
 
     assertThat(keys)
         .containsExactly(new Secret("TOKEN", List.of("baseUrl")))
@@ -248,7 +265,8 @@ class ProcessDefinitionSecretKeyCacheTest {
         .thenReturn(loadBpmn("outbound-with-child-overwrite.bpmn"));
 
     var keys =
-        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1"));
+        secretKeyCache.getSecretKeys(
+            new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1", DEADLINE));
 
     assertThat(keys).isEmpty();
   }
@@ -267,7 +285,8 @@ class ProcessDefinitionSecretKeyCacheTest {
         .thenReturn(loadBpmn("outbound-with-nested-parent-and-child-overwrite.bpmn"));
 
     var keys =
-        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1"));
+        secretKeyCache.getSecretKeys(
+            new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1", DEADLINE));
 
     assertThat(keys).isEmpty();
   }
@@ -284,7 +303,8 @@ class ProcessDefinitionSecretKeyCacheTest {
         .thenReturn(loadBpmn("outbound-with-shadowed-input-as-dependency.bpmn"));
 
     var keys =
-        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1"));
+        secretKeyCache.getSecretKeys(
+            new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1", DEADLINE));
 
     assertThat(keys).containsExactly(new Secret("T", List.of("baseUrl")));
   }
@@ -296,8 +316,9 @@ class ProcessDefinitionSecretKeyCacheTest {
         .thenReturn(loadBpmn("outbound-multiple-tasks-with-secrets.bpmn"));
 
     var alphaKeys =
-        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "task-alpha"));
-    var betaKeys = secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "task-beta"));
+        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "task-alpha", DEADLINE));
+    var betaKeys =
+        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "task-beta", DEADLINE));
 
     assertThat(alphaKeys).extracting(Secret::secretName).containsExactly("SECRET_ALPHA");
     assertThat(betaKeys)
@@ -311,7 +332,8 @@ class ProcessDefinitionSecretKeyCacheTest {
         .thenReturn(loadBpmn("outbound-no-secrets.bpmn"));
 
     var keys =
-        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "no-secrets-task"));
+        secretKeyCache.getSecretKeys(
+            new SecretKeyContext(PROCESS_DEF_KEY, "no-secrets-task", DEADLINE));
 
     assertThat(keys).isEmpty();
   }
@@ -324,7 +346,8 @@ class ProcessDefinitionSecretKeyCacheTest {
     when(camundaOperateClient.getProcessDefinitionModel(PROCESS_DEF_KEY))
         .thenReturn(loadBpmn("outbound-no-template.bpmn"));
 
-    var keys = secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "plain-task"));
+    var keys =
+        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "plain-task", DEADLINE));
 
     assertThat(keys).extracting(Secret::secretName).containsExactly("SECRET_X");
   }
@@ -335,7 +358,8 @@ class ProcessDefinitionSecretKeyCacheTest {
         .thenReturn(loadBpmn("outbound-with-secrets.bpmn"));
 
     var keys =
-        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "nonexistent-task"));
+        secretKeyCache.getSecretKeys(
+            new SecretKeyContext(PROCESS_DEF_KEY, "nonexistent-task", DEADLINE));
 
     assertThat(keys).isEmpty();
   }
@@ -347,7 +371,8 @@ class ProcessDefinitionSecretKeyCacheTest {
     when(camundaOperateClient.getProcessDefinitionModel(PROCESS_DEF_KEY))
         .thenReturn(loadBpmn("outbound-task-types.bpmn"));
 
-    var keys = secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, elementId));
+    var keys =
+        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, elementId, DEADLINE));
 
     assertThat(keys).extracting(Secret::secretName).containsExactly(secretKey);
   }
@@ -368,11 +393,14 @@ class ProcessDefinitionSecretKeyCacheTest {
         .thenReturn(loadBpmn("outbound-nested-embedded-subprocess.bpmn"));
 
     var outerKeys =
-        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "outer-subprocess"));
+        secretKeyCache.getSecretKeys(
+            new SecretKeyContext(PROCESS_DEF_KEY, "outer-subprocess", DEADLINE));
     var innerKeys =
-        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "inner-subprocess"));
+        secretKeyCache.getSecretKeys(
+            new SecretKeyContext(PROCESS_DEF_KEY, "inner-subprocess", DEADLINE));
     var grandchildKeys =
-        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "grandchild-task"));
+        secretKeyCache.getSecretKeys(
+            new SecretKeyContext(PROCESS_DEF_KEY, "grandchild-task", DEADLINE));
 
     assertThat(outerKeys).extracting(Secret::secretName).containsExactly("OUTER_SECRET");
     assertThat(innerKeys).extracting(Secret::secretName).containsExactly("INNER_SECRET");
@@ -386,9 +414,11 @@ class ProcessDefinitionSecretKeyCacheTest {
         .thenReturn(loadBpmn("outbound-message-events.bpmn"));
 
     var throwEventKeys =
-        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "send-message-throw"));
+        secretKeyCache.getSecretKeys(
+            new SecretKeyContext(PROCESS_DEF_KEY, "send-message-throw", DEADLINE));
     var endEventKeys =
-        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "send-message-end"));
+        secretKeyCache.getSecretKeys(
+            new SecretKeyContext(PROCESS_DEF_KEY, "send-message-end", DEADLINE));
 
     assertThat(throwEventKeys).extracting(Secret::secretName).containsExactly("THROW_EVENT_SECRET");
     assertThat(endEventKeys).extracting(Secret::secretName).containsExactly("END_EVENT_SECRET");
@@ -400,7 +430,9 @@ class ProcessDefinitionSecretKeyCacheTest {
         new ProcessDefinitionSecretKeyCache(null, Caffeine.newBuilder().build());
 
     assertThatThrownBy(
-            () -> cacheWithoutClient.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "task")))
+            () ->
+                cacheWithoutClient.getSecretKeys(
+                    new SecretKeyContext(PROCESS_DEF_KEY, "task", DEADLINE)))
         .isInstanceOf(SecretFilterUnavailableException.class)
         .hasMessageContaining("No CamundaOperateClient available");
   }
@@ -415,9 +447,113 @@ class ProcessDefinitionSecretKeyCacheTest {
         .thenThrow(new io.camunda.operate.exception.OperateException("404"));
 
     assertThatThrownBy(
-            () -> secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "task")))
+            () ->
+                secretKeyCache.getSecretKeys(
+                    new SecretKeyContext(PROCESS_DEF_KEY, "task", DEADLINE)))
         .isInstanceOf(SecretKeyLookupException.class)
         .hasCauseInstanceOf(io.camunda.operate.exception.OperateException.class);
+  }
+
+  @Test
+  void getSecretKeys_xmlFetchTransientlyFails_retriesAndSucceeds() throws Exception {
+    // simulates the get-model endpoint's eventual-consistency window right after deployment: the
+    // first two attempts 404 before the definition becomes visible, the third succeeds
+    var retryingCache =
+        new ProcessDefinitionSecretKeyCache(
+            camundaOperateClient, Caffeine.newBuilder().build(), Duration.ofMillis(1));
+    when(camundaOperateClient.getProcessDefinitionModel(PROCESS_DEF_KEY))
+        .thenThrow(new io.camunda.operate.exception.OperateException("not found (yet)"))
+        .thenThrow(new io.camunda.operate.exception.OperateException("not found (yet)"))
+        .thenReturn(loadBpmn("outbound-with-secrets.bpmn"));
+
+    var keys =
+        retryingCache.getSecretKeys(
+            new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1", DEADLINE));
+
+    assertThat(keys)
+        .extracting(Secret::secretName)
+        .containsExactlyInAnyOrder("API_KEY", "MY_TOKEN");
+    verify(camundaOperateClient, times(3)).getProcessDefinitionModel(PROCESS_DEF_KEY);
+  }
+
+  @Test
+  void getSecretKeys_xmlFetchFailsPastMaxRetries_throwsLastFailure() throws Exception {
+    var retryingCache =
+        new ProcessDefinitionSecretKeyCache(
+            camundaOperateClient, Caffeine.newBuilder().build(), Duration.ofMillis(1));
+    when(camundaOperateClient.getProcessDefinitionModel(PROCESS_DEF_KEY))
+        .thenThrow(new io.camunda.operate.exception.OperateException("still not found"));
+
+    assertThatThrownBy(
+            () ->
+                retryingCache.getSecretKeys(
+                    new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1", DEADLINE)))
+        .isInstanceOf(SecretKeyLookupException.class)
+        .hasCauseInstanceOf(io.camunda.operate.exception.OperateException.class);
+    // 1 initial attempt + 3 retries
+    verify(camundaOperateClient, times(4)).getProcessDefinitionModel(PROCESS_DEF_KEY);
+  }
+
+  @Test
+  void getSecretKeys_deadlineWithinSafetyMargin_failsWithoutAttemptingFetch() throws Exception {
+    assertThatThrownBy(
+            () ->
+                secretKeyCache.getSecretKeys(
+                    new SecretKeyContext(
+                        PROCESS_DEF_KEY, "service-task-1", Instant.now().plusSeconds(2))))
+        .isInstanceOf(IllegalStateException.class);
+    verify(camundaOperateClient, times(0)).getProcessDefinitionModel(PROCESS_DEF_KEY);
+  }
+
+  @Test
+  void getSecretKeys_deadlineLeavesOnlyAPartialRetryWindow_stopsRetryingBeforeMaxRetries()
+      throws Exception {
+    var retryingCache =
+        new ProcessDefinitionSecretKeyCache(
+            camundaOperateClient, Caffeine.newBuilder().build(), Duration.ofMillis(200));
+    when(camundaOperateClient.getProcessDefinitionModel(PROCESS_DEF_KEY))
+        .thenThrow(new io.camunda.operate.exception.OperateException("still not found"));
+    Instant deadline = Instant.now().plusSeconds(5).plusMillis(300);
+
+    long start = System.nanoTime();
+    assertThatThrownBy(
+            () ->
+                retryingCache.getSecretKeys(
+                    new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1", deadline)))
+        .satisfiesAnyOf(
+            e -> assertThat(e).isInstanceOf(TimeoutExceededException.class),
+            e -> assertThat(e).isInstanceOf(SecretKeyLookupException.class));
+    long elapsedMillis = (System.nanoTime() - start) / 1_000_000;
+
+    assertThat(elapsedMillis).isLessThan(700);
+    verify(camundaOperateClient, atLeast(2)).getProcessDefinitionModel(PROCESS_DEF_KEY);
+  }
+
+  @Test
+  void getSecretKeys_xmlFetchIgnoresInterruptAndSucceedsPastDeadline_stillFails() throws Exception {
+    var retryingCache =
+        new ProcessDefinitionSecretKeyCache(
+            camundaOperateClient, Caffeine.newBuilder().build(), Duration.ofMillis(200));
+    BpmnModelInstance model = loadBpmn("outbound-with-secrets.bpmn");
+    when(camundaOperateClient.getProcessDefinitionModel(PROCESS_DEF_KEY))
+        .thenAnswer(
+            invocation -> {
+              long until = System.nanoTime() + Duration.ofMillis(250).toNanos();
+              while (System.nanoTime() < until) {
+                try {
+                  Thread.sleep(10);
+                } catch (InterruptedException ignored) {
+                }
+              }
+              return model;
+            });
+    Instant deadline = Instant.now().plusSeconds(5).plusMillis(150);
+
+    assertThatThrownBy(
+            () ->
+                retryingCache.getSecretKeys(
+                    new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1", deadline)))
+        .isInstanceOf(TimeoutExceededException.class);
   }
 
   private BpmnModelInstance loadBpmn(String fileName) throws Exception {


### PR DESCRIPTION
## Description

Backport of #8756 to `stable/8.6`.

`ProcessDefinitionSecretKeyCache`'s BPMN fetch, used to build the per-element secret allow-list, hits an eventually consistent secondary store and can fail right after deployment before the definition is visible there. This replaces the earlier approach of surfacing that failure as a job error (relying on Zeebe's own job retry/backoff) with a deadline-aware, bounded in-process retry (Failsafe `RetryPolicy` + `Timeout`, max 3 retries, stopping 5s ahead of the job's deadline) so the transient race stays invisible to the process instead of being observable by its own error-boundary expressions.

Branch-specific adaptations: stable/8.6 fetches the process definition via the legacy `CamundaOperateClient.getProcessDefinitionModel(...)` (checked `OperateException`, returning a `BpmnModelInstance` directly), not the newer `CamundaClient`/XML-string path used on `main`. The retry helper wraps that checked call and unwraps Failsafe's `FailsafeException` back to the original `OperateException` so it still crosses the Caffeine cache boundary exactly as `SecretKeyLookupException` did before. `SpringConnectorJobHandler` on this branch (in the `outbound.jobhandling` package, not `outbound.job`) doesn't build `SecretFilterContext` itself or carry the `jobTimeout`-header/effective-deadline machinery `main` has since gained -- that construction site is in `ConnectorJobHandler` (connector-runtime-core), which now threads the job's own `getDeadline()` through as the retry deadline. The `dev.failsafe:failsafe` dependency, already present on `main`, was added to `connector-runtime-spring`'s pom (version is already managed by the parent POM). A multi-tenant caching test and an ad-hoc-subprocess test present on `main` don't apply here (stable/8.6 has neither feature) and were left out.

Targeted tests (`ProcessDefinitionSecretKeyCacheTest`, `ConfigurableSecretFilterFactoryTest`, `SpringConnectorJobHandlerTest`, `ConnectorJobHandlerTest`) and the full `connector-runtime-core` and `connector-runtime-spring` module suites pass.

## Related issues

Related to #8756

## Checklist

- [x] This PR targets the requested stable branch directly.
- [x] Tests/Integration tests for the changes have been added if applicable.
- [x] No documentation update is required for this change.