### PR TITLE
[Backport stable/8.8] fix(secrets): retry outbound secret allow-list XML fetch on transient failure

### DIFF
--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretFilterFactory.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretFilterFactory.java
@@ -16,6 +16,8 @@
  */
 package io.camunda.connector.runtime.core.secret;
 
+import java.time.Instant;
+
 public interface SecretFilterFactory {
   SecretFilter create(SecretFilterContext context);
 
@@ -23,5 +25,5 @@ public interface SecretFilterFactory {
     return context -> SecretFilter.allowAll();
   }
 
-  record SecretFilterContext(long processDefinitionKey, String elementId) {}
+  record SecretFilterContext(long processDefinitionKey, String elementId, Instant deadline) {}
 }

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/ConfigurableSecretFilterFactory.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/ConfigurableSecretFilterFactory.java
@@ -51,7 +51,8 @@ public class ConfigurableSecretFilterFactory implements SecretFilterFactory {
         () -> {
           try {
             return secretKeyCache.getSecretKeys(
-                new SecretKeyContext(context.processDefinitionKey(), context.elementId()));
+                new SecretKeyContext(
+                    context.processDefinitionKey(), context.elementId(), context.deadline()));
           } catch (RuntimeException e) {
             // realCause walks to the root of the chain, not just one level: the client can wrap
             // the actual failure in its own generic exception type before it ever reaches here,

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/SpringConnectorJobHandler.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/SpringConnectorJobHandler.java
@@ -47,6 +47,7 @@ import io.camunda.connector.runtime.core.secret.SecretProviderAggregator;
 import io.camunda.connector.runtime.core.secret.SecretProviderDiscovery;
 import io.camunda.connector.runtime.metrics.ConnectorsOutboundMetrics;
 import java.time.Duration;
+import java.time.Instant;
 import java.time.format.DateTimeParseException;
 import java.util.Map;
 import java.util.Optional;
@@ -125,7 +126,10 @@ public class SpringConnectorJobHandler implements JobHandler {
     try {
       SecretFilter secretFilter =
           secretFilterFactory.create(
-              new SecretFilterContext(job.getProcessDefinitionKey(), job.getElementId()));
+              new SecretFilterContext(
+                  job.getProcessDefinitionKey(),
+                  job.getElementId(),
+                  Instant.ofEpochMilli(job.getDeadline())));
       internalHandle(client, job, secretFilter);
     } catch (Exception e) {
       connectorsOutboundMetrics.increaseFailure(job);

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/secret/ProcessDefinitionSecretKeyCache.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/secret/ProcessDefinitionSecretKeyCache.java
@@ -17,6 +17,9 @@
 package io.camunda.connector.runtime.outbound.secret;
 
 import com.github.benmanes.caffeine.cache.Cache;
+import dev.failsafe.Failsafe;
+import dev.failsafe.RetryPolicy;
+import dev.failsafe.Timeout;
 import io.camunda.client.CamundaClient;
 import io.camunda.connector.runtime.core.secret.SecretFilter.Secret;
 import io.camunda.connector.runtime.core.secret.SecretUtil;
@@ -35,6 +38,8 @@ import io.camunda.zeebe.model.bpmn.instance.SubProcess;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeInput;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeIoMapping;
 import java.io.ByteArrayInputStream;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -61,6 +66,18 @@ public class ProcessDefinitionSecretKeyCache implements SecretKeyCache {
   private static final List<Class<? extends BaseElement>> OUTBOUND_ELIGIBLE_TYPES =
       new ArrayList<>();
 
+  private static final int XML_FETCH_MAX_RETRIES = 3;
+
+  private static final Duration XML_FETCH_INITIAL_RETRY_DELAY = Duration.ofSeconds(1);
+
+  /**
+   * Retries stop this far ahead of the activated job's deadline, leaving room for the connector
+   * function itself to run before the job's lease expires -- a fetch that only succeeds after the
+   * lease is gone risks the job being reassigned while this worker keeps executing, per the
+   * duplicate-side-effect concern in {@code SpringConnectorJobHandler}.
+   */
+  private static final Duration XML_FETCH_DEADLINE_SAFETY_MARGIN = Duration.ofSeconds(5);
+
   static {
     OUTBOUND_ELIGIBLE_TYPES.add(ServiceTask.class);
     OUTBOUND_ELIGIBLE_TYPES.add(SendTask.class);
@@ -73,11 +90,21 @@ public class ProcessDefinitionSecretKeyCache implements SecretKeyCache {
 
   private final CamundaClient camundaClient;
   private final Cache<Long, Map<String, List<Secret>>> cache;
+  private final Duration xmlFetchInitialRetryDelay;
 
   public ProcessDefinitionSecretKeyCache(
       CamundaClient camundaClient, Cache<Long, Map<String, List<Secret>>> cache) {
+    this(camundaClient, cache, XML_FETCH_INITIAL_RETRY_DELAY);
+  }
+
+  /** Test-only seam: lets retry tests use a near-zero delay instead of the real one. */
+  public ProcessDefinitionSecretKeyCache(
+      CamundaClient camundaClient,
+      Cache<Long, Map<String, List<Secret>>> cache,
+      Duration xmlFetchInitialRetryDelay) {
     this.camundaClient = camundaClient;
     this.cache = cache;
+    this.xmlFetchInitialRetryDelay = xmlFetchInitialRetryDelay;
   }
 
   @Override
@@ -85,13 +112,15 @@ public class ProcessDefinitionSecretKeyCache implements SecretKeyCache {
     return cache
         .get(
             secretKeyContext.processDefinitionKey(),
-            key -> fetchSecretKeysByElementIds(secretKeyContext.processDefinitionKey()))
+            key ->
+                fetchSecretKeysByElementIds(
+                    secretKeyContext.processDefinitionKey(), secretKeyContext.deadline()))
         .getOrDefault(secretKeyContext.elementId(), Collections.emptyList());
   }
 
-  private Map<String, List<Secret>> fetchSecretKeysByElementIds(long processDefinitionKey) {
-    String bpmnXml =
-        camundaClient.newProcessDefinitionGetXmlRequest(processDefinitionKey).execute();
+  private Map<String, List<Secret>> fetchSecretKeysByElementIds(
+      long processDefinitionKey, Instant deadline) {
+    String bpmnXml = fetchBpmnXmlWithRetry(processDefinitionKey, deadline);
 
     BpmnModelInstance modelInstance =
         Bpmn.readModelFromStream(new ByteArrayInputStream(bpmnXml.getBytes()));
@@ -101,6 +130,40 @@ public class ProcessDefinitionSecretKeyCache implements SecretKeyCache {
     return processes.stream()
         .flatMap(process -> inspectBpmnProcess(process, processDefinitionKey).entrySet().stream())
         .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+  }
+
+  private String fetchBpmnXmlWithRetry(long processDefinitionKey, Instant deadline) {
+    Duration remaining =
+        Duration.between(Instant.now(), deadline).minus(XML_FETCH_DEADLINE_SAFETY_MARGIN);
+    if (remaining.isNegative() || remaining.isZero()) {
+      throw new IllegalStateException(
+          "BPMN XML fetch deadline already elapsed for process definition key "
+              + processDefinitionKey);
+    }
+    Timeout<String> xmlFetchTimeout = Timeout.<String>builder(remaining).withInterrupt().build();
+    if (remaining.compareTo(xmlFetchInitialRetryDelay) <= 0) {
+      return Failsafe.with(xmlFetchTimeout)
+          .get(
+              () ->
+                  camundaClient.newProcessDefinitionGetXmlRequest(processDefinitionKey).execute());
+    }
+    RetryPolicy<String> xmlFetchRetryPolicy =
+        RetryPolicy.<String>builder()
+            .withBackoff(
+                xmlFetchInitialRetryDelay,
+                xmlFetchInitialRetryDelay.multipliedBy(1L << (XML_FETCH_MAX_RETRIES - 1)))
+            .withMaxRetries(XML_FETCH_MAX_RETRIES)
+            .withMaxDuration(remaining)
+            .onFailedAttempt(
+                event ->
+                    LOG.warn(
+                        "Attempt {}/{} to fetch BPMN XML failed: {}",
+                        event.getAttemptCount(),
+                        XML_FETCH_MAX_RETRIES + 1,
+                        event.getLastException().getClass().getName()))
+            .build();
+    return Failsafe.with(xmlFetchTimeout, xmlFetchRetryPolicy)
+        .get(() -> camundaClient.newProcessDefinitionGetXmlRequest(processDefinitionKey).execute());
   }
 
   private Map<String, List<Secret>> inspectBpmnProcess(Process process, long processDefinitionKey) {

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/secret/SecretKeyCache.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/secret/SecretKeyCache.java
@@ -17,10 +17,11 @@
 package io.camunda.connector.runtime.outbound.secret;
 
 import io.camunda.connector.runtime.core.secret.SecretFilter.Secret;
+import java.time.Instant;
 import java.util.List;
 
 public interface SecretKeyCache {
   List<Secret> getSecretKeys(SecretKeyContext secretKeyContext);
 
-  record SecretKeyContext(long processDefinitionKey, String elementId) {}
+  record SecretKeyContext(long processDefinitionKey, String elementId, Instant deadline) {}
 }

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/JobBuilder.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/JobBuilder.java
@@ -129,6 +129,11 @@ public class JobBuilder {
       return this;
     }
 
+    public JobBuilderStep withDeadline(long deadline) {
+      when(job.getDeadline()).thenReturn(deadline);
+      return this;
+    }
+
     public JobBuilderStep withResultVariableHeader(final String value) {
       return withHeader(Keywords.RESULT_VARIABLE_KEYWORD, value);
     }

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/job/ConfigurableSecretFilterFactoryTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/job/ConfigurableSecretFilterFactoryTest.java
@@ -32,6 +32,8 @@ import io.camunda.connector.runtime.outbound.job.ConfigurableSecretFilterFactory
 import io.camunda.connector.runtime.outbound.secret.ProcessDefinitionSecretKeyCache;
 import io.camunda.connector.runtime.outbound.secret.SecretKeyCache;
 import io.camunda.connector.runtime.outbound.secret.SecretKeyCache.SecretKeyContext;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
@@ -44,10 +46,11 @@ class ConfigurableSecretFilterFactoryTest {
 
   private static final long PROCESS_DEF_KEY = 42L;
   private static final String ELEMENT_ID = "service-task-1";
+  private static final Instant DEADLINE = Instant.now().plusSeconds(3600);
   private static final SecretFilterContext CONTEXT =
-      new SecretFilterContext(PROCESS_DEF_KEY, ELEMENT_ID);
+      new SecretFilterContext(PROCESS_DEF_KEY, ELEMENT_ID, DEADLINE);
   private static final SecretKeyContext SECRET_KEY_CONTEXT =
-      new SecretKeyContext(PROCESS_DEF_KEY, ELEMENT_ID);
+      new SecretKeyContext(PROCESS_DEF_KEY, ELEMENT_ID, DEADLINE);
 
   @Mock private SecretKeyCache secretKeyCache;
 
@@ -191,7 +194,8 @@ class ConfigurableSecretFilterFactoryTest {
     var camundaClient = mock(CamundaClient.class);
     when(camundaClient.newProcessDefinitionGetXmlRequest(PROCESS_DEF_KEY))
         .thenThrow(new RuntimeException("Operate returned 404 for process definition 42"));
-    SecretKeyCache realSecretKeyCache = new ProcessDefinitionSecretKeyCache(camundaClient, cache);
+    SecretKeyCache realSecretKeyCache =
+        new ProcessDefinitionSecretKeyCache(camundaClient, cache, Duration.ofMillis(1));
     var factory = new ConfigurableSecretFilterFactory(SecretFilterMode.STRICT, realSecretKeyCache);
 
     var filter = factory.create(CONTEXT);

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/job/SpringConnectorJobHandlerTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/job/SpringConnectorJobHandlerTest.java
@@ -52,13 +52,16 @@ import io.camunda.connector.runtime.JobBuilder;
 import io.camunda.connector.runtime.TestObjectMapperSupplier;
 import io.camunda.connector.runtime.TestValidation;
 import io.camunda.connector.runtime.core.Keywords;
+import io.camunda.connector.runtime.core.secret.SecretFilter;
 import io.camunda.connector.runtime.core.secret.SecretFilterFactory;
+import io.camunda.connector.runtime.core.secret.SecretFilterFactory.SecretFilterContext;
 import io.camunda.connector.runtime.core.secret.SecretProviderAggregator;
 import io.camunda.connector.runtime.metrics.ConnectorsOutboundMetrics;
 import io.camunda.connector.runtime.secret.FooBarSecretProvider;
 import io.camunda.connector.validation.impl.DefaultValidationProvider;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.time.Duration;
+import java.time.Instant;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -724,6 +727,43 @@ class SpringConnectorJobHandlerTest {
       verify(secondStepMock).errorMessage(any());
       verify(secondStepMock, times(0)).retryBackoff(any()); // not set
       verify(secondStepMock).send();
+    }
+  }
+
+  @Nested
+  class SecretFilterDeadlineTests {
+
+    @Test
+    void secretFilterContext_receivesJobDeadlineAsInstant() {
+      // given -- the secret filter factory needs the job's deadline to bound the BPMN XML
+      // fetch retry (ProcessDefinitionSecretKeyCache), so it must be threaded through from the
+      // activated job into the SecretFilterContext used to build the filter.
+      var secretFilterFactory = mock(SecretFilterFactory.class);
+      when(secretFilterFactory.create(any())).thenReturn(SecretFilter.allowAll());
+      var jobHandler =
+          new SpringConnectorJobHandler(
+              new ConnectorsOutboundMetrics(new SimpleMeterRegistry()),
+              new DefaultCommandExceptionHandlingStrategy(
+                  BackoffSupplier.newBackoffBuilder().build(),
+                  Executors.newSingleThreadScheduledExecutor()),
+              new SecretProviderAggregator(List.of(new FooBarSecretProvider())),
+              new DefaultValidationProvider(),
+              mock(DocumentFactory.class),
+              TestObjectMapperSupplier.INSTANCE,
+              (context) -> "ok",
+              new DefaultNoopMetricsRecorder(),
+              secretFilterFactory);
+      long deadline = System.currentTimeMillis() + Duration.ofMinutes(5).toMillis();
+      var jobBuilder = JobBuilder.create().withDeadline(deadline);
+
+      // when
+      jobBuilder.executeAndCaptureResult(jobHandler);
+
+      // then
+      ArgumentCaptor<SecretFilterContext> contextCaptor =
+          ArgumentCaptor.forClass(SecretFilterContext.class);
+      verify(secretFilterFactory).create(contextCaptor.capture());
+      assertThat(contextCaptor.getValue().deadline()).isEqualTo(Instant.ofEpochMilli(deadline));
     }
   }
 

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/secret/ProcessDefinitionSecretKeyCacheTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/secret/ProcessDefinitionSecretKeyCacheTest.java
@@ -17,16 +17,24 @@
 package io.camunda.connector.runtime.outbound.secret;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.github.benmanes.caffeine.cache.Caffeine;
+import dev.failsafe.TimeoutExceededException;
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.fetch.ProcessDefinitionGetXmlRequest;
 import io.camunda.connector.runtime.core.secret.SecretFilter.Secret;
 import io.camunda.connector.runtime.outbound.secret.SecretKeyCache.SecretKeyContext;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -38,6 +46,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 class ProcessDefinitionSecretKeyCacheTest {
 
   private static final long PROCESS_DEF_KEY = 1L;
+  private static final Instant DEADLINE = Instant.now().plusSeconds(3600);
 
   @Mock private CamundaClient camundaClient;
   @Mock private ProcessDefinitionGetXmlRequest xmlRequest;
@@ -50,7 +59,9 @@ class ProcessDefinitionSecretKeyCacheTest {
     // class now relies on.
     secretKeyCache =
         new ProcessDefinitionSecretKeyCache(camundaClient, Caffeine.newBuilder().build());
-    when(camundaClient.newProcessDefinitionGetXmlRequest(anyLong())).thenReturn(xmlRequest);
+    lenient()
+        .when(camundaClient.newProcessDefinitionGetXmlRequest(anyLong()))
+        .thenReturn(xmlRequest);
   }
 
   @Test
@@ -58,7 +69,8 @@ class ProcessDefinitionSecretKeyCacheTest {
     when(xmlRequest.execute()).thenReturn(loadBpmn("outbound-with-secrets.bpmn"));
 
     var keys =
-        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1"));
+        secretKeyCache.getSecretKeys(
+            new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1", DEADLINE));
 
     assertThat(keys)
         .extracting(Secret::secretName)
@@ -74,7 +86,8 @@ class ProcessDefinitionSecretKeyCacheTest {
     when(xmlRequest.execute()).thenReturn(loadBpmn("outbound-with-dotted-target.bpmn"));
 
     var keys =
-        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1"));
+        secretKeyCache.getSecretKeys(
+            new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1", DEADLINE));
 
     assertThat(keys).containsExactly(new Secret("API_KEY", List.of("auth", "token")));
   }
@@ -89,7 +102,8 @@ class ProcessDefinitionSecretKeyCacheTest {
     when(xmlRequest.execute()).thenReturn(loadBpmn("outbound-with-referenced-variable.bpmn"));
 
     var keys =
-        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1"));
+        secretKeyCache.getSecretKeys(
+            new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1", DEADLINE));
 
     assertThat(keys)
         .contains(
@@ -105,7 +119,8 @@ class ProcessDefinitionSecretKeyCacheTest {
     when(xmlRequest.execute()).thenReturn(loadBpmn("outbound-with-chained-references.bpmn"));
 
     var keys =
-        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1"));
+        secretKeyCache.getSecretKeys(
+            new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1", DEADLINE));
 
     assertThat(keys)
         .containsExactlyInAnyOrder(
@@ -123,7 +138,8 @@ class ProcessDefinitionSecretKeyCacheTest {
     when(xmlRequest.execute()).thenReturn(loadBpmn("outbound-with-referenced-variable.bpmn"));
 
     var keys =
-        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1"));
+        secretKeyCache.getSecretKeys(
+            new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1", DEADLINE));
 
     assertThat(keys)
         .doesNotContain(
@@ -142,7 +158,8 @@ class ProcessDefinitionSecretKeyCacheTest {
     when(xmlRequest.execute()).thenReturn(loadBpmn("outbound-with-sibling-fields.bpmn"));
 
     var keys =
-        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1"));
+        secretKeyCache.getSecretKeys(
+            new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1", DEADLINE));
 
     assertThat(keys)
         .contains(
@@ -163,7 +180,8 @@ class ProcessDefinitionSecretKeyCacheTest {
     when(xmlRequest.execute()).thenReturn(loadBpmn("outbound-with-reverse-order-reference.bpmn"));
 
     var keys =
-        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1"));
+        secretKeyCache.getSecretKeys(
+            new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1", DEADLINE));
 
     assertThat(keys)
         .contains(new Secret("API_KEY", List.of("baseUrl")))
@@ -182,7 +200,8 @@ class ProcessDefinitionSecretKeyCacheTest {
     when(xmlRequest.execute()).thenReturn(loadBpmn("outbound-with-parent-overwrite.bpmn"));
 
     var keys =
-        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1"));
+        secretKeyCache.getSecretKeys(
+            new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1", DEADLINE));
 
     // Nothing in this BPMN ever reads authentication.token from a path that's still effective, so
     // TOKEN isn't just absent from the two paths above -- it's not granted anywhere at all. This
@@ -200,7 +219,8 @@ class ProcessDefinitionSecretKeyCacheTest {
     when(xmlRequest.execute()).thenReturn(loadBpmn("outbound-with-same-path-overwrite.bpmn"));
 
     var keys =
-        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1"));
+        secretKeyCache.getSecretKeys(
+            new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1", DEADLINE));
 
     assertThat(keys).isEmpty();
   }
@@ -218,7 +238,8 @@ class ProcessDefinitionSecretKeyCacheTest {
         .thenReturn(loadBpmn("outbound-with-overwritten-propagation-target.bpmn"));
 
     var keys =
-        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1"));
+        secretKeyCache.getSecretKeys(
+            new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1", DEADLINE));
 
     assertThat(keys)
         .containsExactly(new Secret("TOKEN", List.of("baseUrl")))
@@ -238,7 +259,8 @@ class ProcessDefinitionSecretKeyCacheTest {
     when(xmlRequest.execute()).thenReturn(loadBpmn("outbound-with-child-overwrite.bpmn"));
 
     var keys =
-        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1"));
+        secretKeyCache.getSecretKeys(
+            new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1", DEADLINE));
 
     assertThat(keys).isEmpty();
   }
@@ -257,7 +279,8 @@ class ProcessDefinitionSecretKeyCacheTest {
         .thenReturn(loadBpmn("outbound-with-nested-parent-and-child-overwrite.bpmn"));
 
     var keys =
-        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1"));
+        secretKeyCache.getSecretKeys(
+            new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1", DEADLINE));
 
     assertThat(keys).isEmpty();
   }
@@ -274,7 +297,8 @@ class ProcessDefinitionSecretKeyCacheTest {
         .thenReturn(loadBpmn("outbound-with-shadowed-input-as-dependency.bpmn"));
 
     var keys =
-        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1"));
+        secretKeyCache.getSecretKeys(
+            new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1", DEADLINE));
 
     assertThat(keys).containsExactly(new Secret("T", List.of("baseUrl")));
   }
@@ -285,8 +309,9 @@ class ProcessDefinitionSecretKeyCacheTest {
     when(xmlRequest.execute()).thenReturn(loadBpmn("outbound-multiple-tasks-with-secrets.bpmn"));
 
     var alphaKeys =
-        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "task-alpha"));
-    var betaKeys = secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "task-beta"));
+        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "task-alpha", DEADLINE));
+    var betaKeys =
+        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "task-beta", DEADLINE));
 
     assertThat(alphaKeys).extracting(Secret::secretName).containsExactly("SECRET_ALPHA");
     assertThat(betaKeys)
@@ -299,7 +324,8 @@ class ProcessDefinitionSecretKeyCacheTest {
     when(xmlRequest.execute()).thenReturn(loadBpmn("outbound-no-secrets.bpmn"));
 
     var keys =
-        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "no-secrets-task"));
+        secretKeyCache.getSecretKeys(
+            new SecretKeyContext(PROCESS_DEF_KEY, "no-secrets-task", DEADLINE));
 
     assertThat(keys).isEmpty();
   }
@@ -311,7 +337,8 @@ class ProcessDefinitionSecretKeyCacheTest {
     // built by applying an element template in Modeler.
     when(xmlRequest.execute()).thenReturn(loadBpmn("outbound-no-template.bpmn"));
 
-    var keys = secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "plain-task"));
+    var keys =
+        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "plain-task", DEADLINE));
 
     assertThat(keys).extracting(Secret::secretName).containsExactly("SECRET_X");
   }
@@ -321,9 +348,10 @@ class ProcessDefinitionSecretKeyCacheTest {
     when(xmlRequest.execute()).thenReturn(loadBpmn("outbound-adhoc-subprocess.bpmn"));
 
     var subProcessKeys =
-        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "agent-subprocess"));
+        secretKeyCache.getSecretKeys(
+            new SecretKeyContext(PROCESS_DEF_KEY, "agent-subprocess", DEADLINE));
     var childKeys =
-        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "child-task"));
+        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "child-task", DEADLINE));
 
     assertThat(subProcessKeys).extracting(Secret::secretName).containsExactly("ADHOC_SECRET");
     assertThat(childKeys).extracting(Secret::secretName).containsExactly("CHILD_SECRET");
@@ -337,11 +365,14 @@ class ProcessDefinitionSecretKeyCacheTest {
     when(xmlRequest.execute()).thenReturn(loadBpmn("outbound-nested-embedded-subprocess.bpmn"));
 
     var outerKeys =
-        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "outer-subprocess"));
+        secretKeyCache.getSecretKeys(
+            new SecretKeyContext(PROCESS_DEF_KEY, "outer-subprocess", DEADLINE));
     var innerKeys =
-        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "inner-subprocess"));
+        secretKeyCache.getSecretKeys(
+            new SecretKeyContext(PROCESS_DEF_KEY, "inner-subprocess", DEADLINE));
     var grandchildKeys =
-        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "grandchild-task"));
+        secretKeyCache.getSecretKeys(
+            new SecretKeyContext(PROCESS_DEF_KEY, "grandchild-task", DEADLINE));
 
     assertThat(outerKeys).extracting(Secret::secretName).containsExactly("OUTER_SECRET");
     assertThat(innerKeys).extracting(Secret::secretName).containsExactly("INNER_SECRET");
@@ -354,9 +385,11 @@ class ProcessDefinitionSecretKeyCacheTest {
     when(xmlRequest.execute()).thenReturn(loadBpmn("outbound-message-events.bpmn"));
 
     var throwEventKeys =
-        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "send-message-throw"));
+        secretKeyCache.getSecretKeys(
+            new SecretKeyContext(PROCESS_DEF_KEY, "send-message-throw", DEADLINE));
     var endEventKeys =
-        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "send-message-end"));
+        secretKeyCache.getSecretKeys(
+            new SecretKeyContext(PROCESS_DEF_KEY, "send-message-end", DEADLINE));
 
     assertThat(throwEventKeys).extracting(Secret::secretName).containsExactly("THROW_EVENT_SECRET");
     assertThat(endEventKeys).extracting(Secret::secretName).containsExactly("END_EVENT_SECRET");
@@ -367,9 +400,110 @@ class ProcessDefinitionSecretKeyCacheTest {
     when(xmlRequest.execute()).thenReturn(loadBpmn("outbound-with-secrets.bpmn"));
 
     var keys =
-        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "nonexistent-task"));
+        secretKeyCache.getSecretKeys(
+            new SecretKeyContext(PROCESS_DEF_KEY, "nonexistent-task", DEADLINE));
 
     assertThat(keys).isEmpty();
+  }
+
+  @Test
+  void getSecretKeys_xmlFetchTransientlyFails_retriesAndSucceeds() throws IOException {
+    // simulates the get-XML endpoint's eventual-consistency window right after deployment: the
+    // first two attempts 404 before the definition becomes visible, the third succeeds
+    var retryingCache =
+        new ProcessDefinitionSecretKeyCache(
+            camundaClient, Caffeine.newBuilder().build(), Duration.ofMillis(1));
+    when(xmlRequest.execute())
+        .thenThrow(new RuntimeException("not found (yet)"))
+        .thenThrow(new RuntimeException("not found (yet)"))
+        .thenReturn(loadBpmn("outbound-with-secrets.bpmn"));
+
+    var keys =
+        retryingCache.getSecretKeys(
+            new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1", DEADLINE));
+
+    assertThat(keys)
+        .extracting(Secret::secretName)
+        .containsExactlyInAnyOrder("API_KEY", "MY_TOKEN");
+    verify(xmlRequest, times(3)).execute();
+  }
+
+  @Test
+  void getSecretKeys_xmlFetchFailsPastMaxRetries_throwsLastFailure() {
+    var retryingCache =
+        new ProcessDefinitionSecretKeyCache(
+            camundaClient, Caffeine.newBuilder().build(), Duration.ofMillis(1));
+    when(xmlRequest.execute()).thenThrow(new RuntimeException("still not found"));
+
+    assertThatThrownBy(
+            () ->
+                retryingCache.getSecretKeys(
+                    new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1", DEADLINE)))
+        .isInstanceOf(RuntimeException.class)
+        .hasMessage("still not found");
+    // 1 initial attempt + 3 retries
+    verify(xmlRequest, times(4)).execute();
+  }
+
+  @Test
+  void getSecretKeys_deadlineWithinSafetyMargin_failsWithoutAttemptingFetch() {
+    assertThatThrownBy(
+            () ->
+                secretKeyCache.getSecretKeys(
+                    new SecretKeyContext(
+                        PROCESS_DEF_KEY, "service-task-1", Instant.now().plusSeconds(2))))
+        .isInstanceOf(IllegalStateException.class);
+    verify(xmlRequest, times(0)).execute();
+  }
+
+  @Test
+  void getSecretKeys_deadlineLeavesOnlyAPartialRetryWindow_stopsRetryingBeforeMaxRetries() {
+    var retryingCache =
+        new ProcessDefinitionSecretKeyCache(
+            camundaClient, Caffeine.newBuilder().build(), Duration.ofMillis(200));
+    when(xmlRequest.execute()).thenThrow(new RuntimeException("still not found"));
+    Instant deadline = Instant.now().plusSeconds(5).plusMillis(300);
+
+    long start = System.nanoTime();
+    assertThatThrownBy(
+            () ->
+                retryingCache.getSecretKeys(
+                    new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1", deadline)))
+        .satisfiesAnyOf(
+            e -> assertThat(e).isInstanceOf(TimeoutExceededException.class),
+            e -> assertThat(e).hasMessage("still not found"));
+    long elapsedMillis = (System.nanoTime() - start) / 1_000_000;
+
+    assertThat(elapsedMillis).isLessThan(700);
+    verify(xmlRequest, atLeast(2)).execute();
+  }
+
+  @Test
+  void getSecretKeys_xmlFetchIgnoresInterruptAndSucceedsPastDeadline_stillFails()
+      throws IOException {
+    var retryingCache =
+        new ProcessDefinitionSecretKeyCache(
+            camundaClient, Caffeine.newBuilder().build(), Duration.ofMillis(200));
+    String bpmnXml = loadBpmn("outbound-with-secrets.bpmn");
+    when(xmlRequest.execute())
+        .thenAnswer(
+            invocation -> {
+              long until = System.nanoTime() + Duration.ofMillis(250).toNanos();
+              while (System.nanoTime() < until) {
+                try {
+                  Thread.sleep(10);
+                } catch (InterruptedException ignored) {
+                }
+              }
+              return bpmnXml;
+            });
+    Instant deadline = Instant.now().plusSeconds(5).plusMillis(150);
+
+    assertThatThrownBy(
+            () ->
+                retryingCache.getSecretKeys(
+                    new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1", deadline)))
+        .isInstanceOf(TimeoutExceededException.class);
   }
 
   private String loadBpmn(String fileName) throws IOException {

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/jobworker/AiAgentJobWorkerHandlerImpl.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/jobworker/AiAgentJobWorkerHandlerImpl.java
@@ -37,6 +37,7 @@ import io.camunda.connector.runtime.core.secret.SecretFilterFactory.SecretFilter
 import io.camunda.connector.runtime.metrics.ConnectorsOutboundMetrics;
 import io.camunda.connector.runtime.outbound.job.OutboundConnectorExceptionHandler;
 import java.time.Duration;
+import java.time.Instant;
 import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
 import java.util.List;
@@ -85,7 +86,10 @@ public class AiAgentJobWorkerHandlerImpl implements AiAgentJobWorkerHandler {
   private void executeJob(final JobClient jobClient, final ActivatedJob job) {
     final SecretFilter secretFilter =
         secretFilterFactory.create(
-            new SecretFilterContext(job.getProcessDefinitionKey(), job.getElementId()));
+            new SecretFilterContext(
+                job.getProcessDefinitionKey(),
+                job.getElementId(),
+                Instant.ofEpochMilli(job.getDeadline())));
     // kept for the error paths: a secret rotated since the input was bound no longer reads back,
     // and the value an error message carries is the one substituted then
     final List<String> capturedSecrets = new ArrayList<>();


### PR DESCRIPTION
Backport of #8756 to stable/8.8. Manual cherry-pick — automated backport failed due to a merge conflict; resolved by hand (adapted to 8.8's single-tenant `ProcessDefinitionSecretKeyCache` and Caffeine-typed cache, and its `SpringConnectorJobHandler` without job-timeout-header handling).