### PR TITLE
ci(e2e): reduce test and artifact transfer latency

### DIFF
--- a/.github/workflows/E2E_BRANCH_RUN.yml
+++ b/.github/workflows/E2E_BRANCH_RUN.yml
@@ -158,6 +158,10 @@ jobs:
 
       - name: Archive Maven repository
         run: |
+          if ! command -v zstd >/dev/null; then
+            sudo apt-get update -qq
+            sudo apt-get install -y -qq zstd
+          fi
           set -o pipefail
           tar -cf - -C "$HOME/.m2" repository |
             zstd -T0 -3 -q -o "$RUNNER_TEMP/m2-repository.tar.zst"
@@ -274,6 +278,10 @@ jobs:
 
       - name: Extract Maven repository
         run: |
+          if ! command -v zstd >/dev/null; then
+            sudo apt-get update -qq
+            sudo apt-get install -y -qq zstd
+          fi
           set -o pipefail
           mkdir -p "$HOME/.m2"
           zstd -dc "$RUNNER_TEMP/m2-repository/m2-repository.tar.zst" |

--- a/.github/workflows/E2E_BRANCH_RUN.yml
+++ b/.github/workflows/E2E_BRANCH_RUN.yml
@@ -156,12 +156,12 @@ jobs:
         env:
           BRANCH: ${{ inputs.branch }}
 
-      # Resolve only the dependencies and plugins needed by Agentic AI into a dedicated local
-      # repository. The source is the repository populated by the reactor build, so this adds no
-      # network traffic and retains branch-local SNAPSHOT artifacts.
-      - name: Prepare Agentic AI Maven repository
+      # Resolve only the dependencies and plugins needed by modules assigned to slower custom
+      # runners. The source is the repository populated by the reactor build, so this adds no
+      # network traffic and retains branch-local SNAPSHOT artifacts. Guard each module because
+      # older stable branches may predate it.
+      - name: Prepare module-specific Maven repositories
         run: |
-          mkdir -p "$RUNNER_TEMP/m2-agentic/repository"
           cat > "$RUNNER_TEMP/local-maven-mirror-settings.xml" <<EOF
           <settings>
             <mirrors>
@@ -173,13 +173,28 @@ jobs:
             </mirrors>
           </settings>
           EOF
-          $MVN_CMD --batch-mode \
-            --settings "$RUNNER_TEMP/local-maven-mirror-settings.xml" \
-            -Dmaven.repo.local="$RUNNER_TEMP/m2-agentic/repository" \
-            -DskipTests \
-            -DskipChecks \
-            verify \
-            -pl connectors-e2e-test/connectors-e2e-test-agentic-ai
+
+          prepare_repository() {
+            module="$1"
+            repository="$2"
+            [ -f "$module/pom.xml" ] || return 0
+
+            mkdir -p "$RUNNER_TEMP/$repository/repository"
+            $MVN_CMD --batch-mode \
+              --settings "$RUNNER_TEMP/local-maven-mirror-settings.xml" \
+              -Dmaven.repo.local="$RUNNER_TEMP/$repository/repository" \
+              -DskipTests \
+              -DskipChecks \
+              verify \
+              -pl "$module"
+          }
+
+          prepare_repository \
+            connectors-e2e-test/connectors-e2e-test-agentic-ai \
+            m2-agentic
+          prepare_repository \
+            connectors-e2e-test/connectors-e2e-test-inbound-runtime \
+            m2-inbound-runtime
 
       - name: Archive Maven repository
         run: |
@@ -190,8 +205,14 @@ jobs:
           set -o pipefail
           tar -cf - -C "$HOME/.m2" repository |
             zstd -T0 -3 -q -o "$RUNNER_TEMP/m2-repository.tar.zst"
-          tar -cf - -C "$RUNNER_TEMP/m2-agentic" repository |
-            zstd -T0 -3 -q -o "$RUNNER_TEMP/m2-agentic-repository.tar.zst"
+          if [ -d "$RUNNER_TEMP/m2-agentic/repository" ]; then
+            tar -cf - -C "$RUNNER_TEMP/m2-agentic" repository |
+              zstd -T0 -3 -q -o "$RUNNER_TEMP/m2-agentic-repository.tar.zst"
+          fi
+          if [ -d "$RUNNER_TEMP/m2-inbound-runtime/repository" ]; then
+            tar -cf - -C "$RUNNER_TEMP/m2-inbound-runtime" repository |
+              zstd -T0 -3 -q -o "$RUNNER_TEMP/m2-inbound-runtime-repository.tar.zst"
+          fi
 
       # Hand the fully-populated local Maven repo (first-party SNAPSHOTs + all third-party
       # dependencies resolved during the build) to the test matrix, so test jobs resolve
@@ -208,10 +229,21 @@ jobs:
           overwrite: true
 
       - name: Upload Agentic AI Maven repository
+        if: hashFiles('connectors-e2e-test/connectors-e2e-test-agentic-ai/pom.xml') != ''
         uses: actions/upload-artifact@v7
         with:
           name: m2-repo-agentic-${{ steps.sanitize.outputs.branch }}-${{ github.run_id }}
           path: ${{ runner.temp }}/m2-agentic-repository.tar.zst
+          retention-days: 1
+          compression-level: 0
+          overwrite: true
+
+      - name: Upload inbound-runtime Maven repository
+        if: hashFiles('connectors-e2e-test/connectors-e2e-test-inbound-runtime/pom.xml') != ''
+        uses: actions/upload-artifact@v7
+        with:
+          name: m2-repo-inbound-runtime-${{ steps.sanitize.outputs.branch }}-${{ github.run_id }}
+          path: ${{ runner.temp }}/m2-inbound-runtime-repository.tar.zst
           retention-days: 1
           compression-level: 0
           overwrite: true
@@ -298,11 +330,18 @@ jobs:
         run: |
           echo "branch=${BRANCH//\//-}" >> "$GITHUB_OUTPUT"
           echo "module=${MODULE//\//-}" >> "$GITHUB_OUTPUT"
-          if [ "$MODULE" = "connectors-e2e-test-agentic-ai" ]; then
-            echo "repository-artifact=m2-repo-agentic" >> "$GITHUB_OUTPUT"
-          else
-            echo "repository-artifact=m2-repo" >> "$GITHUB_OUTPUT"
-          fi
+          case "$MODULE" in
+            connectors-e2e-test-agentic-ai)
+              repository_artifact=m2-repo-agentic
+              ;;
+            connectors-e2e-test-inbound-runtime)
+              repository_artifact=m2-repo-inbound-runtime
+              ;;
+            *)
+              repository_artifact=m2-repo
+              ;;
+          esac
+          echo "repository-artifact=$repository_artifact" >> "$GITHUB_OUTPUT"
         env:
           BRANCH: ${{ inputs.branch }}
           MODULE: ${{ matrix.entry.module }}

--- a/.github/workflows/E2E_BRANCH_RUN.yml
+++ b/.github/workflows/E2E_BRANCH_RUN.yml
@@ -166,7 +166,7 @@ jobs:
           <settings>
             <mirrors>
               <mirror>
-                <id>populated-local-repository</id>
+                <id>camunda-nexus</id>
                 <url>file://$HOME/.m2/repository</url>
                 <mirrorOf>*</mirrorOf>
               </mirror>

--- a/.github/workflows/E2E_BRANCH_RUN.yml
+++ b/.github/workflows/E2E_BRANCH_RUN.yml
@@ -156,18 +156,24 @@ jobs:
         env:
           BRANCH: ${{ inputs.branch }}
 
+      - name: Archive Maven repository
+        run: |
+          set -o pipefail
+          tar -cf - -C "$HOME/.m2" repository |
+            zstd -T0 -3 -q -o "$RUNNER_TEMP/m2-repository.tar.zst"
+
       # Hand the fully-populated local Maven repo (first-party SNAPSHOTs + all third-party
       # dependencies resolved during the build) to the test matrix, so test jobs resolve
       # everything from the artifact instead of re-downloading their dependency tree from
-      # Nexus. Maven stays online in the test jobs, so anything missing still falls back to
-      # Nexus - the artifact just eliminates the bulk of the per-job resolution.
+      # Nexus. Pre-archive it so the artifact action transfers one file instead of separately
+      # compressing and extracting hundreds of thousands of Maven repository files.
       - name: Upload Maven repository
         uses: actions/upload-artifact@v7
         with:
           name: m2-repo-${{ steps.sanitize.outputs.branch }}-${{ github.run_id }}
-          path: ~/.m2/repository
+          path: ${{ runner.temp }}/m2-repository.tar.zst
           retention-days: 1
-          include-hidden-files: true
+          compression-level: 0
           overwrite: true
 
   # Test phase (matrix: entry): each e2e-test module runs in its own job, in isolation.
@@ -264,7 +270,14 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           name: m2-repo-${{ steps.sanitize.outputs.branch }}-${{ github.run_id }}
-          path: ~/.m2/repository
+          path: ${{ runner.temp }}/m2-repository
+
+      - name: Extract Maven repository
+        run: |
+          set -o pipefail
+          mkdir -p "$HOME/.m2"
+          zstd -dc "$RUNNER_TEMP/m2-repository/m2-repository.tar.zst" |
+            tar -xf - -C "$HOME/.m2"
 
       # Run only this module's tests. No -am: base/connector SNAPSHOTs come from the downloaded
       # artifact, so nothing upstream is rebuilt.

--- a/.github/workflows/E2E_BRANCH_RUN.yml
+++ b/.github/workflows/E2E_BRANCH_RUN.yml
@@ -156,6 +156,31 @@ jobs:
         env:
           BRANCH: ${{ inputs.branch }}
 
+      # Resolve only the dependencies and plugins needed by Agentic AI into a dedicated local
+      # repository. The source is the repository populated by the reactor build, so this adds no
+      # network traffic and retains branch-local SNAPSHOT artifacts.
+      - name: Prepare Agentic AI Maven repository
+        run: |
+          mkdir -p "$RUNNER_TEMP/m2-agentic/repository"
+          cat > "$RUNNER_TEMP/local-maven-mirror-settings.xml" <<EOF
+          <settings>
+            <mirrors>
+              <mirror>
+                <id>populated-local-repository</id>
+                <url>file://$HOME/.m2/repository</url>
+                <mirrorOf>*</mirrorOf>
+              </mirror>
+            </mirrors>
+          </settings>
+          EOF
+          $MVN_CMD --batch-mode \
+            --settings "$RUNNER_TEMP/local-maven-mirror-settings.xml" \
+            -Dmaven.repo.local="$RUNNER_TEMP/m2-agentic/repository" \
+            -DskipTests \
+            -DskipChecks \
+            verify \
+            -pl connectors-e2e-test/connectors-e2e-test-agentic-ai
+
       - name: Archive Maven repository
         run: |
           if ! command -v zstd >/dev/null; then
@@ -165,6 +190,8 @@ jobs:
           set -o pipefail
           tar -cf - -C "$HOME/.m2" repository |
             zstd -T0 -3 -q -o "$RUNNER_TEMP/m2-repository.tar.zst"
+          tar -cf - -C "$RUNNER_TEMP/m2-agentic" repository |
+            zstd -T0 -3 -q -o "$RUNNER_TEMP/m2-agentic-repository.tar.zst"
 
       # Hand the fully-populated local Maven repo (first-party SNAPSHOTs + all third-party
       # dependencies resolved during the build) to the test matrix, so test jobs resolve
@@ -176,6 +203,15 @@ jobs:
         with:
           name: m2-repo-${{ steps.sanitize.outputs.branch }}-${{ github.run_id }}
           path: ${{ runner.temp }}/m2-repository.tar.zst
+          retention-days: 1
+          compression-level: 0
+          overwrite: true
+
+      - name: Upload Agentic AI Maven repository
+        uses: actions/upload-artifact@v7
+        with:
+          name: m2-repo-agentic-${{ steps.sanitize.outputs.branch }}-${{ github.run_id }}
+          path: ${{ runner.temp }}/m2-agentic-repository.tar.zst
           retention-days: 1
           compression-level: 0
           overwrite: true
@@ -262,6 +298,11 @@ jobs:
         run: |
           echo "branch=${BRANCH//\//-}" >> "$GITHUB_OUTPUT"
           echo "module=${MODULE//\//-}" >> "$GITHUB_OUTPUT"
+          if [ "$MODULE" = "connectors-e2e-test-agentic-ai" ]; then
+            echo "repository-artifact=m2-repo-agentic" >> "$GITHUB_OUTPUT"
+          else
+            echo "repository-artifact=m2-repo" >> "$GITHUB_OUTPUT"
+          fi
         env:
           BRANCH: ${{ inputs.branch }}
           MODULE: ${{ matrix.entry.module }}
@@ -273,7 +314,7 @@ jobs:
       - name: Download Maven repository
         uses: actions/download-artifact@v8
         with:
-          name: m2-repo-${{ steps.sanitize.outputs.branch }}-${{ github.run_id }}
+          name: ${{ steps.sanitize.outputs.repository-artifact }}-${{ steps.sanitize.outputs.branch }}-${{ github.run_id }}
           path: ${{ runner.temp }}/m2-repository
 
       - name: Extract Maven repository
@@ -284,7 +325,7 @@ jobs:
           fi
           set -o pipefail
           mkdir -p "$HOME/.m2"
-          zstd -dc "$RUNNER_TEMP/m2-repository/m2-repository.tar.zst" |
+          zstd -dc "$RUNNER_TEMP/m2-repository/"*.tar.zst |
             tar -xf - -C "$HOME/.m2"
 
       # Run only this module's tests. No -am: base/connector SNAPSHOTs come from the downloaded

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/pom.xml
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/pom.xml
@@ -28,6 +28,14 @@
           <skip>true</skip>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <forkCount>2</forkCount>
+          <reuseForks>true</reuseForks>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/a2a/A2aStandaloneTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/a2a/A2aStandaloneTests.java
@@ -64,7 +64,7 @@ import org.springframework.test.context.TestPropertySource;
     properties = {
       "camunda.connector.polling.enabled=true",
       "camunda.connector.webhook.enabled=true",
-      "camunda.connector.polling.interval=2000"
+      "camunda.connector.polling.interval=500"
     })
 @Import(InboundConnectorTestConfiguration.class)
 @WireMockTest

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/subprocess/AgentSubProcessA2aIntegrationTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/subprocess/AgentSubProcessA2aIntegrationTests.java
@@ -54,7 +54,7 @@ import org.springframework.test.context.TestPropertySource;
     properties = {
       "camunda.connector.polling.enabled=true",
       "camunda.connector.webhook.enabled=true",
-      "camunda.connector.polling.interval=2000"
+      "camunda.connector.polling.interval=500"
     })
 @Import(InboundConnectorTestConfiguration.class)
 public class AgentSubProcessA2aIntegrationTests extends BaseAgentSubProcessTest {

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/task/AgentTaskA2aIntegrationTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/task/AgentTaskA2aIntegrationTests.java
@@ -54,7 +54,7 @@ import org.springframework.test.context.TestPropertySource;
     properties = {
       "camunda.connector.polling.enabled=true",
       "camunda.connector.webhook.enabled=true",
-      "camunda.connector.polling.interval=2000"
+      "camunda.connector.polling.interval=500"
     })
 @Import(InboundConnectorTestConfiguration.class)
 public class AgentTaskA2aIntegrationTests extends BaseAgentTaskTest {

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/mcp/authentication/BaseMcpAuthenticationTest.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/mcp/authentication/BaseMcpAuthenticationTest.java
@@ -66,7 +66,11 @@ abstract class BaseMcpAuthenticationTest extends BaseAgenticAiTest {
     BpmnModelInstance bpmnModel = Bpmn.readModelFromStream(testProcess.getInputStream());
 
     // Authentication is exercised on the first attempt; retries only repeat the client timeout.
-    serviceTasksByType(bpmnModel, type -> type.startsWith("io.camunda.agenticai:mcp"))
+    serviceTasksByType(
+            bpmnModel,
+            type ->
+                type.equals("io.camunda.agenticai:mcpclient:1")
+                    || type.equals("io.camunda.agenticai:mcpremoteclient:1"))
         .forEach(
             serviceTask ->
                 serviceTask.getSingleExtensionElement(ZeebeTaskDefinition.class).setRetries("1"));

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/mcp/authentication/BaseMcpAuthenticationTest.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/mcp/authentication/BaseMcpAuthenticationTest.java
@@ -32,6 +32,7 @@ import io.camunda.connector.test.utils.annotation.SlowTest;
 import io.camunda.process.test.api.CamundaAssert;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeTaskDefinition;
 import java.io.IOException;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -63,6 +64,12 @@ abstract class BaseMcpAuthenticationTest extends BaseAgenticAiTest {
   @Test
   void shouldRaiseIncidentWhenAuthenticationFails() throws IOException {
     BpmnModelInstance bpmnModel = Bpmn.readModelFromStream(testProcess.getInputStream());
+
+    // Authentication is exercised on the first attempt; retries only repeat the client timeout.
+    serviceTasksByType(bpmnModel, type -> type.startsWith("io.camunda.agenticai:mcp"))
+        .forEach(
+            serviceTask ->
+                serviceTask.getSingleExtensionElement(ZeebeTaskDefinition.class).setRetries("1"));
 
     // MCP Client
     serviceTasksByType(bpmnModel, type -> type.startsWith("io.camunda.agenticai:mcpclient"))

--- a/connectors-e2e-test/connectors-e2e-test-inbound-runtime/pom.xml
+++ b/connectors-e2e-test/connectors-e2e-test-inbound-runtime/pom.xml
@@ -23,6 +23,14 @@
           <skip>true</skip>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <forkCount>2</forkCount>
+          <reuseForks>true</reuseForks>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 
@@ -61,4 +69,3 @@
 
   </dependencies>
 </project>
-

--- a/connectors-e2e-test/connectors-e2e-test-inbound-runtime/pom.xml
+++ b/connectors-e2e-test/connectors-e2e-test-inbound-runtime/pom.xml
@@ -23,14 +23,6 @@
           <skip>true</skip>
         </configuration>
       </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <configuration>
-          <forkCount>2</forkCount>
-          <reuseForks>true</reuseForks>
-        </configuration>
-      </plugin>
     </plugins>
   </build>
 

--- a/connectors-e2e-test/connectors-e2e-test-inbound-runtime/src/test/java/io/camunda/connector/e2e/inbound/ActivationConditionMultiVersionTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-inbound-runtime/src/test/java/io/camunda/connector/e2e/inbound/ActivationConditionMultiVersionTests.java
@@ -62,7 +62,8 @@ import org.springframework.context.annotation.Import;
     classes = TestConnectorRuntimeApplication.class,
     properties = {
       "spring.main.allow-bean-definition-overriding=true",
-      "camunda.connector.polling.enabled=true"
+      "camunda.connector.polling.enabled=true",
+      "camunda.connector.polling.interval=500"
     },
     webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @CamundaSpringProcessTest

--- a/connectors-e2e-test/connectors-e2e-test-inbound-runtime/src/test/java/io/camunda/connector/e2e/inbound/InboundConnectorMultiVersionTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-inbound-runtime/src/test/java/io/camunda/connector/e2e/inbound/InboundConnectorMultiVersionTests.java
@@ -65,7 +65,8 @@ import org.springframework.context.annotation.Import;
     classes = TestConnectorRuntimeApplication.class,
     properties = {
       "spring.main.allow-bean-definition-overriding=true",
-      "camunda.connector.polling.enabled=true"
+      "camunda.connector.polling.enabled=true",
+      "camunda.connector.polling.interval=500"
     },
     webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @CamundaSpringProcessTest


### PR DESCRIPTION
## Description

Reduce E2E critical-path time by shortening test polling, removing redundant test retries, parallelizing the Agentic AI suite, and replacing the full Maven-repository transfer with validated module-specific repositories for the two longest modules.

## Before this PR / after this PR

Comparison sources:

- Before: [release run 34385291948](https://github.com/camunda/connectors/actions/runs/34385291948)
- After: [final PR E2E run 34473309851](https://github.com/camunda/connectors/actions/runs/34473309851)

| Measurement | Before this PR | After this PR | Time saved | Reduction |
|---|---:|---:|---:|---:|
| Total E2E critical path | 33m 55s | 15m 22s | **18m 33s** | **55%** |
| Shared build job | 11m 17s | 5m 34s | 5m 43s | 51% |
| Agentic AI repository restore | 7m 50s | 53s | **6m 57s** | **89%** |
| Agentic AI test execution | 13m 57s | 7m 56s | **6m 01s** | **43%** |
| Agentic AI complete matrix job | 22m 20s | 9m 22s | **12m 58s** | **58%** |
| Inbound-runtime repository restore | 7m 14s | 3s | **7m 11s** | **99%** |
| Inbound-runtime test execution | 8m 10s | 4m 37s | **3m 33s** | **44%** |
| Inbound-runtime complete matrix job | 15m 54s | 5m 00s | **10m 54s** | **69%** |

The final workflow needed failed-job reruns because of unrelated timing flakes in existing Agentic AI and intrinsic-functions tests. The 15m 22s after-PR total therefore normalizes the critical path using the successful final build and Agentic AI job durations instead of counting time spent waiting for the rerun. Agentic AI used an 8-core GCP runner in both comparisons. The inbound validation job used GitHub-hosted Ubuntu after the PR, while releases use the configured 8-core GCP release runner; its 3-second restore is the observed validation result, not a prediction for GCP. Build duration is cache-sensitive, so the transfer and test rows are the more reliable measures of this PR.

## What changed

- Set a 500 ms polling interval in inbound-runtime and Agentic AI A2A test contexts without changing production defaults.
- Avoid repeated MCP authentication retries that only repeat the same timeout.
- Run Agentic AI tests in two isolated, reusable Surefire forks.
- Archive the shared Maven repository before artifact upload instead of transferring roughly 242,000 files individually.
- Build validated module-specific Maven repositories for Agentic AI and inbound-runtime from the already-populated reactor repository. Maven remains online as a fallback, and the final runs made no fallback downloads.
- Guard module-specific repository preparation and upload by module presence so older stable branches remain supported.

## Artifact impact

| Artifact | Before this PR | After this PR | Reduction |
|---|---:|---:|---:|
| Agentic AI Maven repository | 1.94 GB | 312 MB | **84%** |
| Inbound-runtime Maven repository | 1.94 GB | 209 MB | **89%** |

Preparing both targeted repositories adds 29 seconds to the shared build. Two forks were also measured for inbound-runtime but did not provide a meaningful improvement, so that module remains single-forked.

## Related issues

N/A

## Checklist

- [x] Backports to stable/8.6 through stable/8.10 are requested via labels.
- [x] Existing E2E coverage validates the polling, repository handoff, and parallelization changes.
- [x] No documentation update is required.
