### PR TITLE
fix: pin Jackson 3.x BOM, override junrar, pin tomcat-embed-* to 11.0.25

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -104,6 +104,16 @@ limitations under the License.</license.inlineheader>
     <version.hamcrest>3.0</version.hamcrest>
 
     <version.spring-boot>4.1.1</version.spring-boot>
+    <!-- SEC-3498 (CVE-2026-65905, CVE-2026-68763, CVE-2026-65182, CVE-2026-65637,
+         CVE-2026-68525, CVE-2026-68569, CVE-2026-66422, CVE-2026-65183): tomcat-embed-*
+         transitive override. Setting tomcat.version alone does NOT override Spring Boot's
+         dependency-management import, since spring-boot-dependencies defines its own internal
+         tomcat.version property - the four artifacts below have to be pinned explicitly.
+         Remove only once spring-boot-dependencies itself ships tomcat.version >= 11.0.25.
+         An earlier override was removed once the BOM caught up to a previous, lower threshold,
+         which silently moved Tomcat back into the vulnerable range - do not repeat that: compare
+         against 11.0.25, not against whatever the BOM happens to ship. -->
+    <tomcat.version>11.0.25</tomcat.version>
     <!-- CVE-2026-63337 / GHSA-jh4v-gfqj-7rhx: amqp-client transitive override — remove once
          spring-boot-dependencies ships rabbit-amqp-client >= 5.34.0
          Ref: https://github.com/rabbitmq/rabbitmq-java-client/security/advisories/GHSA-jh4v-gfqj-7rhx -->
@@ -789,6 +799,34 @@ limitations under the License.</license.inlineheader>
         <version>${version.httpcore5}</version>
       </dependency>
 
+      <!-- SEC-3498: tomcat.version alone does not override Spring Boot's dependency-management
+           import, since spring-boot-dependencies defines its own internal tomcat.version
+           property. These four artifacts ship in lockstep from the same Tomcat release and must
+           be pinned together to avoid a version skew. -->
+      <dependency>
+        <groupId>org.apache.tomcat.embed</groupId>
+        <artifactId>tomcat-embed-core</artifactId>
+        <version>${tomcat.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.apache.tomcat.embed</groupId>
+        <artifactId>tomcat-embed-el</artifactId>
+        <version>${tomcat.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.apache.tomcat.embed</groupId>
+        <artifactId>tomcat-embed-websocket</artifactId>
+        <version>${tomcat.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.apache.tomcat</groupId>
+        <artifactId>tomcat-annotations-api</artifactId>
+        <version>${tomcat.version}</version>
+      </dependency>
+
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-collections4</artifactId>
@@ -1218,6 +1256,25 @@ If the new spring-boot-dependencies BOM ships tools.jackson:jackson-bom &gt;= 3.
 the version.jackson3-bom property, the tools.jackson:jackson-bom dependencyManagement entry, and this
 enforcer rule from parent/pom.xml.
 See: https://github.com/FasterXML/jackson-databind/security/advisories/GHSA-q4xh-88c3-wmh7
+                </regexMessage>
+              </requireProperty>
+              <!-- SEC-3498 guard: fails if version.spring-boot is bumped, as a reminder to
+                   check whether the tomcat-embed-* overrides can be removed (see tomcat.version).
+                   spring-boot-dependencies manages Tomcat via its own internal tomcat.version
+                   property, so bumping Spring Boot can move Tomcat without touching this file.
+                   IMPORTANT: only remove the overrides if the new BOM ships tomcat.version
+                   >= 11.0.25. A previous override was dropped because the BOM had caught up to an
+                   older, lower fix version, which downgraded Tomcat back into a vulnerable range. -->
+              <requireProperty>
+                <property>version.spring-boot</property>
+                <regex>^4\.1\.1$</regex>
+                <regexMessage>
+version.spring-boot was changed! Check if the tomcat-embed-* SEC-3498 overrides can be removed.
+Only remove them if the new spring-boot-dependencies BOM ships tomcat.version &gt;= 11.0.25
+(confirm with `mvn dependency:tree -Dincludes=org.apache.tomcat.embed:tomcat-embed-core`, not just
+the property). If it ships anything lower, keep the overrides - removing them would downgrade
+Tomcat into a vulnerable range. To remove: drop the tomcat.version property, the four
+tomcat-embed-*/tomcat-annotations-api dependencyManagement entries, and this enforcer rule.
                 </regexMessage>
               </requireProperty>
             </rules>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -88,6 +88,15 @@ limitations under the License.</license.inlineheader>
     <version.assertj>3.27.7</version.assertj>
     <version.jackson-bom>2.22.2</version.jackson-bom>
     <version.jackson-datatype-jsr310>2.22.2</version.jackson-datatype-jsr310>
+    <!-- CVE-2026-68497 / GHSA-q4xh-88c3-wmh7: Jackson 3.x line (tools.jackson:*), separate from the
+         legacy com.fasterxml.jackson:jackson-bom above and not covered by it. Jackson 3.x reaches the
+         runtime transitively via spring-boot-starter-webmvc -> spring-boot-starter-jackson ->
+         spring-boot-jackson, and spring-boot-dependencies manages it through its own
+         jackson-bom.version property, which does not track the same fix cadence as the legacy line,
+         so it must be pinned independently. Remove once spring-boot-dependencies ships
+         tools.jackson:jackson-bom >= 3.1.6.
+         Ref: https://github.com/FasterXML/jackson-databind/security/advisories/GHSA-q4xh-88c3-wmh7 -->
+    <version.jackson3-bom>3.1.6</version.jackson3-bom>
     <version.hibernate-validator>9.1.3.Final</version.hibernate-validator>
     <version.jsonassert>1.5.3</version.jsonassert>
     <version.json>20250517</version.json>
@@ -235,6 +244,15 @@ limitations under the License.</license.inlineheader>
         <groupId>com.fasterxml.jackson.datatype</groupId>
         <artifactId>jackson-datatype-jsr310</artifactId>
         <version>${version.jackson-datatype-jsr310}</version>
+      </dependency>
+
+      <!-- Jackson 3.x BOM, imported before Spring Boot so its version takes precedence -->
+      <dependency>
+        <groupId>tools.jackson</groupId>
+        <artifactId>jackson-bom</artifactId>
+        <version>${version.jackson3-bom}</version>
+        <type>pom</type>
+        <scope>import</scope>
       </dependency>
 
       <!--
@@ -1148,6 +1166,25 @@ If the new spring-boot-dependencies BOM ships com.rabbitmq:amqp-client &gt;= 5.3
 version.amqp-client property, the amqp-client dependencyManagement entry, and this enforcer rule
 from parent/pom.xml.
 See: https://github.com/rabbitmq/rabbitmq-java-client/security/advisories/GHSA-jh4v-gfqj-7rhx
+                </regexMessage>
+              </requireProperty>
+              <!-- CVE-2026-68497 / GHSA-q4xh-88c3-wmh7 guard: fails if version.spring-boot is
+                   bumped, as a reminder to check whether the jackson3-bom override can be removed
+                   (see version.jackson3-bom). spring-boot-dependencies manages
+                   tools.jackson:jackson-bom via its own jackson-bom.version property, separate from
+                   the legacy com.fasterxml.jackson:jackson-bom line already overridden above - it is
+                   not covered by that override. Confirmed still needed as of spring-boot 4.1.1: its
+                   BOM ships jackson-bom.version 3.1.5, still short of the 3.1.6 fix. -->
+              <requireProperty>
+                <property>version.spring-boot</property>
+                <regex>^4\.1\.1$</regex>
+                <regexMessage>
+version.spring-boot was changed! Check if the jackson3-bom CVE-2026-68497 override can be removed.
+If the new spring-boot-dependencies BOM ships tools.jackson:jackson-bom &gt;= 3.1.6 (confirm with
+`mvn dependency:tree -Dincludes=tools.jackson.core:jackson-databind`, not just the property), remove
+the version.jackson3-bom property, the tools.jackson:jackson-bom dependencyManagement entry, and this
+enforcer rule from parent/pom.xml.
+See: https://github.com/FasterXML/jackson-databind/security/advisories/GHSA-q4xh-88c3-wmh7
                 </regexMessage>
               </requireProperty>
             </rules>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -130,6 +130,11 @@ limitations under the License.</license.inlineheader>
          ships a Tika version whose tika-parser-apple-module pulls dd-plist >= 1.30.
          Ref: https://github.com/3breadt/dd-plist/security/advisories/GHSA-xjjv-qfjr-95c3 -->
     <version.ddplist>1.30</version.ddplist>
+    <!-- GHSA-h9h9-2rmf-rvhp: junrar transitive override — remove once the Tika version pinned in
+         connectors/embeddings-vector-database/pom.xml (version.apache-tika) ships a
+         tika-parser-pkg-module that pulls junrar >= 7.6.1.
+         Ref: https://github.com/junrar/junrar/security/advisories/GHSA-h9h9-2rmf-rvhp -->
+    <version.junrar>7.6.1</version.junrar>
 
     <version.google-api-client>2.9.1</version.google-api-client>
 
@@ -282,6 +287,15 @@ limitations under the License.</license.inlineheader>
         <groupId>com.googlecode.plist</groupId>
         <artifactId>dd-plist</artifactId>
         <version>${version.ddplist}</version>
+      </dependency>
+
+      <!-- GHSA-h9h9-2rmf-rvhp: override junrar transitive version brought in via
+           tika-parsers-standard-package -> tika-parser-pkg-module. Remove once that chain ships
+           junrar >= 7.6.1. -->
+      <dependency>
+        <groupId>com.github.junrar</groupId>
+        <artifactId>junrar</artifactId>
+        <version>${version.junrar}</version>
       </dependency>
 
       <!-- Netty BOM imported before Spring Boot so its version takes precedence -->
@@ -1124,6 +1138,25 @@ version.langchain4j was changed! Check if the dd-plist GHSA-xjjv-qfjr-95c3 overr
 If the new langchain4j-document-parser-apache-tika version ships a Tika whose tika-parser-apple-module
 pulls dd-plist &gt;= 1.30, remove the version.ddplist property and the dd-plist dependencyManagement entry.
 See: https://github.com/3breadt/dd-plist/security/advisories/GHSA-xjjv-qfjr-95c3
+                </regexMessage>
+              </requireProperty>
+              <!-- GHSA-h9h9-2rmf-rvhp guard: fails if langchain4j is bumped, as a reminder to
+                   check whether the junrar override can be removed (see version.junrar). Note that
+                   junrar's version is actually governed by version.apache-tika in
+                   connectors/embeddings-vector-database/pom.xml, which excludes langchain4j's Tika
+                   and re-declares it - so also re-check this override whenever that property moves,
+                   not only on a langchain4j bump. -->
+              <requireProperty>
+                <property>version.langchain4j</property>
+                <regex>^1\.20\.0$</regex>
+                <regexMessage>
+version.langchain4j was changed! Check if the junrar GHSA-h9h9-2rmf-rvhp override can be removed.
+If the Tika version pinned in connectors/embeddings-vector-database/pom.xml ships a
+tika-parser-pkg-module that pulls junrar &gt;= 7.6.1 (confirm with
+`mvn dependency:tree -Dincludes=com.github.junrar:junrar`, not just the property), remove the
+version.junrar property, the junrar dependencyManagement entry, and this enforcer rule from
+parent/pom.xml.
+See: https://github.com/junrar/junrar/security/advisories/GHSA-h9h9-2rmf-rvhp
                 </regexMessage>
               </requireProperty>
               <!-- CVE-2026-9563 guard: fails if opensearch-java is bumped, as a reminder to


### PR DESCRIPTION
## Description

Security dependency updates for `main`, covering three separate internal reports. All are version
changes in `parent/pom.xml` — no code changes.

### 1. Jackson 3.x BOM (INC-7941 / SEC-3502)

Pins `tools.jackson:jackson-bom` (the Jackson 3.x line) to `3.1.6`.

`spring-boot-dependencies` 4.1.1 manages this BOM at `3.1.5` via its own `jackson-bom.version`
property. That line is separate from the existing `com.fasterxml.jackson:jackson-bom` override and
is not covered by it, so it needs its own pin. It is imported before the Spring Boot BOM so the pin
takes precedence.

Jackson 3.x is not used by any of our code. It reaches the runtime two ways — transitively via the
Spring Boot starters, and via the MCP SDK's `mcp-json-jackson3`:

```
spring-boot-starter-webmvc:4.1.1
 └─ spring-boot-starter-jackson:4.1.1
     └─ spring-boot-jackson:4.1.1
         └─ tools.jackson.core:jackson-databind:3.1.5:compile
```

This re-instates the pin that #8306 added and #8485 removed when spring-boot was bumped to 4.1.1:
the removal was correct against the threshold that applied at the time, but that threshold has since
moved. The accompanying enforcer rule is restored too.

### 2. junrar (INC-7939 / SEC-3500)

Overrides `com.github.junrar:junrar` to `7.6.1`.

`junrar` <= 7.6.0 can be forced into a deterministic infinite loop while extracting a crafted RAR4
archive: `RarVM.setIP()` returns early on an out-of-range instruction pointer without advancing the
instruction pointer or decrementing `maxOpCount`, so a single `VM_JMP` freezes the interpreter loop
and the extraction thread spins forever.

It arrives transitively via `tika-parsers-standard-package` → `tika-parser-pkg-module`, and **the
path is reachable**: the `embeddings-vector-database` connector parses Camunda documents via
langchain4j's `ApacheTikaDocumentParser` (`DefaultTextSegmentExtractor`), which auto-detects content
type with no format allowlist, so a document whose bytes are a crafted RAR archive is dispatched to
Tika's RAR parser and on to `Junrar.extract()`. Tika 3.3.2 pins junrar 7.6.0 and no Tika release yet
carries 7.6.1, so it is overridden in `dependencyManagement` — as already done for `parsson`,
`dd-plist` and `lz4-java`.

Caveat recorded in the rule's comment: the guard keys on `version.langchain4j`, matching the
neighbouring dd-plist guard, but junrar's version is actually governed by `version.apache-tika` in
`connectors/embeddings-vector-database/pom.xml` (that module excludes langchain4j's Tika and
re-declares it). A Tika-only bump will not trip the guard, so the comment says to re-check the
override when that property moves too.

### 3. Apache Tomcat (INC-7938 / SEC-3498)

Pins `tomcat-embed-*` to `11.0.25`.

Eight CVEs were reported against Apache Tomcat, all fixed by the same upgrade: CVE-2026-65905,
CVE-2026-68763, CVE-2026-65182, CVE-2026-65637, CVE-2026-68525, CVE-2026-68569, CVE-2026-66422,
CVE-2026-65183. Affected ranges are `11.0.20`–`11.0.24`, `10.1.53`–`10.1.57` and
`9.0.115`–`9.0.120`.

`spring-boot-dependencies` 4.1.1 manages `tomcat.version` at `11.0.24`, so `dependency:tree`
resolved `tomcat-embed-core`/`-el`/`-websocket` at `11.0.24` — inside the affected range. Setting
`tomcat.version` alone does **not** override the imported BOM, which defines its own internal
`tomcat.version` property, so the four artifacts that ship in lockstep from a Tomcat release
(`tomcat-embed-core`, `-el`, `-websocket`, `tomcat-annotations-api`) are pinned explicitly.

The enforcer guard is restored with the threshold stated as `>= 11.0.25` plus an explicit warning
not to drop the overrides while they sit ahead of the BOM. That wording matters: on `stable/8.8` and
`stable/8.7` an equivalent override at `10.1.59` was removed once the BOM caught up to an older,
lower threshold, which moved Tomcat back below the fix.

**Exposure.** Most of the eight CVEs are in container-managed authentication and authorization paths
this runtime does not use — DIGEST and FORM authenticators, `web.xml` security constraints and
`security-role-ref` definitions — plus an HTTP/2 allocation leak, where HTTP/2 is off by Spring Boot
default and not enabled here. The runtime runs embedded Tomcat with Spring Boot defaults: no
`server.xml`, no `web.xml`, no security constraints, no Tomcat customizers, only `server.port` and
`server.max-http-request-header-size` set; authorization is enforced by Spring Security filters. Two
of the eight could not be characterised from the sources reachable here, including CVE-2026-65637 at
CVSS 9.8 whose advisory does not name the affected component — reason enough to upgrade rather than
reason the exposure away.

### Verification

- `mvn dependency:tree` resolves `tools.jackson.core:jackson-databind` `3.1.6`,
  `com.github.junrar:junrar` `7.6.1`, and `tomcat-embed-core`/`-el`/`-websocket` `11.0.25` — all
  were on affected versions before this PR; `com.fasterxml.jackson.core:jackson-databind` unchanged
  at `2.22.2`
- all `maven-enforcer-plugin` rules pass, and both newly added `version.spring-boot` guards were
  confirmed to actually fail on a spring-boot change rather than sit inert
- `spotless:check` clean

## Related issues

Tracked internally in INC-7941 / SEC-3502 (Jackson), INC-7939 / SEC-3500 (junrar) and
INC-7938 / SEC-3498 (Tomcat).
Companion PRs: #8792 (`stable/8.9`), #8796 (`stable/8.8`) and #8798 (`stable/8.7`).

## Checklist

- [x] Backport labels are added if these code changes should be backported. No backport label
  needed: the stable branches are covered by #8792, #8796 and #8798, and the changes differ per
  branch. For Jackson, `stable/8.8` / `stable/8.7` are unaffected (Spring Boot 3.5.x brings no
  Jackson 3.x line). For junrar, `stable/8.7` is unaffected (no `embeddings-vector-database` module;
  its only Tika dependency is `tika-core`, which ships no parsers). For Tomcat, all four branches
  are affected — the 10.1 line is pinned at `10.1.59` there.
- [x] Tests/Integration tests for the changes have been added if applicable. Not applicable —
  dependency version changes, covered by the existing suite.
- [x] If the change requires a documentation update, it has been added to the appropriate section
  in the documentation. Not applicable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015UjzTw6ba1eduqWzheDF88