### PR TITLE
fix: override junrar and restore tomcat-embed-* pin (stable/8.8)

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -90,6 +90,16 @@ limitations under the License.</license.inlineheader>
     <version.hamcrest>3.0</version.hamcrest>
 
     <version.spring-boot>3.5.16-spring-boot-3.5.19</version.spring-boot>
+    <!-- SEC-3498 (CVE-2026-65905, CVE-2026-68763, CVE-2026-65182, CVE-2026-65637,
+         CVE-2026-68525, CVE-2026-68569, CVE-2026-66422, CVE-2026-65183): tomcat-embed-*
+         transitive override. Setting tomcat.version alone does NOT override Spring Boot's
+         dependency-management import, since spring-boot-dependencies defines its own internal
+         tomcat.version property - the four artifacts below have to be pinned explicitly.
+         Remove only once spring-boot-dependencies itself ships tomcat.version >= 10.1.59.
+         An earlier override was removed once the BOM caught up to a previous, lower threshold,
+         which silently moved Tomcat back into the vulnerable range - do not repeat that: compare
+         against 10.1.59, not against whatever the BOM happens to ship. -->
+    <tomcat.version>10.1.59</tomcat.version>
     <!-- CVE-2026-63337 / GHSA-jh4v-gfqj-7rhx: amqp-client transitive override — remove once
          spring-boot-dependencies ships rabbit-amqp-client >= 5.34.0
          Ref: https://github.com/rabbitmq/rabbitmq-java-client/security/advisories/GHSA-jh4v-gfqj-7rhx -->
@@ -613,6 +623,34 @@ limitations under the License.</license.inlineheader>
         <version>${version.httpcore5}</version>
       </dependency>
 
+      <!-- SEC-3498: tomcat.version alone does not override Spring Boot's dependency-management
+           import, since spring-boot-dependencies defines its own internal tomcat.version
+           property. These four artifacts ship in lockstep from the same Tomcat release and must
+           be pinned together to avoid a version skew. -->
+      <dependency>
+        <groupId>org.apache.tomcat.embed</groupId>
+        <artifactId>tomcat-embed-core</artifactId>
+        <version>${tomcat.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.apache.tomcat.embed</groupId>
+        <artifactId>tomcat-embed-el</artifactId>
+        <version>${tomcat.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.apache.tomcat.embed</groupId>
+        <artifactId>tomcat-embed-websocket</artifactId>
+        <version>${tomcat.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.apache.tomcat</groupId>
+        <artifactId>tomcat-annotations-api</artifactId>
+        <version>${tomcat.version}</version>
+      </dependency>
+
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-collections4</artifactId>
@@ -1068,6 +1106,25 @@ If the new spring-boot-dependencies BOM ships io.projectreactor.netty:reactor-ne
 the property), remove the version.reactor-netty property, the reactor-netty-http and
 reactor-netty-core dependencyManagement entries, and this enforcer rule from parent/pom.xml.
 See: https://spring.io/security/cve-2026-47874/
+                </regexMessage>
+              </requireProperty>
+              <!-- SEC-3498 guard: fails if version.spring-boot is bumped, as a reminder to
+                   check whether the tomcat-embed-* overrides can be removed (see tomcat.version).
+                   spring-boot-dependencies manages Tomcat via its own internal tomcat.version
+                   property, so bumping Spring Boot can move Tomcat without touching this file.
+                   IMPORTANT: only remove the overrides if the new BOM ships tomcat.version
+                   >= 10.1.59. A previous override was dropped because the BOM had caught up to an
+                   older, lower fix version, which downgraded Tomcat back into a vulnerable range. -->
+              <requireProperty>
+                <property>version.spring-boot</property>
+                <regex>^3\.5\.16-spring-boot-3\.5\.19$</regex>
+                <regexMessage>
+version.spring-boot was changed! Check if the tomcat-embed-* SEC-3498 overrides can be removed.
+Only remove them if the new spring-boot-dependencies BOM ships tomcat.version &gt;= 10.1.59
+(confirm with `mvn dependency:tree -Dincludes=org.apache.tomcat.embed:tomcat-embed-core`, not just
+the property). If it ships anything lower, keep the overrides - removing them would downgrade
+Tomcat into a vulnerable range. To remove: drop the tomcat.version property, the four
+tomcat-embed-*/tomcat-annotations-api dependencyManagement entries, and this enforcer rule.
                 </regexMessage>
               </requireProperty>
             </rules>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -187,6 +187,11 @@ limitations under the License.</license.inlineheader>
          ships a Tika version whose tika-parser-apple-module pulls dd-plist >= 1.30.
          Ref: https://github.com/3breadt/dd-plist/security/advisories/GHSA-xjjv-qfjr-95c3 -->
     <version.ddplist>1.30</version.ddplist>
+    <!-- GHSA-h9h9-2rmf-rvhp: junrar transitive override — remove once the Tika version pinned in
+         connectors/embeddings-vector-database/pom.xml (version.apache-tika) ships a
+         tika-parser-pkg-module that pulls junrar >= 7.6.1.
+         Ref: https://github.com/junrar/junrar/security/advisories/GHSA-h9h9-2rmf-rvhp -->
+    <version.junrar>7.6.1</version.junrar>
 
     <!-- maven plugins (not managed by parent) -->
     <plugin.version.maven-enforcer-plugin>3.6.3</plugin.version.maven-enforcer-plugin>
@@ -232,6 +237,15 @@ limitations under the License.</license.inlineheader>
         <groupId>com.googlecode.plist</groupId>
         <artifactId>dd-plist</artifactId>
         <version>${version.ddplist}</version>
+      </dependency>
+
+      <!-- GHSA-h9h9-2rmf-rvhp: override junrar transitive version brought in via
+           tika-parsers-standard-package -> tika-parser-pkg-module. Remove once that chain ships
+           junrar >= 7.6.1. -->
+      <dependency>
+        <groupId>com.github.junrar</groupId>
+        <artifactId>junrar</artifactId>
+        <version>${version.junrar}</version>
       </dependency>
 
       <!-- Netty BOM imported before Spring Boot so its version takes precedence -->
@@ -968,6 +982,25 @@ Also check if the dd-plist GHSA-xjjv-qfjr-95c3 override can be removed.
 If the new langchain4j-document-parser-apache-tika version ships a Tika whose tika-parser-apple-module
 pulls dd-plist &gt;= 1.30, remove the version.ddplist property and the dd-plist dependencyManagement entry.
 See: https://github.com/3breadt/dd-plist/security/advisories/GHSA-xjjv-qfjr-95c3
+                </regexMessage>
+              </requireProperty>
+              <!-- GHSA-h9h9-2rmf-rvhp guard: fails if langchain4j is bumped, as a reminder to
+                   check whether the junrar override can be removed (see version.junrar). Note that
+                   junrar's version is actually governed by version.apache-tika in
+                   connectors/embeddings-vector-database/pom.xml, which excludes langchain4j's Tika
+                   and re-declares it - so also re-check this override whenever that property moves,
+                   not only on a langchain4j bump. -->
+              <requireProperty>
+                <property>version.langchain4j</property>
+                <regex>^1\.20\.0$</regex>
+                <regexMessage>
+version.langchain4j was changed! Check if the junrar GHSA-h9h9-2rmf-rvhp override can be removed.
+If the Tika version pinned in connectors/embeddings-vector-database/pom.xml ships a
+tika-parser-pkg-module that pulls junrar &gt;= 7.6.1 (confirm with
+`mvn dependency:tree -Dincludes=com.github.junrar:junrar`, not just the property), remove the
+version.junrar property, the junrar dependencyManagement entry, and this enforcer rule from
+parent/pom.xml.
+See: https://github.com/junrar/junrar/security/advisories/GHSA-h9h9-2rmf-rvhp
                 </regexMessage>
               </requireProperty>
               <!-- CVE-2026-59949 guard: fails if kafka-clients is bumped, as a reminder to


### PR DESCRIPTION
## Description

Security dependency updates for `stable/8.8`, covering two separate internal reports. Both are
version changes in `parent/pom.xml` — no code changes.

### 1. junrar (INC-7939 / SEC-3500)

Overrides `com.github.junrar:junrar` to `7.6.1`.

`junrar` <= 7.6.0 can be forced into a deterministic infinite loop while extracting a crafted RAR4
archive: `RarVM.setIP()` returns early on an out-of-range instruction pointer without advancing the
instruction pointer or decrementing `maxOpCount`, so a single `VM_JMP` freezes the interpreter loop
and the extraction thread spins forever, consuming CPU without terminating.

It is not a declared dependency anywhere — it arrives transitively:

```
tika-parsers-standard-package:3.3.2
 └─ tika-parser-pkg-module:3.3.2
     └─ com.github.junrar:junrar:7.6.0:compile
```

**The path is reachable.** The `embeddings-vector-database` connector parses Camunda documents via
langchain4j's `ApacheTikaDocumentParser` (`DefaultTextSegmentExtractor`), which auto-detects content
type with no format allowlist. A Camunda document whose bytes are a crafted RAR archive is therefore
dispatched to Tika's RAR parser and on to `Junrar.extract()`. That connector ships in the default
bundle on this branch.

Tika 3.3.2 pins junrar 7.6.0 and there is no Tika release yet carrying 7.6.1, so the version is
overridden in `dependencyManagement` — the same approach already used on this branch for `parsson`,
`dd-plist` and `lz4-java` — with an enforcer rule following that existing convention.

One caveat recorded in the rule's comment: the guard keys on `version.langchain4j`, matching the
neighbouring dd-plist guard, but junrar's version is actually governed by `version.apache-tika` in
`connectors/embeddings-vector-database/pom.xml` (that module excludes langchain4j's Tika and
re-declares it). A Tika-only bump will therefore not trip the guard, so the comment says to re-check
the override when that property moves too.

### 2. Apache Tomcat (INC-7938 / SEC-3498)

Restores the explicit `tomcat-embed-*` pin at `10.1.59`.

Eight CVEs were reported against Apache Tomcat, all fixed by the same upgrade. Affected ranges are
`11.0.20`–`11.0.24`, `10.1.53`–`10.1.57` and `9.0.115`–`9.0.120`; this branch is on the 10.1 line.
The advisories name `10.1.58` as the 10.1 fix release, but that version was never published to Maven
Central (404) — `10.1.59` is the first *available* fixed release, and the version this branch
previously pinned.

**Why it needs restoring.** This branch already carried `tomcat.version` `10.1.59`, ahead of the fix.
That override was removed in #8492, which bumped `version.spring-boot` from
`3.5.16-spring-boot-3.5.18` to `-3.5.19`. The removal followed the enforcer guard's own instructions,
but that guard only asked whether the BOM had reached `10.1.57` — the threshold it was written for,
for an earlier CVE. Removing it handed Tomcat's version back to the Spring Boot BOM and moved it
below the current fix. So this is a pin that already existed being restored, with the guard's wording
corrected: the new one states the threshold as `>= 10.1.59` and warns against dropping the overrides
while they sit ahead of the BOM.

Setting `tomcat.version` alone does **not** override the imported BOM, which defines its own internal
`tomcat.version` property, so the four artifacts that ship in lockstep from a Tomcat release
(`tomcat-embed-core`, `-el`, `-websocket`, `tomcat-annotations-api`) are pinned explicitly — the same
shape the override had before removal.

**Exposure.** Most of the eight CVEs are in container-managed authentication and authorization paths
this runtime does not use — DIGEST and FORM authenticators, `web.xml` security constraints and
`security-role-ref` definitions — plus an HTTP/2 allocation leak, where HTTP/2 is off by Spring Boot
default and not enabled here. The runtime runs embedded Tomcat with Spring Boot defaults: no
`server.xml`, no `web.xml`, no security constraints, no Tomcat customizers, only `server.port` and
`server.max-http-request-header-size` set; authorization is enforced by Spring Security filters. Two
of the eight could not be characterised from the sources reachable here, including CVE-2026-65637 at
CVSS 9.8 whose advisory does not name the affected component — reason enough to upgrade rather than
reason the exposure away.

### Verification

- `mvn dependency:tree` resolves `com.github.junrar:junrar` at `7.6.1` and `tomcat-embed-core`,
  `-el`, `-websocket` at `10.1.59` with these changes
- the new enforcer rules are wired and the Tomcat one was confirmed to fire on a
  `version.spring-boot` change rather than sit inert
- `parent/pom.xml` well-formed; `spotless:check` clean

Note: full resolution on this branch cannot be reproduced without credentials for the private Spring
Boot NES artifact repository, so the resolution and enforcer checks were run against a scratch copy
with a public Spring Boot substituted. That substitution affects only the `version.spring-boot`-keyed
guards (expected), not the junrar override; for Tomcat it also demonstrates the point of the change —
the explicit pin holds `10.1.59` regardless of what the BOM ships.

## Related issues

Tracked internally in INC-7939 / SEC-3500 (junrar) and INC-7938 / SEC-3498 (Tomcat).
Companion PRs: #8791 (`main`), #8792 (`stable/8.9`) and #8798 (`stable/8.7`).

## Checklist

- [x] Backport labels are added if these code changes should be backported. No backport label
  needed: this PR targets `stable/8.8` directly; `main`, `stable/8.9` and `stable/8.7` are covered by
  #8791, #8792 and #8798. For junrar, `stable/8.7` is unaffected — it has no
  `embeddings-vector-database` module and its only Tika dependency is `tika-core` in
  `connector-aws-bedrock`, which ships no parsers. For Tomcat, all four branches are affected.
- [x] Tests/Integration tests for the changes have been added if applicable. Not applicable —
  dependency version changes, covered by the existing suite.
- [x] If the change requires a documentation update, it has been added to the appropriate section
  in the documentation. Not applicable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015UjzTw6ba1eduqWzheDF88