### PR TITLE
chore: add connectors-cve-triage-v2 skill

### DIFF
--- a/.claude/skills/connectors-cve-triage-v2/SKILL.md
+++ b/.claude/skills/connectors-cve-triage-v2/SKILL.md
@@ -1,0 +1,900 @@
+---
+name: connectors-cve-triage-v2
+description: >
+  Triage CVEs for the Camunda Connectors project. Assesses Maven dependencies and Docker images,
+  produces a structured per-branch report, creates tracking issues and fix PRs when needed, updates
+  the CVE registry (vulnerability status + fix targets), and closes the incident. Use when the user
+  mentions a CVE or asks "are we affected by X?" in the context of Connectors.
+---
+
+# Connectors CVE Triage
+
+## Repo guard
+
+Before anything else, check that you are operating inside the `camunda/connectors` repository
+(look for `github.com/camunda/connectors` in `git remote -v`).  If you are in a different repo,
+stop and ask the user to confirm before continuing — the paths, branch names, and fix procedures
+below are specific to Connectors.
+
+---
+
+## Batch mode (multiple CVEs)
+
+If the user passes **more than one** CVE ID or advisory URL, follow this flow instead of running
+each CVE end-to-end before moving to the next:
+
+### Phase 1 — Assess all CVEs first (Steps 0–3 for each)
+
+Run Steps 0, 1, 2, and 3 for **every CVE** before taking any action (no issues, no PRs yet).
+Step 0 is per-CVE too — each CVE has its own registry finding and its own re-raise history.
+Process them sequentially, but complete the full assessment for each before moving to the next.
+
+### Phase 2 — Present the batch overview table
+
+After all assessments are done, present a combined summary table:
+
+```
+## CVE Batch Overview — <N> CVEs
+
+| CVE ID | Severity | Affected component | Branches affected | Exploitability | Recommended action |
+|--------|----------|--------------------|-------------------|----------------|--------------------|
+| CVE-XXXX-YYYY | 9.8 Critical | com.example:lib | main, 8.9, 8.8 | Low | Bump 1.2.3 → 1.2.4 |
+| CVE-XXXX-ZZZZ | 5.4 Medium  | com.other:lib2  | None              | —   | Already fixed (all branches) |
+| CVE-XXXX-AAAA | 7.1 High    | base image      | N/A               | —   | No action (Minimus handles) |
+```
+
+Rules for the table:
+- **Branches affected**: list only branches where `Affected? = Yes`. Write "None" if already fixed
+  everywhere, "N/A" for base image CVEs.
+- **Exploitability**: use the Low / Medium / High rating from Step 3, or "—" where no action is
+  needed.
+- **Recommended action**: one short phrase — "Bump X → Y", "Already fixed (all branches)",
+  "No action (Minimus handles)", or "Manual fix needed".
+
+Then ask:
+> Which of these should I proceed with? Reply with **"all"**, **"none"**, or a list of CVE IDs
+> (e.g. `CVE-2024-1234, CVE-2024-5678`).
+
+### Phase 3 — Execute Steps 4–6 only for confirmed CVEs
+
+Run Steps 4, 5, and 6 for each confirmed CVE in turn. After all are done, print one consolidated
+final summary (see updated Step 5 below).
+
+---
+
+## Step 0 — Read existing registry state (do this first)
+
+Never assess a CVE before reading what the registry already knows about it. Most Connectors CVE
+incidents are **re-raises**, not first sightings, and the previous round's analysis is stored on
+the finding itself.
+
+### 0a: Get the finding ID
+
+The CVE incident bot posts a link to the CVE registry in the incident's Slack channel. The channel
+name follows the pattern:
+
+```
+#cve-{cve-id-lowercase}-{severity-lowercase}-connectors[-{suffix}]
+```
+
+Note the optional random suffix (`-w8w`, `-myq`, ...): incident.io creates a **new channel per
+re-raise** and archives the old one after 1 day of inactivity. A suffixed channel is by itself
+evidence that this CVE has been through this process before.
+
+1. `slack_search_channels: query = "cve-{year}-{id}-{severity}-connectors"`
+2. `slack_read_channel: channel_id = <id from step 1>, limit = 50`
+3. Extract the teamFinding ID from the bot's URL:
+   `https://cve-registry.infosec.camunda-it.rocks/cve/team/3/finding/<FINDING_ID>/`
+
+If several channels match, use the newest and record how many exist — that is the round count.
+
+### 0b: Fetch the finding
+
+Authentication: see the **Authentication** section under Step 6.
+
+```bash
+curl -s \
+  "https://cve-registry.infosec.camunda-it.rocks/cve/api/team/3/finding/${FINDING_ID}/" \
+  -H "Accept: application/json" \
+  -H "Cookie: csrftoken=${CSRF_TOKEN}; sessionid=${SESSION_ID}" \
+  -o /tmp/finding${FINDING_ID}.json
+```
+
+### 0c: Print the prior state
+
+```python
+import json
+d = json.load(open(f'/tmp/finding{FINDING_ID}.json'))
+tf = d['teamFinding']
+print('is_vulnerable      :', tf['is_vulnerable'])
+print('vulnerable_reason  :', tf['vulnerable_reason'])
+print('additional_problem :', tf['additional_problem'])
+print('github_issue       :', tf['github_issue'])
+for f in tf['findings']:
+    print(f"\nasset={f['asset']['name']}  status={f['status']}")
+    print('  fix_targets:', [(t['minor_version'] + '.' + t['patch_version'], t['target_date'],
+                              t['github_pr_link'] or 'NO PR') for t in f['fix_targets']])
+    for l in f.get('status_change_logs') or []:
+        print(f"   {l['timestamp']}  {l['old_status']}->{l['new_status']}  "
+              f"{l['triggered_by']}  {l['message']}")
+```
+
+### 0d: Re-raise gate
+
+> If any `status_change_logs` entry predates today, this is a **re-raise — round N**.
+> Print the prior `vulnerable_reason` and `additional_problem` verbatim and carry them into this
+> round's assessment. Do not restart the analysis from scratch, and do not repeat a conclusion a
+> previous round already recorded and the scanner already rejected.
+
+### 0e: Asset cross-diff (free diagnostic)
+
+The registry tracks several assets per CVE. Comparing them against each other, on the same
+released version, is the cheapest diagnostic available and is often the whole answer:
+
+```python
+names = {f['id']: f['asset']['name'] for f in tf['findings']}
+for fid, versions in d['vulnerable_versions_map'].items():
+    vuln = sorted(v['version'] for v in versions if v['is_vulnerable'])
+    print(names[int(fid)], '-> still flagged:', vuln[-5:])
+```
+
+| Pattern | What it means |
+|---|---|
+| All assets flag the same versions | ordinary dependency issue — the poms explain it |
+| `connectors` clean, `connectors-bundle*` flag | the copy enters during **bundle assembly** (shade / scope leak), not via dependency management |
+| Only one minor flags | branch-specific pom divergence — diff that module's poms across branches |
+
+Carry this verdict into Step 2.
+
+---
+
+## Step 1 — Fetch vulnerability details
+
+Use `WebFetch` (or `WebSearch` if only a CVE ID was given) to retrieve:
+
+- **CVE ID** (canonical identifier)
+- **CVSS score + severity** (Critical / High / Medium / Low)
+- **Affected component**: library `groupId:artifactId` and the vulnerable version range
+- **Fix version**: the first version that resolves the issue
+- **Description**: one-paragraph plain-English summary of what can be exploited and how
+- **Source URL**: the authoritative advisory (NVD, GitHub Advisory, OSS-Index, etc.)
+
+If the input is a raw CVE ID, look it up at `https://nvd.nist.gov/vuln/detail/<CVE-ID>` first.
+
+---
+
+## Step 2 — Assess impact
+
+### 2a. Maven dependencies
+
+1. Search `parent/pom.xml` for the affected `groupId:artifactId`.  Version properties are usually
+   declared there (e.g. `<version.jackson>2.15.0</version.jackson>`).
+2. If not found in the parent pom, run:
+   ```
+   cd <repo-root>
+   mvn dependency:tree -DincludeArtifacts=<groupId>:<artifactId> -q 2>/dev/null | grep -i <artifactId> | head -30
+   ```
+   to surface transitive usages.
+3. Compare the in-use version against the vulnerable range from Step 1.
+4. Check **all active branches**: `stable/8.7`, `stable/8.8`, `stable/8.9` (and any newer
+   `stable/X.Y` branches that exist), and `main`.  On each branch, read `parent/pom.xml` (and
+   `pom.xml` at the root if the property lives there) to determine the pinned version per branch.
+5. For any branch where the version is **already at or above the fix version** (i.e. already
+   fixed), search for the Renovate PR that performed the bump:
+   ```bash
+   # Search merged PRs by Renovate that mention the artifactId on the target branch
+   gh pr list \
+     --repo camunda/connectors \
+     --state merged \
+     --search "author:renovate[bot] <artifactId> in:title" \
+     --base <branch> \
+     --json number,title,url,mergedAt \
+     --limit 20
+   ```
+   Pick the PR whose title shows the bump from a vulnerable version to the fixed version (or
+   higher).  Record its URL — it will appear in the assessment table and tracking issue as
+   **Renovate PR**.  If no exact match is found, widen the search:
+   ```bash
+   gh pr list \
+     --repo camunda/connectors \
+     --state merged \
+     --search "author:renovate[bot] <artifactId>" \
+     --json number,title,url,mergedAt \
+     --limit 40
+   ```
+   If still not found, leave the field as `(not found)` and note it.
+
+### 2a-2. Per-module compile-scope check
+
+`dependency:tree` at the repo root does not tell you what lands in a **bundle**. Test-only
+libraries leak onto the compile classpath through a missing `<scope>test</scope>` in a *module*
+pom, and from there into the shaded bundle jar.
+
+For each bundle module, resolve compile scope only — at the **released tag the registry flagged**,
+not at branch HEAD:
+
+```bash
+git worktree add /tmp/cve-<tag> <tag>
+for m in apps/bundle/default-bundle apps/bundle/camunda-saas-bundle; do
+  echo "== $m"
+  mvn -q -f /tmp/cve-<tag>/$m/pom.xml dependency:list -Dscope=compile 2>/dev/null \
+    | grep -E ':(compile|runtime)' | sort -u
+done
+```
+
+Flag as a **scope leak** any test-only family on that list: `org.testcontainers:*`,
+`com.github.docker-java:*`, `org.wiremock:*` / `com.github.tomakehurst:*`, `org.mockito:*`,
+`org.junit*`. Then find the module pom that pulls it in without a test scope:
+
+```bash
+grep -rn --include=pom.xml -A4 "<artifactId>testcontainers" connectors/ | grep -v "<scope>"
+```
+
+A scope leak is a real finding even when `parent/pom.xml` pins a fixed version — it puts an entire
+extra jar into the shipped artifact, with whatever that jar carries inside it.
+
+### 2a-3. Relocated (shaded) copies — conditional
+
+Run this **only** in Case B-0b (Step 4): source says fixed, but an asset still flags a released
+version. It is definitive and the most expensive check, so it is not part of the normal path.
+
+A shaded dependency carries no Maven coordinates. `dependency:tree` prints
+`com.github.docker-java:docker-java-transport-zerodep:3.7.1` and stops — a copy of `httpcore5`
+relocated inside it is invisible both to the tree and to `<dependencyManagement>`, which is why
+pinning the library version cannot fix it.
+
+Both bundle Dockerfiles are a single `COPY target/*-with-dependencies.jar` onto a Minimus base, so
+for a Java-library CVE **the fat jar is the image content**. Inspect the jar — do not build a
+local image and do not run a scanner, the registry already runs one.
+
+1. Derive the class-path prefix from the CVE's coordinates
+   (`org.apache.httpcomponents.core5:httpcore5` gives `org/apache/hc/core5/`).
+2. Get the published jar for the flagged tag (pull the image and copy `/opt/app/*.jar` out, or
+   download the released artifact).
+3. List every distinct location the package appears at:
+
+```bash
+PKG=org/apache/hc/core5/
+unzip -l app.jar | awk '{print $4}' | grep -i "$PKG" \
+  | sed -E "s#(.*)${PKG}.*#\1#" | sort -u
+```
+
+An empty prefix is the canonical copy. **Any non-empty prefix** (e.g.
+`com/github/dockerjava/zerodep/shaded/`) is a relocated copy.
+
+4. Version-identify each relocated copy by class presence: classes removed in the fixed release
+   being present, and classes added in it being absent, identifies it as the vulnerable version.
+
+Record the full route in `vulnerable_reason` — which artifact carries the shaded copy, which
+module pom put that artifact on the compile classpath, and which plugin flattened it into the
+bundle.
+
+### 2b. Docker base images
+
+All three Dockerfiles use Minimus hardened base images (`reg.mini.dev/...`), maintained by the
+Minimus image provider. The fix for any base image CVE comes from Minimus — no code change needed.
+
+Check the three Dockerfiles for their `FROM` line:
+
+| Dockerfile | Path |
+|---|---|
+| connector-runtime-app | `apps/connector-runtime-application/Dockerfile` |
+| bundle-default | `apps/bundle/default-bundle/Dockerfile` |
+| bundle-saas | `apps/bundle/camunda-saas-bundle/Dockerfile` |
+
+> These paths moved. On `stable/8.7` they are still
+> `connector-runtime/connector-runtime-application/`, `bundle/default-bundle/` and
+> `bundle/camunda-saas-bundle/`. Do not hardcode either layout — locate them per branch:
+> ```bash
+> find . -name Dockerfile -not -path '*/target/*' -not -path '*/.worktree/*'
+> ```
+
+If the CVE is in a base image (OS packages, JRE, etc.) rather than a Java library, proceed to
+Step 4 Case A.
+
+---
+
+## Step 2c — Determine next release versions
+
+For each branch (affected or not), determine the next expected release version so the report is
+complete:
+
+1. List all git tags matching the branch's minor version:
+   ```bash
+   # e.g. for stable/8.7:
+   git tag --list '8.7.*' | sort -V | tail -5
+   # e.g. for stable/8.9:
+   git tag --list '8.9.*' | sort -V | tail -5
+   ```
+2. Take the highest patch version found and increment the patch number by 1.
+   - Example: last tag is `8.7.3` → next release is `8.7.4`
+   - Example: last tag is `8.9.0` → next release is `8.9.1`
+3. For `main`, determine the current development version from the root `pom.xml`
+   (`<version>X.Y.Z-SNAPSHOT</version>`) — the next release is the non-SNAPSHOT of that version.
+
+Record these as **expected target releases** — they are informational (actual scheduling is up to
+the team) and are included in both the structured report and the tracking issue.
+
+---
+
+## Step 3 — Produce structured assessment
+
+Present this block to the user **before taking any action**:
+
+```
+## CVE Assessment: <CVE-ID>
+
+**Severity**: <CVSS score> (<Critical/High/Medium/Low>)
+**Advisory**: <URL>
+
+### Vulnerability summary
+<One-paragraph description>
+
+### Affected component
+<groupId>:<artifactId> — vulnerable range: <range>, fix version: <fix-version>
+
+### Per-version status
+
+| Branch     | Current version | Affected? | Action needed                    | Expected target release | Renovate PR |
+|------------|----------------|-----------|----------------------------------|-------------------------|-------------|
+| main       | <version>      | Yes / No  | Bump X → Y / Already fixed / N/A | <next version or "—">  | <PR link or "—"> |
+| stable/8.9 | <version>      | Yes / No  | Bump X → Y / Already fixed / N/A | <next version or "—">  | <PR link or "—"> |
+| stable/8.8 | <version>      | Yes / No  | Bump X → Y / Already fixed / N/A | <next version or "—">  | <PR link or "—"> |
+| stable/8.7 | <version>      | Yes / No  | Bump X → Y / Already fixed / N/A | <next version or "—">  | <PR link or "—"> |
+
+For rows where **Action = Already fixed**, the **Renovate PR** column must be filled with the
+merged PR link (from Step 2a-5).  Leave "—" only where no action was needed (not affected).
+
+### Per-asset scan status
+
+The per-version table above is what the **poms** say. This table is what the **registry scanner**
+measured on the published artifacts (from Step 0). Both must appear — the disagreement between
+them is the diagnostic.
+
+| Branch | Asset | Managed version | Scanned status | Affected? | Action |
+|---|---|---|---|---|---|
+| stable/8.7 | connectors | <version> | CLOSED / flags <ver> | Yes / No | ... |
+| stable/8.7 | connectors-bundle | <version> | CLOSED / flags <ver> | Yes / No | ... |
+| stable/8.7 | connectors-bundle-saas | <version> | CLOSED / flags <ver> | Yes / No | ... |
+| ... one row per (branch x asset) | | | | | |
+
+> **When the managed version and the scanned status disagree, the scan wins.** The poms are a
+> hypothesis about what the artifact contains; the scan is a measurement of it. A branch whose pom
+> pins a fixed version is **not** "Already fixed" while an asset built from that branch still
+> flags a released version — mark it **Affected** and go to Case B-0b.
+
+### Realistic attacker impact
+<What could an attacker realistically do if they exploited this vulnerability specifically in the
+Connectors application? Reason from the vulnerability type (e.g. deserialization, SSRF, DoS) and
+map it to what Connectors actually does — it processes workflow payloads, calls third-party APIs,
+runs in a customer cluster, etc. Be concrete: "attacker could exfiltrate connector credentials
+stored in process variables" is useful; "remote code execution is possible" is not.
+If the library is used in a way that doesn't expose the vulnerable code path, say so explicitly.>
+
+### Exploitability in our app
+<How likely is this to be exploited in practice? Consider:
+- Is the vulnerable code path reachable from untrusted input in normal Connectors usage?
+- Does the attacker need to be authenticated / have process-definition deploy rights / be an
+  internal cluster operator?
+- Are there mitigating factors (e.g. the library is only used for internal serialization,
+  the vulnerable endpoint is not exposed, the attack requires specific HTTP headers we don't set)?
+Rate as one of: **Low** / **Medium** / **High** — and give a one-sentence justification.>
+
+### Tracking issue
+<Filled in after issue creation — see Step 4>
+
+### Recommended action
+<See Step 4 below for what to write here>
+```
+
+---
+
+## Step 4 — Determine action and proceed
+
+### Case A: Base image vulnerability
+
+The vulnerable component lives in the Docker base image, not in Java code.
+Write in the assessment:
+> **Action**: No code change needed. The fix will be delivered by the image provider
+> (Minimus) when they release an updated base image.
+
+Then stop — no PR, issue, or registry update required.
+
+### Case B-0: Source clean on all branches
+
+Split on whether the registry's per-asset scan (Step 0) agrees with the poms. Do not collapse
+these two — "the poms are fixed" and "the artifact is fixed" are different claims.
+
+#### Case B-0a: source clean AND every asset scans clean
+
+Every active branch shows "Already fixed", **and** in Step 0 every asset is `CLOSED` or shows no
+flagged release for the current minors.
+
+> No code changes needed — all branches are already on the fixed version, and all assets scan
+> clean. Proceeding to update the CVE registry.
+
+Set `is_vulnerable` and `vulnerable_reason` (Step 6b). **Write no fix targets** — there is no
+release to schedule, and writing one arms an auto-reopen for a fix that does not exist (see the
+warning in Step 6c). Then go to Step 7.
+
+#### Case B-0b: source clean BUT an asset still flags a released version
+
+The poms have already been ruled out as the explanation. Something reaches the artifact by a route
+dependency management does not describe.
+
+**Do not write fix targets. Do not close the incident. Do not report "already fixed".**
+
+Work the tiers in order, cheapest first, and stop when one explains the disagreement:
+
+1. **Asset cross-diff** (Step 0e) — which assets flag and which are clean on the same tag. Free.
+2. **Per-module compile-scope resolution** at the flagged tag (Step 2a-2) — catches scope leaks.
+3. **Jar-content inspection** for relocated copies (Step 2a-3) — catches shading. Definitive.
+
+The outcome is a root cause plus a real code change, so this becomes **Case B**: create the
+tracking issue (4B-1), open the fix PR (4B-3), and only then set fix targets — with the PR link
+attached.
+
+If all three tiers come back clean and the asset still flags, say so explicitly and record it in
+`additional_problem` rather than marking the finding fixed. An unexplained disagreement stays
+open.
+
+### Case B: Java library version bump
+
+The fix is a version upgrade of a Maven dependency, and **at least one branch** still needs the
+bump.
+
+#### 4B-1: Create a tracking issue in camunda/team-connectors
+
+Before creating any PRs, create one tracking issue in the **private** `camunda/team-connectors`
+repo. This is the central record with full vulnerability details. Since `camunda/connectors` is a
+public repo, PR descriptions there must contain **minimal information** — all sensitive details
+belong here.
+
+Issue title:
+```
+[Security] <CVE-ID> — <artifactId> (<CVSS> <severity>)
+```
+
+Issue body — include **all** details here:
+```markdown
+## <CVE-ID> — <one-line description>
+
+**Severity**: <CVSS score> (<Critical/High/Medium/Low>)
+**Advisory**: <URL>
+**Affected library**: `<groupId>:<artifactId>`
+**Vulnerable range**: <range>
+**Fix version**: <fix-version>
+
+### Vulnerability details
+<Full description of the vulnerability, what can be exploited, attack vectors, conditions>
+
+### Impact on Connectors
+<Which modules, Dockerfiles, or code paths are exposed. Explain why this matters or why
+exposure is limited.>
+
+### Realistic attacker impact
+<What could an attacker realistically achieve by exploiting this vulnerability in the Connectors
+application specifically? Map the vulnerability type to what Connectors does: processing workflow
+payloads, calling third-party APIs, running in a customer cluster, holding connector credentials
+in process variables, etc. Be concrete about the actual consequence, not just the generic CVE
+description. If the vulnerable code path is not reachable in practice, explain why.>
+
+### Exploitability in our app
+**Rating**: Low / Medium / High
+
+<One paragraph explaining: Is the vulnerable code path reachable from untrusted input in normal
+Connectors usage? What level of access does an attacker need (unauthenticated, authenticated user,
+process-definition deploy rights, internal cluster operator)? Are there mitigating factors such as
+the library only being used for internal serialization, the vulnerable endpoint not being exposed,
+or specific preconditions that are never met in our deployment model?>
+
+### Per-version status
+
+| Branch     | Current version | Affected? | Expected target release | Renovate PR |
+|------------|----------------|-----------|-------------------------|-------------|
+| main       | <version>      | Yes / No  | <next version>          | <PR link or "—"> |
+| stable/8.9 | <version>      | Yes / No  | <next version>          | <PR link or "—"> |
+| stable/8.8 | <version>      | Yes / No  | <next version>          | <PR link or "—"> |
+| stable/8.7 | <version>      | Yes / No  | <next version>          | <PR link or "—"> |
+
+### Fix
+Bump `<property-name>` in `parent/pom.xml` from `<old>` to `<fix-version>` on affected branches.
+
+### PRs
+<!-- Updated as PRs are opened -->
+- [ ] main: _pending_
+- [ ] stable/8.9: _pending_
+- [ ] stable/8.8: _pending_
+- [ ] stable/8.7: _pending_
+```
+
+Create the issue:
+```bash
+gh issue create \
+  --repo camunda/team-connectors \
+  --title "[Security] <CVE-ID> — <artifactId> (<CVSS> <severity>)" \
+  --body-file <tmp-body-file>
+```
+
+Record the issue URL (e.g. `https://github.com/camunda/team-connectors/issues/NNN`) and the issue
+number. Update the **Tracking issue** line in the structured assessment with this URL.
+
+#### 4B-2: Ask for confirmation before creating PRs
+
+> I'll create one PR per affected branch bumping `<property>` to `<fix-version>`.
+> Branches: <list>. Tracking issue: <issue URL>. Shall I proceed?
+
+#### 4B-3: Create PRs (after confirmation)
+
+For each affected branch:
+
+a. Create a worktree or checkout the branch in a temp location.
+b. Edit `parent/pom.xml`: update the version property to `<fix-version>`.
+c. Commit with message:
+   ```
+   fix: bump <artifactId> to <fix-version>
+   ```
+   (Do **not** mention the CVE ID in the commit message — it's a public repo.)
+d. Push the branch and open a PR against the target branch.
+
+   **PR description** — keep it minimal (public repo):
+   ```markdown
+   ## Summary
+
+   Bumps `<groupId>:<artifactId>` from `<old-version>` to `<fix-version>`.
+
+   Security fix. Details in the internal tracking issue: camunda/team-connectors#<issue-number>
+   ```
+
+   > ⚠️ Do **not** include the CVE ID, CVSS score, vulnerability description, advisory URL, or
+   > any details about the nature of the fix in the public PR. All such information belongs in
+   > the private tracking issue only.
+
+e. After each PR is created, edit the tracking issue to replace the `_pending_` placeholder for
+   that branch with the actual PR link:
+   ```bash
+   gh issue view <issue-number> --repo camunda/team-connectors --json body -q .body > /tmp/issue-body.md
+   # (edit /tmp/issue-body.md to update the checklist line)
+   gh issue edit <issue-number> --repo camunda/team-connectors --body-file /tmp/issue-body.md
+   ```
+
+f. Do **not** run the full build — a version-only change in the parent pom is safe to push;
+   CI will validate it.
+
+After all PRs are created, proceed to Step 6 (CVE Registry updates).
+
+### Case C: Any other fix
+
+If the remediation requires code changes beyond a version bump (e.g. removing a feature, applying
+a patch, configuration change):
+
+1. Create a tracking issue in `camunda/team-connectors` as described in 4B-1 (with full details).
+2. Write the recommended action in the assessment and ask:
+   > This fix requires changes beyond a dependency bump.
+   > Tracking issue created: <URL>.
+   > Do you want me to proceed with the code changes?
+
+Wait for explicit approval before writing any code. After the fix is merged, proceed to Step 6.
+
+---
+
+## Step 5 — Final summary
+
+### Single CVE
+
+After completing all actions, print a summary table:
+
+| Branch     | Current version | Affected? | Action taken   | Expected release | PR / Note  | Renovate PR |
+|------------|----------------|-----------|----------------|------------------|------------|-------------|
+| main       | <version>      | Yes       | Bumped X → Y   | <next version>   | <PR link>  | —           |
+| stable/8.9 | <version>      | Yes       | Bumped X → Y   | <next version>   | <PR link>  | —           |
+| stable/8.8 | <version>      | No        | Already fixed  | <next version>   | —          | <PR link>   |
+| stable/8.7 | <version>      | No        | Not affected   | —                | —          | —           |
+
+**Tracking issue**: <link to camunda/team-connectors issue, or "N/A — no action required">
+
+### Batch mode (multiple CVEs)
+
+Print one consolidated table covering all processed CVEs:
+
+| CVE ID | Severity | Component | Branch | Action taken | PR | Tracking issue |
+|--------|----------|-----------|--------|--------------|----|----------------|
+| CVE-XXXX-YYYY | 9.8 Critical | com.example:lib | main       | Bumped 1.2.3 → 1.2.4 | <PR link> | <issue link> |
+| CVE-XXXX-YYYY | 9.8 Critical | com.example:lib | stable/8.9 | Bumped 1.2.3 → 1.2.4 | <PR link> | (same issue) |
+| CVE-XXXX-ZZZZ | 5.4 Medium  | com.other:lib2  | all        | Already fixed | —  | N/A |
+| CVE-XXXX-AAAA | 7.1 High    | base image      | N/A        | No action (Minimus) | — | N/A |
+
+List one row per (CVE, branch) pair where action was taken. CVEs with no action or already fixed
+get a single collapsed row. Skipped CVEs (user did not confirm) are omitted entirely.
+
+---
+
+## Step 6 — CVE Registry updates
+
+This step records the fix status in the internal CVE registry at
+`https://cve-registry.infosec.camunda-it.rocks`. Run this for every CVE that was assessed (Cases
+B-0a, B-0b, B, and C) — skip only for Case A (base image).
+
+### Authentication
+
+All registry API calls require the user's browser session cookies. These are ephemeral — they
+expire when the browser session ends. If they are not already available in the current session,
+ask the user to provide fresh values from their browser's DevTools (Application → Cookies on the
+registry domain):
+
+- `csrftoken` — also used as the `X-CSRFToken` request header
+- `sessionid`
+
+If any API call returns HTTP 403, the cookies have expired. Ask the user for fresh ones and retry.
+
+### 6a: Finding ID
+
+Already obtained in **Step 0a**, together with the current per-asset state. Reuse `${FINDING_ID}`
+from there — do not look it up again.
+
+### 6b: Update vulnerability status
+
+`is_vulnerable` reflects whether Connectors actually exercises the vulnerable code path — not just
+whether the library version is old. Determine the value from the exploitability analysis in Step 3:
+
+| Situation | `is_vulnerable` | `vulnerable_reason` |
+|-----------|----------------|---------------------|
+| Vulnerable code path not reachable in Connectors (regardless of version) | `false` | Explain why the code path is never hit |
+| Code path IS used AND all branches are already on a fixed version | `true` | Cite fixed versions and Renovate/fix PR numbers |
+| Code path IS used AND at least one branch is still on a vulnerable version (fix PRs pending merge) | `true` | Cite open fix PRs |
+
+**`vulnerable_reason` format**: Be concise and specific to how Connectors uses the library.
+
+Examples:
+- `false` (code path not used): "Connectors includes netty-codec-http as a transitive dependency
+  but does not expose an HTTP server — the vulnerable HTTP/2 header parsing path is never reached."
+- `true` (already fixed): "Fixed via Spring Boot 4.1.0 (main + stable/8.9, Renovate #7567) and
+  Spring Boot 3.5.15 (stable/8.7 + stable/8.8, Renovate #7568)."
+- `true` (fix PRs open): "Connectors uses the affected ObjectMapper.readValue path. Fix PRs open:
+  main #1234, stable/8.9 #1235, stable/8.8 #1236, stable/8.7 #1237 — not yet merged."
+
+**Request:**
+```
+PUT https://cve-registry.infosec.camunda-it.rocks/cve/api/team/3/finding/{FINDING_ID}/
+Content-Type: application/json
+X-CSRFToken: <csrftoken>
+Cookie: csrftoken=<csrftoken>; sessionid=<sessionid>
+
+{
+  "github_issue": "",
+  "additional_problem": "",
+  "is_vulnerable": <true|false>,
+  "vulnerable_reason": "<concise explanation>",
+  "impact": "N/A",
+  "likelihood": "N/A"
+}
+```
+
+**Execute with curl:**
+```bash
+FINDING_ID=<id>
+CSRF_TOKEN=<csrftoken>
+SESSION_ID=<sessionid>
+
+curl -s -X PUT \
+  "https://cve-registry.infosec.camunda-it.rocks/cve/api/team/3/finding/${FINDING_ID}/" \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json" \
+  -H "X-CSRFToken: ${CSRF_TOKEN}" \
+  -H "Referer: https://cve-registry.infosec.camunda-it.rocks/" \
+  -H "Cookie: csrftoken=${CSRF_TOKEN}; sessionid=${SESSION_ID}" \
+  -d '{
+    "github_issue": "",
+    "additional_problem": "",
+    "is_vulnerable": <true|false>,
+    "vulnerable_reason": "...",
+    "impact": "N/A",
+    "likelihood": "N/A"
+  }'
+```
+
+Expect HTTP 200. Log the result; if non-200 stop and report the error.
+
+> **Note**: `is_vulnerable: true` stays `true` even after the fix is merged — it records that
+> Connectors was affected. Update only the `vulnerable_reason` to reflect the merged fix. Fix
+> targets (Step 6c) can be set at any time.
+
+### 6c: Set fix targets
+
+> **A fix target arms an auto-reopen.** Before any target exists the finding sits inert. The
+> moment one is written, a nightly job flips the finding `SCHEDULED` to `MISSED` if the target
+> date passes while the asset still scans vulnerable — and `MISSED` raises a **new incident in a
+> new Slack channel**. A half-complete triage that writes a target is therefore worse than one
+> that writes nothing at all.
+>
+> Two rules follow:
+>
+> 1. **Never write a fix target with an empty `github_pr_link`** unless the fix is already merged
+>    *and* released *and* the asset scans clean for that release. In Case B-0a write no targets at
+>    all; in Case B-0b write none until the fix PR exists.
+> 2. **The target date must be a date the linked PR can realistically make** — merged, released
+>    and scanning clean by then. Not merely "the next release slot".
+
+Fix targets record which release version resolves the CVE for each tracked asset and minor
+version. The registry tracks multiple assets per CVE (typically `connectors`,
+`connectors-bundle`, and `connectors-bundle-saas`), each as a separate sub-finding.
+
+#### 6c-1: Fetch per-asset finding IDs
+
+Save the GET response to a temp file first, then parse it — avoids shell heredoc quoting issues:
+
+```bash
+curl -s \
+  "https://cve-registry.infosec.camunda-it.rocks/cve/api/team/3/finding/${FINDING_ID}/" \
+  -H "Accept: application/json" \
+  -H "Cookie: csrftoken=${CSRF_TOKEN}; sessionid=${SESSION_ID}" \
+  -o /tmp/finding${FINDING_ID}.json
+```
+
+Parse with Python to discover per-asset sub-finding IDs and any already-set fix_targets:
+
+```python
+import json
+
+data = json.load(open(f'/tmp/finding{FINDING_ID}.json'))
+tf = data['teamFinding']
+print("Per-asset findings:")
+for f in tf['findings']:
+    existing = [ft['minor_version'] for ft in f.get('fix_targets', [])]
+    print(f"  id={f['id']}  asset={f.get('asset_name', f.get('asset', '?'))}  existing fix_targets={existing}")
+```
+
+Each entry in `tf['findings']` has its own `id`. This **per-asset finding ID** (not the
+teamFinding URL ID) is used in the fix_target payload's `"finding"` field.
+
+#### 6c-2: Calculate next patch versions
+
+For each active minor version, determine the last released tag and increment the patch by 1:
+
+```bash
+for minor in 8.7 8.8 8.9; do
+  last=$(git tag --list "${minor}.*" | sort -V | tail -1)
+  patch=$(echo "$last" | cut -d. -f3)
+  echo "${minor}: last=${last}, next=${minor}.$((patch + 1))"
+done
+```
+
+For `main`, read the SNAPSHOT version from the root `pom.xml`:
+```bash
+grep -m1 '<version>' pom.xml   # e.g. <version>8.10.0-SNAPSHOT</version>
+# → next release = 8.10.0
+```
+
+#### 6c-3: Calculate target release date
+
+Releases happen on the **second Tuesday of each month**.
+
+1. Find the second Tuesday of the current month. If it has already passed, use next month.
+2. **If today is fewer than 14 days before the target date**, ask the user:
+   > The next release is on `{date}` which is fewer than 2 weeks away.
+   > Is there already a code freeze? Should I use `{date}` or skip to `{next-month-date}`?
+3. Otherwise use the upcoming second Tuesday directly.
+4. **Sanity-check the date against the actual fix, not just the calendar**: is the linked PR
+   merged, or can it merge, release and scan clean by that date? An unmerged PR against a stable
+   branch with a date in the next slot is the most common way a finding reopens. When in doubt
+   take the later slot — a target that is too early is guaranteed to fire; one that is too late
+   costs nothing but a status row.
+
+Format the date as `YYYY-MM-DD`.
+
+#### 6c-4: Build and send the fix_target payload
+
+The payload must cover **all** (sub-finding × stable minor version) combinations in a single
+array. Fix targets apply to stable branches only (`8.7`, `8.8`, `8.9`, …) — `main` is excluded.
+
+For each combination:
+- If a fix_target **already exists** (has an `id` from the GET response): include that `id`
+- If it does **not yet exist**: use `"isNew": true` instead of `id`
+
+Build the payload in Python using the data from the GET response:
+
+```python
+import json
+
+FINDING_ID = <teamFinding_id>
+TARGET_DATE = "<YYYY-MM-DD>"
+GITHUB_PR_LINK = ""  # empty string if already fixed by Renovate; PR URL if fix PR was opened
+
+# next_patch maps minor_version string → next patch integer
+next_patch = {"8.7": 22, "8.8": 15, "8.9": 6}  # fill from 6c-2
+
+data = json.load(open(f'/tmp/finding{FINDING_ID}.json'))
+findings = data['teamFinding']['findings']
+
+payload = []
+for f in findings:
+    existing = {ft['minor_version']: ft['id'] for ft in f.get('fix_targets', [])}
+    for minor, patch in next_patch.items():
+        entry = {
+            "minor_version": minor,
+            "patch_version": patch,
+            "target_date": TARGET_DATE,
+            "github_pr_link": GITHUB_PR_LINK,
+            "finding": f['id'],
+        }
+        if minor in existing:
+            entry["id"] = existing[minor]   # update existing record
+        else:
+            entry["isNew"] = True            # create new record
+        payload.append(entry)
+
+with open(f'/tmp/fix_target_{FINDING_ID}.json', 'w') as fh:
+    json.dump(payload, fh, indent=2)
+
+print(json.dumps(payload, indent=2))
+```
+
+Send the payload:
+
+```bash
+curl -s -X PUT \
+  "https://cve-registry.infosec.camunda-it.rocks/cve/api/team/3/finding/${FINDING_ID}/fix_target/" \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json" \
+  -H "X-CSRFToken: ${CSRF_TOKEN}" \
+  -H "Referer: https://cve-registry.infosec.camunda-it.rocks/" \
+  -H "Cookie: csrftoken=${CSRF_TOKEN}; sessionid=${SESSION_ID}" \
+  -d @/tmp/fix_target_${FINDING_ID}.json
+```
+
+Expect HTTP 201.
+
+#### 6c-5: Report results
+
+After completing Step 6 for a CVE, report:
+```
+CVE-XXXX-YYYY (finding ID: <id>):
+  ✓ Marked not-vulnerable: HTTP 200
+  ✓ Fix targets set: HTTP 201
+    - 8.7.<N> (finding <id>), 8.8.<N> (finding <id>), 8.9.<N> (finding <id>), 8.10.0 (finding <id>)
+    - Target date: YYYY-MM-DD
+```
+
+If any step was skipped (already set, base image, etc.), note that explicitly.
+
+---
+
+## Step 7 — Close the incident
+
+After the CVE registry is updated, close the incident.io incident. This must be done by the user
+directly in Slack — slash commands cannot be sent via the MCP tool.
+
+### 7a: Verify before closing
+
+Writing to the registry is not the same as clearing the finding. Re-read it and check the
+per-asset status **before** telling the user to close anything:
+
+```bash
+curl -s \
+  "https://cve-registry.infosec.camunda-it.rocks/cve/api/team/3/finding/${FINDING_ID}/" \
+  -H "Accept: application/json" \
+  -H "Cookie: csrftoken=${CSRF_TOKEN}; sessionid=${SESSION_ID}" \
+  | python3 -c "import json,sys; d=json.load(sys.stdin); [print(f['asset']['name'], f['status']) for f in d['teamFinding']['findings']]"
+```
+
+> **If any asset is still `MISSED`, do not instruct the user to close the incident.** Report which
+> assets are unresolved and why. Closing the incident does not clear the finding — the next
+> nightly run re-raises it in a new channel and the round starts over.
+
+Acceptable states for closing: every asset `CLOSED`, or every asset `SCHEDULED` against a fix
+target backed by a real merged-or-open PR.
+
+### 7b: Close
+
+For each CVE, go to the incident channel (`#cve-{cve-id-lowercase}-{severity-lowercase}-connectors`)
+and run:
+```
+/inc close
+```
+
+The incident bot will prompt for a short summary. Briefly describe the outcome, e.g.:
+> "Already fixed on all branches via Spring Boot 4.1.0 / 3.5.15 (Renovate PRs #7567, #7568). CVE registry updated."
+
+Alternatively, click the `:checkered_flag: Resolve` button the bot posts when it detects inactivity.
+
+In batch mode, provide the user with the list of channels to close so they can do them in one pass.


### PR DESCRIPTION
## Summary
- Adds the `connectors-cve-triage-v2` Claude Code skill to `.claude/skills/` for use when triaging CVEs in this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)