### PR TITLE
fix: restore tomcat-embed-* pin at 10.1.59 (stable/8.7)

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -88,6 +88,16 @@ limitations under the License.</license.inlineheader>
     <version.hamcrest>3.0</version.hamcrest>
 
     <version.spring-boot>3.5.16-spring-boot-3.5.19</version.spring-boot>
+    <!-- SEC-3498 (CVE-2026-65905, CVE-2026-68763, CVE-2026-65182, CVE-2026-65637,
+         CVE-2026-68525, CVE-2026-68569, CVE-2026-66422, CVE-2026-65183): tomcat-embed-*
+         transitive override. Setting tomcat.version alone does NOT override Spring Boot's
+         dependency-management import, since spring-boot-dependencies defines its own internal
+         tomcat.version property - the four artifacts below have to be pinned explicitly.
+         Remove only once spring-boot-dependencies itself ships tomcat.version >= 10.1.59.
+         An earlier override was removed once the BOM caught up to a previous, lower threshold,
+         which silently moved Tomcat back into the vulnerable range - do not repeat that: compare
+         against 10.1.59, not against whatever the BOM happens to ship. -->
+    <tomcat.version>10.1.59</tomcat.version>
     <!-- CVE-2026-63337 / GHSA-jh4v-gfqj-7rhx: amqp-client transitive override — remove once
          spring-boot-dependencies ships rabbit-amqp-client >= 5.34.0
          Ref: https://github.com/rabbitmq/rabbitmq-java-client/security/advisories/GHSA-jh4v-gfqj-7rhx -->
@@ -508,6 +518,34 @@ limitations under the License.</license.inlineheader>
         <groupId>org.apache.httpcomponents.core5</groupId>
         <artifactId>httpcore5</artifactId>
         <version>${version.httpcore5}</version>
+      </dependency>
+
+      <!-- SEC-3498: tomcat.version alone does not override Spring Boot's dependency-management
+           import, since spring-boot-dependencies defines its own internal tomcat.version
+           property. These four artifacts ship in lockstep from the same Tomcat release and must
+           be pinned together to avoid a version skew. -->
+      <dependency>
+        <groupId>org.apache.tomcat.embed</groupId>
+        <artifactId>tomcat-embed-core</artifactId>
+        <version>${tomcat.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.apache.tomcat.embed</groupId>
+        <artifactId>tomcat-embed-el</artifactId>
+        <version>${tomcat.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.apache.tomcat.embed</groupId>
+        <artifactId>tomcat-embed-websocket</artifactId>
+        <version>${tomcat.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.apache.tomcat</groupId>
+        <artifactId>tomcat-annotations-api</artifactId>
+        <version>${tomcat.version}</version>
       </dependency>
 
       <dependency>
@@ -968,6 +1006,25 @@ If the new spring-boot-dependencies BOM ships io.projectreactor.netty:reactor-ne
 the property), remove the version.reactor-netty property, the reactor-netty-http and
 reactor-netty-core dependencyManagement entries, and this enforcer rule from parent/pom.xml.
 See: https://spring.io/security/cve-2026-47874/
+                </regexMessage>
+              </requireProperty>
+              <!-- SEC-3498 guard: fails if version.spring-boot is bumped, as a reminder to
+                   check whether the tomcat-embed-* overrides can be removed (see tomcat.version).
+                   spring-boot-dependencies manages Tomcat via its own internal tomcat.version
+                   property, so bumping Spring Boot can move Tomcat without touching this file.
+                   IMPORTANT: only remove the overrides if the new BOM ships tomcat.version
+                   >= 10.1.59. A previous override was dropped because the BOM had caught up to an
+                   older, lower fix version, which downgraded Tomcat back into a vulnerable range. -->
+              <requireProperty>
+                <property>version.spring-boot</property>
+                <regex>^3\.5\.16-spring-boot-3\.5\.19$</regex>
+                <regexMessage>
+version.spring-boot was changed! Check if the tomcat-embed-* SEC-3498 overrides can be removed.
+Only remove them if the new spring-boot-dependencies BOM ships tomcat.version &gt;= 10.1.59
+(confirm with `mvn dependency:tree -Dincludes=org.apache.tomcat.embed:tomcat-embed-core`, not just
+the property). If it ships anything lower, keep the overrides - removing them would downgrade
+Tomcat into a vulnerable range. To remove: drop the tomcat.version property, the four
+tomcat-embed-*/tomcat-annotations-api dependencyManagement entries, and this enforcer rule.
                 </regexMessage>
               </requireProperty>
             </rules>


### PR DESCRIPTION
## Description

Restores the explicit `tomcat-embed-*` version pin in `parent/pom.xml` at `10.1.59`. Security fix,
version change only — no code changes.

Eight CVEs were reported against Apache Tomcat, all fixed by the same upgrade. Affected ranges are
`11.0.20`–`11.0.24`, `10.1.53`–`10.1.57` and `9.0.115`–`9.0.120`. This branch is on the 10.1 line.

Note on the fix version: the advisories name `10.1.58` as the 10.1 fix release, but that version was
never published to Maven Central (404) — `10.1.59` is the first *available* fixed release on this
line, and is the version this branch previously pinned.

### Why the pin needs restoring

This branch already carried `tomcat.version` `10.1.59`, comfortably ahead of the fix. That override
was removed in #8491, which bumped `version.spring-boot` from `3.5.16-spring-boot-3.5.18` to
`-3.5.19`. The removal followed the enforcer guard's own instructions, but that guard only asked
whether the BOM had reached `10.1.57` — the threshold it had been written for, for an earlier CVE.
Removing the override handed Tomcat's version back to the Spring Boot BOM and moved it below the
current fix.

So this is not a fresh gap: it is a pin that already existed being restored, and the guard's wording
is corrected so the same thing does not happen again. The new guard states the threshold as
`>= 10.1.59` and warns explicitly against dropping the overrides while they sit ahead of the BOM.

Setting `tomcat.version` alone does **not** override the imported BOM, which defines its own internal
`tomcat.version` property, so the four artifacts that ship in lockstep from a Tomcat release
(`tomcat-embed-core`, `-el`, `-websocket`, `tomcat-annotations-api`) are pinned explicitly — the same
shape the override had before removal.

### Exposure

Most of the eight CVEs are in container-managed authentication and authorization paths that this
runtime does not use — DIGEST and FORM authenticators, `web.xml` security constraints and
`security-role-ref` definitions — and one is an HTTP/2 allocation leak, where HTTP/2 is off by
Spring Boot default and not enabled here. The runtime runs embedded Tomcat with Spring Boot
defaults: no `server.xml`, no `web.xml`, no security constraints, no Tomcat customizers, and only
`server.port` and `server.max-http-request-header-size` set. Authorization is enforced by Spring
Security filters.

Two of the eight could not be characterised from the sources reachable here, including
CVE-2026-65637 at CVSS 9.8, whose advisory does not name the affected component. Given a
network-facing embedded web server, that is reason to upgrade rather than to reason the exposure
away.

### Verification

- `mvn dependency:tree -Dincludes=org.apache.tomcat*` resolves `tomcat-embed-core`, `-el` and
  `-websocket` at `10.1.59` with this change
- the new enforcer rule is wired and confirmed to fire on a `version.spring-boot` change rather than
  sit inert
- `parent/pom.xml` well-formed

Note: full resolution on this branch cannot be reproduced without credentials for the private Spring
Boot NES artifact repository, so the checks above were run against a scratch copy with a public
Spring Boot substituted. That substitution affects only the `version.spring-boot`-keyed guards
(expected) — and it also demonstrates the point of this change: the explicit pin holds Tomcat at
`10.1.59` regardless of what the BOM ships.

## Related issues

Tracked internally in INC-7938 / SEC-3498.
Companion PRs: #8791 (`main`), #8792 (`stable/8.9`) and #8796 (`stable/8.8`).

## Checklist

- [x] Backport labels are added if these code changes should be backported. No backport label
  needed: this PR targets `stable/8.7` directly, and `main`, `stable/8.9` and `stable/8.8` are
  covered by #8791, #8792 and #8796. All four branches are affected by this one.
- [x] Tests/Integration tests for the changes have been added if applicable. Not applicable —
  dependency version pin, covered by the existing suite.
- [x] If the change requires a documentation update, it has been added to the appropriate section
  in the documentation. Not applicable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015UjzTw6ba1eduqWzheDF88

---
_Generated by [Claude Code](https://claude.ai/code/session_015UjzTw6ba1eduqWzheDF88)_