### PR TITLE
fix(aws): evaluate inbound region override expressions

### DIFF
--- a/connectors-e2e-test/connectors-e2e-test-aws/connectors-e2e-test-aws-base/src/test/java/io/camunda/connector/e2e/SqsInboundPropertiesTest.java
+++ b/connectors-e2e-test/connectors-e2e-test-aws/connectors-e2e-test-aws-base/src/test/java/io/camunda/connector/e2e/SqsInboundPropertiesTest.java
@@ -62,4 +62,37 @@ class SqsInboundPropertiesTest {
         .isEqualTo("cred-ak");
     assertThat(properties.getConfiguration().region()).isEqualTo("eu-west-1");
   }
+
+  @Test
+  void bindsRegionOverrideExpressionThroughFeelReader() throws Exception {
+    String credentialExpression = "=camunda.vars.env.sqsCredential";
+    String regionExpression = "=regionVariable";
+    var credential =
+        Map.of(
+            "authentication",
+            Map.of("type", "credentials", "accessKey", "cred-ak", "secretKey", "cred-sk"),
+            "region",
+            "eu-west-1");
+    var evaluator = mock(FeelExpressionEvaluator.class);
+    when(evaluator.evaluate(eq(credentialExpression), any(Object[].class))).thenReturn(credential);
+    when(evaluator.evaluate(eq(regionExpression), any(Object[].class))).thenReturn("eu-central-1");
+    var objectMapper =
+        ObjectMapperSupplier.getMapperInstance()
+            .copy()
+            .registerModule(new JacksonModuleFeelFunction());
+    JsonNode propertiesJson =
+        objectMapper.valueToTree(
+            Map.of(
+                "awsCredential",
+                credentialExpression,
+                "configuration",
+                Map.of("region", regionExpression)));
+
+    var properties =
+        FeelContextAwareObjectReader.of(objectMapper)
+            .withEvaluator(evaluator)
+            .readValue(propertiesJson, SqsInboundProperties.class);
+
+    assertThat(properties.getConfiguration().region()).isEqualTo("eu-central-1");
+  }
 }

--- a/connectors/aws/aws-base/src/main/java/io/camunda/connector/aws/model/impl/AwsBaseConfiguration.java
+++ b/connectors/aws/aws-base/src/main/java/io/camunda/connector/aws/model/impl/AwsBaseConfiguration.java
@@ -6,13 +6,17 @@
  */
 package io.camunda.connector.aws.model.impl;
 
+import io.camunda.connector.api.annotation.FEEL;
 import io.camunda.connector.aws.model.AwsConfiguration;
 import io.camunda.connector.generator.java.annotation.FeelMode;
 import io.camunda.connector.generator.java.annotation.TemplateProperty;
 import io.camunda.connector.generator.java.annotation.TemplateProperty.PropertyConstraints;
 
 public record AwsBaseConfiguration(
-    @TemplateProperty(group = "configuration", constraints = @PropertyConstraints(notEmpty = true))
+    @FEEL
+        @TemplateProperty(
+            group = "configuration",
+            constraints = @PropertyConstraints(notEmpty = true))
         String region,
     @TemplateProperty(
             group = "configuration",


### PR DESCRIPTION
## Description

Evaluate AWS region FEEL expressions during inbound connector property binding.

SQS reusable credentials expose an optional inline region override, but inbound binding previously left that expression as a literal because the actual region model field was not marked for FEEL evaluation. This change annotates the runtime-bound field and adds coverage for a credential with an expression-based region override.

The alternative of disabling FEEL in inbound templates would remove existing advertised functionality instead of making runtime behavior match the template.

## Related issues

Follow-up to #8706 and #8771.

## Checklist

- [x] Backport label `backport stable/8.10` is added.
- [x] Tests/Integration tests for the changes have been added if applicable.
- [x] No documentation update is required; this aligns runtime behavior with the existing template.
