### PR TITLE
test(runtime): cover the plain and pre-escaped secret refs on validate

### DIFF
--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/configuration/ConfigurationValidationServiceTest.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/configuration/ConfigurationValidationServiceTest.java
@@ -447,6 +447,31 @@ class ConfigurationValidationServiceTest {
   }
 
   @Test
+  void unquotesAPlainSecretNameInAValuePosition() {
+    var expressions = new ArrayList<String>();
+    var service = serviceWith(Map.of("engine-a", feelCapturing("{\"value\":\"x\"}", expressions)));
+
+    service.validate(
+        new ConfigurationValidationRequest(
+            "ok", "={\"token\":\"camunda.secrets.TOKEN\"}", "tenant", "engine-a"));
+
+    assertThat(expressions).containsExactly("={\"token\":camunda.secrets.TOKEN}");
+  }
+
+  @Test
+  void keepsTheCallersBacktickEscapingWhenUnquoting() {
+    // A dashed name is authored escaped (ADR-0007); the backticks must survive unquoting.
+    var expressions = new ArrayList<String>();
+    var service = serviceWith(Map.of("engine-a", feelCapturing("{\"value\":\"x\"}", expressions)));
+
+    service.validate(
+        new ConfigurationValidationRequest(
+            "ok", "={\"token\":\"camunda.secrets.`MY-TOKEN`\"}", "tenant", "engine-a"));
+
+    assertThat(expressions).containsExactly("={\"token\":camunda.secrets.`MY-TOKEN`}");
+  }
+
+  @Test
   void leavesAReferenceShapedJsonKeyQuoted() {
     var expressions = new ArrayList<String>();
     var service = serviceWith(Map.of("engine-a", feelCapturing("{\"value\":\"x\"}", expressions)));


### PR DESCRIPTION
## Description

Follow-up to #8766, which made `POST /configurations/validate` unquote `camunda.secrets.<name>` references in the `credentialRef` before evaluating them. The unquoting shipped with three tests, but neither of the two shapes it actually exists for was among them:

| shape | covered before? |
|---|---|
| `"camunda.secrets.TOKEN"` — plain name in a value position | no |
| ``"camunda.secrets.`MY-TOKEN`"`` — dashed name, backtick-escaped by the caller | no |
| `"camunda.secrets.MY-TOKEN_1"` — dashed name, **unescaped** | yes |
| `"camunda.secrets.TOKEN" :` — reference-shaped JSON key | yes |
| `=camunda.vars.env.awsProd` — not a secret at all | yes |

The one case that looks like the happy path uses an unescaped dashed name, which is the shape a caller is not supposed to send: per [ADR-0007](https://github.com/camunda/connectors/blob/main/docs/adr/ADR-0007-centralized-secret-resolution-in-the-connector-runtime.md) a dash is a name character, not an authoring one, so `db-password` is only ever written ``camunda.secrets.`db-password` `` — FEEL reads the bare form as subtraction. We unquote it faithfully either way, so the assertion is correct, but it left the plainest reference and the escaped one both untested.

The escaped case is the one worth having: tolerating a caller's backticks was the last commit of #8766 and had no coverage at all, so a future edit to the name charset could silently undo it.

Two tests added, no production code touched.

## Related issues

Follow-up to #8766. No separate issue.

## Checklist

- [x] Backport labels are added if these code changes should be backported.
- [x] Tests/Integration tests for the changes have been added if applicable.
- [ ] If the change requires a documentation update, it has been added to the appropriate section in the documentation. — not applicable, tests only.

---

**Verification note:** this module could not be built in the environment these tests were written in (`io.camunda:camunda-client-java:8.11.0-SNAPSHOT` returns 403 from every configured repository), so the two new expectations were checked by running the merged `QUOTED_SECRET_REFERENCE` pattern against the exact inputs rather than by executing the suite. CI is the real gate here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ShVyDTJZ6NnnfQ9AJRhtwr

---
_Generated by [Claude Code](https://claude.ai/code/session_01ShVyDTJZ6NnnfQ9AJRhtwr)_