### PR TITLE
test(e2e): share process test runtimes

### DIFF
--- a/connectors-e2e-test/connectors-e2e-test-automation-anywhere/src/test/resources/application.yml
+++ b/connectors-e2e-test/connectors-e2e-test-automation-anywhere/src/test/resources/application.yml
@@ -1,0 +1,3 @@
+camunda:
+  process-test:
+    runtime-mode: shared

--- a/connectors-e2e-test/connectors-e2e-test-inbound-runtime/src/test/resources/application.yml
+++ b/connectors-e2e-test/connectors-e2e-test-inbound-runtime/src/test/resources/application.yml
@@ -1,0 +1,3 @@
+camunda:
+  process-test:
+    runtime-mode: shared

--- a/connectors-e2e-test/connectors-e2e-test-kafka/src/test/resources/application.yml
+++ b/connectors-e2e-test/connectors-e2e-test-kafka/src/test/resources/application.yml
@@ -1,0 +1,3 @@
+camunda:
+  process-test:
+    runtime-mode: shared

--- a/connectors-e2e-test/connectors-e2e-test-rabbitmq/src/test/resources/application.yml
+++ b/connectors-e2e-test/connectors-e2e-test-rabbitmq/src/test/resources/application.yml
@@ -1,0 +1,3 @@
+camunda:
+  process-test:
+    runtime-mode: shared


### PR DESCRIPTION
## Description

Reuse a single Camunda Process Test runtime across compatible test classes within the Automation Anywhere, Kafka, inbound-runtime, and RabbitMQ E2E modules. This avoids starting a second engine container in each module while preserving module isolation and test cleanup.

The HTTP suites remain unchanged because they require different runtime configurations.

This follows up on the E2E optimization work in #8790.

### E2E measurements

Compared with the final optimized #8790 run (`34473309851`), the affected test steps in run `34494829489` changed as follows:

| Module | Before | After | Saved |
|---|---:|---:|---:|
| Automation Anywhere | 1m16s | 1m03s | 13s (17%) |
| Kafka | 1m41s | 1m26s | 15s (15%) |
| Inbound runtime | 4m37s | 2m34s | 2m03s (44%) |
| RabbitMQ | 1m25s | 1m08s | 17s (20%) |
| **Combined** | **8m59s** | **6m11s** | **2m48s (31%)** |

The complete E2E matrix passed. Since modules execute concurrently and Agentic AI remains the longest job, this primarily reduces compute usage rather than the overall critical path.

## Related issues

Follow-up to #8790.

## Checklist

- [ ] Backport labels are added if these changes should be backported.
- [x] Tests/Integration tests for the changes have been added if applicable.
- [x] No documentation update is required.