### PR TITLE
fix(github): move auth scratch fields off the authentication root

### DIFF
--- a/connectors/github/element-templates/github-connector.json
+++ b/connectors/github/element-templates/github-connector.json
@@ -4,7 +4,7 @@
   "id": "io.camunda.connectors.GitHub.v1",
   "version": 14,
   "engines": {
-    "camunda": "^8.10"
+    "camunda": "^8.7"
   },
   "description": "Manage GitHub issues, branches, releases, and more",
   "keywords": [

--- a/connectors/github/element-templates/github-connector.json
+++ b/connectors/github/element-templates/github-connector.json
@@ -4,7 +4,7 @@
   "id": "io.camunda.connectors.GitHub.v1",
   "version": 14,
   "engines": {
-    "camunda": "^8.7"
+    "camunda": "^8.10"
   },
   "description": "Manage GitHub issues, branches, releases, and more",
   "keywords": [

--- a/connectors/github/element-templates/github-connector.json
+++ b/connectors/github/element-templates/github-connector.json
@@ -478,17 +478,6 @@
       }
     },
     {
-      "type": "Hidden",
-      "label": "Type",
-      "id": "authenticationType",
-      "group": "authentication",
-      "value": "bearer",
-      "binding": {
-        "type": "zeebe:input",
-        "name": "authentication.type"
-      }
-    },
-    {
       "label": "Authentication type",
       "id": "authentication.authType",
       "group": "authentication",
@@ -591,6 +580,17 @@
       "condition": {
         "property": "authentication.authType",
         "equals": "github_app"
+      }
+    },
+    {
+      "type": "Hidden",
+      "label": "Type",
+      "id": "authenticationType",
+      "group": "authentication",
+      "value": "bearer",
+      "binding": {
+        "type": "zeebe:input",
+        "name": "authentication.type"
       }
     },
     {

--- a/connectors/github/element-templates/versioned/github-connector-13.json
+++ b/connectors/github/element-templates/versioned/github-connector-13.json
@@ -2,7 +2,7 @@
   "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
   "name": "GitHub Outbound Connector",
   "id": "io.camunda.connectors.GitHub.v1",
-  "version": 14,
+  "version": 13,
   "engines": {
     "camunda": "^8.10"
   },
@@ -506,7 +506,7 @@
       ],
       "binding": {
         "type": "zeebe:input",
-        "name": "githubAuthType"
+        "name": "authentication.authType"
       }
     },
     {
@@ -520,7 +520,7 @@
       "value": "",
       "binding": {
         "type": "zeebe:input",
-        "name": "githubPat"
+        "name": "authentication.pat"
       },
       "constraints": {
         "notEmpty": false
@@ -541,7 +541,7 @@
       "optional": true,
       "binding": {
         "type": "zeebe:input",
-        "name": "githubAppPrivateKey"
+        "name": "authentication.githubAppPrivateKey"
       },
       "constraints": {
         "notEmpty": false
@@ -562,7 +562,7 @@
       "optional": true,
       "binding": {
         "type": "zeebe:input",
-        "name": "githubAppAppId"
+        "name": "authentication.githubAppAppId"
       },
       "constraints": {
         "notEmpty": false
@@ -583,7 +583,7 @@
       "optional": true,
       "binding": {
         "type": "zeebe:input",
-        "name": "githubAppInstallationId"
+        "name": "authentication.githubAppInstallationId"
       },
       "constraints": {
         "notEmpty": false
@@ -596,7 +596,7 @@
     {
       "group": "authentication",
       "type": "Hidden",
-      "value": "= if githubAuthType = \"github_app\" then {\"camunda.function.type\":\"createGithubAppInstallationToken\",\"params\":[githubAppPrivateKey,githubAppAppId,githubAppInstallationId]} else githubPat",
+      "value": "= if authentication.authType = \"github_app\" then {\"camunda.function.type\":\"createGithubAppInstallationToken\",\"params\":[authentication.githubAppPrivateKey,authentication.githubAppAppId,authentication.githubAppInstallationId]} else authentication.pat",
       "binding": {
         "type": "zeebe:input",
         "name": "authentication.token"
@@ -3962,7 +3962,7 @@
       "id": "version",
       "label": "Version",
       "description": "Version of the element template",
-      "value": "14",
+      "value": "13",
       "group": "connector",
       "binding": {
         "key": "elementTemplateVersion",


### PR DESCRIPTION
## Description

`authentication.token`'s `Hidden` binding computes the bearer token from five sibling fields that all live under the same `authentication` root. Two independent mechanisms key off those target paths, and **no reference form satisfies both** — which is why #8808 reports two different failures.

### 1. Engine FEEL resolution — #8808's second failure

Whether a same-root sibling read resolves depends on the input-mapping mode:

| mode | bare leaf names (`authType`) | qualified (`authentication.authType`) |
| --- | --- | --- |
| `combined` | resolve | **`null`** |
| `ordered` | root overwrite | resolve |

`combined` is the behavior on 8.7/8.8/8.9 (restored by the reverts camunda/camunda#59972, camunda/camunda#59974, camunda/camunda#59976 on 12–13 Aug) and the default on 8.10 (camunda/camunda#61032). `ordered` (camunda/camunda#58801) shipped only in 8.9.14/8.9.15 and is now opt-in via `camunda.processing.engine.mappings.input-mode`. v13 (#8275) qualified the five references, which resolves only under `ordered` — so the current template cannot produce a token on 8.10, where `combined` is the default. Hence `authentication.token: must not be empty`.

### 2. The outbound secret allow-list — #8808's first failure

`STRICT` has been the outbound default since #8506 and its backports (#8507, #8508, #8519, #8521, #8540) — on 8.9 that is **8.9.10**, the version #8808 reports. The full path, in order:

1. `JobHandlerContext.bindVariables` → `mapJson` calls `getJsonReplacedWithSecrets()` **before** `treeToValue`, so substitution runs over the raw `JsonNode` tree first. The ordering is correct.
2. `SecretUtil.replaceSecrets` walks that tree carrying a `fieldPath` (`walkObject` appends field names; `walkArray` does not append indices), and hands each `{{secrets.X}}` hit to the filter as `Secret(name, fieldPath)`.
3. `SecretFilter.allowOnly` grants when the grant's path is a **prefix** of the reference's path — deliberately, so a grant covers its whole subtree.
4. Grants come from `ProcessDefinitionSecretKeyCache#extractSecrets`, which propagates a source's secret names to a *reading* input's path, but only when the expression's referenced path matches a declared target (`matchingWriters`, exact/prefix segments).

With v12, step 4 finds nothing: the token expression references `[githubAppPrivateKey]` (one segment) while every declared target is `[authentication, …]`, so no dependency edge exists and the only grant is at `[authentication, githubAppPrivateKey]`. The engine meanwhile placed the placeholder at `[authentication, token, params]`. The prefix check compares `[authentication, token]` against `[authentication, githubAppPrivateKey]` → **denied**, the placeholder survives, and the sole trace is one DEBUG line (`SecretHandler.java:54`). Deserialization then runs the intrinsic (executed inside Jackson, via `DefaultIntrinsicFunctionExecutor` wired into `JacksonModuleDocumentDeserializer`) on literal text:

```
Failed to execute intrinsic function: createGithubAppInstallationToken with arguments:
[{{secrets.ELT_GITHUB_APP_PRIVATE_KEY}}, {{secrets.ELT_GITHUB_APP_ID}}, {{secrets.ELT_GITHUB_APP_INSTALLATION_ID}}]
```

Note what this is *not*: the allow-list is not blind to intrinsic functions, and nothing runs out of order. The design handles a computed credential on purpose — that is what the dependency walk and the prefix-covers-subtree rule are for. What breaks is narrower: the value **moved**, and the allow-list only follows the move when the reference is textually the declared target path. Same fault line as camunda/camunda#60551, one layer down — `combined` lets a bare leaf name mean "my sibling under this root", the static analysis has no such rule, and the disagreement fails silently.

### Fix

Move the five scratch fields to top-level targets, leaving only `authentication.type` and `authentication.token` under that root — the two fields `BearerAuthentication` actually validates.

```diff
-authentication.authType                → githubAuthType
-authentication.pat                     → githubPat
-authentication.githubAppPrivateKey     → githubAppPrivateKey
-authentication.githubAppAppId          → githubAppAppId
-authentication.githubAppInstallationId → githubAppInstallationId

-  "value": "= if authentication.authType = \"github_app\" then {…,\"params\":[authentication.githubAppPrivateKey,authentication.githubAppAppId,authentication.githubAppInstallationId]} else authentication.pat"
+  "value": "= if githubAuthType = \"github_app\" then {…,\"params\":[githubAppPrivateKey,githubAppAppId,githubAppInstallationId]} else githubPat"
```

One shape, both mechanisms, **no runtime change**:

- **FEEL, under either mode.** No shared root, so nothing shadows: a flat earlier entry in the same context literal resolves under `combined`, an accumulated earlier result resolves under `ordered`.
- **Secret allow-list.** Reference path equals target path, so the edge is found and `extractSecrets` grants at `[authentication, token]` — whose prefix covers `[authentication, token, params]`.

It is also the only shape that survives camunda/camunda#60551 **being fixed**: that issue's scope is "the FEEL expression's variable shares the same root as the target", and v14 contains no such reference, whereas v12 depends on the bug and v13 depends on which way it is resolved. What v14 relies on instead — a later mapping reading an earlier one's target — is not a bug: it is the requirement in camunda/camunda#11789 and the stated purpose of camunda/camunda#58801, implemented by both resolvers.

No new secret exposure: input mappings carry the *placeholder text* in element-local variables, not resolved values; substitution still happens in the runtime after job activation. Operate shows `{{secrets.…}}` either way.

### Blast radius: this template only

All 720 templates were scanned for the same shape — an input expression referencing a bare name whose only declared target is nested. The detector flags all five references in `versioned/github-connector-12.json` and nothing in v14, and every other hit was a false positive of three kinds: context **keys** rather than references (`{name: "min_fare", value: "10.0", type: "…"}` in Databricks; `{content: …, name: …}` in Box/Teams/Email/Drive/SendGrid), FEEL list-filter contexts (ServiceNow's `operationMap[value = operationGroup]`), and deliberate outer-scope reads (the IDP templates' `input.document ← = document`, which takes a caller-supplied process variable and so has no grant to lose). No other connector carries this defect.

### Which clusters this reaches

`engines` is `^8.7`, restoring v12's range; v13's narrowing to `^8.10` was the anomaly. Element templates reach Modeler through `@camunda/connectors-element-templates`, published from `main` and gated per cluster by `engines` — the `stable/*` branches' template copies (v10 on `stable/8.9`, v8 on `stable/8.8`) are not what users are served and cannot be bumped to v14 anyway without breaking `CurrentVersionBumpRule` there. So this range is the only lever that decides whether an 8.7–8.9 user gets the fix, and it also means they need no runtime upgrade — just the template.

Leaving it at `^8.10` would have left 8.7–8.9 on v12, i.e. still failing mechanism 2: the allow-list and its grant propagation are byte-identical on `stable/8.7`, `stable/8.8` and `stable/8.9`, `STRICT` is the default on all of them, and `CreateGithubAppInstallationTokenFunction` exists on all of them. (This is the third commit on the branch and its revert — the deliberation is deliberate: widened, narrowed pending evidence, widened again once #8808's own 8.9.10 error proved mechanism 2 in production.)

Not a compatibility risk either way: deployed processes carry their `ioMapping` inline and are untouched, and existing diagrams stay on v12/v13 until a modeler chooses to upgrade the element.

Other notes for reviewers:

- **Property `id`s are unchanged**, so every `condition: {property: "authentication.authType"}` reference keeps resolving (`ConditionTargetExistsRule` confirms) and the diff stays bindings-only.
- **Declaration order is load-bearing for both mechanisms.** `authentication.type` sits *after* the five scratch mappings (Copilot review catch, 0bc5ad7a8): `combined` emits the regrouped `authentication` object at the root's first occurrence, so declaring it first would emit `token` before the flat entries were bound. The allow-list needs the same order, since `effectiveTargets` is built in declaration order. `authentication.token` stays last.
- v13 archived to `versioned/github-connector-13.json`, as `CurrentVersionBumpRule` requires.

### Verification

```
element-template-validator   720 templates, no findings
docs-link check              120 links, no /next/
```

The validator fetches its schema from unpkg.com, unreachable from my environment; I ran it against the pinned `@camunda/zeebe-element-templates-json-schema@0.44.0` served locally via `--schema-url`, so the schema rule did execute.

Still **read from code, not run against a cluster** — worth confirming before this is called done:

1. That the propagated grant does land at `authentication.token` for the v14 shape, i.e. GitHub App auth completes end to end. The negative direction is already evidenced in production by #8808 on 8.9.10; this is the positive direction. A `ProcessDefinitionSecretKeyCacheTest` fixture would pin it as a regression test.
2. That Modeler's v13 → v14 upgrade carries entered values across. Keeping the `id`s stable is what should make it work, but I have not confirmed the upgrade maps by `id` rather than by binding. If it maps by binding, an upgrading user re-enters their PAT or private key once.
3. That GitHub App auth is exercised on 8.7/8.8 runtimes — the intrinsic is present on both, but in a different module on `stable/8.7` (`connector-sdk/document`), so its registration there deserves a glance. If it turns out unsupported, narrow `engines` rather than changing the expression.

## Related issues

relates to #8808
relates to #8273

## Checklist

- [x] Backport labels are added if these code changes should be backported — `backport stable/8.10`. Older branches cannot take v14 (their `versioned/` snapshots stop at 9 and 8, so `CurrentVersionBumpRule` would fail) and do not need to: what those clusters are served is decided by `engines` from `main`.
- [ ] Tests/Integration tests for the changes have been added if applicable — none added; there is still no `connectors-e2e-test-github` module, which is why this bug class has now slipped through three times (#7532, #8275, this one). Follow-ups worth filing: (a) a validator rule rejecting an input expression that references a name with no matching declared target, references its own target root, or references a target declared after it — it must parse FEEL via `referencedVariablePaths` rather than regex, so that the validator and the runtime agree on what a reference *is*, and to avoid the false-positive classes listed above; (b) a `ProcessDefinitionSecretKeyCache` case for the propagate-through-a-computed-credential shape; (c) splitting `SecretHandler`'s silent DEBUG so a refusal of a secret the element *does* declare elsewhere logs at WARN with element, refused path and declared path — the missing diagnostic that made #8808 take a month.
- [x] No documentation update needed — bugfix to existing documented behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DQGKRvyHznHjQpASEb2RJE