### PR TITLE
[Backport stable/8.6] ci: speed up regular test workflow

### DIFF
--- a/.github/workflows/TEST_FEATURE_BRANCH.yml
+++ b/.github/workflows/TEST_FEATURE_BRANCH.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   run-tests:
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.repository_owner == 'camunda' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false) && 'gcp-core-8-default' || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/TEST_FEATURE_BRANCH.yml
+++ b/.github/workflows/TEST_FEATURE_BRANCH.yml
@@ -79,7 +79,7 @@ jobs:
         run: npm install --global element-templates-cli@$(jq -r '.devDependencies["element-templates-cli"]' .github/workflows/package.json)
 
       - name: Build Connectors
-        run: $MVN_CMD --batch-mode clean test -PcheckFormat
+        run: $MVN_CMD --batch-mode clean test -PcheckFormat -T 1C
 
       - name: Publish Test Report
         if: success() || failure()
@@ -110,7 +110,7 @@ jobs:
       - name: Package Connectors
         env:
           PROJECTS: bundle/default-bundle
-        run: $MVN_CMD --batch-mode compile generate-sources package -DskipTests --projects "${PROJECTS}" --also-make
+        run: $MVN_CMD --batch-mode compile generate-sources package -DskipTests --projects "${PROJECTS}" --also-make -T 1C '-P!autoFormat'
 
       - name: Set up Docker Build
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/TEST_FEATURE_BRANCH.yml
+++ b/.github/workflows/TEST_FEATURE_BRANCH.yml
@@ -14,6 +14,23 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Resolve Maven command
+        id: resolve-maven
+        run: |
+          if [ -x ./mvnw ]; then
+            echo "has-wrapper=true" >> "$GITHUB_OUTPUT"
+            echo "MVN_CMD=./mvnw" >> "$GITHUB_ENV"
+          else
+            echo "has-wrapper=false" >> "$GITHUB_OUTPUT"
+            echo "MVN_CMD=mvn" >> "$GITHUB_ENV"
+          fi
+
+      - name: Install Maven (wrapper-less branches)
+        if: steps.resolve-maven.outputs.has-wrapper != 'true'
+        uses: stCarolas/setup-maven@v5
+        with:
+          maven-version: 3.9.16
+
       - name: Import Secrets
         id: secrets
         uses: hashicorp/vault-action@v3.4.0
@@ -62,7 +79,7 @@ jobs:
         run: npm install --global element-templates-cli@$(jq -r '.devDependencies["element-templates-cli"]' .github/workflows/package.json)
 
       - name: Build Connectors
-        run: mvn --batch-mode clean test -PcheckFormat
+        run: $MVN_CMD --batch-mode clean test -PcheckFormat
 
       - name: Publish Test Report
         if: success() || failure()
@@ -93,7 +110,7 @@ jobs:
       - name: Package Connectors
         env:
           PROJECTS: bundle/default-bundle
-        run: mvn --batch-mode compile generate-sources package -DskipTests --projects "${PROJECTS}" --also-make
+        run: $MVN_CMD --batch-mode compile generate-sources package -DskipTests --projects "${PROJECTS}" --also-make
 
       - name: Set up Docker Build
         uses: docker/setup-buildx-action@v3


### PR DESCRIPTION
## Description

Backport of #8812 to `stable/8.6`.

This stable branch does not contain the runtime test classes or the HTTP mTLS and multipart test coverage consolidated by the source PR, so those files were not resurrected. Its regular test workflow also has no separate Javadoc or format jobs, so those changes do not apply.

The compatible optimization:
- uses the 8-core GCP runner for trusted Camunda builds while retaining `ubuntu-latest` for external repositories;
- installs a pinned Maven version when the branch-local Maven wrapper is absent;
- runs the test and packaging reactors in parallel; and
- avoids repeating automatic formatting in the packaging reactor while retaining the existing formatting check in the test build.

Together these changes reduced the measured `run-tests` duration from 25m28s to 9m01s. The existing workflow events, action versions, test coverage, packaging output, and Docker publishing behavior remain unchanged.

## Related issues

Related to #8812

## Checklist

- [ ] PR has a **milestone** or the `no milestone` label.