### PR TITLE
[Backport stable/8.7] ci: speed up regular test workflow

### DIFF
--- a/.github/workflows/TEST_FEATURE_BRANCH.yml
+++ b/.github/workflows/TEST_FEATURE_BRANCH.yml
@@ -19,7 +19,7 @@ concurrency:
 
 jobs:
   run-tests:
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.repository_owner == 'camunda' && (github.event_name != 'pull_request_target' || github.event.pull_request.head.repo.fork == false) && 'gcp-core-8-default' || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@v4
 
@@ -71,7 +71,7 @@ jobs:
 
       # Build and test (format check runs in a parallel job)
       - name: Build Connectors
-        run: ./mvnw --batch-mode clean test -Dquickly -T 1C
+        run: ./mvnw --batch-mode clean test -Dquickly -T 1C '-P!autoFormat'
 
       - name: Publish Test Report
         if: success() || failure()
@@ -100,7 +100,7 @@ jobs:
           dockerfile: bundle/default-bundle/Dockerfile
 
   check-format:
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.repository_owner == 'camunda' && (github.event_name != 'pull_request_target' || github.event.pull_request.head.repo.fork == false) && 'gcp-core-8-default' || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@v4
 
@@ -143,7 +143,7 @@ jobs:
           mirrors: '[{"url": "https://repository.nexus.camunda.cloud/content/groups/internal/", "id": "camunda-nexus", "mirrorOf": "*,!shibboleth,!confluent", "name": "camunda Nexus"}]'
 
       - name: Install element-template-generator plugin
-        run: ./mvnw --batch-mode install -pl element-template-generator/maven-plugin -am -DskipTests -Dquickly
+        run: ./mvnw --batch-mode install -pl element-template-generator/maven-plugin -am -DskipTests -Dquickly -T 1C
 
       - name: Check Format
         run: ./mvnw --batch-mode validate -PcheckFormat -Dquickly

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/inbound/BaseMultiInstancesTest.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/inbound/BaseMultiInstancesTest.java
@@ -38,8 +38,10 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
-import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestInstance;
 import org.mockito.Mockito;
 import org.mockito.stubbing.Answer;
 import org.springframework.boot.builder.SpringApplicationBuilder;
@@ -47,6 +49,7 @@ import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.support.GenericApplicationContext;
 
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 abstract class BaseMultiInstancesTest {
   final InboundExecutableRegistry executableRegistry1 =
       Mockito.mock(InboundExecutableRegistry.class);
@@ -104,14 +107,14 @@ abstract class BaseMultiInstancesTest {
   ConfigurableApplicationContext context1;
   ConfigurableApplicationContext context2;
 
-  @AfterEach
+  @AfterAll
   void tearDown() {
     if (context1 != null) context1.close();
     if (context2 != null) context2.close();
   }
 
-  @BeforeEach
-  public void init() {
+  @BeforeAll
+  void startApplications() {
     context1 =
         new SpringApplicationBuilder(TestConnectorRuntimeApplication.class)
             .properties(
@@ -157,7 +160,11 @@ abstract class BaseMultiInstancesTest {
                                   instanceForwardingHttpClient, "instance2"));
                 })
             .run();
+  }
 
+  @BeforeEach
+  public void init() {
+    Mockito.reset(executableRegistry1, executableRegistry2);
     when(executableRegistry1.getConnectorName(TYPE_1)).thenReturn("Webhook");
     when(executableRegistry1.getConnectorName(TYPE_2)).thenReturn("AnotherType");
     when(executableRegistry2.getConnectorName(TYPE_1)).thenReturn("Webhook");


### PR DESCRIPTION
## Description

Manual backport of #8812 to `stable/8.7`, adapted to the branch's available workflow and test structure.

- Applies the trusted-runner, duplicate-formatting, and parallel plugin-install optimizations to the existing regular test workflow. The runner condition uses this branch's `pull_request_target` event so fork PRs remain on GitHub-hosted runners.
- Reuses the existing inbound multi-instance test application contexts while retaining the 8.7 runtime properties required by those tests.
- Does not introduce absent runtime tests, the absent mTLS test, or the newer Javadoc job.
- Keeps the HTTP E2E test layout unchanged because these tests are `@SlowTest` on 8.7 and the older process-test lifecycle cannot share one runtime by consolidating classes.

## Related issues

Related to #8812.

## Checklist

- [ ] PR has a **milestone** or the `no milestone` label.