### PR TITLE
[Backport stable/8.9] ci(e2e): use optimized reusable workflow

### DIFF
--- a/.github/workflows/NIGHTLY_E2E.yml
+++ b/.github/workflows/NIGHTLY_E2E.yml
@@ -8,6 +8,7 @@ on:
     types: [ labeled, synchronize ]
 
 permissions:
+  actions: read
   contents: read
   checks: write
 

--- a/.github/workflows/NIGHTLY_E2E.yml
+++ b/.github/workflows/NIGHTLY_E2E.yml
@@ -7,6 +7,10 @@ on:
   pull_request:
     types: [ labeled, synchronize ]
 
+permissions:
+  contents: read
+  checks: write
+
 jobs:
 
   setup:
@@ -15,8 +19,8 @@ jobs:
     if: |
       github.event_name != 'pull_request' ||
       (github.event.pull_request.head.repo.fork == false &&
-       (github.event.action == 'labeled' && github.event.label.name == 'e2e-tests') ||
-       (github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'e2e-tests')))
+       ((github.event.action == 'labeled' && github.event.label.name == 'e2e-tests') ||
+        (github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'e2e-tests'))))
     outputs:
       branches: ${{ steps.set-branches.outputs.branches }}
     steps:

--- a/.github/workflows/NIGHTLY_E2E.yml
+++ b/.github/workflows/NIGHTLY_E2E.yml
@@ -9,19 +9,19 @@ on:
 
 jobs:
 
-  get-branches:
+  setup:
     runs-on: ubuntu-latest
     # Only run if scheduled/manual OR if the 'e2e-tests' label exists on a non-fork PR
     if: |
-      github.event_name != 'pull_request' || 
-      (github.event.pull_request.head.repo.fork == false && 
+      github.event_name != 'pull_request' ||
+      (github.event.pull_request.head.repo.fork == false &&
        (github.event.action == 'labeled' && github.event.label.name == 'e2e-tests') ||
        (github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'e2e-tests')))
     outputs:
-      branches: ${{ steps.set-matrix.outputs.branches }}
+      branches: ${{ steps.set-branches.outputs.branches }}
     steps:
       - name: Fetch stable branches
-        id: set-matrix
+        id: set-branches
         run: |
           if [ "${{ github.event_name }}" == "pull_request" ]; then
             # For PR, only test the PR's head ref
@@ -37,96 +37,13 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   run-e2e-tests:
-    name: (${{ matrix.branch }}) Nightly E2E test run
-    needs: get-branches
-    runs-on: ubuntu-latest
+    name: (${{ matrix.branch }})
+    needs: setup
     strategy:
       fail-fast: false
       matrix:
-        branch: ${{ fromJson(needs.get-branches.outputs.branches) }}
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          ref: ${{ matrix.branch }}
-
-      - name: Import Secrets
-        id: secrets
-        uses: hashicorp/vault-action@v3.4.0
-        with:
-          url: ${{ secrets.VAULT_ADDR }}
-          method: approle
-          roleId: ${{ secrets.VAULT_ROLE_ID }}
-          secretId: ${{ secrets.VAULT_SECRET_ID }}
-          exportEnv: false # we rely on step outputs, no need for environment variables
-          secrets: |
-            secret/data/products/connectors/ci/common ARTIFACTORY_USR | CI_LDAP_USER;
-            secret/data/products/connectors/ci/common ARTIFACTORY_PSW | CI_LDAP_PASSWORD;
-
-      - name: Restore cache
-        uses: actions/cache@v5
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
-
-      - uses: actions/setup-java@v5
-        with:
-          distribution: 'temurin'
-          java-version: '21.0.9'
-
-      # Use CI Nexus as co-located pull-through cache for Maven artifacts via ~/.m2/settings.xml
-
-      - name: 'Create settings.xml'
-        uses: s4u/maven-settings-action@v4.0.0
-        with:
-          githubServer: false
-          servers: |
-            [{
-               "id": "camunda-nexus",
-               "username": "${{ steps.secrets.outputs.CI_LDAP_USER }}",
-               "password": "${{ steps.secrets.outputs.CI_LDAP_PASSWORD }}"
-             }]
-          mirrors: '[{"url": "https://repository.nexus.camunda.cloud/content/groups/internal/", "id": "camunda-nexus", "mirrorOf": "*,!confluent,!shibboleth", "name": "camunda Nexus"}]'
-
-      - uses: actions/setup-node@v6
-        with:
-          node-version: '24'
-
-      - name: Install element templates CLI
-        run: npm install --global element-templates-cli@$(jq -r '.devDependencies["element-templates-cli"]' .github/workflows/package.json)
-
-      - name: Build Connectors
-        run: ./mvnw --batch-mode -U clean test -PcheckFormat
-
-      - name: Publish Test Report
-        if: always()
-        uses: scacap/action-surefire-report@v1
-
-      - name: Sanitize branch name for artifact
-        if: always()
-        id: sanitize
-        run: |
-          SANITIZED="${BRANCH//\//-}"
-          echo "branch=$SANITIZED" >> $GITHUB_OUTPUT
-        env:
-          BRANCH: ${{ matrix.branch }}
-
-      - name: Upload detailed surefire reports
-        if: always()
-        uses: actions/upload-artifact@v7
-        with:
-          name: surefire-reports-${{ steps.sanitize.outputs.branch }}-${{ github.run_id }}-${{ github.run_attempt }}
-          path: '**/target/surefire-reports/*.xml'
-
-      - name: Send Slack notification on failure
-        if: failure() && (matrix.branch == 'main' || startsWith(matrix.branch, 'stable/'))
-        uses: slackapi/slack-github-action@v3.0.5
-        with:
-          token: ${{ secrets.CONNECTORS_SLACK_BOT_TOKEN }}
-          method: chat.postMessage
-          payload: |
-            {
-              "channel": ${{ secrets.CONNECTORS_SUPPORT_SLACK_CHANNEL_ID }},
-              "text": ":alarm: ${{ secrets.CONNECTORS_MEDIC_SLACK_GROUP_ID }} E2E test run failed on branch `${{ matrix.branch}}`.\nCheck details: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-            }
+        branch: ${{ fromJson(needs.setup.outputs.branches) }}
+    uses: ./.github/workflows/E2E_BRANCH_RUN.yml
+    with:
+      branch: ${{ matrix.branch }}
+    secrets: inherit


### PR DESCRIPTION
## Description

Wire stable/8.9 nightly and labeled-PR E2E runs to the reusable workflow introduced by #8803. Without this change, `NIGHTLY_E2E.yml` continues to run the legacy monolithic `clean test` build and does not use the E2E optimizations from #8790.

## Related issues

Follow-up to #8790 and #8803.

## Checklist

- [x] This directly targets stable/8.9; no additional backport label is needed.
- [x] The workflow matches the validated reusable-workflow entry point on main.
- [x] No documentation update is required.