### PR TITLE
[stable/8.6] fix(e2e): remove unsupported shared runtime mode

### DIFF
--- a/connectors-e2e-test/connectors-e2e-test-automation-anywhere/src/test/resources/application.yml
+++ b/connectors-e2e-test/connectors-e2e-test-automation-anywhere/src/test/resources/application.yml
@@ -1,3 +1,0 @@
-camunda:
-  process-test:
-    runtime-mode: shared

--- a/connectors-e2e-test/connectors-e2e-test-kafka/src/test/resources/application.yml
+++ b/connectors-e2e-test/connectors-e2e-test-kafka/src/test/resources/application.yml
@@ -1,3 +1,0 @@
-camunda:
-  process-test:
-    runtime-mode: shared

--- a/connectors-e2e-test/connectors-e2e-test-rabbitmq/src/test/resources/application.yml
+++ b/connectors-e2e-test/connectors-e2e-test-rabbitmq/src/test/resources/application.yml
@@ -1,3 +1,0 @@
-camunda:
-  process-test:
-    runtime-mode: shared


### PR DESCRIPTION
## Description

Removes the shared Camunda Process Test runtime configuration backported in #8842. The CPT version on stable/8.6 does not provide the `SHARED` runtime mode, so retaining these files would fail E2E test startup rather than improve it.

This keeps the branch on its supported per-test runtime behavior.

## Related issues

Follow-up to #8842.