### PR TITLE
fix(e2e): harden reusable workflow caller

### DIFF
--- a/.github/workflows/NIGHTLY_E2E.yml
+++ b/.github/workflows/NIGHTLY_E2E.yml
@@ -7,6 +7,11 @@ on:
   pull_request:
     types: [ labeled, synchronize ]
 
+permissions:
+  actions: read
+  contents: read
+  checks: write
+
 jobs:
 
   setup:
@@ -15,8 +20,8 @@ jobs:
     if: |
       github.event_name != 'pull_request' ||
       (github.event.pull_request.head.repo.fork == false &&
-       (github.event.action == 'labeled' && github.event.label.name == 'e2e-tests') ||
-       (github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'e2e-tests')))
+       ((github.event.action == 'labeled' && github.event.label.name == 'e2e-tests') ||
+        (github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'e2e-tests'))))
     outputs:
       branches: ${{ steps.set-branches.outputs.branches }}
     steps:


### PR DESCRIPTION
## Description

Prevents fork PR synchronizations from invoking the secrets-dependent E2E workflow by applying the fork guard to both supported pull-request actions.

Also explicitly grants the reusable workflow the read access needed for repository and Actions data, plus write access for test report checks. This avoids relying on changing repository defaults.

## Related issues

Follow-up to #8790.