### PR TITLE
fix(agentic-ai): log ChatModel close() failures at error, not warn

### DIFF
--- a/connectors/agentic-ai/connector-agentic-ai/pom.xml
+++ b/connectors/agentic-ai/connector-agentic-ai/pom.xml
@@ -407,6 +407,16 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.awaitility</groupId>
       <artifactId>awaitility</artifactId>
       <scope>test</scope>

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/anthropic/AnthropicChatModel.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/anthropic/AnthropicChatModel.java
@@ -153,7 +153,7 @@ public class AnthropicChatModel implements ChatModel {
     try {
       client.close();
     } catch (Exception e) {
-      LOG.warn("Failed to close AnthropicClient", e);
+      LOG.error("Failed to close AnthropicClient", e);
     }
   }
 }

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/bedrock/BedrockConverseChatModel.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/bedrock/BedrockConverseChatModel.java
@@ -140,7 +140,7 @@ public class BedrockConverseChatModel implements ChatModel {
     try {
       client.close();
     } catch (Exception e) {
-      LOG.warn("Failed to close BedrockRuntimeAsyncClient", e);
+      LOG.error("Failed to close BedrockRuntimeAsyncClient", e);
     }
   }
 }

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiChatModel.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiChatModel.java
@@ -148,7 +148,7 @@ public class GeminiChatModel implements ChatModel {
     try {
       client.close();
     } catch (Exception e) {
-      LOG.warn("Failed to close Gemini Client", e);
+      LOG.error("Failed to close Gemini Client", e);
     }
   }
 }

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/langchain4j/CloseableChatModelDelegate.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/langchain4j/CloseableChatModelDelegate.java
@@ -59,7 +59,7 @@ public record CloseableChatModelDelegate(ChatModel delegate, AutoCloseable resou
     try {
       resource.close();
     } catch (Exception e) {
-      LOGGER.warn("Failed to close chat model resource", e);
+      LOGGER.error("Failed to close chat model resource", e);
     }
   }
 }

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/langchain4j/LangChain4JChatModel.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/langchain4j/LangChain4JChatModel.java
@@ -168,7 +168,7 @@ public class LangChain4JChatModel implements ChatModel {
     try {
       chatModel.close();
     } catch (Exception e) {
-      LOG.warn("Failed to close CloseableChatModel", e);
+      LOG.error("Failed to close CloseableChatModel", e);
     }
   }
 }

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/openai/OpenAiChatModel.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/openai/OpenAiChatModel.java
@@ -113,7 +113,7 @@ public class OpenAiChatModel implements ChatModel {
     try {
       client.close();
     } catch (Exception e) {
-      LOG.warn("Failed to close OpenAIClient", e);
+      LOG.error("Failed to close OpenAIClient", e);
     }
   }
 }

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/LogEventsTestSupport.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/LogEventsTestSupport.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.agenticai.aiagent.chatmodel;
+
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import java.util.List;
+import org.slf4j.LoggerFactory;
+
+public final class LogEventsTestSupport {
+
+  private LogEventsTestSupport() {}
+
+  /** Every log event {@code loggerClass}'s logger emits while {@code action} runs. */
+  public static List<ILoggingEvent> logsOf(Class<?> loggerClass, Runnable action) {
+    var logger = (Logger) LoggerFactory.getLogger(loggerClass);
+    var appender = new ListAppender<ILoggingEvent>();
+    appender.start();
+    logger.addAppender(appender);
+    try {
+      action.run();
+    } finally {
+      logger.detachAppender(appender);
+      appender.stop();
+    }
+    return appender.list;
+  }
+}

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/anthropic/AnthropicChatModelTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/anthropic/AnthropicChatModelTest.java
@@ -16,6 +16,10 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
 import com.anthropic.client.AnthropicClient;
 import com.anthropic.core.JsonValue;
 import com.anthropic.core.http.Headers;
@@ -46,6 +50,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.LoggerFactory;
 
 @ExtendWith(MockitoExtension.class)
 class AnthropicChatModelTest {
@@ -237,8 +242,29 @@ class AnthropicChatModelTest {
   void closeLogsErrorInsteadOfThrowingWhenClientCloseFails() {
     doThrow(new RuntimeException("boom")).when(client).close();
 
-    api.close();
+    var events = logsOf(api::close);
 
     verify(client).close();
+    assertThat(events)
+        .singleElement()
+        .satisfies(
+            event -> {
+              assertThat(event.getLevel()).isEqualTo(Level.ERROR);
+              assertThat(event.getFormattedMessage()).isEqualTo("Failed to close AnthropicClient");
+            });
+  }
+
+  private static List<ILoggingEvent> logsOf(Runnable action) {
+    var logger = (Logger) LoggerFactory.getLogger(AnthropicChatModel.class);
+    var appender = new ListAppender<ILoggingEvent>();
+    appender.start();
+    logger.addAppender(appender);
+    try {
+      action.run();
+    } finally {
+      logger.detachAppender(appender);
+      appender.stop();
+    }
+    return appender.list;
   }
 }

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/anthropic/AnthropicChatModelTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/anthropic/AnthropicChatModelTest.java
@@ -6,6 +6,7 @@
  */
 package io.camunda.connector.agenticai.aiagent.chatmodel.provider.anthropic;
 
+import static io.camunda.connector.agenticai.aiagent.chatmodel.LogEventsTestSupport.logsOf;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
@@ -17,9 +18,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import ch.qos.logback.classic.Level;
-import ch.qos.logback.classic.Logger;
-import ch.qos.logback.classic.spi.ILoggingEvent;
-import ch.qos.logback.core.read.ListAppender;
 import com.anthropic.client.AnthropicClient;
 import com.anthropic.core.JsonValue;
 import com.anthropic.core.http.Headers;
@@ -50,7 +48,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.slf4j.LoggerFactory;
 
 @ExtendWith(MockitoExtension.class)
 class AnthropicChatModelTest {
@@ -242,7 +239,7 @@ class AnthropicChatModelTest {
   void closeLogsErrorInsteadOfThrowingWhenClientCloseFails() {
     doThrow(new RuntimeException("boom")).when(client).close();
 
-    var events = logsOf(api::close);
+    var events = logsOf(AnthropicChatModel.class, api::close);
 
     verify(client).close();
     assertThat(events)
@@ -252,19 +249,5 @@ class AnthropicChatModelTest {
               assertThat(event.getLevel()).isEqualTo(Level.ERROR);
               assertThat(event.getFormattedMessage()).isEqualTo("Failed to close AnthropicClient");
             });
-  }
-
-  private static List<ILoggingEvent> logsOf(Runnable action) {
-    var logger = (Logger) LoggerFactory.getLogger(AnthropicChatModel.class);
-    var appender = new ListAppender<ILoggingEvent>();
-    appender.start();
-    logger.addAppender(appender);
-    try {
-      action.run();
-    } finally {
-      logger.detachAppender(appender);
-      appender.stop();
-    }
-    return appender.list;
   }
 }

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/anthropic/AnthropicChatModelTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/anthropic/AnthropicChatModelTest.java
@@ -234,7 +234,7 @@ class AnthropicChatModelTest {
   }
 
   @Test
-  void closeLogsWarningInsteadOfThrowingWhenClientCloseFails() {
+  void closeLogsErrorInsteadOfThrowingWhenClientCloseFails() {
     doThrow(new RuntimeException("boom")).when(client).close();
 
     api.close();

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/bedrock/BedrockConverseChatModelTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/bedrock/BedrockConverseChatModelTest.java
@@ -6,6 +6,7 @@
  */
 package io.camunda.connector.agenticai.aiagent.chatmodel.provider.bedrock;
 
+import static io.camunda.connector.agenticai.aiagent.chatmodel.LogEventsTestSupport.logsOf;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
@@ -18,9 +19,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import ch.qos.logback.classic.Level;
-import ch.qos.logback.classic.Logger;
-import ch.qos.logback.classic.spi.ILoggingEvent;
-import ch.qos.logback.core.read.ListAppender;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.connector.agenticai.aiagent.agent.AgentErrorCodes;
 import io.camunda.connector.agenticai.aiagent.chatmodel.ChatRequest;
@@ -44,7 +42,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.awscore.exception.AwsErrorDetails;
 import software.amazon.awssdk.awscore.exception.AwsServiceException;
 import software.amazon.awssdk.core.async.SdkPublisher;
@@ -240,6 +237,7 @@ class BedrockConverseChatModelTest {
 
     var events =
         logsOf(
+            BedrockConverseChatModel.class,
             () -> {
               api.close();
               api.close();
@@ -254,20 +252,6 @@ class BedrockConverseChatModelTest {
               assertThat(event.getFormattedMessage())
                   .isEqualTo("Failed to close BedrockRuntimeAsyncClient");
             });
-  }
-
-  private static List<ILoggingEvent> logsOf(Runnable action) {
-    var logger = (Logger) LoggerFactory.getLogger(BedrockConverseChatModel.class);
-    var appender = new ListAppender<ILoggingEvent>();
-    appender.start();
-    logger.addAppender(appender);
-    try {
-      action.run();
-    } finally {
-      logger.detachAppender(appender);
-      appender.stop();
-    }
-    return appender.list;
   }
 
   private static AwsServiceException awsServiceException() {

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/bedrock/BedrockConverseChatModelTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/bedrock/BedrockConverseChatModelTest.java
@@ -230,7 +230,7 @@ class BedrockConverseChatModelTest {
   }
 
   @Test
-  void closeIsIdempotentAndLogsWarningInsteadOfThrowingWhenClientCloseFails() {
+  void closeIsIdempotentAndLogsErrorInsteadOfThrowingWhenClientCloseFails() {
     doThrow(new RuntimeException("boom")).when(client).close();
 
     api.close();

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/bedrock/BedrockConverseChatModelTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/bedrock/BedrockConverseChatModelTest.java
@@ -17,6 +17,10 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.connector.agenticai.aiagent.agent.AgentErrorCodes;
 import io.camunda.connector.agenticai.aiagent.chatmodel.ChatRequest;
@@ -40,6 +44,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.awscore.exception.AwsErrorDetails;
 import software.amazon.awssdk.awscore.exception.AwsServiceException;
 import software.amazon.awssdk.core.async.SdkPublisher;
@@ -233,10 +238,36 @@ class BedrockConverseChatModelTest {
   void closeIsIdempotentAndLogsErrorInsteadOfThrowingWhenClientCloseFails() {
     doThrow(new RuntimeException("boom")).when(client).close();
 
-    api.close();
-    api.close();
+    var events =
+        logsOf(
+            () -> {
+              api.close();
+              api.close();
+            });
 
     verify(client, times(2)).close();
+    assertThat(events).hasSize(2);
+    assertThat(events)
+        .allSatisfy(
+            event -> {
+              assertThat(event.getLevel()).isEqualTo(Level.ERROR);
+              assertThat(event.getFormattedMessage())
+                  .isEqualTo("Failed to close BedrockRuntimeAsyncClient");
+            });
+  }
+
+  private static List<ILoggingEvent> logsOf(Runnable action) {
+    var logger = (Logger) LoggerFactory.getLogger(BedrockConverseChatModel.class);
+    var appender = new ListAppender<ILoggingEvent>();
+    appender.start();
+    logger.addAppender(appender);
+    try {
+      action.run();
+    } finally {
+      logger.detachAppender(appender);
+      appender.stop();
+    }
+    return appender.list;
   }
 
   private static AwsServiceException awsServiceException() {

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiChatModelTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiChatModelTest.java
@@ -222,7 +222,7 @@ class GeminiChatModelTest {
   }
 
   @Test
-  void closeLogsWarningInsteadOfThrowingWhenClientCloseFails() {
+  void closeLogsErrorInsteadOfThrowingWhenClientCloseFails() {
     doThrow(new RuntimeException("boom")).when(client).close();
 
     api.close();

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiChatModelTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiChatModelTest.java
@@ -18,6 +18,10 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
 import com.google.genai.Client;
 import com.google.genai.Models;
 import com.google.genai.ResponseStream;
@@ -47,6 +51,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.LoggerFactory;
 import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
@@ -225,8 +230,29 @@ class GeminiChatModelTest {
   void closeLogsErrorInsteadOfThrowingWhenClientCloseFails() {
     doThrow(new RuntimeException("boom")).when(client).close();
 
-    api.close();
+    var events = logsOf(api::close);
 
     verify(client).close();
+    assertThat(events)
+        .singleElement()
+        .satisfies(
+            event -> {
+              assertThat(event.getLevel()).isEqualTo(Level.ERROR);
+              assertThat(event.getFormattedMessage()).isEqualTo("Failed to close Gemini Client");
+            });
+  }
+
+  private static List<ILoggingEvent> logsOf(Runnable action) {
+    var logger = (Logger) LoggerFactory.getLogger(GeminiChatModel.class);
+    var appender = new ListAppender<ILoggingEvent>();
+    appender.start();
+    logger.addAppender(appender);
+    try {
+      action.run();
+    } finally {
+      logger.detachAppender(appender);
+      appender.stop();
+    }
+    return appender.list;
   }
 }

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiChatModelTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/gemini/GeminiChatModelTest.java
@@ -7,6 +7,7 @@
 package io.camunda.connector.agenticai.aiagent.chatmodel.provider.gemini;
 
 import static io.camunda.connector.agenticai.aiagent.agent.AgentErrorCodes.ERROR_CODE_FAILED_MODEL_CALL;
+import static io.camunda.connector.agenticai.aiagent.chatmodel.LogEventsTestSupport.logsOf;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
@@ -19,9 +20,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import ch.qos.logback.classic.Level;
-import ch.qos.logback.classic.Logger;
-import ch.qos.logback.classic.spi.ILoggingEvent;
-import ch.qos.logback.core.read.ListAppender;
 import com.google.genai.Client;
 import com.google.genai.Models;
 import com.google.genai.ResponseStream;
@@ -51,7 +49,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.slf4j.LoggerFactory;
 import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
@@ -230,7 +227,7 @@ class GeminiChatModelTest {
   void closeLogsErrorInsteadOfThrowingWhenClientCloseFails() {
     doThrow(new RuntimeException("boom")).when(client).close();
 
-    var events = logsOf(api::close);
+    var events = logsOf(GeminiChatModel.class, api::close);
 
     verify(client).close();
     assertThat(events)
@@ -240,19 +237,5 @@ class GeminiChatModelTest {
               assertThat(event.getLevel()).isEqualTo(Level.ERROR);
               assertThat(event.getFormattedMessage()).isEqualTo("Failed to close Gemini Client");
             });
-  }
-
-  private static List<ILoggingEvent> logsOf(Runnable action) {
-    var logger = (Logger) LoggerFactory.getLogger(GeminiChatModel.class);
-    var appender = new ListAppender<ILoggingEvent>();
-    appender.start();
-    logger.addAppender(appender);
-    try {
-      action.run();
-    } finally {
-      logger.detachAppender(appender);
-      appender.stop();
-    }
-    return appender.list;
   }
 }

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/langchain4j/CloseableChatModelDelegateTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/langchain4j/CloseableChatModelDelegateTest.java
@@ -13,6 +13,10 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
 import dev.langchain4j.model.ModelProvider;
 import dev.langchain4j.model.chat.Capability;
 import dev.langchain4j.model.chat.ChatModel;
@@ -27,6 +31,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.LoggerFactory;
 
 @ExtendWith(MockitoExtension.class)
 class CloseableChatModelDelegateTest {
@@ -94,7 +99,30 @@ class CloseableChatModelDelegateTest {
   void swallowsExceptionFromResourceClose() throws Exception {
     doThrow(new RuntimeException("close failed")).when(resource).close();
 
-    assertThatNoException().isThrownBy(() -> subject.close());
+    var events = logsOf(() -> assertThatNoException().isThrownBy(() -> subject.close()));
+
     verify(resource).close();
+    assertThat(events)
+        .singleElement()
+        .satisfies(
+            event -> {
+              assertThat(event.getLevel()).isEqualTo(Level.ERROR);
+              assertThat(event.getFormattedMessage())
+                  .isEqualTo("Failed to close chat model resource");
+            });
+  }
+
+  private static List<ILoggingEvent> logsOf(Runnable action) {
+    var logger = (Logger) LoggerFactory.getLogger(CloseableChatModelDelegate.class);
+    var appender = new ListAppender<ILoggingEvent>();
+    appender.start();
+    logger.addAppender(appender);
+    try {
+      action.run();
+    } finally {
+      logger.detachAppender(appender);
+      appender.stop();
+    }
+    return appender.list;
   }
 }

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/langchain4j/CloseableChatModelDelegateTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/langchain4j/CloseableChatModelDelegateTest.java
@@ -6,6 +6,7 @@
  */
 package io.camunda.connector.agenticai.aiagent.chatmodel.provider.langchain4j;
 
+import static io.camunda.connector.agenticai.aiagent.chatmodel.LogEventsTestSupport.logsOf;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.mockito.Mockito.doThrow;
@@ -14,9 +15,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import ch.qos.logback.classic.Level;
-import ch.qos.logback.classic.Logger;
-import ch.qos.logback.classic.spi.ILoggingEvent;
-import ch.qos.logback.core.read.ListAppender;
 import dev.langchain4j.model.ModelProvider;
 import dev.langchain4j.model.chat.Capability;
 import dev.langchain4j.model.chat.ChatModel;
@@ -31,7 +29,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.slf4j.LoggerFactory;
 
 @ExtendWith(MockitoExtension.class)
 class CloseableChatModelDelegateTest {
@@ -99,7 +96,10 @@ class CloseableChatModelDelegateTest {
   void swallowsExceptionFromResourceClose() throws Exception {
     doThrow(new RuntimeException("close failed")).when(resource).close();
 
-    var events = logsOf(() -> assertThatNoException().isThrownBy(() -> subject.close()));
+    var events =
+        logsOf(
+            CloseableChatModelDelegate.class,
+            () -> assertThatNoException().isThrownBy(() -> subject.close()));
 
     verify(resource).close();
     assertThat(events)
@@ -110,19 +110,5 @@ class CloseableChatModelDelegateTest {
               assertThat(event.getFormattedMessage())
                   .isEqualTo("Failed to close chat model resource");
             });
-  }
-
-  private static List<ILoggingEvent> logsOf(Runnable action) {
-    var logger = (Logger) LoggerFactory.getLogger(CloseableChatModelDelegate.class);
-    var appender = new ListAppender<ILoggingEvent>();
-    appender.start();
-    logger.addAppender(appender);
-    try {
-      action.run();
-    } finally {
-      logger.detachAppender(appender);
-      appender.stop();
-    }
-    return appender.list;
   }
 }

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/langchain4j/LangChain4JChatModelTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/langchain4j/LangChain4JChatModelTest.java
@@ -20,6 +20,10 @@ import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
 import dev.langchain4j.agent.tool.ToolSpecification;
 import dev.langchain4j.data.message.ChatMessage;
 import dev.langchain4j.exception.ModelNotFoundException;
@@ -60,6 +64,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.LoggerFactory;
 
 @ExtendWith(MockitoExtension.class)
 class LangChain4JChatModelTest {
@@ -346,6 +351,37 @@ class LangChain4JChatModelTest {
   void closeClosesTheUnderlyingChatModel() {
     api.close();
     verify(chatModel).close();
+  }
+
+  @Test
+  void closeLogsErrorInsteadOfThrowingWhenChatModelCloseFails() {
+    doThrow(new RuntimeException("boom")).when(chatModel).close();
+
+    var events = logsOf(api::close);
+
+    verify(chatModel).close();
+    assertThat(events)
+        .singleElement()
+        .satisfies(
+            event -> {
+              assertThat(event.getLevel()).isEqualTo(Level.ERROR);
+              assertThat(event.getFormattedMessage())
+                  .isEqualTo("Failed to close CloseableChatModel");
+            });
+  }
+
+  private static List<ILoggingEvent> logsOf(Runnable action) {
+    var logger = (Logger) LoggerFactory.getLogger(LangChain4JChatModel.class);
+    var appender = new ListAppender<ILoggingEvent>();
+    appender.start();
+    logger.addAppender(appender);
+    try {
+      action.run();
+    } finally {
+      logger.detachAppender(appender);
+      appender.stop();
+    }
+    return appender.list;
   }
 
   private AgentExecutionContext createExecutionContext() {

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/langchain4j/LangChain4JChatModelTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/langchain4j/LangChain4JChatModelTest.java
@@ -9,6 +9,7 @@ package io.camunda.connector.agenticai.aiagent.chatmodel.provider.langchain4j;
 import static io.camunda.connector.agenticai.aiagent.TestMessagesFixture.assistantMessage;
 import static io.camunda.connector.agenticai.aiagent.TestMessagesFixture.systemMessage;
 import static io.camunda.connector.agenticai.aiagent.TestMessagesFixture.userMessage;
+import static io.camunda.connector.agenticai.aiagent.chatmodel.LogEventsTestSupport.logsOf;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
@@ -21,9 +22,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import ch.qos.logback.classic.Level;
-import ch.qos.logback.classic.Logger;
-import ch.qos.logback.classic.spi.ILoggingEvent;
-import ch.qos.logback.core.read.ListAppender;
 import dev.langchain4j.agent.tool.ToolSpecification;
 import dev.langchain4j.data.message.ChatMessage;
 import dev.langchain4j.exception.ModelNotFoundException;
@@ -64,7 +62,6 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.slf4j.LoggerFactory;
 
 @ExtendWith(MockitoExtension.class)
 class LangChain4JChatModelTest {
@@ -357,7 +354,7 @@ class LangChain4JChatModelTest {
   void closeLogsErrorInsteadOfThrowingWhenChatModelCloseFails() {
     doThrow(new RuntimeException("boom")).when(chatModel).close();
 
-    var events = logsOf(api::close);
+    var events = logsOf(LangChain4JChatModel.class, api::close);
 
     verify(chatModel).close();
     assertThat(events)
@@ -368,20 +365,6 @@ class LangChain4JChatModelTest {
               assertThat(event.getFormattedMessage())
                   .isEqualTo("Failed to close CloseableChatModel");
             });
-  }
-
-  private static List<ILoggingEvent> logsOf(Runnable action) {
-    var logger = (Logger) LoggerFactory.getLogger(LangChain4JChatModel.class);
-    var appender = new ListAppender<ILoggingEvent>();
-    appender.start();
-    logger.addAppender(appender);
-    try {
-      action.run();
-    } finally {
-      logger.detachAppender(appender);
-      appender.stop();
-    }
-    return appender.list;
   }
 
   private AgentExecutionContext createExecutionContext() {

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/openai/OpenAiChatModelTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/openai/OpenAiChatModelTest.java
@@ -6,6 +6,7 @@
  */
 package io.camunda.connector.agenticai.aiagent.chatmodel.provider.openai;
 
+import static io.camunda.connector.agenticai.aiagent.chatmodel.LogEventsTestSupport.logsOf;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.eq;
@@ -16,9 +17,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import ch.qos.logback.classic.Level;
-import ch.qos.logback.classic.Logger;
-import ch.qos.logback.classic.spi.ILoggingEvent;
-import ch.qos.logback.core.read.ListAppender;
 import com.openai.client.OpenAIClient;
 import com.openai.core.http.Headers;
 import com.openai.errors.BadRequestException;
@@ -46,7 +44,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.slf4j.LoggerFactory;
 
 @ExtendWith(MockitoExtension.class)
 class OpenAiChatModelTest {
@@ -220,7 +217,7 @@ class OpenAiChatModelTest {
   void closeLogsErrorInsteadOfThrowingWhenClientCloseFails() {
     doThrow(new RuntimeException("boom")).when(client).close();
 
-    var events = logsOf(api::close);
+    var events = logsOf(OpenAiChatModel.class, api::close);
 
     verify(client).close();
     assertThat(events)
@@ -230,19 +227,5 @@ class OpenAiChatModelTest {
               assertThat(event.getLevel()).isEqualTo(Level.ERROR);
               assertThat(event.getFormattedMessage()).isEqualTo("Failed to close OpenAIClient");
             });
-  }
-
-  private static List<ILoggingEvent> logsOf(Runnable action) {
-    var logger = (Logger) LoggerFactory.getLogger(OpenAiChatModel.class);
-    var appender = new ListAppender<ILoggingEvent>();
-    appender.start();
-    logger.addAppender(appender);
-    try {
-      action.run();
-    } finally {
-      logger.detachAppender(appender);
-      appender.stop();
-    }
-    return appender.list;
   }
 }

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/openai/OpenAiChatModelTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/openai/OpenAiChatModelTest.java
@@ -15,6 +15,10 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
 import com.openai.client.OpenAIClient;
 import com.openai.core.http.Headers;
 import com.openai.errors.BadRequestException;
@@ -42,6 +46,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.LoggerFactory;
 
 @ExtendWith(MockitoExtension.class)
 class OpenAiChatModelTest {
@@ -215,8 +220,29 @@ class OpenAiChatModelTest {
   void closeLogsErrorInsteadOfThrowingWhenClientCloseFails() {
     doThrow(new RuntimeException("boom")).when(client).close();
 
-    api.close();
+    var events = logsOf(api::close);
 
     verify(client).close();
+    assertThat(events)
+        .singleElement()
+        .satisfies(
+            event -> {
+              assertThat(event.getLevel()).isEqualTo(Level.ERROR);
+              assertThat(event.getFormattedMessage()).isEqualTo("Failed to close OpenAIClient");
+            });
+  }
+
+  private static List<ILoggingEvent> logsOf(Runnable action) {
+    var logger = (Logger) LoggerFactory.getLogger(OpenAiChatModel.class);
+    var appender = new ListAppender<ILoggingEvent>();
+    appender.start();
+    logger.addAppender(appender);
+    try {
+      action.run();
+    } finally {
+      logger.detachAppender(appender);
+      appender.stop();
+    }
+    return appender.list;
   }
 }

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/openai/OpenAiChatModelTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/openai/OpenAiChatModelTest.java
@@ -212,7 +212,7 @@ class OpenAiChatModelTest {
   }
 
   @Test
-  void closeLogsWarningInsteadOfThrowingWhenClientCloseFails() {
+  void closeLogsErrorInsteadOfThrowingWhenClientCloseFails() {
     doThrow(new RuntimeException("boom")).when(client).close();
 
     api.close();


### PR DESCRIPTION
## Description

The SDK/framework client's `close()` failure inside `ChatModel.close()` was logged at `warn` across every provider, native and LangChain4j-backed alike. A failed client close can leak connections, so it warrants an `error` log instead. One-pass, cross-cutting normalization, no behavior change.

## Related issues

closes #8376

## Checklist

- [x] Backport labels are added if these code changes should be backported.
- [x] Tests/Integration tests for the changes have been added if applicable.
- [x] If the change requires a documentation update, it has been added to the appropriate section in the documentation.