### PR TITLE
[stable/8.6] fix(ci): skip unsupported Helm deployment test

### DIFF
--- a/.github/workflows/FEATURE_BRANCH_HELM_TEST.yaml
+++ b/.github/workflows/FEATURE_BRANCH_HELM_TEST.yaml
@@ -142,17 +142,6 @@ jobs:
           push: true
           tags: registry.camunda.cloud/team-connectors/connectors-bundle-saas:${{ env.TAG }}
 
-  trigger-sm-e2e:
-    name: Trigger SM E2E tests
-    needs: [ build-image ]
-    uses: ./.github/workflows/INTEGRATION_TEST.yml
-    secrets: inherit
-    with:
-      image-source: artifactory
-      connectors-version: ${{ needs.build-image.outputs.connectors-version }}
-      release-branch: main
-      helm-dir: camunda-platform-8.6
-
   trigger-saas-e2e:
     name: Trigger SaaS E2E tests
     runs-on: ubuntu-latest

--- a/.github/workflows/FEATURE_BRANCH_HELM_TEST.yaml
+++ b/.github/workflows/FEATURE_BRANCH_HELM_TEST.yaml
@@ -142,6 +142,17 @@ jobs:
           push: true
           tags: registry.camunda.cloud/team-connectors/connectors-bundle-saas:${{ env.TAG }}
 
+  trigger-sm-e2e:
+    name: Trigger SM E2E tests
+    needs: [ build-image ]
+    uses: ./.github/workflows/INTEGRATION_TEST.yml
+    secrets: inherit
+    with:
+      image-source: artifactory
+      connectors-version: ${{ needs.build-image.outputs.connectors-version }}
+      release-branch: main
+      helm-dir: camunda-platform-8.6
+
   trigger-saas-e2e:
     name: Trigger SaaS E2E tests
     runs-on: ubuntu-latest

--- a/.github/workflows/INTEGRATION_TEST.yml
+++ b/.github/workflows/INTEGRATION_TEST.yml
@@ -166,12 +166,12 @@ jobs:
     if: github.ref != 'refs/heads/main' && !contains(github.event.pull_request.labels.*.name, 'skip-helm-deploy')
     needs: prepare-inputs
     name: Helm chart Integration Tests
-    uses: camunda/camunda-platform-helm/.github/workflows/test-integration-template.yaml@177bee5d9f794950b7b6f47f731f6b9a64432d3f
+    uses: camunda/camunda-platform-helm/.github/workflows/test-integration-template.yaml@main
     secrets: inherit
     with:
       identifier: connectors-int-${{ github.run_id }}
       camunda-helm-dir: ${{ needs.prepare-inputs.outputs.helm-dir }}
-      camunda-helm-git-ref: 56633ff6aa8c6896d780292701dde07391d99f84
+      camunda-helm-git-ref: main
       # test-enabled enables testing generally, both IT and E2E tests.
       test-enabled: true
       # e2e-enabled is our way to disable E2E tests if needed.

--- a/.github/workflows/INTEGRATION_TEST.yml
+++ b/.github/workflows/INTEGRATION_TEST.yml
@@ -163,7 +163,7 @@ jobs:
           echo "=========================================="
 
   helm-deploy:
-    if: github.ref != 'refs/heads/main' && !contains(github.event.pull_request.labels.*.name, 'skip-helm-deploy')
+    if: github.ref != 'refs/heads/main' && needs.prepare-inputs.outputs.helm-dir != 'camunda-platform-8.6' && !contains(github.event.pull_request.labels.*.name, 'skip-helm-deploy')
     needs: prepare-inputs
     name: Helm chart Integration Tests
     uses: camunda/camunda-platform-helm/.github/workflows/test-integration-template.yaml@main

--- a/.github/workflows/INTEGRATION_TEST.yml
+++ b/.github/workflows/INTEGRATION_TEST.yml
@@ -166,12 +166,12 @@ jobs:
     if: github.ref != 'refs/heads/main' && !contains(github.event.pull_request.labels.*.name, 'skip-helm-deploy')
     needs: prepare-inputs
     name: Helm chart Integration Tests
-    uses: camunda/camunda-platform-helm/.github/workflows/test-integration-template.yaml@main
+    uses: camunda/camunda-platform-helm/.github/workflows/test-integration-template.yaml@56633ff6aa8c6896d780292701dde07391d99f84
     secrets: inherit
     with:
       identifier: connectors-int-${{ github.run_id }}
       camunda-helm-dir: ${{ needs.prepare-inputs.outputs.helm-dir }}
-      camunda-helm-git-ref: main
+      camunda-helm-git-ref: 56633ff6aa8c6896d780292701dde07391d99f84
       # test-enabled enables testing generally, both IT and E2E tests.
       test-enabled: true
       # e2e-enabled is our way to disable E2E tests if needed.

--- a/.github/workflows/INTEGRATION_TEST.yml
+++ b/.github/workflows/INTEGRATION_TEST.yml
@@ -166,7 +166,7 @@ jobs:
     if: github.ref != 'refs/heads/main' && !contains(github.event.pull_request.labels.*.name, 'skip-helm-deploy')
     needs: prepare-inputs
     name: Helm chart Integration Tests
-    uses: camunda/camunda-platform-helm/.github/workflows/test-integration-template.yaml@56633ff6aa8c6896d780292701dde07391d99f84
+    uses: camunda/camunda-platform-helm/.github/workflows/test-integration-template.yaml@177bee5d9f794950b7b6f47f731f6b9a64432d3f
     secrets: inherit
     with:
       identifier: connectors-int-${{ github.run_id }}


### PR DESCRIPTION
## Description

Skip the Self-Managed Helm deployment when the shared integration workflow resolves `camunda-platform-8.6`. The upstream `camunda-platform-helm` matrix intentionally tests alpha and standard-support minors; 8.6 moved to extended support on April 17 and is now rejected before deployment with `requested version "8.6" is not active`.

The guard lives in the shared integration workflow so feature-branch, snapshot, and release callers behave consistently. They still prepare inputs, build and publish connectors images, and retain their other E2E paths; only the unsupported 8.6 Helm deployment job is skipped.

## Related issues

Follow-up to #8845.

## Checklist

- [ ] PR has a **milestone** or the `no milestone` label.