### PR TITLE
refactor(agentic-ai): report backend and API family in agent-instance provider string

### DIFF
--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/agentinstance/CamundaAgentInstanceClient.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/agentinstance/CamundaAgentInstanceClient.java
@@ -109,11 +109,8 @@ public class CamundaAgentInstanceClient implements AgentInstanceClient {
         "Creating agent instance for element instance {}: model={}, provider={}",
         elementInstanceKey,
         configuration.chatModel().model(),
-        configuration.chatModel().provider());
+        configuration.chatModel().descriptiveProvider());
 
-    // model/provider are set only here, at create time; later CONFIGURATION items omit them.
-    // maxModelCalls isn't set here either: the engine rejects top-level limits alongside a
-    // history batch.
     final var command =
         camundaClient
             .newCreateAgentInstanceCommand()
@@ -123,8 +120,7 @@ public class CamundaAgentInstanceClient implements AgentInstanceClient {
             .history(
                 List.of(
                     configurationHistoryItem(configuration, FIRST_ITERATION, OffsetDateTime.now())
-                        .model(configuration.chatModel().model())
-                        .provider(configuration.chatModel().provider())));
+                        .model(configuration.chatModel().model())));
 
     try {
       final var key = AgentInstanceKey.of(command.execute().getAgentInstanceKey());
@@ -250,6 +246,7 @@ public class CamundaAgentInstanceClient implements AgentInstanceClient {
         .content(List.of())
         .loopIteration(iterationKey)
         .producedAt(producedAt)
+        .provider(configuration.chatModel().descriptiveProvider())
         .systemPrompt(
             List.of(AgentInstanceHistoryContent.text(configuration.systemPrompt().prompt())))
         .tools(toolMapper.mapTools(configuration.toolDefinitions()))

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/ChatModelConfiguration.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/ChatModelConfiguration.java
@@ -17,4 +17,11 @@ public interface ChatModelConfiguration {
 
   /** Identifier of the model to use (provider-specific format). */
   String model();
+
+  /**
+   * A more specific provider identifier than {@link #provider()}. Defaults to {@link #provider()}.
+   */
+  default String descriptiveProvider() {
+    return provider();
+  }
 }

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/AgentConfiguration.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/AgentConfiguration.java
@@ -83,7 +83,7 @@ public record AgentConfiguration(
         String.join(
             " ",
             chatModel.model(),
-            chatModel.provider(),
+            chatModel.descriptiveProvider(),
             systemPrompt.prompt(),
             String.valueOf(limits != null ? limits.maxModelCalls() : null),
             String.valueOf(toolDefinitions));

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/v2/AnthropicChatModelConfiguration.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/v2/AnthropicChatModelConfiguration.java
@@ -52,6 +52,11 @@ public record AnthropicChatModelConfiguration(@Valid @NotNull AnthropicConnectio
     return anthropic.model().model();
   }
 
+  @Override
+  public String descriptiveProvider() {
+    return "%s/%s".formatted(provider(), anthropic.backend().type());
+  }
+
   /** All Anthropic-specific configuration, nested under the {@code anthropic} wire key. */
   public record AnthropicConnection(
       @Valid @NotNull AnthropicBackend backend,

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/v2/GeminiChatModelConfiguration.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/v2/GeminiChatModelConfiguration.java
@@ -48,6 +48,11 @@ public record GeminiChatModelConfiguration(@Valid @NotNull GeminiConnection goog
     return googleGemini.model().model();
   }
 
+  @Override
+  public String descriptiveProvider() {
+    return "%s/%s".formatted(provider(), googleGemini.backend().type());
+  }
+
   /** All Gemini-specific configuration, nested under the {@code googleGemini} wire key. */
   public record GeminiConnection(
       @Valid @NotNull GeminiBackend backend,

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/v2/OpenAiChatModelConfiguration.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/v2/OpenAiChatModelConfiguration.java
@@ -52,6 +52,11 @@ public record OpenAiChatModelConfiguration(@Valid @NotNull OpenAiConnection open
     return openai.model().model();
   }
 
+  @Override
+  public String descriptiveProvider() {
+    return "%s/%s/%s".formatted(provider(), openai.api().type(), openai.backend().type());
+  }
+
   /** All OpenAI-specific configuration, nested under the {@code openai} wire key. */
   public record OpenAiConnection(
       @Valid @NotNull OpenAiApi api,

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/agentinstance/CamundaAgentInstanceClientTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/agentinstance/CamundaAgentInstanceClientTest.java
@@ -37,6 +37,7 @@ import io.camunda.client.api.command.UpdateAgentInstanceCommandStep1.UpdateAgent
 import io.camunda.client.api.response.CreateAgentInstanceResponse;
 import io.camunda.client.api.search.enums.AgentInstanceHistoryRole;
 import io.camunda.connector.agenticai.adhoctoolsschema.model.AdHocToolElement;
+import io.camunda.connector.agenticai.aiagent.chatmodel.ChatModelConfiguration;
 import io.camunda.connector.agenticai.aiagent.model.AgentConfiguration;
 import io.camunda.connector.agenticai.aiagent.model.AgentContext;
 import io.camunda.connector.agenticai.aiagent.model.AgentConversationTurn;
@@ -51,6 +52,14 @@ import io.camunda.connector.agenticai.aiagent.model.message.content.TextContent;
 import io.camunda.connector.agenticai.aiagent.model.request.LimitsConfiguration;
 import io.camunda.connector.agenticai.aiagent.model.request.PromptConfiguration;
 import io.camunda.connector.agenticai.aiagent.model.request.v1.OpenAiProviderConfiguration;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.OpenAiChatModelConfiguration;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.OpenAiChatModelConfiguration.OpenAiApi.OpenAiCompletionsApi;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.OpenAiChatModelConfiguration.OpenAiBackend;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.OpenAiChatModelConfiguration.OpenAiBackend.OpenAiApiBackend;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.OpenAiChatModelConfiguration.OpenAiBackend.OpenAiApiBackend.OpenAiApiConnection;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.OpenAiChatModelConfiguration.OpenAiBackend.OpenAiCustomBackend;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.OpenAiChatModelConfiguration.OpenAiBackend.OpenAiCustomBackend.CustomBackend;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.OpenAiCustomEndpointAuthentication.ApiKeyAuthentication;
 import io.camunda.connector.agenticai.aiagent.model.tool.ToolCall;
 import io.camunda.connector.agenticai.aiagent.model.tool.ToolCallResult;
 import io.camunda.connector.agenticai.aiagent.model.tool.ToolCallResultContent;
@@ -196,6 +205,41 @@ class CamundaAgentInstanceClientTest {
                 assertThat(item.getLimits().getMaxModelCalls()).isEqualTo(10);
                 assertThat(item.getLimits().getMaxTokens()).isEqualTo(-1);
                 assertThat(item.getLimits().getMaxToolCalls()).isEqualTo(-1);
+              });
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void shouldReportDescriptiveProviderIncludingBackendAndApiFamily() {
+      givenCreateCommand();
+      when(createCommandStep5.execute()).thenReturn(response);
+      when(response.getAgentInstanceKey()).thenReturn(12345L);
+
+      final var chatModel =
+          new OpenAiChatModelConfiguration(
+              new OpenAiChatModelConfiguration.OpenAiConnection(
+                  new OpenAiCompletionsApi(null),
+                  new OpenAiCustomBackend(
+                      new CustomBackend(
+                          "https://custom.example.com/v1",
+                          null,
+                          null,
+                          null,
+                          new ApiKeyAuthentication("sk-test"))),
+                  new OpenAiChatModelConfiguration.OpenAiModel("gpt-5.5"),
+                  null));
+
+      client.create(TestAgentExecutionContext.withChatModel(chatModel));
+
+      final ArgumentCaptor<List<AgentInstanceHistoryItem>> historyCaptor =
+          ArgumentCaptor.forClass(List.class);
+      verify(createCommandStep4).history(historyCaptor.capture());
+      assertThat(historyCaptor.getValue())
+          .singleElement()
+          .satisfies(
+              item -> {
+                assertThat(item.getModel()).isEqualTo("gpt-5.5");
+                assertThat(item.getProvider()).isEqualTo("openai/completions/custom");
               });
     }
 
@@ -522,6 +566,22 @@ class CamundaAgentInstanceClientTest {
           .withToolDefinitions(tools);
     }
 
+    private AgentConfiguration openAiConfiguration(OpenAiBackend backend) {
+      return new AgentConfiguration(
+          new OpenAiChatModelConfiguration(
+              new OpenAiChatModelConfiguration.OpenAiConnection(
+                  new OpenAiCompletionsApi(null),
+                  backend,
+                  new OpenAiChatModelConfiguration.OpenAiModel("gpt-5.5"),
+                  null)),
+          new PromptConfiguration.SystemPromptConfiguration("Be nice."),
+          null,
+          null,
+          null,
+          null,
+          null);
+    }
+
     private AgentConversationTurn userTurn(String text, String configurationFingerprint) {
       return new AgentConversationTurn(
           1,
@@ -667,9 +727,8 @@ class CamundaAgentInstanceClientTest {
       assertThat(configurationItem.getLoopIteration()).isEqualTo(1);
       // a CONFIGURATION item has no natural content of its own
       assertThat(configurationItem.getContent()).isEmpty();
-      // model/provider are fixed at create time only, not re-pushed by turn-start items
       assertThat(configurationItem.getModel()).isNull();
-      assertThat(configurationItem.getProvider()).isNull();
+      assertThat(configurationItem.getProvider()).isEqualTo(OpenAiProviderConfiguration.OPENAI_ID);
       assertThat(configurationItem.getSystemPrompt())
           .singleElement()
           .isInstanceOfSatisfying(
@@ -747,6 +806,38 @@ class CamundaAgentInstanceClientTest {
       final var configurationItem = historyCaptor.getValue().get(0);
       assertThat(configurationItem.getRole()).isEqualTo(AgentInstanceHistoryRole.CONFIGURATION);
       assertThat(configurationItem.getLimits().getMaxModelCalls()).isEqualTo(20);
+    }
+
+    @Test
+    void shouldPrependConfigurationItemWithUpdatedProviderWhenBackendChanged() {
+      givenUpdateCommand();
+      final var apiBackend =
+          new OpenAiApiBackend(
+              new OpenAiApiConnection("sk-test", null, null, null, null, null, null));
+      final var customBackend =
+          new OpenAiCustomBackend(
+              new CustomBackend(
+                  "https://custom.example.com/v1",
+                  null,
+                  null,
+                  null,
+                  new ApiKeyAuthentication("sk-test")));
+      final var previousConfiguration = openAiConfiguration(apiBackend);
+      final var configuration = openAiConfiguration(customBackend);
+
+      client.applyTurnStart(
+          TestAgentExecutionContext.withLimits(),
+          configuration,
+          AgentInstanceKey.of(AGENT_INSTANCE_KEY),
+          userTurn("hi", configuration.fingerprint()),
+          Optional.of(precedingTurn(previousConfiguration.fingerprint())),
+          TURN_INGESTION_TIMESTAMP);
+
+      verify(updateCommandStep4).history(historyCaptor.capture());
+      assertThat(historyCaptor.getValue()).hasSize(2);
+      final var configurationItem = historyCaptor.getValue().get(0);
+      assertThat(configurationItem.getRole()).isEqualTo(AgentInstanceHistoryRole.CONFIGURATION);
+      assertThat(configurationItem.getProvider()).isEqualTo("openai/completions/custom");
     }
 
     @Test
@@ -1232,9 +1323,21 @@ class CamundaAgentInstanceClientTest {
       return new TestAgentExecutionContext(new LimitsConfiguration(10), null);
     }
 
+    public static TestAgentExecutionContext withChatModel(ChatModelConfiguration chatModel) {
+      return new TestAgentExecutionContext(
+          new LimitsConfiguration(10), DEFAULT_LEASE_TOKEN, chatModel);
+    }
+
+    private static final ChatModelConfiguration DEFAULT_CHAT_MODEL =
+        new OpenAiProviderConfiguration(
+            new OpenAiProviderConfiguration.OpenAiConnection(
+                null, null, new OpenAiProviderConfiguration.OpenAiModel("gpt-4o", null)));
+
     private final TestJobContext jobContext;
 
     private final LimitsConfiguration limitsConfiguration;
+
+    private final ChatModelConfiguration chatModel;
 
     private TestAgentExecutionContext(LimitsConfiguration limitsConfiguration) {
       this(limitsConfiguration, DEFAULT_LEASE_TOKEN);
@@ -1242,6 +1345,13 @@ class CamundaAgentInstanceClientTest {
 
     private TestAgentExecutionContext(
         LimitsConfiguration limitsConfiguration, @Nullable String leaseToken) {
+      this(limitsConfiguration, leaseToken, DEFAULT_CHAT_MODEL);
+    }
+
+    private TestAgentExecutionContext(
+        LimitsConfiguration limitsConfiguration,
+        @Nullable String leaseToken,
+        ChatModelConfiguration chatModel) {
       this.jobContext = new TestJobContext(Map::of, () -> "");
       jobContext.setElementInstanceKey(ELEMENT_INSTANCE_KEY);
       jobContext.setJobKey(JOB_KEY);
@@ -1250,6 +1360,7 @@ class CamundaAgentInstanceClientTest {
       }
 
       this.limitsConfiguration = limitsConfiguration;
+      this.chatModel = chatModel;
     }
 
     @Override
@@ -1280,9 +1391,7 @@ class CamundaAgentInstanceClientTest {
     @Override
     public AgentConfiguration configuration() {
       return new AgentConfiguration(
-          new OpenAiProviderConfiguration(
-              new OpenAiProviderConfiguration.OpenAiConnection(
-                  null, null, new OpenAiProviderConfiguration.OpenAiModel("gpt-4o", null))),
+          chatModel,
           new PromptConfiguration.SystemPromptConfiguration("system prompt"),
           null,
           null,

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/model/AgentConfigurationTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/model/AgentConfigurationTest.java
@@ -13,6 +13,14 @@ import io.camunda.connector.agenticai.aiagent.model.request.PromptConfiguration.
 import io.camunda.connector.agenticai.aiagent.model.request.v1.OpenAiProviderConfiguration;
 import io.camunda.connector.agenticai.aiagent.model.request.v1.OpenAiProviderConfiguration.OpenAiConnection;
 import io.camunda.connector.agenticai.aiagent.model.request.v1.OpenAiProviderConfiguration.OpenAiModel;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.OpenAiChatModelConfiguration;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.OpenAiChatModelConfiguration.OpenAiApi.OpenAiCompletionsApi;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.OpenAiChatModelConfiguration.OpenAiBackend;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.OpenAiChatModelConfiguration.OpenAiBackend.OpenAiApiBackend;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.OpenAiChatModelConfiguration.OpenAiBackend.OpenAiApiBackend.OpenAiApiConnection;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.OpenAiChatModelConfiguration.OpenAiBackend.OpenAiCustomBackend;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.OpenAiChatModelConfiguration.OpenAiBackend.OpenAiCustomBackend.CustomBackend;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.OpenAiCustomEndpointAuthentication.ApiKeyAuthentication;
 import io.camunda.connector.agenticai.aiagent.model.tool.ToolDefinition;
 import java.util.List;
 import java.util.Map;
@@ -43,6 +51,22 @@ class AgentConfigurationTest {
             null,
             null)
         .withToolDefinitions(tools);
+  }
+
+  private static AgentConfiguration configurationWithOpenAiBackend(OpenAiBackend backend) {
+    return new AgentConfiguration(
+        new OpenAiChatModelConfiguration(
+            new OpenAiChatModelConfiguration.OpenAiConnection(
+                new OpenAiCompletionsApi(null),
+                backend,
+                new OpenAiChatModelConfiguration.OpenAiModel("gpt-5.5"),
+                null)),
+        new SystemPromptConfiguration("Be nice."),
+        null,
+        null,
+        null,
+        null,
+        null);
   }
 
   @Nested
@@ -114,6 +138,27 @@ class AgentConfigurationTest {
       final var second = configuration("gpt-4o", "Be nice.", null, toolsB).fingerprint();
 
       assertThat(first).isNotEqualTo(second);
+    }
+
+    @Test
+    void changedBackendYieldsDifferentFingerprintEvenWithSameProviderModelAndPrompt() {
+      final var apiBackend =
+          new OpenAiApiBackend(
+              new OpenAiApiConnection("sk-test", null, null, null, null, null, null));
+      final var customBackend =
+          new OpenAiCustomBackend(
+              new CustomBackend(
+                  "https://custom.example.com/v1",
+                  null,
+                  null,
+                  null,
+                  new ApiKeyAuthentication("sk-test")));
+
+      final var first = configurationWithOpenAiBackend(apiBackend);
+      final var second = configurationWithOpenAiBackend(customBackend);
+
+      assertThat(first.chatModel().provider()).isEqualTo(second.chatModel().provider());
+      assertThat(first.fingerprint()).isNotEqualTo(second.fingerprint());
     }
 
     @Test

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/model/request/v2/AnthropicChatModelConfigurationTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/model/request/v2/AnthropicChatModelConfigurationTest.java
@@ -74,6 +74,7 @@ class AnthropicChatModelConfigurationTest {
 
     assertThat(parsed).isInstanceOf(AnthropicChatModelConfiguration.class);
     assertThat(parsed.provider()).isEqualTo("anthropic");
+    assertThat(parsed.descriptiveProvider()).isEqualTo("anthropic/anthropic-api");
     assertThat(parsed.model()).isEqualTo("claude-sonnet-4-6");
 
     final AnthropicChatModelConfiguration anthropic = (AnthropicChatModelConfiguration) parsed;
@@ -467,6 +468,7 @@ class AnthropicChatModelConfigurationTest {
         (AnthropicChatModelConfiguration) mapper.readValue(json, ProviderConfiguration.class);
 
     assertThat(parsed.anthropic().backend()).isInstanceOf(AnthropicAwsBedrockMantleBackend.class);
+    assertThat(parsed.descriptiveProvider()).isEqualTo("anthropic/aws-bedrock-mantle");
     final AnthropicAwsBedrockMantleBackend bedrockBackend =
         (AnthropicAwsBedrockMantleBackend) parsed.anthropic().backend();
     assertThat(bedrockBackend.awsBedrockMantle().region()).isEqualTo("eu-central-1");

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/model/request/v2/BedrockConverseChatModelConfigurationTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/model/request/v2/BedrockConverseChatModelConfigurationTest.java
@@ -67,6 +67,7 @@ class BedrockConverseChatModelConfigurationTest {
 
     assertThat(parsed).isInstanceOf(BedrockConverseChatModelConfiguration.class);
     assertThat(parsed.provider()).isEqualTo("bedrock");
+    assertThat(parsed.descriptiveProvider()).isEqualTo(parsed.provider());
     assertThat(parsed.model()).isEqualTo("us.amazon.nova-2-lite-v1:0");
 
     final BedrockConverseChatModelConfiguration bedrock =

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/model/request/v2/GeminiChatModelConfigurationTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/model/request/v2/GeminiChatModelConfigurationTest.java
@@ -75,6 +75,7 @@ class GeminiChatModelConfigurationTest {
 
     assertThat(parsed).isInstanceOf(GeminiChatModelConfiguration.class);
     assertThat(parsed.provider()).isEqualTo("google-gemini");
+    assertThat(parsed.descriptiveProvider()).isEqualTo("google-gemini/google-gemini-api");
     assertThat(parsed.model()).isEqualTo("gemini-3-pro-preview");
 
     final GeminiChatModelConfiguration gemini = (GeminiChatModelConfiguration) parsed;
@@ -290,6 +291,7 @@ class GeminiChatModelConfigurationTest {
 
     assertThat(parsed).isInstanceOf(GeminiChatModelConfiguration.class);
     assertThat(parsed.provider()).isEqualTo("google-gemini");
+    assertThat(parsed.descriptiveProvider()).isEqualTo("google-gemini/google-vertex-ai");
     assertThat(parsed.model()).isEqualTo("gemini-3-pro-preview");
 
     final GeminiChatModelConfiguration gemini = (GeminiChatModelConfiguration) parsed;

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/model/request/v2/OpenAiChatModelConfigurationTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/model/request/v2/OpenAiChatModelConfigurationTest.java
@@ -215,6 +215,7 @@ class OpenAiChatModelConfigurationTest {
 
     assertThat(parsed).isInstanceOf(OpenAiChatModelConfiguration.class);
     assertThat(parsed.provider()).isEqualTo("openai");
+    assertThat(parsed.descriptiveProvider()).isEqualTo("openai/responses/openai-api");
     assertThat(parsed.model()).isEqualTo("gpt-5.5");
 
     final OpenAiChatModelConfiguration openai = (OpenAiChatModelConfiguration) parsed;
@@ -307,6 +308,7 @@ class OpenAiChatModelConfigurationTest {
         (OpenAiChatModelConfiguration) mapper.readValue(json, ProviderConfiguration.class);
 
     assertThat(parsed.openai().backend()).isInstanceOf(OpenAiCustomBackend.class);
+    assertThat(parsed.descriptiveProvider()).isEqualTo("openai/responses/custom");
     final OpenAiCustomBackend custom = (OpenAiCustomBackend) parsed.openai().backend();
     assertThat(custom.custom().endpoint()).isEqualTo("https://custom.example.com/v1");
     assertThat(custom.custom().headers()).containsEntry("X-Custom-Header", "value");
@@ -457,6 +459,7 @@ class OpenAiChatModelConfigurationTest {
         (OpenAiChatModelConfiguration) mapper.readValue(json, ProviderConfiguration.class);
 
     assertThat(parsed.openai().backend()).isInstanceOf(OpenAiFoundryBackend.class);
+    assertThat(parsed.descriptiveProvider()).isEqualTo("openai/responses/foundry");
     final OpenAiFoundryBackend foundry = (OpenAiFoundryBackend) parsed.openai().backend();
     assertThat(foundry.foundry().endpoint()).isEqualTo("https://my-resource.openai.azure.com");
     assertThat(foundry.foundry().authentication())

--- a/connectors/agentic-ai/docs/reference/ai-agent.md
+++ b/connectors/agentic-ai/docs/reference/ai-agent.md
@@ -1746,8 +1746,8 @@ list — never a separate create-history command:
 
 - **`applyTurnStart`** (`BaseAgentRequestHandler.proceed`, before the LLM call): moves the agent
   instance to `THINKING` and appends the current turn's input-message history items (see below),
-  prepending a `CONFIGURATION` item when the system prompt or tool list changed since the previous
-  turn.
+  prepending a `CONFIGURATION` item when the model, provider, system prompt, tool list, or model-call
+  limit changed since the previous turn.
 - **`applyTurnCompletion`** (`BaseAgentRequestHandler.driveContinuationLoop`, once per round including
   intermediate `ChatResult.Continuation` rounds): appends one `ASSISTANT` item carrying that round's
   assistant text, `toolCalls`, and metrics (input/output tokens + `durationMs`, measured by the
@@ -1758,9 +1758,11 @@ list — never a separate create-history command:
 
 Once a batch is attached to an `update()` command, the engine only allows `status` at the request
 level — `model`/`provider`/`systemPrompt`/`limits`/`tools` can only change through a `CONFIGURATION`
-history item. This connector still narrows that to system prompt and tool list only (`model`/
-`provider`/`limits` are fixed at `create` time and not currently re-pushed via `CONFIGURATION`; see
-the ADR's Deferred section).
+history item. Of those, `systemPrompt`, `tools`, `limits`, and `provider` are re-pushed on every
+`CONFIGURATION` item; `model` stays fixed at `create` time (see the ADR's Deferred section). The
+reported `provider` is a more specific identifier than the plain `provider()` constant — it also
+covers backend and, for OpenAI, API family (e.g. `openai/completions/custom`,
+`anthropic/aws-bedrock-mantle`) — so a configuration change limited to that no longer goes unnoticed.
 
 There is no more deferred, completion-listener-driven agent instance update: `applyTurnStart` and
 `applyTurnCompletion` both fire synchronously inline, so a job that never completes (crash, timeout)

--- a/connectors/agentic-ai/docs/reference/ai-agent.md
+++ b/connectors/agentic-ai/docs/reference/ai-agent.md
@@ -1759,10 +1759,10 @@ list — never a separate create-history command:
 Once a batch is attached to an `update()` command, the engine only allows `status` at the request
 level — `model`/`provider`/`systemPrompt`/`limits`/`tools` can only change through a `CONFIGURATION`
 history item. Of those, `systemPrompt`, `tools`, `limits`, and `provider` are re-pushed on every
-`CONFIGURATION` item; `model` stays fixed at `create` time (see the ADR's Deferred section). The
-reported `provider` is a more specific identifier than the plain `provider()` constant — it also
-covers backend and, for OpenAI, API family (e.g. `openai/completions/custom`,
-`anthropic/aws-bedrock-mantle`) — so a configuration change limited to that no longer goes unnoticed.
+`CONFIGURATION` item; `model` stays fixed at `create` time. The reported `provider` is a more
+specific identifier than the plain `provider()` constant — it also covers backend and, for OpenAI,
+API family (e.g. `openai/completions/custom`, `anthropic/aws-bedrock-mantle`) — so a configuration
+change limited to that no longer goes unnoticed.
 
 There is no more deferred, completion-listener-driven agent instance update: `applyTurnStart` and
 `applyTurnCompletion` both fire synchronously inline, so a job that never completes (crash, timeout)

--- a/connectors/agentic-ai/docs/reference/native-providers.md
+++ b/connectors/agentic-ai/docs/reference/native-providers.md
@@ -10,7 +10,8 @@ per-provider "here's what's special" detail that would otherwise bloat that sect
 ## Anthropic
 
 One wire format (the Messages API), so a single backend axis covers everything: `AnthropicBackend`
-(`anthropic-api` | `aws-bedrock-mantle` | `custom`).
+(`anthropic-api` | `aws-bedrock-mantle` | `custom`). `descriptiveProvider()` reports this backend
+too, e.g. `anthropic/aws-bedrock-mantle`.
 
 ### Backends
 
@@ -157,6 +158,7 @@ Two orthogonal sealed axes: `OpenAiApi` (`completions` | `responses`, default `r
 backend can serve either wire format. The wire format is a sealed discriminator rather than a flat enum
 so each family gets its own namespace for family-specific knobs — e.g. the differing max-token field
 name (`maxCompletionTokens` vs `maxOutputTokens`) — without `condition` gating or collisions.
+`descriptiveProvider()` reports both axes too, e.g. `openai/completions/custom`.
 
 ### Backends
 
@@ -290,7 +292,8 @@ branch and shares every converter described below unchanged.
 
 `GeminiChatModelFactory.buildClient` builds the SDK's `Client` directly from the API key; there is no
 custom-backend variant (no user-configurable headers/query params, unlike Anthropic/OpenAI's
-`*CustomBackend`).
+`*CustomBackend`). `descriptiveProvider()` reports this backend too, e.g.
+`google-gemini/google-vertex-ai`.
 
 ### Reasoning
 


### PR DESCRIPTION
## Description

Agent-instance history reported only a coarse provider name (`openai`, `anthropic`, ...), so operators couldn't tell apart configurations that actually behave very differently — for example a native OpenAI setup vs. an OpenAI-compatible custom endpoint, or Chat Completions vs. Responses. Both showed up as plain `openai`.

The reported value now also reflects the backend and API family in use (e.g. `openai/completions/custom`), so operators can distinguish these configurations from agent-instance history alone. Switching backend mid-conversation is also now correctly picked up and reflected in history, instead of being silently missed.

## Related issues

closes #8433

## Checklist

- [x] Backport labels are added if these code changes should be backported.
- [x] Tests/Integration tests for the changes have been added if applicable.
- [x] If the change requires a documentation update, it has been added to the appropriate section in the documentation.