### PR TITLE
ci: retry Harbor login in merge queue Helm test

### DIFF
--- a/.github/workflows/MERGE_QUEUE_HELM_TEST.yaml
+++ b/.github/workflows/MERGE_QUEUE_HELM_TEST.yaml
@@ -84,12 +84,30 @@ jobs:
       - name: Set up Docker Build
         uses: docker/setup-buildx-action@v3
 
+      # docker/login-action has no retry, and Harbor's LDAP-backed token service
+      # intermittently answers a valid credential with a bare `unauthorized:` under
+      # concurrent merge-queue load. Because build-image is continue-on-error on
+      # merge_group, that single 401 empties connectors-version and silently skips
+      # both E2E jobs while the run still reports success -- so retry the login
+      # rather than lose the coverage this gate exists to provide.
       - name: Login to Harbor
-        uses: docker/login-action@v3
-        with:
-          registry: registry.camunda.cloud
-          username: ${{ steps.secrets.outputs.CI_LDAP_USER }}
-          password: ${{ steps.secrets.outputs.CI_LDAP_PASSWORD }}
+        env:
+          HARBOR_USER: ${{ steps.secrets.outputs.CI_LDAP_USER }}
+          HARBOR_PASSWORD: ${{ steps.secrets.outputs.CI_LDAP_PASSWORD }}
+        run: |
+          set -uo pipefail
+          for attempt in 1 2 3 4 5; do
+            if printf '%s' "$HARBOR_PASSWORD" \
+              | docker login registry.camunda.cloud -u "$HARBOR_USER" --password-stdin; then
+              exit 0
+            fi
+            if [[ $attempt -lt 5 ]]; then
+              echo "::warning::Harbor login attempt ${attempt}/5 failed; retrying in $((attempt * 5))s"
+              sleep $((attempt * 5))
+            fi
+          done
+          echo "::error::Harbor login to registry.camunda.cloud failed after 5 attempts"
+          exit 1
 
       - name: Set connectors version
         id: connectors-version


### PR DESCRIPTION
## Description

`Build and Publish Connectors Docker Image` failed on the `Login to Harbor` step in
[run 34598312696](https://github.com/camunda/connectors/actions/runs/34598312696/job/103259217193):

```
Error response from daemon: Get "https://registry.camunda.cloud/v2/": unauthorized:
```

The credential was fine. Four sibling merge-queue runs logged in with the same Vault
secret (`secret/data/products/connectors/ci/common ARTIFACTORY_USR/PSW`) at 12:25, 12:25,
12:27 and 12:29 and all succeeded; this one failed at 12:34. Successful logins return in
2–6s — the failing one hung 5.9s and then returned a 401 with an empty detail string,
which is Harbor's LDAP-backed token service timing out rather than a rejected password.

`docker/login-action` has no retry, so that single blip took out the whole job. And
because `build-image` is `continue-on-error` on `merge_group`, the consequence was
invisible: `connectors-version` came back empty, `trigger-sm-e2e` and `trigger-saas-e2e`
were both skipped by their `!= ''` guards, neither `*-debug-summary` feedback job fired
(they gate on `trigger-*` *failing*, not being skipped), and the run concluded **success**.
A six-second registry hiccup silently removed the coverage this gate exists to provide.

This replaces the action with a `docker login --password-stdin` loop — 5 attempts, linear
backoff (5s/10s/15s/20s). A transient 401 self-heals; a sustained Harbor outage still
fails the step, so the failure is not masked.

The same unretried pattern exists elsewhere (`Login to Minimus` in this job, and two
Harbor logins on `main`). Left alone here to keep this branch-scoped to the failure
observed; worth a shared composite action if it recurs.

## Related issues

n/a — transient CI infrastructure failure, no tracking issue.

## Checklist

- [ ] PR has a **milestone** or the `no milestone` label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
