### PR TITLE
fix(agentic-ai): support JSON response schema with a system prompt instruction if provider schema is empty

### DIFF
--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/wiremock/ProviderWireFormatSmokeTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/wiremock/ProviderWireFormatSmokeTests.java
@@ -283,12 +283,7 @@ public class ProviderWireFormatSmokeTests extends BaseAgentSubProcessTest {
     }
   }
 
-  /**
-   * Providers whose native structured-output mechanism is schema-only (see {@code
-   * SchemaOnlyJsonResponseFormatSystemPromptContributor}): with no response JSON schema configured,
-   * these get a JSON-emission instruction appended to the system prompt instead of a native
-   * schema-less JSON mode.
-   */
+  /** APIs with no native schema-less JSON mode: they get a system-prompt instruction instead. */
   private static final Set<String> SCHEMA_ONLY_JSON_MODE_APIS =
       Set.of(
           "AnthropicMessagesV1", "AnthropicMessagesV2", "BedrockConverseV1", "BedrockConverseV2");

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/wiremock/ProviderWireFormatSmokeTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/wiremock/ProviderWireFormatSmokeTests.java
@@ -44,6 +44,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
@@ -280,5 +281,60 @@ public class ProviderWireFormatSmokeTests extends BaseAgentSubProcessTest {
     } catch (JsonProcessingException e) {
       throw new RuntimeException(e);
     }
+  }
+
+  /**
+   * Providers whose native structured-output mechanism is schema-only (see {@code
+   * SchemaOnlyJsonResponseFormatSystemPromptContributor}): with no response JSON schema configured,
+   * these get a JSON-emission instruction appended to the system prompt instead of a native
+   * schema-less JSON mode.
+   */
+  private static final Set<String> SCHEMA_ONLY_JSON_MODE_APIS =
+      Set.of(
+          "AnthropicMessagesV1", "AnthropicMessagesV2", "BedrockConverseV1", "BedrockConverseV2");
+
+  @Test
+  void jsonResponseFormatWithoutSchema() throws Exception {
+    final var userPrompt = "Write a haiku about the sea";
+
+    fixture.stubConversation(TurnStub.text(HAIKU_JSON, 10, 20));
+    enqueueUserFeedback(userSatisfiedFeedback());
+
+    final var zeebeTest =
+        awaitProcessCompletion(
+            createProcessInstance(
+                elementTemplate -> elementTemplate.property("data.response.format.type", "json"),
+                Map.of("userPrompt", userPrompt)));
+
+    assertThat(fixture.modelCallCount()).isEqualTo(1);
+    final var request = fixture.lastRecordedRequest();
+    final var systemMessageText = request.messages().getFirst().textContent();
+
+    if (SCHEMA_ONLY_JSON_MODE_APIS.contains(fixture.apiName())) {
+      assertThat(request.responseFormat())
+          .as("no native structured-output config for schema-less JSON on %s", fixture.apiName())
+          .isEmpty();
+      assertThat(systemMessageText)
+          .as("system prompt augmented with JSON instruction on %s", fixture.apiName())
+          .startsWith(expectedSystemPrompt() + "\n\n")
+          .containsIgnoringCase("json");
+    } else {
+      assertThat(request.responseFormat())
+          .as("native schema-less JSON mode configured on %s", fixture.apiName())
+          .isPresent();
+      assertThat(request.responseFormat().orElseThrow().type()).isEqualTo("json_object");
+      assertThat(systemMessageText)
+          .as(
+              "system prompt left untouched on %s (native schema-less JSON mode)",
+              fixture.apiName())
+          .isEqualTo(expectedSystemPrompt());
+    }
+
+    assertAgentResponse(
+        zeebeTest,
+        agentResponse ->
+            AgentSubProcessResponseAssert.assertThat(agentResponse)
+                .isReady()
+                .hasResponseJsonSatisfying(HAIKU_JSON_ASSERTIONS));
   }
 }

--- a/connectors/agentic-ai/connector-agentic-ai/element-templates/agenticai-ai-agent-subprocess.v2.json
+++ b/connectors/agentic-ai/connector-agentic-ai/element-templates/agenticai-ai-agent-subprocess.v2.json
@@ -3422,13 +3422,14 @@
   }, {
     "id" : "data.response.format.type",
     "label" : "Response format",
-    "description" : "Specify the response format. Support for JSON mode varies by provider. On providers without native schema-less JSON support (Anthropic, Bedrock Converse), a JSON instruction is added automatically to the system prompt when no schema is supplied.",
+    "description" : "Specify the response format. Support for JSON mode varies by provider.",
     "value" : "text",
     "group" : "response",
     "binding" : {
       "name" : "data.response.format.type",
       "type" : "zeebe:input"
     },
+    "tooltip" : "For providers without native schema-less JSON support (e.g. Anthropic, Bedrock Converse), a JSON instruction is added to the system prompt as a best-effort attempt when no schema is supplied.",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "Text",

--- a/connectors/agentic-ai/connector-agentic-ai/element-templates/agenticai-ai-agent-subprocess.v2.json
+++ b/connectors/agentic-ai/connector-agentic-ai/element-templates/agenticai-ai-agent-subprocess.v2.json
@@ -3422,7 +3422,7 @@
   }, {
     "id" : "data.response.format.type",
     "label" : "Response format",
-    "description" : "Specify the response format. Support for JSON mode varies by provider.",
+    "description" : "Specify the response format. Support for JSON mode varies by provider. On providers without native schema-less JSON support (Anthropic, Bedrock Converse), a JSON instruction is added automatically to the system prompt when no schema is supplied.",
     "value" : "text",
     "group" : "response",
     "binding" : {

--- a/connectors/agentic-ai/connector-agentic-ai/element-templates/agenticai-ai-agent-task.v2.json
+++ b/connectors/agentic-ai/connector-agentic-ai/element-templates/agenticai-ai-agent-task.v2.json
@@ -3402,13 +3402,14 @@
   }, {
     "id" : "data.response.format.type",
     "label" : "Response format",
-    "description" : "Specify the response format. Support for JSON mode varies by provider. On providers without native schema-less JSON support (Anthropic, Bedrock Converse), a JSON instruction is added automatically to the system prompt when no schema is supplied.",
+    "description" : "Specify the response format. Support for JSON mode varies by provider.",
     "value" : "text",
     "group" : "response",
     "binding" : {
       "name" : "data.response.format.type",
       "type" : "zeebe:input"
     },
+    "tooltip" : "For providers without native schema-less JSON support (e.g. Anthropic, Bedrock Converse), a JSON instruction is added to the system prompt as a best-effort attempt when no schema is supplied.",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "Text",

--- a/connectors/agentic-ai/connector-agentic-ai/element-templates/agenticai-ai-agent-task.v2.json
+++ b/connectors/agentic-ai/connector-agentic-ai/element-templates/agenticai-ai-agent-task.v2.json
@@ -3402,7 +3402,7 @@
   }, {
     "id" : "data.response.format.type",
     "label" : "Response format",
-    "description" : "Specify the response format. Support for JSON mode varies by provider.",
+    "description" : "Specify the response format. Support for JSON mode varies by provider. On providers without native schema-less JSON support (Anthropic, Bedrock Converse), a JSON instruction is added automatically to the system prompt when no schema is supplied.",
     "value" : "text",
     "group" : "response",
     "binding" : {

--- a/connectors/agentic-ai/connector-agentic-ai/element-templates/agenticai-aiagent-job-worker.json
+++ b/connectors/agentic-ai/connector-agentic-ai/element-templates/agenticai-aiagent-job-worker.json
@@ -1658,13 +1658,14 @@
   }, {
     "id" : "data.response.format.type",
     "label" : "Response format",
-    "description" : "Specify the response format. Support for JSON mode varies by provider. On providers without native schema-less JSON support (Anthropic, Bedrock Converse), a JSON instruction is added automatically to the system prompt when no schema is supplied.",
+    "description" : "Specify the response format. Support for JSON mode varies by provider.",
     "value" : "text",
     "group" : "response",
     "binding" : {
       "name" : "data.response.format.type",
       "type" : "zeebe:input"
     },
+    "tooltip" : "For providers without native schema-less JSON support (e.g. Anthropic, Bedrock Converse), a JSON instruction is added to the system prompt as a best-effort attempt when no schema is supplied.",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "Text",

--- a/connectors/agentic-ai/connector-agentic-ai/element-templates/agenticai-aiagent-job-worker.json
+++ b/connectors/agentic-ai/connector-agentic-ai/element-templates/agenticai-aiagent-job-worker.json
@@ -1658,7 +1658,7 @@
   }, {
     "id" : "data.response.format.type",
     "label" : "Response format",
-    "description" : "Specify the response format. Support for JSON mode varies by provider.",
+    "description" : "Specify the response format. Support for JSON mode varies by provider. On providers without native schema-less JSON support (Anthropic, Bedrock Converse), a JSON instruction is added automatically to the system prompt when no schema is supplied.",
     "value" : "text",
     "group" : "response",
     "binding" : {

--- a/connectors/agentic-ai/connector-agentic-ai/element-templates/agenticai-aiagent-outbound-connector.json
+++ b/connectors/agentic-ai/connector-agentic-ai/element-templates/agenticai-aiagent-outbound-connector.json
@@ -1638,13 +1638,14 @@
   }, {
     "id" : "data.response.format.type",
     "label" : "Response format",
-    "description" : "Specify the response format. Support for JSON mode varies by provider. On providers without native schema-less JSON support (Anthropic, Bedrock Converse), a JSON instruction is added automatically to the system prompt when no schema is supplied.",
+    "description" : "Specify the response format. Support for JSON mode varies by provider.",
     "value" : "text",
     "group" : "response",
     "binding" : {
       "name" : "data.response.format.type",
       "type" : "zeebe:input"
     },
+    "tooltip" : "For providers without native schema-less JSON support (e.g. Anthropic, Bedrock Converse), a JSON instruction is added to the system prompt as a best-effort attempt when no schema is supplied.",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "Text",

--- a/connectors/agentic-ai/connector-agentic-ai/element-templates/agenticai-aiagent-outbound-connector.json
+++ b/connectors/agentic-ai/connector-agentic-ai/element-templates/agenticai-aiagent-outbound-connector.json
@@ -1638,7 +1638,7 @@
   }, {
     "id" : "data.response.format.type",
     "label" : "Response format",
-    "description" : "Specify the response format. Support for JSON mode varies by provider.",
+    "description" : "Specify the response format. Support for JSON mode varies by provider. On providers without native schema-less JSON support (Anthropic, Bedrock Converse), a JSON instruction is added automatically to the system prompt when no schema is supplied.",
     "value" : "text",
     "group" : "response",
     "binding" : {

--- a/connectors/agentic-ai/connector-agentic-ai/element-templates/hybrid/agenticai-ai-agent-subprocess.v2-hybrid.json
+++ b/connectors/agentic-ai/connector-agentic-ai/element-templates/hybrid/agenticai-ai-agent-subprocess.v2-hybrid.json
@@ -3427,7 +3427,7 @@
   }, {
     "id" : "data.response.format.type",
     "label" : "Response format",
-    "description" : "Specify the response format. Support for JSON mode varies by provider.",
+    "description" : "Specify the response format. Support for JSON mode varies by provider. On providers without native schema-less JSON support (Anthropic, Bedrock Converse), a JSON instruction is added automatically to the system prompt when no schema is supplied.",
     "value" : "text",
     "group" : "response",
     "binding" : {

--- a/connectors/agentic-ai/connector-agentic-ai/element-templates/hybrid/agenticai-ai-agent-subprocess.v2-hybrid.json
+++ b/connectors/agentic-ai/connector-agentic-ai/element-templates/hybrid/agenticai-ai-agent-subprocess.v2-hybrid.json
@@ -3427,13 +3427,14 @@
   }, {
     "id" : "data.response.format.type",
     "label" : "Response format",
-    "description" : "Specify the response format. Support for JSON mode varies by provider. On providers without native schema-less JSON support (Anthropic, Bedrock Converse), a JSON instruction is added automatically to the system prompt when no schema is supplied.",
+    "description" : "Specify the response format. Support for JSON mode varies by provider.",
     "value" : "text",
     "group" : "response",
     "binding" : {
       "name" : "data.response.format.type",
       "type" : "zeebe:input"
     },
+    "tooltip" : "For providers without native schema-less JSON support (e.g. Anthropic, Bedrock Converse), a JSON instruction is added to the system prompt as a best-effort attempt when no schema is supplied.",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "Text",

--- a/connectors/agentic-ai/connector-agentic-ai/element-templates/hybrid/agenticai-ai-agent-task.v2-hybrid.json
+++ b/connectors/agentic-ai/connector-agentic-ai/element-templates/hybrid/agenticai-ai-agent-task.v2-hybrid.json
@@ -3407,7 +3407,7 @@
   }, {
     "id" : "data.response.format.type",
     "label" : "Response format",
-    "description" : "Specify the response format. Support for JSON mode varies by provider.",
+    "description" : "Specify the response format. Support for JSON mode varies by provider. On providers without native schema-less JSON support (Anthropic, Bedrock Converse), a JSON instruction is added automatically to the system prompt when no schema is supplied.",
     "value" : "text",
     "group" : "response",
     "binding" : {

--- a/connectors/agentic-ai/connector-agentic-ai/element-templates/hybrid/agenticai-ai-agent-task.v2-hybrid.json
+++ b/connectors/agentic-ai/connector-agentic-ai/element-templates/hybrid/agenticai-ai-agent-task.v2-hybrid.json
@@ -3407,13 +3407,14 @@
   }, {
     "id" : "data.response.format.type",
     "label" : "Response format",
-    "description" : "Specify the response format. Support for JSON mode varies by provider. On providers without native schema-less JSON support (Anthropic, Bedrock Converse), a JSON instruction is added automatically to the system prompt when no schema is supplied.",
+    "description" : "Specify the response format. Support for JSON mode varies by provider.",
     "value" : "text",
     "group" : "response",
     "binding" : {
       "name" : "data.response.format.type",
       "type" : "zeebe:input"
     },
+    "tooltip" : "For providers without native schema-less JSON support (e.g. Anthropic, Bedrock Converse), a JSON instruction is added to the system prompt as a best-effort attempt when no schema is supplied.",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "Text",

--- a/connectors/agentic-ai/connector-agentic-ai/element-templates/hybrid/agenticai-aiagent-job-worker-hybrid.json
+++ b/connectors/agentic-ai/connector-agentic-ai/element-templates/hybrid/agenticai-aiagent-job-worker-hybrid.json
@@ -1663,7 +1663,7 @@
   }, {
     "id" : "data.response.format.type",
     "label" : "Response format",
-    "description" : "Specify the response format. Support for JSON mode varies by provider.",
+    "description" : "Specify the response format. Support for JSON mode varies by provider. On providers without native schema-less JSON support (Anthropic, Bedrock Converse), a JSON instruction is added automatically to the system prompt when no schema is supplied.",
     "value" : "text",
     "group" : "response",
     "binding" : {

--- a/connectors/agentic-ai/connector-agentic-ai/element-templates/hybrid/agenticai-aiagent-job-worker-hybrid.json
+++ b/connectors/agentic-ai/connector-agentic-ai/element-templates/hybrid/agenticai-aiagent-job-worker-hybrid.json
@@ -1663,13 +1663,14 @@
   }, {
     "id" : "data.response.format.type",
     "label" : "Response format",
-    "description" : "Specify the response format. Support for JSON mode varies by provider. On providers without native schema-less JSON support (Anthropic, Bedrock Converse), a JSON instruction is added automatically to the system prompt when no schema is supplied.",
+    "description" : "Specify the response format. Support for JSON mode varies by provider.",
     "value" : "text",
     "group" : "response",
     "binding" : {
       "name" : "data.response.format.type",
       "type" : "zeebe:input"
     },
+    "tooltip" : "For providers without native schema-less JSON support (e.g. Anthropic, Bedrock Converse), a JSON instruction is added to the system prompt as a best-effort attempt when no schema is supplied.",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "Text",

--- a/connectors/agentic-ai/connector-agentic-ai/element-templates/hybrid/agenticai-aiagent-outbound-connector-hybrid.json
+++ b/connectors/agentic-ai/connector-agentic-ai/element-templates/hybrid/agenticai-aiagent-outbound-connector-hybrid.json
@@ -1643,7 +1643,7 @@
   }, {
     "id" : "data.response.format.type",
     "label" : "Response format",
-    "description" : "Specify the response format. Support for JSON mode varies by provider.",
+    "description" : "Specify the response format. Support for JSON mode varies by provider. On providers without native schema-less JSON support (Anthropic, Bedrock Converse), a JSON instruction is added automatically to the system prompt when no schema is supplied.",
     "value" : "text",
     "group" : "response",
     "binding" : {

--- a/connectors/agentic-ai/connector-agentic-ai/element-templates/hybrid/agenticai-aiagent-outbound-connector-hybrid.json
+++ b/connectors/agentic-ai/connector-agentic-ai/element-templates/hybrid/agenticai-aiagent-outbound-connector-hybrid.json
@@ -1643,13 +1643,14 @@
   }, {
     "id" : "data.response.format.type",
     "label" : "Response format",
-    "description" : "Specify the response format. Support for JSON mode varies by provider. On providers without native schema-less JSON support (Anthropic, Bedrock Converse), a JSON instruction is added automatically to the system prompt when no schema is supplied.",
+    "description" : "Specify the response format. Support for JSON mode varies by provider.",
     "value" : "text",
     "group" : "response",
     "binding" : {
       "name" : "data.response.format.type",
       "type" : "zeebe:input"
     },
+    "tooltip" : "For providers without native schema-less JSON support (e.g. Anthropic, Bedrock Converse), a JSON instruction is added to the system prompt as a best-effort attempt when no schema is supplied.",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "Text",

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/anthropic/AnthropicMessageRequestConverter.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/anthropic/AnthropicMessageRequestConverter.java
@@ -348,7 +348,9 @@ public class AnthropicMessageRequestConverter {
     final AnthropicEffort rawEffort = params == null ? null : params.effort();
     final AnthropicEffort effort = rawEffort == AnthropicEffort.MODEL_DEFAULT ? null : rawEffort;
     final Map<String, Object> jsonSchema =
-        response != null && response.format() instanceof JsonResponseFormatConfiguration json
+        response != null
+                && response.format() instanceof JsonResponseFormatConfiguration json
+                && json.hasSchema()
             ? json.schema()
             : null;
 

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/ResponseFormatConfiguration.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/ResponseFormatConfiguration.java
@@ -28,7 +28,10 @@ import java.util.Map;
     group = "response",
     label = "Response format",
     name = "type",
-    description = "Specify the response format. Support for JSON mode varies by provider.",
+    description =
+        "Specify the response format. Support for JSON mode varies by provider. On providers "
+            + "without native schema-less JSON support (Anthropic, Bedrock Converse), a JSON "
+            + "instruction is added automatically to the system prompt when no schema is supplied.",
     defaultValue = "text")
 public sealed interface ResponseFormatConfiguration {
   @TemplateSubType(id = "text", label = "Text")

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/ResponseFormatConfiguration.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/ResponseFormatConfiguration.java
@@ -28,10 +28,11 @@ import java.util.Map;
     group = "response",
     label = "Response format",
     name = "type",
-    description =
-        "Specify the response format. Support for JSON mode varies by provider. On providers "
-            + "without native schema-less JSON support (Anthropic, Bedrock Converse), a JSON "
-            + "instruction is added automatically to the system prompt when no schema is supplied.",
+    description = "Specify the response format. Support for JSON mode varies by provider.",
+    tooltip =
+        "For providers without native schema-less JSON support (e.g. Anthropic, Bedrock "
+            + "Converse), a JSON instruction is added to the system prompt as a best-effort "
+            + "attempt when no schema is supplied.",
     defaultValue = "text")
 public sealed interface ResponseFormatConfiguration {
   @TemplateSubType(id = "text", label = "Text")

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/systemprompt/SchemaOnlyJsonResponseFormatSystemPromptContributor.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/systemprompt/SchemaOnlyJsonResponseFormatSystemPromptContributor.java
@@ -14,10 +14,8 @@ import io.camunda.connector.agenticai.aiagent.model.request.v2.BedrockConverseCh
 import org.jspecify.annotations.Nullable;
 
 /**
- * Contributes a JSON-emission instruction to the system prompt when the JSON response format is
- * requested without a schema on a provider whose native structured-output mechanism is schema-only
- * (Anthropic, Bedrock Converse). Neither provider has a native schema-less JSON mode, so without
- * this nudge the model is left neither constrained nor instructed to emit JSON.
+ * Adds a JSON instruction to the system prompt when JSON response format is requested without a
+ * schema on a provider with no native schema-less JSON mode (Anthropic, Bedrock Converse).
  */
 public class SchemaOnlyJsonResponseFormatSystemPromptContributor
     implements SystemPromptContributor {

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/systemprompt/SchemaOnlyJsonResponseFormatSystemPromptContributor.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/systemprompt/SchemaOnlyJsonResponseFormatSystemPromptContributor.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.agenticai.aiagent.systemprompt;
+
+import io.camunda.connector.agenticai.aiagent.model.AgentContext;
+import io.camunda.connector.agenticai.aiagent.model.AgentExecutionContext;
+import io.camunda.connector.agenticai.aiagent.model.request.ResponseFormatConfiguration.JsonResponseFormatConfiguration;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.AnthropicChatModelConfiguration;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.BedrockConverseChatModelConfiguration;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Contributes a JSON-emission instruction to the system prompt when the JSON response format is
+ * requested without a schema on a provider whose native structured-output mechanism is schema-only
+ * (Anthropic, Bedrock Converse). Neither provider has a native schema-less JSON mode, so without
+ * this nudge the model is left neither constrained nor instructed to emit JSON.
+ */
+public class SchemaOnlyJsonResponseFormatSystemPromptContributor
+    implements SystemPromptContributor {
+
+  static final String INSTRUCTION =
+      "Respond only with a single valid JSON value. Do not include any explanatory text, "
+          + "markdown code fences, or commentary outside the JSON.";
+
+  @Override
+  public @Nullable String contribute(
+      AgentExecutionContext executionContext, AgentContext agentContext) {
+    final var response = executionContext.configuration().response();
+    if (response == null
+        || !(response.format() instanceof JsonResponseFormatConfiguration json)
+        || json.hasSchema()) {
+      return null;
+    }
+
+    final var chatModel = executionContext.configuration().chatModel();
+    if (!(chatModel instanceof AnthropicChatModelConfiguration
+        || chatModel instanceof BedrockConverseChatModelConfiguration)) {
+      return null;
+    }
+
+    return INSTRUCTION;
+  }
+}

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/systemprompt/SchemaOnlyJsonResponseFormatSystemPromptContributor.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/systemprompt/SchemaOnlyJsonResponseFormatSystemPromptContributor.java
@@ -6,8 +6,10 @@
  */
 package io.camunda.connector.agenticai.aiagent.systemprompt;
 
+import io.camunda.connector.agenticai.aiagent.chatmodel.ChatModelConfiguration;
 import io.camunda.connector.agenticai.aiagent.model.AgentContext;
 import io.camunda.connector.agenticai.aiagent.model.AgentExecutionContext;
+import io.camunda.connector.agenticai.aiagent.model.request.ResponseConfiguration;
 import io.camunda.connector.agenticai.aiagent.model.request.ResponseFormatConfiguration.JsonResponseFormatConfiguration;
 import io.camunda.connector.agenticai.aiagent.model.request.v2.AnthropicChatModelConfiguration;
 import io.camunda.connector.agenticai.aiagent.model.request.v2.BedrockConverseChatModelConfiguration;
@@ -27,19 +29,28 @@ public class SchemaOnlyJsonResponseFormatSystemPromptContributor
   @Override
   public @Nullable String contribute(
       AgentExecutionContext executionContext, AgentContext agentContext) {
-    final var response = executionContext.configuration().response();
-    if (response == null
-        || !(response.format() instanceof JsonResponseFormatConfiguration json)
-        || json.hasSchema()) {
+    final var configuration = executionContext.configuration();
+    if (!requestsSchemaLessJson(configuration.response())
+        || !isSchemaOnlyProvider(configuration.chatModel())) {
       return null;
     }
-
-    final var chatModel = executionContext.configuration().chatModel();
-    if (!(chatModel instanceof AnthropicChatModelConfiguration
-        || chatModel instanceof BedrockConverseChatModelConfiguration)) {
-      return null;
-    }
-
     return INSTRUCTION;
+  }
+
+  private static boolean requestsSchemaLessJson(@Nullable ResponseConfiguration response) {
+    return response != null
+        && response.format() instanceof JsonResponseFormatConfiguration json
+        && !json.hasSchema();
+  }
+
+  private static boolean isSchemaOnlyProvider(ChatModelConfiguration chatModel) {
+    return chatModel instanceof AnthropicChatModelConfiguration
+        || chatModel instanceof BedrockConverseChatModelConfiguration;
+  }
+
+  /** Runs after every other contributor, so its instruction always closes the system prompt. */
+  @Override
+  public int getOrder() {
+    return Integer.MAX_VALUE;
   }
 }

--- a/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/autoconfigure/AgenticAiConnectorsAutoConfiguration.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/main/java/io/camunda/connector/agenticai/autoconfigure/AgenticAiConnectorsAutoConfiguration.java
@@ -59,6 +59,7 @@ import io.camunda.connector.agenticai.aiagent.memory.conversation.document.Camun
 import io.camunda.connector.agenticai.aiagent.memory.conversation.inprocess.InProcessConversationStore;
 import io.camunda.connector.agenticai.aiagent.model.request.V1ToV2ProviderConfigurationMapper;
 import io.camunda.connector.agenticai.aiagent.model.request.V1ToV2ProviderConfigurationMapperImpl;
+import io.camunda.connector.agenticai.aiagent.systemprompt.SchemaOnlyJsonResponseFormatSystemPromptContributor;
 import io.camunda.connector.agenticai.aiagent.systemprompt.SystemPromptComposer;
 import io.camunda.connector.agenticai.aiagent.systemprompt.SystemPromptComposerImpl;
 import io.camunda.connector.agenticai.aiagent.systemprompt.SystemPromptContributor;
@@ -272,6 +273,13 @@ public class AgenticAiConnectorsAutoConfiguration {
   public SystemPromptComposer aiAgentSystemPromptComposer(
       List<SystemPromptContributor> contributors) {
     return new SystemPromptComposerImpl(contributors);
+  }
+
+  @Bean
+  @ConditionalOnMissingBean
+  public SchemaOnlyJsonResponseFormatSystemPromptContributor
+      aiAgentSchemaOnlyJsonResponseFormatSystemPromptContributor() {
+    return new SchemaOnlyJsonResponseFormatSystemPromptContributor();
   }
 
   @Bean

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/anthropic/AnthropicMessageRequestConverterTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/anthropic/AnthropicMessageRequestConverterTest.java
@@ -501,8 +501,7 @@ class AnthropicMessageRequestConverterTest {
 
   @Test
   void jsonResponseFormatWithEmptySchemaEmitsNoOutputConfig() {
-    // An empty schema (FEEL ={}) constrains nothing, same as no schema at all -- must not be sent
-    // to Anthropic as a literal empty object schema.
+    // Empty schema (FEEL ={}) counts as no schema.
     final var response =
         new AgentTaskResponseConfiguration(
             new JsonResponseFormatConfiguration(Map.of(), null), null);
@@ -711,8 +710,7 @@ class AnthropicMessageRequestConverterTest {
 
   @Test
   void emptySchemaWithEffortEmitsOutputConfigWithoutFormat() {
-    // Regression guard for the hasSchema() fix: an empty schema must still let the effort-only
-    // path through -- output_config is emitted with effort but no format.
+    // Empty schema must not block the effort-only output_config path.
     final var response =
         new AgentTaskResponseConfiguration(
             new JsonResponseFormatConfiguration(Map.of(), null), null);

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/anthropic/AnthropicMessageRequestConverterTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/chatmodel/provider/anthropic/AnthropicMessageRequestConverterTest.java
@@ -500,6 +500,20 @@ class AnthropicMessageRequestConverterTest {
   }
 
   @Test
+  void jsonResponseFormatWithEmptySchemaEmitsNoOutputConfig() {
+    // An empty schema (FEEL ={}) constrains nothing, same as no schema at all -- must not be sent
+    // to Anthropic as a literal empty object schema.
+    final var response =
+        new AgentTaskResponseConfiguration(
+            new JsonResponseFormatConfiguration(Map.of(), null), null);
+    final var snapshot = new ConversationSnapshot(List.of(), List.of());
+
+    final var params = converter.toMessageCreateParams(model(null), response, snapshot);
+
+    assertThat(params.outputConfig()).isEmpty();
+  }
+
+  @Test
   void defaultsMaxTokensToTheDefaultConstantWhenConfigNull() {
     final var snapshot = new ConversationSnapshot(List.of(), List.of());
 
@@ -693,6 +707,23 @@ class AnthropicMessageRequestConverterTest {
     assertThat(outputConfigNode.path("format").path("type").asText()).isEqualTo("json_schema");
     assertThat(params.outputConfig().orElseThrow().format()).isPresent();
     assertThat(params.outputConfig().orElseThrow().effort()).isPresent();
+  }
+
+  @Test
+  void emptySchemaWithEffortEmitsOutputConfigWithoutFormat() {
+    // Regression guard for the hasSchema() fix: an empty schema must still let the effort-only
+    // path through -- output_config is emitted with effort but no format.
+    final var response =
+        new AgentTaskResponseConfiguration(
+            new JsonResponseFormatConfiguration(Map.of(), null), null);
+    final var parameters = effortParams(AnthropicEffort.HIGH);
+    final var snapshot = new ConversationSnapshot(List.of(), List.of());
+
+    final var params = converter.toMessageCreateParams(model(parameters), response, snapshot);
+
+    assertThat(params.outputConfig()).isPresent();
+    assertThat(params.outputConfig().orElseThrow().effort()).isPresent();
+    assertThat(params.outputConfig().orElseThrow().format()).isEmpty();
   }
 
   // --- Prompt caching ---------------------------------------------------------------------------

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/systemprompt/SchemaOnlyJsonResponseFormatSystemPromptContributorTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/systemprompt/SchemaOnlyJsonResponseFormatSystemPromptContributorTest.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.agenticai.aiagent.systemprompt;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.camunda.connector.agenticai.aiagent.chatmodel.ChatModelConfiguration;
+import io.camunda.connector.agenticai.aiagent.model.AgentConfiguration;
+import io.camunda.connector.agenticai.aiagent.model.AgentContext;
+import io.camunda.connector.agenticai.aiagent.model.AgentExecutionContext;
+import io.camunda.connector.agenticai.aiagent.model.AgentState;
+import io.camunda.connector.agenticai.aiagent.model.request.AgentTaskResponseConfiguration;
+import io.camunda.connector.agenticai.aiagent.model.request.ResponseConfiguration;
+import io.camunda.connector.agenticai.aiagent.model.request.ResponseFormatConfiguration.JsonResponseFormatConfiguration;
+import io.camunda.connector.agenticai.aiagent.model.request.ResponseFormatConfiguration.TextResponseFormatConfiguration;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.AnthropicChatModelConfiguration;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.AnthropicChatModelConfiguration.AnthropicBackend.AnthropicApiBackend;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.AnthropicChatModelConfiguration.AnthropicConnection;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.AnthropicChatModelConfiguration.AnthropicModel;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.AwsAuthentication;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.BedrockConverseChatModelConfiguration;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.BedrockConverseChatModelConfiguration.BedrockConverseConnection;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.BedrockConverseChatModelConfiguration.BedrockConverseModel;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.CustomProviderConfiguration;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.GeminiChatModelConfiguration;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.GeminiChatModelConfiguration.GeminiBackend.GeminiApiBackend;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.GeminiChatModelConfiguration.GeminiBackend.GeminiApiBackend.GoogleGeminiApi;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.GeminiChatModelConfiguration.GeminiConnection;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.GeminiChatModelConfiguration.GeminiModel;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.OpenAiChatModelConfiguration;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.OpenAiChatModelConfiguration.OpenAiApi.OpenAiCompletionsApi;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.OpenAiChatModelConfiguration.OpenAiApi.OpenAiCompletionsApi.CompletionsParameters;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.OpenAiChatModelConfiguration.OpenAiBackend.OpenAiApiBackend;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.OpenAiChatModelConfiguration.OpenAiBackend.OpenAiApiBackend.OpenAiApiConnection;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.OpenAiChatModelConfiguration.OpenAiConnection;
+import io.camunda.connector.agenticai.aiagent.model.request.v2.OpenAiChatModelConfiguration.OpenAiModel;
+import java.util.Map;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class SchemaOnlyJsonResponseFormatSystemPromptContributorTest {
+
+  private static final AgentContext CTX = AgentContext.builder().state(AgentState.READY).build();
+
+  private final SchemaOnlyJsonResponseFormatSystemPromptContributor contributor =
+      new SchemaOnlyJsonResponseFormatSystemPromptContributor();
+
+  private static AnthropicChatModelConfiguration anthropicModel() {
+    return new AnthropicChatModelConfiguration(
+        new AnthropicConnection(
+            new AnthropicApiBackend(
+                new AnthropicApiBackend.AnthropicApi("sk-ant-test", null, null, null, null)),
+            new AnthropicModel("claude-sonnet-4-6", null),
+            null));
+  }
+
+  private static BedrockConverseChatModelConfiguration bedrockModel() {
+    return new BedrockConverseChatModelConfiguration(
+        new BedrockConverseConnection(
+            "eu-central-1",
+            null,
+            new AwsAuthentication.AwsDefaultCredentialsChainAuthentication(),
+            null,
+            null,
+            null,
+            null,
+            new BedrockConverseModel("us.amazon.nova-2-lite-v1:0", null)));
+  }
+
+  private static OpenAiChatModelConfiguration openAiModel() {
+    return new OpenAiChatModelConfiguration(
+        new OpenAiConnection(
+            new OpenAiCompletionsApi(new CompletionsParameters(null, null, null, null)),
+            new OpenAiApiBackend(
+                new OpenAiApiConnection("sk-test", null, null, null, null, null, null)),
+            new OpenAiModel("gpt-4o"),
+            null));
+  }
+
+  private static GeminiChatModelConfiguration geminiModel() {
+    return new GeminiChatModelConfiguration(
+        new GeminiConnection(
+            new GeminiApiBackend(new GoogleGeminiApi("gm-test", null)),
+            new GeminiModel("gemini-3-pro-preview", null),
+            null));
+  }
+
+  private static CustomProviderConfiguration customModel() {
+    return new CustomProviderConfiguration("some-custom-provider", "some-model", Map.of());
+  }
+
+  private static AgentExecutionContext executionContext(
+      ChatModelConfiguration chatModel, ResponseConfiguration response) {
+    var configuration = new AgentConfiguration(chatModel, null, null, null, null, null, response);
+    var executionContext = mock(AgentExecutionContext.class);
+    when(executionContext.configuration()).thenReturn(configuration);
+    return executionContext;
+  }
+
+  @ParameterizedTest
+  @MethodSource("schemaOnlyProvidersWithoutSchema")
+  void contributesInstructionForSchemaOnlyProvidersWithoutSchema(ChatModelConfiguration chatModel) {
+    var response =
+        new AgentTaskResponseConfiguration(new JsonResponseFormatConfiguration(null, null), false);
+    var executionContext = executionContext(chatModel, response);
+
+    var result = contributor.contribute(executionContext, CTX);
+
+    assertThat(result).isEqualTo(SchemaOnlyJsonResponseFormatSystemPromptContributor.INSTRUCTION);
+  }
+
+  @ParameterizedTest
+  @MethodSource("schemaOnlyProvidersWithoutSchema")
+  void contributesInstructionForSchemaOnlyProvidersWithEmptySchema(
+      ChatModelConfiguration chatModel) {
+    var response =
+        new AgentTaskResponseConfiguration(
+            new JsonResponseFormatConfiguration(Map.of(), null), false);
+    var executionContext = executionContext(chatModel, response);
+
+    var result = contributor.contribute(executionContext, CTX);
+
+    assertThat(result).isEqualTo(SchemaOnlyJsonResponseFormatSystemPromptContributor.INSTRUCTION);
+  }
+
+  static Stream<Arguments> schemaOnlyProvidersWithoutSchema() {
+    return Stream.of(Arguments.of(anthropicModel()), Arguments.of(bedrockModel()));
+  }
+
+  @ParameterizedTest
+  @MethodSource("nonSchemaOnlyProviders")
+  void doesNotContributeForProvidersWithNativeSchemaLessJsonMode(ChatModelConfiguration chatModel) {
+    var response =
+        new AgentTaskResponseConfiguration(new JsonResponseFormatConfiguration(null, null), false);
+    var executionContext = executionContext(chatModel, response);
+
+    var result = contributor.contribute(executionContext, CTX);
+
+    assertThat(result).isNull();
+  }
+
+  static Stream<Arguments> nonSchemaOnlyProviders() {
+    return Stream.of(
+        Arguments.of(openAiModel()), Arguments.of(geminiModel()), Arguments.of(customModel()));
+  }
+
+  @ParameterizedTest
+  @MethodSource("schemaOnlyProvidersWithoutSchema")
+  void doesNotContributeWhenSchemaIsPresent(ChatModelConfiguration chatModel) {
+    var response =
+        new AgentTaskResponseConfiguration(
+            new JsonResponseFormatConfiguration(Map.of("type", "object"), null), false);
+    var executionContext = executionContext(chatModel, response);
+
+    var result = contributor.contribute(executionContext, CTX);
+
+    assertThat(result).isNull();
+  }
+
+  @ParameterizedTest
+  @MethodSource("schemaOnlyProvidersWithoutSchema")
+  void doesNotContributeForTextResponseFormat(ChatModelConfiguration chatModel) {
+    var response =
+        new AgentTaskResponseConfiguration(new TextResponseFormatConfiguration(false), false);
+    var executionContext = executionContext(chatModel, response);
+
+    var result = contributor.contribute(executionContext, CTX);
+
+    assertThat(result).isNull();
+  }
+
+  @ParameterizedTest
+  @MethodSource("schemaOnlyProvidersWithoutSchema")
+  void doesNotContributeWhenResponseConfigurationIsNull(ChatModelConfiguration chatModel) {
+    var executionContext = executionContext(chatModel, null);
+
+    var result = contributor.contribute(executionContext, CTX);
+
+    assertThat(result).isNull();
+  }
+}

--- a/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/systemprompt/SchemaOnlyJsonResponseFormatSystemPromptContributorTest.java
+++ b/connectors/agentic-ai/connector-agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/systemprompt/SchemaOnlyJsonResponseFormatSystemPromptContributorTest.java
@@ -42,6 +42,7 @@ import io.camunda.connector.agenticai.aiagent.model.request.v2.OpenAiChatModelCo
 import io.camunda.connector.agenticai.aiagent.model.request.v2.OpenAiChatModelConfiguration.OpenAiModel;
 import java.util.Map;
 import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -185,5 +186,10 @@ class SchemaOnlyJsonResponseFormatSystemPromptContributorTest {
     var result = contributor.contribute(executionContext, CTX);
 
     assertThat(result).isNull();
+  }
+
+  @Test
+  void runsLastAmongContributors() {
+    assertThat(contributor.getOrder()).isEqualTo(Integer.MAX_VALUE);
   }
 }

--- a/connectors/agentic-ai/docs/reference/ai-agent.md
+++ b/connectors/agentic-ai/docs/reference/ai-agent.md
@@ -1099,9 +1099,10 @@ Spring auto-wires all `SystemPromptContributor` beans into the composer.
 
 ### Known Implementations
 
-| Implementation               | Order | Activation Condition                                  |
-|------------------------------|-------|-------------------------------------------------------|
-| `A2aSystemPromptContributor` | 100   | `agentContext.properties["a2aClients"]` is non-empty  |
+| Implementation                                       | Order | Activation Condition                                                                                                                            |
+|-------------------------------------------------------|-------|--------------------------------------------------------------------------------------------------------------------------------------------------|
+| `A2aSystemPromptContributor`                         | 100   | `agentContext.properties["a2aClients"]` is non-empty                                                                                            |
+| `SchemaOnlyJsonResponseFormatSystemPromptContributor` | 0     | JSON response format requested without a schema, on a provider whose native structured output is schema-only (Anthropic, Bedrock Converse)     |
 
 The architecture supports adding more contributors by creating a Spring bean implementing the interface — the composer picks them up automatically.
 

--- a/connectors/agentic-ai/docs/reference/ai-agent.md
+++ b/connectors/agentic-ai/docs/reference/ai-agent.md
@@ -1099,10 +1099,10 @@ Spring auto-wires all `SystemPromptContributor` beans into the composer.
 
 ### Known Implementations
 
-| Implementation                                       | Order | Activation Condition                                                                                                                            |
-|-------------------------------------------------------|-------|--------------------------------------------------------------------------------------------------------------------------------------------------|
-| `A2aSystemPromptContributor`                         | 100   | `agentContext.properties["a2aClients"]` is non-empty                                                                                            |
-| `SchemaOnlyJsonResponseFormatSystemPromptContributor` | 0     | JSON response format requested without a schema, on a provider whose native structured output is schema-only (Anthropic, Bedrock Converse)     |
+| Implementation                                        | Order | Activation Condition                                                                                                                        |
+|--------------------------------------------------------|-------|----------------------------------------------------------------------------------------------------------------------------------------------|
+| `A2aSystemPromptContributor`                           | 100   | `agentContext.properties["a2aClients"]` is non-empty                                                                                        |
+| `SchemaOnlyJsonResponseFormatSystemPromptContributor`  | 0     | JSON response format requested without a schema, on a provider whose native structured output is schema-only (Anthropic, Bedrock Converse) |
 
 The architecture supports adding more contributors by creating a Spring bean implementing the interface — the composer picks them up automatically.
 

--- a/connectors/agentic-ai/docs/reference/ai-agent.md
+++ b/connectors/agentic-ai/docs/reference/ai-agent.md
@@ -1099,10 +1099,10 @@ Spring auto-wires all `SystemPromptContributor` beans into the composer.
 
 ### Known Implementations
 
-| Implementation                                        | Order | Activation Condition                                                                                                                        |
-|--------------------------------------------------------|-------|----------------------------------------------------------------------------------------------------------------------------------------------|
-| `A2aSystemPromptContributor`                           | 100   | `agentContext.properties["a2aClients"]` is non-empty                                                                                        |
-| `SchemaOnlyJsonResponseFormatSystemPromptContributor`  | 0     | JSON response format requested without a schema, on a provider whose native structured output is schema-only (Anthropic, Bedrock Converse) |
+| Implementation                                        | Order                | Activation Condition                                                                                                                        |
+|--------------------------------------------------------|----------------------|----------------------------------------------------------------------------------------------------------------------------------------------|
+| `A2aSystemPromptContributor`                           | 100                  | `agentContext.properties["a2aClients"]` is non-empty                                                                                        |
+| `SchemaOnlyJsonResponseFormatSystemPromptContributor`  | `Integer.MAX_VALUE`  | JSON response format requested without a schema, on a provider whose native structured output is schema-only (Anthropic, Bedrock Converse) |
 
 The architecture supports adding more contributors by creating a Spring bean implementing the interface — the composer picks them up automatically.
 


### PR DESCRIPTION
## Description

Selecting JSON response format without a schema on Anthropic or Bedrock Converse now makes a best-effort attempt to return parsed JSON, instead of silently doing nothing on the request and only failing later with a confusing parse error.

**What changed**

- AI Agent: JSON response format without a schema now prompts Anthropic and Bedrock Converse to emit JSON, closing the gap with the native support already available on OpenAI and Gemini.
- Fixed a related defect: an empty schema (`={}`) on Anthropic no longer reaches the model as a literal empty schema.
- Element template: the response format field now documents this best-effort behavior.

## Related issues

closes #8407

## Checklist

- [x] Backport labels are added if these code changes should be backported. No backport label is added to the latest
  release, as this branch will be rebased onto main before the next release. Example backport labels:
    - `backport stable/8.8`: for changes that should be included in the next 8.8.x release.
    - **or** `backport release-8.8.7`: for changes that should be included in the specific release 8.8.7, and this
      *release has already been created*. The release branch will be merged back into stable/8.8 later, so the change
      will be included in future 8.8.x releases as well.
- [x] Tests/Integration tests for the changes have been added if applicable.
- [x] If the change requires a documentation update, it has been added to the appropriate section in the documentation.