### PR TITLE
fix(ci): let merge_group trigger fire for stable/8.10 queue

### DIFF
--- a/.github/workflows/TEST_FEATURE_BRANCH.yml
+++ b/.github/workflows/TEST_FEATURE_BRANCH.yml
@@ -12,7 +12,7 @@ on:
       - '!main'
       - '!gh-readonly-queue/**'
   merge_group:
-    branches: [ main ]
+    branches: [ main, 'stable/**' ]
 
 # Cancel stale runs of the same type (push-on-push, PR-on-PR) without
 # letting push and pull_request events cancel each other. Merge-queue runs


### PR DESCRIPTION
## Summary
- The merge queue was enabled for `stable/8.10` (and other stable branches), but PRs targeting it get stuck: the required `run-tests` check never reports for entries in the queue.
- Root cause: `Test branch`'s `push` trigger excludes `gh-readonly-queue/**`, while its `merge_group` trigger is scoped to `branches: [main]` only. On `stable/8.10` neither trigger matches a queue entry, so `run-tests` never runs.
- Fix: widen `merge_group.branches` to `[main, 'stable/**']` so queue entries on stable branches are covered too.

Ref: #8856 (the PR that surfaced this — merge queue entries for it never completed `run-tests`).

## Test plan
- [ ] Merge this PR itself through the queue and confirm `run-tests` runs and reports on the `gh-readonly-queue/stable/8.10/...` entry
- [ ] Re-attempt merging #8856 through the queue afterward

🤖 Generated with [Claude Code](https://claude.com/claude-code)