### PR TITLE
fix(ci): properly route merge queue runs through merge_group on stable/8.6

### DIFF
--- a/.github/workflows/TEST_FEATURE_BRANCH.yml
+++ b/.github/workflows/TEST_FEATURE_BRANCH.yml
@@ -5,8 +5,9 @@ on:
     branches:
       - '**'
       - '!main'
+      - '!gh-readonly-queue/**'
   merge_group:
-    branches: [ main ]
+    branches: [ main, 'stable/**' ]
 
 jobs:
   run-tests:


### PR DESCRIPTION
## Summary
- `stable/8.6`'s copy of the \`Test branch\` workflow currently satisfies the required \`run-tests\` check on merge-queue entries only by accident: \`push\` doesn't exclude \`gh-readonly-queue/**\`, so it fires there instead of via \`merge_group\` (which is scoped to \`branches: [main]\` only).
- This is a latent landmine: \`stable/8.10\` had this same old shape until its workflow file got synced with \`main\` (which added the \`push\` exclusion) without widening \`merge_group\` — and its merge queue got stuck as a result (camunda/connectors#8884).
- Fix: proactively align this branch with the corrected \`main\`/\`stable/8.10\` trigger — exclude \`gh-readonly-queue/**\` from \`push\` and widen \`merge_group.branches\` to include stable branches, so both changes land together and the queue keeps working through \`merge_group\` as intended.

## Test plan
- [ ] Merge this PR through the queue and confirm \`run-tests\` runs via the \`merge_group\` event (not \`push\`) on the \`gh-readonly-queue/stable/8.6/...\` entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)